### PR TITLE
Prevent E2E tests from failing randomly due to getting product block attribute locators before they are rendered

### DIFF
--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -431,6 +431,9 @@ export function getProductBlockEditorUtils( page ) {
 		},
 
 		async getAvailableProductAttributesWithTestValues() {
+			// Avoiding tests may start to get locators before they are rendered,
+			// leading to random failures.
+			await this.getProductAttributesHeading().waitFor();
 			return getAvailableProductAttributesWithTestValues(
 				page,
 				this.getDateAndTimeFields


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This false alarm is often encountered in recent code reviews and during the latest release.

![1](https://github.com/user-attachments/assets/7f779fb9-70b2-4d49-8d2e-569e71a31153)

![image](https://github.com/user-attachments/assets/1f49abb7-ce66-449f-a598-a38ad5fb0e43)

This PR fixes it by waiting for the product attributes header to be rendered before starting to get the locators.

### Detailed test instructions:

1. View the e2e test result on GitHub Actions: https://github.com/woocommerce/google-listings-and-ads/actions/runs/10467317996/job/28985828821
2. `npm run test:e2e -- --ui`
3. Run the "Save all product attributes to simple product" and "Save all product attributes to variation product" test cases under **product-editor > block-integration.test.js > Product Block Editor integration**

### Changelog entry
