### PR TITLE
Use remote-site-status to check the WPCOM Auth status

### DIFF
--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -171,10 +171,11 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 * If the Notifications are ready
 	 * This happens when the WPCOM API is Authorized and the feature is enabled.
 	 *
+	 * @param bool $with_health_check If true. Performs a remote request to WPCOM API to get the status.
 	 * @return bool
 	 */
-	public function is_ready(): bool {
-		return $this->options->is_wpcom_api_authorized() && $this->is_enabled() && $this->merchant_center->is_ready_for_syncing() && $this->account_service->is_wpcom_api_status_healthy();
+	public function is_ready( bool $with_health_check = true ): bool {
+		return $this->options->is_wpcom_api_authorized() && $this->is_enabled() && $this->merchant_center->is_ready_for_syncing() && ( $with_health_check === false || $this->account_service->is_wpcom_api_status_healthy() );
 	}
 
 	/**

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -72,7 +72,7 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 * Class constructor
 	 *
 	 * @param MerchantCenterService $merchant_center
-	 * @param AccountService $account_service
+	 * @param AccountService        $account_service
 	 */
 	public function __construct( MerchantCenterService $merchant_center, AccountService $account_service ) {
 		$blog_id                = Jetpack_Options::get_option( 'id' );

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\WP;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
@@ -59,15 +60,24 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 */
 	public MerchantCenterService $merchant_center;
 
+	/**
+	 * The AccountService service
+	 *
+	 * @var AccountService $account_service
+	 */
+	public AccountService $account_service;
+
 
 	/**
 	 * Class constructor
 	 *
 	 * @param MerchantCenterService $merchant_center
+	 * @param AccountService $account_service
 	 */
-	public function __construct( MerchantCenterService $merchant_center ) {
+	public function __construct( MerchantCenterService $merchant_center, AccountService $account_service ) {
 		$blog_id                = Jetpack_Options::get_option( 'id' );
 		$this->merchant_center  = $merchant_center;
+		$this->account_service  = $account_service;
 		$this->notification_url = "https://public-api.wordpress.com/wpcom/v2/sites/{$blog_id}/partners/google/notifications";
 	}
 
@@ -164,7 +174,7 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 * @return bool
 	 */
 	public function is_ready(): bool {
-		return $this->options->is_wpcom_api_authorized() && $this->is_enabled() && $this->merchant_center->is_ready_for_syncing();
+		return $this->options->is_wpcom_api_authorized() && $this->is_enabled() && $this->merchant_center->is_ready_for_syncing() && $this->account_service->is_wpcom_api_status_healthy();
 	}
 
 	/**

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -23,6 +23,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateProducts;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
@@ -652,7 +653,7 @@ class ConnectionTest implements Service, Registerable {
 				<?php
 				  $options = $this->container->get( OptionsInterface::class );
 				  $wp_api_status = $options->get( OptionsInterface::WPCOM_REST_API_STATUS );
-				  $notification_service = new NotificationsService( $this->container->get( MerchantCenterService::class ) );
+				  $notification_service = new NotificationsService( $this->container->get( MerchantCenterService::class ), $this->container->get( AccountService::class ) );
 				  $notification_service->set_options_object( $options );
 				?>
 				<h2 class="title">Partner API Pull Integration</h2>
@@ -865,7 +866,7 @@ class ConnectionTest implements Service, Registerable {
 			$mc    = $this->container->get( MerchantCenterService::class );
 			/** @var OptionsInterface $options */
 			$options = $this->container->get( OptionsInterface::class );
-			$service = new NotificationsService( $mc );
+			$service = new NotificationsService( $mc, $this->container->get( AccountService::class ) );
 			$service->set_options_object( $options );
 
 			if ( $service->notify( $topic, $item ) ) {

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -65,6 +65,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Reports;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupAds;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupMerchantCenter;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService as MerchantAccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
@@ -254,7 +255,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( MerchantCenterService::class );
 
 		// Set up Notifications service.
-		$this->share_with_tags( NotificationsService::class, MerchantCenterService::class );
+		$this->share_with_tags( NotificationsService::class, MerchantCenterService::class, AccountService::class );
 
 		// Set up OAuthService service.
 		$this->share_with_tags( OAuthService::class );

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -668,12 +668,6 @@ class AccountService implements OptionsAwareInterface, Service {
 			}
 
 			$status = json_decode( wp_remote_retrieve_body( $integration_remote_request_response ), true ) ?? [];
-
-			if ( isset( $status['error'] ) ) {
-				$this->delete_wpcom_api_status_transient();
-				return false;
-			}
-
 			$transients->set( TransientsInterface::WPCOM_API_STATUS, $status, MINUTE_IN_SECONDS * 30 );
 		}
 

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -3,11 +3,13 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
+use Automattic\Jetpack\Connection\Client;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\OAuthService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
@@ -226,6 +228,11 @@ class AccountService implements OptionsAwareInterface, Service {
 
 		$id                    = $this->options->get_merchant_id();
 		$wpcom_rest_api_status = $this->options->get( OptionsInterface::WPCOM_REST_API_STATUS );
+
+		// If token is revoked outside the extension. Set the status as error to force the merchant to grant access again.
+		if ( $wpcom_rest_api_status === 'approved' && ! $this->is_wpcom_api_status_healthy() ) {
+			$wpcom_rest_api_status = OAuthService::STATUS_ERROR;
+		}
 
 		$status = [
 			'id'                           => $id,
@@ -539,6 +546,7 @@ class AccountService implements OptionsAwareInterface, Service {
 	 */
 	public function reset_wpcom_api_authorization_data(): bool {
 		$this->delete_wpcom_api_auth_nonce();
+		$this->delete_wpcom_api_status_transient();
 		return $this->options->delete( OptionsInterface::WPCOM_REST_API_STATUS );
 	}
 
@@ -592,6 +600,7 @@ class AccountService implements OptionsAwareInterface, Service {
 				]
 			);
 
+			$this->delete_wpcom_api_status_transient();
 			return $this->options->update( OptionsInterface::WPCOM_REST_API_STATUS, $status );
 		} catch ( ExceptionWithResponseData $e ) {
 
@@ -622,5 +631,52 @@ class AccountService implements OptionsAwareInterface, Service {
 	 */
 	public function delete_wpcom_api_auth_nonce(): bool {
 		return $this->options->delete( OptionsInterface::GOOGLE_WPCOM_AUTH_NONCE );
+	}
+
+	/**
+	 * Deletes the transient storing the WPCOM Status data.
+	 */
+	public function delete_wpcom_api_status_transient(): void {
+		$transients = $this->container->get( TransientsInterface::class );
+		$transients->delete( TransientsInterface::WPCOM_API_STATUS );
+	}
+
+	/**
+	 * Check if the WPCOM API Status is healthy by doing a request to /wc/partners/google/remote-site-status endpoint in WPCOM.
+	 *
+	 * @return bool True when the status is healthy, false otherwise.
+	 */
+	public function is_wpcom_api_status_healthy() {
+		/** @var TransientsInterface $transients */
+		$transients = $this->container->get( TransientsInterface::class );
+		$status     = $transients->get( TransientsInterface::WPCOM_API_STATUS );
+
+		if ( ! $status ) {
+
+			$integration_status_args = [
+				'method'  => 'GET',
+				'timeout' => 30,
+				'url'     => 'https://public-api.wordpress.com/wpcom/v2/sites/' . Jetpack_Options::get_option( 'id' ) . '/wc/partners/google/remote-site-status',
+				'user_id' => get_current_user_id(),
+			];
+
+			$integration_remote_request_response = Client::remote_request( $integration_status_args, null );
+
+			if ( is_wp_error( $integration_remote_request_response ) ) {
+				$this->delete_wpcom_api_status_transient();
+				return false;
+			}
+
+			$status = json_decode( wp_remote_retrieve_body( $integration_remote_request_response ), true ) ?? [];
+
+			if ( isset( $status['error'] ) ) {
+				$this->delete_wpcom_api_status_transient();
+				return false;
+			}
+
+			$transients->set( TransientsInterface::WPCOM_API_STATUS, $status, MINUTE_IN_SECONDS * 30 );
+		}
+
+		return isset( $status['is_healthy'] ) && $status['is_healthy'] && $status['is_wc_rest_api_healthy'] && $status['is_partner_token_healthy'];
 	}
 }

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -17,6 +17,7 @@ interface TransientsInterface {
 	public const MC_IS_SUBACCOUNT     = 'mc_is_subaccount';
 	public const MC_STATUSES          = 'mc_statuses';
 	public const URL_MATCHES          = 'url_matches';
+	public const WPCOM_API_STATUS     = 'wpcom_api_status';
 
 	public const VALID_OPTIONS = [
 		self::ADS_CAMPAIGN_COUNT   => true,
@@ -26,6 +27,7 @@ interface TransientsInterface {
 		self::MC_IS_SUBACCOUNT     => true,
 		self::MC_STATUSES          => true,
 		self::URL_MATCHES          => true,
+		self::WPCOM_API_STATUS     => true,
 	];
 
 	/**

--- a/src/Settings/SyncerHooks.php
+++ b/src/Settings/SyncerHooks.php
@@ -80,7 +80,7 @@ class SyncerHooks implements Service, Registerable {
 	 * Register the service.
 	 */
 	public function register(): void {
-		if ( ! $this->notifications_service->is_ready() ) {
+		if ( ! $this->notifications_service->is_ready( false ) ) {
 			return;
 		}
 

--- a/tests/Unit/API/WP/NotificationsServiceTest.php
+++ b/tests/Unit/API/WP/NotificationsServiceTest.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\WP;
 
 use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\OAuthService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;

--- a/tests/Unit/API/WP/NotificationsServiceTest.php
+++ b/tests/Unit/API/WP/NotificationsServiceTest.php
@@ -229,6 +229,12 @@ class NotificationsServiceTest extends UnitTest {
 		$this->assertTrue( $this->service->is_ready( false ) );
 	}
 
+	public function test_is_ready_calling_status_api_if_with_health_check_is_true() {
+		$this->service = $this->get_mock( true, true, true );
+		$this->account->expects( $this->once() )->method( 'is_wpcom_api_status_healthy' );
+		$this->assertTrue( $this->service->is_ready() );
+	}
+
 	/**
 	 * Mocks the service
 	 *

--- a/tests/Unit/API/WP/NotificationsServiceTest.php
+++ b/tests/Unit/API/WP/NotificationsServiceTest.php
@@ -223,6 +223,11 @@ class NotificationsServiceTest extends UnitTest {
 		$this->assertEquals( did_action( 'woocommerce_gla_error' ), 1 );
 	}
 
+	public function test_is_ready_not_calling_status_api_if_with_health_check_is_false() {
+		$this->service = $this->get_mock( true, true, false );
+		$this->account->expects( $this->never() )->method( 'is_wpcom_api_status_healthy' );
+		$this->assertTrue( $this->service->is_ready( false ) );
+	}
 
 	/**
 	 * Mocks the service

--- a/tests/Unit/API/WP/NotificationsServiceTest.php
+++ b/tests/Unit/API/WP/NotificationsServiceTest.php
@@ -230,7 +230,7 @@ class NotificationsServiceTest extends UnitTest {
 	}
 
 	public function test_is_ready_calling_status_api_if_with_health_check_is_true() {
-		$this->service = $this->get_mock( true, true, true );
+		$this->service = $this->get_mock();
 		$this->account->expects( $this->once() )->method( 'is_wpcom_api_status_healthy' );
 		$this->assertTrue( $this->service->is_ready() );
 	}

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -762,6 +762,17 @@ class AccountServiceTest extends UnitTest {
 			->method( 'is_enabled' )
 			->willReturn( true );
 
+		$this->transients->expects( $this->exactly( 1 ) )
+			->method( 'get' )
+			->with( TransientsInterface::WPCOM_API_STATUS )
+			->willReturn(
+				[
+					'is_healthy'               => true,
+					'is_wc_rest_api_healthy'   => true,
+					'is_partner_token_healthy' => true,
+				]
+			);
+
 		$this->options->method( 'get' )
 			->with( OptionsInterface::WPCOM_REST_API_STATUS )
 			->willReturn( 'approved' );
@@ -785,6 +796,17 @@ class AccountServiceTest extends UnitTest {
 		$this->notifications_service->expects( $this->once() )
 			->method( 'is_enabled' )
 			->willReturn( false );
+
+		$this->transients->expects( $this->exactly( 1 ) )
+			->method( 'get' )
+			->with( TransientsInterface::WPCOM_API_STATUS )
+			->willReturn(
+				[
+					'is_healthy'               => true,
+					'is_wc_rest_api_healthy'   => true,
+					'is_partner_token_healthy' => true,
+				]
+			);
 
 		$this->options->method( 'get' )
 			->with( OptionsInterface::WPCOM_REST_API_STATUS )
@@ -825,6 +847,42 @@ class AccountServiceTest extends UnitTest {
 			$this->account->get_connected_status()
 		);
 	}
+
+	public function test_get_connected_status_not_healthy() {
+		$this->options->expects( $this->once() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->notifications_service->expects( $this->once() )
+			->method( 'is_enabled' )
+			->willReturn( true );
+
+		$this->transients->expects( $this->exactly( 1 ) )
+			->method( 'get' )
+			->with( TransientsInterface::WPCOM_API_STATUS )
+			->willReturn(
+				[
+					'is_healthy'               => true,
+					'is_wc_rest_api_healthy'   => true,
+					'is_partner_token_healthy' => false,
+				]
+			);
+
+		$this->options->method( 'get' )
+			->with( OptionsInterface::WPCOM_REST_API_STATUS )
+			->willReturn( 'approved' );
+
+		$this->assertEquals(
+			[
+				'id'                           => self::TEST_ACCOUNT_ID,
+				'status'                       => 'connected',
+				'notification_service_enabled' => true,
+				'wpcom_rest_api_status'        => 'error',
+			],
+			$this->account->get_connected_status()
+		);
+	}
+
 
 	public function test_get_setup_status() {
 		$this->mc_service->expects( $this->once() )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Context: p1724064639654099/1722414955.111429-slack-C02BB3F30TG

When authorizing Google to fetch data from the Shop as well as generating a token we set an option `gla_wpcom_rest_api_status` as `approved`. If the token is revoked outside the extension, the option will still be `approved` and the notifications will be sent. 

This PR handles that and checks the status of the token using the WPCOM REST API.

### Screenshots:

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  Disable fetch data from  Settings or disconnect it from the Connection Test page
2. Grant access from scratch still works.
3. You can send notifications in the Connection test page for example
4. Now disconnect WPCOM Access from Connection Test page
5. You CANNOT send notifications anymore
6. Set `gla_wpcom_rest_api_status` as `approved` to simulate a granted access that has no token.
7. You CANNOT send notifications anymore
8. Go to settings. You see the warning notice in the MC Card
9. Grant access again
10. Now You can send notifications again in the Connection test page 


### Additional details:

ℹ️  I was thinking about removing `gla_wpcom_rest_api_status`  and only relying on the transient + WPCOM REST API. status endpoint for considering the WPCOM API as ready. I would appreciate thoughts on this. 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Use remote-site-status to check the WPCOM Auth status