### PR TITLE
Avoid errors caused by automatically saving invalid shipping times during onboarding

### DIFF
--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -136,12 +136,17 @@ const SetupFreeListings = ( {
 				setValue( 'shipping_country_rates', nextValue );
 			}
 		} else if ( change.name === 'shipping_country_times' ) {
+			// Skip the call of `onShippingTimesChange` if any shipping times are invalid.
+			const error = handleValidate( values );
+			const isValid = ! error.hasOwnProperty( change.name );
+
 			// Skip the call of `onShippingTimesChange` if there are incomplete shipping times.
 			// This should only happen during onboarding when the shipping times haven't been stored yet.
 			const shippingIsIncomplete = values.shipping_country_times.some(
 				( item ) => item.time === null || item.maxTime === null
 			);
-			if ( ! shippingIsIncomplete ) {
+
+			if ( ! shippingIsIncomplete && isValid ) {
 				onShippingTimesChange( values.shipping_country_times );
 			}
 		} else if ( settingsFieldNames.includes( change.name ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR avoids errors caused by automatically saving invalid shipping times during onboarding.

https://github.com/user-attachments/assets/42e2d770-7082-42fb-90ff-ca47964b41b3

The issue also causes [a flaky E2E test case](https://github.com/woocommerce/google-listings-and-ads/actions/runs/12119347486/job/33785728575#step:10:234) although it can pass on the second retry:

![image](https://github.com/user-attachments/assets/75949d5f-4a8e-4cbc-8c39-8dde10e18340)

### Screenshots:

https://github.com/user-attachments/assets/bd717860-e6c6-4cf4-b7e2-0c02b9a3d72d

### Detailed test instructions:

1. Go to step 2 of the onboarding flow
2. Enter a shipping time setup where the min days is greater than its max days
3. Check if the API error, "There was an error saving shipping times.", doesn't occur
4. View the E2E tests run on GitHub Actions to see if the flaky E2E test case no longer occur
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/12133002898

### Changelog entry

