### PR TITLE
Streamline campaign setup: Add confirmation modal when user skips without creating campaign during onboarding

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/constants.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/constants.js
@@ -1,0 +1,2 @@
+export const ACTION_COMPLETE = 'complete-ads';
+export const ACTION_SKIP = 'skip-ads';

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -167,7 +167,6 @@ export default function SetupPaidAds() {
 		return (
 			<AppButton
 				isTertiary
-				data-action={ ACTION_SKIP }
 				text={ text }
 				loading={ completing === ACTION_SKIP }
 				disabled={ disabledSkip }

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -212,7 +212,7 @@ export default function SetupPaidAds() {
 			{ showSkipPaidAdsConfirmationModal && (
 				<SkipPaidAdsConfirmationModal
 					onRequestClose={ handleCancelSkipConfirmationClick }
-					onSkipConfirmation={ handleCompleteClick }
+					onSkipConfirmation={ finishOnboardingSetup }
 					isProcessing={ !! completing }
 				/>
 			) }

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -22,13 +22,12 @@ import FaqsSection from '.~/components/paid-ads/faqs-section';
 import AppButton from '.~/components/app-button';
 import PaidAdsFeaturesSection from './paid-ads-features-section';
 import PaidAdsSetupSections from './paid-ads-setup-sections';
+import SkipPaidAdsConfirmationModal from './skip-paid-ads-confirmation-modal';
 import { getProductFeedUrl } from '.~/utils/urls';
 import clientSession from './clientSession';
 import { API_NAMESPACE, STORE_KEY } from '.~/data/constants';
 import { GUIDE_NAMES } from '.~/constants';
-
-const ACTION_COMPLETE = 'complete-ads';
-const ACTION_SKIP = 'skip-ads';
+import { ACTION_COMPLETE, ACTION_SKIP } from './constants';
 
 /**
  * Clicking on the "Create a paid ad campaign" button to open the paid ads setup in the onboarding flow.
@@ -76,6 +75,10 @@ export default function SetupPaidAds() {
 	);
 	const [ paidAds, setPaidAds ] = useState( {} );
 	const [ completing, setCompleting ] = useState( null );
+	const [
+		showSkipPaidAdsConfirmationModal,
+		setShowSkipPaidAdsConfirmationModal,
+	] = useState( false );
 
 	const handleContinuePaidAdsSetupClick = () => {
 		setShowPaidAdsSetup( true );
@@ -117,6 +120,14 @@ export default function SetupPaidAds() {
 		await finishOnboardingSetup( event, onBeforeFinish );
 	};
 
+	const handleSkipModal = () => {
+		setShowSkipPaidAdsConfirmationModal( true );
+	};
+
+	const handleCancelSkipConfirmationClick = () => {
+		setShowSkipPaidAdsConfirmationModal( false );
+	};
+
 	// The status check of Google Ads account connection is included in `paidAds.isReady`,
 	// because when there is no connected account, it will disable the budget section and set the `amount` to `undefined`.
 	const disabledComplete = completing === ACTION_SKIP || ! paidAds.isReady;
@@ -150,7 +161,10 @@ export default function SetupPaidAds() {
 				text={ text }
 				loading={ completing === ACTION_SKIP }
 				disabled={ disabledSkip }
-				onClick={ finishOnboardingSetup }
+				onClick={
+					// Show the skip modal only for the "Skip this step for now" button only.
+					showPaidAdsSetup ? finishOnboardingSetup : handleSkipModal
+				}
 				eventName="gla_onboarding_complete_button_click"
 				eventProps={ eventProps }
 			/>
@@ -194,6 +208,15 @@ export default function SetupPaidAds() {
 				<PaidAdsSetupSections onStatesReceived={ setPaidAds } />
 			) }
 			<FaqsSection />
+
+			{ showSkipPaidAdsConfirmationModal && (
+				<SkipPaidAdsConfirmationModal
+					onRequestClose={ handleCancelSkipConfirmationClick }
+					onSkipConfirmation={ handleCompleteClick }
+					isProcessing={ !! completing }
+				/>
+			) }
+
 			<StepContentFooter hidden={ ! showPaidAdsSetup }>
 				<Flex justify="right" gap={ 4 }>
 					{ createSkipButton(

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -120,11 +120,11 @@ export default function SetupPaidAds() {
 		await finishOnboardingSetup( event, onBeforeFinish );
 	};
 
-	const handleSkipModal = () => {
+	const handleShowSkipPaidAdsConfirmationModal = () => {
 		setShowSkipPaidAdsConfirmationModal( true );
 	};
 
-	const handleCancelSkipConfirmationClick = () => {
+	const handleCancelSkipPaidAdsClick = () => {
 		setShowSkipPaidAdsConfirmationModal( false );
 	};
 
@@ -163,8 +163,11 @@ export default function SetupPaidAds() {
 				disabled={ disabledSkip }
 				onClick={
 					// Show the skip modal only for the "Skip this step for now" button only.
-					showPaidAdsSetup ? finishOnboardingSetup : handleSkipModal
+					showPaidAdsSetup
+						? finishOnboardingSetup
+						: handleShowSkipPaidAdsConfirmationModal
 				}
+				// TODO: might want to review eventName and eventProps
 				eventName="gla_onboarding_complete_button_click"
 				eventProps={ eventProps }
 			/>
@@ -211,7 +214,7 @@ export default function SetupPaidAds() {
 
 			{ showSkipPaidAdsConfirmationModal && (
 				<SkipPaidAdsConfirmationModal
-					onRequestClose={ handleCancelSkipConfirmationClick }
+					onRequestClose={ handleCancelSkipPaidAdsClick }
 					onSkipConfirmation={ finishOnboardingSetup }
 					isProcessing={ !! completing }
 				/>

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/setup-paid-ads.js
@@ -161,13 +161,9 @@ export default function SetupPaidAds() {
 				text={ text }
 				loading={ completing === ACTION_SKIP }
 				disabled={ disabledSkip }
-				onClick={
-					// Show the skip modal only for the "Skip this step for now" button only.
-					showPaidAdsSetup
-						? finishOnboardingSetup
-						: handleShowSkipPaidAdsConfirmationModal
-				}
-				// TODO: might want to review eventName and eventProps
+				onClick={ handleShowSkipPaidAdsConfirmationModal }
+				// TODO: Review eventName and eventProps
+				// The same eventName and eventProps has been copied over to the "Confirm" button in the SkipPaidAdsConfirmationModal component.
 				eventName="gla_onboarding_complete_button_click"
 				eventProps={ eventProps }
 			/>
@@ -217,6 +213,8 @@ export default function SetupPaidAds() {
 					onRequestClose={ handleCancelSkipPaidAdsClick }
 					onSkipConfirmation={ finishOnboardingSetup }
 					isProcessing={ !! completing }
+					showPaidAdsSetup={ showPaidAdsSetup }
+					paidAds={ paidAds }
 				/>
 			) }
 

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/skip-paid-ads-confirmation-modal.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/skip-paid-ads-confirmation-modal.js
@@ -80,7 +80,10 @@ const SkipPaidAdsConfirmationModal = ( {
 					eventProps={ eventProps }
 					isPrimary
 				>
-					{ __( 'Complete setup', 'google-listings-and-ads' ) }
+					{ __(
+						'Complete setup without setting up ads',
+						'google-listings-and-ads'
+					) }
 				</AppButton>,
 			] }
 			onRequestClose={ onRequestClose }

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/skip-paid-ads-confirmation-modal.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/skip-paid-ads-confirmation-modal.js
@@ -14,15 +14,10 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
 import { ACTION_SKIP } from './constants';
 
 /**
- * Triggered when the request review is successful
+ * Triggered when the skip button is clicked
+ * // TODO: to review
  *
- * @event gla_request_review_success
- */
-
-/**
- * Triggered when the request review fails
- *
- * @event gla_request_review_failure
+ * @event gla_skip_paid_ads_modal_confirm_button_click
  */
 
 /**
@@ -39,10 +34,6 @@ const SkipPaidAdsConfirmationModal = ( {
 	onSkipConfirmation = noop,
 	isProcessing = false,
 } ) => {
-	const handleSkipConfirmationClick = ( event ) => {
-		onSkipConfirmation( event );
-	};
-
 	return (
 		<AppModal
 			className="gla-ads-skip-paid-ads-modal"
@@ -55,7 +46,7 @@ const SkipPaidAdsConfirmationModal = ( {
 					key="yes"
 					// TODO: confirm the eventName
 					eventName="gla_skip_paid_ads_modal_confirm_button_click"
-					onClick={ handleSkipConfirmationClick }
+					onClick={ onSkipConfirmation }
 					loading={ isProcessing }
 					data-action={ ACTION_SKIP }
 					isPrimary

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/skip-paid-ads-confirmation-modal.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/skip-paid-ads-confirmation-modal.js
@@ -2,9 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { select } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
-import { noop, merge } from 'lodash';
 
 /**
  * Internal dependencies
@@ -12,9 +9,7 @@ import { noop, merge } from 'lodash';
 import AppModal from '.~/components/app-modal';
 import AppButton from '.~/components/app-button';
 import AppDocumentationLink from '.~/components/app-documentation-link';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
 import { ACTION_SKIP } from './constants';
-import { STORE_KEY } from '.~/data/constants';
 
 /**
  * Triggered when the skip button is clicked
@@ -24,47 +19,23 @@ import { STORE_KEY } from '.~/data/constants';
  */
 
 /**
+ * @fires gla_documentation_link_click with `{ context: 'skip-paid-ads-modal', link_id: 'paid-ads-with-performance-max-campaigns-learn-more', href: 'https://support.google.com/google-ads/answer/10724817' }`
+ */
+
+/**
  * Renders a modal dialog that confirms whether the user wants to skip setting up paid ads.
  * It provides information about the benefits of enabling Performance Max and includes a link to learn more.
  *
  * @param {Object} props React props.
- * @param {Function} props.onRequestClose Function to be called when the modal should be closed. Defaults to a no-op function.
- * @param {Function} props.onSkipConfirmation Function to be called when the user confirms skipping the paid ads setup. Defaults to a no-op function.
- * @param {boolean} [props.isProcessing=false] Indicates whether a process is currently running (e.g., the confirmation is being processed). If true, the confirmation button will show a loading state.
- * @param {boolean} [props.showPaidAdsSetup=false] Indicates whether the paid ads setup is currently shown. If true, additional event properties will be included in the eventProps.
- * @param {Object} [props.paidAds={}] The paid ads data, including the campaign form data and validation status.
+ * @param {Function} props.onRequestClose Function to be called when the modal should be closed.
+ * @param {Function} props.onSkipCreatePaidAds Function to be called when the user confirms skipping the paid ads setup.
  */
 const SkipPaidAdsConfirmationModal = ( {
-	onRequestClose = noop,
-	onSkipConfirmation = noop,
-	isProcessing = false,
-	showPaidAdsSetup = false,
-	paidAds = {},
+	onRequestClose,
+	onSkipCreatePaidAds,
 } ) => {
-	const { googleAdsAccount } = useGoogleAdsAccount();
-
-	const eventProps = {
-		opened_paid_ads_setup: 'no',
-		google_ads_account_status: googleAdsAccount?.status,
-		billing_method_status: 'unknown',
-		campaign_form_validation: 'unknown',
-	};
-
-	// TODO: Review once https://github.com/woocommerce/google-listings-and-ads/issues/2500 is merged
-	if ( showPaidAdsSetup ) {
-		const selector = select( STORE_KEY );
-		const billing = selector.getGoogleAdsAccountBillingStatus();
-
-		merge( eventProps, {
-			opened_paid_ads_setup: 'yes',
-			billing_method_status: billing?.status,
-			campaign_form_validation: paidAds.isValid ? 'valid' : 'invalid',
-		} );
-	}
-
 	return (
 		<AppModal
-			className="gla-ads-skip-paid-ads-modal"
 			title={ __( 'Skip setting up ads?', 'google-listings-and-ads' ) }
 			buttons={ [
 				<AppButton key="cancel" isSecondary onClick={ onRequestClose }>
@@ -72,12 +43,8 @@ const SkipPaidAdsConfirmationModal = ( {
 				</AppButton>,
 				<AppButton
 					key="complete-setup"
-					// TODO: confirm the eventName
-					eventName="gla_onboarding_complete_button_click"
-					onClick={ onSkipConfirmation }
-					loading={ isProcessing }
+					onClick={ onSkipCreatePaidAds }
 					data-action={ ACTION_SKIP }
-					eventProps={ eventProps }
 					isPrimary
 				>
 					{ __(
@@ -101,22 +68,16 @@ const SkipPaidAdsConfirmationModal = ( {
 				) }
 			</p>
 			<p>
-				{ createInterpolateElement(
-					__(
-						'<Link>Learn more about Performance Max.</Link>',
+				<AppDocumentationLink
+					href="https://support.google.com/google-ads/answer/10724817"
+					context="skip-paid-ads-modal"
+					linkId="paid-ads-with-performance-max-campaigns-learn-more"
+				>
+					{ __(
+						'Learn more about Performance Max.',
 						'google-listings-and-ads'
-					),
-					{
-						Link: (
-							<AppDocumentationLink
-								href="https://support.google.com/google-ads/answer/10724817"
-								// TODO: review context and linkId values
-								context="skip-paid-ads-modal"
-								linkId="skip-paid-ads-modal-learn-more-performance-max"
-							/>
-						),
-					}
-				) }
+					) }
+				</AppDocumentationLink>
 			</p>
 		</AppModal>
 	);

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/skip-paid-ads-confirmation-modal.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/skip-paid-ads-confirmation-modal.js
@@ -12,13 +12,6 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
 import { ACTION_SKIP } from './constants';
 
 /**
- * Triggered when the skip button is clicked
- * // TODO: to review
- *
- * @event gla_onboarding_complete_button_click
- */
-
-/**
  * @fires gla_documentation_link_click with `{ context: 'skip-paid-ads-modal', link_id: 'paid-ads-with-performance-max-campaigns-learn-more', href: 'https://support.google.com/google-ads/answer/10724817' }`
  */
 

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/skip-paid-ads-confirmation-modal.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/skip-paid-ads-confirmation-modal.js
@@ -11,7 +11,7 @@ import { noop } from 'lodash';
 import AppModal from '.~/components/app-modal';
 import AppButton from '.~/components/app-button';
 import AppDocumentationLink from '.~/components/app-documentation-link';
-import { ACTION_COMPLETE } from './constants';
+import { ACTION_SKIP } from './constants';
 
 /**
  * Triggered when the request review is successful
@@ -53,10 +53,11 @@ const SkipPaidAdsConfirmationModal = ( {
 				</AppButton>,
 				<AppButton
 					key="yes"
+					// TODO: confirm the eventName
 					eventName="gla_skip_paid_ads_modal_confirm_button_click"
 					onClick={ handleSkipConfirmationClick }
 					loading={ isProcessing }
-					data-action={ ACTION_COMPLETE }
+					data-action={ ACTION_SKIP }
 					isPrimary
 				>
 					{ __( 'Yes', 'google-listings-and-ads' ) }
@@ -86,6 +87,7 @@ const SkipPaidAdsConfirmationModal = ( {
 						Link: (
 							<AppDocumentationLink
 								href="https://support.google.com/google-ads/answer/10724817"
+								// TODO: review context and linkId values
 								context="skip-paid-ads-modal"
 								linkId="skip-paid-ads-modal-learn-more-performance-max"
 							/>

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads/skip-paid-ads-confirmation-modal.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads/skip-paid-ads-confirmation-modal.js
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import AppModal from '.~/components/app-modal';
+import AppButton from '.~/components/app-button';
+import AppDocumentationLink from '.~/components/app-documentation-link';
+import { ACTION_COMPLETE } from './constants';
+
+/**
+ * Triggered when the request review is successful
+ *
+ * @event gla_request_review_success
+ */
+
+/**
+ * Triggered when the request review fails
+ *
+ * @event gla_request_review_failure
+ */
+
+/**
+ * Renders a modal dialog that confirms whether the user wants to skip setting up paid ads.
+ * It provides information about the benefits of enabling Performance Max and includes a link to learn more.
+ *
+ * @param {Object} props React props.
+ * @param {Function} props.onRequestClose Function to be called when the modal should be closed. Defaults to a no-op function.
+ * @param {Function} props.onSkipConfirmation Function to be called when the user confirms skipping the paid ads setup. Defaults to a no-op function.
+ * @param {boolean} [props.isProcessing=false] Indicates whether a process is currently running (e.g., the confirmation is being processed). If true, the confirmation button will show a loading state.
+ */
+const SkipPaidAdsConfirmationModal = ( {
+	onRequestClose = noop,
+	onSkipConfirmation = noop,
+	isProcessing = false,
+} ) => {
+	const handleSkipConfirmationClick = ( event ) => {
+		onSkipConfirmation( event );
+	};
+
+	return (
+		<AppModal
+			className="gla-ads-skip-paid-ads-modal"
+			title={ __( 'Skip setting up ads?', 'google-listings-and-ads' ) }
+			buttons={ [
+				<AppButton key="no" isSecondary onClick={ onRequestClose }>
+					{ __( 'No', 'google-listings-and-ads' ) }
+				</AppButton>,
+				<AppButton
+					key="yes"
+					eventName="gla_skip_paid_ads_modal_confirm_button_click"
+					onClick={ handleSkipConfirmationClick }
+					loading={ isProcessing }
+					data-action={ ACTION_COMPLETE }
+					isPrimary
+				>
+					{ __( 'Yes', 'google-listings-and-ads' ) }
+				</AppButton>,
+			] }
+			onRequestClose={ onRequestClose }
+		>
+			<p>
+				{ __(
+					'Enabling Performance Max is highly recommended to drive more sales and reach new audiences across Google channels like Search, YouTube and Discover.',
+					'google-listings-and-ads'
+				) }
+			</p>
+			<p>
+				{ __(
+					'Performance Max uses the best of Google’s AI to show the most impactful ads for your products at the right time and place. Google will use your product data to create ads for this campaign.',
+					'google-listings-and-ads'
+				) }
+			</p>
+			<p>
+				{ createInterpolateElement(
+					__(
+						'<Link>Learn more about Performance Max.</Link>',
+						'google-listings-and-ads'
+					),
+					{
+						Link: (
+							<AppDocumentationLink
+								href="https://support.google.com/google-ads/answer/10724817"
+								context="skip-paid-ads-modal"
+								linkId="skip-paid-ads-modal-learn-more-performance-max"
+							/>
+						),
+					}
+				) }
+			</p>
+		</AppModal>
+	);
+};
+
+export default SkipPaidAdsConfirmationModal;

--- a/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
+++ b/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
@@ -397,7 +397,7 @@ test.describe( 'Complete your campaign', () => {
 				} );
 
 				test( 'should see the url contains product-feed if the user skips', async () => {
-					await completeCampaign.clickYesButton();
+					await completeCampaign.clickCompleteSetupButton();
 					await page.waitForURL( /path=%2Fgoogle%2Fproduct-feed/ );
 					expect( page.url() ).toMatch(
 						/path=%2Fgoogle%2Fproduct-feed/
@@ -408,6 +408,23 @@ test.describe( 'Complete your campaign', () => {
 					const setupSuccessModal =
 						completeCampaign.getSetupSuccessModal();
 					await expect( setupSuccessModal ).toBeVisible();
+				} );
+
+				test( 'should see buttons on Dashboard for Google Ads onboarding', async () => {
+					await page.keyboard.press( 'Escape' );
+					await page
+						.getByRole( 'tab', { name: 'Dashboard' } )
+						.click();
+
+					const buttons = page.getByRole( 'button', {
+						name: 'Add paid campaign',
+					} );
+
+					await expect( buttons ).toHaveCount( 2 );
+					for ( const button of await buttons.all() ) {
+						await expect( button ).toBeVisible();
+						await expect( button ).toBeEnabled();
+					}
 				} );
 			} );
 
@@ -421,7 +438,7 @@ test.describe( 'Complete your campaign', () => {
 				} );
 
 				test( 'should no longer see the confirmation modal', async () => {
-					await completeCampaign.clickNoButton();
+					await completeCampaign.clickCancelModalButton();
 
 					const skipPaidAdsModal =
 						completeCampaign.getSkipPaidAdsCreationModal();
@@ -437,36 +454,22 @@ test.describe( 'Complete your campaign', () => {
 		}
 	);
 
-	test.describe( 'Complete onboarding by "Skip paid ads creation"', () => {
-		test.beforeAll( async () => {
-			await setupAdsAccountPage.mockAdsAccountIncomplete();
-			await completeCampaign.goto();
-			await completeCampaign.clickCreatePaidAdButton();
-			await completeCampaign.clickSkipPaidAdsCreationButon();
-		} );
-
-		test( 'should also see the setup success modal', async () => {
-			const setupSuccessModal = completeCampaign.getSetupSuccessModal();
-			await expect( setupSuccessModal ).toBeVisible();
-		} );
-
-		test( 'should also see the url contains product-feed', async () => {
-			expect( page.url() ).toMatch( /path=%2Fgoogle%2Fproduct-feed/ );
-		} );
-
-		test( 'should see buttons on Dashboard for Google Ads onboarding', async () => {
-			await page.keyboard.press( 'Escape' );
-			await page.getByRole( 'tab', { name: 'Dashboard' } ).click();
-
-			const buttons = page.getByRole( 'button', {
-				name: 'Add paid campaign',
+	// TODO: Should no longer be needed once https://github.com/woocommerce/google-listings-and-ads/issues/2500 is merged.
+	test.describe(
+		'Ask user for confirmation when clicking the "Skip paid ads creation"',
+		() => {
+			test.beforeAll( async () => {
+				await setupAdsAccountPage.mockAdsAccountIncomplete();
+				await completeCampaign.goto();
+				await completeCampaign.clickCreatePaidAdButton();
+				await completeCampaign.clickSkipPaidAdsCreationButon();
 			} );
 
-			await expect( buttons ).toHaveCount( 2 );
-			for ( const button of await buttons.all() ) {
-				await expect( button ).toBeVisible();
-				await expect( button ).toBeEnabled();
-			}
-		} );
-	} );
+			test( 'should see the confirmation modal', async () => {
+				const skipPaidAdsModal =
+					completeCampaign.getSkipPaidAdsCreationModal();
+				await expect( skipPaidAdsModal ).toBeVisible();
+			} );
+		}
+	);
 } );

--- a/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
+++ b/tests/e2e/specs/setup-mc/step-4-complete-campaign.test.js
@@ -397,7 +397,7 @@ test.describe( 'Complete your campaign', () => {
 				} );
 
 				test( 'should see the url contains product-feed if the user skips', async () => {
-					await completeCampaign.clickCompleteSetupButton();
+					await completeCampaign.clickCompleteSetupModalButton();
 					await page.waitForURL( /path=%2Fgoogle%2Fproduct-feed/ );
 					expect( page.url() ).toMatch(
 						/path=%2Fgoogle%2Fproduct-feed/

--- a/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
+++ b/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
@@ -181,47 +181,47 @@ export default class CompleteCampaign extends MockRequests {
 	}
 
 	/**
-	 * Retrieves the "Yes" button from the skip paid ads creation modal.
+	 * Retrieves the "Complete setup" button from the skip paid ads creation modal.
 	 *
-	 * @return {import('@playwright/test').Locator} Locator for the "Yes" button.
+	 * @return {import('@playwright/test').Locator} Locator for the "Complete setup" button.
 	 */
-	getYesButton() {
+	getCompleteSetuModalButton() {
 		return this.page.getByRole( 'button', {
-			name: 'Yes',
+			name: 'Complete setup',
 			exact: true,
 		} );
 	}
 
 	/**
-	 * Clicks the "Yes" button in the skip paid ads creation modal.
+	 * Clicks the "Complete setup" button in the skip paid ads creation modal.
 	 *
 	 * @return {Promise<void>} Resolves when the click action is completed and the page has loaded.
 	 */
-	async clickYesButton() {
-		const button = this.getYesButton();
+	async clickCompleteSetupModalButton() {
+		const button = this.getCompleteSetuModalButton();
 		await button.click();
 		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 	}
 
 	/**
-	 * Retrieves the "No" button from the skip paid ads creation modal.
+	 * Retrieves the "Cancel" button from the skip paid ads creation modal.
 	 *
-	 * @return {import('@playwright/test').Locator} Locator for the "No" button.
+	 * @return {import('@playwright/test').Locator} Locator for the "Cancel" button.
 	 */
-	getNoButton() {
+	getCancelModalButton() {
 		return this.page.getByRole( 'button', {
-			name: 'No',
+			name: 'Cancel',
 			exact: true,
 		} );
 	}
 
 	/**
-	 * Clicks the "No" button in the skip paid ads creation modal.
+	 * Clicks the "Cancel" button in the skip paid ads creation modal.
 	 *
 	 * @return {Promise<void>} Resolves when the click action is completed and the page has loaded.
 	 */
-	async clickNoButton() {
-		const button = this.getNoButton();
+	async clickCancelModalButton() {
+		const button = this.getCancelModalButton();
 		await button.click();
 		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 	}

--- a/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
+++ b/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
@@ -181,19 +181,19 @@ export default class CompleteCampaign extends MockRequests {
 	}
 
 	/**
-	 * Retrieves the "Complete setup" button from the skip paid ads creation modal.
+	 * Retrieves the "Complete setup without setting up ads" button from the skip paid ads creation modal.
 	 *
-	 * @return {import('@playwright/test').Locator} Locator for the "Complete setup" button.
+	 * @return {import('@playwright/test').Locator} Locator for the "Complete setup without setting up ads" button.
 	 */
 	getCompleteSetuModalButton() {
 		return this.page.getByRole( 'button', {
-			name: 'Complete setup',
+			name: 'Complete setup without setting up ads',
 			exact: true,
 		} );
 	}
 
 	/**
-	 * Clicks the "Complete setup" button in the skip paid ads creation modal.
+	 * Clicks the "Complete setup without setting up ads" button in the skip paid ads creation modal.
 	 *
 	 * @return {Promise<void>} Resolves when the click action is completed and the page has loaded.
 	 */

--- a/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
+++ b/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
@@ -179,4 +179,72 @@ export default class CompleteCampaign extends MockRequests {
 			mcSettingsSyncRequestPromise,
 		] );
 	}
+
+	/**
+	 * Retrieves the "Yes" button from the skip paid ads creation modal.
+	 *
+	 * @return {import('@playwright/test').Locator} Locator for the "Yes" button.
+	 */
+	getYesButton() {
+		return this.page.getByRole( 'button', {
+			name: 'Yes',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Clicks the "Yes" button in the skip paid ads creation modal.
+	 *
+	 * @return {Promise<void>} Resolves when the click action is completed and the page has loaded.
+	 */
+	async clickYesButton() {
+		const button = this.getYesButton();
+		await button.click();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Retrieves the "No" button from the skip paid ads creation modal.
+	 *
+	 * @return {import('@playwright/test').Locator} Locator for the "No" button.
+	 */
+	getNoButton() {
+		return this.page.getByRole( 'button', {
+			name: 'No',
+			exact: true,
+		} );
+	}
+
+	/**
+	 * Clicks the "No" button in the skip paid ads creation modal.
+	 *
+	 * @return {Promise<void>} Resolves when the click action is completed and the page has loaded.
+	 */
+	async clickNoButton() {
+		const button = this.getNoButton();
+		await button.click();
+		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+	}
+
+	/**
+	 * Retrieves the skip paid ads creation modal element.
+	 *
+	 * @return {import('@playwright/test').Locator} Locator for the modal containing the text "Skip setting up ads?".
+	 */
+	getSkipPaidAdsCreationModal() {
+		return this.page.locator( '.components-modal__content' ).filter( {
+			hasText: 'Skip setting up ads?',
+		} );
+	}
+
+	/**
+	 * Retrieves the setup success modal element.
+	 *
+	 * @return {import('@playwright/test').Locator} Locator for the modal containing the text "You’ve successfully set up Google for WooCommerce!".
+	 */
+	getSetupSuccessModal() {
+		return this.page.locator( '.components-modal__content' ).filter( {
+			hasText: 'You’ve successfully set up Google for WooCommerce!',
+		} );
+	}
 }

--- a/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
+++ b/tests/e2e/utils/pages/setup-mc/step-4-complete-campaign.js
@@ -218,12 +218,11 @@ export default class CompleteCampaign extends MockRequests {
 	/**
 	 * Clicks the "Cancel" button in the skip paid ads creation modal.
 	 *
-	 * @return {Promise<void>} Resolves when the click action is completed and the page has loaded.
+	 * @return {Promise<void>} Resolves when the click action is completed.
 	 */
 	async clickCancelModalButton() {
 		const button = this.getCancelModalButton();
 		await button.click();
-		await this.page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2504 

_Replace this with a good description of your changes & reasoning._


### Screenshots:
<img width="613" alt="image" src="https://github.com/user-attachments/assets/d94f7b6d-e403-4453-a8ca-4f3a167475cd">




### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go through the onboarding flow.
2. On the fourth step, click on the "Skip this step for now" button.
3. There should be a modal asking the user to confirm if they want to skip.
4. If the user clicks "Yes", the onboarding flow continues and the user is redirected to the dashboard.
5. If the user clicks "No", the modal is no longer displayed and the user stays on the page.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Confirmation modal when user skips without creating a campaign during onboarding.
