### PR TITLE
Refactor & fix undesired exceptions in AS Jobs

### DIFF
--- a/src/HelperTraits/GTINMigrationUtilities.php
+++ b/src/HelperTraits/GTINMigrationUtilities.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\MigrateGTIN;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Exception;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -83,5 +84,71 @@ trait GTINMigrationUtilities {
 	 */
 	protected function options() {
 		return $this->options ?? woogle_get_container()->get( OptionsInterface::class );
+	}
+
+	/**
+	 * Prepares the GTIN to be saved.
+	 *
+	 * @param string $gtin
+	 * @return string
+	 */
+	protected function prepare_gtin( string $gtin ) {
+		return str_replace( '-', '', $gtin );
+	}
+
+	/**
+	 * Gets the message when the GTIN is invalid.
+	 *
+	 * @param \WC_Product $product
+	 * @param string      $gtin
+	 * @return string
+	 */
+	protected function error_gtin_invalid( \WC_Product $product, string $gtin ) {
+		return sprintf( 'GTIN [ %s ] has been skipped for Product ID: %s - %s. Invalid GTIN was found.', $gtin, $product->get_id(), $product->get_name() );
+	}
+
+	/**
+	 * Gets the message when the GTIN is already in the Product Inventory
+	 *
+	 * @param \WC_Product $product
+	 * @return string
+	 */
+	protected function error_gtin_already_set( \WC_Product $product ) {
+		return sprintf( 'GTIN has been skipped for Product ID: %s - %s. GTIN was found in Product Inventory tab.', $product->get_id(), $product->get_name() );
+	}
+
+	/**
+	 * Gets the message when the GTIN is not found.
+	 *
+	 * @param \WC_Product $product
+	 * @return string
+	 */
+	protected function error_gtin_not_found( \WC_Product $product ) {
+		return sprintf( 'GTIN has been skipped for Product ID: %s - %s. No GTIN was found', $product->get_id(), $product->get_name() );
+	}
+
+	/**
+	 * Gets the message when the GTIN had an error when saving.
+	 *
+	 * @param \WC_Product $product
+	 * @param string      $gtin
+	 * @param Exception   $e
+	 *
+	 * @return string
+	 */
+	protected function error_gtin_not_saved( \WC_Product $product, string $gtin, Exception $e ) {
+		return sprintf( 'GTIN [ %s ] for Product ID: %s - %s has an error - %s', $gtin, $product->get_id(), $product->get_name(), $e->getMessage() );
+	}
+
+	/**
+	 * Gets the message when the GTIN is successfully migrated.
+	 *
+	 * @param \WC_Product $product
+	 * @param string      $gtin
+	 *
+	 * @return string
+	 */
+	protected function successful_migrated_gtin( \WC_Product $product, string $gtin ) {
+		return sprintf( 'GTIN [ %s ] has been migrated for Product ID: %s - %s', $gtin, $product->get_id(), $product->get_name() );
 	}
 }

--- a/src/Jobs/MigrateGTIN.php
+++ b/src/Jobs/MigrateGTIN.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+use Exception;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -85,11 +86,6 @@ class MigrateGTIN extends AbstractBatchedActionSchedulerJob implements OptionsAw
 		// update the product core GTIN using G4W GTIN
 		$products = $this->product_repository->find_by_ids( $items );
 		foreach ( $products as $product ) {
-			// void if core GTIN is already set.
-			if ( $product->get_global_unique_id() ) {
-				continue;
-			}
-
 			// process variations
 			if ( $product instanceof \WC_Product_Variable ) {
 				$variations = $product->get_children();
@@ -98,9 +94,23 @@ class MigrateGTIN extends AbstractBatchedActionSchedulerJob implements OptionsAw
 			}
 
 			$gtin = $this->attribute_manager->get_value( $product, 'gtin' );
-			if ( $gtin ) {
+			if ( ! $gtin ) {
+				$this->debug( $this->error_gtin_not_found( $product ) );
+				continue;
+			}
+
+			$gtin = $this->prepare_gtin( $gtin );
+			if ( ! is_numeric( $gtin ) ) {
+				$this->debug( $this->error_gtin_invalid( $product, $gtin ) );
+				continue;
+			}
+
+			try {
 				$product->set_global_unique_id( $gtin );
 				$product->save();
+				$this->debug( $this->successful_migrated_gtin( $product, $gtin ) );
+			} catch ( Exception $e ) {
+				$this->debug( $this->error_gtin_not_saved( $product, $gtin, $e ) );
 			}
 		}
 	}
@@ -139,5 +149,20 @@ class MigrateGTIN extends AbstractBatchedActionSchedulerJob implements OptionsAw
 	 */
 	protected function get_batch( int $batch_number ): array {
 		return $this->product_repository->find_all_product_ids( $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+	}
+
+	/**
+	 * Debug info in the logs.
+	 *
+	 * @param string $message
+	 *
+	 * @return void
+	 */
+	protected function debug( string $message ): void {
+		do_action(
+			'woocommerce_gla_debug_message',
+			$message,
+			__METHOD__
+		);
 	}
 }

--- a/src/Utility/WPCLIMigrationGTIN.php
+++ b/src/Utility/WPCLIMigrationGTIN.php
@@ -213,7 +213,7 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 
 	/**
 	 * Add some info in the debug console.
-	 * Add --debug to see this kind of logs in WP CLI
+	 * Add --debug to see these logs in WP CLI
 	 *
 	 * @param string $message
 	 * @return void

--- a/src/Utility/WPCLIMigrationGTIN.php
+++ b/src/Utility/WPCLIMigrationGTIN.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Utility;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\GTINMigrationUtilities;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
@@ -22,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
  * @since x.x.x
  */
 class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
-
+	use GTINMigrationUtilities;
 
 	/** @var AttributeManager  */
 	public AttributeManager $attribute_manager;
@@ -157,7 +158,6 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 	 * @return int The number of items processed.
 	 */
 	protected function process_items( array $items ): int {
-		// todo: refactor avoiding duplication with MigrateGTIN Job after https://github.com/woocommerce/google-listings-and-ads/pull/2656 gets merged.
 		// update the product core GTIN using G4W GTIN
 		$products  = $this->product_repository->find_by_ids( $items );
 		$processed = 0;
@@ -172,20 +172,19 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 
 			// void if core GTIN is already set.
 			if ( $product->get_global_unique_id() ) {
-				WP_CLI::debug( sprintf( 'GTIN has been skipped for Product ID: %s - %s. GTIN was found in Product Inventory tab.', $product->get_id(), $product->get_name() ) );
+				$this->debug( $this->error_gtin_already_set( $product ) );
 				continue;
 			}
 
 			$gtin = $this->attribute_manager->get_value( $product, 'gtin' );
 			if ( ! $gtin ) {
-				WP_CLI::debug( sprintf( 'GTIN has been skipped for Product ID: %s - %s. No GTIN was found', $product->get_id(), $product->get_name() ) );
+				$this->debug( $this->error_gtin_not_found( $product ) );
 				continue;
 			}
 
-			$gtin = str_replace( '-', '', $gtin );
-
+			$gtin = $this->prepare_gtin( $gtin );
 			if ( ! is_numeric( $gtin ) ) {
-				WP_CLI::debug( sprintf( 'GTIN [ %s ] has been skipped for Product ID: %s - %s. Invalid GTIN was found.', $gtin, $product->get_id(), $product->get_name() ) );
+				$this->debug( $this->error_gtin_invalid( $product, $gtin ) );
 				continue;
 			}
 
@@ -193,9 +192,9 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 				$product->set_global_unique_id( $gtin );
 				$product->save();
 				++$processed;
-				WP_CLI::debug( sprintf( 'GTIN [ %s ] has been migrated for Product ID: %s - %s', $gtin, $product->get_id(), $product->get_name() ) );
+				$this->debug( $this->successful_migrated_gtin( $product, $gtin ) );
 			} catch ( Exception $e ) {
-				WP_CLI::error( sprintf( 'GTIN [ %s ] for Product ID: %s - %s has an error - %s', $gtin, $product->get_id(), $product->get_name(), $e->getMessage() ), false );
+				$this->error( $this->error_gtin_not_saved( $product, $gtin, $e ) );
 			}
 		}
 
@@ -210,5 +209,26 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 	 */
 	public static function is_needed(): bool {
 		return defined( 'WP_CLI' ) && WP_CLI;
+	}
+
+	/**
+	 * Add some info in the debug console.
+	 * Add --debug to see this kind of logs in WP CLI
+	 *
+	 * @param string $message
+	 * @return void
+	 */
+	protected function debug( string $message ): void {
+		WP_CLI::debug( $message );
+	}
+
+	/**
+	 * Add some info in the error console.
+	 *
+	 * @param string $message
+	 * @return void
+	 */
+	protected function error( string $message ): void {
+		WP_CLI::error( $message, false );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of https://github.com/woocommerce/google-listings-and-ads/issues/2617 

- This PR adds some try catch preventing AS to fail when saving the GTIN
- Additionally this PR refactors some of the common methods to make the code cleaner


### Screenshots:

<img width="1473" alt="Screenshot 2024-11-08 at 19 56 48" src="https://github.com/user-attachments/assets/993e73f4-788a-4af3-b576-71dbde6b9fa8">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Run the GTIN migration with the next GTINs
2. GTINs with dashes but 8 numbers 
3. GTINs with other chars like dots . or letters
4. GTIN that also has the GTIN saved in Product Inventory for that product
5. Duplicated GTIN
6. GTINS in variations
7. See the AS doesn't fail and you can see some logs also. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Prevent fatal in GTIN MIgration AS Job
