### PR TITLE
Prevent Warning when Saving a Variation if YOAST is activated

### DIFF
--- a/src/Admin/Input/SelectWithTextInput.php
+++ b/src/Admin/Input/SelectWithTextInput.php
@@ -134,8 +134,8 @@ class SelectWithTextInput extends Input {
 			return;
 		}
 
-		$select_value = is_array( $data ) ? $data[ self::SELECT_INPUT_KEY ] : $data;
-		$custom_value = is_array( $data ) ? $data[ self::CUSTOM_INPUT_KEY ] : $data;
+		$select_value = is_array( $data ) ? $data[ self::SELECT_INPUT_KEY ] ?? "" : $data;
+		$custom_value = is_array( $data ) ? $data[ self::CUSTOM_INPUT_KEY ] ?? "" : $data;
 		if ( ! isset( $this->get_options()[ $select_value ] ) ) {
 			$this->get_select_input()->set_data( self::CUSTOM_INPUT_KEY );
 			$this->get_custom_input()->set_data( $custom_value );

--- a/src/Admin/Input/SelectWithTextInput.php
+++ b/src/Admin/Input/SelectWithTextInput.php
@@ -134,8 +134,8 @@ class SelectWithTextInput extends Input {
 			return;
 		}
 
-		$select_value = is_array( $data ) ? $data[ self::SELECT_INPUT_KEY ] ?? "" : $data;
-		$custom_value = is_array( $data ) ? $data[ self::CUSTOM_INPUT_KEY ] ?? "" : $data;
+		$select_value = is_array( $data ) ? $data[ self::SELECT_INPUT_KEY ] ?? '' : $data;
+		$custom_value = is_array( $data ) ? $data[ self::CUSTOM_INPUT_KEY ] ?? '' : $data;
 		if ( ! isset( $this->get_options()[ $select_value ] ) ) {
 			$this->get_select_input()->set_data( self::CUSTOM_INPUT_KEY );
 			$this->get_custom_input()->set_data( $custom_value );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2701 

This PR addresses a PHP Warning when saving a variation only if YOAST is activated.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Enable Wordprsss DEbugging so see the warnings
2. Install YOAST SEO
3. Edit a variable product and change some details in one of it's variations
4. Save the variation changes
5. See the Warning
6. CHeckout PR
7. Perform steps 3-4
8. No warning 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Prevent Warning when Saving a Variation if YOAST is activated
