### PR TITLE
[GTIN] Prepare GTIN with the correct format before sending it to MC

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -941,7 +941,8 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 			return $this;
 		}
 
-		$global_unique_id = $this->wc_product->get_global_unique_id();
+		// avoid dashes and other unsupported format
+		$global_unique_id = preg_replace( '/[^0-9]/', '', $this->wc_product->get_global_unique_id() );
 
 		if ( ! empty( $global_unique_id ) ) {
 			$this->setGtin( $global_unique_id );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR prepares the GTIN for sending data to MC by removing everything but numbers.

Before this PR. When setting a GTIN in Inventory with dashes (which is an accepted format) it fails when syncing that product. This PR fixes that.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Add a GTIN in inventory like 0000-0000  (use the dashes)
2. Sync the product in Connection test page
3. The product is successfully synced.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak -  Prepare GTIN with the correct format before sending it to MC
