### PR TITLE
Tweak FAQS for Getting started page

### DIFF
--- a/js/src/get-started-page/faqs/index.js
+++ b/js/src/get-started-page/faqs/index.js
@@ -302,7 +302,7 @@ const faqItems = [
 						link: (
 							<AppDocumentationLink
 								context="faqs"
-								linkId="google-countrytable"
+								linkId="google-country-table"
 								href="https://support.google.com/merchants/answer/160637#countrytable"
 							/>
 						),

--- a/js/src/get-started-page/faqs/index.js
+++ b/js/src/get-started-page/faqs/index.js
@@ -11,92 +11,84 @@ import FaqsPanel from '.~/components/faqs-panel';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import './index.scss';
 
+const linkMc = (
+	<AppDocumentationLink
+		context="faqs"
+		linkId="google-merchant-center-link"
+		href="https://woocommerce.com/document/google-for-woocommerce/#connect-your-store-with-google-merchant-center"
+	/>
+);
+
+const linkPmax = (
+	<AppDocumentationLink
+		context="faqs"
+		linkId="performance-max-link"
+		href="https://woocommerce.com/document/google-for-woocommerce/get-started/google-performance-max-campaigns/"
+	/>
+);
 const faqItems = [
 	{
-		trackId: 'what-do-i-need-to-get-started',
+		trackId: 'what-is-google-merchant-center',
 		question: __(
-			'What do I need to get started?',
+			'What is Google Merchant Center?',
 			'google-listings-and-ads'
 		),
 		answer: (
 			<p>
 				{ createInterpolateElement(
 					__(
-						'In order to sync your WooCommerce store with Google and begin showcasing your products online, you will need to provide the following during setup; Google account access, target audience, shipping information, tax rate information (required for US only), and ensure your store is running on a compatible PHP version. <link>Learn more.</link>',
+						"<link>Google Merchant Center</link> is like a digital storefront for your products on Google. It's where you upload and manage information about your products, like titles, descriptions, images, prices, and availability. This data is used to create product listings that can appear across Google.",
 						'google-listings-and-ads'
 					),
 					{
-						link: (
-							<AppDocumentationLink
-								context="faqs"
-								linkId="general-requirements"
-								href="https://woocommerce.com/document/google-for-woocommerce/get-started/requirements/#general-requirements"
-							/>
-						),
+						link: linkMc,
 					}
 				) }
 			</p>
 		),
 	},
 	{
-		trackId: 'what-if-i-already-have-free-listings',
+		trackId: 'why-should-i-connect-google-merchant-center',
 		question: __(
-			'What if I already have Google listings or ads set up? Will syncing my store replace my current Google listings?',
+			'Why should I connect to Google Merchant Center?',
 			'google-listings-and-ads'
 		),
 		answer: (
 			<>
 				<p>
-					{ __(
-						'Once you link an existing account to connect your store, your Shopping ads and free listings will stop running. You’ll need to re-upload your feed and product data in order to run Shopping ads and show free listings.',
-						'google-listings-and-ads'
-					) }
-				</p>
-				<p>
 					{ createInterpolateElement(
 						__(
-							'Learn more about claiming URLs <link>here</link>.',
+							'By syncing your product information to <linkMc>Google Merchant Center</linkMc>, your products can appear in relevant Google searches, Shopping tab, image searches, and even on other platforms like YouTube. When running <linkPmax>Performance Max campaigns</linkPmax>, Google Merchant Center ensures that shoppers see the most up-to-date and accurate information about your product feed, reducing confusion and improving the chances of a purchase.',
 							'google-listings-and-ads'
 						),
 						{
-							link: (
-								<AppDocumentationLink
-									context="faqs"
-									linkId="claiming-urls"
-									href="https://support.google.com/merchants/answer/7527436"
-								/>
-							),
+							linkMc,
+							linkPmax,
 						}
-					) }
-				</p>
-				<p>
-					{ __(
-						'If you have an existing Content API feed, it will not be changed, overwritten or deleted by this WooCommerce integration. Instead, products will be added to your existing Content API feed.',
-						'google-listings-and-ads'
 					) }
 				</p>
 			</>
 		),
 	},
 	{
-		trackId: 'is-my-store-ready-to-sync-with-google',
+		trackId: 'will-my-deals-and-promotions-display-on-google',
 		question: __(
-			'Is my store ready to sync with Google?',
+			'Will my deals and promotions display on Google?',
 			'google-listings-and-ads'
 		),
 		answer: (
 			<p>
 				{ createInterpolateElement(
 					__(
-						'In order to meet the Google Merchant Center requirements make sure your website has the following; secure checkout process and payment information, refund and return policies, billing terms and conditions, business contact information. <link>Learn more.</link>',
+						'To show your coupons and promotions on Google Shopping listings, make sure you’re using the latest version of Google for WooCommerce. When you create or update a coupon in your WordPress dashboard under Marketing > Coupons, you’ll see a Channel Visibility settings box on the right: select “Show coupon on Google” to enable it. <link>Learn more</link> about managing promotions for Google for WooCommerce. This feature is currently available in Australia, Canada, Germany, France, India, the United Kingdom, and the United States.',
 						'google-listings-and-ads'
 					),
 					{
 						link: (
 							<AppDocumentationLink
 								context="faqs"
-								linkId="google-merchant-center-requirements"
-								href="https://woocommerce.com/document/google-for-woocommerce/get-started/requirements/#google-merchant-center-requirements"
+								linkId="google-promotions-using-woocommerce"
+								href="https://support.google.com/merchants/answer/11338950#zippy=%2Cmanage-promotions-using-woocommerce"
 							/>
 						),
 					}
@@ -105,49 +97,126 @@ const faqItems = [
 		),
 	},
 	{
-		trackId: 'what-is-a-performance-max-campaign',
+		trackId: 'what-is-product-sync',
+		question: __( 'What is Product Sync?', 'google-listings-and-ads' ),
+		answer: (
+			<>
+				<p>
+					{ __(
+						'Product Sync is a feature fully integrated into WooCommerce’s management platform that automatically lets you sync your product feed to Google Merchant Center. It will sync all your WooCommerce product data, and you can also add or edit products individually or in bulk. To ensure products are approved by Google, check that your product feed includes the following information:',
+						'google-listings-and-ads'
+					) }
+				</p>
+				<p>
+					<ul>
+						<li>
+							{ __(
+								'General product information',
+								'google-listings-and-ads'
+							) }
+						</li>
+						<li>
+							{ __(
+								'Unique product identifiers',
+								'google-listings-and-ads'
+							) }
+						</li>
+						<li>
+							{ __(
+								'Data requirements for specific categories (auto-assigned by Google):',
+								'google-listings-and-ads'
+							) }
+							<ul>
+								<li>
+									{ __(
+										'Apparel & Accessories',
+										'google-listings-and-ads'
+									) }
+								</li>
+								<li>
+									{ __( 'Media', 'google-listings-and-ads' ) }
+								</li>
+								<li>
+									{ __( 'Books', 'google-listings-and-ads' ) }
+								</li>
+							</ul>
+						</li>
+					</ul>
+				</p>
+			</>
+		),
+	},
+	{
+		trackId:
+			'where-do-i-manage-my-product-feed-and-my-google-ads-campaigns',
 		question: __(
-			'What is a Performance Max campaign?',
+			'Where do I manage my product feed and my Google Ads campaigns?',
+			'google-listings-and-ads'
+		),
+		answer: (
+			<p>
+				{ __(
+					'You can manage and edit all of your products and your Google Ads campaigns right from your WooCommerce dashboard and on the WooCommerce Mobile App.',
+					'google-listings-and-ads'
+				) }
+			</p>
+		),
+	},
+	{
+		trackId: 'where-will-my-products-appear',
+		question: __(
+			'Where will my products appear?',
 			'google-listings-and-ads'
 		),
 		answer: (
 			<p>
 				{ createInterpolateElement(
 					__(
-						'Performance Max campaigns make it easy to connect your WooCommerce store to Google Shopping ads so you can showcase your products to shoppers across Google Search, Maps, Shopping, YouTube, Gmail, the Display Network and Discover feed to drive traffic and sales for your store. <link>Learn more.</link>',
+						'Once you start running a <linkPmax>Performance Max ads campaign</linkPmax>, your approved products will reach more shoppers to help grow your business by being shown on Google Search, Google Maps, the Shopping tab, Gmail, Youtube, the Google Display Network, and Discover feed.',
 						'google-listings-and-ads'
 					),
 					{
-						link: (
-							<AppDocumentationLink
-								context="faqs"
-								linkId="performance-max"
-								href="https://woocommerce.com/document/google-for-woocommerce/get-started/google-performance-max-campaigns"
-							/>
-						),
+						linkPmax,
 					}
 				) }
 			</p>
 		),
 	},
 	{
-		trackId: 'what-are-free-listings',
-		question: __( 'What are free listings?', 'google-listings-and-ads' ),
+		trackId: 'what-are-performance-max-campaigns',
+		question: __(
+			'What are Performance Max campaigns?',
+			'google-listings-and-ads'
+		),
 		answer: (
 			<p>
 				{ createInterpolateElement(
 					__(
-						'Google Free Listings allows stores to showcase eligible products to shoppers looking for what you offer and drive traffic to your store with Google’s free listings on the Shopping tab. Your products can also appear on Google Search, Google Images, and Gmail if you’re selling in the United States. <link>Learn more.</link>',
+						'<linkPmax>Performance Max campaigns</linkPmax> help you combine your expertise with Google AI to reach your most valuable customers and drive sales. Just set your goals and budget and Google AI will get your ads seen by the right customers at the right time across Google Search, Google Maps, the Shopping tab, Gmail, Youtube, the Google Display Network, and Discover feed.',
 						'google-listings-and-ads'
 					),
 					{
-						link: (
-							<AppDocumentationLink
-								context="faqs"
-								linkId="free-listings"
-								href="https://woocommerce.com/document/google-for-woocommerce/get-started/product-feed-information-and-free-listings/#section-1"
-							/>
-						),
+						linkPmax,
+					}
+				) }
+			</p>
+		),
+	},
+	{
+		trackId: 'how-much-do-performance-max-campaigns-cost',
+		question: __(
+			'How much do Performance Max campaigns cost?',
+			'google-listings-and-ads'
+		),
+		answer: (
+			<p>
+				{ createInterpolateElement(
+					__(
+						'<linkPmax>Performance Max campaigns</linkPmax> are pay-per-click, meaning you only pay when someone clicks on your ads. To get the best results and ensure your products reach the right customers, we recommend starting with the suggested Google for WooCommerce minimum daily budget for your <linkPmax>Performance Max campaign</linkPmax>. This helps jumpstart your campaign and drive early conversions. You can always adjust your budget later as you see what works best for your business.',
+						'google-listings-and-ads'
+					),
+					{
+						linkPmax,
 					}
 				) }
 			</p>
@@ -155,24 +224,59 @@ const faqItems = [
 	},
 	{
 		trackId:
-			'where-to-track-free-listings-and-performance-max-campaign-performance',
+			'can-i-sync-my-products-and-run-performance-max-campaigns-on-google-for-woocommerce-at-the-same-time',
 		question: __(
-			'Where can I track my free listings and Performance Max campaign performance?',
+			'Can I sync my products and run Performance Max campaigns on Google for WooCommerce at the same time?',
 			'google-listings-and-ads'
 		),
 		answer: (
 			<p>
 				{ createInterpolateElement(
 					__(
-						'Once your free listings and Performance Max campaigns are set up, you will be able to track your performance straight from your WooCommerce dashboard. You can view your reports yearly, quarterly, monthly, weekly, or daily. The following metrics will be visible within your report: conversions, clicks, impressions, total sales and total spend. <link>Learn more.</link>',
+						'Yes, you can run both at the same time, and we recommend you do! Once you sync your store it’s automatically listed on Google, so you can choose to run a paid <linkPmax>Performance Max campaign</linkPmax> as soon as you’d like. In the US, advertisers who sync their products to Google and run Google Ads <linkPmax>Performance Max campaigns</linkPmax> have seen an average of over 50% increase in clicks and over 100% increase in impressions in both their product listings and their ads on the Shopping tab. ',
+						'google-listings-and-ads'
+					),
+					{
+						linkPmax,
+					}
+				) }
+			</p>
+		),
+	},
+	{
+		trackId: 'how-does-google-for-woocommerce-help-me-drive-sales',
+		question: __(
+			'How does Google for WooCommerce help me drive sales?',
+			'google-listings-and-ads'
+		),
+		answer: (
+			<p>
+				{ __(
+					'With Google for WooCommerce, you can serve the best-performing ads more often, by using Google AI to pull headlines, images, product details, and more from your product feed and find more relevant customers. Your campaigns will learn and optimize in real time – to help deliver better performance and boost your ROI.',
+					'google-listings-and-ads'
+				) }
+			</p>
+		),
+	},
+	{
+		trackId: 'what-are-enhanced-conversions',
+		question: __(
+			'What are Enhanced conversions?',
+			'google-listings-and-ads'
+		),
+		answer: (
+			<p>
+				{ createInterpolateElement(
+					__(
+						'<link>Enhanced conversions</link> is a feature that can improve the accuracy of your conversion measurement and unlock more powerful bidding. It supplements your existing conversion tags by sending hashed first-party conversion data from your website to Google in a privacy-safe way.',
 						'google-listings-and-ads'
 					),
 					{
 						link: (
 							<AppDocumentationLink
 								context="faqs"
-								linkId="campaign-analytics"
-								href="https://woocommerce.com/document/google-for-woocommerce/get-started/campaign-analytics"
+								linkId="google-enhanced-conversions"
+								href="https://support.google.com/google-ads/answer/9888656?hl=en-GB"
 							/>
 						),
 					}
@@ -181,61 +285,111 @@ const faqItems = [
 		),
 	},
 	{
-		trackId: 'how-to-sync-products-to-google-free-listings',
+		trackId: 'which-countries-are-available-for-google-for-woocommerce',
 		question: __(
-			'How do I sync my products to Google free listings?',
+			'Which countries are available for Google for WooCommerce?',
+			'google-listings-and-ads'
+		),
+		answer: (
+			<p>
+				{ createInterpolateElement(
+					__(
+						'For <linkPmax>Performance Max campaigns</linkPmax>, learn more about supported countries and currencies <link>here</link>.',
+						'google-listings-and-ads'
+					),
+					{
+						linkPmax,
+						link: (
+							<AppDocumentationLink
+								context="faqs"
+								linkId="google-countrytable"
+								href="https://support.google.com/merchants/answer/160637#countrytable"
+							/>
+						),
+					}
+				) }
+			</p>
+		),
+	},
+	{
+		trackId: 'what-is-multi-country-advertising',
+		question: __(
+			'What is Multi-Country Advertising?',
 			'google-listings-and-ads'
 		),
 		answer: (
 			<p>
 				{ __(
-					'The Google for WooCommerce plugin allows you to upload your store and product data to Google. Your products will sync automatically to make relevant information available for free listings, Google Ads, and other Google services. You can create a new Merchant Center account or link an existing account to connect your store and list products across Google.',
+					'Multi-Country Advertising enables you to create a single Google Ads campaign that targets multiple countries at once. Google for WooCommerce automatically populates eligible countries from your Google Merchant Center account into the plug-in ads campaign creation flow.',
 					'google-listings-and-ads'
 				) }
 			</p>
 		),
 	},
 	{
-		trackId: 'can-i-run-both-shopping-ads-and-free-listings-campaigns',
+		trackId:
+			'can-i-enable-multi-country-advertising-on-my-existing-campaigns',
 		question: __(
-			'Can I run both Shopping ads and free listings campaigns at the same time?',
+			'Can I enable Multi-Country Advertising on my existing campaigns?',
 			'google-listings-and-ads'
 		),
 		answer: (
 			<p>
 				{ __(
-					'Yes, you can run both at the same time, and we recommend it! In the US, advertisers running free listings and ads together have seen an average of over 50% increase in clicks and over 100% increase in impressions on both free listings and ads on the Shopping tab. Your store is automatically opted into free listings automatically and can choose to run a paid Performance Max campaign.',
+					'If you created a campaign before this feature launched, you’ll need to create a new campaign to target new countries with Multi-Country Advertising',
 					'google-listings-and-ads'
 				) }
 			</p>
 		),
 	},
 	{
-		trackId: 'how-can-i-get-the-ad-credit-offer',
+		trackId: 'how-is-my-ads-budget-split-between-the-different-countries',
 		question: __(
-			'How can I get the $500 ad credit offer?',
+			'How is my ads budget split between the different countries?',
+			'google-listings-and-ads'
+		),
+		answer: (
+			<p>
+				{ __(
+					'Identify the best performing targeted countries with the help of Google AI, to make your ads reach the right shoppers at the right time.',
+					'google-listings-and-ads'
+				) }
+			</p>
+		),
+	},
+	{
+		trackId: 'which-countries-can-i-target',
+		question: __(
+			'Which countries can I target?',
 			'google-listings-and-ads'
 		),
 		answer: (
 			<>
 				<p>
 					{ __(
-						'Create a new Google Ads account through Google for WooCommerce and a promotional code will be automatically applied to your account. You’ll have 60 days to spend $500 to qualify for the $500 ads credit.',
+						'You can only select the countries that you’re targeting on Google Merchant Center. Your target countries must be eligible for both Google Merchant Center and Google Ads.',
 						'google-listings-and-ads'
 					) }
 				</p>
 				<p>
 					{ createInterpolateElement(
 						__(
-							'Ad credit amounts vary by country and region. Full terms and conditions can be found <link>here</link>.',
+							'To allow your products to appear in all relevant locations, make sure you’ve correctly <linkShipping>configured your shipping</linkShipping> for countries where your products can be delivered. Keep in mind that shipping services can cover multiple countries. <linkMultiCountryShipping>Learn more about multi-country shipping</linkMultiCountryShipping>.',
 							'google-listings-and-ads'
 						),
 						{
-							link: (
+							linkShipping: (
 								<AppDocumentationLink
 									context="faqs"
-									linkId="terms-and-conditions-of-google-ads-coupons"
-									href="https://www.google.com/ads/coupons/terms/"
+									linkId="google-set-up-shipping"
+									href="https://support.google.com/merchants/answer/6069284"
+								/>
+							),
+							linkMultiCountryShipping: (
+								<AppDocumentationLink
+									context="faqs"
+									linkId="google-set-up-multi-country-shipping"
+									href="https://support.google.com/merchants/answer/6069284#multicountryshipping"
 								/>
 							),
 						}

--- a/js/src/get-started-page/faqs/index.js
+++ b/js/src/get-started-page/faqs/index.js
@@ -107,42 +107,40 @@ const faqItems = [
 						'google-listings-and-ads'
 					) }
 				</p>
-				<p>
-					<ul>
-						<li>
-							{ __(
-								'General product information',
-								'google-listings-and-ads'
-							) }
-						</li>
-						<li>
-							{ __(
-								'Unique product identifiers',
-								'google-listings-and-ads'
-							) }
-						</li>
-						<li>
-							{ __(
-								'Data requirements for specific categories (auto-assigned by Google):',
-								'google-listings-and-ads'
-							) }
-							<ul>
-								<li>
-									{ __(
-										'Apparel & Accessories',
-										'google-listings-and-ads'
-									) }
-								</li>
-								<li>
-									{ __( 'Media', 'google-listings-and-ads' ) }
-								</li>
-								<li>
-									{ __( 'Books', 'google-listings-and-ads' ) }
-								</li>
-							</ul>
-						</li>
-					</ul>
-				</p>
+				<ul>
+					<li>
+						{ __(
+							'General product information',
+							'google-listings-and-ads'
+						) }
+					</li>
+					<li>
+						{ __(
+							'Unique product identifiers',
+							'google-listings-and-ads'
+						) }
+					</li>
+					<li>
+						{ __(
+							'Data requirements for specific categories (auto-assigned by Google):',
+							'google-listings-and-ads'
+						) }
+						<ul>
+							<li>
+								{ __(
+									'Apparel & Accessories',
+									'google-listings-and-ads'
+								) }
+							</li>
+							<li>
+								{ __( 'Media', 'google-listings-and-ads' ) }
+							</li>
+							<li>
+								{ __( 'Books', 'google-listings-and-ads' ) }
+							</li>
+						</ul>
+					</li>
+				</ul>
 			</>
 		),
 	},

--- a/js/src/get-started-page/faqs/index.scss
+++ b/js/src/get-started-page/faqs/index.scss
@@ -19,4 +19,9 @@
 			line-height: $gla-line-height-small;
 		}
 	}
+
+	ul {
+		padding: revert;
+		list-style: revert;
+	}
 }

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -324,7 +324,7 @@ When a documentation link is clicked.
 - [`AppDocumentationLink`](../../js/src/components/app-documentation-link/index.js#L29)
 - [`ChooseAudienceSection`](../../js/src/components/free-listings/choose-audience-section/choose-audience-section.js#L29) with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
 - [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L42) with `{ context: 'setup-ads-connect-account', link_id: 'connect-sub-account', href: 'https://support.google.com/google-ads/answer/6139186' }`
-- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/requirements/#general-requirements' }`
+- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/setup-and-configuration/#required-google-permissions' }`
 - [`ContactInformation`](../../js/src/components/contact-information/index.js#L91)
 	- with `{ context: 'setup-mc-contact-information', link_id: 'contact-information-read-more', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/requirements/#contact-information' }`
 	- with `{ context: 'settings-no-phone-number-notice', link_id: 'contact-information-read-more', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/requirements/#contact-information' }`
@@ -335,7 +335,7 @@ When a documentation link is clicked.
 	- with `{ context: "reports-programs", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
 - [`EditPhoneNumber`](../../js/src/settings/edit-phone-number.js#L29) with `{ context: "settings-phone-number", link_id: "contact-information-read-more", href: "https://woocommerce.com/document/google-for-woocommerce/get-started/requirements/#contact-information" }`
 - [`EditStoreAddress`](../../js/src/settings/edit-store-address.js#L41) with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://woocommerce.com/document/google-for-woocommerce/get-started/requirements/#contact-information" }`
-- [`Faqs`](../../js/src/get-started-page/faqs/index.js#L276)
+- [`Faqs`](../../js/src/get-started-page/faqs/index.js#L428)
 	- with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/requirements/#general-requirements' }`.
 	- with `{ context: 'faqs', linkId: 'claiming-urls', href: 'https://support.google.com/merchants/answer/7527436' }`.
 	- with `{ context: 'faqs', linkId: 'google-merchant-center-requirements', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/requirements/#google-merchant-center-requirements' }`.
@@ -347,14 +347,14 @@ When a documentation link is clicked.
 - [`FaqsSection`](../../js/src/components/paid-ads/asset-group/faqs-section.js#L73) with `{ context: 'assets-faq', linkId: 'assets-faq-about-ad-formats-available-in-different-campaign-types', href: 'https://support.google.com/google-ads/answer/1722124' }`.
 - [`FreeAdCredit`](../../js/src/setup-ads/ads-stepper/setup-accounts/free-ad-credit/index.js#L27) with `{ context: 'setup-ads', link_id: 'free-ad-credit-terms', href: 'https://www.google.com/ads/coupons/terms/' }`
 - [`GetStartedCard`](../../js/src/get-started-page/get-started-card/index.js#L23) with `{ context: 'get-started', linkId: 'wp-terms-of-service', href: 'https://wordpress.com/tos/' }`.
-- [`GetStartedWithVideoCard`](../../js/src/get-started-page/get-started-with-video-card/index.js#L23) with `{ context: 'get-started-with-video', linkId: 'wp-terms-of-service', href: 'https://wordpress.com/tos/' }`.
+- [`GetStartedWithHeroCard`](../../js/src/get-started-page/get-started-with-hero-card/index.js#L23) with `{ context: 'get-started-with-hero', linkId: 'wp-terms-of-service', href: 'https://wordpress.com/tos/' }`.
 - [`GoogleMCDisclaimer`](../../js/src/setup-mc/setup-stepper/setup-accounts/index.js#L36)
 	- with `{ context: 'setup-mc-accounts', link_id: 'comparison-shopping-services', href: 'https://support.google.com/merchants/topic/9080307' }`
 	- with `{ context: 'setup-mc-accounts', link_id: 'comparison-shopping-partners-find-a-partner', href: 'https://comparisonshoppingpartners.withgoogle.com/find_a_partner/' }`
 - [`IssuesTableDataModal`](../../js/src/product-feed/issues-table-card/issues-table-data-modal.js#L21) with { context: 'issues-data-table-modal' }
 - [`ProductStatusHelpPopover`](../../js/src/product-feed/product-statistics/product-status-help-popover/index.js#L16) with `{ context: 'product-feed', link_id: 'product-sync-statuses', href: 'https://support.google.com/merchants/answer/160491' }`
 - [`ReclaimUrlCard`](../../js/src/components/google-mc-account-card/reclaim-url-card/index.js#L41) with `{ context: 'setup-mc', link_id: 'claim-url', href: 'https://support.google.com/merchants/answer/176793' }`
-- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/requirements/#general-requirements' }`
+- [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/setup-and-configuration/#required-google-permissions' }`
 - [`ShippingRateSection`](../../js/src/components/shipping-rate-section/shipping-rate-section.js#L23)
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
@@ -429,7 +429,7 @@ Clicking on faq item to collapse or expand it.
 `action` | `string` | (`expand`\|`collapse`)
 `context` | `string` | Indicates which page / module the FAQ is in
 #### Emitters
-- [`Faqs`](../../js/src/get-started-page/faqs/index.js#L276)
+- [`Faqs`](../../js/src/get-started-page/faqs/index.js#L428)
 	- with `{ context: 'get-started', id: 'what-do-i-need-to-get-started', action: 'expand' }`.
 	- with `{ context: 'get-started', id: 'what-do-i-need-to-get-started', action: 'collapse' }`.
 	- with `{ context: 'get-started', id: 'what-if-i-already-have-free-listings', action: 'expand' }`.
@@ -773,7 +773,7 @@ Setup Merchant Center
 `context` | `string \| undefined` | Indicates which CTA is clicked
 #### Emitters
 - [`GetStartedCard`](../../js/src/get-started-page/get-started-card/index.js#L23) with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started' }`.
-- [`GetStartedWithVideoCard`](../../js/src/get-started-page/get-started-with-video-card/index.js#L23) with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started-with-video' }`.
+- [`GetStartedWithHeroCard`](../../js/src/get-started-page/get-started-with-hero-card/index.js#L23) with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started-with-hero' }`.
 - [`SavedSetupStepper`](../../js/src/setup-mc/setup-stepper/saved-setup-stepper.js#L39)
 	- with `{ triggered_by: 'step1-continue-button' | 'step2-continue-button', 'step3-continue-button', action: 'go-to-step2' | 'go-to-step3' | 'go-to-step4' }`.
 	- with `{ triggered_by: 'stepper-step1-button' | 'stepper-step2-button' | 'stepper-step3-button', action: 'go-to-step1' | 'go-to-step2' | 'go-to-step3' }`.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR tweaks the FAQs for the getting started page. 
The FAQs are the same as in [woocommerce.com product page](https://woocommerce.com/products/google-listings-and-ads/)  FAQ or you ca also ask for access to the document here p1722256353475989-slack-C02BB3F30TG

### Screenshots:

<img width="938" alt="Screenshot 2024-08-07 at 17 18 56" src="https://github.com/user-attachments/assets/466bc01f-1349-485d-acf5-60506f39b92c">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Got to get started page
2. Verify the FAQ looking equal as in [woocommerce.com product page](https://woocommerce.com/products/google-listings-and-ads/)  FAQ 
3. Verify the  Links work and makes sense.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Update FAQS in Getting Started page