### PR TITLE
Prioritise core WooCommerce GTIN field in product adapter

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -109,6 +109,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		$this->map_woocommerce_product();
 		$this->map_attribute_mapping_rules( $mapping_rules );
 		$this->map_gla_attributes( $gla_attributes );
+		$this->map_gtin();
 
 		// Allow users to override the product's attributes using a WordPress filter.
 		$this->override_attributes();
@@ -922,6 +923,28 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		// Size
 		if ( ! empty( $attributes['size'] ) ) {
 			$this->setSizes( [ $attributes['size'] ] );
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Map the WooCommerce core global unique ID (GTIN) value if it's available.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return $this
+	 */
+	protected function map_gtin(): WCProductAdapter {
+		// compatibility-code "WC < 9.2" -- Core global unique ID field was added in 9.2
+		if ( ! method_exists( $this->wc_product, 'get_global_unique_id' ) ) {
+			return $this;
+		}
+
+		$global_unique_id = $this->wc_product->get_global_unique_id();
+
+		if ( ! empty( $global_unique_id ) ) {
+			$this->setGtin( $global_unique_id );
 		}
 
 		return $this;

--- a/tests/Unit/Product/Attributes/GtinMappingTest.php
+++ b/tests/Unit/Product/Attributes/GtinMappingTest.php
@@ -1,0 +1,123 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\Attributes;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductAdapter;
+use PHPUnit\Framework\TestCase;
+use WC_Helper_Product;
+
+/**
+ * Class GtinMappingTest
+ *
+ * Unit tests to confirm that the GTIN value is mapped correctly.
+ * The value should be prioritised in the following order:
+ * 
+ * 1. WooCommerce Core:       Global Unique ID
+ * 2. Google for WooCommerce: GTIN attribute
+ * 3. Google for WooCommerce: Attribute mapping rules
+ */
+class GtinMappingTest extends TestCase {
+
+    /** @var string $core_gtin Mock value to be used as the core gtin field. */
+    private $core_gtin = '219837492834';
+
+    /** @var string $gla_gtin Mock value to be used as the Google for WooCommerce gtin field. */
+    private $gla_gtin = 'gla-gtin-field';
+
+    /** @var string $gla_attribute_mapping_gtin Mock value to be used as the Google for WooCommerce attribute mapping gtin value. */
+    private $gla_attribute_mapping_gtin = 'gla-attribute-mapping-gtin';
+
+	/**
+	 * Test GTIN mapping from WooCommerce Core Global Unique ID.
+     *
+     * @return void
+	 */
+	public function test_gtin_populated_from_wc_core_global_unique_id() {
+        $mock_product = WC_Helper_Product::create_simple_product( false );
+        $mock_product->set_global_unique_id( $this->core_gtin );
+
+		$adapter = new WCProductAdapter();
+		$adapter->mapTypes( [
+			'wc_product'     => $mock_product,
+			'targetCountry'  => 'US',
+            'gla_attributes' => [
+                'gtin' => $this->gla_gtin
+            ],
+		] );
+
+		$this->assertEquals( $this->core_gtin, $adapter->getGtin() );
+	}
+
+	/**
+	 * Test GTIN mapping from Google for WooCommerce GTIN attribute.
+     *
+     * @return void
+	 */
+	public function test_gtin_populated_from_gla_gtin_attribute() {
+        $mock_product = WC_Helper_Product::create_simple_product( false );
+        $mock_product->set_sku( $this->gla_attribute_mapping_gtin );
+
+		$adapter = new WCProductAdapter();
+		$adapter->mapTypes( [
+			'wc_product'     => $mock_product,
+			'targetCountry'  => 'US',
+            'mapping_rules'  => [
+                [
+                    'attribute'               => 'gtin',
+                    'source'                  => 'product:sku',
+                    'category_condition_type' => 'all',
+                    'categories'              => ''
+                ]
+            ],
+            'gla_attributes' => [
+                'gtin' => $this->gla_gtin
+            ],
+		] );
+
+		$this->assertEquals( $this->gla_gtin, $adapter->getGtin() );
+	}
+
+	/**
+	 * Test GTIN mapping from Google for WooCommerce attribute mapping rules.
+     *
+     * @return void
+	 */
+	public function test_gtin_populated_from_attribute_mapping_rules() {
+        $mock_product = WC_Helper_Product::create_simple_product( false );
+        $mock_product->set_sku( $this->gla_attribute_mapping_gtin );
+
+		$adapter = new WCProductAdapter();
+		$adapter->mapTypes( [
+            'wc_product'    => $mock_product,
+            'targetCountry' => 'US',
+            'mapping_rules' => [
+                [
+                    'attribute'               => 'gtin',
+                    'source'                  => 'product:sku',
+                    'category_condition_type' => 'all',
+                    'categories'              => ''
+                ]
+            ],
+        ] );
+
+		$this->assertEquals( $this->gla_attribute_mapping_gtin, $adapter->getGtin() );
+	}
+
+	/**
+	 * Test GTIN remains empty when no data is available.
+     *
+     * @return void
+	 */
+	public function test_gtin_remains_empty_when_no_data_available() {
+		$mock_product = WC_Helper_Product::create_simple_product( false );
+
+		$adapter = new WCProductAdapter();
+		$adapter->mapTypes( [
+            'wc_product'    => $mock_product,
+            'targetCountry' => 'US',
+        ] );
+
+		$this->assertEquals( '', $adapter->getGtin() );
+	}
+}

--- a/tests/Unit/Product/Attributes/GtinMappingTest.php
+++ b/tests/Unit/Product/Attributes/GtinMappingTest.php
@@ -12,111 +12,119 @@ use WC_Helper_Product;
  *
  * Unit tests to confirm that the GTIN value is mapped correctly.
  * The value should be prioritised in the following order:
- * 
+ *
  * 1. WooCommerce Core:       Global Unique ID
  * 2. Google for WooCommerce: GTIN attribute
  * 3. Google for WooCommerce: Attribute mapping rules
  */
 class GtinMappingTest extends TestCase {
 
-    /** @var string $core_gtin Mock value to be used as the core gtin field. */
-    private $core_gtin = '219837492834';
+	/** @var string $core_gtin Mock value to be used as the core gtin field. */
+	private $core_gtin = '219837492834';
 
-    /** @var string $gla_gtin Mock value to be used as the Google for WooCommerce gtin field. */
-    private $gla_gtin = 'gla-gtin-field';
+	/** @var string $gla_gtin Mock value to be used as the Google for WooCommerce gtin field. */
+	private $gla_gtin = 'gla-gtin-field';
 
-    /** @var string $gla_attribute_mapping_gtin Mock value to be used as the Google for WooCommerce attribute mapping gtin value. */
-    private $gla_attribute_mapping_gtin = 'gla-attribute-mapping-gtin';
+	/** @var string $gla_attribute_mapping_gtin Mock value to be used as the Google for WooCommerce attribute mapping gtin value. */
+	private $gla_attribute_mapping_gtin = 'gla-attribute-mapping-gtin';
 
 	/**
 	 * Test GTIN mapping from WooCommerce Core Global Unique ID.
-     *
-     * @return void
+	 *
+	 * @return void
 	 */
 	public function test_gtin_populated_from_wc_core_global_unique_id() {
-        $mock_product = WC_Helper_Product::create_simple_product( false );
-        $mock_product->set_global_unique_id( $this->core_gtin );
+		$mock_product = WC_Helper_Product::create_simple_product( false );
+		$mock_product->set_global_unique_id( $this->core_gtin );
 
 		$adapter = new WCProductAdapter();
-		$adapter->mapTypes( [
-			'wc_product'     => $mock_product,
-			'targetCountry'  => 'US',
-            'gla_attributes' => [
-                'gtin' => $this->gla_gtin
-            ],
-		] );
+		$adapter->mapTypes(
+			[
+				'wc_product'     => $mock_product,
+				'targetCountry'  => 'US',
+				'gla_attributes' => [
+					'gtin' => $this->gla_gtin,
+				],
+			]
+		);
 
 		$this->assertEquals( $this->core_gtin, $adapter->getGtin() );
 	}
 
 	/**
 	 * Test GTIN mapping from Google for WooCommerce GTIN attribute.
-     *
-     * @return void
+	 *
+	 * @return void
 	 */
 	public function test_gtin_populated_from_gla_gtin_attribute() {
-        $mock_product = WC_Helper_Product::create_simple_product( false );
-        $mock_product->set_sku( $this->gla_attribute_mapping_gtin );
+		$mock_product = WC_Helper_Product::create_simple_product( false );
+		$mock_product->set_sku( $this->gla_attribute_mapping_gtin );
 
 		$adapter = new WCProductAdapter();
-		$adapter->mapTypes( [
-			'wc_product'     => $mock_product,
-			'targetCountry'  => 'US',
-            'mapping_rules'  => [
-                [
-                    'attribute'               => 'gtin',
-                    'source'                  => 'product:sku',
-                    'category_condition_type' => 'all',
-                    'categories'              => ''
-                ]
-            ],
-            'gla_attributes' => [
-                'gtin' => $this->gla_gtin
-            ],
-		] );
+		$adapter->mapTypes(
+			[
+				'wc_product'     => $mock_product,
+				'targetCountry'  => 'US',
+				'mapping_rules'  => [
+					[
+						'attribute'               => 'gtin',
+						'source'                  => 'product:sku',
+						'category_condition_type' => 'all',
+						'categories'              => '',
+					],
+				],
+				'gla_attributes' => [
+					'gtin' => $this->gla_gtin,
+				],
+			]
+		);
 
 		$this->assertEquals( $this->gla_gtin, $adapter->getGtin() );
 	}
 
 	/**
 	 * Test GTIN mapping from Google for WooCommerce attribute mapping rules.
-     *
-     * @return void
+	 *
+	 * @return void
 	 */
 	public function test_gtin_populated_from_attribute_mapping_rules() {
-        $mock_product = WC_Helper_Product::create_simple_product( false );
-        $mock_product->set_sku( $this->gla_attribute_mapping_gtin );
+		$mock_product = WC_Helper_Product::create_simple_product( false );
+		$mock_product->set_sku( $this->gla_attribute_mapping_gtin );
 
 		$adapter = new WCProductAdapter();
-		$adapter->mapTypes( [
-            'wc_product'    => $mock_product,
-            'targetCountry' => 'US',
-            'mapping_rules' => [
-                [
-                    'attribute'               => 'gtin',
-                    'source'                  => 'product:sku',
-                    'category_condition_type' => 'all',
-                    'categories'              => ''
-                ]
-            ],
-        ] );
+		$adapter->mapTypes(
+			[
+				'wc_product'    => $mock_product,
+				'targetCountry' => 'US',
+				'mapping_rules' => [
+					[
+						'attribute'               => 'gtin',
+						'source'                  => 'product:sku',
+						'category_condition_type' => 'all',
+						'categories'              => '',
+					],
+				],
+			]
+		);
 
 		$this->assertEquals( $this->gla_attribute_mapping_gtin, $adapter->getGtin() );
 	}
 
 	/**
 	 * Test GTIN remains empty when no data is available.
-     *
-     * @return void
+	 *
+	 * @return void
 	 */
 	public function test_gtin_remains_empty_when_no_data_available() {
 		$mock_product = WC_Helper_Product::create_simple_product( false );
 
 		$adapter = new WCProductAdapter();
-		$adapter->mapTypes( [
-            'wc_product'    => $mock_product,
-            'targetCountry' => 'US',
-        ] );
+		$adapter->mapTypes(
+			[
+				'wc_product'    => $mock_product,
+				'targetCountry' => 'US',
+			]
+		);
 
 		$this->assertEquals( '', $adapter->getGtin() );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2614

Adjusts `WCProductAdapter.php` to map the GTIN field from WooCommerce core if it's available. This is checked after the attribute mapping rules and Google for WooCommerce attributes as we want to prioritise the core field.

We return early if the product does not have a `get_global_unique_id` method to maintain backwards compatibility.

### Screenshots:

<img width="1257" alt="Screenshot 2024-09-20 at 12 20 42" src="https://github.com/user-attachments/assets/09044b49-b313-48b4-ba35-979c622535fe">

### Detailed test instructions:

1. Checkout `update/2614-prioritise-core-gtin-field-in-product-adapter`
2. Set up an attribute mapping rule for GTIN to some field
3. Create a product and enter different valid GTIN values (_for example 00000001, 00000002, 00000003_) in
    - The core `GTIN` field on the `Inventory` tab
    - The `GTIN` field on the `Google for WooCommerce` tab
    - The field set via the attribute mapping rule created in step 2
4. Go to `wp-admin/admin.php?page=connection-test-admin-page` and sync the product to Google
5. View the product in Merchant Center and confirm the GTIN number matches the value entered in the `Inventory` tab
6. Delete the GTIN value from the `Inventory` tab
7. Re-sync the product and then confirm the value in Merchant Center now matches the value from the `Google for WooCommerce` tab
8. Delete the GTIN value from the `Google for WooCommerce` tab
9. Re-sync the product and then confirm the value in Merchant Center now matches the value from the attribute mapping rule

### Changelog entry

> Update - Product adapter to map GTIN value from WooCommerce core field if it's available