### PR TITLE
[GTIN] Add GTIN migration JOB

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -21,6 +21,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteAllProducts;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\MigrateGTIN;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
@@ -644,6 +645,18 @@ class ConnectionTest implements Service, Registerable {
 					<input name="merchant_id" type="hidden" value="<?php echo ! empty( $_GET['merchant_id'] ) ? intval( $_GET['merchant_id'] ) : ''; ?>" />
 					<input name="page" value="connection-test-admin-page" type="hidden" />
 					<input name="action" value="wcs-cleanup-products" type="hidden" />
+				</form>
+				<form action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" method="GET">
+					<table class="form-table" role="presentation">
+						<tr>
+							<th><label>GTIN Migration:</label></th>
+							<td>
+								<p>
+									<a class="button" href="<?php echo esc_url( wp_nonce_url( add_query_arg( [ 'action' => 'migrate-gtin' ], $url ), 'migrate-gtin' ) ); ?>">Start GTIN Migration</a>
+								</p>
+							</td>
+						</tr>
+					</table>
 				</form>
 			<?php } ?>
 
@@ -1321,6 +1334,14 @@ class ConnectionTest implements Service, Registerable {
 				$this->response = 'Successfully scheduled a job to cleanup all products!';
 			}
 		}
+
+		if ( 'migrate-gtin' === $_GET['action'] && check_admin_referer( 'migrate-gtin' ) ) {
+			/** @var MigrateGTIN $job */
+			$job = $this->container->get( MigrateGTIN::class );
+			$job->schedule();
+			$this->response = 'Successfully scheduled a job to migrate GTIN';
+		}
+
 
 	}
 

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -24,6 +24,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\MigrateGTIN;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\CouponNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\ProductNotificationJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Notifications\SettingsNotificationJob;
@@ -126,6 +127,14 @@ class JobServiceProvider extends AbstractServiceProvider {
 			NotificationsService::class,
 			CouponHelper::class
 		);
+
+		// share GTIN migration job
+		$this->share_action_scheduler_job(
+			MigrateGTIN::class,
+			ProductRepository::class,
+			Product\Attributes\AttributeManager::class
+		);
+
 
 		$this->share_with_tags(
 			JobRepository::class,

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -135,7 +135,6 @@ class JobServiceProvider extends AbstractServiceProvider {
 			Product\Attributes\AttributeManager::class
 		);
 
-
 		$this->share_with_tags(
 			JobRepository::class,
 			JobInterface::class

--- a/src/Jobs/MigrateGTIN.php
+++ b/src/Jobs/MigrateGTIN.php
@@ -1,0 +1,136 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MigrateGTIN
+ *
+ * Schedules GTIN migration for all the products in the store.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
+ * @since x.x.x
+ */
+class MigrateGTIN extends AbstractBatchedActionSchedulerJob implements OptionsAwareInterface {
+	use OptionsAwareTrait;
+
+	/**
+	 * @var ProductRepository
+	 */
+	protected $product_repository;
+
+
+	/**
+	 * @var AttributeManager
+	 */
+	protected $attribute_manager;
+
+
+	/**
+	 * Job constructor.
+	 *
+	 * @param ActionSchedulerInterface  $action_scheduler
+	 * @param ActionSchedulerJobMonitor $monitor
+	 * @param ProductRepository         $product_repository
+	 * @param AttributeManager          $attribute_manager
+	 */
+	public function __construct( ActionSchedulerInterface $action_scheduler, ActionSchedulerJobMonitor $monitor, ProductRepository $product_repository, AttributeManager $attribute_manager ) {
+		parent::__construct( $action_scheduler, $monitor );
+		$this->product_repository = $product_repository;
+		$this->attribute_manager  = $attribute_manager;
+	}
+
+	/**
+	 * Get the name of the job.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'migrate_gtin';
+	}
+
+	/**
+	 * Can the job be scheduled.
+	 *
+	 * @param array|null $args
+	 *
+	 * @return bool Returns true if the job can be scheduled.
+	 */
+	public function can_schedule( $args = [] ): bool {
+		return parent::can_schedule( $args ) && $this->is_gtin_available_in_core();
+	}
+
+	/**
+	 * Process batch items.
+	 *
+	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 */
+	protected function process_items( array $items ) {
+		// todo: prevent execution if migration was completed?
+
+		// update the product core GTIN using G4W GTIN
+		$products = $this->product_repository->find_by_ids( $items );
+		foreach ( $products as $product ) {
+			// void if core GTIN is already set.
+			if ( $product->get_global_unique_id() ) {
+				continue;
+			}
+
+			// process variations
+			if ( $product instanceof \WC_Product_Variable ) {
+				$variations = $product->get_available_variations();
+				$ids        = array_column( $variations, 'variation_id' );
+				$this->process_items( $ids );
+				continue;
+			}
+
+			$gtin = $this->attribute_manager->get_value( $product, 'gtin' );
+			if ( $gtin ) {
+				$product->set_global_unique_id( $gtin );
+				$product->save();
+			}
+		}
+	}
+
+	/**
+	 * Called when the job is completed.
+	 *
+	 * @param int $final_batch_number The final batch number when the job was completed.
+	 *                                If equal to 1 then no items were processed by the job.
+	 */
+	protected function handle_complete( int $final_batch_number ) {
+		// todo: set migration as completed?
+	}
+
+	/**
+	 * Get a single batch of items.
+	 *
+	 * If no items are returned the job will stop.
+	 *
+	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 *
+	 * @return array
+	 *
+	 * @throws Exception If an error occurs. The exception will be logged by ActionScheduler.
+	 */
+	protected function get_batch( int $batch_number ): array {
+		return $this->product_repository->find_all_product_ids( $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+	}
+
+	/**
+	 * Verifies if GTIN logic is available in core.
+	 *
+	 * @return bool
+	 */
+	protected function is_gtin_available_in_core(): bool {
+		return method_exists( \WC_Product::class, 'get_global_unique_id' );
+	}
+}

--- a/src/Jobs/MigrateGTIN.php
+++ b/src/Jobs/MigrateGTIN.php
@@ -86,9 +86,8 @@ class MigrateGTIN extends AbstractBatchedActionSchedulerJob implements OptionsAw
 
 			// process variations
 			if ( $product instanceof \WC_Product_Variable ) {
-				$variations = $product->get_available_variations();
-				$ids        = array_column( $variations, 'variation_id' );
-				$this->process_items( $ids );
+				$variations = $product->get_children();
+				$this->process_items( $variations );
 				continue;
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of #2616 as part of pcTzPl-2p2-p2.

This PR creates the logic for the Job responsible for the migration GTIN in batches for all the products.

### Screenshots:

<img width="1547" alt="Screenshot 2024-10-17 at 18 29 40" src="https://github.com/user-attachments/assets/27ce8d45-67bb-4b0c-88b4-939acf683cfb">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Set a simple product and add a GTIN in Google for WooCommerce tab
2. Set a simple product  and add a different GTIN in Google for WooCommerce tab and in the Inventory tab
3. Set a Variable product and set GTIN on one of the variations in Google for WooCommerce  only and in both (inventory and Google for WooCommerce) in other.
4. Go to Connection Test page and click on "Start GTIN Migration"
5. See the job  `gla/jobs/migrate_gtin/create_batch` scheduled in WooCommerce - Status -  Scheduled actions
6. Run the job and see the `gla/jobs/migrate_gtin/process_items` created with the product ids.
7. Run it
8. Go back to the products created in steps 1,2,3 and verify that:
9. For the product in step 1- the GTIN was loaded  in the inventory GTIN
10. For the product in step 2 - The GTIN is still the GTIN you set initially and is not override  by the GTIN in google for WooCommerce GTIN
11. Check the same in the variations (GTIN set in core should not be overrided in the migration).


### Additional details:

In follow-up PRs I will add:

-  the banners for starting the migration
-  tests
-  WP CLI tool


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Add GTIN Migration Job
