### PR TITLE
Streamline onboarding: Remove the language setting

### DIFF
--- a/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
+++ b/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
@@ -1,16 +1,13 @@
 /**
  * External dependencies
  */
-import { RadioControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { useAdaptiveFormContext } from '.~/components/adaptive-form';
 import AppRadioContentControl from '.~/components/app-radio-content-control';
-import AppDocumentationLink from '.~/components/app-documentation-link';
 import Section from '.~/wcdl/section';
 import Subsection from '.~/wcdl/subsection';
 import RadioHelperText from '.~/wcdl/radio-helper-text';
@@ -28,11 +25,9 @@ import './choose-audience-section.scss';
  */
 const ChooseAudienceSection = () => {
 	const {
-		values,
 		getInputProps,
 		adapter: { renderRequestedValidation },
 	} = useAdaptiveFormContext();
-	const { locale, language } = values;
 
 	return (
 		<>

--- a/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
+++ b/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
@@ -52,37 +52,6 @@ const ChooseAudienceSection = () => {
 					<Section.Card.Body>
 						<Subsection>
 							<Subsection.Title>
-								{ __( 'Language', 'google-listings-and-ads' ) }
-							</Subsection.Title>
-							<Subsection.HelperText className="gla-choose-audience-section__language-helper">
-								{ createInterpolateElement(
-									__(
-										'Listings can only be displayed in your site language. <link>Read more</link>',
-										'google-listings-and-ads'
-									),
-									{
-										link: (
-											<AppDocumentationLink
-												context="setup-mc-audience"
-												linkId="site-language"
-												href="https://support.google.com/merchants/answer/160637"
-											/>
-										),
-									}
-								) }
-							</Subsection.HelperText>
-							<RadioControl
-								selected={ locale }
-								options={ [
-									{
-										label: language,
-										value: locale,
-									},
-								] }
-							/>
-						</Subsection>
-						<Subsection>
-							<Subsection.Title>
 								{ __( 'Location', 'google-listings-and-ads' ) }
 							</Subsection.Title>
 							<Subsection.HelperText>

--- a/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
+++ b/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
@@ -20,8 +20,6 @@ import './choose-audience-section.scss';
  *
  * To be used in onboarding and further editing.
  * Does not provide any save strategy, this is to be bound externaly.
- *
- * @fires gla_documentation_link_click with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
  */
 const ChooseAudienceSection = () => {
 	const {

--- a/js/src/components/free-listings/choose-audience-section/choose-audience-section.scss
+++ b/js/src/components/free-listings/choose-audience-section/choose-audience-section.scss
@@ -1,8 +1,6 @@
 .gla-choose-audience-section {
-	&__language-helper,
 	.wcdl-radio-helper-text {
 		font-style: normal;
-		color: $gray-700;
 	}
 
 	.wcdl-subsection-helper-text {

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -322,7 +322,6 @@ When a documentation link is clicked.
 `href` | `string` | link's URL
 #### Emitters
 - [`AppDocumentationLink`](../../js/src/components/app-documentation-link/index.js#L29)
-- [`ChooseAudienceSection`](../../js/src/components/free-listings/choose-audience-section/choose-audience-section.js#L29) with `{ context: 'setup-mc-audience', link_id: 'site-language', href: 'https://support.google.com/merchants/answer/160637' }`
 - [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L42) with `{ context: 'setup-ads-connect-account', link_id: 'connect-sub-account', href: 'https://support.google.com/google-ads/answer/6139186' }`
 - [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-listings-and-ads/#required-google-permissions' }`
 - [`ContactInformation`](../../js/src/components/contact-information/index.js#L91)
@@ -565,10 +564,10 @@ Clicking on the button to connect an existing Google Merchant Center account.
 #### Emitters
 - [`ConnectMC`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L42)
 
-### [`gla_mc_account_connect_different_account_button_click`](../../js/src/components/google-mc-account-card/connected-google-mc-account-card.js#L21)
+### [`gla_mc_account_connect_different_account_button_click`](../../js/src/components/google-mc-account-card/connected-google-mc-account-card.js#L29)
 Clicking on the "connect to a different Google Merchant Center account" button.
 #### Emitters
-- [`ConnectedGoogleMCAccountCard`](../../js/src/components/google-mc-account-card/connected-google-mc-account-card.js#L36)
+- [`ConnectedGoogleMCAccountCard`](../../js/src/components/google-mc-account-card/connected-google-mc-account-card.js#L45)
 
 ### [`gla_mc_account_create_button_click`](../../js/src/components/google-mc-account-card/terms-modal/index.js#L16)
 Clicking on the button to create a new Google Merchant Center account, after agreeing to the terms and conditions.
@@ -629,7 +628,7 @@ A modal is closed.
 `action` | `string` | Indicates the modal is closed by what action (e.g. `maybe-later`\|`dismiss` \| `create-another-campaign`)    - `maybe-later` is used when the "Maybe later" button on the modal is clicked    - `dismiss` is used when the modal is dismissed by clicking on "X" icon, overlay, generic "Cancel" button, or pressing ESC    - `create-another-campaign` is used when the button "Create another campaign" is clicked    - `create-paid-campaign` is used when the button "Create paid campaign" is clicked    - `confirm` is used when the button "Confirm", "Save"  or similar generic "Accept" button is clicked
 #### Emitters
 - [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is closed
-- [`Dashboard`](../../js/src/dashboard/index.js#L33) when CES modal is closed.
+- [`Dashboard`](../../js/src/dashboard/index.js#L34) when CES modal is closed.
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `action: 'request-review-success' | 'maybe-later' | 'dismiss', context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L159) with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss'`
 

--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -103,11 +103,6 @@ test.describe( 'Configure product listings', () => {
 		).toBeVisible();
 	} );
 
-	test( 'should select the default language English', async () => {
-		const languageRadioRow = productListingsPage.getLanguageRadioRow();
-		await expect( languageRadioRow ).toBeChecked();
-	} );
-
 	test( 'should see US but should not see UK in the country search box', async () => {
 		const countrySearchBoxContainer =
 			getCountryInputSearchBoxContainer( page );
@@ -369,15 +364,6 @@ test.describe( 'Configure product listings', () => {
 		test.beforeAll( async () => {
 			// Check simple shipping rate first so we can get "Shipping rates" and "Shipping times" fields.
 			await productListingsPage.checkSimpleShippingRateRadioButton();
-		} );
-
-		test( 'should contain the correct URL for "Read more for Language" link', async () => {
-			const link = productListingsPage.getReadMoreLanguageLink();
-			await expect( link ).toBeVisible();
-			await expect( link ).toHaveAttribute(
-				'href',
-				'https://support.google.com/merchants/answer/160637'
-			);
 		} );
 
 		test( 'should contain the correct URL for "Read more for Shipping Rates" link', async () => {

--- a/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
+++ b/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
@@ -38,18 +38,6 @@ export default class ProductListingsPage extends MockRequests {
 	}
 
 	/**
-	 * Get language radio row.
-	 *
-	 * @return {import('@playwright/test').Locator} Get language radio row.
-	 */
-	getLanguageRadioRow() {
-		return this.page.getByRole( 'radio', {
-			name: 'English',
-			exact: true,
-		} );
-	}
-
-	/**
 	 * Get selected countries only radio row.
 	 *
 	 * @return {import('@playwright/test').Locator} Get selected countries only radio row.
@@ -298,18 +286,6 @@ export default class ProductListingsPage extends MockRequests {
 	getContinueButton() {
 		return this.page.getByRole( 'button', {
 			name: 'Continue',
-			exact: true,
-		} );
-	}
-
-	/**
-	 * Get "Read more" for Language link.
-	 *
-	 * @return {import('@playwright/test').Locator} Get "Read more" for Language link.
-	 */
-	getReadMoreLanguageLink() {
-		return this.getAudienceCard().getByRole( 'link', {
-			name: 'Read more',
 			exact: true,
 		} );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2489 .

This PR hides the language settings UI during the onboarding steps.


### Screenshots:

![Screenshot from 2024-08-13 11-36-30](https://github.com/user-attachments/assets/40833ef6-38ae-4cc2-8d8b-723bc889052c)



### Detailed test instructions:

1. On a fresh setup, go through the onboarding process.
2. On the second page of onboarding, you should no longer see the Language Selection radio button.


### Additional details:

Update - Hides the language setting during onboarding

### Changelog entry

> Update - Remove the language setting from onboarding.
