### PR TITLE
[GTIN] Add Migration support for YOAST SEO

### DIFF
--- a/src/HelperTraits/GTINMigrationUtilities.php
+++ b/src/HelperTraits/GTINMigrationUtilities.php
@@ -161,27 +161,10 @@ trait GTINMigrationUtilities {
 	 * @return string|null
 	 */
 	protected function get_gtin( WC_Product $product ): ?string {
-		$gtin = $this->attribute_manager->get_value( $product, 'gtin' );
-
-		if ( ! $gtin ) {
-			$gtin = $this->get_yoast_gtin( $product );
-		}
-
-		return $gtin;
-	}
-
-	/**
-	 * Gets the GTIN value from YOAST SEO
-	 *
-	 * @param WC_Product $product The product
-	 * @return string|null
-	 */
-	protected function get_yoast_gtin( WC_Product $product ): ?string {
-		if ( ! defined( 'WPSEO_WOO_VERSION' ) ) {
-			return null;
-		}
-
-		$yoast_seo_integration = new YoastWooCommerceSeo();
-		return $yoast_seo_integration->get_gtin( YoastWooCommerceSeo::VALUE_KEY, $product );
+		/**
+		 * Filters the value of the GTIN before performing the migration.
+		 * This value will be he one that we copy inside the Product Inventory GTIN.
+		 */
+		return apply_filters( 'woocommerce_gla_gtin_migration_value', $this->attribute_manager->get_value( $product, 'gtin' ), $product );
 	}
 }

--- a/src/HelperTraits/GTINMigrationUtilities.php
+++ b/src/HelperTraits/GTINMigrationUtilities.php
@@ -3,10 +3,12 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\YoastWooCommerceSeo;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\MigrateGTIN;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Exception;
+use WC_Product;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -35,7 +37,7 @@ trait GTINMigrationUtilities {
 	 * @return bool
 	 */
 	protected function is_gtin_available_in_core(): bool {
-		return version_compare( WC_VERSION, '9.2', '>=' ) && method_exists( \WC_Product::class, 'get_global_unique_id' );
+		return version_compare( WC_VERSION, '9.2', '>=' ) && method_exists( WC_Product::class, 'get_global_unique_id' );
 	}
 
 	/**
@@ -82,7 +84,7 @@ trait GTINMigrationUtilities {
 	 *
 	 * @return OptionsInterface
 	 */
-	protected function options() {
+	protected function options(): OptionsInterface {
 		return $this->options ?? woogle_get_container()->get( OptionsInterface::class );
 	}
 
@@ -92,63 +94,94 @@ trait GTINMigrationUtilities {
 	 * @param string $gtin
 	 * @return string
 	 */
-	protected function prepare_gtin( string $gtin ) {
+	protected function prepare_gtin( string $gtin ): string {
 		return str_replace( '-', '', $gtin );
 	}
 
 	/**
 	 * Gets the message when the GTIN is invalid.
 	 *
-	 * @param \WC_Product $product
-	 * @param string      $gtin
+	 * @param WC_Product $product
+	 * @param string     $gtin
 	 * @return string
 	 */
-	protected function error_gtin_invalid( \WC_Product $product, string $gtin ) {
+	protected function error_gtin_invalid( WC_Product $product, string $gtin ): string {
 		return sprintf( 'GTIN [ %s ] has been skipped for Product ID: %s - %s. Invalid GTIN was found.', $gtin, $product->get_id(), $product->get_name() );
 	}
 
 	/**
 	 * Gets the message when the GTIN is already in the Product Inventory
 	 *
-	 * @param \WC_Product $product
+	 * @param WC_Product $product
 	 * @return string
 	 */
-	protected function error_gtin_already_set( \WC_Product $product ) {
+	protected function error_gtin_already_set( WC_Product $product ): string {
 		return sprintf( 'GTIN has been skipped for Product ID: %s - %s. GTIN was found in Product Inventory tab.', $product->get_id(), $product->get_name() );
 	}
 
 	/**
 	 * Gets the message when the GTIN is not found.
 	 *
-	 * @param \WC_Product $product
+	 * @param WC_Product $product
 	 * @return string
 	 */
-	protected function error_gtin_not_found( \WC_Product $product ) {
+	protected function error_gtin_not_found( WC_Product $product ): string {
 		return sprintf( 'GTIN has been skipped for Product ID: %s - %s. No GTIN was found', $product->get_id(), $product->get_name() );
 	}
 
 	/**
 	 * Gets the message when the GTIN had an error when saving.
 	 *
-	 * @param \WC_Product $product
-	 * @param string      $gtin
-	 * @param Exception   $e
+	 * @param WC_Product $product
+	 * @param string     $gtin
+	 * @param Exception  $e
 	 *
 	 * @return string
 	 */
-	protected function error_gtin_not_saved( \WC_Product $product, string $gtin, Exception $e ) {
+	protected function error_gtin_not_saved( WC_Product $product, string $gtin, Exception $e ): string {
 		return sprintf( 'GTIN [ %s ] for Product ID: %s - %s has an error - %s', $gtin, $product->get_id(), $product->get_name(), $e->getMessage() );
 	}
 
 	/**
 	 * Gets the message when the GTIN is successfully migrated.
 	 *
-	 * @param \WC_Product $product
-	 * @param string      $gtin
+	 * @param WC_Product $product
+	 * @param string     $gtin
 	 *
 	 * @return string
 	 */
-	protected function successful_migrated_gtin( \WC_Product $product, string $gtin ) {
+	protected function successful_migrated_gtin( WC_Product $product, string $gtin ): string {
 		return sprintf( 'GTIN [ %s ] has been migrated for Product ID: %s - %s', $gtin, $product->get_id(), $product->get_name() );
+	}
+
+	/**
+	 * Gets the GTIN value
+	 *
+	 * @param WC_Product $product The product
+	 * @return string|null
+	 */
+	protected function get_gtin( WC_Product $product ): ?string {
+		$gtin = $this->attribute_manager->get_value( $product, 'gtin' );
+
+		if ( ! $gtin ) {
+			$gtin = $this->get_yoast_gtin( $product );
+		}
+
+		return $gtin;
+	}
+
+	/**
+	 * Gets the GTIN value from YOAST SEO
+	 *
+	 * @param WC_Product $product The product
+	 * @return string|null
+	 */
+	protected function get_yoast_gtin( WC_Product $product ): ?string {
+		if ( ! defined( 'WPSEO_WOO_VERSION' ) ) {
+			return null;
+		}
+
+		$yoast_seo_integration = new YoastWooCommerceSeo();
+		return $yoast_seo_integration->get_gtin( YoastWooCommerceSeo::VALUE_KEY, $product );
 	}
 }

--- a/src/HelperTraits/GTINMigrationUtilities.php
+++ b/src/HelperTraits/GTINMigrationUtilities.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Integration\YoastWooCommerceSeo;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\MigrateGTIN;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;

--- a/src/Integration/YoastWooCommerceSeo.php
+++ b/src/Integration/YoastWooCommerceSeo.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class YoastWooCommerceSeo implements IntegrationInterface {
 
-	public const VALUE_KEY = 'yoast_seo';
+	protected const VALUE_KEY = 'yoast_seo';
 
 	/**
 	 * @var array Meta values stored by Yoast WooCommerce SEO plugin (per product).
@@ -76,6 +76,19 @@ class YoastWooCommerceSeo implements IntegrationInterface {
 			10,
 			2
 		);
+
+		add_filter(
+			'woocommerce_gla_gtin_migration_value',
+			function ( $gtin, $product ) {
+				if ( ! $gtin ) {
+					return $this->get_gtin( self::VALUE_KEY, $product );
+				}
+
+				return $gtin;
+			},
+			10,
+			2
+		);
 	}
 
 	/**
@@ -109,7 +122,7 @@ class YoastWooCommerceSeo implements IntegrationInterface {
 	 *
 	 * @return mixed
 	 */
-	public function get_gtin( $value, WC_Product $product ) {
+	protected function get_gtin( $value, WC_Product $product ) {
 		if ( strpos( $value, self::VALUE_KEY ) === 0 ) {
 			$gtin_values = [
 				$this->get_identifier_value( 'isbn', $product ),

--- a/src/Integration/YoastWooCommerceSeo.php
+++ b/src/Integration/YoastWooCommerceSeo.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class YoastWooCommerceSeo implements IntegrationInterface {
 
-	protected const VALUE_KEY = 'yoast_seo';
+	public const VALUE_KEY = 'yoast_seo';
 
 	/**
 	 * @var array Meta values stored by Yoast WooCommerce SEO plugin (per product).
@@ -109,7 +109,7 @@ class YoastWooCommerceSeo implements IntegrationInterface {
 	 *
 	 * @return mixed
 	 */
-	protected function get_gtin( $value, WC_Product $product ) {
+	public function get_gtin( $value, WC_Product $product ) {
 		if ( strpos( $value, self::VALUE_KEY ) === 0 ) {
 			$gtin_values = [
 				$this->get_identifier_value( 'isbn', $product ),

--- a/src/Integration/YoastWooCommerceSeo.php
+++ b/src/Integration/YoastWooCommerceSeo.php
@@ -80,7 +80,7 @@ class YoastWooCommerceSeo implements IntegrationInterface {
 		add_filter(
 			'woocommerce_gla_gtin_migration_value',
 			function ( $gtin, $product ) {
-				if ( ! $gtin ) {
+				if ( ! $gtin || self::VALUE_KEY === $gtin ) {
 					return $this->get_gtin( self::VALUE_KEY, $product );
 				}
 

--- a/src/Jobs/MigrateGTIN.php
+++ b/src/Jobs/MigrateGTIN.php
@@ -93,7 +93,8 @@ class MigrateGTIN extends AbstractBatchedActionSchedulerJob implements OptionsAw
 				continue;
 			}
 
-			$gtin = $this->attribute_manager->get_value( $product, 'gtin' );
+			$gtin = $this->get_gtin( $product );
+
 			if ( ! $gtin ) {
 				$this->debug( $this->error_gtin_not_found( $product ) );
 				continue;

--- a/src/Utility/WPCLIMigrationGTIN.php
+++ b/src/Utility/WPCLIMigrationGTIN.php
@@ -176,7 +176,7 @@ class WPCLIMigrationGTIN implements Service, Registerable, Conditional {
 				continue;
 			}
 
-			$gtin = $this->attribute_manager->get_value( $product, 'gtin' );
+			$gtin = $this->get_gtin( $product );
 			if ( ! $gtin ) {
 				$this->debug( $this->error_gtin_not_found( $product ) );
 				continue;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2665

This PR adds support for the YOAST GTIN field in the GTIN migration feature

### Screenshots:

<img width="1046" alt="Screenshot 2024-11-18 at 11 33 19" src="https://github.com/user-attachments/assets/d2e684d6-da1c-4ebf-b03d-1a7cf27a3544">

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. You need to have YOAST WooCommerce installed (notice the WooCommerce part, WordPress one doesn't have GTIN support)
2. Set GTIN field for a simple product in Yoast SEO Tab
3. Set GTIN field for a variation in Yoast SEO Tab (under the variations tab)
4. Start the migration using the Connection test - Start GTIN Migration (be sure there is no other AS Job already running for GTIN migration)
5. See the 2 products have the GTIN migrated
6. Delete the GTINS for those products under Product Inventory (for the simple product) and from the variations tab for the variation.
7. Start the migration using the WP CLI `wp wc g4wc gtin-migration start --debug`
8. See the GTIN successfully migrated
9. Run steo 7 again
10. See logs about skipping the products. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Support YOAST SEO GTIN field in the migration tools. 
