### PR TITLE
Streamline campaign setup: Remove ads audience field from paid ads setup during onboarding

### DIFF
--- a/js/src/components/paid-ads/__snapshots__/validateCampaign.test.js.snap
+++ b/js/src/components/paid-ads/__snapshots__/validateCampaign.test.js.snap
@@ -11,5 +11,3 @@ exports[`validateCampaign When the amount is not a number, should not pass 4`] =
 exports[`validateCampaign When the amount is ≤ 0, should not pass 1`] = `"Please make sure daily average cost is greater than 0."`;
 
 exports[`validateCampaign When the amount is ≤ 0, should not pass 2`] = `"Please make sure daily average cost is greater than 0."`;
-
-exports[`validateCampaign When the country codes array is empty, should not pass 1`] = `"Please select at least one country for your ads campaign."`;

--- a/js/src/components/paid-ads/ads-campaign.js
+++ b/js/src/components/paid-ads/ads-campaign.js
@@ -94,6 +94,7 @@ export default function AdsCampaign( {
 			<BudgetSection
 				formProps={ formContext }
 				disabled={ disabledBudgetSection }
+				countryCodes={ formContext.values.countryCodes }
 			>
 				<CampaignPreviewCard />
 			</BudgetSection>

--- a/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
+++ b/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
@@ -11,6 +11,7 @@ import GridiconNoticeOutline from 'gridicons/dist/notice-outline';
  */
 import useCountryKeyNameMap from '.~/hooks/useCountryKeyNameMap';
 import useFetchBudgetRecommendationEffect from './useFetchBudgetRecommendationEffect';
+import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import './index.scss';
 
 /*
@@ -50,7 +51,8 @@ function toRecommendationRange( isMultiple, ...values ) {
 }
 
 const BudgetRecommendation = ( props ) => {
-	const { countryCodes, dailyAverageCost = Infinity } = props;
+	const { dailyAverageCost = Infinity } = props;
+	const { data: countryCodes } = useTargetAudienceFinalCountryCodes();
 	const { data } = useFetchBudgetRecommendationEffect( countryCodes );
 	const map = useCountryKeyNameMap();
 

--- a/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
+++ b/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
@@ -11,7 +11,6 @@ import GridiconNoticeOutline from 'gridicons/dist/notice-outline';
  */
 import useCountryKeyNameMap from '.~/hooks/useCountryKeyNameMap';
 import useFetchBudgetRecommendationEffect from './useFetchBudgetRecommendationEffect';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import './index.scss';
 
 /*
@@ -51,8 +50,7 @@ function toRecommendationRange( isMultiple, ...values ) {
 }
 
 const BudgetRecommendation = ( props ) => {
-	const { dailyAverageCost = Infinity } = props;
-	const { data: countryCodes } = useTargetAudienceFinalCountryCodes();
+	const { countryCodes, dailyAverageCost = Infinity } = props;
 	const { data } = useFetchBudgetRecommendationEffect( countryCodes );
 	const map = useCountryKeyNameMap();
 

--- a/js/src/components/paid-ads/budget-section/index.js
+++ b/js/src/components/paid-ads/budget-section/index.js
@@ -29,15 +29,15 @@ const nonInteractableProps = {
  *
  * @param {Object} props React props.
  * @param {Object} props.formProps Form props forwarded from `Form` component.
+ * @param {Array<CountryCode>} props.countryCodes Country codes to fetch budget recommendations for.
  * @param {boolean} [props.disabled=false] Whether display the Card in disabled style.
  * @param {JSX.Element} [props.children] Extra content to be rendered under the card of budget inputs.
- * @param {Array<CountryCode>} [props.countryCodes] Country codes to fetch budget recommendations for.
  */
 const BudgetSection = ( {
 	formProps,
+	countryCodes,
 	disabled = false,
 	children,
-	countryCodes,
 } ) => {
 	const { getInputProps, setValue, values } = formProps;
 	const { amount } = values;

--- a/js/src/components/paid-ads/budget-section/index.js
+++ b/js/src/components/paid-ads/budget-section/index.js
@@ -29,7 +29,7 @@ const nonInteractableProps = {
  *
  * @param {Object} props React props.
  * @param {Object} props.formProps Form props forwarded from `Form` component.
- * @param {Array<CountryCode>} props.countryCodes Country codes to fetch budget recommendations for.
+ * @param {Array<CountryCode>|undefined} props.countryCodes Country codes to fetch budget recommendations for.
  * @param {boolean} [props.disabled=false] Whether display the Card in disabled style.
  * @param {JSX.Element} [props.children] Extra content to be rendered under the card of budget inputs.
  */
@@ -99,7 +99,7 @@ const BudgetSection = ( {
 								value={ monthlyMaxEstimated }
 							/>
 						</div>
-						{ countryCodes.length > 0 && (
+						{ countryCodes?.length > 0 && (
 							<BudgetRecommendation
 								countryCodes={ countryCodes }
 								dailyAverageCost={ amount }

--- a/js/src/components/paid-ads/budget-section/index.js
+++ b/js/src/components/paid-ads/budget-section/index.js
@@ -12,8 +12,11 @@ import getMonthlyMaxEstimated from './getMonthlyMaxEstimated';
 import './index.scss';
 import BudgetRecommendation from './budget-recommendation';
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import AppInputPriceControl from '.~/components/app-input-price-control';
+
+/**
+ * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ */
 
 const nonInteractableProps = {
 	noPointerEvents: true,
@@ -28,11 +31,16 @@ const nonInteractableProps = {
  * @param {Object} props.formProps Form props forwarded from `Form` component.
  * @param {boolean} [props.disabled=false] Whether display the Card in disabled style.
  * @param {JSX.Element} [props.children] Extra content to be rendered under the card of budget inputs.
+ * @param {Array<CountryCode>} [props.countryCodes] Country codes to fetch budget recommendations for.
  */
-const BudgetSection = ( { formProps, disabled = false, children } ) => {
+const BudgetSection = ( {
+	formProps,
+	disabled = false,
+	children,
+	countryCodes,
+} ) => {
 	const { getInputProps, setValue, values } = formProps;
 	const { amount } = values;
-	const { data: countryCodes } = useTargetAudienceFinalCountryCodes();
 	const { googleAdsAccount } = useGoogleAdsAccount();
 	const monthlyMaxEstimated = getMonthlyMaxEstimated( amount );
 	// Display the currency code that will be used by Google Ads, but still use the store's currency formatting settings.

--- a/js/src/components/paid-ads/budget-section/index.js
+++ b/js/src/components/paid-ads/budget-section/index.js
@@ -12,6 +12,7 @@ import getMonthlyMaxEstimated from './getMonthlyMaxEstimated';
 import './index.scss';
 import BudgetRecommendation from './budget-recommendation';
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
+import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import AppInputPriceControl from '.~/components/app-input-price-control';
 
 const nonInteractableProps = {
@@ -30,7 +31,8 @@ const nonInteractableProps = {
  */
 const BudgetSection = ( { formProps, disabled = false, children } ) => {
 	const { getInputProps, setValue, values } = formProps;
-	const { countryCodes, amount } = values;
+	const { amount } = values;
+	const { data: countryCodes } = useTargetAudienceFinalCountryCodes();
 	const { googleAdsAccount } = useGoogleAdsAccount();
 	const monthlyMaxEstimated = getMonthlyMaxEstimated( amount );
 	// Display the currency code that will be used by Google Ads, but still use the store's currency formatting settings.

--- a/js/src/components/paid-ads/validateCampaign.js
+++ b/js/src/components/paid-ads/validateCampaign.js
@@ -16,13 +16,6 @@ import { __ } from '@wordpress/i18n';
 const validateCampaign = ( values ) => {
 	const errors = {};
 
-	if ( values.countryCodes.length === 0 ) {
-		errors.countryCodes = __(
-			'Please select at least one country for your ads campaign.',
-			'google-listings-and-ads'
-		);
-	}
-
 	if ( ! Number.isFinite( values.amount ) || values.amount <= 0 ) {
 		errors.amount = __(
 			'Please make sure daily average cost is greater than 0.',

--- a/js/src/components/paid-ads/validateCampaign.test.js
+++ b/js/src/components/paid-ads/validateCampaign.test.js
@@ -12,12 +12,11 @@ describe( 'validateCampaign', () => {
 
 	beforeEach( () => {
 		// Initial values
-		values = { countryCodes: [], amount: 0 };
+		values = { amount: 0 };
 	} );
 
 	it( 'When all checks are passed, should return an empty object', () => {
 		const errors = validateCampaign( {
-			countryCodes: [ 'US' ],
 			amount: 1,
 		} );
 
@@ -27,15 +26,7 @@ describe( 'validateCampaign', () => {
 	it( 'should indicate multiple unpassed checks by setting properties in the returned object', () => {
 		const errors = validateCampaign( values );
 
-		expect( errors ).toHaveProperty( 'countryCodes' );
 		expect( errors ).toHaveProperty( 'amount' );
-	} );
-
-	it( 'When the country codes array is empty, should not pass', () => {
-		const errors = validateCampaign( values );
-
-		expect( errors ).toHaveProperty( 'countryCodes' );
-		expect( errors.countryCodes ).toMatchSnapshot();
 	} );
 
 	it( 'When the amount is not a number, should not pass', () => {

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/clientSession.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/clientSession.js
@@ -1,9 +1,6 @@
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
- *
  * @typedef {Object} CampaignData
  * @property {number|undefined} amount Daily average cost of the paid ads campaign.
- * @property {Array<CountryCode>} countryCodes Audience country codes of the paid ads campaign. Example: 'US'.
  */
 
 const KEY_SHOW_PAID_ADS_SETUP = 'gla-onboarding-show-paid-ads-setup';
@@ -32,10 +29,9 @@ const clientSession = {
 	/**
 	 * @param {CampaignData} data Campaign data to be stored.
 	 * @param {number|undefined} data.amount Daily average cost of the campaign.
-	 * @param {Array<CountryCode>} data.countryCodes Country codes of the campaign.
 	 */
-	setCampaign( { amount, countryCodes } ) {
-		const json = JSON.stringify( { amount, countryCodes } );
+	setCampaign( { amount } ) {
+		const json = JSON.stringify( { amount } );
 		sessionStorage.setItem( KEY_PAID_ADS, json );
 	},
 

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
@@ -53,7 +53,7 @@ function resolveInitialPaidAds( paidAds ) {
  *
  * @param {Object} props React props.
  * @param {(onStatesReceived: PaidAdsData)=>void} props.onStatesReceived Callback to receive the data for setting up paid ads when initial and also when the budget and billing are updated.
- * @param {Array<CountryCode>} props.countryCodes Country codes for the campaign.
+ * @param {Array<CountryCode>|undefined} props.countryCodes Country codes for the campaign.
  */
 export default function PaidAdsSetupSections( {
 	onStatesReceived,

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useState, useRef, useEffect } from '@wordpress/element';
 import { Form } from '@woocommerce/components';
 
@@ -11,7 +10,6 @@ import { Form } from '@woocommerce/components';
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
 import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import useGoogleAdsAccountBillingStatus from '.~/hooks/useGoogleAdsAccountBillingStatus';
-import AudienceSection from '.~/components/paid-ads/audience-section';
 import BudgetSection from '.~/components/paid-ads/budget-section';
 import BillingCard from '.~/components/paid-ads/billing-card';
 import SpinnerCard from '.~/components/spinner-card';
@@ -45,23 +43,8 @@ const defaultPaidAds = {
  * @param {Array<CountryCode>} targetAudience Country codes of selected target audience.
  * @return {PaidAdsData} The resolved paid ads data.
  */
-function resolveInitialPaidAds( paidAds, targetAudience ) {
-	const nextPaidAds = { ...paidAds };
-
-	if ( targetAudience ) {
-		if ( nextPaidAds.countryCodes === defaultPaidAds.countryCodes ) {
-			// Replace the country codes with the loaded target audience only if the reference is
-			// the same as the default because the given country codes might be the restored ones.
-			nextPaidAds.countryCodes = targetAudience;
-		} else {
-			// The selected target audience may be changed back and forth during the onboarding flow.
-			// Remove countries if any don't exist in the latest state.
-			nextPaidAds.countryCodes = nextPaidAds.countryCodes.filter(
-				( code ) => targetAudience.includes( code )
-			);
-		}
-	}
-
+function resolveInitialPaidAds( paidAds, targetAudience = [] ) {
+	const nextPaidAds = { ...paidAds, countryCodes: targetAudience };
 	nextPaidAds.isValid = ! Object.keys( validateCampaign( nextPaidAds ) )
 		.length;
 
@@ -160,22 +143,12 @@ export default function PaidAdsSetupSections( { onStatesReceived } ) {
 					disabledAudience || countryCodes.length === 0;
 
 				return (
-					<>
-						<AudienceSection
-							formProps={ formProps }
-							disabled={ disabledAudience }
-							countrySelectHelperText={ __(
-								'You can only choose from countries you’ve selected during product listings configuration.',
-								'google-listings-and-ads'
-							) }
-						/>
-						<BudgetSection
-							formProps={ formProps }
-							disabled={ disabledBudget }
-						>
-							{ ! disabledBudget && <BillingCard /> }
-						</BudgetSection>
-					</>
+					<BudgetSection
+						formProps={ formProps }
+						disabled={ disabledBudget }
+					>
+						{ ! disabledBudget && <BillingCard /> }
+					</BudgetSection>
 				);
 			} }
 		</Form>

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
@@ -34,7 +34,7 @@ const defaultPaidAds = {
 };
 
 /**
- * Resolve the initial paid ads data from the given paid ads data with the loaded target audience.
+ * Resolve the initial paid ads data from the given paid ads data.
  * Parts of the resolved data are used in the `initialValues` prop of `Form` component.
  *
  * @param {PaidAdsData} paidAds The paid ads data as the base to be resolved with other states.

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
@@ -7,8 +7,6 @@ import { Form } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import useGoogleAdsAccountBillingStatus from '.~/hooks/useGoogleAdsAccountBillingStatus';
 import BudgetSection from '.~/components/paid-ads/budget-section';
 import BillingCard from '.~/components/paid-ads/billing-card';
@@ -19,18 +17,14 @@ import clientSession from './clientSession';
 import { GOOGLE_ADS_BILLING_STATUS } from '.~/constants';
 
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
- *
  * @typedef {Object} PaidAdsData
  * @property {number|undefined} amount Daily average cost of the paid ads campaign.
- * @property {Array<CountryCode>} countryCodes Audience country codes of the paid ads campaign. Example: 'US'.
  * @property {boolean} isValid Whether the campaign data are valid values.
  * @property {boolean} isReady Whether the campaign data and the billing setting are ready for completing the paid ads setup.
  */
 
 const defaultPaidAds = {
 	amount: 0,
-	countryCodes: [],
 	isValid: false,
 	isReady: false,
 };
@@ -40,11 +34,10 @@ const defaultPaidAds = {
  * Parts of the resolved data are used in the `initialValues` prop of `Form` component.
  *
  * @param {PaidAdsData} paidAds The paid ads data as the base to be resolved with other states.
- * @param {Array<CountryCode>} targetAudience Country codes of selected target audience.
  * @return {PaidAdsData} The resolved paid ads data.
  */
-function resolveInitialPaidAds( paidAds, targetAudience = [] ) {
-	const nextPaidAds = { ...paidAds, countryCodes: targetAudience };
+function resolveInitialPaidAds( paidAds ) {
+	const nextPaidAds = { ...paidAds };
 	nextPaidAds.isValid = ! Object.keys( validateCampaign( nextPaidAds ) )
 		.length;
 
@@ -52,14 +45,12 @@ function resolveInitialPaidAds( paidAds, targetAudience = [] ) {
 }
 
 /**
- * Renders sections of Google Ads account, audience, budget, and billing for setting up the paid ads.
+ * Renders sections of Google Ads account, budget and billing for setting up the paid ads.
  *
  * @param {Object} props React props.
- * @param {(onStatesReceived: PaidAdsData)=>void} props.onStatesReceived Callback to receive the data for setting up paid ads when initial and also when the audience, budget, and billing are updated.
+ * @param {(onStatesReceived: PaidAdsData)=>void} props.onStatesReceived Callback to receive the data for setting up paid ads when initial and also when the budget and billing are updated.
  */
 export default function PaidAdsSetupSections( { onStatesReceived } ) {
-	const { hasGoogleAdsConnection } = useGoogleAdsAccount();
-	const { data: targetAudience } = useTargetAudienceFinalCountryCodes();
 	const { billingStatus } = useGoogleAdsAccountBillingStatus();
 
 	const onStatesReceivedRef = useRef();
@@ -71,7 +62,7 @@ export default function PaidAdsSetupSections( { onStatesReceived } ) {
 			...defaultPaidAds,
 			...clientSession.getCampaign(),
 		};
-		return resolveInitialPaidAds( startingPaidAds, targetAudience );
+		return resolveInitialPaidAds( startingPaidAds );
 	} );
 
 	const isBillingCompleted =
@@ -100,22 +91,7 @@ export default function PaidAdsSetupSections( { onStatesReceived } ) {
 		clientSession.setCampaign( nextPaidAds );
 	}, [ paidAds, isBillingCompleted ] );
 
-	/*
-	  Resolve the initial states after the `targetAudience` is loaded.
-
-	  Please note that the loaded `targetAudience` is NOT expected to have further changes
-	  in the runtime. If it happens one day and it will need to update <Form>'s internal state
-	  with the changed `targetAudience`, please refer to the following practice.
-	  - https://github.com/woocommerce/google-listings-and-ads/blob/5b6522ca10ad75556e6b2de7c120cc712aab70b1/js/src/components/free-listings/setup-free-listings/index.js#L120-L134
-	  - https://github.com/woocommerce/google-listings-and-ads/blob/5b6522ca10ad75556e6b2de7c120cc712aab70b1/js/src/components/free-listings/setup-free-listings/index.js#L172-L186
-	*/
-	useEffect( () => {
-		setPaidAds( ( currentPaidAds ) =>
-			resolveInitialPaidAds( currentPaidAds, targetAudience )
-		);
-	}, [ targetAudience ] );
-
-	if ( ! targetAudience || ! billingStatus ) {
+	if ( ! billingStatus ) {
 		return (
 			<Section>
 				<SpinnerCard />
@@ -124,7 +100,6 @@ export default function PaidAdsSetupSections( { onStatesReceived } ) {
 	}
 
 	const initialValues = {
-		countryCodes: paidAds.countryCodes,
 		amount: paidAds.amount,
 	};
 
@@ -137,17 +112,9 @@ export default function PaidAdsSetupSections( { onStatesReceived } ) {
 			validate={ validateCampaign }
 		>
 			{ ( formProps ) => {
-				const { countryCodes } = formProps.values;
-				const disabledAudience = ! hasGoogleAdsConnection;
-				const disabledBudget =
-					disabledAudience || countryCodes.length === 0;
-
 				return (
-					<BudgetSection
-						formProps={ formProps }
-						disabled={ disabledBudget }
-					>
-						{ ! disabledBudget && <BillingCard /> }
+					<BudgetSection formProps={ formProps }>
+						<BillingCard />
 					</BudgetSection>
 				);
 			} }

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
@@ -53,7 +53,7 @@ function resolveInitialPaidAds( paidAds ) {
  *
  * @param {Object} props React props.
  * @param {(onStatesReceived: PaidAdsData)=>void} props.onStatesReceived Callback to receive the data for setting up paid ads when initial and also when the budget and billing are updated.
- * @param {Array<CountryCode>} [props.countryCodes] Country codes for the campaign.
+ * @param {Array<CountryCode>} props.countryCodes Country codes for the campaign.
  */
 export default function PaidAdsSetupSections( {
 	onStatesReceived,

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/paid-ads-setup-sections.js
@@ -17,6 +17,10 @@ import clientSession from './clientSession';
 import { GOOGLE_ADS_BILLING_STATUS } from '.~/constants';
 
 /**
+ * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ */
+
+/**
  * @typedef {Object} PaidAdsData
  * @property {number|undefined} amount Daily average cost of the paid ads campaign.
  * @property {boolean} isValid Whether the campaign data are valid values.
@@ -49,8 +53,12 @@ function resolveInitialPaidAds( paidAds ) {
  *
  * @param {Object} props React props.
  * @param {(onStatesReceived: PaidAdsData)=>void} props.onStatesReceived Callback to receive the data for setting up paid ads when initial and also when the budget and billing are updated.
+ * @param {Array<CountryCode>} [props.countryCodes] Country codes for the campaign.
  */
-export default function PaidAdsSetupSections( { onStatesReceived } ) {
+export default function PaidAdsSetupSections( {
+	onStatesReceived,
+	countryCodes,
+} ) {
 	const { billingStatus } = useGoogleAdsAccountBillingStatus();
 
 	const onStatesReceivedRef = useRef();
@@ -113,7 +121,10 @@ export default function PaidAdsSetupSections( { onStatesReceived } ) {
 		>
 			{ ( formProps ) => {
 				return (
-					<BudgetSection formProps={ formProps }>
+					<BudgetSection
+						formProps={ formProps }
+						countryCodes={ countryCodes }
+					>
 						<BillingCard />
 					</BudgetSection>
 				);

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -15,6 +15,7 @@ import useAdminUrl from '.~/hooks/useAdminUrl';
 import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
 import useAdsSetupCompleteCallback from '.~/hooks/useAdsSetupCompleteCallback';
+import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
 import StepContent from '.~/components/stepper/step-content';
 import StepContentHeader from '.~/components/stepper/step-content-header';
 import StepContentFooter from '.~/components/stepper/step-content-footer';
@@ -69,6 +70,7 @@ const ACTION_SKIP = 'skip-ads';
 export default function SetupPaidAds() {
 	const adminUrl = useAdminUrl();
 	const { createNotice } = useDispatchCoreNotices();
+	const { data: countryCodes } = useTargetAudienceFinalCountryCodes();
 	const { googleAdsAccount, hasGoogleAdsConnection } = useGoogleAdsAccount();
 	const [ handleSetupComplete ] = useAdsSetupCompleteCallback();
 	const [ showPaidAdsSetup, setShowPaidAdsSetup ] = useState( () =>
@@ -112,7 +114,7 @@ export default function SetupPaidAds() {
 		const onBeforeFinish = handleSetupComplete.bind(
 			null,
 			paidAds.amount,
-			paidAds.countryCodes
+			countryCodes
 		);
 		await finishOnboardingSetup( event, onBeforeFinish );
 	};
@@ -215,7 +217,7 @@ export default function SetupPaidAds() {
 						eventName="gla_onboarding_complete_with_paid_ads_button_click"
 						eventProps={ {
 							budget: paidAds.amount,
-							audiences: paidAds.countryCodes?.join( ',' ),
+							audiences: countryCodes?.join( ',' ),
 						} }
 					/>
 				</Flex>

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -193,7 +193,10 @@ export default function SetupPaidAds() {
 				}
 			/>
 			{ showPaidAdsSetup && (
-				<PaidAdsSetupSections onStatesReceived={ setPaidAds } />
+				<PaidAdsSetupSections
+					onStatesReceived={ setPaidAds }
+					countryCodes={ countryCodes }
+				/>
 			) }
 			<FaqsSection />
 			<StepContentFooter hidden={ ! showPaidAdsSetup }>

--- a/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
+++ b/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
@@ -183,17 +183,6 @@ test.describe( 'Complete your campaign', () => {
 			} );
 
 			test.describe( 'Setup up ads to a Google Ads account', () => {
-				test( 'should see "Ads audience" section is enabled', async () => {
-					const adsAudienceSection =
-						completeCampaign.getAdsAudienceSection();
-					await expect( adsAudienceSection ).toBeVisible();
-
-					// Confirm that the section title contains the correct text.
-					await expect(
-						adsAudienceSection.locator( 'h1' )
-					).toContainText( 'Ads audience' );
-				} );
-
 				test( 'should see "Set your budget" section is enabled', async () => {
 					const budgetSection = completeCampaign.getBudgetSection();
 					await expect( budgetSection ).toBeVisible();
@@ -217,78 +206,6 @@ test.describe( 'Complete your campaign', () => {
 			test.beforeAll( async () => {
 				await setupAdsAccountPage.mockAdsAccountConnected();
 				await completeCampaign.goto();
-			} );
-
-			test.describe( 'Select audience', () => {
-				test( 'should see only three country tags in country input search box', async () => {
-					const countrySearchBoxContainer =
-						getCountryInputSearchBoxContainer( page );
-					const countryTags =
-						getCountryTagsFromInputSearchBoxContainer( page );
-					await expect( countryTags ).toHaveCount( 3 );
-					await expect( countrySearchBoxContainer ).toContainText(
-						'United States'
-					);
-					await expect( countrySearchBoxContainer ).toContainText(
-						'Taiwan'
-					);
-					await expect( countrySearchBoxContainer ).toContainText(
-						'United Kingdom'
-					);
-				} );
-
-				test( 'should only allow searching for the same set of the countries selected in step 2, which is returned by target audience API', async () => {
-					const treeSelectMenu = getTreeSelectMenu( page );
-
-					await fillCountryInSearchBox( page, 'United States' );
-					await expect( treeSelectMenu ).toBeVisible();
-
-					await fillCountryInSearchBox( page, 'United Kingdom' );
-					await expect( treeSelectMenu ).toBeVisible();
-
-					await fillCountryInSearchBox( page, 'Taiwan' );
-					await expect( treeSelectMenu ).toBeVisible();
-
-					await fillCountryInSearchBox( page, 'Japan' );
-					await expect( treeSelectMenu ).not.toBeVisible();
-
-					await fillCountryInSearchBox( page, 'Spain' );
-					await expect( treeSelectMenu ).not.toBeVisible();
-				} );
-
-				test( 'should see the budget recommendation value changed, and see the budget recommendation request is triggered when changing the ads audience', async () => {
-					let textContent = await setupBudgetPage
-						.getBudgetRecommendationTextRow()
-						.textContent();
-
-					const textBeforeRemoveCountry =
-						setupBudgetPage.extractBudgetRecommendationValue(
-							textContent
-						);
-
-					const responsePromise =
-						setupBudgetPage.registerBudgetRecommendationResponse();
-
-					await removeCountryFromSearchBox(
-						page,
-						'United Kingdom (UK)'
-					);
-
-					await responsePromise;
-
-					textContent = await setupBudgetPage
-						.getBudgetRecommendationTextRow()
-						.textContent();
-
-					const textAfterRemoveCountry =
-						setupBudgetPage.extractBudgetRecommendationValue(
-							textContent
-						);
-
-					await expect( textBeforeRemoveCountry ).not.toBe(
-						textAfterRemoveCountry
-					);
-				} );
 			} );
 
 			test.describe( 'Set up budget', () => {

--- a/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
+++ b/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
@@ -11,13 +11,8 @@ import CompleteCampaign from '../../utils/pages/setup-mc/step-4-complete-campaig
 import SetupAdsAccountPage from '../../utils/pages/setup-ads/setup-ads-accounts';
 import {
 	checkFAQExpandable,
-	fillCountryInSearchBox,
-	getCountryInputSearchBoxContainer,
-	getCountryTagsFromInputSearchBoxContainer,
 	getFAQPanelTitle,
 	getFAQPanelRow,
-	getTreeSelectMenu,
-	removeCountryFromSearchBox,
 	checkBillingAdsPopup,
 } from '../../utils/page';
 

--- a/tests/e2e/utils/page.js
+++ b/tests/e2e/utils/page.js
@@ -81,17 +81,6 @@ export function getCountryInputSearchBox( page ) {
 }
 
 /**
- * Get tree select menu.
- *
- * @param {import('@playwright/test').Page} page The current page.
- *
- * @return {import('@playwright/test').Locator} Get tree select menu.
- */
-export function getTreeSelectMenu( page ) {
-	return page.locator( '.woocommerce-tree-select-control__main' );
-}
-
-/**
  * Get tree item by country name.
  *
  * @param {import('@playwright/test').Page} page The current page.

--- a/tests/e2e/utils/pages/setup-ads/setup-budget.js
+++ b/tests/e2e/utils/pages/setup-ads/setup-budget.js
@@ -13,15 +13,6 @@ export default class SetupBudget extends MockRequests {
 	}
 
 	/**
-	 * Get budget recommendation text row.
-	 *
-	 * @return {import('@playwright/test').Locator} The budget recommendation text row.
-	 */
-	getBudgetRecommendationTextRow() {
-		return this.page.locator( '.components-tip p > em > strong' );
-	}
-
-	/**
 	 * Get budget input.
 	 *
 	 * @return {import('@playwright/test').Locator} The budget input box.
@@ -81,36 +72,6 @@ export default class SetupBudget extends MockRequests {
 	getBillingSetupSuccessSection() {
 		return this.page.locator(
 			'.gla-google-ads-billing-card__success-status'
-		);
-	}
-
-	/**
-	 * Extract budget recommendation value.
-	 *
-	 * @param {string} text
-	 *
-	 * @return {string} The budget recommendation value.
-	 */
-	extractBudgetRecommendationValue( text ) {
-		const match = text.match( /set a daily budget of (\d+)/ );
-		if ( match ) {
-			return match[ 1 ];
-		}
-		return '';
-	}
-
-	/**
-	 * Register the responses when removing an ads audience.
-	 *
-	 * @return {Promise<import('@playwright/test').Response>} The response.
-	 */
-	registerBudgetRecommendationResponse() {
-		return this.page.waitForResponse(
-			( response ) =>
-				response
-					.url()
-					.includes( '/gla/ads/campaigns/budget-recommendation' ) &&
-				response.status() === 200
 		);
 	}
 

--- a/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
+++ b/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
@@ -47,15 +47,6 @@ export default class CompleteCampaign extends MockRequests {
 	}
 
 	/**
-	 * Get ads audience section.
-	 *
-	 * @return {import('@playwright/test').Locator} Get ads audience section.
-	 */
-	getAdsAudienceSection() {
-		return this.getSections().nth( 1 );
-	}
-
-	/**
 	 * Get budget section.
 	 *
 	 * @return {import('@playwright/test').Locator} Get budget section.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2501 

* Removed the `AudienceSection` from the `PaidAdsSetupSections` component.
* The `countryCodes` prop in the `paidAds` state variable is now initialized with the values of `targetAudience` which itself contains the values from the second step of the onboarding process.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go through the onboarding flow.
2. Note the countries selected in Step 2 in the **Audience** section (**Location**). You can choose specific countries or all countries.
3. On the fourth step of the flow, there should not longer be the "Ads Audience" section. (Refer to the [screenshot in the ticket description](https://github.com/woocommerce/google-listings-and-ads/issues/2501))
4. Create a new paid ad.
5. Go to the dashboard and edit the ad which was just created.
6. Check if the countries displayed match those which were selected in Step 2 of the onboarding process.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Update - Remove ads audience field from paid ads setup during onboarding.
