### PR TITLE
[GTIN] Add WP CLI command for migration

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -217,7 +217,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		AttributeMapping::class          => true,
 		MarketingChannelRegistrar::class => true,
 		OAuthService::class              => true,
-		WPCLIMigrationGTIN::class     	 => true,
+		WPCLIMigrationGTIN::class        => true,
 	];
 
 	/**

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -126,6 +126,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Utility\AddressUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ImageUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ISOUtility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Utility\WPCLIMigrationGTIN;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
@@ -216,6 +217,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		AttributeMapping::class          => true,
 		MarketingChannelRegistrar::class => true,
 		OAuthService::class              => true,
+		WPCLIMigrationGTIN::class     	 => true,
 	];
 
 	/**
@@ -431,5 +433,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			$this->share_with_tags( GLAChannel::class, MerchantCenterService::class, AdsCampaign::class, Ads::class, MerchantStatuses::class, ProductSyncStats::class );
 			$this->share_with_tags( MarketingChannelRegistrar::class, GLAChannel::class, WC::class );
 		}
+
+		// ClI Classes
+		$this->share_with_tags( WPCLIMigrationGTIN::class, ProductRepository::class, AttributeManager::class );
 	}
 }

--- a/src/Utility/WPCLIMigrationGTIN.php
+++ b/src/Utility/WPCLIMigrationGTIN.php
@@ -177,7 +177,7 @@ class WPCLIMigrationGTIN implements Service, Registerable {
 			if ( $gtin ) {
 				$product->set_global_unique_id( $gtin );
 				$product->save();
-				WP_CLI::success( sprintf( 'GTIN [ %s ] has been migrated for Product ID: %s - %s', $gtin, $product->get_id(), $product->get_name() ) );
+				WP_CLI::debug( sprintf( 'GTIN [ %s ] has been migrated for Product ID: %s - %s', $gtin, $product->get_id(), $product->get_name() ) );
 				++$processed;
 			}
 		}

--- a/src/Utility/WPCLIMigrationGTIN.php
+++ b/src/Utility/WPCLIMigrationGTIN.php
@@ -190,7 +190,7 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 					WP_CLI::debug( sprintf( 'GTIN [ %s ] has been migrated for Product ID: %s - %s', $gtin, $product->get_id(), $product->get_name() ) );
 					++$processed;
 				} catch ( Exception $e ) {
-					WP_CLI::error( $e->getMessage(), false );
+					WP_CLI::error( sprintf('GTIN [ %s ] for Product ID: %s - %s has an error - %s', $gtin, $product->get_id(), $product->get_name(), $e->getMessage()), false );
 				}
 			} else {
 				WP_CLI::debug( sprintf( 'GTIN [ %s ] has been skipped for Product ID: %s - %s. Invalid GTIN was found.', $gtin, $product->get_id(), $product->get_name() ) );

--- a/src/Utility/WPCLIMigrationGTIN.php
+++ b/src/Utility/WPCLIMigrationGTIN.php
@@ -183,17 +183,19 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 			}
 
 			$gtin = str_replace( '-', '', $gtin );
-			if ( is_numeric( $gtin ) ) {
-				try {
-					$product->set_global_unique_id( $gtin );
-					$product->save();
-					WP_CLI::debug( sprintf( 'GTIN [ %s ] has been migrated for Product ID: %s - %s', $gtin, $product->get_id(), $product->get_name() ) );
-					++$processed;
-				} catch ( Exception $e ) {
-					WP_CLI::error( sprintf('GTIN [ %s ] for Product ID: %s - %s has an error - %s', $gtin, $product->get_id(), $product->get_name(), $e->getMessage()), false );
-				}
-			} else {
+
+			if ( ! is_numeric( $gtin ) ) {
 				WP_CLI::debug( sprintf( 'GTIN [ %s ] has been skipped for Product ID: %s - %s. Invalid GTIN was found.', $gtin, $product->get_id(), $product->get_name() ) );
+				continue;
+			}
+
+			try {
+				$product->set_global_unique_id( $gtin );
+				$product->save();
+				WP_CLI::debug( sprintf( 'GTIN [ %s ] has been migrated for Product ID: %s - %s', $gtin, $product->get_id(), $product->get_name() ) );
+				++$processed;
+			} catch ( Exception $e ) {
+				WP_CLI::error( sprintf( 'GTIN [ %s ] for Product ID: %s - %s has an error - %s', $gtin, $product->get_id(), $product->get_name(), $e->getMessage() ), false );
 			}
 		}
 

--- a/src/Utility/WPCLIMigrationGTIN.php
+++ b/src/Utility/WPCLIMigrationGTIN.php
@@ -163,16 +163,16 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 		$processed = 0;
 
 		foreach ( $products as $product ) {
-			// void if core GTIN is already set.
-			if ( $product->get_global_unique_id() ) {
-				WP_CLI::debug( sprintf( 'GTIN has been skipped for Product ID: %s - %s. GTIN was found in Product Inventory tab.', $product->get_id(), $product->get_name() ) );
-				continue;
-			}
-
 			// process variations
 			if ( $product instanceof \WC_Product_Variable ) {
 				$variations = $product->get_children();
 				$processed += $this->process_items( $variations );
+				continue;
+			}
+
+			// void if core GTIN is already set.
+			if ( $product->get_global_unique_id() ) {
+				WP_CLI::debug( sprintf( 'GTIN has been skipped for Product ID: %s - %s. GTIN was found in Product Inventory tab.', $product->get_id(), $product->get_name() ) );
 				continue;
 			}
 

--- a/src/Utility/WPCLIMigrationGTIN.php
+++ b/src/Utility/WPCLIMigrationGTIN.php
@@ -1,0 +1,187 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Utility;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+use WP_CLI;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WP_CLI_GTIN_Migration
+ * Creates a set of utility commands in WP CLI for GTIN Migration
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Utility
+ *
+ * @since x.x.x
+ */
+class WPCLIMigrationGTIN implements Service, Registerable {
+
+
+	/** @var AttributeManager  */
+	public AttributeManager $attribute_manager;
+
+	/** @var ProductRepository  */
+	public ProductRepository $product_repository;
+
+	/**
+	 * Constructor
+	 *
+	 * @param ProductRepository $product_repository
+	 * @param AttributeManager  $attribute_manager
+	 */
+	public function __construct( ProductRepository $product_repository, AttributeManager $attribute_manager ) {
+		$this->product_repository = $product_repository;
+		$this->attribute_manager  = $attribute_manager;
+	}
+
+	/**
+	 * Register service and initialize hooks.
+	 */
+	public function register(): void {
+		WP_CLI::add_hook( 'after_wp_load', [ $this, 'register_commands' ] );
+	}
+
+	/**
+	 * Register the commands
+	 */
+	public function register_commands(): void {
+		WP_CLI::add_command( 'wc g4wc gtin-migration start', [ $this, 'gtin_migration_start' ] );
+	}
+
+	/**
+	 * Starts the GTIN migration in batches
+	 */
+	public function gtin_migration_start(): void {
+		$batch_size   = $this->get_batch_size();
+		$num_products = $this->get_total_products_count();
+		WP_CLI::log( sprintf( 'Starting GTIN migration for %s products in the store.', $num_products ) );
+		$progress     = WP_CLI\Utils\make_progress_bar( 'GTIN Migration', $num_products / $batch_size );
+		$processed    = 0;
+		$batch_number = 1;
+		$start_time   = microtime( true );
+
+		// First batch
+		$items      = $this->get_items( $batch_number );
+		$processed += $this->process_items( $items );
+		$progress->tick();
+
+		// Next batches
+		while ( ! empty( $items ) ) {
+			++$batch_number;
+			$items      = $this->get_items( $batch_number );
+			$processed += $this->process_items( $items );
+			$progress->tick();
+		}
+
+		$progress->finish();
+		$total_time = microtime( true ) - $start_time;
+
+		// Issue a warning if nothing is migrated.
+		if ( ! $processed ) {
+			WP_CLI::warning( __( 'No GTIN were migrated.', 'google-listings-and-ads' ) );
+			return;
+		}
+
+		WP_CLI::success(
+			sprintf(
+			/* Translators: %1$d is the number of migrated GTINS and %2$d is the execution time in seconds. */
+				_n(
+					'%1$d GTIN was migrated in %2$d seconds.',
+					'%1$d GTIN were migrated in %2$d seconds.',
+					$processed,
+					'google-listings-and-ads'
+				),
+				$processed,
+				$total_time
+			)
+		);
+	}
+
+	/**
+	 * Get total of products in the store to be migrated.
+	 *
+	 * @return int The total number of products.
+	 */
+	private function get_total_products_count(): int {
+		$args = [
+			'status' => 'publish',
+			'return' => 'ids',
+			'type'   => [ 'simple', 'variation' ],
+		];
+
+		return count( $this->product_repository->find_ids( $args ) );
+	}
+
+
+	/**
+	 * Get the items for the current batch
+	 *
+	 * @param int $batch_number
+	 * @return int[] Array of WooCommerce product IDs
+	 */
+	private function get_items( int $batch_number ): array {
+		return $this->product_repository->find_all_product_ids( $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+	}
+
+	/**
+	 * Get the query offset based on a given batch number and the specified batch size.
+	 *
+	 * @param int $batch_number
+	 *
+	 * @return int
+	 */
+	protected function get_query_offset( int $batch_number ): int {
+		return $this->get_batch_size() * ( $batch_number - 1 );
+	}
+
+	/**
+	 * Get the batch size. By default, 100.
+	 *
+	 * @return int The batch size.
+	 */
+	private function get_batch_size(): int {
+		return apply_filters( 'woocommerce_gla_batched_cli_size', 100 );
+	}
+
+	/**
+	 * Process batch items.
+	 *
+	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @return int The number of items processed.
+	 */
+	protected function process_items( array $items ): int {
+		// todo: refactor avoiding duplication with MigrateGTIN Job after https://github.com/woocommerce/google-listings-and-ads/pull/2656 gets merged.
+		// update the product core GTIN using G4W GTIN
+		$products  = $this->product_repository->find_by_ids( $items );
+		$processed = 0;
+
+		foreach ( $products as $product ) {
+			// void if core GTIN is already set.
+			if ( $product->get_global_unique_id() ) {
+				continue;
+			}
+
+			// process variations
+			if ( $product instanceof \WC_Product_Variable ) {
+				$variations = $product->get_children();
+				$processed += $this->process_items( $variations );
+				continue;
+			}
+
+			$gtin = $this->attribute_manager->get_value( $product, 'gtin' );
+			if ( $gtin ) {
+				$product->set_global_unique_id( $gtin );
+				$product->save();
+				WP_CLI::success( sprintf( 'GTIN [ %s ] has been migrated for Product ID: %s - %s', $gtin, $product->get_id(), $product->get_name() ) );
+				++$processed;
+			}
+		}
+
+		return $processed;
+	}
+}

--- a/src/Utility/WPCLIMigrationGTIN.php
+++ b/src/Utility/WPCLIMigrationGTIN.php
@@ -192,8 +192,8 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 			try {
 				$product->set_global_unique_id( $gtin );
 				$product->save();
-				WP_CLI::debug( sprintf( 'GTIN [ %s ] has been migrated for Product ID: %s - %s', $gtin, $product->get_id(), $product->get_name() ) );
 				++$processed;
+				WP_CLI::debug( sprintf( 'GTIN [ %s ] has been migrated for Product ID: %s - %s', $gtin, $product->get_id(), $product->get_name() ) );
 			} catch ( Exception $e ) {
 				WP_CLI::error( sprintf( 'GTIN [ %s ] for Product ID: %s - %s has an error - %s', $gtin, $product->get_id(), $product->get_name(), $e->getMessage() ), false );
 			}

--- a/src/Utility/WPCLIMigrationGTIN.php
+++ b/src/Utility/WPCLIMigrationGTIN.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Utility;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
@@ -19,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since x.x.x
  */
-class WPCLIMigrationGTIN implements Service, Registerable {
+class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 
 
 	/** @var AttributeManager  */
@@ -183,5 +184,14 @@ class WPCLIMigrationGTIN implements Service, Registerable {
 		}
 
 		return $processed;
+	}
+
+	/**
+	 * Check if this Service is needed.
+	 * @see https://make.wordpress.org/cli/handbook/guides/commands-cookbook/#include-in-a-plugin-or-theme
+	 * @return bool
+	 */
+	public static function is_needed(): bool {
+		return defined( 'WP_CLI' ) && WP_CLI;
 	}
 }

--- a/src/Utility/WPCLIMigrationGTIN.php
+++ b/src/Utility/WPCLIMigrationGTIN.php
@@ -182,7 +182,7 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 				continue;
 			}
 
-			$gtin = str_replace( "-", "", $gtin );
+			$gtin = str_replace( '-', '', $gtin );
 			if ( is_numeric( $gtin ) ) {
 				try {
 					$product->set_global_unique_id( $gtin );
@@ -202,6 +202,7 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 
 	/**
 	 * Check if this Service is needed.
+	 *
 	 * @see https://make.wordpress.org/cli/handbook/guides/commands-cookbook/#include-in-a-plugin-or-theme
 	 * @return bool
 	 */

--- a/src/Utility/WPCLIMigrationGTIN.php
+++ b/src/Utility/WPCLIMigrationGTIN.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+use Exception;
 use WP_CLI;
 
 defined( 'ABSPATH' ) || exit;
@@ -164,6 +165,7 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 		foreach ( $products as $product ) {
 			// void if core GTIN is already set.
 			if ( $product->get_global_unique_id() ) {
+				WP_CLI::debug( sprintf( 'GTIN has been skipped for Product ID: %s - %s. GTIN was found in Product Inventory tab.', $product->get_id(), $product->get_name() ) );
 				continue;
 			}
 
@@ -175,11 +177,23 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 			}
 
 			$gtin = $this->attribute_manager->get_value( $product, 'gtin' );
-			if ( $gtin ) {
-				$product->set_global_unique_id( $gtin );
-				$product->save();
-				WP_CLI::debug( sprintf( 'GTIN [ %s ] has been migrated for Product ID: %s - %s', $gtin, $product->get_id(), $product->get_name() ) );
-				++$processed;
+			if ( ! $gtin ) {
+				WP_CLI::debug( sprintf( 'GTIN has been skipped for Product ID: %s - %s. No GTIN was found', $product->get_id(), $product->get_name() ) );
+				continue;
+			}
+
+			$gtin = str_replace( "-", "", $gtin );
+			if ( is_numeric( $gtin ) ) {
+				try {
+					$product->set_global_unique_id( $gtin );
+					$product->save();
+					WP_CLI::debug( sprintf( 'GTIN [ %s ] has been migrated for Product ID: %s - %s', $gtin, $product->get_id(), $product->get_name() ) );
+					++$processed;
+				} catch ( Exception $e ) {
+					WP_CLI::error( $e->getMessage(), false );
+				}
+			} else {
+				WP_CLI::debug( sprintf( 'GTIN [ %s ] has been skipped for Product ID: %s - %s. Invalid GTIN was found.', $gtin, $product->get_id(), $product->get_name() ) );
 			}
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/2616 as part of pcTzPl-2p2-p2.

This PR creates a WP CLI GTIN Migration command.

### Screenshots:

<img width="1459" alt="Screenshot 2024-11-01 at 12 17 25" src="https://github.com/user-attachments/assets/3cd82413-bf05-466f-8c9f-20f7cf79dec0">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout the PR and prepare some products for GTIN migration (it should be published variation or simple and have the GTIN in Google for WooCommerce tab and not in Inventory)
2. Run WP CLI  `wp wc g4wc gtin-migration start` 
3. See the GTIN migrated. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - WP CLI Command for GTIN Migration