### PR TITLE
Streamline onboarding: Update E2E tests for the conditionally hidden WordPress.com account connection setting

### DIFF
--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -151,7 +151,6 @@ test.describe( 'Set up accounts', () => {
 			const wpAccountCard = setUpAccountsPage.getWPAccountCard();
 			await expect( wpAccountCard ).not.toBeVisible();
 		} );
-
 	} );
 
 	test.describe( 'Connect Google account', () => {

--- a/tests/e2e/specs/setup-mc/step-1-accounts.test.js
+++ b/tests/e2e/specs/setup-mc/step-1-accounts.test.js
@@ -79,28 +79,6 @@ test.describe( 'Set up accounts', () => {
 		await expect( continueButton ).toBeDisabled();
 	} );
 
-	test( 'JetpackConnected: should verify that the Jetpack connect button is hidden if already connected', async () => {
-		await setUpAccountsPage.goto();
-
-		await expect(
-			page.getByRole( 'heading', { name: 'Set up your accounts' } )
-		).toBeVisible();
-
-		await expect(
-			page.getByText(
-				'Connect the accounts required to use Google for WooCommerce.'
-			)
-		).toBeVisible();
-
-		await expect(
-			page.getByRole( 'button', { name: 'Connect' } ).first()
-		).toBeEnabled();
-
-		const firstCard = setUpAccountsPage.getWPAccountCard();
-		await expect( firstCard ).toBeEnabled();
-		await expect( firstCard ).not.toContainText( 'WordPress.com' );
-	} );
-
 	test.describe( 'FAQ panels', () => {
 		test( 'should see two questions in FAQ', async () => {
 			const faqTitles = getFAQPanelTitle( page );
@@ -138,6 +116,44 @@ test.describe( 'Set up accounts', () => {
 		} );
 	} );
 
+	test.describe( 'Connected WordPress.com account', async () => {
+		test.beforeAll( async () => {
+			// Mock Jetpack as connected
+			await setUpAccountsPage.mockJetpackConnected(
+				'Test user',
+				'jetpack@example.com'
+			);
+
+			// Mock google as not connected.
+			// When pending even WPORG will not render yet.
+			// If not mocked will fail and render nothing,
+			// as Jetpack is mocked only on the client-side.
+			await setUpAccountsPage.mockGoogleNotConnected();
+
+			await setUpAccountsPage.goto();
+		} );
+
+		test( 'should not show the WP.org connection card when already connected', async () => {
+			await expect(
+				page.getByRole( 'heading', { name: 'Set up your accounts' } )
+			).toBeVisible();
+
+			await expect(
+				page.getByText(
+					'Connect the accounts required to use Google for WooCommerce.'
+				)
+			).toBeVisible();
+
+			await expect(
+				page.getByRole( 'button', { name: 'Connect' } ).first()
+			).toBeEnabled();
+
+			const wpAccountCard = setUpAccountsPage.getWPAccountCard();
+			await expect( wpAccountCard ).not.toBeVisible();
+		} );
+
+	} );
+
 	test.describe( 'Connect Google account', () => {
 		test.beforeAll( async () => {
 			// Mock Jetpack as connected
@@ -156,13 +172,6 @@ test.describe( 'Set up accounts', () => {
 		} );
 
 		test( 'should see their WPORG email, "Google" title & connect button', async () => {
-			const jetpackDescriptionRow =
-				setUpAccountsPage.getJetpackDescriptionRow();
-
-			await expect( jetpackDescriptionRow ).toContainText(
-				'jetpack@example.com'
-			);
-
 			const googleAccountCard = setUpAccountsPage.getGoogleAccountCard();
 
 			await expect(
@@ -415,12 +424,6 @@ test.describe( 'Set up accounts', () => {
 			} );
 
 			test( 'should see their WPORG email, Google email, "Google Merchant Center" title & "Create account" button', async () => {
-				const jetpackDescriptionRow =
-					setUpAccountsPage.getJetpackDescriptionRow();
-				await expect( jetpackDescriptionRow ).toContainText(
-					'jetpack@example.com'
-				);
-
 				const googleDescriptionRow =
 					setUpAccountsPage.getGoogleDescriptionRow();
 				await expect( googleDescriptionRow ).toContainText(

--- a/tests/e2e/utils/pages/setup-mc/step-1-set-up-accounts.js
+++ b/tests/e2e/utils/pages/setup-mc/step-1-set-up-accounts.js
@@ -70,30 +70,14 @@ export default class SetUpAccountsPage extends MockRequests {
 	}
 
 	/**
-	 * Get .gla-account-card__title class.
-	 *
-	 * @return {import('@playwright/test').Locator} Get .gla-account-card__title class.
-	 */
-	getCardTitleClass() {
-		return this.page.locator( '.gla-account-card__title' );
-	}
-
-	/**
-	 * Get .gla-account-card__description class.
-	 *
-	 * @return {import('@playwright/test').Locator} Get .gla-account-card__description class.
-	 */
-	getCardDescriptionClass() {
-		return this.page.locator( '.gla-account-card__description' );
-	}
-
-	/**
 	 * Get Jetpack description row.
 	 *
 	 * @return {import('@playwright/test').Locator} Get Jetpack description row.
 	 */
 	getJetpackDescriptionRow() {
-		return this.getCardDescriptionClass().first();
+		return this.getWPAccountCard().locator(
+			'.gla-account-card__description'
+		);
 	}
 
 	/**
@@ -102,7 +86,9 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Google description row.
 	 */
 	getGoogleDescriptionRow() {
-		return this.getCardDescriptionClass().nth( 1 );
+		return this.getGoogleAccountCard().locator(
+			'.gla-account-card__description'
+		);
 	}
 
 	/**
@@ -111,7 +97,9 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Merchant Center description row.
 	 */
 	getMCDescriptionRow() {
-		return this.getCardDescriptionClass().nth( 3 );
+		return this.getMCAccountCard().locator(
+			'.gla-account-card__description'
+		);
 	}
 
 	/**
@@ -120,7 +108,9 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Google Ads title.
 	 */
 	getAdsTitleRow() {
-		return this.getCardTitleClass().nth( 2 );
+		return this.getGoogleAdsAccountCard().locator(
+			'.gla-account-card__title'
+		);
 	}
 
 	/**
@@ -129,7 +119,7 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Google Merchant Center title.
 	 */
 	getMCTitleRow() {
-		return this.getCardTitleClass().nth( 3 );
+		return this.getMCAccountCard().locator( '.gla-account-card__title' );
 	}
 
 	/**
@@ -178,21 +168,12 @@ export default class SetUpAccountsPage extends MockRequests {
 	}
 
 	/**
-	 * Get .gla-connected-icon-label class.
-	 *
-	 * @return {import('@playwright/test').Locator} Get .gla-connected-icon-label class.
-	 */
-	getConnectedLabelClass() {
-		return this.page.locator( '.gla-connected-icon-label' );
-	}
-
-	/**
 	 * Get Jetpack connected label.
 	 *
 	 * @return {import('@playwright/test').Locator} Get Jetpack connected label.
 	 */
 	getJetpackConnectedLabel() {
-		return this.getConnectedLabelClass().first();
+		return this.getWPAccountCard().locator( '.gla-connected-icon-label' );
 	}
 
 	/**
@@ -201,7 +182,9 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Google connected label.
 	 */
 	getGoogleConnectedLabel() {
-		return this.getConnectedLabelClass().nth( 1 );
+		return this.getGoogleAccountCard().locator(
+			'.gla-connected-icon-label'
+		);
 	}
 
 	/**
@@ -210,7 +193,7 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Merchant Center connected label.
 	 */
 	getMCConnectedLabel() {
-		return this.getConnectedLabelClass().nth( 2 );
+		return this.getMCAccountCard().locator( '.gla-connected-icon-label' );
 	}
 
 	/**
@@ -247,30 +230,14 @@ export default class SetUpAccountsPage extends MockRequests {
 	}
 
 	/**
-	 * Get sub section title row.
-	 *
-	 * @return {import('@playwright/test').Locator} Get sub section title row.
-	 */
-	getSubSectionTitleRow() {
-		return this.page.locator( '.wcdl-subsection-title' );
-	}
-
-	/**
-	 * Get section footer row.
-	 *
-	 * @return {import('@playwright/test').Locator} Get section footer row.
-	 */
-	getSectionFooterRow() {
-		return this.page.locator( '.wcdl-section-card-footer' );
-	}
-
-	/**
 	 * Get select existing Merchant Center account title.
 	 *
 	 * @return {import('@playwright/test').Locator} Get select existing Merchant Center account title.
 	 */
 	getSelectExistingMCAccountTitle() {
-		return this.getSubSectionTitleRow().nth( 4 );
+		return this.getMCAccountCard()
+			.locator( '.wcdl-subsection-title' )
+			.nth( 1 );
 	}
 
 	/**
@@ -297,10 +264,11 @@ export default class SetUpAccountsPage extends MockRequests {
 	/**
 	 * Get account cards.
 	 *
+	 * @param {Object} options
 	 * @return {import('@playwright/test').Locator} Get account cards.
 	 */
-	getAccountCards() {
-		return this.page.locator( '.gla-account-card' );
+	getAccountCards( options = {} ) {
+		return this.page.locator( '.gla-account-card', options );
 	}
 
 	/**
@@ -309,7 +277,7 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get WordPress account card.
 	 */
 	getWPAccountCard() {
-		return this.getAccountCards().first();
+		return this.getAccountCards( { hasText: 'WordPress.com' } ).first();
 	}
 
 	/**
@@ -318,7 +286,11 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Google account card.
 	 */
 	getGoogleAccountCard() {
-		return this.getAccountCards().nth( 1 );
+		return this.getAccountCards( {
+			has: this.page.locator( '.gla-account-card__title', {
+				hasText: 'Google',
+			} ),
+		} ).first();
 	}
 
 	/**
@@ -327,7 +299,11 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Google Ads account card.
 	 */
 	getGoogleAdsAccountCard() {
-		return this.getAccountCards().nth( 2 );
+		return this.getAccountCards( {
+			has: this.page.locator( '.gla-account-card__title', {
+				hasText: 'Google Ads',
+			} ),
+		} ).first();
 	}
 
 	/**
@@ -336,7 +312,11 @@ export default class SetUpAccountsPage extends MockRequests {
 	 * @return {import('@playwright/test').Locator} Get Merchant Center account card.
 	 */
 	getMCAccountCard() {
-		return this.getAccountCards().nth( 3 );
+		return this.getAccountCards( {
+			has: this.page.locator( '.gla-account-card__title', {
+				hasText: 'Google Merchant Center',
+			} ),
+		} ).first();
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

See #2487. This is meant to be added to the existing PR prior to final code review/merging. Opening this as a separate PR to ease internal review.

This updates the e2e tests following the removal of the WP.com account.

First, this moves the test for confirming that the WP.com card is not shown after it's connected to a new test described by "Connected WordPress.com account", which mocks the Jetpack connection before loading the page.

Second, one the WP.com account card is no longer shown, many of the following e2e tests that relied on [nth-locators](https://playwright.dev/docs/api/class-locator#locator-nth) to find elements in the DOM needed to be refactored so that they work regardless of whether the WP.com card was present.

To do so, this updates the `getAccountCards()` method to accept options that get passed to the locator locator ([see docs](https://playwright.dev/docs/api/class-locator#locator-locator)) to find a specific account card, which can then be used in other helper methods when trying to locate a specific title or description.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. If using `wp-env` locally, run `npm run test:e2e -- setup-mc`
