### PR TITLE
Fix error when Google Merchant Center account is undefined

### DIFF
--- a/js/src/components/enable-new-product-sync-notice.js
+++ b/js/src/components/enable-new-product-sync-notice.js
@@ -26,8 +26,8 @@ const EnableNewProductSyncNotice = () => {
 	// Do not render if already switch to new product sync.
 	if (
 		! hasGoogleMCAccountFinishedResolution ||
-		! googleMCAccount.notification_service_enabled ||
-		googleMCAccount.wpcom_rest_api_status
+		! googleMCAccount?.notification_service_enabled ||
+		googleMCAccount?.wpcom_rest_api_status
 	) {
 		return null;
 	}

--- a/js/src/components/enable-new-product-sync-notice.test.js
+++ b/js/src/components/enable-new-product-sync-notice.test.js
@@ -1,0 +1,116 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
+import EnableNewProductSyncNotice from './enable-new-product-sync-notice';
+
+jest.mock( '.~/hooks/useGoogleMCAccount' );
+
+describe( 'Enable New Product Sync Notice', () => {
+	it( 'should render the notice if the account has not switched to new product sync', () => {
+		useGoogleMCAccount.mockImplementation( () => {
+			return {
+				hasFinishedResolution: true,
+				googleMCAccount: {
+					notification_service_enabled: true,
+					wpcom_rest_api_status: null,
+				},
+			};
+		} );
+
+		const { getByText, getByRole } = render(
+			<EnableNewProductSyncNotice />
+		);
+
+		expect(
+			getByText(
+				'We will soon transition to a new and improved method for synchronizing product data with Google.'
+			)
+		).toBeInTheDocument();
+
+		const button = getByRole( 'button', {
+			name: /Get early access/i,
+		} );
+
+		expect( button ).toBeEnabled();
+	} );
+	it( 'should not render the notice if the account has switched to new product sync', () => {
+		useGoogleMCAccount.mockImplementation( () => {
+			return {
+				hasFinishedResolution: true,
+				googleMCAccount: {
+					notification_service_enabled: true,
+					wpcom_rest_api_status: 'approved',
+				},
+			};
+		} );
+
+		const { queryByText, queryByRole } = render(
+			<EnableNewProductSyncNotice />
+		);
+
+		expect(
+			queryByText(
+				'We will soon transition to a new and improved method for synchronizing product data with Google.'
+			)
+		).not.toBeInTheDocument();
+
+		expect(
+			queryByRole( 'button', { name: /Get early access/i } )
+		).not.toBeInTheDocument();
+	} );
+	it( 'should not render the notice if the notification service is not enabled', () => {
+		useGoogleMCAccount.mockImplementation( () => {
+			return {
+				hasFinishedResolution: true,
+				googleMCAccount: {
+					notification_service_enabled: false,
+					wpcom_rest_api_status: 'approved',
+				},
+			};
+		} );
+
+		const { queryByText, queryByRole } = render(
+			<EnableNewProductSyncNotice />
+		);
+
+		expect(
+			queryByText(
+				'We will soon transition to a new and improved method for synchronizing product data with Google.'
+			)
+		).not.toBeInTheDocument();
+
+		expect(
+			queryByRole( 'button', { name: /Get early access/i } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render the notice if googleMCAccount is undefined because the google account is not connected or missing scopes', () => {
+		useGoogleMCAccount.mockImplementation( () => {
+			return {
+				hasFinishedResolution: true,
+				googleMCAccount: undefined,
+			};
+		} );
+
+		const { queryByText, queryByRole } = render(
+			<EnableNewProductSyncNotice />
+		);
+
+		expect(
+			queryByText(
+				'We will soon transition to a new and improved method for synchronizing product data with Google.'
+			)
+		).not.toBeInTheDocument();
+
+		expect(
+			queryByRole( 'button', { name: /Get early access/i } )
+		).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://wordpress.org/support/topic/typeerror-cannot-read-properties-of-undefined-2/

This PR fixes an issue where `googleMCAccount` is `undefined` when checking if `notification_service_enabled` is active. This can happen if the Google account isn’t connected or is missing scopes, leading to the following error:

`Cannot read properties of undefined (reading ‘notification_service_enabled’)`

https://github.com/woocommerce/google-listings-and-ads/blob/90e9747c463df9007e72637452ea5eb327400ab8/js/src/hooks/useGoogleMCAccount.js#L37-L47



### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go here: https://github.com/woocommerce/google-listings-and-ads/blob/90e9747c463df9007e72637452ea5eb327400ab8/src/API/Site/Controllers/Google/AccountController.php#L168 and set the `active` to `no`
2. Go to the Settings page.
3. Check that you don't see the following error:

![image](https://github.com/user-attachments/assets/ecabe128-e3a3-4c08-8a98-454816a9b7f2)



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Error when Google Merchant Center account is undefined while checking the notification service enabled property.

