### PR TITLE
WordPress 6.7 Compatibility: Adjust the radio control layout to align well with the extended content

### DIFF
--- a/js/src/components/app-radio-content-control/index.scss
+++ b/js/src/components/app-radio-content-control/index.scss
@@ -9,6 +9,8 @@
 	// Hack to align multiple lines of label after the radio/checkbox to the same indentation,
 	// by placing them on the same brid.
 	.components-radio-control,
+	.components-radio-control .components-flex,
+	.components-base-control__label,
 	.components-base-control__field,
 	.components-base-control__field .components-flex,
 	.components-radio-control__option {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The layout of the radio control is a bit displaced.
This PR adjusts it to make it sill align well with the extended content.

💡 WordPress 6.7 has decreased the size of the Radio control a bit. For the sake of consistency of the overall experience, the size is not further adjusted in this plugin.

### Screenshots:

#### 📷 WordPress 6.6

![Image](https://github.com/user-attachments/assets/43654d56-4899-498c-965c-763d5cd7f3cb)

#### 📷 WordPress 6.7 without this fix

![Image](https://github.com/user-attachments/assets/286d8fa5-0bb0-4c17-b849-84a91fe8055b)

#### 📷 WordPress 6.7 with this fix

![image](https://github.com/user-attachments/assets/f01a6a5f-eb58-46dc-a4b9-c0eff04ac0a0)

### Detailed test instructions:

1. Set up WordPress with [6.7-RC3](https://wordpress.org/wordpress-6.7-RC3.zip)
2. Go to the Edit free listings page
3. Check if the layouts of radio controls and their content are aligned well

### Changelog entry

> Tweak - WordPress 6.7 Compatibility: Adjust the layout of the radio control to align well with the extended content.
