### PR TITLE
WordPress 6.7 Compatibility: Avoid errors in the database where a TEXT type can't have a default value

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         php: [ 8.2 ]
-        wp-version: [ latest ]
+        wp-version: [ latest, '6.7-RC3' ]
         wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions) }}
         include:
           - php: 8.3

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         php: [ 8.2 ]
-        wp-version: [ latest, '6.7-RC3' ]
+        wp-version: [ latest ]
         wc-versions: ${{ fromJson(needs.GetMatrix.outputs.wc-versions) }}
         include:
           - php: 8.3

--- a/src/DB/Table/AttributeMappingRulesTable.php
+++ b/src/DB/Table/AttributeMappingRulesTable.php
@@ -28,7 +28,7 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     `attribute` varchar(255) NOT NULL,
     `source` varchar(100) NOT NULL,
     `category_condition_type` varchar(10) NOT NULL,
-    `categories` text DEFAULT '',
+    `categories` text NOT NULL,
     PRIMARY KEY `id` (`id`)
 ) {$this->get_collation()};
 SQL;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

There are database errors when running PHP Unit Tests with WordPress 6.7-RC3.

```
WordPress database error BLOB, TEXT, GEOMETRY or JSON column 'categories' can't have a default value for query
ALTER TABLE wptests_gla_attribute_mapping_rules ALTER COLUMN `categories` SET DEFAULT ''
made by include('phpvfscomposer:///home/runner/work/google-listings-and-ads/google-listings-and-ads/vendor/phpunit/phpunit/phpunit'),
PHPUnit\TextUI\Command::main,
PHPUnit\TextUI\Command->run,
PHPUnit\TextUI\TestRunner->run,
PHPUnit\Framework\TestSuite->run,
PHPUnit\Framework\TestSuite->run,
PHPUnit\Framework\TestSuite->run,
PHPUnit\Framework\TestCase->run,
PHPUnit\Framework\TestResult->run,
PHPUnit\Framework\TestCase->runBare,
Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Integration\WPCOMProxyTest->setUp,
Automattic\WooCommerce\GoogleListingsAndAds\DB\Table->install,
Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP->db_delta,
dbDelta
```

Considering the null `categories` will be sanitized to `''` before inserting it into database, it may not be an issue to change the `categories` column in the `gla_attribute_mapping_rules` table to:

- No default value
- Not allow null
- No migration for existing tables and data, as they should be compatible on this premise.

https://github.com/woocommerce/google-listings-and-ads/blob/4535b7124ca3ecd256c006945342d3faf983ca85/src/DB/Query/AttributeMappingRulesQuery.php#L42-L44

### Screenshots:

#### 📷 [Before](https://github.com/woocommerce/google-listings-and-ads/actions/runs/11701884828/job/32588901868#step:6:29)

![image](https://github.com/user-attachments/assets/7e31af0c-ef9d-43fb-ae51-ab5309e23065)

#### 📷 [After](https://github.com/woocommerce/google-listings-and-ads/actions/runs/11773996882/job/32791822305?pr=2667#step:8:20)

![image](https://github.com/user-attachments/assets/ca950776-eedd-41a5-8bb9-e7365a75024b)

### Detailed test instructions:

1. Alter the table if needed
   - Before fix
      ```sql
      ALTER TABLE `wp_gla_attribute_mapping_rules` MODIFY COLUMN `categories` text DEFAULT '';
      ```
   - After fix
      ```sql
      ALTER TABLE `wp_gla_attribute_mapping_rules` MODIFY COLUMN `categories` text NOT NULL;
      ```
2. Go to the plugin's Attributes page.
3. Create and update some attribute rules to see if its CRUD work well.
4. View the runs of PHP Unit Tests on GitHub Actions to confirm the errors no longer occur.
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/11773996882/job/32791822305?pr=2667

### Changelog entry

> Tweak - WordPress 6.7 Compatibility: Avoid errors in the database where a TEXT type can't have a default value.
