### PR TITLE
Add margins for Notices

### DIFF
--- a/js/src/css/shared/_woocommerce-admin.scss
+++ b/js/src/css/shared/_woocommerce-admin.scss
@@ -71,16 +71,13 @@
 			max-width: $grid-unit-60;
 		}
 	}
+
+	.components-notice:not(.app-notice) {
+		margin-bottom: $grid-unit-15;
+	}
 }
 
 // compatibility-code "WC >= 7.3" -- adding margin in the first question label.
 .wp-admin .woocommerce-customer-effort-score__intro {
 	margin-bottom: 1em;
-}
-
-
-.gla-admin-page {
-	.components-notice:not(.app-notice) {
-		margin-bottom: $grid-unit-15;
-	}
 }

--- a/js/src/css/shared/_woocommerce-admin.scss
+++ b/js/src/css/shared/_woocommerce-admin.scss
@@ -77,3 +77,10 @@
 .wp-admin .woocommerce-customer-effort-score__intro {
 	margin-bottom: 1em;
 }
+
+
+.gla-admin-page {
+	.components-notice:not(.app-notice) {
+		margin-bottom: $grid-unit-15;
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes a bug where the notices have no separations between them:


### Screenshots:

Before

![Screenshot 2024-11-26 at 16 55 48](https://github.com/user-attachments/assets/f8ecda81-e2e9-4a16-abb1-341d2838b009)


After

<img width="1531" alt="Screenshot 2024-11-26 at 16 56 55" src="https://github.com/user-attachments/assets/e7d08d41-ad6d-4725-9a1c-1835448361c3">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to Google for WooCommerce
2. Set wp_option gla_install_version as 2.8.7
3. Complete a fresh onboarding 
4. Go to settings
5. See both banners GTIN migration and API PUll Get started separated with margins.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Add margin for separating notices in the admin

