### PR TITLE
Add Shipping Max time column in gla_shipping_times Table

### DIFF
--- a/src/DB/Migration/Migration20240813T1653383133.php
+++ b/src/DB/Migration/Migration20240813T1653383133.php
@@ -1,0 +1,62 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Migration20240813T1653383133
+ *
+ * Migration class to enable min and max time shippings.
+ *
+ * @see pcTzPl-2qP
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration
+ *
+ * @since x.x.x
+ */
+class Migration20240813T1653383133 extends AbstractMigration {
+
+	/**
+	 * @var ShippingTimeTable
+	 */
+	protected $shipping_time_table;
+
+	/**
+	 * Migration constructor.
+	 *
+	 * @param \wpdb             $wpdb
+	 * @param ShippingTimeTable $shipping_time_table
+	 */
+	public function __construct( \wpdb $wpdb, ShippingTimeTable $shipping_time_table ) {
+		parent::__construct( $wpdb );
+		$this->shipping_time_table = $shipping_time_table;
+	}
+
+
+	/**
+	 * Returns the version to apply this migration for.
+	 *
+	 * @return string A version number. For example: 1.4.1
+	 */
+	public function get_applicable_version(): string {
+		return 'x.x.x';
+	}
+
+	/**
+	 * Apply the migrations.
+	 *
+	 * @return void
+	 */
+	public function apply(): void {
+		if ( $this->shipping_time_table->exists() && ! $this->shipping_time_table->has_column( 'max_time' ) ) {
+			$this->wpdb->query( "ALTER TABLE `{$this->wpdb->_escape( $this->shipping_time_table->get_name() )}` Add COLUMN `max_time` bigint(20) NOT NULL default 0" ); // phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		}
+
+		// Fill the new column with the current values
+		$this->wpdb->query( "UPDATE `{$this->wpdb->_escape( $this->shipping_time_table->get_name() )}` SET `max_time`=`time` WHERE 1=1" );
+	}
+}

--- a/src/DB/Table/ShippingTimeTable.php
+++ b/src/DB/Table/ShippingTimeTable.php
@@ -27,6 +27,7 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     id bigint(20) NOT NULL AUTO_INCREMENT,
     country varchar(2) NOT NULL,
     time bigint(20) NOT NULL default 0,
+	max_time bigint(20) NOT NULL default 0,
     PRIMARY KEY (id),
     KEY country (country)
 ) {$this->get_collation()};

--- a/src/Internal/DependencyManagement/DBServiceProvider.php
+++ b/src/Internal/DependencyManagement/DBServiceProvider.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migration20231109T1
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\MigrationInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migration20211228T1640692399;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migration20220524T1653383133;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migration20240813T1653383133;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\MigrationVersion141;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migrator;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
@@ -102,6 +103,7 @@ class DBServiceProvider extends AbstractServiceProvider {
 		$this->share_migration( Migration20211228T1640692399::class, ShippingRateTable::class, OptionsInterface::class );
 		$this->share_with_tags( Migration20220524T1653383133::class, BudgetRecommendationTable::class );
 		$this->share_migration( Migration20231109T1653383133::class, BudgetRecommendationTable::class );
+		$this->share_migration( Migration20240813T1653383133::class, ShippingTimeTable::class );
 		$this->share_with_tags( Migrator::class, MigrationInterface::class );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of pcTzPl-2qP-p2

This PR updates the DB to support minimum and maximum shipping times. We'll keep the existing `time` column (which will be used as min time) for backwards compatibility and add a new column called `max_time`, which will be populated with the current values from the `time` column for existing users.

Once the UI is set up to handle max and min times, we’ll update the backend to manage these new columns accordingly.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Edit your Free Listing to have different countries and shipping times. 
2. Update the Migration class to your current GLA version: https://github.com/woocommerce/google-listings-and-ads/pull/2520/files#diff-898d6eb44e5ad0a4ef4f1b8ac7af29f6d561f5ddfb30b1ab79398dd81a629df8R46 for example: `2.8.1`
3. Adjust the `gla_db_version` option to an older version, such as 2.8.0, so that the migration class is triggered.: `UPDATE wp_options SET option_value = '2.8.0' WHERE option_name = 'gla_db_version';`
4. Refresh the GFW page.
5. Check the DB and see that there is a new column called `max_time` and is populated with the values used in `time`.
6. To simulate a new installation run the following queries: 

```
DROP TABLE wp_gla_shipping_times;
DELETE FROM wp_options WHERE `option_name` = 'gla_db_version';
```
7. Refresh and see that a new column is added. 

### Additional details:
I didn’t include tests since this code will only run once.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>