### PR TITLE
PHP Units tests: Symlink WC instead of moving the WC folder

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -203,7 +203,7 @@ install_wc() {
     git clone --quiet --depth=1 --branch="${WC_VERSION}" https://github.com/woocommerce/woocommerce.git "${WC_TMPDIR}"
 
     ln -s "${WC_TMPDIR}"/plugins/woocommerce "$WC_DIR"
-	  touch "$WC_VERSION_FILE"
+    touch "$WC_VERSION_FILE"
 
     # Install composer for WooCommerce
     cd "${WC_DIR}"

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -196,14 +196,14 @@ install_wc() {
   if [ ! -f "$WC_VERSION_FILE" ]; then
     # set up testing suite
     rm -rf "$WC_DIR"
-    mkdir -p "$WC_DIR"
     echo "Installing WooCommerce ($WC_VERSION)."
     # Grab the necessary plugins.
     WC_TMPDIR="${TMPDIR}/woocommerce-${WC_VERSION}"
     rm -rf "${WC_TMPDIR}"
     git clone --quiet --depth=1 --branch="${WC_VERSION}" https://github.com/woocommerce/woocommerce.git "${WC_TMPDIR}"
-    mv "${WC_TMPDIR}"/plugins/woocommerce/* "$WC_DIR"
-	touch "$WC_VERSION_FILE"
+
+    ln -s "${WC_TMPDIR}"/plugins/woocommerce "$WC_DIR"
+	  touch "$WC_VERSION_FILE"
 
     # Install composer for WooCommerce
     cd "${WC_DIR}"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes p1725522825461799-slack-C0410KV3YLW

The PHP Unit tests couldn't be installed because a dependency located in the WooCommerce repo is outside the plugin folder. The issue is because we  moved the WC folder inside the plugin folder, preventing `composer` from accessing packages in the WooCommerce repo.

**WC composer.json**: https://github.com/woocommerce/woocommerce/blob/37bb36994b08d417e34b9043fea0bf92a3f9c236/plugins/woocommerce/composer.json#L19-L24

**Package**: https://github.com/woocommerce/woocommerce/tree/trunk/packages/php/blueprint

This PR resolve the issue by symlinking the WooCommerce folder instead of moving it.

The error was the following:

` Source path "../../packages/php/blueprint" is not found for package woocommerce/blueprint  `

See: https://github.com/woocommerce/google-listings-and-ads/actions/runs/11035010424/job/30658509144#step:6:81

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this branch and check that the PHP unit tests are installed correctly. 


### Additional details:

[ It seems that one test is failing](https://github.com/woocommerce/google-listings-and-ads/actions/runs/11038284833/job/30661334264#step:6:54): `test_delete_created_product_calls_notify_directly` but doesn't seem related to this PR. 

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Fix missing blueprint dependency. 