### PR TITLE
[GTIN] Hide / disable GTIN also when YOAST is active.

### DIFF
--- a/src/Admin/Input/Input.php
+++ b/src/Admin/Input/Input.php
@@ -153,6 +153,13 @@ class Input extends Form implements InputInterface {
 	}
 
 	/**
+	 * @return bool
+	 */
+	public function is_readonly(): bool {
+		return $this->is_readonly;
+	}
+
+	/**
 	 * @param bool $value
 	 *
 	 * @return InputInterface

--- a/src/Admin/Input/SelectWithTextInput.php
+++ b/src/Admin/Input/SelectWithTextInput.php
@@ -105,6 +105,15 @@ class SelectWithTextInput extends Input {
 		// add custom value option
 		$select_input['options'][ self::CUSTOM_INPUT_KEY ] = __( 'Enter a custom value', 'google-listings-and-ads' );
 
+		if ( $this->is_readonly ) {
+			$select_input['custom_attributes'] = [
+				'disabled' => 'disabled',
+			];
+			$custom_input['custom_attributes'] = [
+				'readonly' => 'readonly',
+			];
+		}
+
 		$view_data['children'][ self::CUSTOM_INPUT_KEY ] = $custom_input;
 		$view_data['children'][ self::SELECT_INPUT_KEY ] = $select_input;
 

--- a/src/Admin/Product/Attributes/AttributesForm.php
+++ b/src/Admin/Product/Attributes/AttributesForm.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\FormException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\InputInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\Select;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Input\SelectWithTextInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\Input\GTINInput;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeInterface;
@@ -131,6 +132,13 @@ class AttributesForm extends Form {
 				$new_input = new SelectWithTextInput();
 				$new_input->set_label( $input->get_label() )
 					->set_description( $input->get_description() );
+
+				// Copy values from GTIN
+				if ( $input->name === 'gtin' ) {
+					$gtin_input = new GTINInput();
+					$new_input->set_hidden( $gtin_input->is_hidden() );
+					$new_input->set_readonly( $gtin_input->is_readonly() );
+				}
 
 				return self::init_input( $new_input, $attribute );
 			}

--- a/src/Admin/Product/Attributes/AttributesForm.php
+++ b/src/Admin/Product/Attributes/AttributesForm.php
@@ -133,7 +133,7 @@ class AttributesForm extends Form {
 				$new_input->set_label( $input->get_label() )
 					->set_description( $input->get_description() );
 
-				// Copy values from GTIN
+				// When GTIN uses the SelectWithTextInput field, copy the readonly/hidden attributes from the GTINInput field.
 				if ( $input->name === 'gtin' ) {
 					$gtin_input = new GTINInput();
 					$new_input->set_hidden( $gtin_input->is_hidden() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of #2617 

This PR fixes a Bug in which GTIN is not hidden or disabled when YOAST is activated.

### Screenshots:

<img width="618" alt="Screenshot 2024-11-21 at 19 33 26" src="https://github.com/user-attachments/assets/df16b923-e91f-459b-8295-c9e836485e58">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install YOAST for WooCommerce
2. Set the wp_option `gla_install_version`as 2.8.6
3. Go to a Product - Google for WooCommerce
4. See the selector as disabled (if you selected "Enter custom value" it should be also disabled)
5. Set the wp_option `gla_install_version` as 2.8.8
6. See the selector hiden

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Hide/disable GTIN also when YOAST is active
