### PR TITLE
WordPress 6.7 Compatibility: Fix the issue that E2E test can't log in to wp-admin

### DIFF
--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -55,7 +55,7 @@ module.exports = async ( config ) => {
 			await adminPage
 				.locator( 'input[name="pwd"]' )
 				.fill( admin.password );
-			await adminPage.locator( 'text=Log In' ).click();
+			await adminPage.getByRole( 'button', { name: 'Log In' } ).click();
 			await adminPage.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
 			await adminPage.goto( `/wp-admin` );
 			await adminPage.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

With WordPress 6.7-RC3, the E2E test failed to start due to match two elements when trying to click the "Log In" button.

```
Trying to log-in as admin...
Admin log-in failed, Retrying... 0/5
locator.click: Error: strict mode violation: locator('text=Log In') resolved to 2 elements:
    1) <h1 class="screen-reader-text">Log In</h1> aka getByRole('heading', { name: 'Log In' })
    2) <input type="submit" id="wp-submit" value="Log In" name="wp-submit" class="button button-primary button-large"/> aka getByRole('button', { name: 'Log In' })
```

This PR ensures that it can locate the "Log In" button.

📌 The failed test case will be handled in a separate RP.

### Detailed test instructions:

1. View the failed run: https://github.com/woocommerce/google-listings-and-ads/actions/runs/11774628750/job/32793771070#step:10:20
2. View the successful log-in run: https://github.com/woocommerce/google-listings-and-ads/actions/runs/11775116109/job/32794945918#step:10:18

### Changelog entry

> Dev - WordPress 6.7 Compatibility: Fix the issue that E2E test can't log in to wp-admin.
