### PR TITLE
Update the shipping time controllers to handle the maximum shipping time

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/ShippingTimeBatchController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingTimeBatchController.php
@@ -53,6 +53,7 @@ class ShippingTimeBatchController extends ShippingTimeController {
 		return function ( Request $request ) {
 			$country_codes = $request->get_param( 'country_codes' );
 			$time          = $request->get_param( 'time' );
+			$max_time      = $request->get_param( 'max_time' );
 
 			$responses = [];
 			$errors    = [];
@@ -62,6 +63,7 @@ class ShippingTimeBatchController extends ShippingTimeController {
 					[
 						'country_code' => $country_code,
 						'time'         => $time,
+						'max_time'     => $max_time,
 					]
 				);
 

--- a/src/API/Site/Controllers/MerchantCenter/ShippingTimeController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingTimeController.php
@@ -100,6 +100,7 @@ class ShippingTimeController extends BaseController implements ISO3166AwareInter
 					[
 						'country_code' => $time['country'],
 						'time'         => $time['time'],
+						'max_time'     => $time['max_time'],
 					],
 					$request
 				);
@@ -134,6 +135,7 @@ class ShippingTimeController extends BaseController implements ISO3166AwareInter
 				[
 					'country_code' => $time[0]['country'],
 					'time'         => $time[0]['time'],
+					'max_time'     => $time[0]['max_time'],
 				],
 				$request
 			);
@@ -153,8 +155,9 @@ class ShippingTimeController extends BaseController implements ISO3166AwareInter
 
 			try {
 				$data = [
-					'country' => $country_code,
-					'time'    => $request->get_param( 'time' ),
+					'country'  => $country_code,
+					'time'     => $request->get_param( 'time' ),
+					'max_time' => $request->get_param( 'max_time' ),
 				];
 				if ( $existing ) {
 					$query->update(
@@ -265,7 +268,13 @@ class ShippingTimeController extends BaseController implements ISO3166AwareInter
 			],
 			'time'         => [
 				'type'              => 'integer',
-				'description'       => __( 'The shipping time in days.', 'google-listings-and-ads' ),
+				'description'       => __( 'The minimum shipping time in days.', 'google-listings-and-ads' ),
+				'context'           => [ 'view', 'edit' ],
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'max_time'     => [
+				'type'              => 'integer',
+				'description'       => __( 'The maximum shipping time in days.', 'google-listings-and-ads' ),
 				'context'           => [ 'view', 'edit' ],
 				'validate_callback' => 'rest_validate_request_arg',
 			],

--- a/src/DB/Table/ShippingTimeTable.php
+++ b/src/DB/Table/ShippingTimeTable.php
@@ -50,9 +50,10 @@ SQL;
 	 */
 	public function get_columns(): array {
 		return [
-			'id'      => true,
-			'country' => true,
-			'time'    => true,
+			'id'       => true,
+			'country'  => true,
+			'time'     => true,
+			'max_time' => true,
 		];
 	}
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeBatchControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeBatchControllerTest.php
@@ -64,6 +64,7 @@ class ShippingTimeBatchControllerTest extends RESTControllerUnitTest {
 		$payload = [
 			'country_codes' => [ 'US', 'GB' ],
 			'time'          => 5,
+			'max_time'      => 10,
 		];
 
 		$response = $this->do_request( self::ROUTE_SHIPPING_TIME_BATCH, 'POST', $payload );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeControllerTest.php
@@ -280,4 +280,50 @@ class ShippingTimeControllerTest extends RESTControllerUnitTest {
 			$this->assertEquals( 'error', $e->getMessage() );
 		}
 	}
+
+	public function test_missing_time_param() {
+		$payload = [
+			'country_code' => 'US',
+			'max_time'     => 10,
+		];
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIMES, 'POST', $payload );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Missing parameter(s): time', $response->get_data()['message'] );
+	}
+
+	public function test_missing_max_time_param() {
+		$payload = [
+			'country_code' => 'US',
+			'time'         => 10,
+		];
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIMES, 'POST', $payload );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Missing parameter(s): max_time', $response->get_data()['message'] );
+	}
+
+	public function test_negative_time_param() {
+		$payload = [
+			'country_code' => 'US',
+			'time'         => -1,
+			'max_time'     => 10,
+		];
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIMES, 'POST', $payload );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Shipping times cannot be negative.', $response->get_data()['data']['params']['time'] );
+	}
+
+	public function test_minimum_shipping_time_bigger_than_max_time_param() {
+		$payload = [
+			'country_code' => 'US',
+			'time'         => 20,
+			'max_time'     => 10,
+		];
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIMES, 'POST', $payload );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'The minimum shipping time cannot be greater than the maximum shipping time.', $response->get_data()['data']['params']['time'] );
+	}
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeControllerTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ShippingTimeController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidQuery;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class ShippingTimeControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
+ */
+class ShippingTimeControllerTest extends RESTControllerUnitTest {
+
+	/** @var Container $container */
+	protected $container;
+
+	/** @var ShippingTimeController $controller */
+	protected $controller;
+
+	/** @var MockObject|ISO3166DataProvider $iso_provider */
+	protected $iso_provider;
+
+	/** @var MockObject|ShippingTimeQuery $conversion_action */
+	protected $shiping_time_query;
+
+	protected const ROUTE_SHIPPING_TIMES = '/wc/gla/mc/shipping/times';
+
+	protected const ROUTE_SHIPPING_TIMES_COUNTRY = '/wc/gla/mc/shipping/times/ES';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->shiping_time_query = $this->createMock( ShippingTimeQuery::class );
+		$this->iso_provider       = $this->createMock( ISO3166DataProvider::class );
+
+		$this->container = new Container();
+		$this->container->share( RESTServer::class, $this->server );
+		$this->container->share( ShippingTimeQuery::class, $this->shiping_time_query );
+
+		$this->controller = new ShippingTimeController( $this->container );
+		$this->controller->set_iso3166_provider( $this->iso_provider );
+		$this->controller->register();
+	}
+
+	public function test_get_shipping_times() {
+		$this->shiping_time_query->expects( $this->once() )
+			->method( 'set_limit' )
+			->willReturn(
+				$this->shiping_time_query
+			);
+
+		$this->shiping_time_query->expects( $this->once() )
+			->method( 'get_results' )
+			->willReturn(
+				[
+					[
+						'id'       => '1',
+						'country'  => 'ES',
+						'time'     => 3,
+						'max_time' => 1,
+					],
+				]
+			);
+
+		$this->iso_provider
+		->method( 'alpha2' )
+		->willReturn( [ 'name' => 'Spain' ] );
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIMES, 'GET' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals(
+			[
+				'ES' => [
+					'country_code' => 'ES',
+					'country'      => 'Spain',
+					'time'         => 3,
+					'max_time'     => 1,
+				],
+			],
+			$response->get_data()
+		);
+	}
+
+	public function test_create_shipping_rate_insert() {
+		$payload = [
+			'country_code' => 'US',
+			'time'         => 5,
+			'max_time'     => 10,
+		];
+
+		$this->shiping_time_query->expects( $this->once() )
+			->method( 'where' )
+			->with( 'country', 'US' )
+			->willReturn(
+				$this->shiping_time_query
+			);
+
+		$this->shiping_time_query->expects( $this->once() )
+			->method( 'get_results' )
+			->willReturn(
+				[]
+			);
+
+		$this->shiping_time_query->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				[
+					'country'  => 'US',
+					'time'     => 5,
+					'max_time' => 10,
+				]
+			);
+
+		$this->shiping_time_query->expects( $this->never() )
+			->method( 'update' );
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIMES, 'POST', $payload );
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertEquals( 'success', $response->get_data()['status'] );
+		$this->assertEquals( 'Successfully added time for country: "US".', $response->get_data()['message'] );
+	}
+
+	public function test_create_shipping_rate_update() {
+		$payload = [
+			'country_code' => 'US',
+			'time'         => 5,
+			'max_time'     => 10,
+		];
+
+		$this->shiping_time_query->expects( $this->once() )
+			->method( 'where' )
+			->with( 'country', 'US' )
+			->willReturn(
+				$this->shiping_time_query
+			);
+
+		$this->shiping_time_query->expects( $this->exactly( 2 ) )
+			->method( 'get_results' )
+			->willReturn(
+				[
+					[
+						'id'       => 1,
+						'country'  => 'US',
+						'time'     => 3,
+						'max_time' => 1,
+					],
+				]
+			);
+
+		$this->shiping_time_query->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				[
+					'country'  => 'US',
+					'time'     => 5,
+					'max_time' => 10,
+				],
+				[
+					'id' => 1,
+				]
+			);
+
+		$this->shiping_time_query->expects( $this->never() )
+			->method( 'insert' );
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIMES, 'POST', $payload );
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertEquals( 'success', $response->get_data()['status'] );
+		$this->assertEquals( 'Successfully added time for country: "US".', $response->get_data()['message'] );
+	}
+
+	public function test_create_shipping_time_invalid_query() {
+		$payload = [
+			'country_code' => 'US',
+			'time'         => 5,
+			'max_time'     => 10,
+		];
+
+		$this->shiping_time_query->expects( $this->once() )
+			->method( 'where' )
+			->with( 'country', 'US' )
+			->willThrowException(
+				new InvalidQuery( 'error' )
+			);
+
+		try {
+			$this->do_request( self::ROUTE_SHIPPING_TIMES, 'POST', $payload );
+		} catch ( InvalidQuery $e ) {
+			$this->assertEquals( 'error', $e->getMessage() );
+		}
+	}
+
+	public function test_get_shipping_time_country() {
+		$this->shiping_time_query->expects( $this->once() )
+			->method( 'where' )
+			->with( 'country', 'ES' )
+			->willReturn(
+				$this->shiping_time_query
+			);
+
+		$this->shiping_time_query->expects( $this->exactly( 1 ) )
+			->method( 'get_results' )
+			->willReturn(
+				[
+					[
+						'id'       => 1,
+						'country'  => 'ES',
+						'time'     => 3,
+						'max_time' => 1,
+					],
+				]
+			);
+
+		$this->iso_provider
+			->method( 'alpha2' )
+			->willReturn( [ 'name' => 'Spain' ] );
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIMES_COUNTRY, 'GET' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'ES', $response->get_data()['country_code'] );
+		$this->assertEquals( 3, $response->get_data()['time'] );
+		$this->assertEquals( 1, $response->get_data()['max_time'] );
+	}
+
+	public function test_get_shipping_time_country_not_found() {
+		$this->shiping_time_query->expects( $this->once() )
+			->method( 'where' )
+			->with( 'country', 'ES' )
+			->willReturn(
+				$this->shiping_time_query
+			);
+
+		$this->shiping_time_query->expects( $this->exactly( 1 ) )
+			->method( 'get_results' )
+			->willReturn(
+				[]
+			);
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIMES_COUNTRY, 'GET' );
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertEquals( 'No time available.', $response->get_data()['message'] );
+		$this->assertEquals( 'ES', $response->get_data()['country'] );
+	}
+
+	public function test_delete_shipping_time_country() {
+		$this->shiping_time_query->expects( $this->once() )
+			->method( 'delete' )
+			->with( 'country', 'ES' );
+
+		$response = $this->do_request( self::ROUTE_SHIPPING_TIMES_COUNTRY, 'DELETE' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'success', $response->get_data()['status'] );
+		$this->assertEquals( 'Successfully deleted the time for country: "ES".', $response->get_data()['message'] );
+	}
+
+	public function test_delete_shipping_time_country_invalid_query() {
+		$this->shiping_time_query->expects( $this->once() )
+			->method( 'delete' )
+			->with( 'country', 'ES' )
+			->willThrowException(
+				new InvalidQuery( 'error' )
+			);
+
+		try {
+			$this->do_request( self::ROUTE_SHIPPING_TIMES_COUNTRY, 'DELETE' );
+		} catch ( InvalidQuery $e ) {
+			$this->assertEquals( 'error', $e->getMessage() );
+		}
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of pcTzPl-2qP-p2

This PR updates the shipping time controllers to allow for updating and fetching the maximum shipping time, which will be used in a second PR that I’m currently working on for the UI.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

### Prerequisites
1. Follow the steps mentioned in this PR to update the database: https://github.com/woocommerce/google-listings-and-ads/pull/2520

###
1. Make a GET `/wc/gla/mc/shipping/times` request and check that the `max_time` property is now included in the response.
3. Update one of the shipping times by making the following request: `POST gla/mc/shipping/times` and the following body: `{"country_code":"ES","time":2, "max_time": 3}`
4. Make the following request for one specific country: `GET gla/mc/shipping/times/YOUR_COUNTRY` for example `GET gla/mc/shipping/times/ES` and check that the `max_time` property is now included.



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>