### PR TITLE
WordPress 6.7 Compatibility: Avoid block toolbar appearing when interacting custom product blocks

### DIFF
--- a/js/src/blocks/product-channel-visibility/block.json
+++ b/js/src/blocks/product-channel-visibility/block.json
@@ -32,6 +32,7 @@
 	"supports": {
 		"html": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	}
 }

--- a/js/src/blocks/product-date-time-field/block.json
+++ b/js/src/blocks/product-date-time-field/block.json
@@ -19,6 +19,7 @@
 	"supports": {
 		"html": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	}
 }

--- a/js/src/blocks/product-onboarding-prompt/block.json
+++ b/js/src/blocks/product-onboarding-prompt/block.json
@@ -13,6 +13,7 @@
 	"supports": {
 		"html": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	}
 }

--- a/js/src/blocks/product-select-field/block.json
+++ b/js/src/blocks/product-select-field/block.json
@@ -26,6 +26,7 @@
 	"supports": {
 		"html": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	}
 }

--- a/js/src/blocks/product-select-with-text-field/block.json
+++ b/js/src/blocks/product-select-with-text-field/block.json
@@ -29,6 +29,7 @@
 	"supports": {
 		"html": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"__experimentalToolbar": false
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

With WordPress 6.7-RC3, block toolbars pop up unexpectedly when interacting with custom product blocks, and it also causes the E2E test to fail.

- ![1](https://github.com/user-attachments/assets/f54fea6f-b9d4-4c98-9ae0-b692e6365daa)
- ![2](https://github.com/user-attachments/assets/3008441c-d8eb-46d6-b2c1-8c8b01deda3a)
- ![3](https://github.com/user-attachments/assets/71990bdf-82b7-42ac-91cb-d337fa674000)

This PR adds `"__experimentalToolbar": false` to all custom product blocks to prevent block toolbars from appearing.

### Screenshots:

https://github.com/user-attachments/assets/bdf616a2-004f-4474-b965-ef454316e2a6

### Detailed test instructions:

1. Set up WordPress with [6.7-RC3](https://wordpress.org/wordpress-6.7-RC3.zip)
2. Go to **WooCommerce > Settings > Advanced > Features** and enable "New product editor"
3. Go to edit a product
4. In the blockified product editor
   1. Switch to the "Google for WooCommerce" tab
   2. Interact with custom product blocks like Channel visibility, Condition, Availability Date, etc
   3. Check if the block toolbars won't appear
5. View the successful E2E test run on GitHub Actions: https://github.com/woocommerce/google-listings-and-ads/actions/runs/11776255409/job/32798297581

### Changelog entry

> Fix - WordPress 6.7 Compatibility: Avoid the block toolbar appearing when interacting blockified product editor.
