### PR TITLE
Prevent translations from being called early

### DIFF
--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\TosAccepted;
@@ -32,6 +33,7 @@ defined( 'ABSPATH' ) || exit;
  * - DateTimeUtility
  * - GoogleHelper
  * - Merchant
+ * - WC
  * - WP
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
@@ -290,7 +292,7 @@ class Middleware implements OptionsAwareInterface {
 	 */
 	public function create_ads_account(): array {
 		try {
-			$country = WC()->countries->get_base_country();
+			$country = $this->container->get( WC::class )->get_base_country();
 
 			/** @var GoogleHelper $google_helper */
 			$google_helper = $this->container->get( GoogleHelper::class );

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -24,6 +24,15 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class Settings
  *
+ * Container used for:
+ * - OptionsInterface
+ * - ShippingRateQuery
+ * - ShippingTimeQuery
+ * - ShippingZone
+ * - ShoppingContent
+ * - TargetAudience
+ * - WC
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */
 class Settings {
@@ -277,10 +286,7 @@ class Settings {
 	 * @return string
 	 */
 	protected function get_store_country(): string {
-		/** @var WC $wc */
-		$wc = $this->container->get( WC::class );
-
-		return $wc->get_wc_countries()->get_base_country();
+		return $this->container->get( WC::class )->get_base_country();
 	}
 
 	/**

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -858,6 +858,8 @@ class ConnectionTest implements Service, Registerable {
 			/** @var OptionsInterface $options */
 			$options = $this->container->get( OptionsInterface::class );
 			$this->response .= "\n\n" . 'Saved Connection option = ' . ( $options->get( OptionsInterface::JETPACK_CONNECTED ) ? 'connected' : 'disconnected' );
+
+			$this->response .= "\n\n" . 'Connected plugins: ' . implode( ', ', array_column( $manager->get_connected_plugins(), 'name' ) ) . "\n";
 		}
 
 		if ( 'wcs-test' === $_GET['action'] && check_admin_referer( 'wcs-test' ) ) {

--- a/src/Exception/ExtensionRequirementException.php
+++ b/src/Exception/ExtensionRequirementException.php
@@ -3,19 +3,18 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Exception;
 
-use RuntimeException;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Class ExtensionRequirementException
  *
  * Error messages generated in this class should be translated, as they are intended to be displayed
- * to end users.
+ * to end users. We pass the translated message as a function so they are only translated when shown.
+ * This prevents translation functions to be called before init which is not allowed in WP 6.7+.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Exception
  */
-class ExtensionRequirementException extends RuntimeException implements GoogleListingsAndAdsException {
+class ExtensionRequirementException extends RuntimeExceptionWithMessageFunction implements GoogleListingsAndAdsException {
 
 	/**
 	 * Create a new instance of the exception when a required plugin/extension isn't activated.
@@ -27,6 +26,12 @@ class ExtensionRequirementException extends RuntimeException implements GoogleLi
 	public static function missing_required_plugin( string $plugin_name ): ExtensionRequirementException {
 		return new static(
 			sprintf(
+				'Requires %1$s to be enabled.', // Fallback exception message.
+				$plugin_name
+			),
+			0,
+			null,
+			fn () => sprintf(
 				/* translators: 1 the missing plugin name */
 				__( 'Google for WooCommerce requires %1$s to be enabled.', 'google-listings-and-ads' ),
 				$plugin_name
@@ -44,6 +49,12 @@ class ExtensionRequirementException extends RuntimeException implements GoogleLi
 	public static function incompatible_plugin( string $plugin_name ): ExtensionRequirementException {
 		return new static(
 			sprintf(
+				'Incompatible with %1$s.', // Fallback exception message.
+				$plugin_name
+			),
+			0,
+			null,
+			fn () => sprintf(
 				/* translators: 1 the incompatible plugin name */
 				__( 'Google for WooCommerce is incompatible with %1$s.', 'google-listings-and-ads' ),
 				$plugin_name

--- a/src/Exception/ExtensionRequirementException.php
+++ b/src/Exception/ExtensionRequirementException.php
@@ -26,7 +26,7 @@ class ExtensionRequirementException extends RuntimeExceptionWithMessageFunction 
 	public static function missing_required_plugin( string $plugin_name ): ExtensionRequirementException {
 		return new static(
 			sprintf(
-				'Requires %1$s to be enabled.', // Fallback exception message.
+				'Google for WooCommerce requires %1$s to be enabled.', // Fallback exception message.
 				$plugin_name
 			),
 			0,
@@ -49,7 +49,7 @@ class ExtensionRequirementException extends RuntimeExceptionWithMessageFunction 
 	public static function incompatible_plugin( string $plugin_name ): ExtensionRequirementException {
 		return new static(
 			sprintf(
-				'Incompatible with %1$s.', // Fallback exception message.
+				'Google for WooCommerce is incompatible with %1$s.', // Fallback exception message.
 				$plugin_name
 			),
 			0,

--- a/src/Exception/InvalidVersion.php
+++ b/src/Exception/InvalidVersion.php
@@ -3,19 +3,18 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Exception;
 
-use RuntimeException;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Class InvalidVersion
  *
  * Error messages generated in this class should be translated, as they are intended to be displayed
- * to end users.
+ * to end users. We pass the translated message as a function so they are only translated when shown.
+ * This prevents translation functions to be called before init which is not allowed in WP 6.7+.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Exception
  */
-class InvalidVersion extends RuntimeException implements GoogleListingsAndAdsException {
+class InvalidVersion extends RuntimeExceptionWithMessageFunction implements GoogleListingsAndAdsException {
 
 	/**
 	 * Create a new instance of the exception when an invalid version is detected.
@@ -29,6 +28,14 @@ class InvalidVersion extends RuntimeException implements GoogleListingsAndAdsExc
 	public static function from_requirement( string $requirement, string $found_version, string $minimum_version ): InvalidVersion {
 		return new static(
 			sprintf(
+				'Requires %1$s version %2$s or higher. You are using version %3$s.', // Fallback exception message.
+				$requirement,
+				$minimum_version,
+				$found_version
+			),
+			0,
+			null,
+			fn () => sprintf(
 				/* translators: 1 is the required component, 2 is the minimum required version, 3 is the version in use on the site */
 				__( 'Google for WooCommerce requires %1$s version %2$s or higher. You are using version %3$s.', 'google-listings-and-ads' ),
 				$requirement,
@@ -49,6 +56,13 @@ class InvalidVersion extends RuntimeException implements GoogleListingsAndAdsExc
 	public static function requirement_missing( string $requirement, string $minimum_version ): InvalidVersion {
 		return new static(
 			sprintf(
+				'Requires %1$s version %2$s or higher.', // Fallback exception message.
+				$requirement,
+				$minimum_version
+			),
+			0,
+			null,
+			fn () => sprintf(
 				/* translators: 1 is the required component, 2 is the minimum required version */
 				__( 'Google for WooCommerce requires %1$s version %2$s or higher.', 'google-listings-and-ads' ),
 				$requirement,
@@ -65,7 +79,10 @@ class InvalidVersion extends RuntimeException implements GoogleListingsAndAdsExc
 	 */
 	public static function invalid_architecture(): InvalidVersion {
 		return new static(
-			__( 'Google for WooCommerce requires a 64 bit version of PHP.', 'google-listings-and-ads' )
+			'Requires a 64 bit version of PHP.', // Fallback exception message.
+			0,
+			null,
+			fn () => __( 'Google for WooCommerce requires a 64 bit version of PHP.', 'google-listings-and-ads' )
 		);
 	}
 }

--- a/src/Exception/InvalidVersion.php
+++ b/src/Exception/InvalidVersion.php
@@ -28,7 +28,7 @@ class InvalidVersion extends RuntimeExceptionWithMessageFunction implements Goog
 	public static function from_requirement( string $requirement, string $found_version, string $minimum_version ): InvalidVersion {
 		return new static(
 			sprintf(
-				'Requires %1$s version %2$s or higher. You are using version %3$s.', // Fallback exception message.
+				'Google for WooCommerce requires %1$s version %2$s or higher. You are using version %3$s.', // Fallback exception message.
 				$requirement,
 				$minimum_version,
 				$found_version
@@ -56,7 +56,7 @@ class InvalidVersion extends RuntimeExceptionWithMessageFunction implements Goog
 	public static function requirement_missing( string $requirement, string $minimum_version ): InvalidVersion {
 		return new static(
 			sprintf(
-				'Requires %1$s version %2$s or higher.', // Fallback exception message.
+				'Google for WooCommerce requires %1$s version %2$s or higher.', // Fallback exception message.
 				$requirement,
 				$minimum_version
 			),
@@ -79,7 +79,7 @@ class InvalidVersion extends RuntimeExceptionWithMessageFunction implements Goog
 	 */
 	public static function invalid_architecture(): InvalidVersion {
 		return new static(
-			'Requires a 64 bit version of PHP.', // Fallback exception message.
+			'Google for WooCommerce requires a 64 bit version of PHP.', // Fallback exception message.
 			0,
 			null,
 			fn () => __( 'Google for WooCommerce requires a 64 bit version of PHP.', 'google-listings-and-ads' )

--- a/src/Exception/RuntimeExceptionWithMessageFunction.php
+++ b/src/Exception/RuntimeExceptionWithMessageFunction.php
@@ -1,0 +1,51 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Exception;
+
+use Exception;
+use RuntimeException;
+use Throwable;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class RuntimeExceptionWithMessageFunction
+ *
+ * The purpose of this Exception type is to be able to throw an exception early,
+ * but translate the string late. This is because WP 6.7+ requires translations
+ * to happen after the init hook.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Exception
+ */
+class RuntimeExceptionWithMessageFunction extends RuntimeException implements GoogleListingsAndAdsException {
+
+	/** @var callable $message_function */
+	private $message_function;
+
+	/**
+	 * Construct the exception
+	 *
+	 * @param string         $message [optional] The Exception message to throw.
+	 * @param int            $code [optional] The Exception code.
+	 * @param Throwable|null $previous [optional] The previous throwable used for the exception chaining.
+	 * @param callable       $message_function [optional] Function to format/translate the message string.
+	 */
+	public function __construct( string $message = '', int $code = 0, Throwable $previous = null, ?callable $message_function = null ) {
+		parent::__construct( $message, $code, $previous );
+		$this->message_function = $message_function;
+	}
+
+	/**
+	 * Override getMessage function to return message from function if available.
+	 *
+	 * @return string Exception message.
+	 */
+	public function get_formatted_message(): string {
+		if ( is_callable( $this->message_function ) ) {
+			return ( $this->message_function )();
+		}
+
+		return parent::getMessage();
+	}
+}

--- a/src/Internal/DependencyManagement/ThirdPartyServiceProvider.php
+++ b/src/Internal/DependencyManagement/ThirdPartyServiceProvider.php
@@ -55,7 +55,7 @@ class ThirdPartyServiceProvider extends AbstractServiceProvider {
 				new RawArgument( 'connection' ),
 				[
 					'slug' => $jetpack_id->getValue(),
-					'name' => __( 'Google for WooCommerce', 'google-listings-and-ads' ),
+					'name' => 'Google for WooCommerce', // Use hardcoded name for initial registration.
 				],
 			]
 		);
@@ -71,6 +71,18 @@ class ThirdPartyServiceProvider extends AbstractServiceProvider {
 				return Validation::createValidatorBuilder()
 					->addMethodMapping( 'load_validator_metadata' )
 					->getValidator();
+			}
+		);
+
+		// Update Jetpack connection with a translatable name, after init is called.
+		add_action(
+			'init',
+			function () {
+				$manager = $this->getLeagueContainer()->get( Manager::class );
+				$manager->get_plugin()->add(
+					__( 'Google for WooCommerce', 'google-listings-and-ads' ),
+					[]
+				);
 			}
 		);
 	}

--- a/src/Internal/DependencyManagement/ThirdPartyServiceProvider.php
+++ b/src/Internal/DependencyManagement/ThirdPartyServiceProvider.php
@@ -80,8 +80,7 @@ class ThirdPartyServiceProvider extends AbstractServiceProvider {
 			function () {
 				$manager = $this->getLeagueContainer()->get( Manager::class );
 				$manager->get_plugin()->add(
-					__( 'Google for WooCommerce', 'google-listings-and-ads' ),
-					[]
+					__( 'Google for WooCommerce', 'google-listings-and-ads' )
 				);
 			}
 		);

--- a/src/Internal/Requirements/RequirementValidator.php
+++ b/src/Internal/Requirements/RequirementValidator.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\Requirements;
 
-use RuntimeException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\RuntimeExceptionWithMessageFunction;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -36,15 +36,15 @@ abstract class RequirementValidator implements RequirementValidatorInterface {
 	/**
 	 * Add a standard requirement validation error notice.
 	 *
-	 * @param RuntimeException $e
+	 * @param RuntimeExceptionWithMessageFunction $e
 	 */
-	protected function add_admin_notice( RuntimeException $e ) {
+	protected function add_admin_notice( RuntimeExceptionWithMessageFunction $e ) {
 		// Display notice error message.
 		add_action(
 			'admin_notices',
 			function () use ( $e ) {
 				echo '<div class="notice notice-error">' . PHP_EOL;
-				echo '	<p>' . esc_html( $e->getMessage() ) . '</p>' . PHP_EOL;
+				echo '	<p>' . esc_html( $e->get_formatted_message() ) . '</p>' . PHP_EOL;
 				echo '</div>' . PHP_EOL;
 			}
 		);

--- a/src/Proxies/WC.php
+++ b/src/Proxies/WC.php
@@ -55,20 +55,19 @@ class WC {
 	 * @param WC_Countries|null $countries
 	 */
 	public function __construct( ?WC_Countries $countries = null ) {
-		$countries               = $countries ?? new WC_Countries();
-		$this->wc_countries      = $countries;
-		$this->base_country      = $countries->get_base_country() ?? 'US';
-		$this->countries         = $countries->get_countries() ?? [];
-		$this->allowed_countries = $countries->get_allowed_countries() ?? [];
-		$this->continents        = $countries->get_continents() ?? [];
+		$this->wc_countries = $countries ?? new WC_Countries();
 	}
 
 	/**
-	 * Get WooCommerce
+	 * Get WooCommerce countries.
 	 *
 	 * @return array
 	 */
 	public function get_countries(): array {
+		if ( null === $this->countries ) {
+			$this->countries = $this->wc_countries->get_countries() ?? [];
+		}
+
 		return $this->countries;
 	}
 
@@ -78,6 +77,10 @@ class WC {
 	 * @return array
 	 */
 	public function get_allowed_countries(): array {
+		if ( null === $this->allowed_countries ) {
+			$this->allowed_countries = $this->wc_countries->get_allowed_countries() ?? [];
+		}
+
 		return $this->allowed_countries;
 	}
 
@@ -87,6 +90,10 @@ class WC {
 	 * @return string
 	 */
 	public function get_base_country(): string {
+		if ( null === $this->base_country ) {
+			$this->base_country = $this->wc_countries->get_base_country() ?? 'US';
+		}
+
 		return $this->base_country;
 	}
 
@@ -96,6 +103,10 @@ class WC {
 	 * @return array
 	 */
 	public function get_continents(): array {
+		if ( null === $this->continents ) {
+			$this->continents = $this->wc_countries->get_continents() ?? [];
+		}
+
 		return $this->continents;
 	}
 

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidDomainName;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GuzzleClientTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
@@ -41,6 +42,9 @@ class MiddlewareTest extends UnitTest {
 
 	/** @var MockObject|Merchant $merchant */
 	protected $merchant;
+
+	/** @var MockObject|WC $wc */
+	protected $wc;
 
 	/** @var MockObject|WP $wp */
 	protected $wp;
@@ -76,6 +80,7 @@ class MiddlewareTest extends UnitTest {
 		$this->merchant      = $this->createMock( Merchant::class );
 		$this->options       = $this->createMock( OptionsInterface::class );
 		$this->transients    = $this->createMock( TransientsInterface::class );
+		$this->wc            = $this->createMock( WC::class );
 		$this->wp            = $this->createMock( WP::class );
 
 		$this->container->share( Ads::class, $this->ads );
@@ -83,6 +88,7 @@ class MiddlewareTest extends UnitTest {
 		$this->container->share( GoogleHelper::class, $this->google_helper );
 		$this->container->share( Merchant::class, $this->merchant );
 		$this->container->share( TransientsInterface::class, $this->transients );
+		$this->container->share( WC::class, $this->wc );
 		$this->container->share( WP::class, $this->wp );
 
 		$this->middleware = new Middleware( $this->container );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR prevents translations from being called early. There are quite a few places where we translate code before init, so this PR contains the following fixes to prevent the notices from showing:

#### Jetpack Connection plugin name
The Jetpack connection has to be registered on `plugins_loaded` priority 1 as shown in the [example here](https://github.com/Automattic/jetpack-connection/blob/trunk/docs/register-site.md#initialize-the-package). Since we aren't able to change this to a later hook, I initially called the registration with a hardcoded plugin name. After init the plugin name is updated to a translatable name.

##### Test instructions:
1. Switch to another language in Settings (choose a language with translations available like Spanish)
2. Go to Dashboard > Updates and make sure Translations are updated and downloaded
3. Enable WP_DEBUG and WP_DEBUG_LOG so we can monitor debug notices in the log file
4. Use a test snippet to translate the plugin name:
```php
add_filter(
	'gettext',
	function ( $translation = '', $text = '', $domain = '' ) {
		if ( 'google-listings-and-ads' === $domain && 'Google for WooCommerce' === $text ) {
			return 'Google for WooCommerce (translated)';
		}

		return $translation;
	},
	10,
	3
);
```
5. Use the connection test page and click "WordPress.com Connection Status"
6. Confirm that we see the translated name in the list of connected plugins
7. Check the log file to confirm there are no notices about translations being called too early

#### Pre-requisite tests
We want to continue checking pre-requisites like required plugins / versions at an early stage, but we shouldn't call any translation functions till after init. Since we use an exception when encounter a problem, I created a new type `RuntimeExceptionWithMessageFunction`. This custom exception accepts a callback function which can be used to format the final message. This means we can throw an exception early with the error message wrapped in a function, the function will only be called when we want to actually display the errors which will be after init. Several classes had to get updated to support this new type of exception.

> [!Note]
> I used PHP arrow functions to simplify how the strings are wrapped. Arrow functions are available since PHP 7.4 and they allow automatic use of variables from the parent scope, which makes the code a little shorter than using anonymous functions.

##### Test instructions:
1. Switch to another language in Settings (choose a language with translations available like Spanish)
2. Go to Dashboard > Updates and make sure Translations are updated and downloaded
3. Enable WP_DEBUG and WP_DEBUG_LOG so we can monitor debug notices in the log file
4. Use a test snippet to disable WCAdmin:
```php
add_filter( 'woocommerce_admin_disabled', '__return_true' );
```
5. Confirm the admin notice is displayed and there are no notices in the log file
![image](https://github.com/user-attachments/assets/f3473770-e2cf-4a9a-9a43-ef8e0a2cd9f3)
6. Use a test snippet to enable Google Product Feed
```php
define( 'WOOCOMMERCE_GPF_VERSION', '1' );
```
7. Go to Marketing > Google for WooCommerce > Product Feed and confirm the issues table shows the error (need to clear cache if the product feed page has been listed before)
![image](https://github.com/user-attachments/assets/200a7024-e64c-4710-adb2-cdff29ddb423)
8. Temporarily increase `WC_GLA_MIN_PHP_VER` to a higher value
9. Confirm the admin notice is displayed and there are no notices in the log file
![image](https://github.com/user-attachments/assets/473668f0-ee05-42aa-8552-6e0ce91bb366)
10. Temporarily increase `WC_GLA_MIN_WC_VER` to a higher value
11. Confirm the admin notice is displayed and there are no notices in the log file
![image](https://github.com/user-attachments/assets/4e1187f5-73a6-438d-9a5d-bc55598388b2)
10. Temporarily change the check for `PHP_INT_SIZE !== 8` to return false
11. Confirm the admin notice is displayed and there are no notices in the log file
![image](https://github.com/user-attachments/assets/7c2709e5-fee7-4aff-adc9-426745645716)

#### Load country data JIT
We rely on the WooCommerce country data much of which are wrapped in translation functions. Previously in the `Proxies\WC` we were initializing all the country data in the constructor, which means it's loaded as soon as the plugin loads. So this change is both a slight optimization as the country list doesn't need to be loaded when it's not used, and it also prevents translation strings from being called too early.

The easiest way to test this is to run the unit tests, but we can also go through the onboarding and confirm all countries are available as expected without any notices in the log file.


### Additional details:
peeuvX-20i-p2

### Changelog entry
* Fix - Prevent translations from being called early.