### PR TITLE
Limits steps in onboarding based on previously completed state

### DIFF
--- a/js/src/setup-mc/setup-stepper/index.js
+++ b/js/src/setup-mc/setup-stepper/index.js
@@ -9,28 +9,14 @@ import { getHistory, getNewPath } from '@woocommerce/navigation';
 import AppSpinner from '.~/components/app-spinner';
 import SavedSetupStepper from './saved-setup-stepper';
 import useMCSetup from '.~/hooks/useMCSetup';
-import useStoreAddress from '.~/hooks/useStoreAddress';
-import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
 import stepNameKeyMap from './stepNameKeyMap';
 
 const SetupStepper = () => {
 	const { hasFinishedResolution, data: mcSetup } = useMCSetup();
-	const { data: address, loaded: addressLoaded } = useStoreAddress();
-	const { data: phone, loaded: phoneLoaded } = useGoogleMCPhoneNumber();
 
-	const hasValidPhoneNumber =
-		phoneLoaded && phone?.isValid && phone?.isVerified;
-
-	const hasValidAddress =
-		addressLoaded &&
-		address?.isAddressFilled &&
-		! address?.isMCAddressDifferent;
-
-	const hasConfirmedStoreRequirements =
-		hasValidPhoneNumber && hasValidAddress;
-
-	const hasLoaded =
-		hasFinishedResolution && mcSetup && addressLoaded && phoneLoaded;
+	if ( ! hasFinishedResolution && ! mcSetup ) {
+		return <AppSpinner />;
+	}
 
 	if ( hasFinishedResolution && ! mcSetup ) {
 		// this means error occurred, we just need to return null here,
@@ -38,32 +24,14 @@ const SetupStepper = () => {
 		return null;
 	}
 
-	if ( ! hasLoaded ) {
-		return <AppSpinner />;
-	}
-
-	const { status } = mcSetup;
-	const { step } = mcSetup;
-
-	// If the user has already completed the store requirements, but is currently still on the
-	// store requirements step, we should skip the store requirements step and go to the paid ads step.
-	// else they will get stuck on a non-existent step #3
-	const currentStep =
-		step === 'store_requirements' && hasConfirmedStoreRequirements
-			? 'paid_ads'
-			: step;
+	const { status, step } = mcSetup;
 
 	if ( status === 'complete' ) {
 		getHistory().replace( getNewPath( {}, '/google/dashboard' ) );
 		return null;
 	}
 
-	return (
-		<SavedSetupStepper
-			savedStep={ stepNameKeyMap[ currentStep ] }
-			hasConfirmedStoreRequirements={ hasConfirmedStoreRequirements }
-		/>
-	);
+	return <SavedSetupStepper savedStep={ stepNameKeyMap[ step ] } />;
 };
 
 export default SetupStepper;

--- a/js/src/setup-mc/setup-stepper/index.js
+++ b/js/src/setup-mc/setup-stepper/index.js
@@ -12,7 +12,6 @@ import useMCSetup from '.~/hooks/useMCSetup';
 import useStoreAddress from '.~/hooks/useStoreAddress';
 import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
 import stepNameKeyMap from './stepNameKeyMap';
-import { has } from 'lodash';
 
 const SetupStepper = () => {
 	const { hasFinishedResolution, data: mcSetup } = useMCSetup();

--- a/js/src/setup-mc/setup-stepper/index.js
+++ b/js/src/setup-mc/setup-stepper/index.js
@@ -12,6 +12,7 @@ import useMCSetup from '.~/hooks/useMCSetup';
 import useStoreAddress from '.~/hooks/useStoreAddress';
 import useGoogleMCPhoneNumber from '.~/hooks/useGoogleMCPhoneNumber';
 import stepNameKeyMap from './stepNameKeyMap';
+import { has } from 'lodash';
 
 const SetupStepper = () => {
 	const { hasFinishedResolution, data: mcSetup } = useMCSetup();
@@ -43,14 +44,15 @@ const SetupStepper = () => {
 	}
 
 	const { status } = mcSetup;
-	let { step } = mcSetup;
+	const { step } = mcSetup;
 
 	// If the user has already completed the store requirements, but is currently still on the
 	// store requirements step, we should skip the store requirements step and go to the paid ads step.
 	// else they will get stuck on a non-existent step #3
-	if ( step === 'store_requirements' && hasConfirmedStoreRequirements ) {
-		step = 'paid_ads';
-	}
+	const currentStep =
+		step === 'store_requirements' && hasConfirmedStoreRequirements
+			? 'paid_ads'
+			: step;
 
 	if ( status === 'complete' ) {
 		getHistory().replace( getNewPath( {}, '/google/dashboard' ) );
@@ -59,7 +61,7 @@ const SetupStepper = () => {
 
 	return (
 		<SavedSetupStepper
-			savedStep={ stepNameKeyMap[ step ] }
+			savedStep={ stepNameKeyMap[ currentStep ] }
 			hasConfirmedStoreRequirements={ hasConfirmedStoreRequirements }
 		/>
 	);

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
@@ -33,6 +33,7 @@ import {
 /**
  * @param {Object} props React props
  * @param {string} [props.savedStep] A saved step overriding the current step
+ * @param {boolean} [props.hasConfirmedStoreRequirements] Whether the store requirements have been confirmed
  * @fires gla_setup_mc with `{ triggered_by: 'step1-continue-button' | 'step2-continue-button', 'step3-continue-button', action: 'go-to-step2' | 'go-to-step3' | 'go-to-step4' }`.
  * @fires gla_setup_mc with `{ triggered_by: 'stepper-step1-button' | 'stepper-step2-button' | 'stepper-step3-button', action: 'go-to-step1' | 'go-to-step2' | 'go-to-step3' }`.
  */

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
@@ -36,7 +36,10 @@ import {
  * @fires gla_setup_mc with `{ triggered_by: 'step1-continue-button' | 'step2-continue-button', 'step3-continue-button', action: 'go-to-step2' | 'go-to-step3' | 'go-to-step4' }`.
  * @fires gla_setup_mc with `{ triggered_by: 'stepper-step1-button' | 'stepper-step2-button' | 'stepper-step3-button', action: 'go-to-step1' | 'go-to-step2' | 'go-to-step3' }`.
  */
-const SavedSetupStepper = ( { savedStep } ) => {
+const SavedSetupStepper = ( {
+	savedStep,
+	hasConfirmedStoreRequirements = false,
+} ) => {
 	const [ step, setStep ] = useState( savedStep );
 
 	const { settings } = useSettings();
@@ -102,7 +105,11 @@ const SavedSetupStepper = ( { savedStep } ) => {
 	};
 
 	const handleSetupListingsContinue = () => {
-		continueStep( stepNameKeyMap.store_requirements );
+		if ( hasConfirmedStoreRequirements ) {
+			continueStep( stepNameKeyMap.paid_ads );
+		} else {
+			continueStep( stepNameKeyMap.store_requirements );
+		}
 	};
 
 	const handleStoreRequirementsContinue = () => {
@@ -209,19 +216,25 @@ const SavedSetupStepper = ( { savedStep } ) => {
 					),
 					onClick: handleStepClick,
 				},
-				{
-					key: stepNameKeyMap.store_requirements,
-					label: __(
-						'Confirm store requirements',
-						'google-listings-and-ads'
-					),
-					content: (
-						<StoreRequirements
-							onContinue={ handleStoreRequirementsContinue }
-						/>
-					),
-					onClick: handleStepClick,
-				},
+				...( ! hasConfirmedStoreRequirements
+					? [
+							{
+								key: stepNameKeyMap.store_requirements,
+								label: __(
+									'Confirm store requirements',
+									'google-listings-and-ads'
+								),
+								content: (
+									<StoreRequirements
+										onContinue={
+											handleStoreRequirementsContinue
+										}
+									/>
+								),
+								onClick: handleStepClick,
+							},
+					  ]
+					: [] ),
 				{
 					key: stepNameKeyMap.paid_ads,
 					label: __( 'Create a campaign', 'google-listings-and-ads' ),

--- a/tests/e2e/specs/setup-mc/step-3-hide-store-requirements.test.js
+++ b/tests/e2e/specs/setup-mc/step-3-hide-store-requirements.test.js
@@ -1,0 +1,81 @@
+/**
+ * Internal dependencies
+ */
+import SetUpAccountsPage from '../../utils/pages/setup-mc/step-1-set-up-accounts';
+
+/**
+ * External dependencies
+ */
+const { test, expect } = require( '@playwright/test' );
+
+test.use( { storageState: process.env.ADMINSTATE } );
+
+test.describe.configure( { mode: 'serial' } );
+
+/**
+ * @type {import('../../utils/pages/setup-mc/step-1-set-up-accounts.js').default} setUpAccountsPage
+ */
+let setUpAccountsPage = null;
+
+/**
+ * @type {import('@playwright/test').Page} page
+ */
+let page = null;
+
+test.describe( 'Hide Store Requirements Step', () => {
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		setUpAccountsPage = new SetUpAccountsPage( page );
+		await Promise.all( [
+			// Mock google as connected.
+			setUpAccountsPage.mockGoogleNotConnected(),
+
+			// Mock MC contact information
+			setUpAccountsPage.mockContactInformation(),
+		] );
+	} );
+
+	test.afterAll( async () => {
+		await setUpAccountsPage.closePage();
+	} );
+
+	test( 'should have store requirements step if incomplete', async () => {
+		await setUpAccountsPage.goto();
+
+		// Mock MC step at step 1:
+		setUpAccountsPage.mockMCSetup( 'incomplete', 'accounts' );
+
+		// 1. Assert there are 3 steps
+		const steps = await page.locator( '.woocommerce-stepper__step' );
+		await expect( steps ).toHaveCount( 4 );
+
+		// 2. Assert the label of the 3rd step is 'Confirm store requirements'
+		const thirdStepLabel = await steps
+			.nth( 2 )
+			.locator( '.woocommerce-stepper__step-label' );
+		await expect( thirdStepLabel ).toHaveText(
+			'Confirm store requirements'
+		);
+	} );
+
+	test( 'should not have store requirements step if complete', async () => {
+		await setUpAccountsPage.goto();
+
+		// TODO: Mock email is verified & address is filled
+
+		// 1. Assert there are 3 steps
+		const steps = await page.locator( '.woocommerce-stepper__step' );
+		await expect( steps ).toHaveCount( 3 );
+
+		// 2. Assert the label of the 3rd step is not 'Confirm store requirements'
+		const thirdStepLabel = await steps
+			.nth( 2 )
+			.locator( '.woocommerce-stepper__step-label' );
+		await expect( thirdStepLabel ).not.toHaveText(
+			'Confirm store requirements'
+		);
+
+		// 3. Assert the label of the 3rd step equals 'Create a campaign'
+		await expect( thirdStepLabel ).toHaveText( 'Create a campaign' );
+	} );
+} );

--- a/tests/e2e/specs/setup-mc/step-3-hide-store-requirements.test.js
+++ b/tests/e2e/specs/setup-mc/step-3-hide-store-requirements.test.js
@@ -62,6 +62,7 @@ test.describe( 'Hide Store Requirements Step', () => {
 		await setUpAccountsPage.goto();
 
 		// TODO: Mock email is verified & address is filled
+		setUpAccountsPage.mockMCSetup( 'complete', 'accounts' );
 
 		// 1. Assert there are 3 steps
 		const steps = await page.locator( '.woocommerce-stepper__step' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2493 

This PR hides the confirm registration step if the user has sufficient data filled in already. If the user was on the confirm registration step previously, they are sent to the next step.


### Screenshots:

With incomplete store requirements: (Confirm store requirements is present)
![image](https://github.com/user-attachments/assets/bcdca583-0252-4c42-939b-0400a2305072)


With complete store requirements: (Confirm store requirements is absent)
![image](https://github.com/user-attachments/assets/85416575-29bb-40e9-85c8-fd1abedccd80)


### Detailed test instructions:


1. Start the onboarding process with incomplete store data.
2. You should see the Step no. 3 Confirm Store Requirements
3. Reset your env, and delete some store data (eg:- Delete City under WooCommerce Store Address)
4. Restart the onboarding process
5. You should not see the Step no. 3


### Additional details:

Update: Hides the Confirm Store Requirements step when feasible

### Changelog entry

Update: Hides the Confirm Store Requirements step when feasible
