### PR TITLE
Fix issue with syncing shipping rates with more than two decimals

### DIFF
--- a/src/Shipping/ShippingRate.php
+++ b/src/Shipping/ShippingRate.php
@@ -37,7 +37,10 @@ class ShippingRate implements JsonSerializable {
 	 * @param float $rate The shipping cost in store currency.
 	 */
 	public function __construct( float $rate ) {
-		$this->rate = $rate;
+		// Google only accepts rates with two decimal places.
+		// We avoid using wc_format_decimal or number_format_i18n because these functions format numbers according to locale settings, which may include thousands separators and different decimal separators.
+		// At this stage, we want to ensure the number is formatted strictly as a float, with no thousands separators and a dot as the decimal separator.
+		$this->rate = (float) number_format( $rate, 2 );
 	}
 
 	/**

--- a/tests/Unit/Shipping/ZoneMethodsParserTest.php
+++ b/tests/Unit/Shipping/ZoneMethodsParserTest.php
@@ -88,6 +88,27 @@ class ZoneMethodsParserTest extends UnitTest {
 		$this->assertEquals( 10.6, $shipping_rates[0]->get_rate() );
 	}
 
+	public function test_returns_flat_rate_methods_with_more_than_two_decimals() {
+		$flat_rate     = $this->createMock( WC_Shipping_Flat_Rate::class );
+		$flat_rate->id = ZoneMethodsParser::METHOD_FLAT_RATE;
+		$flat_rate->expects( $this->any() )
+			->method( 'get_option' )
+			->willReturnMap(
+				[
+					[ 'cost', null, '10.6123' ],
+				]
+			);
+
+		$zone = $this->createMock( WC_Shipping_Zone::class );
+		$zone->expects( $this->any() )
+			->method( 'get_shipping_methods' )
+			->willReturn( [ $flat_rate ] );
+
+		$shipping_rates = $this->methods_parser->parse( $zone );
+		$this->assertCount( 1, $shipping_rates );
+		$this->assertEquals( 10.61, $shipping_rates[0]->get_rate() );
+	}
+
 	public function test_returns_flat_rate_methods_including_shipping_classes() {
 		// Return three sample shipping classes.
 		$light_class          = new \stdClass();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

While working on #2527, @mikkamp found an [issue](https://github.com/woocommerce/google-listings-and-ads/pull/2527#pullrequestreview-2254664348) where shipping rates with more than two decimal places were not syncing correctly. This PR makes sure that rates are always synced with exactly two decimal places.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to WC -> Settings -> Shipping
2. Go to the flat rate section, right-click on "Edit," and open it in a new tab to access the classic Shipping settings screen.

![image](https://github.com/user-attachments/assets/40a05721-ea06-4949-90ca-772180bf5429)

3. Set a price with more than two decimal places.

![image](https://github.com/user-attachments/assets/b1bc382e-3c05-4408-8113-d06f44c8c8aa)

4. Go to GFW -> Dashboard and click "Edit" in the free listings section.

![image](https://github.com/user-attachments/assets/b0f497c6-e570-47e5-b5c1-38adf6c7dc90)

5. Click "Save Changes" and verify that there are no errors and that the shipping settings are correctly updated in your Merchant Center.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Issue with syncing shipping rates with more than two decimals
