### PR TITLE
Update UI to support minimum and maximum shipping times.

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
+++ b/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
@@ -30,6 +30,8 @@ exports[`checkErrors Shipping times For flat type When there are any selected co
 
 exports[`checkErrors Shipping times For flat type When there are any shipping times is < 0, should not pass 1`] = `"Please specify estimated shipping times for all the countries, and the time cannot be less than 0."`;
 
+exports[`checkErrors Shipping times For flat type shouldnt pass if min time is bigger than max time 1`] = `"The minimum shipping time must not be less than the maximum shipping time."`;
+
 exports[`checkErrors Shipping times When the type of shipping time is an invalid value or missing, should not pass 1`] = `"Please select a shipping time option."`;
 
 exports[`checkErrors Shipping times When the type of shipping time is an invalid value or missing, should not pass 2`] = `"Please select a shipping time option."`;

--- a/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
+++ b/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
@@ -26,11 +26,15 @@ exports[`checkErrors Shipping rates When the type of shipping rate is an invalid
 
 exports[`checkErrors Shipping rates When the type of shipping rate is an invalid value or missing, should not pass 3`] = `"Please select a shipping rate option."`;
 
+exports[`checkErrors Shipping times For flat type When minimum max_time is < 0, should not pass 1`] = `"The minimum shipping time must not be more than the maximum shipping time."`;
+
+exports[`checkErrors Shipping times For flat type When minimum times is < 0, should not pass 1`] = `"Please specify estimated shipping times for all the countries, and the time cannot be less than 0."`;
+
 exports[`checkErrors Shipping times For flat type When there are any selected countries' shipping times is not set, should not pass 1`] = `"Please specify estimated shipping times for all the countries, and the time cannot be less than 0."`;
 
-exports[`checkErrors Shipping times For flat type When there are any shipping times is < 0, should not pass 1`] = `"Please specify estimated shipping times for all the countries, and the time cannot be less than 0."`;
+exports[`checkErrors Shipping times For flat type When there are any shipping times are < 0, should not pass 1`] = `"Please specify estimated shipping times for all the countries, and the time cannot be less than 0."`;
 
-exports[`checkErrors Shipping times For flat type shouldnt pass if min time is bigger than max time 1`] = `"The minimum shipping time must not be less than the maximum shipping time."`;
+exports[`checkErrors Shipping times For flat type shouldnt pass if min time is bigger than max time 1`] = `"The minimum shipping time must not be more than the maximum shipping time."`;
 
 exports[`checkErrors Shipping times When the type of shipping time is an invalid value or missing, should not pass 1`] = `"Please select a shipping time option."`;
 

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -98,7 +98,7 @@ const checkErrors = (
 	if (
 		values.shipping_time === 'flat' &&
 		( shippingTimes.length < finalCountryCodes.length ||
-			shippingTimes.some( ( el ) => el.time < 0 ) )
+			shippingTimes.some( ( el ) => el.time < 0 || el.maxTime < 0 ) )
 	) {
 		errors.shipping_country_times = __(
 			'Please specify estimated shipping times for all the countries, and the time cannot be less than 0.',

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -106,6 +106,16 @@ const checkErrors = (
 		);
 	}
 
+	if (
+		values.shipping_time === 'flat' &&
+		shippingTimes.some( ( el ) => el.time > el.maxTime )
+	) {
+		errors.shipping_country_times = __(
+			'The minimum shipping time must not be less than the maximum shipping time.',
+			'google-listings-and-ads'
+		);
+	}
+
 	/**
 	 * Check tax rate (required for U.S. only).
 	 */

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -111,7 +111,7 @@ const checkErrors = (
 		shippingTimes.some( ( el ) => el.time > el.maxTime )
 	) {
 		errors.shipping_country_times = __(
-			'The minimum shipping time must not be less than the maximum shipping time.',
+			'The minimum shipping time must not be more than the maximum shipping time.',
 			'google-listings-and-ads'
 		);
 	}

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
@@ -419,7 +419,7 @@ describe( 'checkErrors', () => {
 				expect( errors ).toHaveProperty( 'shipping_country_times' );
 				expect( errors.shipping_country_times ).toMatchSnapshot();
 			} );
-			
+
 			it( `When minimum max_time is < 0, should not pass`, () => {
 				const times = toTimes( [ 'US', 10, 10 ], [ 'JP', 1, -10 ] );
 				const codes = [ 'US', 'JP' ];
@@ -428,7 +428,7 @@ describe( 'checkErrors', () => {
 
 				expect( errors ).toHaveProperty( 'shipping_country_times' );
 				expect( errors.shipping_country_times ).toMatchSnapshot();
-			} );			
+			} );
 
 			it( `When all shipping times are ≥ 0, should pass`, () => {
 				const times = toTimes( [ 'US', 1, 1 ], [ 'JP', 0, 0 ] );

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
@@ -15,9 +15,10 @@ function toRates( ...tuples ) {
 }
 
 function toTimes( ...tuples ) {
-	return tuples.map( ( [ countryCode, time ] ) => ( {
+	return tuples.map( ( [ countryCode, time, maxTime ] ) => ( {
 		countryCode,
 		time,
+		maxTime,
 	} ) );
 }
 
@@ -44,7 +45,7 @@ describe( 'checkErrors', () => {
 			shipping_country_rates: toRates( [ 'US', 10 ], [ 'JP', 30, 88 ] ),
 			offer_free_shipping: true,
 		};
-		const times = toTimes( [ 'US', 3 ], [ 'JP', 10 ] );
+		const times = toTimes( [ 'US', 3, 3 ], [ 'JP', 10, 10 ] );
 		const codes = [ 'US', 'JP' ];
 
 		const errors = checkErrors( values, times, codes );
@@ -381,7 +382,7 @@ describe( 'checkErrors', () => {
 
 		describe( 'For flat type', () => {
 			it( `When there are any selected countries' shipping times is not set, should not pass`, () => {
-				const times = toTimes( [ 'US', 7 ], [ 'FR', 16 ] );
+				const times = toTimes( [ 'US', 7, 7 ], [ 'FR', 16, 16 ] );
 				const codes = [ 'US', 'JP', 'FR' ];
 
 				const errors = checkErrors( flatShipping, times, codes );
@@ -391,7 +392,7 @@ describe( 'checkErrors', () => {
 			} );
 
 			it( `When all selected countries' shipping times are set, should pass`, () => {
-				const times = toTimes( [ 'US', 7 ], [ 'FR', 16 ] );
+				const times = toTimes( [ 'US', 7, 7 ], [ 'FR', 16, 16 ] );
 				const codes = [ 'US', 'FR' ];
 
 				const errors = checkErrors( flatShipping, times, codes );
@@ -400,7 +401,7 @@ describe( 'checkErrors', () => {
 			} );
 
 			it( `When there are any shipping times is < 0, should not pass`, () => {
-				const times = toTimes( [ 'US', 10 ], [ 'JP', -1 ] );
+				const times = toTimes( [ 'US', 10, 10 ], [ 'JP', -1, -1 ] );
 				const codes = [ 'US', 'JP' ];
 
 				const errors = checkErrors( flatShipping, times, codes );
@@ -410,12 +411,22 @@ describe( 'checkErrors', () => {
 			} );
 
 			it( `When all shipping times are ≥ 0, should pass`, () => {
-				const times = toTimes( [ 'US', 1 ], [ 'JP', 0 ] );
+				const times = toTimes( [ 'US', 1, 1 ], [ 'JP', 0, 0 ] );
 				const codes = [ 'US', 'JP' ];
 
 				const errors = checkErrors( flatShipping, times, codes );
 
 				expect( errors ).not.toHaveProperty( 'shipping_time' );
+			} );
+
+			it( `shouldnt pass if min time is bigger than max time`, () => {
+				const times = toTimes( [ 'US', 1, 0 ], [ 'JP', 1, 1 ] );
+				const codes = [ 'US', 'JP' ];
+
+				const errors = checkErrors( flatShipping, times, codes );
+
+				expect( errors ).toHaveProperty( 'shipping_country_times' );
+				expect( errors.shipping_country_times ).toMatchSnapshot();
 			} );
 		} );
 	} );

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
@@ -400,7 +400,7 @@ describe( 'checkErrors', () => {
 				expect( errors ).not.toHaveProperty( 'shipping_time' );
 			} );
 
-			it( `When there are any shipping times is < 0, should not pass`, () => {
+			it( `When there are any shipping times are < 0, should not pass`, () => {
 				const times = toTimes( [ 'US', 10, 10 ], [ 'JP', -1, -1 ] );
 				const codes = [ 'US', 'JP' ];
 
@@ -409,6 +409,26 @@ describe( 'checkErrors', () => {
 				expect( errors ).toHaveProperty( 'shipping_country_times' );
 				expect( errors.shipping_country_times ).toMatchSnapshot();
 			} );
+
+			it( `When minimum times is < 0, should not pass`, () => {
+				const times = toTimes( [ 'US', 10, 10 ], [ 'JP', -1, 10 ] );
+				const codes = [ 'US', 'JP' ];
+
+				const errors = checkErrors( flatShipping, times, codes );
+
+				expect( errors ).toHaveProperty( 'shipping_country_times' );
+				expect( errors.shipping_country_times ).toMatchSnapshot();
+			} );
+			
+			it( `When minimum max_time is < 0, should not pass`, () => {
+				const times = toTimes( [ 'US', 10, 10 ], [ 'JP', 1, -10 ] );
+				const codes = [ 'US', 'JP' ];
+
+				const errors = checkErrors( flatShipping, times, codes );
+
+				expect( errors ).toHaveProperty( 'shipping_country_times' );
+				expect( errors.shipping_country_times ).toMatchSnapshot();
+			} );			
 
 			it( `When all shipping times are ≥ 0, should pass`, () => {
 				const times = toTimes( [ 'US', 1, 1 ], [ 'JP', 0, 0 ] );

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -36,6 +36,7 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 			initialValues={ {
 				countries,
 				time: 0,
+				maxTime: 0,
 			} }
 			validate={ validateShippingTimeGroup }
 			onSubmit={ handleSubmitCallback }
@@ -81,7 +82,7 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 							/>
 							<AppInputNumberControl
 								label={ __(
-									'Then the estimated shipping time displayed in the product listing is',
+									'Then the minimum estimated shipping time displayed in the product listing is',
 									'google-listings-and-ads'
 								) }
 								suffix={ __(
@@ -89,6 +90,17 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 									'google-listings-and-ads'
 								) }
 								{ ...getInputProps( 'time' ) }
+							/>
+							<AppInputNumberControl
+								label={ __(
+									'And the maximum time is',
+									'google-listings-and-ads'
+								) }
+								suffix={ __(
+									'days',
+									'google-listings-and-ads'
+								) }
+								{ ...getInputProps( 'maxTime' ) }
 							/>
 						</VerticalGapLayout>
 					</AppModal>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
@@ -43,6 +43,7 @@ export default function ShippingCountriesForm( {
 		countriesTimeArray.push( {
 			countries: audienceCountries,
 			time: null,
+			maxTime: null,
 		} );
 	}
 
@@ -66,7 +67,10 @@ export default function ShippingCountriesForm( {
 
 		onChange( shippingTimes.concat( addedIndividualTimes ) );
 	}
-	function handleChange( { countries, time }, deletedCountries = [] ) {
+	function handleChange(
+		{ countries, time, maxTime },
+		deletedCountries = []
+	) {
 		deletedCountries.forEach( ( countryCode ) =>
 			actualCountries.delete( countryCode )
 		);
@@ -76,6 +80,7 @@ export default function ShippingCountriesForm( {
 			actualCountries.set( countryCode, {
 				countryCode,
 				time,
+				maxTime,
 			} );
 		} );
 		onChange( Array.from( actualCountries.values() ) );

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-form.js
@@ -58,11 +58,12 @@ export default function ShippingCountriesForm( {
 			)
 		);
 	}
-	function handleAdd( { countries, time } ) {
+	function handleAdd( { countries, time, maxTime } ) {
 		// Split aggregated time, to individial times per country.
 		const addedIndividualTimes = countries.map( ( countryCode ) => ( {
 			countryCode,
 			time,
+			maxTime,
 		} ) );
 
 		onChange( shippingTimes.concat( addedIndividualTimes ) );

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -57,6 +57,7 @@ const EditTimeModal = ( {
 			initialValues={ {
 				countries: time.countries,
 				time: time.time,
+				maxTime: time.maxTime,
 			} }
 			validate={ validateShippingTimeGroup }
 			onSubmit={ handleSubmitCallback }
@@ -108,9 +109,10 @@ const EditTimeModal = ( {
 								}
 								{ ...getInputProps( 'countries' ) }
 							/>
+
 							<AppInputNumberControl
 								label={ __(
-									'Then the estimated shipping time displayed in the product listing is',
+									'Then the minimum estimated shipping time displayed in the product listing is',
 									'google-listings-and-ads'
 								) }
 								suffix={ __(
@@ -118,6 +120,18 @@ const EditTimeModal = ( {
 									'google-listings-and-ads'
 								) }
 								{ ...getInputProps( 'time' ) }
+							/>
+
+							<AppInputNumberControl
+								label={ __(
+									'And the maximum time is',
+									'google-listings-and-ads'
+								) }
+								suffix={ __(
+									'days',
+									'google-listings-and-ads'
+								) }
+								{ ...getInputProps( 'maxTime' ) }
 							/>
 						</VerticalGapLayout>
 					</AppModal>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -1,15 +1,16 @@
 /**
  * External dependencies
  */
+import { Flex, FlexItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import AppInputNumberControl from '.~/components/app-input-number-control';
 import AppSpinner from '.~/components/app-spinner';
 import ShippingTimeInputControlLabelText from '.~/components/shipping-time-input-control-label-text';
 import EditTimeButton from './edit-time-button';
+import Stepper from '../time-stepper';
 import './index.scss';
 
 /**
@@ -47,26 +48,40 @@ const CountriesTimeInput = ( {
 	};
 
 	return (
-		<div className="gla-countries-time-input">
-			<AppInputNumberControl
-				label={
-					<div className="label">
-						<ShippingTimeInputControlLabelText
-							countries={ countries }
-						/>
-						<EditTimeButton
-							audienceCountries={ audienceCountries }
+		<>
+			<div className="label">
+				<ShippingTimeInputControlLabelText countries={ countries } />
+				<EditTimeButton
+					audienceCountries={ audienceCountries }
+					onChange={ onChange }
+					onDelete={ onDelete }
+					time={ value }
+				/>
+			</div>
+			<Flex justify="start">
+				<FlexItem>
+					<div className="gla-countries-time-input">
+						<Stepper
 							onChange={ onChange }
 							onDelete={ onDelete }
-							time={ value }
+							handleBlur={ handleBlur }
+							value={ value }
 						/>
 					</div>
-				}
-				suffix={ __( 'days', 'google-listings-and-ads' ) }
-				value={ time }
-				onBlur={ handleBlur }
-			/>
-		</div>
+				</FlexItem>
+				<FlexItem>{ __( 'to', 'google-listings-and-ads' ) }</FlexItem>
+				<FlexItem>
+					<div className="gla-countries-time-input">
+						<Stepper
+							onChange={ onChange }
+							onDelete={ onDelete }
+							handleBlur={ handleBlur }
+							value={ value }
+						/>
+					</div>
+				</FlexItem>
+			</Flex>
+		</>
 	);
 };
 

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -30,7 +30,7 @@ const CountriesTimeInput = ( {
 	onChange,
 	onDelete,
 } ) => {
-	const { countries, time } = value;
+	const { countries, time, maxTime } = value;
 
 	if ( ! audienceCountries ) {
 		return <AppSpinner />;
@@ -66,7 +66,8 @@ const CountriesTimeInput = ( {
 								onChange={ onChange }
 								onDelete={ onDelete }
 								handleBlur={ handleBlur }
-								value={ value }
+								countries={ countries }
+								time={ time }
 							/>
 						</div>
 					</FlexItem>
@@ -79,7 +80,8 @@ const CountriesTimeInput = ( {
 								onChange={ onChange }
 								onDelete={ onDelete }
 								handleBlur={ handleBlur }
-								value={ value }
+								countries={ countries }
+								time={ maxTime }
 							/>
 						</div>
 					</FlexItem>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -48,7 +48,7 @@ const CountriesTimeInput = ( {
 	};
 
 	return (
-		<>
+		<Flex direction="column" className="gla-countries-time-input-container">
 			<div className="label">
 				<ShippingTimeInputControlLabelText countries={ countries } />
 				<EditTimeButton
@@ -58,30 +58,34 @@ const CountriesTimeInput = ( {
 					time={ value }
 				/>
 			</div>
-			<Flex justify="start">
-				<FlexItem>
-					<div className="gla-countries-time-input">
-						<Stepper
-							onChange={ onChange }
-							onDelete={ onDelete }
-							handleBlur={ handleBlur }
-							value={ value }
-						/>
-					</div>
-				</FlexItem>
-				<FlexItem>{ __( 'to', 'google-listings-and-ads' ) }</FlexItem>
-				<FlexItem>
-					<div className="gla-countries-time-input">
-						<Stepper
-							onChange={ onChange }
-							onDelete={ onDelete }
-							handleBlur={ handleBlur }
-							value={ value }
-						/>
-					</div>
-				</FlexItem>
-			</Flex>
-		</>
+			<FlexItem>
+				<Flex justify="space-evenly" gap="4">
+					<FlexItem>
+						<div className="gla-countries-time-input">
+							<Stepper
+								onChange={ onChange }
+								onDelete={ onDelete }
+								handleBlur={ handleBlur }
+								value={ value }
+							/>
+						</div>
+					</FlexItem>
+					<FlexItem>
+						<span>{ __( 'to', 'google-listings-and-ads' ) }</span>
+					</FlexItem>
+					<FlexItem>
+						<div className="gla-countries-time-input">
+							<Stepper
+								onChange={ onChange }
+								onDelete={ onDelete }
+								handleBlur={ handleBlur }
+								value={ value }
+							/>
+						</div>
+					</FlexItem>
+				</Flex>
+			</FlexItem>
+		</Flex>
 	);
 };
 

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -36,38 +36,50 @@ const CountriesTimeInput = ( {
 		return <AppSpinner />;
 	}
 
-	const handleBlur = ( e, numberValue ) => {
+	const handleBlur = ( e, numberValue, field ) => {
 		if ( time === numberValue ) {
 			return;
 		}
 
 		onChange( {
-			countries,
-			time: numberValue,
+			...value,
+			[ field ]: numberValue,
+		} );
+	};
+
+	const handleIncrement = ( numberValue, field ) => {
+		onChange( {
+			...value,
+			[ field ]: numberValue,
 		} );
 	};
 
 	return (
 		<Flex direction="column" className="gla-countries-time-input-container">
-			<div className="label">
-				<ShippingTimeInputControlLabelText countries={ countries } />
-				<EditTimeButton
-					audienceCountries={ audienceCountries }
-					onChange={ onChange }
-					onDelete={ onDelete }
-					time={ value }
-				/>
-			</div>
 			<FlexItem>
-				<Flex justify="space-evenly" gap="4">
+				<div className="label">
+					<ShippingTimeInputControlLabelText
+						countries={ countries }
+					/>
+					<EditTimeButton
+						audienceCountries={ audienceCountries }
+						onChange={ onChange }
+						onDelete={ onDelete }
+						time={ value }
+					/>
+				</div>
+			</FlexItem>
+
+			<FlexItem>
+				<Flex justify="space-between" gap="4">
 					<FlexItem>
 						<div className="gla-countries-time-input">
 							<Stepper
-								onChange={ onChange }
 								onDelete={ onDelete }
 								handleBlur={ handleBlur }
-								countries={ countries }
 								time={ time }
+								handleIncrement={ handleIncrement }
+								field="time"
 							/>
 						</div>
 					</FlexItem>
@@ -77,11 +89,11 @@ const CountriesTimeInput = ( {
 					<FlexItem>
 						<div className="gla-countries-time-input">
 							<Stepper
-								onChange={ onChange }
 								onDelete={ onDelete }
 								handleBlur={ handleBlur }
-								countries={ countries }
+								handleIncrement={ handleIncrement }
 								time={ maxTime }
+								field="maxTime"
 							/>
 						</div>
 					</FlexItem>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -36,8 +36,14 @@ const CountriesTimeInput = ( {
 		return <AppSpinner />;
 	}
 
+	/**
+	 *
+	 * @param {Object} e The event object
+	 * @param {number} numberValue The string value of the input field converted to a number
+	 * @param {string} field The field name: time or maxTime
+	 */
 	const handleBlur = ( e, numberValue, field ) => {
-		if ( time === numberValue ) {
+		if ( value[ field ] === numberValue ) {
 			return;
 		}
 
@@ -47,6 +53,11 @@ const CountriesTimeInput = ( {
 		} );
 	};
 
+	/**
+	 *
+	 * @param {number} numberValue The string value of the input field converted to a number
+	 * @param {string} field The field name: time or maxTime
+	 */
 	const handleIncrement = ( numberValue, field ) => {
 		onChange( {
 			...value,

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -86,7 +86,6 @@ const CountriesTimeInput = ( {
 					<FlexItem>
 						<div className="gla-countries-time-input">
 							<Stepper
-								onDelete={ onDelete }
 								handleBlur={ handleBlur }
 								time={ time }
 								handleIncrement={ handleIncrement }
@@ -100,7 +99,6 @@ const CountriesTimeInput = ( {
 					<FlexItem>
 						<div className="gla-countries-time-input">
 							<Stepper
-								onDelete={ onDelete }
 								handleBlur={ handleBlur }
 								handleIncrement={ handleIncrement }
 								time={ maxTime }

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.scss
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.scss
@@ -1,6 +1,5 @@
-.gla-countries-time-input {
-	max-width: $gla-width-smaller;
-
+.gla-countries-time-input-container {
+	max-width: $gla-width-medium-large;	
 	.label {
 		display: flex;
 		justify-content: space-between;

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.scss
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.scss
@@ -1,5 +1,5 @@
 .gla-countries-time-input-container {
-	max-width: $gla-width-medium-large;	
+	max-width: $gla-width-medium-large;
 	.label {
 		display: flex;
 		justify-content: space-between;

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.scss
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.scss
@@ -1,5 +1,5 @@
 .gla-countries-time-input {
-	max-width: $gla-width-medium;
+	max-width: $gla-width-smaller;
 
 	.label {
 		display: flex;

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.test.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.test.js
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import CountriesTimeInput from './index';
+
+describe( 'CountriesTimeInput', () => {
+	describe( 'Test Same delivery placeholder', () => {
+		it( 'Shouldnt have placeholder if times are null', () => {
+			const { getByText, getByRole, getAllByRole } = render(
+				<CountriesTimeInput
+					value={ { countries: [ 'ES' ], time: null, maxTime: null } }
+					audienceCountries={ [ 'ES' ] }
+					onChange={ jest.fn() }
+					onDelete={ jest.fn() }
+				/>
+			);
+
+			expect( getByText( 'Shipping time for' ) ).toBeInTheDocument();
+
+			expect(
+				getByRole( 'button', { name: 'Edit' } )
+			).toBeInTheDocument();
+
+			const inputs = getAllByRole( 'textbox' );
+
+			expect( inputs ).toHaveLength( 2 );
+
+			for ( const input of inputs ) {
+				expect( input ).toHaveAttribute( 'placeholder', '' );
+			}
+		} );
+
+		it( 'Should set placeholders if times are different than 0', () => {
+			const { getByDisplayValue, queryAllByPlaceholderText } = render(
+				<CountriesTimeInput
+					value={ { countries: [ 'ES' ], time: 0, maxTime: 32 } }
+					audienceCountries={ [ 'ES' ] }
+					onChange={ jest.fn() }
+					onDelete={ jest.fn() }
+				/>
+			);
+
+			expect( queryAllByPlaceholderText( 'Same Day' ) ).toHaveLength( 2 );
+
+			expect( getByDisplayValue( '32' ) ).toBeInTheDocument();
+
+			// The 0 is changed to an empty string, allowing the placeholder/default value to be displayed.
+			expect( getByDisplayValue( '' ) ).toBeInTheDocument();
+		} );
+	} );
+	describe( 'Test Stepper', () => {
+		it( 'Should call onChange when increasing an decreasing the days', async () => {
+			const onChange = jest.fn();
+			const { queryAllByRole } = render(
+				<CountriesTimeInput
+					value={ { countries: [ 'ES' ], time: 1, maxTime: 32 } }
+					audienceCountries={ [ 'ES' ] }
+					onChange={ onChange }
+					onDelete={ jest.fn() }
+				/>
+			);
+
+			const incrementButtons = queryAllByRole( 'button', {
+				name: 'Increment',
+			} );
+			const decrementButtons = queryAllByRole( 'button', {
+				name: 'Decrement',
+			} );
+
+			// One for the min and one for the max = 2 increment buttons and 2 decrement buttons
+			expect( incrementButtons ).toHaveLength( 2 );
+			expect( decrementButtons ).toHaveLength( 2 );
+
+			for ( const button of incrementButtons ) {
+				fireEvent.mouseDown( button );
+			}
+
+			for ( const button of decrementButtons ) {
+				fireEvent.mouseDown( button );
+			}
+
+			expect( onChange ).toHaveBeenCalledTimes( 4 );
+
+			//Increasing
+			expect( onChange.mock.calls[ 0 ][ 0 ].time ).toBe( 2 );
+			expect( onChange.mock.calls[ 1 ][ 0 ].maxTime ).toBe( 33 );
+
+			//Decreasing
+			expect( onChange.mock.calls[ 2 ][ 0 ].time ).toBe( 1 );
+			expect( onChange.mock.calls[ 3 ][ 0 ].maxTime ).toBe( 32 );
+		} );
+	} );
+} );

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.test.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.test.js
@@ -96,4 +96,47 @@ describe( 'CountriesTimeInput', () => {
 			expect( onChange.mock.calls[ 3 ][ 0 ].maxTime ).toBe( 32 );
 		} );
 	} );
+
+	describe( 'Test handleBlur', () => {
+		it( 'Test onChange when handleBlur is called', async () => {
+			const onChange = jest.fn();
+			const onDelete = jest.fn();
+			const { queryAllByRole } = render(
+				<CountriesTimeInput
+					value={ { countries: [ 'ES' ], time: 1, maxTime: 32 } }
+					audienceCountries={ [ 'ES' ] }
+					onChange={ onChange }
+					onDelete={ onDelete }
+				/>
+			);
+
+			const inputs = queryAllByRole( 'textbox' );
+
+			expect( inputs ).toHaveLength( 2 );
+
+			const [ timeInput, maxTimeInput ] = inputs;
+
+			// The value is the same, so the onChange function shouldnt be called
+			fireEvent.blur( timeInput, { target: { value: '1' } } );
+			expect( onChange ).toHaveBeenCalledTimes( 0 );
+
+			// The value is different, so the onChange function should be called
+			fireEvent.blur( timeInput, { target: { value: '2' } } );
+			expect( onChange ).toHaveBeenCalledTimes( 1 );
+			// It should update the time property.
+			expect( onChange.mock.calls[ 0 ][ 0 ].time ).toBe( 2 );
+
+			onChange.mockClear();
+
+			// The value is the same, so the onChange function shouldnt be called
+			fireEvent.blur( maxTimeInput, { target: { value: '32' } } );
+			expect( onChange ).toHaveBeenCalledTimes( 0 );
+
+			// The value is different, so the onChange function should be called
+			fireEvent.blur( maxTimeInput, { target: { value: '10' } } );
+			expect( onChange ).toHaveBeenCalledTimes( 1 );
+			// It should update the maxTime property.
+			expect( onChange.mock.calls[ 0 ][ 0 ].maxTime ).toBe( 10 );
+		} );
+	} );
 } );

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/getCountriesTimeArray.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/getCountriesTimeArray.js
@@ -7,15 +7,18 @@
  * const shippingTimes = [
  *     {
  *         countryCode: 'US',
- *         time: 10
+ *         time: 10,
+ *		   maxTime: 20,
  *     },
  *     {
  *         countryCode: 'AU',
- *         time: 10
+ *         time: 10,
+ *		   maxTime: 20,
  *     },
  *     {
  *         countryCode: 'CN',
- *         time: 15
+ *         time: 15,
+ *		   maxTime: 22,
  *     },
  * ]
  *
@@ -26,10 +29,12 @@
  * //     {
  * //         countries: ['US', 'AU'],
  * //         time: 10
+ *  //		  maxTime: 20,
  * //     },
  * //     {
  * //         countries: ['CN'],
  * //         time: 15
+ * //		  maxTime: 22,
  * //     },
  * ]
  * ```
@@ -41,13 +46,15 @@ const getCountriesTimeArray = ( shippingTimes ) => {
 	const timeGroupMap = new Map();
 
 	shippingTimes.forEach( ( shippingTime ) => {
-		const { countryCode, time } = shippingTime;
-		const group = timeGroupMap.get( time ) || {
+		const { countryCode, time, maxTime } = shippingTime;
+		const mapKey = `${ time }-${ maxTime }`;
+		const group = timeGroupMap.get( mapKey ) || {
 			countries: [],
 			time,
+			maxTime,
 		};
 		group.countries.push( countryCode );
-		timeGroupMap.set( time, group );
+		timeGroupMap.set( mapKey, group );
 	} );
 
 	return Array.from( timeGroupMap.values() );

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/getCountriesTimeArray.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/getCountriesTimeArray.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import getShippingTimeMapKey from '.~/utils/getShippingTimeMapKey';
+
+/**
  * Groups shipping times based on time.
  *
  * Usage example:
@@ -47,7 +52,7 @@ const getCountriesTimeArray = ( shippingTimes ) => {
 
 	shippingTimes.forEach( ( shippingTime ) => {
 		const { countryCode, time, maxTime } = shippingTime;
-		const mapKey = `${ time }-${ maxTime }`;
+		const mapKey = getShippingTimeMapKey( time, maxTime );
 		const group = timeGroupMap.get( mapKey ) || {
 			countries: [],
 			time,

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
@@ -21,7 +21,7 @@ const Stepper = ( {
 	handleIncrement,
 	field = 'time',
 } ) => {
-	const [ value, setValue ] = useState( '' );
+	const [ value, setValue ] = useState( time );
 
 	useEffect( () => {
 		// If the time is 0, we want to display an empty string to show the "Same Day" delivery placeholder.
@@ -46,7 +46,7 @@ const Stepper = ( {
 			step={ step }
 			placeholder={
 				// When onboarding, the time is null, and we don't want to show the placeholder because we need the user to enter a value for us to store.
-				time !== null && __( 'Same Day', 'google-listings-and-ads' )
+				time === null ? '' : __( 'Same Day', 'google-listings-and-ads' )
 			}
 			suffix={
 				<>

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import { plus, reset } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import AppInputNumberControl from '.~/components/app-input-number-control';
+import { FREE_LISTINGS_SAME_DAY_DELIVERY_STRING } from '.~/constants';
+
+const Stepper = ( {
+	step = 1,
+	min = 0,
+	max = Infinity,
+	onChange,
+	value: savedValue,
+	handleBlur,
+} ) => {
+	const { countries, time } = savedValue;
+
+	const [ value, setValue ] = useState(
+		FREE_LISTINGS_SAME_DAY_DELIVERY_STRING
+	);
+
+	useEffect( () => {
+		setValue( time === 0 ? FREE_LISTINGS_SAME_DAY_DELIVERY_STRING : time );
+	}, [ time ] );
+
+	function handleIncrement( thisStep = step ) {
+		const newValue = parseFloat( value || '0' ) + thisStep;
+
+		if ( newValue >= min && newValue <= max ) {
+			const newValueString =
+				newValue === 0
+					? FREE_LISTINGS_SAME_DAY_DELIVERY_STRING
+					: String( newValue );
+			onChange( {
+				countries,
+				time: newValueString,
+			} );
+
+			setValue( newValueString );
+		}
+	}
+
+	return (
+		<AppInputNumberControl
+			step={ step }
+			placeholder={ 'Same day' }
+			suffix={
+				<>
+					<>
+						<Button
+							className="woocommerce-number-control__increment"
+							icon={ plus }
+							isSmall
+							aria-hidden="true"
+							onMouseDown={ () => handleIncrement( step ) }
+							aria-label={ __(
+								'Increment',
+								'google-listings-and-ads'
+							) }
+							tabIndex={ -1 }
+						/>
+						<Button
+							icon={ reset }
+							className="woocommerce-number-control__decrement"
+							isSmall
+							aria-hidden="true"
+							onMouseDown={ () => handleIncrement( -step ) }
+							aria-label={ __(
+								'Decrement',
+								'google-listings-and-ads'
+							) }
+							tabIndex={ -1 }
+						/>
+					</>
+				</>
+			}
+			value={ value }
+			onBlur={ handleBlur }
+		/>
+	);
+};
+
+export default Stepper;

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
@@ -10,47 +10,44 @@ import { plus, reset } from '@wordpress/icons';
  * Internal dependencies
  */
 import AppInputNumberControl from '.~/components/app-input-number-control';
-import { FREE_LISTINGS_SAME_DAY_DELIVERY_STRING } from '.~/constants';
 import './index.scss';
 
 const Stepper = ( {
 	step = 1,
 	min = 0,
-	max = 250, // 250 days is the maximum allowed by Google
-	onChange,
-	countries,
+	max = 250, // Google's UI in the MC shows a maximum limit of 250 days, though the API doesn’t appear to have any such restriction.
 	time,
 	handleBlur,
+	handleIncrement,
+	field = 'time',
 } ) => {
-	const [ value, setValue ] = useState(
-		FREE_LISTINGS_SAME_DAY_DELIVERY_STRING
-	);
+	const [ value, setValue ] = useState( '' );
 
 	useEffect( () => {
-		setValue( time === 0 ? FREE_LISTINGS_SAME_DAY_DELIVERY_STRING : time );
+		// If the time is 0, we want to display an empty string to show the "Same Day" delivery placeholder.
+		setValue( time === 0 ? '' : time );
 	}, [ time ] );
 
-	function handleIncrement( thisStep = step ) {
-		const newValue = parseFloat( value || '0' ) + thisStep;
+	function onIncrement( increment ) {
+		const newValue = parseFloat( value || 0 ) + increment;
 
 		if ( newValue >= min && newValue <= max ) {
-			const newValueString =
-				newValue === 0
-					? FREE_LISTINGS_SAME_DAY_DELIVERY_STRING
-					: String( newValue );
-			onChange( {
-				countries,
-				time: newValueString,
-			} );
-
-			setValue( newValueString );
+			handleIncrement( newValue, field );
+			setValue( newValue );
 		}
 	}
+
+	const onBlur = ( e, numberValue ) => {
+		handleBlur( e, numberValue, field );
+	};
 
 	return (
 		<AppInputNumberControl
 			step={ step }
-			placeholder={ 'Same day' }
+			placeholder={
+				// When onboarding, the time is null, and we don't want to show the placeholder because we need the user to enter a value for us to store.
+				time !== null && __( 'Same Day', 'google-listings-and-ads' )
+			}
 			suffix={
 				<>
 					{ parseInt( value, 10 ) >= 1 && (
@@ -69,7 +66,7 @@ const Stepper = ( {
 							className="woocommerce-number-control__increment"
 							icon={ plus }
 							isSmall
-							onMouseDown={ () => handleIncrement( step ) }
+							onMouseDown={ () => onIncrement( step ) }
 							aria-label={ __(
 								'Increment',
 								'google-listings-and-ads'
@@ -80,7 +77,7 @@ const Stepper = ( {
 							icon={ reset }
 							className="woocommerce-number-control__decrement"
 							isSmall
-							onMouseDown={ () => handleIncrement( -step ) }
+							onMouseDown={ () => onIncrement( -step ) }
 							aria-label={ __(
 								'Decrement',
 								'google-listings-and-ads'
@@ -91,7 +88,7 @@ const Stepper = ( {
 				</>
 			}
 			value={ value }
-			onBlur={ handleBlur }
+			onBlur={ onBlur }
 			className="gla-countries-time-stepper"
 		/>
 	);

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
@@ -65,7 +65,7 @@ const Stepper = ( {
 						<Button
 							className="woocommerce-number-control__increment"
 							icon={ plus }
-							isSmall
+							size="small"
 							onMouseDown={ () => onIncrement( step ) }
 							aria-label={ __(
 								'Increment',
@@ -76,7 +76,7 @@ const Stepper = ( {
 						<Button
 							icon={ reset }
 							className="woocommerce-number-control__decrement"
-							isSmall
+							size="small"
 							onMouseDown={ () => onIncrement( -step ) }
 							aria-label={ __(
 								'Decrement',

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
@@ -16,7 +16,7 @@ import './index.scss';
 const Stepper = ( {
 	step = 1,
 	min = 0,
-	max = Infinity,
+	max = 250, // 250 days is the maximum allowed by Google
 	onChange,
 	value: savedValue,
 	handleBlur,

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
@@ -18,11 +18,10 @@ const Stepper = ( {
 	min = 0,
 	max = 250, // 250 days is the maximum allowed by Google
 	onChange,
-	value: savedValue,
+	countries,
+	time,
 	handleBlur,
 } ) => {
-	const { countries, time } = savedValue;
-
 	const [ value, setValue ] = useState(
 		FREE_LISTINGS_SAME_DAY_DELIVERY_STRING
 	);

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { plus, reset } from '@wordpress/icons';
@@ -11,6 +11,7 @@ import { plus, reset } from '@wordpress/icons';
  */
 import AppInputNumberControl from '.~/components/app-input-number-control';
 import { FREE_LISTINGS_SAME_DAY_DELIVERY_STRING } from '.~/constants';
+import './index.scss';
 
 const Stepper = ( {
 	step = 1,
@@ -53,12 +54,22 @@ const Stepper = ( {
 			placeholder={ 'Same day' }
 			suffix={
 				<>
+					{ parseInt( value, 10 ) >= 1 && (
+						<span className="gla-countries-time-suffix">
+							{ _n(
+								'day',
+								'days',
+								parseInt( value, 10 ),
+								'google-listings-and-ads'
+							) }
+						</span>
+					) }
+
 					<>
 						<Button
 							className="woocommerce-number-control__increment"
 							icon={ plus }
 							isSmall
-							aria-hidden="true"
 							onMouseDown={ () => handleIncrement( step ) }
 							aria-label={ __(
 								'Increment',
@@ -70,7 +81,6 @@ const Stepper = ( {
 							icon={ reset }
 							className="woocommerce-number-control__decrement"
 							isSmall
-							aria-hidden="true"
 							onMouseDown={ () => handleIncrement( -step ) }
 							aria-label={ __(
 								'Decrement',
@@ -83,6 +93,7 @@ const Stepper = ( {
 			}
 			value={ value }
 			onBlur={ handleBlur }
+			className="gla-countries-time-stepper"
 		/>
 	);
 };

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.scss
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.scss
@@ -1,0 +1,5 @@
+.gla-countries-time-stepper {
+    .gla-countries-time-suffix{
+        margin-right: $grid-unit-05;
+    }
+}

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.scss
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.scss
@@ -1,4 +1,5 @@
 .gla-countries-time-stepper {
+    width: $gla-width-smaller;
     .gla-countries-time-suffix{
         margin-right: $grid-unit-05;
     }

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.scss
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.scss
@@ -1,6 +1,6 @@
 .gla-countries-time-stepper {
-    width: $gla-width-smaller;
-    .gla-countries-time-suffix{
-        margin-right: $grid-unit-05;
-    }
+	width: $gla-width-smaller;
+	.gla-countries-time-suffix {
+		margin-right: $grid-unit-05;
+	}
 }

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.test.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.test.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Stepper from './index';
+
+describe( 'Stepper', () => {
+	it( 'Should increase value when clicking on the plus button', () => {
+		const handleBlur = jest.fn();
+		const handleIncrement = jest.fn();
+
+		const { getByRole, getByDisplayValue } = render(
+			<Stepper
+				time={ 1 }
+				handleBlur={ handleBlur }
+				handleIncrement={ handleIncrement }
+			/>
+		);
+
+		fireEvent.mouseDown( getByRole( 'button', { name: 'Increment' } ) );
+
+		expect( handleIncrement ).toHaveBeenCalledTimes( 1 );
+		expect( handleIncrement ).toHaveBeenCalledWith( 2, 'time' );
+		expect( getByDisplayValue( '2' ) ).toBeInTheDocument();
+	} );
+
+	it( 'Should decrease value when clicking on the minus button', () => {
+		const handleBlur = jest.fn();
+		const handleIncrement = jest.fn();
+
+		const { getByRole, getByDisplayValue } = render(
+			<Stepper
+				time={ 4 }
+				handleBlur={ handleBlur }
+				handleIncrement={ handleIncrement }
+			/>
+		);
+
+		fireEvent.mouseDown( getByRole( 'button', { name: 'Decrement' } ) );
+
+		expect( handleIncrement ).toHaveBeenCalledTimes( 1 );
+		expect( handleIncrement ).toHaveBeenCalledWith( 3, 'time' );
+		expect( getByDisplayValue( '3' ) ).toBeInTheDocument();
+	} );
+
+	it( 'Should set empty value if value is 0', () => {
+		const handleBlur = jest.fn();
+		const handleIncrement = jest.fn();
+
+		const { getByDisplayValue } = render(
+			<Stepper
+				time={ 0 }
+				handleBlur={ handleBlur }
+				handleIncrement={ handleIncrement }
+			/>
+		);
+
+		expect( getByDisplayValue( '' ) ).toBeInTheDocument();
+	} );
+} );

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -142,7 +142,14 @@ const SetupFreeListings = ( {
 				setValue( 'shipping_country_rates', nextValue );
 			}
 		} else if ( change.name === 'shipping_country_times' ) {
-			onShippingTimesChange( values.shipping_country_times );
+			// Skip the call of `onShippingTimesChange` if there are incomplete shipping times.
+			// This should only happen during onboarding when the shipping times haven't been stored yet.
+			const shippingIsIncomplete = values.shipping_country_times.some(
+				( item ) => item.time === null || item.maxTime === null
+			);
+			if ( ! shippingIsIncomplete ) {
+				onShippingTimesChange( values.shipping_country_times );
+			}
 		} else if ( settingsFieldNames.includes( change.name ) ) {
 			// The value of `shipping_time` option is determined by the value of `shipping_rate` option.
 			// So if the current form change is considered it needs to change `shipping_time` as well,

--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -6,6 +6,7 @@ export const glaData = window.glaData;
 export const glaProductData = window.glaProductData;
 
 export const FREE_LISTINGS_PROGRAM_ID = 0;
+export const FREE_LISTINGS_SAME_DAY_DELIVERY_STRING = '';
 
 // Products report related
 export const REPORT_SOURCE_PARAM = 'report-source';

--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -6,7 +6,6 @@ export const glaData = window.glaData;
 export const glaProductData = window.glaProductData;
 
 export const FREE_LISTINGS_PROGRAM_ID = 0;
-export const FREE_LISTINGS_SAME_DAY_DELIVERY_STRING = '';
 
 // Products report related
 export const REPORT_SOURCE_PARAM = 'report-source';

--- a/js/src/css/abstracts/_variables.scss
+++ b/js/src/css/abstracts/_variables.scss
@@ -31,6 +31,7 @@ $gla-line-height-large: 32px;
 $gla-border-radius: 3px;
 $gla-size-control-height: 36px;
 $gla-popover-width: 200px;
+$gla-width-smaller: 150px;
 $gla-width-small: 250px;
 $gla-width-medium: 300px;
 $gla-width-medium-large: 360px;

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -233,6 +233,7 @@ export function* fetchShippingTimes() {
 			return {
 				countryCode: el.country_code,
 				time: Number( el.time ),
+				maxTime: Number( el.max_time ),
 			};
 		} );
 
@@ -266,7 +267,7 @@ export function* fetchShippingTimes() {
  * @throws Will throw an error if the request failed.
  */
 export function* upsertShippingTimes( shippingTime ) {
-	const { countryCodes, time } = shippingTime;
+	const { countryCodes, time, maxTime } = shippingTime;
 
 	yield apiFetch( {
 		path: `${ API_NAMESPACE }/mc/shipping/times/batch`,
@@ -274,6 +275,7 @@ export function* upsertShippingTimes( shippingTime ) {
 		data: {
 			country_codes: countryCodes,
 			time,
+			max_time: maxTime,
 		},
 	} );
 

--- a/js/src/hooks/useSaveShippingTimes.js
+++ b/js/src/hooks/useSaveShippingTimes.js
@@ -10,6 +10,7 @@ import { useAppDispatch } from '.~/data';
 import useShippingTimes from './useShippingTimes';
 import getDeletedShippingTimes from '.~/utils/getDeletedShippingTimes';
 import getDifferentShippingTimes from '.~/utils/getDifferentShippingTimes';
+import { FREE_LISTINGS_SAME_DAY_DELIVERY_STRING } from '.~/constants';
 
 /**
  * @typedef { import(".~/data/actions").ShippingTime } ShippingTime
@@ -45,6 +46,8 @@ const getDeletedCountryCodes = ( newShippingTimes, oldShippingTimes ) => {
 const getShippingTimesGroups = ( shippingTimes ) => {
 	const timeGroupMap = new Map();
 	shippingTimes.forEach( ( { countryCode, time } ) => {
+		// Empty time is considered as 0 or Same day delivery.
+		time = time === FREE_LISTINGS_SAME_DAY_DELIVERY_STRING ? 0 : time;
 		const group = timeGroupMap.get( time ) || { countryCodes: [], time };
 		group.countryCodes.push( countryCode );
 		timeGroupMap.set( time, group );

--- a/js/src/hooks/useSaveShippingTimes.js
+++ b/js/src/hooks/useSaveShippingTimes.js
@@ -10,7 +10,7 @@ import { useAppDispatch } from '.~/data';
 import useShippingTimes from './useShippingTimes';
 import getDeletedShippingTimes from '.~/utils/getDeletedShippingTimes';
 import getDifferentShippingTimes from '.~/utils/getDifferentShippingTimes';
-import { FREE_LISTINGS_SAME_DAY_DELIVERY_STRING } from '.~/constants';
+import getShippingTimeMapKey from '.~/utils/getShippingTimeMapKey';
 
 /**
  * @typedef { import(".~/data/actions").ShippingTime } ShippingTime
@@ -46,18 +46,14 @@ const getDeletedCountryCodes = ( newShippingTimes, oldShippingTimes ) => {
 const getShippingTimesGroups = ( shippingTimes ) => {
 	const timeGroupMap = new Map();
 	shippingTimes.forEach( ( { countryCode, time, maxTime } ) => {
-		// Empty time is considered as 0 or Same day delivery.
-		time = time === FREE_LISTINGS_SAME_DAY_DELIVERY_STRING ? 0 : time;
-		maxTime =
-			maxTime === FREE_LISTINGS_SAME_DAY_DELIVERY_STRING ? 0 : maxTime;
-		const mapKey = `${ time }-${ maxTime }`;
+		const mapKey = getShippingTimeMapKey( time, maxTime );
 		const group = timeGroupMap.get( mapKey ) || {
 			countryCodes: [],
 			time,
 			maxTime,
 		};
 		group.countryCodes.push( countryCode );
-		timeGroupMap.set( time, group );
+		timeGroupMap.set( mapKey, group );
 	} );
 
 	return Array.from( timeGroupMap.values() );

--- a/js/src/hooks/useSaveShippingTimes.js
+++ b/js/src/hooks/useSaveShippingTimes.js
@@ -45,10 +45,17 @@ const getDeletedCountryCodes = ( newShippingTimes, oldShippingTimes ) => {
  */
 const getShippingTimesGroups = ( shippingTimes ) => {
 	const timeGroupMap = new Map();
-	shippingTimes.forEach( ( { countryCode, time } ) => {
+	shippingTimes.forEach( ( { countryCode, time, maxTime } ) => {
 		// Empty time is considered as 0 or Same day delivery.
 		time = time === FREE_LISTINGS_SAME_DAY_DELIVERY_STRING ? 0 : time;
-		const group = timeGroupMap.get( time ) || { countryCodes: [], time };
+		maxTime =
+			maxTime === FREE_LISTINGS_SAME_DAY_DELIVERY_STRING ? 0 : maxTime;
+		const mapKey = `${ time }-${ maxTime }`;
+		const group = timeGroupMap.get( mapKey ) || {
+			countryCodes: [],
+			time,
+			maxTime,
+		};
 		group.countryCodes.push( countryCode );
 		timeGroupMap.set( time, group );
 	} );

--- a/js/src/utils/getShippingTimeMapKey.js
+++ b/js/src/utils/getShippingTimeMapKey.js
@@ -1,0 +1,5 @@
+const getShippingTimeMapKey = ( time, maxtime ) => {
+	return `${ time }-${ maxtime }`;
+};
+
+export default getShippingTimeMapKey;

--- a/src/API/Site/Controllers/MerchantCenter/ShippingTimeController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingTimeController.php
@@ -316,10 +316,6 @@ class ShippingTimeController extends BaseController implements ISO3166AwareInter
 			);
 		}
 
-		if ( ! $value ) {
-			return new WP_Error( 'invalid_shipping_times', __( 'Shipping times are required.', 'google-listings-and-ads' ), [ 'param' => $param ] );
-		}
-
 		if ( $value < 0 ) {
 			return new WP_Error( 'invalid_shipping_times', __( 'Shipping times cannot be negative.', 'google-listings-and-ads' ), [ 'param' => $param ] );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Part of pcTzPl-2qP-p2

This PR introduces a UI to manage minimum and maximum shipping times, and it updates the input to include increase and decrease buttons (like a stepper input). Additionally, we're considering showing "Same Day" instead of 0 to make it clearer for merchants.

![image](https://github.com/user-attachments/assets/a77918ce-f688-4aef-af4d-737cb5d3a9a5)


Since mixing a string like "Same Day" with the actual integer values for shipping times could make the code more complex, I opted to use the placeholder attribute to display "Same Day" instead of 0 days to keep things simple. However, I'm open to other suggestions or approaches.

For more context see this comment here: pcTzPl-2qP-p2#comment-3652

#### Other Steeper Inputs in WC

https://github.com/woocommerce/woocommerce/blob/64dcafe29b52cff2dee1d56f5e06caad09a0c470/packages/js/product-editor/src/components/number-control/number-control.tsx#L166-L222

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow the steps mentioned in this PR to update the database: https://github.com/woocommerce/google-listings-and-ads/pull/2520
2. Navigate to Dashboard -> Free Listings -> Edit
3. Test the new input buttons by increasing or decreasing the values. If the value is 0, it should display "Same Day".
4. Verify that the data is being stored correctly.
5. Add and modify shipping times as needed.
6. Disconnect all your accounts.
7. Do the onboarding, and see if everything works correctly.

### Additional details:

I haven't updated the add and edit modals to use the stepper component yet to make reviewing this PR easier. Also, I want to ask for confirmation from the designers to see if we want to implement it there as well.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>