### PR TITLE
Stick rebranding tour to the hamburger icon on mobile

### DIFF
--- a/js/src/components/tours/rebranding-tour.js
+++ b/js/src/components/tours/rebranding-tour.js
@@ -29,6 +29,7 @@ export default function RebrandingTour() {
 				referenceElements: {
 					desktop:
 						'.toplevel_page_woocommerce-marketing a[href*="google"]',
+					mobile: '#wp-admin-bar-menu-toggle',
 				},
 				meta: {
 					heading: (
@@ -59,7 +60,6 @@ export default function RebrandingTour() {
 			classNames: 'gla-admin-page,gla-rebranding-tour',
 			effects: { overlay: false },
 		},
-		placement: 'top',
 		closeHandler: () => setTourChecked( true ),
 	};
 


### PR DESCRIPTION


### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Set reference element for rebranding tour to main menu hamburger icon on mobile viewports.

Fixes https://github.com/woocommerce/google-listings-and-ads/issues/2680

_Replace this with a good description of your changes & reasoning._


### Screenshots:

#### Before
![image](https://github.com/user-attachments/assets/f8c3c092-0b7e-4c1c-9175-a1c6a7f8e9a4)

#### After
![image](https://github.com/user-attachments/assets/f0336ab9-804e-4c56-8431-32cbbe7e55bf)


<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  Checkout and build this branch
2. Restart the rebranding tour `wp.data.dispatch( 'wc/gla' ).upsertTour( { id: 'rebranding-tour', checked: false } )`
3. Open any G4W on a mobile viewport
4. Check that the tour step is visible and dismissable with `x` button


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix rebranding tour on mobile
