### PR TITLE
Log Exception if an asset is enqueued before being registered

### DIFF
--- a/src/Assets/BaseAsset.php
+++ b/src/Assets/BaseAsset.php
@@ -212,7 +212,11 @@ abstract class BaseAsset implements Asset {
 	 */
 	protected function defer_action( string $action, callable $callback, int $priority = 10 ): void {
 		if ( did_action( $action ) ) {
-			$callback();
+			try {
+				$callback();
+			} catch ( InvalidAsset $exception ) {
+				do_action( 'woocommerce_gla_exception', $exception, __METHOD__ );
+			}
 
 			return;
 		}

--- a/tests/Unit/Assets/ScriptAssetTest.php
+++ b/tests/Unit/Assets/ScriptAssetTest.php
@@ -28,4 +28,19 @@ class ScriptAssetTest extends TestCase {
 		$asset = new ScriptAsset( __FUNCTION__, self::URI, [], '' );
 		$this->assertTrue( $asset->can_enqueue() );
 	}
+
+	/**
+	 * Confirm an exception is logged using the `woocommerce_gla_exception`
+	 * action if an asset is enqueued before it is registered.
+	 *
+	 * @return void
+	 */
+	public function test_exception_logged_if_asset_enqueued_before_registration() {
+		do_action( 'wp_enqueue_scripts' );
+
+		$asset = new ScriptAsset( __FUNCTION__, self::URI, [], '', '__return_true' );
+		$asset->enqueue();
+
+		$this->assertEquals( 1, did_action( 'woocommerce_gla_exception' ) );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1659 

Adjusts asset enqueuing to catch InvalidAsset exceptions thrown when an asset is enqueued before being registered.

### Detailed test instructions:

1. Without checking out this branch, install and activate [WooCommerce Print Invoices and Packing Lists](https://woocommerce.com/products/print-invoices-packing-lists/) on a site that has GLA setup complete
2. Install and activate [WP Consent API](https://wordpress.org/plugins/wp-consent-api/)
3. Make sure Google Analytics for WooCommerce **is not** active on the site
4. Go to `WooCommerce > Settings > Invoices/Packing Lists`
5. Click on `Customize` under `Template Customizer`
6. See the fatal error triggered by the uncaught `InvalidAsset` exception
7. Checkout `fix/1659-asset-enqueued-before-registered`
8. Repeat step 3
9. Confirm no error is displayed
10. Go to `WooCommerce > Status > Logs`
11. Confirm the error was logged in the `google-listings-and-ads-...` log file

### Changelog entry

> Fix - Log exceptions triggered by assets being enqueued before being registered