### PR TITLE
Update Block validation to support error context

### DIFF
--- a/js/src/blocks/product-date-time-field/edit.js
+++ b/js/src/blocks/product-date-time-field/edit.js
@@ -32,7 +32,7 @@ async function resolveValidationMessage( inputRef, context ) {
 
 		return {
 			message: input.validationMessage,
-			context
+			context,
 		};
 	}
 }
@@ -43,6 +43,7 @@ async function resolveValidationMessage( inputRef, context ) {
  * @param {Object} props React props.
  * @param {ProductBasicAttributes} props.attributes
  * @param {ProductEditorBlockContext} props.context
+ * @param {string} props.clientId
  */
 export default function Edit( { attributes, context, clientId } ) {
 	const { property } = attributes;

--- a/js/src/blocks/product-date-time-field/edit.js
+++ b/js/src/blocks/product-date-time-field/edit.js
@@ -10,6 +10,7 @@ import {
 	useValidation,
 } from '@woocommerce/product-editor';
 import { Flex, FlexBlock } from '@wordpress/components';
+import { isWcVersion } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 
 /**
  * Internal dependencies
@@ -21,11 +22,18 @@ import styles from './editor.module.scss';
  * @typedef {import('../types.js').ProductBasicAttributes} ProductBasicAttributes
  */
 
-async function resolveValidationMessage( inputRef ) {
+async function resolveValidationMessage( inputRef, context ) {
 	const input = inputRef.current;
 
 	if ( ! input.validity.valid ) {
-		return input.validationMessage;
+		if ( isWcVersion( '9.2.0', '>' ) ) {
+			return input.validationMessage;
+		}
+
+		return {
+			message: input.validationMessage,
+			context
+		};
 	}
 }
 
@@ -36,7 +44,7 @@ async function resolveValidationMessage( inputRef ) {
  * @param {ProductBasicAttributes} props.attributes
  * @param {ProductEditorBlockContext} props.context
  */
-export default function Edit( { attributes, context } ) {
+export default function Edit( { attributes, context, clientId } ) {
 	const { property } = attributes;
 	const blockProps = useWooBlockProps( attributes );
 	const [ value, setValue ] = useProductEntityProp( property, {
@@ -76,11 +84,11 @@ export default function Edit( { attributes, context } ) {
 	};
 
 	const dateValidation = useValidation( `${ property }-date`, () =>
-		resolveValidationMessage( dateInputRef )
+		resolveValidationMessage( dateInputRef, clientId )
 	);
 
 	const timeValidation = useValidation( `${ property }-time`, () =>
-		resolveValidationMessage( timeInputRef )
+		resolveValidationMessage( timeInputRef, clientId )
 	);
 
 	return (

--- a/js/src/blocks/product-date-time-field/edit.js
+++ b/js/src/blocks/product-date-time-field/edit.js
@@ -26,7 +26,8 @@ async function resolveValidationMessage( inputRef, context ) {
 	const input = inputRef.current;
 
 	if ( ! input.validity.valid ) {
-		if ( isWcVersion( '9.2.0', '>' ) ) {
+		// compatibility-code "WC < 9.2"
+		if ( isWcVersion( '9.2.0', '<' ) ) {
 			return input.validationMessage;
 		}
 

--- a/src/Admin/Input/Integer.php
+++ b/src/Admin/Input/Integer.php
@@ -20,6 +20,12 @@ class Integer extends Input {
 		// the text field block to work around it.
 		parent::__construct( 'integer', 'woocommerce/product-text-field' );
 
-		$this->set_block_attribute( 'type', [ 'value' => 'number' ] );
+		$this->set_block_attribute(
+			'pattern',
+			[
+				'value'   => '\d+',
+				'message' => __( 'Please enter a valid value.', 'woocommerce' ),
+			]
+		);
 	}
 }

--- a/src/Admin/Input/Integer.php
+++ b/src/Admin/Input/Integer.php
@@ -24,6 +24,9 @@ class Integer extends Input {
 			'pattern',
 			[
 				'value'   => '\d+',
+				// This error message is used in core so to avoid needing to translate
+				// the string a second time WooCommerce is supplied as the text domain.
+				// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
 				'message' => __( 'Please enter a valid value.', 'woocommerce' ),
 			]
 		);

--- a/src/Admin/Input/Integer.php
+++ b/src/Admin/Input/Integer.php
@@ -23,7 +23,7 @@ class Integer extends Input {
 		$this->set_block_attribute(
 			'pattern',
 			[
-				'value' => '\d+',
+				'value' => '0|[1-9]\d*',
 			]
 		);
 	}

--- a/src/Admin/Input/Integer.php
+++ b/src/Admin/Input/Integer.php
@@ -23,11 +23,7 @@ class Integer extends Input {
 		$this->set_block_attribute(
 			'pattern',
 			[
-				'value'   => '\d+',
-				// This error message is used in core so to avoid needing to translate
-				// the string a second time WooCommerce is supplied as the text domain.
-				// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
-				'message' => __( 'Please enter a valid value.', 'woocommerce' ),
+				'value' => '\d+',
 			]
 		);
 	}

--- a/tests/Unit/Admin/Input/InputCollectionTest.php
+++ b/tests/Unit/Admin/Input/InputCollectionTest.php
@@ -108,7 +108,7 @@ class InputCollectionTest extends UnitTest {
 
 		$this->assertEquals( 'integer', $input->get_type() );
 		$this->assertEquals( 'woocommerce/product-text-field', $input->get_block_name() );
-		$this->assertEquals( [ 'value' => 'number' ], $input->get_block_attributes()['type'] );
+		$this->assertEquals( [ 'value' => '\d+', 'message' => 'Please enter a valid value.' ], $input->get_block_attributes()['pattern'] );
 	}
 
 	public function test_select() {

--- a/tests/Unit/Admin/Input/InputCollectionTest.php
+++ b/tests/Unit/Admin/Input/InputCollectionTest.php
@@ -110,7 +110,7 @@ class InputCollectionTest extends UnitTest {
 		$this->assertEquals( 'woocommerce/product-text-field', $input->get_block_name() );
 		$this->assertEquals(
 			[
-				'value' => '\d+',
+				'value' => '0|[1-9]\d*',
 			],
 			$input->get_block_attributes()['pattern']
 		);

--- a/tests/Unit/Admin/Input/InputCollectionTest.php
+++ b/tests/Unit/Admin/Input/InputCollectionTest.php
@@ -110,8 +110,7 @@ class InputCollectionTest extends UnitTest {
 		$this->assertEquals( 'woocommerce/product-text-field', $input->get_block_name() );
 		$this->assertEquals(
 			[
-				'value'   => '\d+',
-				'message' => 'Please enter a valid value.',
+				'value' => '\d+',
 			],
 			$input->get_block_attributes()['pattern']
 		);

--- a/tests/Unit/Admin/Input/InputCollectionTest.php
+++ b/tests/Unit/Admin/Input/InputCollectionTest.php
@@ -108,7 +108,13 @@ class InputCollectionTest extends UnitTest {
 
 		$this->assertEquals( 'integer', $input->get_type() );
 		$this->assertEquals( 'woocommerce/product-text-field', $input->get_block_name() );
-		$this->assertEquals( [ 'value' => '\d+', 'message' => 'Please enter a valid value.' ], $input->get_block_attributes()['pattern'] );
+		$this->assertEquals(
+			[
+				'value'   => '\d+',
+				'message' => 'Please enter a valid value.',
+			],
+			$input->get_block_attributes()['pattern']
+		);
 	}
 
 	public function test_select() {

--- a/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
+++ b/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
@@ -485,7 +485,10 @@ class AttributeInputCollectionTest extends UnitTest {
 					'property' => 'meta_data._wc_gla_multipack',
 					'label'    => 'Multipack',
 					'tooltip'  => 'The number of identical products in a multipack. Use this attribute to indicate that you\'ve grouped multiple identical products for sale as one item.',
-					'pattern'  => [ 'value' => '\d+', 'message' => 'Please enter a valid value.' ],
+					'pattern'  => [
+						'value'   => '\d+',
+						'message' => 'Please enter a valid value.',
+					],
 					'min'      => [ 'value' => 0 ],
 				],
 			],

--- a/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
+++ b/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
@@ -486,8 +486,7 @@ class AttributeInputCollectionTest extends UnitTest {
 					'label'    => 'Multipack',
 					'tooltip'  => 'The number of identical products in a multipack. Use this attribute to indicate that you\'ve grouped multiple identical products for sale as one item.',
 					'pattern'  => [
-						'value'   => '\d+',
-						'message' => 'Please enter a valid value.',
+						'value' => '\d+',
 					],
 					'min'      => [ 'value' => 0 ],
 				],

--- a/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
+++ b/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
@@ -486,7 +486,7 @@ class AttributeInputCollectionTest extends UnitTest {
 					'label'    => 'Multipack',
 					'tooltip'  => 'The number of identical products in a multipack. Use this attribute to indicate that you\'ve grouped multiple identical products for sale as one item.',
 					'pattern'  => [
-						'value' => '\d+',
+						'value' => '0|[1-9]\d*',
 					],
 					'min'      => [ 'value' => 0 ],
 				],

--- a/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
+++ b/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
@@ -485,7 +485,7 @@ class AttributeInputCollectionTest extends UnitTest {
 					'property' => 'meta_data._wc_gla_multipack',
 					'label'    => 'Multipack',
 					'tooltip'  => 'The number of identical products in a multipack. Use this attribute to indicate that you\'ve grouped multiple identical products for sale as one item.',
-					'type'     => [ 'value' => 'number' ],
+					'pattern'  => [ 'value' => '\d+', 'message' => 'Please enter a valid value.' ],
 					'min'      => [ 'value' => 0 ],
 				],
 			],

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -521,6 +521,8 @@ test.describe( 'Product Block Editor integration', () => {
 		await expect( input ).toHaveValue( '' );
 		await expect( help ).toHaveCount( 0 );
 
+		// Assert invalid values
+
 		await input.fill( '-1' );
 
 		await editorUtils.assertUnableSave( 'Invalid value for the field.' );
@@ -537,6 +539,31 @@ test.describe( 'Product Block Editor integration', () => {
 			await editorUtils.evaluateValidationMessage( input )
 		);
 
+		await input.fill( '00' );
+
+		await editorUtils.assertUnableSave( 'Invalid value for the field.' );
+		await expect( help ).toBeVisible();
+		await expect( help ).toHaveText(
+			await editorUtils.evaluateValidationMessage( input )
+		);
+
+		await input.fill( '01' );
+
+		await editorUtils.assertUnableSave( 'Invalid value for the field.' );
+		await expect( help ).toBeVisible();
+		await expect( help ).toHaveText(
+			await editorUtils.evaluateValidationMessage( input )
+		);
+
+		await input.fill( '2e5' );
+
+		await editorUtils.assertUnableSave( 'Invalid value for the field.' );
+		await expect( help ).toBeVisible();
+		await expect( help ).toHaveText(
+			await editorUtils.evaluateValidationMessage( input )
+		);
+
+		// Assert valid values
 		await input.fill( '0' );
 		await editorUtils.save();
 

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -93,23 +93,18 @@ test.describe( 'Product Block Editor integration', () => {
 		await expect( panel.getByRole( 'combobox' ) ).toHaveCount( 9 );
 
 		/*
-		 * 8 <input type="text|date|time">:
+		 * 9 <input type="text|date|time">:
 		 * - GTIN
 		 * - MPN
 		 * - Size
 		 * - Color
 		 * - Material
 		 * - Pattern
+		 * - Multipack
 		 * - Availability date
 		 * - Availability time
 		 */
-		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 8 );
-
-		/*
-		 * 1 <input type="number">:
-		 * - Multipack
-		 */
-		await expect( panel.getByRole( 'spinbutton' ) ).toHaveCount( 1 );
+		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 9 );
 
 		/*
 		 * 16 pairs of <label> and help icon buttons:
@@ -243,16 +238,11 @@ test.describe( 'Product Block Editor integration', () => {
 		 * - Color
 		 * - Material
 		 * - Pattern
+		 * - Multipack
 		 * - Availability date
 		 * - Availability time
 		 */
-		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 8 );
-
-		/*
-		 * 1 <input type="number"> for variation product:
-		 * - Multipack
-		 */
-		await expect( panel.getByRole( 'spinbutton' ) ).toHaveCount( 1 );
+		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 9 );
 	} );
 
 	test( 'Channel visibility is disabled when hiding in product catalog', async () => {
@@ -534,7 +524,7 @@ test.describe( 'Product Block Editor integration', () => {
 		await input.fill( '-1' );
 
 		await editorUtils.assertUnableSave(
-			'The minimum value of the field is 0'
+			'Please enter a valid value.'
 		);
 		await expect( help ).toBeVisible();
 		await expect( help ).toHaveText(

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -523,7 +523,7 @@ test.describe( 'Product Block Editor integration', () => {
 
 		await input.fill( '-1' );
 
-		await editorUtils.assertUnableSave( 'Please enter a valid value.' );
+		await editorUtils.assertUnableSave( 'Invalid value for the field.' );
 		await expect( help ).toBeVisible();
 		await expect( help ).toHaveText(
 			await editorUtils.evaluateValidationMessage( input )
@@ -531,7 +531,7 @@ test.describe( 'Product Block Editor integration', () => {
 
 		await input.fill( '9.5' );
 
-		await editorUtils.assertUnableSave();
+		await editorUtils.assertUnableSave( 'Invalid value for the field.' );
 		await expect( help ).toBeVisible();
 		await expect( help ).toHaveText(
 			await editorUtils.evaluateValidationMessage( input )

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -523,9 +523,7 @@ test.describe( 'Product Block Editor integration', () => {
 
 		await input.fill( '-1' );
 
-		await editorUtils.assertUnableSave(
-			'Please enter a valid value.'
-		);
+		await editorUtils.assertUnableSave( 'Please enter a valid value.' );
 		await expect( help ).toBeVisible();
 		await expect( help ).toHaveText(
 			await editorUtils.evaluateValidationMessage( input )

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -455,7 +455,7 @@ test.describe( 'Product Block Editor integration', () => {
 		 */
 		await dateInput.pressSequentially( '9' );
 
-		await editorUtils.assertUnableSave();
+		await editorUtils.assertUnableSave( 'Please enter a valid value. The field is incomplete or has an invalid date.' );
 		await expect( dateHelp ).toBeVisible();
 		await expect( dateHelp ).toHaveText(
 			await editorUtils.evaluateValidationMessage( dateInput )
@@ -465,7 +465,7 @@ test.describe( 'Product Block Editor integration', () => {
 
 		await timeInput.pressSequentially( '9' );
 
-		await editorUtils.assertUnableSave();
+		await editorUtils.assertUnableSave( 'Please enter a valid value. The field is incomplete or has an invalid date.' );
 		await expect( timeHelp ).toBeVisible();
 		await expect( timeHelp ).toHaveText(
 			await editorUtils.evaluateValidationMessage( timeInput )

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -455,7 +455,9 @@ test.describe( 'Product Block Editor integration', () => {
 		 */
 		await dateInput.pressSequentially( '9' );
 
-		await editorUtils.assertUnableSave( 'Please enter a valid value. The field is incomplete or has an invalid date.' );
+		await editorUtils.assertUnableSave(
+			'Please enter a valid value. The field is incomplete or has an invalid date.'
+		);
 		await expect( dateHelp ).toBeVisible();
 		await expect( dateHelp ).toHaveText(
 			await editorUtils.evaluateValidationMessage( dateInput )
@@ -465,7 +467,9 @@ test.describe( 'Product Block Editor integration', () => {
 
 		await timeInput.pressSequentially( '9' );
 
-		await editorUtils.assertUnableSave( 'Please enter a valid value. The field is incomplete or has an invalid date.' );
+		await editorUtils.assertUnableSave(
+			'Please enter a valid value. The field is incomplete or has an invalid date.'
+		);
 		await expect( timeHelp ).toBeVisible();
 		await expect( timeHelp ).toHaveText(
 			await editorUtils.evaluateValidationMessage( timeInput )

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -582,10 +582,18 @@ export function getProductBlockEditorUtils( page ) {
 			);
 
 			await expect( failureNotice ).toBeVisible();
-			await expect( failureNotice ).toHaveText( message );
+			await expect( failureNotice ).toContainText( message );
 
-			// // Dismiss the notice.
-			await failureNotice.click();
+			const failureNoticeButton = failureNotice.getByRole( 'button' );
+
+			// Dismiss the notice.
+			if ( await failureNoticeButton.isVisible() ) {
+				// compatibility-code "WC < 9.2" -- Dismiss by its inner close button.
+				await failureNoticeButton.click();
+			} else {
+				failureNotice.click();
+			}
+
 			await expect( failureNotice ).toHaveCount( 0 );
 		},
 	};

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -578,16 +578,13 @@ export function getProductBlockEditorUtils( page ) {
 			await this.clickSave();
 
 			const failureNotice = page
-				.locator( '.components-snackbar__content' )
-				.filter( { hasText: new RegExp( message ) } );
-
-			const failureNoticeDismissButton =
-				failureNotice.getByRole( 'button' );
+				.locator( '.components-snackbar__content' );
 
 			await expect( failureNotice ).toBeVisible();
+			await expect( failureNotice ).toHaveText( message );
 
-			// Dismiss the notice.
-			await failureNoticeDismissButton.click();
+			// // Dismiss the notice.
+			await failureNotice.click();
 			await expect( failureNotice ).toHaveCount( 0 );
 		},
 	};

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -577,8 +577,9 @@ export function getProductBlockEditorUtils( page ) {
 		async assertUnableSave( message = 'Please enter a valid value.' ) {
 			await this.clickSave();
 
-			const failureNotice = page
-				.locator( '.components-snackbar__content' );
+			const failureNotice = page.locator(
+				'.components-snackbar__content'
+			);
 
 			await expect( failureNotice ).toBeVisible();
 			await expect( failureNotice ).toHaveText( message );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2507 

Updates Block validation to return an object containing the error message and the clientId as context to support the new link displayed in the snackbar.

<img width="983" alt="Screenshot 2024-08-07 at 16 09 11" src="https://github.com/user-attachments/assets/e38ce68c-893c-4241-bf7c-727d814afee5">

Additionally, with WooCommerce `9.2.0-rc.1` the `Multipack` field validation changes so if a decimal value was entered a blank error message was displayed:

<img width="1002" alt="Screenshot 2024-08-07 at 21 58 27" src="https://github.com/user-attachments/assets/f6303264-5f77-49cb-9842-19d8e3351bf4">

As it's not possible to either set a default validation error message or add custom rules outside of the supported few, the field has been updated to use a text field instead of number. A [pattern is then supplied with a custom error message](https://github.com/woocommerce/google-listings-and-ads/blob/681a07c3c107ccc33014680fa9ad64a3e3812737/src/Admin/Input/Integer.php#L23) to prevent users from entering non numeric values, decimal values, or negative values.

<img width="1071" alt="Screenshot 2024-08-08 at 12 06 32" src="https://github.com/user-attachments/assets/78c10230-01b2-4eff-bb06-fb873473d45a">

### Detailed test instructions:
1. `npm run wp-env:up`
1. `npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version=9.2.0-rc.1`
1. `npm run -- wp-env run tests-cli -- wp wc update`
1. `npm run test:e2e`
1. Confirm tests pass
1. Enable the new product editor in `WooCommerce > Settings > Advanced > Features`
1. Edit a product and test different values in the `Multipack` field under the `Google for WooCommerce` tab
1. Confirm only whole numbers are accepted input

### Additional
⚠️  Please merge once approved as this PR is required before GLA can be released with the `9.2.0` compat bump.

### Changelog entry

> Update - Block validation to support error context