### PR TITLE
Consolidate accounts onboarding: Prevent Google Ads account setup from trying to connect to an unclaimed and disconnected account ID

### DIFF
--- a/js/src/components/google-ads-account-card/disconnect-account.js
+++ b/js/src/components/google-ads-account-card/disconnect-account.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useCallback } from '@wordpress/element';
+import { noop } from 'lodash';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -24,18 +25,21 @@ import { FILTER_ONBOARDING } from '.~/utils/tracks';
  * Renders a button to disconnect the Google Ads account.
  *
  * @fires gla_ads_account_disconnect_button_click When the user clicks on the button to disconnect the Google Ads account.
+ *
+ * @param {Object} props React props.
+ * @param {Function} [props.onDisconnected] Callback after the account is disconnected.
  */
-const DisconnectAccount = () => {
+const DisconnectAccount = ( { onDisconnected = noop } ) => {
 	const { disconnectGoogleAdsAccount } = useAppDispatch();
 	const [ isDisconnecting, setDisconnecting ] = useState( false );
 	const getEventProps = useEventPropertiesFilter( FILTER_ONBOARDING );
 
-	const handleSwitch = useCallback( () => {
+	const handleSwitch = () => {
 		setDisconnecting( true );
-		disconnectGoogleAdsAccount( true ).catch( () =>
-			setDisconnecting( false )
-		);
-	}, [ disconnectGoogleAdsAccount ] );
+		disconnectGoogleAdsAccount( true )
+			.then( () => onDisconnected() )
+			.catch( () => setDisconnecting( false ) );
+	};
 
 	return (
 		<AppButton

--- a/js/src/components/google-ads-account-card/disconnect-account.test.js
+++ b/js/src/components/google-ads-account-card/disconnect-account.test.js
@@ -63,6 +63,53 @@ describe( 'DisconnectAccount', () => {
 		expect( button ).toBeDisabled();
 	} );
 
+	it( 'should trigger the onDisconnected callback after the account is disconnected', async () => {
+		const user = userEvent.setup();
+		const handleDisconnected = jest.fn();
+		let resolve;
+
+		disconnectGoogleAdsAccount.mockReturnValue(
+			new Promise( ( _resolve ) => {
+				resolve = _resolve;
+			} )
+		);
+
+		render( <DisconnectAccount onDisconnected={ handleDisconnected } /> );
+		const button = screen.getByRole( 'button' );
+
+		expect( handleDisconnected ).toHaveBeenCalledTimes( 0 );
+
+		await user.click( button );
+
+		expect( handleDisconnected ).toHaveBeenCalledTimes( 0 );
+
+		await act( async () => resolve() );
+
+		expect( handleDisconnected ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should not trigger the onDisconnected callback after a failed disconnection', async () => {
+		const user = userEvent.setup();
+		const handleDisconnected = jest.fn();
+		let reject;
+
+		disconnectGoogleAdsAccount.mockReturnValue(
+			new Promise( ( _, _reject ) => {
+				reject = _reject;
+			} )
+		);
+
+		render( <DisconnectAccount onDisconnected={ handleDisconnected } /> );
+		const button = screen.getByRole( 'button' );
+
+		expect( handleDisconnected ).toHaveBeenCalledTimes( 0 );
+
+		await user.click( button );
+		await act( async () => reject() );
+
+		expect( handleDisconnected ).toHaveBeenCalledTimes( 0 );
+	} );
+
 	it( 'should enable the button after a failed disconnection', async () => {
 		const user = userEvent.setup();
 		let reject;

--- a/js/src/components/google-combo-account-card/connect-ads/connect-existing-account-actions.js
+++ b/js/src/components/google-combo-account-card/connect-ads/connect-existing-account-actions.js
@@ -18,6 +18,7 @@ import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
  * @param {Object} props Props.
  * @param {boolean} props.isConnected Whether the account is connected.
  * @param {Function} props.onCreateNewClick Callback when clicking on the button to create a new account.
+ * @param {Function} [props.onDisconnected] Callback after the account is disconnected.
  * @param {boolean} props.disabled Whether to disable the create account button.
  * @param {Object} props.restProps Rest props. Passed to AppButton.
  * @return {JSX.Element} Footer component.
@@ -25,6 +26,7 @@ import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
 const ConnectExistingAccountActions = ( {
 	isConnected,
 	onCreateNewClick,
+	onDisconnected,
 	disabled,
 	...restProps
 } ) => {
@@ -36,7 +38,7 @@ const ConnectExistingAccountActions = ( {
 	);
 
 	if ( isConnected && existingAccounts.length > 0 ) {
-		return <DisconnectAccountButton />;
+		return <DisconnectAccountButton onDisconnected={ onDisconnected } />;
 	}
 
 	const disabledButton =

--- a/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
+++ b/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
@@ -72,6 +72,17 @@ const ConnectExistingAccount = ( { onCreateClick } ) => {
 		}
 	};
 
+	const handleDisconnected = () => {
+		/*
+		 * Prevent the `value` from staying on the unclaimed and disconnected account ID.
+		 * Please note that the reset works because the `AdsAccountSelectControl` happens to
+		 * switch between two different `AppSelectControls` so that `autoSelectFirstOption`
+		 * can be triggered again. Otherwise, it would need to specify `key={ Boolean(value) }`
+		 * in the `<AdsAccountSelectControl>` use of this component.
+		 */
+		setValue( undefined );
+	};
+
 	const getIndicator = () => {
 		if ( ! hasFinishedResolution ) {
 			return <LoadingLabel />;
@@ -124,6 +135,7 @@ const ConnectExistingAccount = ( { onCreateClick } ) => {
 					disabled={ isLoading }
 					isConnected={ hasGoogleAdsConnection }
 					onCreateNewClick={ onCreateClick }
+					onDisconnected={ handleDisconnected }
 				/>
 			}
 		/>

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -48,7 +48,7 @@ module.exports = async ( config ) => {
 	for ( let i = 0; i < adminRetries; i++ ) {
 		try {
 			console.log( 'Trying to log-in as admin...' );
-			await adminPage.goto( `/wp-admin` );
+			await adminPage.goto( `/wp-login.php` );
 			await adminPage
 				.locator( 'input[name="log"]' )
 				.fill( admin.username );

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -48,7 +48,7 @@ module.exports = async ( config ) => {
 	for ( let i = 0; i < adminRetries; i++ ) {
 		try {
 			console.log( 'Trying to log-in as admin...' );
-			await adminPage.goto( `/wp-login.php` );
+			await adminPage.goto( `/wp-admin` );
 			await adminPage
 				.locator( 'input[name="log"]' )
 				.fill( admin.username );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While doing overall testing with #2682, found an issue that it may try to connect to an unclaimed and disconnected account ID. The test instructions below show the reproduction steps.

https://github.com/user-attachments/assets/9c3a2378-4e77-4b12-9394-99a8c14ebbb4

It turns out that the account ID used to call API is not the same as the one selected on UI, and it's an unclaimed and disconnected account.

https://github.com/user-attachments/assets/21beecd2-abb7-48c1-bec5-404b7e7d9337

This PR fixes it by resetting the account ID after disconnecting.

https://github.com/woocommerce/google-listings-and-ads/blob/a6862909946e8bcf4544401cf0238fd40e104e99/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js#L75-L84

### Screenshots:

https://github.com/user-attachments/assets/a913abcd-8745-4071-8b94-7b62815eebe6

### Detailed test instructions:

1. Go to step 1 of the onboarding flow
   - Disconnect Google Ads account if there is a connection
   - Have at least one Google Ads account in the existing list
2. Create a new Google Ads account but don't claim it
3. Disconnect Google Ads account
4. Directly connects to the existing Google Ads account currently selected on the UI without any other UI interactions
5. Check if the account can be connected without errors
