### PR TITLE
Fix broken unit tests with WooCommerce `9.2.0-rc.1`

### DIFF
--- a/tests/e2e/specs/get-started.test.js
+++ b/tests/e2e/specs/get-started.test.js
@@ -32,7 +32,7 @@ test( 'Merchant who is getting started clicks on the Marketing > GLA link, click
 	await expect( page ).toHaveTitle( /Google for WooCommerce/ );
 
 	// click on the call-to-action button.
-	await page.getByText( 'Start listing products →' ).first().click();
+	await page.getByText( 'Sell more on Google →' ).first().click();
 	await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 
 	// Check we are in the Setup MC page.

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -97,7 +97,7 @@ export async function checkout( page ) {
 			.fill( user.addressfirstline );
 		await page.getByLabel( 'City' ).fill( user.city );
 		await page.getByLabel( 'ZIP Code' ).fill( user.postcode );
-		await page.locator( '#billing-state input' ).fill( user.statename );
+		await page.locator( '#billing-state' ).selectOption( user.statename );
 	}
 
 	//TODO: See if there's an alternative method to click the button without relying on waitForTimeout.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2506 

- Updates the CTA text from `Start listing products` to `Sell more on Google`
- Adjusts the `#billing-state` locator

### Detailed test instructions:
1. `npm run wp-env:up`
2. `npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version=9.1.0-rc.1`
3. `npm run -- wp-env run tests-cli -- wp wc update`
4. `npm run test:e2e`
4. Confirm tests pass

### Changelog entry
