### PR TITLE
Consolidate accounts onboarding: Temporarily remove Google Merchant Center and Google Ads account setup to facilitate the subsequent changes to the combo setup

### DIFF
--- a/js/src/setup-mc/setup-stepper/setup-accounts/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/index.js
@@ -160,15 +160,7 @@ const SetupAccounts = ( props ) => {
 						<WPComAccountCard jetpack={ jetpack } />
 					) }
 					<GoogleAccountCard disabled={ ! isJetpackActive } />
-					<GoogleAdsAccountCard />
 				</VerticalGapLayout>
-			</Section>
-			<Section
-				className="gla-google-mc-account-section"
-				description={ <GoogleMCDisclaimer /> }
-				disabledLeft={ ! isGMCPreconditionReady }
-			>
-				<GoogleMCAccountCard />
 			</Section>
 
 			<StepContentFooter>
@@ -181,8 +173,14 @@ const SetupAccounts = ( props ) => {
 						{ __( 'Continue', 'google-listings-and-ads' ) }
 					</AppButton>
 				</StepContentActions>
-				<Faqs />
 			</StepContentFooter>
+			<Section
+				className="gla-google-mc-account-section"
+				description={ <GoogleMCDisclaimer /> }
+				disabledLeft={ ! isGMCPreconditionReady }
+			>
+				<Faqs />
+			</Section>
 		</StepContent>
 	);
 };

--- a/js/src/setup-mc/setup-stepper/setup-accounts/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/index.js
@@ -21,8 +21,6 @@ import AppDocumentationLink from '.~/components/app-documentation-link';
 import VerticalGapLayout from '.~/components/vertical-gap-layout';
 import WPComAccountCard from '.~/components/wpcom-account-card';
 import GoogleAccountCard from '.~/components/google-account-card';
-import GoogleMCAccountCard from '.~/components/google-mc-account-card';
-import GoogleAdsAccountCard from '.~/components/google-ads-account-card';
 import Faqs from './faqs';
 import './index.scss';
 import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the cards that are being reworked from setup-accounts.

Closes #2565

### Screenshots:

![image](https://github.com/user-attachments/assets/7aa6122e-7c47-42f1-946a-8a9e15af19c4)


### Detailed test instructions:

1. Reset your local, and start the onboarding flow
2. You should not see the Google Ads and MC
3. You should see the disclaimer at its new position

### Changelog entry
