### PR TITLE
Use a fixed SKU number when testing product adapter

### DIFF
--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -487,7 +487,12 @@ trait ProductTrait {
 	 * @return WCProductAdapter The adapted products with the rules applied.
 	 */
 	protected function generate_attribute_mapping_adapted_product( $rules, $categories = [] ) {
-		$product = WC_Helper_Product::create_simple_product( false );
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'sku' => 'Mapped Product SKU',
+			]
+		);
 
 		$attributes = [
 			WC_Helper_Product::create_product_attribute_object( 'size', [ 's', 'xs' ] ),

--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -112,7 +112,7 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
 		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
 
-		$this->assertEquals( 'DUMMY SKU', $adapted_product->getGtin() );
+		$this->assertEquals( 'Mapped Product SKU', $adapted_product->getGtin() );
 		$this->assertEquals( 'DUMMY SKU VARIABLE HUGE BLUE ANY NUMBER', $adapted_variation->getGtin() );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The [change here](https://github.com/woocommerce/woocommerce/pull/47476/files#diff-20a66246abc2143df44116e1fcb439eba54a6420cba941ce82773812760abcc2R49) introduced in WC 9.2, adds a numeric suffix to the SKU when generating products. This is only a default value if the property is not set. So this PR passes a fixed SKU when generating the product so it will be consistent when we compare it in the test results.

Closes #2556 

### Detailed test instructions:

1. Install latest versions for unit testing `bin/install-wp-tests.sh <db_name> <db_user> <db_pass>`
2. Run unit tests `vendor/bin/phpunit`
3. Confirm that the test `test_maps_rules_product_fields_sku` no longer fails
4. Check the [unit tests in this PR](https://github.com/woocommerce/google-listings-and-ads/actions/runs/10508327502/job/29111986851?pr=2559) against the latest version of WC and ensure it passes

### Changelog entry

* Dev - Use a fixed SKU number when testing product adapter.
