### PR TITLE
Adjust auto-sync shipping option

### DIFF
--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -32,9 +32,7 @@ const ShippingRateSection = () => {
 	const hideAutomatticShippingRate =
 		! settings?.shipping_rates_count &&
 		hasFinishedResolution &&
-		mcSetup?.status === 'incomplete'
-			? true
-			: false;
+		mcSetup?.status === 'incomplete';
 
 	return (
 		<Section

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -64,14 +64,9 @@ const ShippingRateSection = () => {
 							{ ! hideAutomatticShippingRate && (
 								<AppRadioContentControl
 									{ ...inputProps }
-									label={ createInterpolateElement(
-										__(
-											'Automatically sync my store’s shipping settings to Google.',
-											'google-listings-and-ads'
-										),
-										{
-											strong: <strong></strong>,
-										}
+									label={ __(
+										'Automatically sync my store’s shipping settings to Google.',
+										'google-listings-and-ads'
 									) }
 									value="automatic"
 									collapsible

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -14,6 +14,8 @@ import RadioHelperText from '.~/wcdl/radio-helper-text';
 import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import FlatShippingRatesInputCards from './flat-shipping-rates-input-cards';
+import useSettings from '.~/components/free-listings/configure-product-listings/useSettings';
+import useMCSetup from '.~/hooks/useMCSetup';
 
 /**
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
@@ -22,7 +24,17 @@ import FlatShippingRatesInputCards from './flat-shipping-rates-input-cards';
 
 const ShippingRateSection = () => {
 	const { getInputProps, values } = useAdaptiveFormContext();
+	const { settings } = useSettings();
+	const { hasFinishedResolution, data: mcSetup } = useMCSetup();
 	const inputProps = getInputProps( 'shipping_rate' );
+
+	// Hide the automatic shipping rate option if there are no shipping rates and the merchant is onboarding.
+	const hideAutomatticShippingRate =
+		! settings?.shipping_rates_count &&
+		hasFinishedResolution &&
+		mcSetup?.status === 'incomplete'
+			? true
+			: false;
 
 	return (
 		<Section
@@ -51,27 +63,29 @@ const ShippingRateSection = () => {
 				<Section.Card>
 					<Section.Card.Body>
 						<VerticalGapLayout size="large">
-							<AppRadioContentControl
-								{ ...inputProps }
-								label={ createInterpolateElement(
-									__(
-										'<strong>Recommended:</strong> Automatically sync my store’s shipping settings to Google.',
-										'google-listings-and-ads'
-									),
-									{
-										strong: <strong></strong>,
-									}
-								) }
-								value="automatic"
-								collapsible
-							>
-								<RadioHelperText>
-									{ __(
-										'My current settings and any future changes to my store’s shipping rates and classes will be automatically synced to Google Merchant Center.',
-										'google-listings-and-ads'
+							{ ! hideAutomatticShippingRate && (
+								<AppRadioContentControl
+									{ ...inputProps }
+									label={ createInterpolateElement(
+										__(
+											'Automatically sync my store’s shipping settings to Google.',
+											'google-listings-and-ads'
+										),
+										{
+											strong: <strong></strong>,
+										}
 									) }
-								</RadioHelperText>
-							</AppRadioContentControl>
+									value="automatic"
+									collapsible
+								>
+									<RadioHelperText>
+										{ __(
+											'My current settings and any future changes to my store’s shipping rates and classes will be automatically synced to Google Merchant Center.',
+											'google-listings-and-ads'
+										) }
+									</RadioHelperText>
+								</AppRadioContentControl>
+							) }
 							<AppRadioContentControl
 								{ ...inputProps }
 								label={ __(

--- a/js/src/components/shipping-rate-section/shipping-rate-section.test.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.test.js
@@ -1,0 +1,211 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useSettings from '.~/components/free-listings/configure-product-listings/useSettings';
+import useMCSetup from '.~/hooks/useMCSetup';
+import ShippingRateSection from './shipping-rate-section';
+//import FlatShippingRatesInputCards from './flat-shipping-rates-input-cards';
+
+jest.mock( './flat-shipping-rates-input-cards', () => () => <></> );
+
+jest.mock( '.~/components/adaptive-form', () => ( {
+	useAdaptiveFormContext: jest
+		.fn()
+		.mockName( 'useAdaptiveFormContext' )
+		.mockImplementation( () => {
+			return {
+				getInputProps: () => {
+					return {
+						checked: true,
+						className: '',
+						help: null,
+						onBlur: () => {},
+						onChange: () => {},
+						selected: 'flat',
+						value: 'flat',
+					};
+				},
+				values: {
+					countries: [ 'ES' ],
+					language: 'English',
+					locale: 'en_US',
+					location: 'selected',
+					offer_free_shipping: false,
+					shipping_country_rates: [],
+					shipping_country_times: [],
+					shipping_rate: 'flat',
+					shipping_time: 'flat',
+					tax_rate: null,
+				},
+			};
+		} ),
+} ) );
+
+jest.mock(
+	'.~/components/free-listings/configure-product-listings/useSettings'
+);
+jest.mock( '.~/hooks/useMCSetup' );
+
+describe( 'ShippingRateSection', () => {
+	it( 'shouldnt render automatic rates if there are not shipping rates and it is onboarding', () => {
+		useMCSetup.mockImplementation( () => {
+			return {
+				hasFinishedResolution: true,
+				data: {
+					status: 'incomplete',
+				},
+			};
+		} );
+
+		useSettings.mockImplementation( () => {
+			return {
+				settings: {
+					shipping_rates_count: 0,
+				},
+			};
+		} );
+
+		const { getByText, queryByRole } = render( <ShippingRateSection /> );
+
+		expect(
+			getByText(
+				'My shipping settings are simple. I can manually estimate flat shipping rates.'
+			)
+		).toBeInTheDocument();
+
+		expect(
+			getByText(
+				'My shipping settings are complex. I will enter my shipping rates and times manually in Google Merchant Center.'
+			)
+		).toBeInTheDocument();
+
+		expect(
+			queryByRole(
+				'Automatically sync my store’s shipping settings to Google.'
+			)
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should render automatic rates if there are shipping rates and it is onboarding', () => {
+		useMCSetup.mockImplementation( () => {
+			return {
+				hasFinishedResolution: true,
+				data: {
+					status: 'incomplete',
+				},
+			};
+		} );
+
+		useSettings.mockImplementation( () => {
+			return {
+				settings: {
+					shipping_rates_count: 1,
+				},
+			};
+		} );
+
+		const { getByText } = render( <ShippingRateSection /> );
+
+		expect(
+			getByText(
+				'My shipping settings are simple. I can manually estimate flat shipping rates.'
+			)
+		).toBeInTheDocument();
+
+		expect(
+			getByText(
+				'My shipping settings are complex. I will enter my shipping rates and times manually in Google Merchant Center.'
+			)
+		).toBeInTheDocument();
+
+		expect(
+			getByText(
+				'Automatically sync my store’s shipping settings to Google.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render automatic rates if there are not shipping rates and it is not onboarding', () => {
+		useMCSetup.mockImplementation( () => {
+			return {
+				hasFinishedResolution: true,
+				data: {
+					status: 'completed',
+				},
+			};
+		} );
+
+		useSettings.mockImplementation( () => {
+			return {
+				settings: {
+					shipping_rates_count: 0,
+				},
+			};
+		} );
+
+		const { getByText } = render( <ShippingRateSection /> );
+
+		expect(
+			getByText(
+				'My shipping settings are simple. I can manually estimate flat shipping rates.'
+			)
+		).toBeInTheDocument();
+
+		expect(
+			getByText(
+				'My shipping settings are complex. I will enter my shipping rates and times manually in Google Merchant Center.'
+			)
+		).toBeInTheDocument();
+
+		expect(
+			getByText(
+				'Automatically sync my store’s shipping settings to Google.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render automatic rates if there are shipping rates and it is not onboarding', () => {
+		useMCSetup.mockImplementation( () => {
+			return {
+				hasFinishedResolution: true,
+				data: {
+					status: 'completed',
+				},
+			};
+		} );
+
+		useSettings.mockImplementation( () => {
+			return {
+				settings: {
+					shipping_rates_count: 1,
+				},
+			};
+		} );
+
+		const { getByText } = render( <ShippingRateSection /> );
+
+		expect(
+			getByText(
+				'My shipping settings are simple. I can manually estimate flat shipping rates.'
+			)
+		).toBeInTheDocument();
+
+		expect(
+			getByText(
+				'My shipping settings are complex. I will enter my shipping rates and times manually in Google Merchant Center.'
+			)
+		).toBeInTheDocument();
+
+		expect(
+			getByText(
+				'Automatically sync my store’s shipping settings to Google.'
+			)
+		).toBeInTheDocument();
+	} );
+} );

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
@@ -79,7 +79,7 @@ const SavedSetupStepper = ( { savedStep } ) => {
 		if ( settings?.shipping_rate === null ) {
 			saveSettings( {
 				...settings,
-				shipping_rate: 'automatic',
+				shipping_rate: 'flat',
 				shipping_time: 'flat',
 			} );
 		}

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -105,7 +105,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->share( SettingsController::class );
+		$this->share( SettingsController::class, ShippingZone::class );
 		$this->share( ConnectionController::class );
 		$this->share( AdsAccountController::class, AdsAccountService::class );
 		$this->share( AdsCampaignController::class, AdsCampaign::class );

--- a/src/Shipping/ShippingZone.php
+++ b/src/Shipping/ShippingZone.php
@@ -78,6 +78,16 @@ class ShippingZone implements Service {
 	}
 
 	/**
+	 * Get the number of shipping rates enable in WooCommerce.
+	 *
+	 * @return int
+	 */
+	public function get_shipping_rates_count(): int {
+		$this->parse_shipping_zones();
+		return count( $this->location_rates ?? [] );
+	}
+
+	/**
 	 * Returns the available shipping rates for a country and its subdivisions.
 	 *
 	 * @param string $country_code

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class SettingsControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ */
+class SettingsControllerTest extends RESTControllerUnitTest {
+
+
+	/** @var MockObject|ShippingZone $shipping_zone */
+	protected $shipping_zone;
+
+	/** @var SettingsSyncController $controller */
+	protected $controller;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+
+	protected const ROUTE = '/wc/gla/mc/settings';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->shipping_zone = $this->createMock( ShippingZone::class );
+		$this->options       = $this->createMock( OptionsInterface::class );
+		$this->controller    = new SettingsController( $this->server, $this->shipping_zone );
+		$this->controller->set_options_object( $this->options );
+		$this->controller->register();
+	}
+
+	public function test_get_settings() {
+		$options = [
+			'shipping_rate'           => 'flat',
+			'shipping_time'           => 'flat',
+			'tax_rate'                => null,
+			'website_live'            => true,
+			'checkout_process_secure' => true,
+			'payment_methods_visible' => true,
+			'refund_tos_visible'      => true,
+			'contact_info_visible'    => true,
+
+		];
+
+		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
+			$options
+		);
+		$this->shipping_zone->expects( $this->once() )->method( 'get_shipping_rates_count' )->willReturn( 1 );
+
+		$expected = $options + [
+			'shipping_rates_count' => 1,
+		];
+
+		$response = $this->do_request( self::ROUTE, 'GET' );
+
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_edit_settings() {
+		$options = [
+			'shipping_rate'           => 'flat',
+			'shipping_time'           => 'flat',
+			'tax_rate'                => null,
+			'website_live'            => true,
+			'checkout_process_secure' => true,
+			'payment_methods_visible' => true,
+			'refund_tos_visible'      => true,
+			'contact_info_visible'    => true,
+
+		];
+
+		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
+			$options
+		);
+
+		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::MERCHANT_CENTER, array_merge( $options, [ 'shipping_time' => 'manual' ] ) );
+
+		$response = $this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'shipping_time' => 'manual',
+			]
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'success', $response->get_data()['status'] );
+	}
+}

--- a/tests/Unit/Shipping/ShippingZoneTest.php
+++ b/tests/Unit/Shipping/ShippingZoneTest.php
@@ -152,6 +152,50 @@ class ShippingZoneTest extends UnitTest {
 		$this->assertEmpty( $this->shipping_zone->get_shipping_countries() );
 	}
 
+	public function test_get_shipping_rates_count() {
+		$this->wc->expects( $this->exactly( 1 ) )
+			->method( 'get_shipping_zones' )
+			->willReturn( [ [ 'zone_id' => 1 ] ] );
+
+			$this->locations_parser->expects( $this->once() )
+			->method( 'parse' )
+			->willReturn(
+				[
+					new ShippingLocation( 21137, 'US', 'CA' ),
+				]
+			);
+		$this->methods_parser->expects( $this->once() )
+			->method( 'parse' )
+			->willReturn(
+				[
+					new ShippingRate( 10 ),
+				]
+			);
+
+		$this->assertEquals( 1, $this->shipping_zone->get_shipping_rates_count() );
+	}
+
+	public function test_get_shipping_rates_count_with_no_rates() {
+		$this->wc->expects( $this->exactly( 1 ) )
+			->method( 'get_shipping_zones' )
+			->willReturn( [ [ 'zone_id' => 1 ] ] );
+
+			$this->locations_parser->expects( $this->once() )
+			->method( 'parse' )
+			->willReturn(
+				[
+					new ShippingLocation( 21137, 'US', 'CA' ),
+				]
+			);
+		$this->methods_parser->expects( $this->once() )
+			->method( 'parse' )
+			->willReturn(
+				[]
+			);
+
+		$this->assertEquals( 0, $this->shipping_zone->get_shipping_rates_count() );
+	}
+
 	/**
 	 * Runs before each test is executed.
 	 */

--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -64,12 +64,13 @@ test.describe( 'Configure product listings', () => {
 			// Mock MC settings
 			productListingsPage.fulfillSettings(
 				{
-					shipping_rate: 'automatic',
+					shipping_rate: 'flat',
 					website_live: false,
 					checkout_process_secure: false,
 					payment_methods_visible: false,
 					refund_tos_visible: false,
 					contact_info_visible: false,
+					shipping_rates_count: 0,
 				},
 				200,
 				[ 'GET' ]
@@ -185,12 +186,24 @@ test.describe( 'Configure product listings', () => {
 		await expect( taxRateSection ).not.toBeVisible();
 	} );
 
+	test.describe( 'Automatic rate', () => {
+		test.beforeAll( async () => {
+			await page.reload();
+		} );
+
+		test( 'shouldnt display automatic rate if no shipping methods are set up, shipping_rates_count = 0', async () => {
+			await expect(
+				productListingsPage.getRecommendedShippingRateRadioRow()
+			).toHaveCount( 0 );
+		} );
+	} );
+
 	test.describe( 'Shipping rate is simple', () => {
 		test.beforeAll( async () => {
 			await page.reload();
 
 			// Check another shipping rate first in case the simple shipping rate radio button is already checked.
-			await productListingsPage.checkRecommendedShippingRateRadioButton();
+			await productListingsPage.checkComplexShippingRateRadioButton();
 		} );
 
 		test( 'should send settings POST request after checking simple shipping rate radio button', async () => {
@@ -267,9 +280,6 @@ test.describe( 'Configure product listings', () => {
 				productListingsPage.getEstimatedShippingRatesCard();
 			estimatedTimesCard =
 				productListingsPage.getEstimatedShippingTimesCard();
-
-			// Check another shipping rate first in case the complex shipping rate radio button is already checked.
-			await productListingsPage.checkRecommendedShippingRateRadioButton();
 		} );
 
 		test( 'should send settings POST request after checking complex shipping rate radio button', async () => {
@@ -306,6 +316,21 @@ test.describe( 'Configure product listings', () => {
 
 	test.describe( 'Shipping rate is recommended', () => {
 		test.beforeAll( async () => {
+			productListingsPage.fulfillSettings(
+				{
+					shipping_rate: 'flat',
+					website_live: false,
+					checkout_process_secure: false,
+					payment_methods_visible: false,
+					refund_tos_visible: false,
+					contact_info_visible: false,
+					shipping_rates_count: 1, // Set shipping rates count to 1 to show the recommended shipping rate radio button.
+				},
+				200,
+				[ 'GET' ]
+			);
+
+			await page.reload();
 			// Check another shipping rate first in case the recommended shipping rate radio button is already checked.
 			await productListingsPage.checkSimpleShippingRateRadioButton();
 		} );

--- a/tests/e2e/utils/pages/edit-free-listings.js
+++ b/tests/e2e/utils/pages/edit-free-listings.js
@@ -42,7 +42,7 @@ export default class EditFreeListingsPage extends MockRequests {
 	async checkRecommendShippingSettings() {
 		return this.page
 			.locator(
-				'text=Recommended: Automatically sync my store’s shipping settings to Google.'
+				'text=Automatically sync my store’s shipping settings to Google.'
 			)
 			.check();
 	}

--- a/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
+++ b/tests/e2e/utils/pages/setup-mc/step-2-product-listings.js
@@ -80,7 +80,7 @@ export default class ProductListingsPage extends MockRequests {
 	 */
 	getRecommendedShippingRateRadioRow() {
 		return this.page.getByRole( 'radio', {
-			name: 'Recommended: Automatically sync my store’s shipping settings to Google.',
+			name: 'Automatically sync my store’s shipping settings to Google.',
 			exact: true,
 		} );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of pcTzPl-2qP-p2

This PR includes the following changes:

1. Removes the "Recommended" label from the auto-sync option.
2. By default, selects the manual option ("My shipping settings are simple. I can manually estimate flat shipping rates.") if no shipping settings were previously stored, such as during onboarding.
3. Hides the auto-sync option during onboarding if the merchant has no shipping methods set up.


### Onboarding:

https://github.com/user-attachments/assets/e8676c18-944f-4e7f-9f49-a724e9656a4f

### Editing Page (the auto-sync option is always displayed, regardless of shipping settings):

https://github.com/user-attachments/assets/78c6ece8-2869-4161-b30d-a91b00f484fb


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Disconnect all your accounts and remove any shipping method in WC.
2. Go to GFW onboarding.
3. When setting up the Shipping Rates, see that the `auto-sync` option is not available.
4. In WC add a new shipping method.
5. Refresh the onboarding page.
6. See that the `auto-sync` option is available.
7. See that always the option: `My shipping settings are simple. I can manually estimate flat shipping rates` is checked.
8. Finish the onboarding.
9. Go to Edit Free Listings and see that the `auto-sync` option is always displayed, regardless of shipping settings

### Additional details:
- Local Pickup isn't currently recognized as a valid shipping method, but it looks like we're not syncing it to Google either. So, I think it's fine if Local Pickup isn't counted as a valid method in this case.
- While working on this, I discovered a bug. If you use a comma as the decimal separator, the shipping rate won't be recognized as valid because `is_numeric` will return false. I'll create the issue.

![image](https://github.com/user-attachments/assets/e9503a28-1d5c-4e33-9bbf-ca44fddf63ac)


https://github.com/woocommerce/google-listings-and-ads/blob/fe41b5be9da361607780bb913a7a4c4e553fbe3c/src/Shipping/ZoneMethodsParser.php#L128-L131

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>