### PR TITLE
Update 'Linked accounts' to include Google Ads

### DIFF
--- a/js/src/settings/linked-accounts-section-wrapper.js
+++ b/js/src/settings/linked-accounts-section-wrapper.js
@@ -13,7 +13,7 @@ export default function LinkedAccountsSectionWrapper( props ) {
 		<Section
 			title={ __( 'Linked accounts', 'google-listings-and-ads' ) }
 			description={ __(
-				'A WordPress.com account, Google account, and Google Merchant Center account are required to use this extension in WooCommerce.',
+				'A WordPress.com account, Google account, Google Merchant Center account, and Google Ads account are required to use this extension in WooCommerce.',
 				'google-listings-and-ads'
 			) }
 			{ ...props }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2541.

Google Ads have been added to the description.


### Screenshots:

Before: 
Text: **A WordPress.com account, Google account, and Google Merchant Center account are required to use this extension in WooCommerce.**
![image](https://github.com/user-attachments/assets/87d12232-934c-4a8b-9dda-19639548cf6a)

After: 
Text: **A WordPress.com account, Google account, Google Merchant Center account, and Google Ads account are required to use this extension in WooCommerce.**
![Screenshot 2024-08-22 at 12 26 05](https://github.com/user-attachments/assets/0f5ca61d-8aa8-4ee1-b055-b3c9b457e33b)

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Start onboarding process 1st step. Under `Linked Accounts` check the text.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Update the copy in the "Linked accounts" of the accounts connection setting to include Google Ads account.
