### PR TITLE
Fix the failed E2E test case introduced by pull request 2698

### DIFF
--- a/tests/e2e/specs/dashboard/edit-free-listings.test.js
+++ b/tests/e2e/specs/dashboard/edit-free-listings.test.js
@@ -36,6 +36,11 @@ test.describe( 'Edit Free Listings', () => {
 		page = await browser.newPage();
 		dashboardPage = new DashboardPage( page );
 		editFreeListingsPage = new EditFreeListingsPage( page );
+
+		await editFreeListingsPage.fulfillSettings( {
+			shipping_rate: 'flat',
+			tax_rate: 'destination',
+		} );
 		await setOnboardedMerchant();
 		await dashboardPage.mockRequests();
 		await dashboardPage.goto();

--- a/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
+++ b/tests/e2e/specs/setup-mc/step-2-product-listings.test.js
@@ -61,14 +61,10 @@ test.describe( 'Configure product listings', () => {
 			} ),
 
 			// Mock MC settings
-			productListingsPage.fulfillSettings(
-				{
-					shipping_rate: 'automatic',
-					tax_rate: 'destination',
-				},
-				200,
-				[ 'GET' ]
-			),
+			productListingsPage.fulfillSettings( {
+				shipping_rate: 'automatic',
+				tax_rate: 'destination',
+			} ),
 		] );
 
 		await productListingsPage.goto();

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -237,11 +237,11 @@ export default class MockRequests {
 	 * Fulfill the Settings request.
 	 *
 	 * @param {Object} payload
-	 * @param {number} status
-	 * @param {Array}  methods
+	 * @param {number} [status=200]
+	 * @param {Array}  [methods=['GET']]
 	 * @return {Promise<void>}
 	 */
-	async fulfillSettings( payload, status = 200, methods = [] ) {
+	async fulfillSettings( payload, status = 200, methods = [ 'GET' ] ) {
 		await this.fulfillRequest(
 			/\/wc\/gla\/mc\/settings\b/,
 			payload,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The change in #2698 caused an E2E test failure due to the infinite loading state.

![test-failed-2](https://github.com/user-attachments/assets/55a41a47-9422-400b-91d6-fe9eb8c3dadc)

![image](https://github.com/user-attachments/assets/623582eb-070a-49ff-80df-a2ccb844e729)

Ref: https://github.com/woocommerce/google-listings-and-ads/actions/runs/12112506569

### Detailed test instructions:

1. View the E2E tests run on GitHub Actions: https://github.com/woocommerce/google-listings-and-ads/actions/runs/12115664237
2. (Optional) Run E2E tests locally to see if the test case **Edit Free Listings › Check recommended shipping settings** can pass

### Changelog entry
