### PR TITLE
[GTIN] Adjust plugin version for hidding GTIN

### DIFF
--- a/src/HelperTraits/GTINMigrationUtilities.php
+++ b/src/HelperTraits/GTINMigrationUtilities.php
@@ -25,7 +25,7 @@ trait GTINMigrationUtilities {
 	 * @return string
 	 */
 	protected function get_gtin_hidden_version(): string {
-		return '2.8.7';
+		return '2.8.8';
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2648 

This PR adjusted the G4W version to 2.8.8. This version number is used to hide GTIN field for new users. 

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Use a G4W version lower than 2.8.8 
2. Go to a product and see that GTIN field is read only under Google for WooCommerce tab
3. Patch the plugin version to 2.8.8 or higher 
4.  Go to a product and see that GTIN field is not visible anymore under Google for WooCommerce tab


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Adjust plugin version to hide GTIN 
