### PR TITLE
Streamline onboarding: Set the default value of the tax rate to destination-based

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/SettingsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsController.php
@@ -130,6 +130,7 @@ class SettingsController extends BaseOptionsController {
 					'destination',
 					'manual',
 				],
+				'default'           => 'destination',
 			],
 			'website_live'            => [
 				'type'              => 'boolean',

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -18,6 +18,9 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 	/** @var SettingsController $controller */
 	protected $controller;
 
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
 	protected const ROUTE = '/wc/gla/mc/settings';
 
 	public function setUp(): void {

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -27,7 +27,7 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 		$this->controller->register();
 	}
 
-	public function test_default_settings() {
+	public function test_default_tax_rate_settings() {
 		$response = $this->do_request( self::ROUTE, 'GET' );
 
 		$this->assertEquals( 'destination', $response->get_data()['tax_rate'] );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\TrackingTrait;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -24,11 +24,14 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 		parent::setUp();
 
 		$this->controller = new SettingsController( $this->server );
+
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->controller->set_options_object( $this->options );
 		$this->controller->register();
 	}
 
 	public function test_default_tax_rate_settings() {
-		$response = $this->do_request( self::ROUTE, 'GET' );
+		$response = $this->do_request( self::ROUTE );
 
 		$this->assertEquals( 'destination', $response->get_data()['tax_rate'] );
 		$this->assertEquals( 200, $response->get_status() );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -5,8 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
-use Exception;
-use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class SettingsControllerTest

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUn
 /**
  * Class SettingsControllerTest
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
  */
 class SettingsControllerTest extends RESTControllerUnitTest {
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\TrackingTrait;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class SettingsControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ */
+class SettingsControllerTest extends RESTControllerUnitTest {
+
+	/** @var SettingsController $controller */
+	protected $controller;
+
+	protected const ROUTE = '/wc/gla/mc/settings';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->controller = new SettingsController( $this->server );
+		$this->controller->register();
+	}
+
+	public function test_default_settings() {
+		$response = $this->do_request( self::ROUTE, 'GET' );
+
+		$this->assertEquals( 'destination', $response->get_data()['tax_rate'] );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -39,4 +39,11 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'destination', $response->get_data()['tax_rate'] );
 		$this->assertEquals( 200, $response->get_status() );
 	}
+
+	public function test_default_tax_rate_settings_post() {
+		$response = $this->do_request( self::ROUTE, 'POST', [] );
+
+		$this->assertEquals( 'destination', $response->get_data()['data']['tax_rate'] );
+		$this->assertEquals( 200, $response->get_status() );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Tax Rate (the UI will be removed later; see #2490), shown on the second screen when a US country is selected, must default to destination.

Closes  #2491.

Set the default value in the scheme property to `destination`. After the change, `/wp-json/wc/gla/mc/settings` does show default `tax_rate` as `destination`, in comparison to early `null.  This was also reflected in Tax Rate UI.
 See the before and after change screenshot of the setting endpoint. 

### Screenshots:
**Before**: you can see `tax_rate` is `null`
![before](https://github.com/user-attachments/assets/4041fc82-95ed-4ced-8654-22e82479355b)

**After**: you can see `tax_rate` is `destination`
![after](https://github.com/user-attachments/assets/2016146d-feda-448b-bf14-62bc40211ea8)


<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Move to onboarding second screen. 
2. While on the second page, clear the option `npm run wp-env run cli wp option delete gla_merchant_center` to ensure it was not previously saved on a previous test.
3. Reload the 2nd screen, and under location select North American. You should see UI for `Tax rate (required for U.S. only)` below. 
4. Check if the default option is `My store uses destination-based tax rates.`.
5. Check db. `npm run wp-env run cli wp option get gla_merchant_center`. Note to QA:- You need to check this again once the UI removal is complete (#2490)


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Set the default value of the tax rate to destination-based during onboarding.
