### PR TITLE
Remove vendor files that prints php information `phpinfo()`

### DIFF
--- a/bin/cleanup-vendor-files.sh
+++ b/bin/cleanup-vendor-files.sh
@@ -2,3 +2,6 @@
 
 echo Removing unused vendor files to reduce space
 rm vendor/symfony/validator/Resources/translations/*.xlf || true
+
+echo Removing vendor files that prints php information
+rm vendor/googleads/google-ads-php/scripts/print_php_information.php || true


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

SIRT: p3btAN-2W0-p2

This PR removes a Google Ads API file `vendor/googleads/google-ads-php/scripts/print_php_information.php` that prints the php information using `phpinfo()`.

There is already a script `bin/cleanup-vendor-files.sh` that removes the unneeded vendor files, adding one more removal there.

The file wasn't used anywhere in the code, so it's safe to remove it after `composer install`.

I also checked other files under `vendor/` folder and confirmed no one is also calling `phpinfo()`.

#### What does `vendor/googleads/google-ads-php/scripts/print_php_information.php` do?

It's mainly used in [googleads/google-ads-php](https://github.com/googleads/google-ads-php/) repo when anyone creates a bug report issue, they [recommend the issue opener attaches the output](https://github.com/googleads/google-ads-php/issues/new?assignees=&labels=bug%2C+triage&projects=&template=bug_report.md&title=) of that script.

Ref: https://github.com/googleads/google-ads-php/pull/466

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

#### How to reproduce it

1. Build the plugin using `develop` branch by running `nvm use && npm i && composer install && npm run build`
2. Install the `google-listing-and-ads.zip` that just being built in your site
3. Go to `https://<your-site>/wp-content/plugins/google-listings-and-ads/vendor/googleads/google-ads-php/scripts/print_php_information.php`, replace `<your-site>` with your site's URL.
4. You should see the php information page

#### How to test it

1. Build the plugin using this branch by running `nvm use && npm i && composer install && npm run build`
2. Install the `google-listing-and-ads.zip` that just being built in your site
3. Go to `https://<your-site>/wp-content/plugins/google-listings-and-ads/vendor/googleads/google-ads-php/scripts/print_php_information.php`, replace `<your-site>` with your site's URL
4. You should see 404 page not found
5. Make sure the functionality of the plugin works as expected

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Remove a Google Ads API vendor file that prints php information