### PR TITLE
Set WPCOM_API_STATUS transient for E2E tests

### DIFF
--- a/tests/e2e/test-data/test-data.php
+++ b/tests/e2e/test-data/test-data.php
@@ -140,6 +140,14 @@ function set_notifications_ready() {
 	$options    = woogle_get_container()->get( OptionsInterface::class );
 	$transients = woogle_get_container()->get( TransientsInterface::class );
 	$transients->set( TransientsInterface::URL_MATCHES, 'yes' );
+	$transients->set(
+		TransientsInterface::WPCOM_API_STATUS,
+		array(
+			'is_healthy'               => true,
+			'is_wc_rest_api_healthy'   => true,
+			'is_partner_token_healthy' => true
+		)
+	);
 	$options->update(
 		OptionsInterface::WPCOM_REST_API_STATUS, 'approved'
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2587

Updates E2E test data to set the default value for `WPCOM_API_STATUS`.

### Detailed test instructions:

1. Checkout `fix/2587-e2e-tests`
2. `npm run test:e2e`