### PR TITLE
Increase the specificity of `__styled--overflow-visible` selector

### DIFF
--- a/js/src/components/app-modal/index.scss
+++ b/js/src/components/app-modal/index.scss
@@ -31,7 +31,7 @@
 	}
 
 	&__styled--overflow-visible {
-		&,
+		&.app-modal,
 		.components-modal__content {
 			overflow: visible;
 		}


### PR DESCRIPTION


### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
This PR increases the specificity of the selector introduced in https://github.com/woocommerce/google-listings-and-ads/pull/1442

Fixes https://github.com/woocommerce/google-listings-and-ads/issues/2702

_Replace this with a good description of your changes & reasoning._


### Screenshots:
#### Before
![image](https://github.com/user-attachments/assets/1899ec67-7b19-4aa6-8a0b-648ca13a2464)
#### After
![image](https://github.com/user-attachments/assets/497b4fd0-08d0-4bf2-9247-cc29875ac862)

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Switch to another language in Settings (choose a language with translations available like Spanish)
1. Go to Dashboard > Updates and make sure Translations are updated and downloaded
1. Enable WP_DEBUG and WP_DEBUG_LOG so we can monitor debug notices in the log file

I'm not sure if that's enough to always reproduce the component styles being loaded after G4W. But that is when it happens to me. Also, I see nothing preventing this race in regular non-error cases.


1. Go to editing the free listings (`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&subpath=%2Ffree-listings%2Fedit`)
1. Check country selectors of adding/editing shipping modals (rate & time) with the following steps.
   1. Open a modal and open the inside dropdown options of the tree selector.
   1. Expend some options to see if the dropdown is no longer covered by the viewport of modal.



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - The country selector in setup/edit free listing flow from being hidden.
