### PR TITLE
[API PULL] Fix tests for Notifying delete products 

### DIFF
--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -324,8 +324,6 @@ class SyncerHooks implements Service, Registerable {
 	 */
 	protected function maybe_send_delete_notification( int $product_id ) {
 		$product = $this->wc->maybe_get_product( $product_id );
-		var_dump( $product->get_meta('_wc_gla_notification_status') );
-
 		if ( $product instanceof WC_Product && $this->product_helper->has_notified_creation( $product ) ) {
 			$result = $this->notifications_service->notify( NotificationsService::TOPIC_PRODUCT_DELETED, $product_id, [ 'offer_id' => $this->product_helper->get_offer_id( $product_id ) ] );
 			if ( $result ) {

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -306,14 +306,6 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $product_id
 	 */
 	protected function handle_delete_product( int $product_id ) {
-		if ( $this->notifications_service->is_ready() ) {
-			/**
-			 * For deletions, we do send directly the notification instead of scheduling it.
-			 * This is because we want to avoid that the product is not in the database anymore when the scheduled action runs.
-			*/
-			$this->maybe_send_delete_notification( $product_id );
-		}
-
 		if ( isset( $this->delete_requests_map[ $product_id ] ) ) {
 			$product_id_map = BatchProductIDRequestEntry::convert_to_id_map( $this->delete_requests_map[ $product_id ] )->get();
 			if ( ! empty( $product_id_map ) && ! $this->is_already_scheduled_to_delete( $product_id ) ) {
@@ -331,7 +323,8 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $product_id
 	 */
 	protected function maybe_send_delete_notification( int $product_id ) {
-		$product = wc_get_product( $product_id );
+		$product = $this->wc->maybe_get_product( $product_id );
+		var_dump( $product->get_meta('_wc_gla_notification_status') );
 
 		if ( $product instanceof WC_Product && $this->product_helper->has_notified_creation( $product ) ) {
 			$result = $this->notifications_service->notify( NotificationsService::TOPIC_PRODUCT_DELETED, $product_id, [ 'offer_id' => $this->product_helper->get_offer_id( $product_id ) ] );
@@ -365,6 +358,14 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $product_id
 	 */
 	protected function handle_pre_delete_product( int $product_id ) {
+		if ( $this->notifications_service->is_ready() ) {
+			/**
+			 * For deletions, we do send directly the notification instead of scheduling it.
+			 * This is because we want to avoid that the product is not in the database anymore when the scheduled action runs.
+			 */
+			$this->maybe_send_delete_notification( $product_id );
+		}
+
 		$product = $this->wc->maybe_get_product( $product_id );
 
 		// each variation is passed to this method separately so we don't need to delete the variable product


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There is a test failing in regards 

```
Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\SyncerHooksTest::test_delete_created_product_calls_notify_directly
Expectation failed for method name is "notify" when invoked 1 time(s).
Method was expected to be called 1 times, actually called 0 times.
```

This seems to happen because the metadata is empty after the code calls the delete hook. To solve it. I moved the notifications to the pre-delete.


### Screenshots:



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  Tests are passing
2.  Create a simple product. It will schedule a create notification. See it works as expected and shows in the logs after the action is completed.
3. Trash the simple product. See directly the delete notification in the logs.  


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Logic for Delete notifications.
