### PR TITLE
Set empty props as objects in WPCOM Proxy responses

### DIFF
--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -158,7 +158,7 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 		add_filter(
 			'rest_request_after_callbacks',
 			/**
-			 * Add the Google Listings and Ads settings to the settings/general response.
+			 * Add the Google for WooCommerce and Ads settings to the settings/general response.
 			 *
 			 * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response The response object.
 			 * @param mixed                                             $handler  The handler.
@@ -169,34 +169,57 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 					return $response;
 				}
 
+				$data = $response->get_data();
+
 				if ( $request->get_route() === '/wc/v3/settings/general' && $response instanceof WP_REST_Response ) {
-					$data   = $response->get_data();
 					$data[] = [
 						'id'    => 'gla_target_audience',
-						'label' => 'Google Listings and Ads: Target Audience',
+						'label' => 'Google for WooCommerce: Target Audience',
 						'value' => $this->options->get( OptionsInterface::TARGET_AUDIENCE, [] ),
 					];
 
 					$data[] = [
 						'id'    => 'gla_shipping_times',
-						'label' => 'Google Listings and Ads: Shipping Times',
+						'label' => 'Google for WooCommerce: Shipping Times',
 						'value' => $this->shipping_time_query->get_all_shipping_times(),
 					];
 
 					$data[] = [
 						'id'    => 'gla_language',
-						'label' => 'Google Listings and Ads: Store language',
+						'label' => 'Google for WooCommerce: Store language',
 						'value' => get_locale(),
 					];
 
 					$response->set_data( array_values( $data ) );
 				}
 
+				$response->set_data( $this->prepare_data( $response->get_data() ) );
+
 				return $response;
 			},
 			10,
 			3
 		);
+	}
+
+	/**
+	 * Prepares the data converting the empty arrays in objects for consistency.
+	 *
+	 * @param array $data The response data to parse
+	 * @return mixed
+	 */
+	public function prepare_data( $data ) {
+		if ( ! is_array( $data ) ) {
+			return $data;
+		}
+
+		foreach ( array_keys( $data ) as $key ) {
+			if ( is_array( $data[ $key ] ) && empty( $data[ $key ] ) ) {
+				$data[ $key ] = (object) $data[ $key ];
+			}
+		}
+
+		return $data;
 	}
 
 	/**

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -165,13 +165,13 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 			 * @param WP_REST_Request                                   $request  The request object.
 			 */
 			function ( $response, $handler, $request ) {
-				if ( ! $this->is_gla_request( $request ) ) {
+				if ( ! $this->is_gla_request( $request ) || ! $response instanceof WP_REST_Response ) {
 					return $response;
 				}
 
 				$data = $response->get_data();
 
-				if ( $request->get_route() === '/wc/v3/settings/general' && $response instanceof WP_REST_Response ) {
+				if ( $request->get_route() === '/wc/v3/settings/general' ) {
 					$data[] = [
 						'id'    => 'gla_target_audience',
 						'label' => 'Google for WooCommerce: Target Audience',
@@ -194,7 +194,6 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 				}
 
 				$response->set_data( $this->prepare_data( $response->get_data() ) );
-
 				return $response;
 			},
 			10,

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -461,10 +461,10 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 	public function test_get_empty_data_as_object() {
 		// dummy data
 		$data = [
-			'foo' => 'bar',
-			'var' => array(),
-			'baz' => null,
-			'bool' => false
+			'foo'  => 'bar',
+			'var'  => [],
+			'baz'  => null,
+			'bool' => false,
 		];
 
 		$proxy = new WPCOMProxy(
@@ -472,12 +472,14 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 			$this->container->get( AttributeManager::class )
 		);
 
-		$this->assertEquals( [
-			'foo' => 'bar',
-			'var' => (object) array(),
-			'baz' => null,
-			'bool' => false
-		], $proxy->prepare_data( $data ) );
-
+		$this->assertEquals(
+			[
+				'foo'  => 'bar',
+				'var'  => (object) [],
+				'baz'  => null,
+				'bool' => false,
+			],
+			$proxy->prepare_data( $data )
+		);
 	}
 }

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -2,6 +2,8 @@
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
@@ -454,5 +456,28 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 
 		$this->assertArrayHasKey( 'gla_target_audience', $response_mapped );
 		$this->assertArrayHasKey( 'gla_shipping_times', $response_mapped );
+	}
+
+	public function test_get_empty_data_as_object() {
+		// dummy data
+		$data = [
+			'foo' => 'bar',
+			'var' => array(),
+			'baz' => null,
+			'bool' => false
+		];
+
+		$proxy = new WPCOMProxy(
+			$this->container->get( ShippingTimeQuery::class ),
+			$this->container->get( AttributeManager::class )
+		);
+
+		$this->assertEquals( [
+			'foo' => 'bar',
+			'var' => (object) array(),
+			'baz' => null,
+			'bool' => false
+		], $proxy->prepare_data( $data ) );
+
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Context: p1723540799285679/1722414955.111429-slack-C02BB3F30TG

In this PR we convert empty array properties into empty objects. 

### Screenshots:
<img width="357" alt="Screenshot 2024-08-13 at 18 47 37" src="https://github.com/user-attachments/assets/552196d7-e910-4321-b00b-9aba160a7204">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Hardcode an empty prop like `$data['test'] = []`; in the first line of the new `prepare_data()` function to simulate we get an empty array in a prop.
2. See the prop is returned as {} 
3. Rest of the props still working as before.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Return empty array props as empty objects in WCOM Proxy responses