### PR TITLE
Tweak Connect Test Page errors when WPCOM token is not connected.

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -893,6 +893,11 @@ class ConnectionTest implements Service, Registerable {
 			} else {
 				$this->integration_status_response = json_decode( wp_remote_retrieve_body( $integration_remote_request_response ), true ) ?? [];
 
+				// If the merchant isn't connected to the Google App, it's not necessary to display an error indicating that the partner token isn't associated.
+				if ( ! $this->integration_status_response['is_partner_token_healthy'] && isset( $this->integration_status_response['errors'] ['rest_api_partner_token']['error_code'] ) && $this->integration_status_response['errors'] ['rest_api_partner_token']['error_code'] === 'wpcom_partner_token_not_associated' ) {
+					unset( $this->integration_status_response['errors'] ['rest_api_partner_token'] );
+				}
+
 				if ( json_last_error() || ! isset( $this->integration_status_response['site'] ) ) {
 					$this->response .= wp_remote_retrieve_body( $integration_remote_request_response );
 				}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of https://wordpress.org/support/topic/error-on-sync/#post-17964837

When the merchant is on the connection test page and clicks "Get API Pull Integration Status" without having onboarded to the new mechanism, we currently display the following error message:

![image](https://github.com/user-attachments/assets/b43cedd2-321f-4090-9831-00e62d0d3156)

This can be confusing, as mentioned in the forum ticket. To address this, this PR removes the error if the "Google Token Health" is disconnected, as it already indicated that there is no token. 

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Make sure that you haven’t onboarded to the new sync mechanism.
2. Go to the Connect Test Page: `/wp-admin/admin.php?page=connection-test-admin-page`
3. Click "Get API Pull Integration Status"
4. See that the "Google Token Health" already indicates that there is no token associated and no errors are shown.  


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Connect Test Page errors when WPCOM token is not connected.
