### PR TITLE
Fix the issue that the initial values of the form on free listings editing page may be empty

### DIFF
--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -59,25 +59,18 @@ const EditFreeCampaign = () => {
 	const [ settings, updateSettings ] = useState( savedSettings );
 
 	const {
-		hasFinishedResolution: hfrShippingRates,
+		hasFinishedResolution: hasResolvedShippingRates,
 		data: savedShippingRates,
 	} = useShippingRates();
 	const [ shippingRates, updateShippingRates ] =
 		useState( savedShippingRates );
-	// This is a quick and not safe workaround for
-	// https://github.com/woocommerce/google-listings-and-ads/pull/422#discussion_r607796375
-	// - `<Form>` element ignoring changes to its `initialValues` prop
-	// - default state of shipping* data of `[]`
-	// - resolver not signaling, that data is not ready yet
-	const loadedShippingRates = ! hfrShippingRates ? null : shippingRates;
 
 	const {
-		hasFinishedResolution: hfrShippingTimes,
+		hasFinishedResolution: hasResolvedShippingTimes,
 		data: savedShippingTimes,
 	} = useShippingTimes();
 	const [ shippingTimes, updateShippingTimes ] =
 		useState( savedShippingTimes );
-	const loadedShippingTimes = ! hfrShippingTimes ? null : shippingTimes;
 
 	// TODO: Consider making it less repetitive.
 	useEffect( () => updateSettings( savedSettings ), [ savedSettings ] );
@@ -188,6 +181,11 @@ const EditFreeCampaign = () => {
 		}
 	};
 
+	const initialAudience = targetAudience?.countries ? targetAudience : null;
+	const initialSettings = settings?.shipping_rate ? settings : null;
+	const initialRates = hasResolvedShippingRates ? savedShippingRates : null;
+	const initialTimes = hasResolvedShippingTimes ? savedShippingTimes : null;
+
 	return (
 		<>
 			<TopBar
@@ -202,14 +200,14 @@ const EditFreeCampaign = () => {
 					'Edit your listings',
 					'google-listings-and-ads'
 				) }
-				targetAudience={ targetAudience }
+				targetAudience={ initialAudience }
 				resolveFinalCountries={ getFinalCountries }
 				onTargetAudienceChange={ updateTargetAudience }
-				settings={ settings }
+				settings={ initialSettings }
 				onSettingsChange={ updateSettings }
-				shippingRates={ loadedShippingRates }
+				shippingRates={ initialRates }
 				onShippingRatesChange={ updateShippingRates }
-				shippingTimes={ loadedShippingTimes }
+				shippingTimes={ initialTimes }
 				onShippingTimesChange={ updateShippingTimes }
 				onContinue={ handleSetupFreeListingsContinue }
 				submitLabel={ __( 'Save changes', 'google-listings-and-ads' ) }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the issue that the initial values of the form on free listings editing page may be empty.

#### Root cause

Since the values fetched from the APIs are updated asynchronously via `useEffect`, there is a chance that [the default empty array](https://github.com/woocommerce/google-listings-and-ads/blob/43b03e513fa8ddf9baa9472a8068840a40e136d4/js/src/data/reducer.js#L21-L24) in the **wp-data** store may be passed as the initial values to the form. As a result, empty form fields may appear occasionally when editing free listings because the empty array can pass [checks](https://github.com/woocommerce/google-listings-and-ads/blob/43b03e513fa8ddf9baa9472a8068840a40e136d4/js/src/components/free-listings/setup-free-listings/index.js#L92-L94) in `SetupFreeListings`.

The issue usually happens on the shipping time data because it's almost always the last to be fetched.

https://github.com/user-attachments/assets/20c27c73-86d6-4329-b1a2-bfbb92c0e1aa

### Detailed test instructions:

1. Go to edit free listings
2. Check if the saved shipping rates and times are shown on the form
3. Refresh the webpage and check again
4. Repeat steps 2-3 several times to see if the issue won't appear occasionally

### Changelog entry

> Fix - The initial values of the form on free listings editing page may be empty.
