### PR TITLE
Make the value entering of the billing state field in e2e test compatible with WC < 9.2

### DIFF
--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -97,7 +97,17 @@ export async function checkout( page ) {
 			.fill( user.addressfirstline );
 		await page.getByLabel( 'City' ).fill( user.city );
 		await page.getByLabel( 'ZIP Code' ).fill( user.postcode );
-		await page.locator( '#billing-state' ).selectOption( user.statename );
+
+		const stateField = page.getByRole( 'combobox', { name: /State$/ } );
+		const stateFieldTagName = await stateField.evaluate(
+			( element ) => element.tagName
+		);
+		if ( stateFieldTagName === 'SELECT' ) {
+			stateField.selectOption( user.statename );
+		} else {
+			// compatibility-code "WC < 9.2"
+			stateField.fill( user.statename );
+		}
 	}
 
 	//TODO: See if there's an alternative method to click the button without relying on waitForTimeout.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR applies the same adjustment in https://github.com/woocommerce/woocommerce-google-analytics-integration/pull/457 to make e2e test compatible with WC < 9.2.

![image](https://github.com/user-attachments/assets/71dbcfb5-fb95-4619-b9f5-bd97b4e4ff8c)

### Detailed test instructions:

1. `npm run wp-env:up`
2. `npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version=9.1.4 && npm run -- wp-env run tests-cli -- wp wc update`
3. `npm run test:e2e`
4. Confirm tests pass
5. `npm run -- wp-env run tests-cli -- wp plugin update woocommerce --version=9.2.0-rc.1 && npm run -- wp-env run tests-cli -- wp wc update`
6. `npm run test:e2e`
7. Confirm tests pass

### Changelog entry
