### PR TITLE
Tweak E2E tests supporting GTIN migration

### DIFF
--- a/src/HelperTraits/GTINMigrationUtilities.php
+++ b/src/HelperTraits/GTINMigrationUtilities.php
@@ -26,7 +26,7 @@ trait GTINMigrationUtilities {
 	 * @return string
 	 */
 	protected function get_gtin_hidden_version(): string {
-		return '2.8.8';
+		return '2.8.7';
 	}
 
 	/**
@@ -51,7 +51,7 @@ trait GTINMigrationUtilities {
 		}
 
 		$first_install_version = $this->options()->get( OptionsInterface::INSTALL_VERSION, false );
-		return $first_install_version && version_compare( $first_install_version, $this->get_gtin_hidden_version(), '>=' );
+		return $first_install_version && version_compare( $first_install_version, $this->get_gtin_hidden_version(), '>' );
 	}
 
 	/**

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -26,7 +26,6 @@ test.describe( 'Product Block Editor integration', () => {
 		await editorUtils.toggleBlockFeature( true );
 		await api.setOnboardedMerchant();
 		await api.setVersionForHideGtin(); // be sure the version is set back for hiding GTIN
-
 	} );
 
 	test( 'Prompt to Get Started when not yet finished onboarding', async () => {

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -25,6 +25,8 @@ test.describe( 'Product Block Editor integration', () => {
 
 		await editorUtils.toggleBlockFeature( true );
 		await api.setOnboardedMerchant();
+		await api.setVersionForHideGtin(); // be sure the version is set back for hiding GTIN
+
 	} );
 
 	test( 'Prompt to Get Started when not yet finished onboarding', async () => {
@@ -93,8 +95,7 @@ test.describe( 'Product Block Editor integration', () => {
 		await expect( panel.getByRole( 'combobox' ) ).toHaveCount( 9 );
 
 		/*
-		 * 9 <input type="text|date|time">:
-		 * - GTIN
+		 * 8 <input type="text|date|time">:
 		 * - MPN
 		 * - Size
 		 * - Color
@@ -104,11 +105,10 @@ test.describe( 'Product Block Editor integration', () => {
 		 * - Availability date
 		 * - Availability time
 		 */
-		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 9 );
+		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 8 );
 
 		/*
-		 * 16 pairs of <label> and help icon buttons:
-		 * - GTIN
+		 * 15 pairs of <label> and help icon buttons:
 		 * - MPN
 		 * - Brand
 		 * - Condition
@@ -128,11 +128,11 @@ test.describe( 'Product Block Editor integration', () => {
 		 */
 		await expect(
 			panel.locator( 'label' ).filter( { hasText: /\w+/ } )
-		).toHaveCount( 16 );
+		).toHaveCount( 15 );
 
 		await expect(
 			panel.getByRole( 'button', { name: 'help' } )
-		).toHaveCount( 16 );
+		).toHaveCount( 15 );
 
 		/*
 		 * Click the help icon to view the popover and its content for each type of field block
@@ -141,7 +141,7 @@ test.describe( 'Product Block Editor integration', () => {
 		const blocks = [
 			[
 				'woocommerce/product-text-field',
-				/global trade item number \(gtin\) for your item/i,
+				/This code uniquely identifies the product to its manufacturer/i,
 			],
 			[
 				'google-listings-and-ads/product-select-with-text-field',
@@ -232,7 +232,6 @@ test.describe( 'Product Block Editor integration', () => {
 
 		/*
 		 * 8 <input type="text|date|time"> for variation product:
-		 * - GTIN
 		 * - MPN
 		 * - Size
 		 * - Color
@@ -242,7 +241,7 @@ test.describe( 'Product Block Editor integration', () => {
 		 * - Availability date
 		 * - Availability time
 		 */
-		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 9 );
+		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 8 );
 	} );
 
 	test( 'Channel visibility is disabled when hiding in product catalog', async () => {
@@ -282,7 +281,7 @@ test.describe( 'Product Block Editor integration', () => {
 		await editorUtils.fillProductName();
 		await editorUtils.clickPluginTab();
 
-		const issueTexts = [ 'Invalid price', 'Invalid GTIN' ];
+		const issueTexts = [ 'Invalid price' ];
 		const { selection, notice, status, issues } =
 			editorUtils.getChannelVisibility();
 
@@ -591,7 +590,7 @@ test.describe( 'Product Block Editor integration', () => {
 		const pairs =
 			await editorUtils.getAvailableProductAttributesWithTestValues();
 
-		expect( pairs ).toHaveLength( 17 );
+		expect( pairs ).toHaveLength( 16 );
 
 		/*
 		 * Assert:
@@ -635,7 +634,7 @@ test.describe( 'Product Block Editor integration', () => {
 		const pairs =
 			await editorUtils.getAvailableProductAttributesWithTestValues();
 
-		expect( pairs ).toHaveLength( 16 );
+		expect( pairs ).toHaveLength( 15 );
 
 		/*
 		 * Assert:
@@ -669,6 +668,17 @@ test.describe( 'Product Block Editor integration', () => {
 		for ( const [ attribute ] of pairs ) {
 			await expect( attribute ).toHaveValue( '' );
 		}
+	} );
+
+	test( 'Test GTIN field is visible but disabled when gla_install_version is <= 2.8.7', async () => {
+		await api.setVersionForDisabledGtin();
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.clickPluginTab();
+		const panel = page.getByRole( 'tabpanel' );
+		await expect( panel.getByLabel( /\(GTIN\)$/ ) ).toBeVisible();
+		await expect( panel.getByLabel( /\(GTIN\)$/ ) ).not.toBeEditable();
+
+		await api.setVersionForHideGtin(); // be sure the version is set back for hiding GTIN
 	} );
 
 	test.afterEach( async () => {

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -25,7 +25,7 @@ test.describe( 'Product Block Editor integration', () => {
 
 		await editorUtils.toggleBlockFeature( true );
 		await api.setOnboardedMerchant();
-		await api.setVersionForHideGtin(); // be sure the version is set back for hiding GTIN
+		await api.setVersionForHideGtin(); // be sure the version is set for hiding GTIN
 	} );
 
 	test( 'Prompt to Get Started when not yet finished onboarding', async () => {

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -25,7 +25,6 @@ test.describe( 'Classic Product Editor integration', () => {
 
 		await api.setOnboardedMerchant();
 		await api.setVersionForHideGtin(); // be sure the version is set back for hiding GTIN
-
 	} );
 
 	test( 'Prompt to Get Started when not yet finished onboarding', async () => {
@@ -657,8 +656,8 @@ test.describe( 'Classic Product Editor integration', () => {
 		await api.setVersionForDisabledGtin();
 		await editorUtils.gotoAddProductPage();
 		await editorUtils.clickPluginTab();
-		const panel= editorUtils.getPluginPanel();
-		const gtin = await panel.getByLabel( /\(GTIN\)$/ );
+		const panel = editorUtils.getPluginPanel();
+		const gtin = panel.getByLabel( /\(GTIN\)$/ );
 		await expect( gtin ).toBeVisible();
 		await expect( gtin ).not.toBeEditable();
 		await api.setVersionForHideGtin(); // be sure the version is set back for hiding GTIN

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -24,6 +24,8 @@ test.describe( 'Classic Product Editor integration', () => {
 		editorUtils = getClassicProductEditorUtils( page );
 
 		await api.setOnboardedMerchant();
+		await api.setVersionForHideGtin(); // be sure the version is set back for hiding GTIN
+
 	} );
 
 	test( 'Prompt to Get Started when not yet finished onboarding', async () => {
@@ -108,8 +110,7 @@ test.describe( 'Classic Product Editor integration', () => {
 		await expect( panel.getByRole( 'combobox' ) ).toHaveCount( 8 );
 
 		/*
-		 * 8 <input type="text|date|time">:
-		 * - GTIN
+		 * 7 <input type="text|date|time">:
 		 * - MPN
 		 * - Size
 		 * - Color
@@ -118,7 +119,7 @@ test.describe( 'Classic Product Editor integration', () => {
 		 * - Availability date
 		 * - Availability time
 		 */
-		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 8 );
+		await expect( panel.getByRole( 'textbox' ) ).toHaveCount( 7 );
 
 		/*
 		 * 1 <input type="number">:
@@ -127,8 +128,7 @@ test.describe( 'Classic Product Editor integration', () => {
 		await expect( panel.getByRole( 'spinbutton' ) ).toHaveCount( 1 );
 
 		/*
-		 * 16 pairs of <label> and help icon buttons:
-		 * - GTIN
+		 * 15 pairs of <label> and help icon buttons:
 		 * - MPN
 		 * - Brand
 		 * - Condition
@@ -145,9 +145,9 @@ test.describe( 'Classic Product Editor integration', () => {
 		 * - Availability date and time
 		 * - Adult content
 		 */
-		await expect( panel.locator( 'label:visible' ) ).toHaveCount( 16 );
+		await expect( panel.locator( 'label:visible' ) ).toHaveCount( 15 );
 		await expect( panel.locator( '.woocommerce-help-tip' ) ).toHaveCount(
-			16
+			15
 		);
 
 		/*
@@ -157,8 +157,8 @@ test.describe( 'Classic Product Editor integration', () => {
 		const fields = [
 			// Text
 			[
-				'.gla_attributes_gtin_field',
-				/global trade item number \(gtin\) for your item/i,
+				'.gla_attributes_mpn_field',
+				/This code uniquely identifies the product to its manufacturer/i,
 			],
 
 			// Select with text
@@ -275,8 +275,7 @@ test.describe( 'Classic Product Editor integration', () => {
 		await expect( variation.getByRole( 'combobox' ) ).toHaveCount( 7 );
 
 		/*
-		 * 8 <input type="text|date|time"> for variation product:
-		 * - GTIN
+		 * 7 <input type="text|date|time"> for variation product:
 		 * - MPN
 		 * - Size
 		 * - Color
@@ -285,7 +284,7 @@ test.describe( 'Classic Product Editor integration', () => {
 		 * - Availability date
 		 * - Availability time
 		 */
-		await expect( variation.getByRole( 'textbox' ) ).toHaveCount( 8 );
+		await expect( variation.getByRole( 'textbox' ) ).toHaveCount( 7 );
 
 		/*
 		 * 1 <input type="number"> for variation product:
@@ -569,7 +568,7 @@ test.describe( 'Classic Product Editor integration', () => {
 		const pairs =
 			await editorUtils.getAvailableProductAttributesWithTestValues();
 
-		expect( pairs ).toHaveLength( 17 );
+		expect( pairs ).toHaveLength( 16 );
 
 		/*
 		 * Assert:
@@ -616,7 +615,7 @@ test.describe( 'Classic Product Editor integration', () => {
 				editorUtils.getPluginVariationMetaBox()
 			);
 
-		expect( pairs ).toHaveLength( 16 );
+		expect( pairs ).toHaveLength( 15 );
 
 		/*
 		 * Assert:
@@ -652,6 +651,17 @@ test.describe( 'Classic Product Editor integration', () => {
 		for ( const [ attribute ] of pairs ) {
 			await expect( attribute ).toHaveValue( '' );
 		}
+	} );
+
+	test( 'Test GTIN field is visible but disabled when gla_install_version is <= 2.8.7', async () => {
+		await api.setVersionForDisabledGtin();
+		await editorUtils.gotoAddProductPage();
+		await editorUtils.clickPluginTab();
+		const panel= editorUtils.getPluginPanel();
+		const gtin = await panel.getByLabel( /\(GTIN\)$/ );
+		await expect( gtin ).toBeVisible();
+		await expect( gtin ).not.toBeEditable();
+		await api.setVersionForHideGtin(); // be sure the version is set back for hiding GTIN
 	} );
 
 	test.afterAll( async () => {

--- a/tests/e2e/specs/product-editor/classic-integration.test.js
+++ b/tests/e2e/specs/product-editor/classic-integration.test.js
@@ -24,7 +24,7 @@ test.describe( 'Classic Product Editor integration', () => {
 		editorUtils = getClassicProductEditorUtils( page );
 
 		await api.setOnboardedMerchant();
-		await api.setVersionForHideGtin(); // be sure the version is set back for hiding GTIN
+		await api.setVersionForHideGtin(); // be sure the version is set for hiding GTIN
 	} );
 
 	test( 'Prompt to Get Started when not yet finished onboarding', async () => {

--- a/tests/e2e/test-data/test-data.php
+++ b/tests/e2e/test-data/test-data.php
@@ -67,6 +67,30 @@ function register_routes() {
 			],
 		],
 	);
+
+	register_rest_route(
+		'wc/v3',
+		'gla-test/gtin-disabled',
+		[
+			[
+				'methods'             => 'POST',
+				'callback'            => __NAMESPACE__ . '\set_disabled_gtin_version',
+				'permission_callback' => __NAMESPACE__ . '\permissions',
+			],
+		],
+	);
+
+	register_rest_route(
+		'wc/v3',
+		'gla-test/gtin-hidden',
+		[
+			[
+				'methods'             => 'POST',
+				'callback'            => __NAMESPACE__ . '\set_hidden_gtin_version',
+				'permission_callback' => __NAMESPACE__ . '\permissions',
+			],
+		],
+	);
 }
 
 /**
@@ -163,3 +187,22 @@ function clear_notifications_ready() {
 	$options->delete( OptionsInterface::WPCOM_REST_API_STATUS );
 }
 
+/**
+ * Set gla_install_version as 2.9.0 for hiding the GTIN
+ * Notice GTIN should be hidden when gla_install_version > 2.8.7
+ */
+function set_hidden_gtin_version() {
+	/** @var OptionsInterface $options */
+	$options = woogle_get_container()->get( OptionsInterface::class );
+	$options->update( OptionsInterface::INSTALL_VERSION, '2.9.0' );
+}
+
+/**
+ * Set gla_install_version for set the GTIN as readonly
+ * Notice GTIN should be visible but disabled when gla_install_version <= 2.8.7
+ */
+function set_disabled_gtin_version() {
+	/** @var OptionsInterface $options */
+	$options = woogle_get_container()->get( OptionsInterface::class );
+	$options->update( OptionsInterface::INSTALL_VERSION, '2.8.7' );
+}

--- a/tests/e2e/utils/api.js
+++ b/tests/e2e/utils/api.js
@@ -126,3 +126,17 @@ export async function setNotificationsReady() {
 export async function clearNotificationsReady() {
 	await api().delete( 'gla-test/notifications-ready' );
 }
+
+/**
+ * Set gla_install_version for Hiding GTIN
+ */
+export async function setVersionForHideGtin() {
+	await api().post( 'gla-test/gtin-hidden' );
+}
+
+/**
+ * Set gla_install_version for disabling GTIN
+ */
+export async function setVersionForDisabledGtin() {
+	await api().post( 'gla-test/gtin-disabled' );
+}

--- a/tests/e2e/utils/product-editor.js
+++ b/tests/e2e/utils/product-editor.js
@@ -17,7 +17,6 @@ async function getAvailableProductAttributesWithTestValues(
 	const { dateInput: availabilityDate, timeInput: availabilityTime } =
 		funcGetDateAndTime( locator );
 
-	const gtin = locator.getByLabel( /\(GTIN\)$/ );
 	const mpn = locator.getByLabel( 'MPN' );
 	const brand = locator.getByLabel( 'Brand', { exact: true } );
 	const condition = locator.getByLabel( 'Condition', { exact: true } );
@@ -34,7 +33,6 @@ async function getAvailableProductAttributesWithTestValues(
 	const adultContent = locator.getByLabel( 'Adult content' );
 
 	const allPairs = [
-		[ gtin, '3234567890126' ],
 		[ mpn, 'GO12345OOGLE' ],
 		[ brand, 'e2e_test_woocommerce_brands' ],
 		[ condition, 'new' ],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Fixes E2E tests related to GTIN errors without depending on the release version. 
- Additionally adds a test for checking the GTIN field is visible but read-only for users that have the plugin installed <= 2.8.7

### Screenshots:

<img width="986" alt="Screenshot 2024-11-22 at 22 51 25" src="https://github.com/user-attachments/assets/3b795839-9c97-4f8e-8276-8f551926d441">



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Run the e2e tests locally and see them passing
2. See [GH E2E passing](https://github.com/woocommerce/google-listings-and-ads/actions/runs/11978448048)
3. Set `gla_install_version` version as 2.8.7 and go to Product Page
4. GTIN should be read only but visible
5. Set `gla_install_version` version as 2.9.0 and go to Product Page
6. GTIN should not be visible


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Tweak E2E tests for GTIN migration in versions > 2.8.7.
