### PR TITLE
Make tab-nav a bit more responsive

### DIFF
--- a/js/src/components/app-tab-nav/index.scss
+++ b/js/src/components/app-tab-nav/index.scss
@@ -8,7 +8,7 @@
 	&-item {
 		background: transparent;
 		border: none;
-		box-shadow: none;
+		box-shadow: inset 0 -1px 0 #ccc;
 		border-radius: 0;
 		cursor: pointer;
 		height: $grid-unit-60;
@@ -16,7 +16,6 @@
 		margin-left: 0;
 		font-weight: 500;
 		box-sizing: border-box;
-		box-shadow: inset 0 -1px 0 #ccc;
 
 		// This pseudo-element "duplicates" the tab label and sets the text to bold.
 		// This ensures that the tab doesn't change width when selected.

--- a/js/src/components/app-tab-nav/index.scss
+++ b/js/src/components/app-tab-nav/index.scss
@@ -8,7 +8,7 @@
 	&-item {
 		background: transparent;
 		border: none;
-		box-shadow: inset 0 -1px 0 #ccc;
+		box-shadow: inset 0 -1px 0 $gray-400;
 		border-radius: 0;
 		cursor: pointer;
 		height: $grid-unit-60;

--- a/js/src/components/app-tab-nav/index.scss
+++ b/js/src/components/app-tab-nav/index.scss
@@ -1,5 +1,6 @@
 .app-tab-nav__tabs {
 	display: flex;
+	flex-wrap: wrap;
 	align-items: stretch;
 	box-shadow: inset 0 -1px 0 $gray-400;
 	margin-bottom: var(--main-gap);
@@ -15,6 +16,7 @@
 		margin-left: 0;
 		font-weight: 500;
 		box-sizing: border-box;
+		box-shadow: inset 0 -1px 0 #ccc;
 
 		// This pseudo-element "duplicates" the tab label and sets the text to bold.
 		// This ensures that the tab doesn't change width when selected.

--- a/js/src/product-feed/issues-table-card/index.scss
+++ b/js/src/product-feed/issues-table-card/index.scss
@@ -11,6 +11,9 @@
 		&__tabs {
 			padding: 0 $grid-unit-30;
 			margin-bottom: 0;
+			@media (max-width: $break-mobile) {
+				padding: 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR makes the tab navigation a bit more responsive, my making tabs wrap when the container is too narrow. It also adds the  bottom "bar" to the items, sot when the elements wrap, the "bar" is visible under all tabs.

Closes #2473

_Replace this with a good description of your changes & reasoning._


### Screenshots:

#### Before
![image](https://github.com/user-attachments/assets/7e93645a-5aac-44a3-b645-78720d4bb796)

#### After
![image](https://github.com/user-attachments/assets/d1119328-238b-4b95-bd1d-7f95a0876776)

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  Go to G4W dashboard `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard`
2. Change the viewport size to something narrower
3. Check that all the tabs are visible
4. Go to Product feed `/wp-admin/admin.php?page=wc-admin&issueType=product&path=%2Fgoogle%2Fproduct-feed`
5. Check that all "Issues to resolve" tabs are visible.


### Additional details:

1. We may consider implementing more dedicated UI for the narrower screens, but I believe it's a good enough quick fix in the meantime.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Make the tab navigation tabs wrap when the screen narrows.
