### PR TITLE
Streamline onboarding: Hide WordPress.com account connection setting from the onboarding if already connected

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-accounts/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/index.js
@@ -101,17 +101,15 @@ const SetupAccounts = ( props ) => {
 	 * and the whole page would display this AppSpinner, which is not desired.
 	 */
 	const isLoadingJetpack = ! jetpack;
-	const isJetpackInactive = jetpack?.active !== 'yes';
+	const isJetpackActive = jetpack?.active === 'yes';
 
-	const isLoadingGoogle = jetpack?.active === 'yes' && ! google;
+	const isLoadingGoogle = isJetpackActive && ! google;
 	const isLoadingGoogleMCAccount =
 		google?.active === 'yes' && scope.gmcRequired && ! googleMCAccount;
 
 	if ( isLoadingJetpack || isLoadingGoogle || isLoadingGoogleMCAccount ) {
 		return <AppSpinner />;
 	}
-
-	const isGoogleAccountDisabled = jetpack?.active !== 'yes';
 
 	// Ads is ready when we have a connection and verified and verified access.
 	// Billing is not required, and the 'link_merchant' step will be resolved
@@ -157,10 +155,10 @@ const SetupAccounts = ( props ) => {
 				) }
 			>
 				<VerticalGapLayout size="large">
-					{ isJetpackInactive && (
+					{ ! isJetpackActive && (
 						<WPComAccountCard jetpack={ jetpack } />
 					) }
-					<GoogleAccountCard disabled={ isGoogleAccountDisabled } />
+					<GoogleAccountCard disabled={ ! isJetpackActive } />
 					<GoogleAdsAccountCard />
 				</VerticalGapLayout>
 			</Section>

--- a/js/src/setup-mc/setup-stepper/setup-accounts/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/index.js
@@ -148,27 +148,22 @@ const SetupAccounts = ( props ) => {
 					'google-listings-and-ads'
 				) }
 			/>
-			{ isJetpackInactive && (
-				<Section
-					className="gla-wp-google-accounts-section"
-					title={ __(
-						'Connect accounts',
-						'google-listings-and-ads'
-					) }
-					description={ __(
-						'The following accounts are required to use the Google for WooCommerce plugin.',
-						'google-listings-and-ads'
-					) }
-				>
-					<VerticalGapLayout size="large">
+			<Section
+				className="gla-wp-google-accounts-section"
+				title={ __( 'Connect accounts', 'google-listings-and-ads' ) }
+				description={ __(
+					'The following accounts are required to use the Google for WooCommerce plugin.',
+					'google-listings-and-ads'
+				) }
+			>
+				<VerticalGapLayout size="large">
+					{ isJetpackInactive && (
 						<WPComAccountCard jetpack={ jetpack } />
-						<GoogleAccountCard
-							disabled={ isGoogleAccountDisabled }
-						/>
-						<GoogleAdsAccountCard />
-					</VerticalGapLayout>
-				</Section>
-			) }
+					) }
+					<GoogleAccountCard disabled={ isGoogleAccountDisabled } />
+					<GoogleAdsAccountCard />
+				</VerticalGapLayout>
+			</Section>
 			<Section
 				className="gla-google-mc-account-section"
 				description={ <GoogleMCDisclaimer /> }

--- a/js/src/setup-mc/setup-stepper/setup-accounts/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/index.js
@@ -101,6 +101,8 @@ const SetupAccounts = ( props ) => {
 	 * and the whole page would display this AppSpinner, which is not desired.
 	 */
 	const isLoadingJetpack = ! jetpack;
+	const isJetpackInactive = jetpack?.active !== 'yes';
+
 	const isLoadingGoogle = jetpack?.active === 'yes' && ! google;
 	const isLoadingGoogleMCAccount =
 		google?.active === 'yes' && scope.gmcRequired && ! googleMCAccount;
@@ -146,20 +148,27 @@ const SetupAccounts = ( props ) => {
 					'google-listings-and-ads'
 				) }
 			/>
-			<Section
-				className="gla-wp-google-accounts-section"
-				title={ __( 'Connect accounts', 'google-listings-and-ads' ) }
-				description={ __(
-					'The following accounts are required to use the Google for WooCommerce plugin.',
-					'google-listings-and-ads'
-				) }
-			>
-				<VerticalGapLayout size="large">
-					<WPComAccountCard jetpack={ jetpack } />
-					<GoogleAccountCard disabled={ isGoogleAccountDisabled } />
-					<GoogleAdsAccountCard />
-				</VerticalGapLayout>
-			</Section>
+			{ isJetpackInactive && (
+				<Section
+					className="gla-wp-google-accounts-section"
+					title={ __(
+						'Connect accounts',
+						'google-listings-and-ads'
+					) }
+					description={ __(
+						'The following accounts are required to use the Google for WooCommerce plugin.',
+						'google-listings-and-ads'
+					) }
+				>
+					<VerticalGapLayout size="large">
+						<WPComAccountCard jetpack={ jetpack } />
+						<GoogleAccountCard
+							disabled={ isGoogleAccountDisabled }
+						/>
+						<GoogleAdsAccountCard />
+					</VerticalGapLayout>
+				</Section>
+			) }
 			<Section
 				className="gla-google-mc-account-section"
 				description={ <GoogleMCDisclaimer /> }

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -61,6 +61,7 @@ test.describe( 'Set up accounts', () => {
 		const wpAccountCard = setUpAccountsPage.getWPAccountCard();
 		await expect( wpAccountCard ).toBeEnabled();
 		await expect( wpAccountCard ).toContainText( 'WordPress.com' );
+		await expect( wpAccountCard.getByRole( 'button' ) ).toBeEnabled();
 
 		const googleAccountCard = setUpAccountsPage.getGoogleAccountCard();
 		await expect( googleAccountCard.getByRole( 'button' ) ).toBeDisabled();
@@ -139,10 +140,6 @@ test.describe( 'Set up accounts', () => {
 					'Connect the accounts required to use Google for WooCommerce.'
 				)
 			).toBeVisible();
-
-			await expect(
-				page.getByRole( 'button', { name: 'Connect' } ).first()
-			).toBeEnabled();
 
 			const wpAccountCard = setUpAccountsPage.getWPAccountCard();
 			await expect( wpAccountCard ).not.toBeVisible();

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -151,7 +151,6 @@ test.describe( 'Set up accounts', () => {
 			const wpAccountCard = setUpAccountsPage.getWPAccountCard();
 			await expect( wpAccountCard ).not.toBeVisible();
 		} );
-
 	} );
 
 	test.describe( 'Connect Google account', () => {

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -58,10 +58,6 @@ test.describe( 'Set up accounts', () => {
 			)
 		).toBeVisible();
 
-		await expect(
-			page.getByRole( 'button', { name: 'Connect' } ).first()
-		).toBeEnabled();
-
 		const wpAccountCard = setUpAccountsPage.getWPAccountCard();
 		await expect( wpAccountCard ).toBeEnabled();
 		await expect( wpAccountCard ).toContainText( 'WordPress.com' );
@@ -178,9 +174,7 @@ test.describe( 'Set up accounts', () => {
 			).toBeVisible();
 
 			await expect(
-				googleAccountCard
-					.getByRole( 'button', { name: 'Connect' } )
-					.first()
+				googleAccountCard.getByRole( 'button', { name: 'Connect' } )
 			).toBeEnabled();
 
 			const mcAccountCard = setUpAccountsPage.getMCAccountCard();

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -79,28 +79,6 @@ test.describe( 'Set up accounts', () => {
 		await expect( continueButton ).toBeDisabled();
 	} );
 
-	test( 'JetpackConnected: should verify that the Jetpack connect button is hidden if already connected', async () => {
-		await setUpAccountsPage.goto();
-
-		await expect(
-			page.getByRole( 'heading', { name: 'Set up your accounts' } )
-		).toBeVisible();
-
-		await expect(
-			page.getByText(
-				'Connect the accounts required to use Google for WooCommerce.'
-			)
-		).toBeVisible();
-
-		await expect(
-			page.getByRole( 'button', { name: 'Connect' } ).first()
-		).toBeEnabled();
-
-		const firstCard = setUpAccountsPage.getWPAccountCard();
-		await expect( firstCard ).toBeEnabled();
-		await expect( firstCard ).not.toContainText( 'WordPress.com' );
-	} );
-
 	test.describe( 'FAQ panels', () => {
 		test( 'should see two questions in FAQ', async () => {
 			const faqTitles = getFAQPanelTitle( page );
@@ -138,6 +116,44 @@ test.describe( 'Set up accounts', () => {
 		} );
 	} );
 
+	test.describe( 'Connected WordPress.com account', async () => {
+		test.beforeAll( async () => {
+			// Mock Jetpack as connected
+			await setUpAccountsPage.mockJetpackConnected(
+				'Test user',
+				'jetpack@example.com'
+			);
+
+			// Mock google as not connected.
+			// When pending even WPORG will not render yet.
+			// If not mocked will fail and render nothing,
+			// as Jetpack is mocked only on the client-side.
+			await setUpAccountsPage.mockGoogleNotConnected();
+
+			await setUpAccountsPage.goto();
+		} );
+
+		test( 'should not show the WP.org connection card when already connected', async () => {
+			await expect(
+				page.getByRole( 'heading', { name: 'Set up your accounts' } )
+			).toBeVisible();
+
+			await expect(
+				page.getByText(
+					'Connect the accounts required to use Google for WooCommerce.'
+				)
+			).toBeVisible();
+
+			await expect(
+				page.getByRole( 'button', { name: 'Connect' } ).first()
+			).toBeEnabled();
+
+			const wpAccountCard = setUpAccountsPage.getWPAccountCard();
+			await expect( wpAccountCard ).not.toBeVisible();
+		} );
+
+	} );
+
 	test.describe( 'Connect Google account', () => {
 		test.beforeAll( async () => {
 			// Mock Jetpack as connected
@@ -156,13 +172,6 @@ test.describe( 'Set up accounts', () => {
 		} );
 
 		test( 'should see their WPORG email, "Google" title & connect button', async () => {
-			const jetpackDescriptionRow =
-				setUpAccountsPage.getJetpackDescriptionRow();
-
-			await expect( jetpackDescriptionRow ).toContainText(
-				'jetpack@example.com'
-			);
-
 			const googleAccountCard = setUpAccountsPage.getGoogleAccountCard();
 
 			await expect(
@@ -415,12 +424,6 @@ test.describe( 'Set up accounts', () => {
 			} );
 
 			test( 'should see their WPORG email, Google email, "Google Merchant Center" title & "Create account" button', async () => {
-				const jetpackDescriptionRow =
-					setUpAccountsPage.getJetpackDescriptionRow();
-				await expect( jetpackDescriptionRow ).toContainText(
-					'jetpack@example.com'
-				);
-
 				const googleDescriptionRow =
 					setUpAccountsPage.getGoogleDescriptionRow();
 				await expect( googleDescriptionRow ).toContainText(

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -45,7 +45,7 @@ test.describe( 'Set up accounts', () => {
 		await setUpAccountsPage.closePage();
 	} );
 
-	test( 'should see accounts step header, "Connect your WordPress.com account" & connect button', async () => {
+	test( 'JetpackDisconnected: should see accounts step header, "Connect your WordPress.com account" & connect button', async () => {
 		await setUpAccountsPage.goto();
 
 		await expect(
@@ -77,6 +77,28 @@ test.describe( 'Set up accounts', () => {
 
 		const continueButton = setUpAccountsPage.getContinueButton();
 		await expect( continueButton ).toBeDisabled();
+	} );
+
+	test( 'JetpackConnected: should verify that the Jetpack connect button is hidden if already connected', async () => {
+		await setUpAccountsPage.goto();
+
+		await expect(
+			page.getByRole( 'heading', { name: 'Set up your accounts' } )
+		).toBeVisible();
+
+		await expect(
+			page.getByText(
+				'Connect the accounts required to use Google for WooCommerce.'
+			)
+		).toBeVisible();
+
+		await expect(
+			page.getByRole( 'button', { name: 'Connect' } ).first()
+		).toBeEnabled();
+
+		const firstCard = setUpAccountsPage.getWPAccountCard();
+		await expect( firstCard ).toBeEnabled();
+		await expect( firstCard ).not.toContainText( 'WordPress.com' );
 	} );
 
 	test.describe( 'FAQ panels', () => {

--- a/tests/e2e/utils/pages/setup-mc/step-1-set-up-accounts.js
+++ b/tests/e2e/utils/pages/setup-mc/step-1-set-up-accounts.js
@@ -70,30 +70,14 @@ export default class SetUpAccountsPage extends MockRequests {
 	}
 
 	/**
-	 * Get .gla-account-card__title class.
-	 *
-	 * @return {import('@playwright/test').Locator} Get .gla-account-card__title class.
-	 */
-	getCardTitleClass() {
-		return this.page.locator( '.gla-account-card__title' );
-	}
-
-	/**
-	 * Get .gla-account-card__description class.
-	 *
-	 * @return {import('@playwright/test').Locator} Get .gla-account-card__description class.
-	 */
-	getCardDescriptionClass() {
-		return this.page.locator( '.gla-account-card__description' );
-	}
-
-	/**
 	 * Get Jetpack description row.
 	 *
 	 * @return {import('@playwright/test').Locator} Get Jetpack description row.
 	 */
 	getJetpackDescriptionRow() {
-		return this.getCardDescriptionClass().first();
+		return this.getWPAccountCard().locator(
+			'.gla-account-card__description'
+		);
 	}
 
 	/**
@@ -102,7 +86,9 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Google description row.
 	 */
 	getGoogleDescriptionRow() {
-		return this.getCardDescriptionClass().nth( 1 );
+		return this.getGoogleAccountCard().locator(
+			'.gla-account-card__description'
+		);
 	}
 
 	/**
@@ -111,7 +97,9 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Merchant Center description row.
 	 */
 	getMCDescriptionRow() {
-		return this.getCardDescriptionClass().nth( 3 );
+		return this.getMCAccountCard().locator(
+			'.gla-account-card__description'
+		);
 	}
 
 	/**
@@ -120,7 +108,9 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Google Ads title.
 	 */
 	getAdsTitleRow() {
-		return this.getCardTitleClass().nth( 2 );
+		return this.getGoogleAdsAccountCard().locator(
+			'.gla-account-card__title'
+		);
 	}
 
 	/**
@@ -129,7 +119,7 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Google Merchant Center title.
 	 */
 	getMCTitleRow() {
-		return this.getCardTitleClass().nth( 3 );
+		return this.getMCAccountCard().locator( '.gla-account-card__title' );
 	}
 
 	/**
@@ -178,21 +168,12 @@ export default class SetUpAccountsPage extends MockRequests {
 	}
 
 	/**
-	 * Get .gla-connected-icon-label class.
-	 *
-	 * @return {import('@playwright/test').Locator} Get .gla-connected-icon-label class.
-	 */
-	getConnectedLabelClass() {
-		return this.page.locator( '.gla-connected-icon-label' );
-	}
-
-	/**
 	 * Get Jetpack connected label.
 	 *
 	 * @return {import('@playwright/test').Locator} Get Jetpack connected label.
 	 */
 	getJetpackConnectedLabel() {
-		return this.getConnectedLabelClass().first();
+		return this.getWPAccountCard().locator( '.gla-connected-icon-label' );
 	}
 
 	/**
@@ -201,7 +182,9 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Google connected label.
 	 */
 	getGoogleConnectedLabel() {
-		return this.getConnectedLabelClass().nth( 1 );
+		return this.getGoogleAccountCard().locator(
+			'.gla-connected-icon-label'
+		);
 	}
 
 	/**
@@ -210,7 +193,7 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Merchant Center connected label.
 	 */
 	getMCConnectedLabel() {
-		return this.getConnectedLabelClass().nth( 2 );
+		return this.getMCAccountCard().locator( '.gla-connected-icon-label' );
 	}
 
 	/**
@@ -247,30 +230,14 @@ export default class SetUpAccountsPage extends MockRequests {
 	}
 
 	/**
-	 * Get sub section title row.
-	 *
-	 * @return {import('@playwright/test').Locator} Get sub section title row.
-	 */
-	getSubSectionTitleRow() {
-		return this.page.locator( '.wcdl-subsection-title' );
-	}
-
-	/**
-	 * Get section footer row.
-	 *
-	 * @return {import('@playwright/test').Locator} Get section footer row.
-	 */
-	getSectionFooterRow() {
-		return this.page.locator( '.wcdl-section-card-footer' );
-	}
-
-	/**
 	 * Get select existing Merchant Center account title.
 	 *
 	 * @return {import('@playwright/test').Locator} Get select existing Merchant Center account title.
 	 */
 	getSelectExistingMCAccountTitle() {
-		return this.getSubSectionTitleRow().nth( 4 );
+		return this.getMCAccountCard()
+			.locator( '.wcdl-subsection-title' )
+			.nth( 1 );
 	}
 
 	/**
@@ -297,10 +264,11 @@ export default class SetUpAccountsPage extends MockRequests {
 	/**
 	 * Get account cards.
 	 *
+	 * @param {Object} options
 	 * @return {import('@playwright/test').Locator} Get account cards.
 	 */
-	getAccountCards() {
-		return this.page.locator( '.gla-account-card' );
+	getAccountCards( options = {} ) {
+		return this.page.locator( '.gla-account-card', options );
 	}
 
 	/**
@@ -309,7 +277,7 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get WordPress account card.
 	 */
 	getWPAccountCard() {
-		return this.getAccountCards().first();
+		return this.getAccountCards( { hasText: 'WordPress.com' } ).first();
 	}
 
 	/**
@@ -318,7 +286,11 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Google account card.
 	 */
 	getGoogleAccountCard() {
-		return this.getAccountCards().nth( 1 );
+		return this.getAccountCards( {
+			has: this.page.locator( '.gla-account-card__title', {
+				hasText: 'Google',
+			} ),
+		} ).first();
 	}
 
 	/**
@@ -327,7 +299,11 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Google Ads account card.
 	 */
 	getGoogleAdsAccountCard() {
-		return this.getAccountCards().nth( 2 );
+		return this.getAccountCards( {
+			has: this.page.locator( '.gla-account-card__title', {
+				hasText: 'Google Ads',
+			} ),
+		} ).first();
 	}
 
 	/**
@@ -336,7 +312,11 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Merchant Center account card.
 	 */
 	getMCAccountCard() {
-		return this.getAccountCards().nth( 3 );
+		return this.getAccountCards( {
+			has: this.page.locator( '.gla-account-card__title', {
+				hasText: 'Google Merchant Center',
+			} ),
+		} ).first();
 	}
 
 	/**

--- a/tests/e2e/utils/pages/setup-mc/step-1-set-up-accounts.js
+++ b/tests/e2e/utils/pages/setup-mc/step-1-set-up-accounts.js
@@ -70,17 +70,6 @@ export default class SetUpAccountsPage extends MockRequests {
 	}
 
 	/**
-	 * Get Jetpack description row.
-	 *
-	 * @return {import('@playwright/test').Locator} Get Jetpack description row.
-	 */
-	getJetpackDescriptionRow() {
-		return this.getWPAccountCard().locator(
-			'.gla-account-card__description'
-		);
-	}
-
-	/**
 	 * Get Google description row.
 	 *
 	 * @return {import('@playwright/test').Locator} Get Google description row.
@@ -99,17 +88,6 @@ export default class SetUpAccountsPage extends MockRequests {
 	getMCDescriptionRow() {
 		return this.getMCAccountCard().locator(
 			'.gla-account-card__description'
-		);
-	}
-
-	/**
-	 * Get Google Ads title.
-	 *
-	 * @return {import('@playwright/test').Locator} Get Google Ads title.
-	 */
-	getAdsTitleRow() {
-		return this.getGoogleAdsAccountCard().locator(
-			'.gla-account-card__title'
 		);
 	}
 
@@ -165,26 +143,6 @@ export default class SetUpAccountsPage extends MockRequests {
 	 */
 	getModalSecondaryButton() {
 		return this.getModal().locator( 'button.is-secondary' );
-	}
-
-	/**
-	 * Get Jetpack connected label.
-	 *
-	 * @return {import('@playwright/test').Locator} Get Jetpack connected label.
-	 */
-	getJetpackConnectedLabel() {
-		return this.getWPAccountCard().locator( '.gla-connected-icon-label' );
-	}
-
-	/**
-	 * Get Google connected label.
-	 *
-	 * @return {import('@playwright/test').Locator} Get Google connected label.
-	 */
-	getGoogleConnectedLabel() {
-		return this.getGoogleAccountCard().locator(
-			'.gla-connected-icon-label'
-		);
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR improves the plugin setup process by conditionally hiding the WP.com account connection card when the store is already connected to WP.com.

Closes: https://github.com/woocommerce/google-listings-and-ads/issues/2487

### Screenshots:

Disconnected:
![image](https://github.com/user-attachments/assets/8887e460-cafd-4770-9776-e4dbb2f1ef07)


Connected:
![image](https://github.com/user-attachments/assets/67024f97-1055-4621-a0c4-ef77565ffed4)

Settings:
![image](https://github.com/user-attachments/assets/c95ac96d-df23-408b-be8d-d79c253dec24)


### Detailed test instructions:

1. Switch to this branch, and rebuild the plugin with `npm run build`
2. With Jetpack not connected, go to the onboarding flow.
  - You should see the WP.com / Jetpack Connection Card
3. Connect Jetpack, and then refresh the page to restart the onboarding steps
  - The WP.com / Jetpack Connection Card should be hidden
4. Verify that the WP.com card is still shown on the settings tab.
  
You can use the below code in an mu-plugin to temporarily test this by toggling the active state to 'yes' / 'no'.

```php
add_filter( 'rest_pre_echo_response', function( $result, $server, $request ) {
	if ( '/wc/gla/jetpack/connected' === $request->get_route() ) {
		$result['active'] = 'no';
	}

	return $result;
}, 10, 3 );
```


### Additional details:

Update - Hides WP.com card if already connected

To run the e2e tests for the onboarding process you can use,

```bash
$ npm run test:e2e -- tests/e2e/specs/setup-mc/step-1-accounts.test.js'
```

This PR also includes some refactoring of the E2E test playwright utilities to avoid relying on nth-child locations for account cards, now that the WP.com account card will not be displayed in some scenarios.

### Changelog entry

> Update - Hides WordPress.com account connection setting from the onboarding flow if already connected.
