### PR TITLE
Align namespaces for unit tests

### DIFF
--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsSyncControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsSyncControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsSyncController;
@@ -12,7 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Class SettingsSyncControllerTest
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
  */
 class SettingsSyncControllerTest extends RESTControllerUnitTest {
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeBatchControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeBatchControllerTest.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ShippingTimeBatchController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;

--- a/tests/Unit/Assets/ScriptAssetTest.php
+++ b/tests/Unit/Assets/ScriptAssetTest.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Assets;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\ScriptAsset;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidAsset;
 use PHPUnit\Framework\TestCase;
 
 class ScriptAssetTest extends TestCase {

--- a/tests/Unit/DB/Table/BudgetRecommendationTableTest.php
+++ b/tests/Unit/DB/Table/BudgetRecommendationTableTest.php
@@ -12,7 +12,7 @@ use wpdb;
 /**
  * Class MigratorTest
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB\Migration
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB\Table
  */
 class BudgetRecommendationTableTest extends UnitTest {
 

--- a/tests/Unit/DB/Table/MerchantIssueTableTest.php
+++ b/tests/Unit/DB/Table/MerchantIssueTableTest.php
@@ -12,7 +12,7 @@ use wpdb;
 /**
  * Class MerchantIssueTableTest
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB\Migration
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB\Table
  */
 class MerchantIssueTableTest extends UnitTest {
 

--- a/tests/Unit/Google/GoogleHelperTest.php
+++ b/tests/Unit/Google/GoogleHelperTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Class GoogleHelperTest
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Google
  */
 class GoogleHelperTest extends UnitTest {
 

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Integration;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
@@ -19,7 +19,7 @@ use WP_REST_Response;
 /**
  * Class WPCOMProxyTest
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Integration
  */
 class WPCOMProxyTest extends RESTControllerUnitTest {
 

--- a/tests/Unit/Product/Attributes/AbstractAttributeTest.php
+++ b/tests/Unit/Product/Attributes/AbstractAttributeTest.php
@@ -11,7 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 /**
  * Class AbstractAttributeTest
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\Attributes
  */
 class AbstractAttributeTest extends UnitTest {
 	public function test_casts_value_based_on_value_type() {

--- a/tests/Unit/Product/Attributes/AttributeManagerTest.php
+++ b/tests/Unit/Product/Attributes/AttributeManagerTest.php
@@ -21,7 +21,7 @@ use WC_Helper_Product;
 /**
  * Class AttributeManagerTest
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\Attributes
  */
 class AttributeManagerTest extends ContainerAwareUnitTest {
 

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -12,7 +12,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUn
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
 use WC_Helper_Product;
 use WC_Product;
 

--- a/tests/Unit/TaskList/CompleteSetupTaskTest.php
+++ b/tests/Unit/TaskList/CompleteSetupTaskTest.php
@@ -1,7 +1,7 @@
 <?php
 declare( strict_types=1 );
 
-namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\tasks;
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\TaskList;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;

--- a/tests/Unit/View/PHPViewFactoryTest.php
+++ b/tests/Unit/View/PHPViewFactoryTest.php
@@ -12,7 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\View\ViewException;
 /**
  * Class PHPViewFactoryTest
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\View
  */
 class PHPViewFactoryTest extends UnitTest {
 

--- a/tests/Unit/View/PHPViewTest.php
+++ b/tests/Unit/View/PHPViewTest.php
@@ -12,7 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\View\ViewException;
 /**
  * Class PHPViewTest
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Utility
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\View
  */
 class PHPViewTest extends UnitTest {
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There were several copy and paste errors for the namespaces being used in Unit tests. Because there were no conflicts this isn't a big deal, but this PR ensures the correct namespace is being used for each test. I also removed some unused import lines.

### Detailed test instructions:
1. Install latest versions for unit testing `bin/install-wp-tests.sh <db_name> <db_user> <db_pass>`
2. Run unit tests `vendor/bin/phpunit`
3. Confirm that all tests continue to pass without issues


### Changelog entry
* Dev - Align namespaces for unit tests.
