### PR TITLE
[GTIN] Hide GTIN in product editor

### DIFF
--- a/js/src/blocks/product-select-with-text-field/edit.js
+++ b/js/src/blocks/product-select-with-text-field/edit.js
@@ -86,12 +86,14 @@ export default function Edit( { attributes, context } ) {
 				options={ options }
 				value={ optionValue }
 				onChange={ handleSelectionChange }
+				disabled={ attributes.disabled }
 			/>
 			{ isSelectedCustomInput && (
 				<TextControl
 					type="text"
 					value={ text }
 					onChange={ handleTextChange }
+					disabled={ attributes.disabled }
 				/>
 			) }
 		</div>

--- a/src/Admin/Input/Input.php
+++ b/src/Admin/Input/Input.php
@@ -258,15 +258,21 @@ class Input extends Form implements InputInterface {
 	public function get_block_attributes(): array {
 		$meta_key = $this->prefix_meta_key( $this->get_id() );
 
-		return array_merge(
+		$block_attributes = array_merge(
 			[
 				'property' => "meta_data.{$meta_key}",
 				'label'    => $this->get_label(),
 				'tooltip'  => $this->get_description(),
-				'disabled' => $this->is_readonly()
 			],
 			$this->block_attributes
 		);
+
+		// Set boolean disabled property only if it's needed.
+		if ( $this->is_readonly() ) {
+			$block_attributes['disabled'] = true;
+		}
+
+		return $block_attributes;
 	}
 
 	/**

--- a/src/Admin/Input/Input.php
+++ b/src/Admin/Input/Input.php
@@ -263,6 +263,7 @@ class Input extends Form implements InputInterface {
 				'property' => "meta_data.{$meta_key}",
 				'label'    => $this->get_label(),
 				'tooltip'  => $this->get_description(),
+				'disabled' => $this->is_readonly()
 			],
 			$this->block_attributes
 		);

--- a/src/Admin/ProductBlocksService.php
+++ b/src/Admin/ProductBlocksService.php
@@ -275,6 +275,12 @@ class ProductBlocksService implements Service, Registerable, Conditional {
 			$input_type = call_user_func( [ $attribute_type, 'get_input_type' ] );
 			$input      = AttributesForm::init_input( new $input_type(), new $attribute_type() );
 
+			// Avoid to render Inputs that are defined as hidden in the Input.
+			// i.e We don't render GTIN for new WC versions anymore.
+			if ( $input->is_hidden() ) {
+				continue;
+			}
+
 			if ( $is_variation_template ) {
 				// When editing a variation, its product type on the frontend side won't be changed dynamically.
 				// In addition, the property of `editedProduct.type` doesn't exist in the variation product.

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -435,6 +435,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		}
 
 		// ClI Classes
-		$this->share_with_tags( WPCLIMigrationGTIN::class, ProductRepository::class, AttributeManager::class );
+		$this->conditionally_share_with_tags( WPCLIMigrationGTIN::class, ProductRepository::class, AttributeManager::class );
 	}
 }

--- a/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
+++ b/tests/Unit/Admin/Product/Attributes/Input/AttributeInputCollectionTest.php
@@ -361,6 +361,7 @@ class AttributeInputCollectionTest extends UnitTest {
 					'property' => 'meta_data._wc_gla_gtin',
 					'label'    => 'Global Trade Item Number (GTIN)',
 					'tooltip'  => $description,
+					'disabled' => true,
 				],
 			],
 			$input->get_block_config()

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -607,7 +607,9 @@ test.describe( 'Product Block Editor integration', () => {
 		await editorUtils.save();
 
 		for ( const [ attribute, value ] of pairs ) {
-			await expect( attribute ).toHaveValue( value );
+			if ( await attribute.isEditable() ) {
+				await expect( attribute ).toHaveValue( value );
+			}
 		}
 
 		/*
@@ -649,7 +651,9 @@ test.describe( 'Product Block Editor integration', () => {
 		await editorUtils.save();
 
 		for ( const [ attribute, value ] of pairs ) {
-			await expect( attribute ).toHaveValue( value );
+			if ( await attribute.isEditable() ) {
+				await expect( attribute ).toHaveValue( value );
+			}
 		}
 
 		/*

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -586,7 +586,9 @@ test.describe( 'Classic Product Editor integration', () => {
 		await editorUtils.clickPluginTab();
 
 		for ( const [ attribute, value ] of pairs ) {
-			await expect( attribute ).toHaveValue( value );
+			if ( await attribute.isEditable() ) {
+				await expect( attribute ).toHaveValue( value );
+			}
 		}
 
 		/*
@@ -631,7 +633,9 @@ test.describe( 'Classic Product Editor integration', () => {
 		await editorUtils.gotoEditVariation();
 
 		for ( const [ attribute, value ] of pairs ) {
-			await expect( attribute ).toHaveValue( value );
+			if ( await attribute.isEditable() ) {
+				await expect( attribute ).toHaveValue( value );
+			}
 		}
 
 		/*

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -67,6 +67,10 @@ async function getAvailableProductAttributesWithTestValues(
 async function setAttributeValue( locator, value ) {
 	const tagName = await locator.evaluate( ( element ) => element.tagName );
 
+	if ( ( await locator.isEditable() ) === false ) {
+		return;
+	}
+
 	if ( tagName === 'SELECT' ) {
 		await locator.selectOption( value );
 	} else {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes part of #2684  

This PR fixes a bug in which GTIN field was not hidden or disabled in Product Block Editor. Additionally fixes some e2e tests in product editor and classic editor

### Screenshots:

<img width="815" alt="Screenshot 2024-11-22 at 18 09 11" src="https://github.com/user-attachments/assets/dbb73d87-9dbf-4114-add9-daa2d30b7988">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Setup Product Block editor
2. Set the WP Option `gla_install_version`as < 2.8.8 
3. Go to Google for WooCommerce tab in the product editor
4. GTIN should be readonly
5. Set the WP Option `gla_install_version`as >= 2.8.8 
6. Go to Google for WooCommerce tab in the product editor
7. GTIN should not be rendered in the UI
8. Install YOAST for WooComemerce
9. Repeat steps 2-7


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Hide or disable  GTIN in Product Block editor
