### PR TITLE
Remove assertions from `reducer.test.js` that prevent the next state from being created by a way mutating unrelated references

### DIFF
--- a/js/src/data/test/__helpers__/index.js
+++ b/js/src/data/test/__helpers__/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { cloneDeep, set, get, isPlainObject } from 'lodash';
+import { cloneDeep, set } from 'lodash';
 
 /**
  * Use native `Object.freeze()` to make an object immutable, recursively freeze each property which is of type object.
@@ -27,96 +27,21 @@ export function deepFreeze( object ) {
 }
 
 /**
- * @typedef {Object} CheckingGroup
- * @property {Object} ref The attached object for further reference checks.
- * @property {string} refPath The access path of `ref` in the object tree.
- */
-/**
- * Loops through the passed-in `object` recursively and attaches (by mutating on passed-in `object`)
- * a new object as a reference checking mark to any nodes which is a plain object type.
- * Returns an array that contains each attached reference checking mark and its access path.
- *
- * @param {Object} object The object to be attached reference marks.
- * @param {Array<string>} ignore The paths to be ignored to attach reference marks.
- * @param {Array<CheckingGroup>} [checkingGroups=[]] The accumulator of attached reference marks passed by internal recursive call.
- * @param {Array<string>} [paths=[]] The current looping sub-tree paths by internal recursive call.
- *
- * @return {Array<CheckingGroup>} An array that contains each attached reference checking mark and its access path.
- */
-function attachRef( object, ignore, checkingGroups = [], paths = [] ) {
-	const refKey = '__refForCheck';
-
-	for ( const [ name, value ] of Object.entries( object ) ) {
-		if ( isPlainObject( value ) ) {
-			const checkPaths = [ ...paths, name ];
-			attachRef( value, ignore, checkingGroups, checkPaths );
-
-			const currentPath = checkPaths.join( '.' );
-			if ( ! ignore.includes( currentPath ) ) {
-				const ref = {
-					whyFail: `If there's no mutation at \`state.${ currentPath }\`, it should be kept the same reference.`,
-				};
-				checkingGroups.push( {
-					ref,
-					refPath: `${ currentPath }.${ refKey }`,
-				} );
-				value[ refKey ] = ref;
-			}
-		}
-	}
-	return checkingGroups;
-}
-
-/**
  * Creates a deep freeze state based on the passed-in state,
- * and also implants a `assertConsistentRef` function for reference check.
- * An initial value of a specific path can be set optionally to facilitate testing.
- *
- * Usage of `assertConsistentRef`:
- *   After getting the new state from `reducer( preparedState, action )`,
- *   calls `newState.assertConsistentRef()` for reference checking.
+ * and an initial value of a specific path can be set optionally to facilitate testing.
  *
  * @param {Object|Array} srcState The state to be attached deep freeze and reference checking.
  * @param {string} [path] The path of state to be set.
  * @param {*} [value] The initial value to be set.
- * @param {true|Array<string>} [ignoreRefCheckOnMutatingPath] Indicate state paths that don't require reference check.
- *   `true` - Set `true` to use the passed-in `path` parameter as the ignoring path.
- *   `Array<string>` - Given an array of state paths to be ignored.
  *
  * @return {Object} Prepared state.
  */
-export function prepareImmutableStateWithRefCheck(
-	srcState,
-	path,
-	value,
-	ignoreRefCheckOnMutatingPath
-) {
+export function prepareImmutableState( srcState, path, value ) {
 	const state = cloneDeep( srcState );
+
 	if ( path ) {
 		set( state, path, value );
 	}
-
-	// Prepare the paths to be ignored the reference check.
-	const ignorePaths = [];
-	if ( ignoreRefCheckOnMutatingPath === true ) {
-		ignorePaths.push( path );
-	} else if ( Array.isArray( ignoreRefCheckOnMutatingPath ) ) {
-		ignorePaths.push( ...ignoreRefCheckOnMutatingPath );
-	}
-	const checkingGroups = attachRef( state, ignorePaths );
-
-	state.assertConsistentRef = function () {
-		if ( this === state ) {
-			throw new Error(
-				'Please use the state returned by `reducer` to check this assertion in the test case.'
-			);
-		}
-
-		checkingGroups.forEach( ( { refPath, ref } ) => {
-			// If you see this failed assertion, it may be because a reference has been changed unexpectedly, please check if other states have been changed. Or, the reference chage is expected but hasn't be specified ignoring. Please add that path to the `ignoreRefCheckOnMutatingPath` parameter.
-			expect( get( this, refPath ) ).toBe( ref );
-		} );
-	};
 
 	return deepFreeze( state );
 }

--- a/js/src/data/test/reducer.test.js
+++ b/js/src/data/test/reducer.test.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
  */
 import reducer from '../reducer';
 import TYPES from '../action-types';
-import { deepFreeze, prepareImmutableStateWithRefCheck } from './__helpers__';
+import { deepFreeze, prepareImmutableState } from './__helpers__';
 
 describe( 'reducer', () => {
 	let defaultState;
@@ -77,10 +77,7 @@ describe( 'reducer', () => {
 			gtinMigrationStatus: null,
 		} );
 
-		prepareState = prepareImmutableStateWithRefCheck.bind(
-			null,
-			defaultState
-		);
+		prepareState = prepareImmutableState.bind( null, defaultState );
 	} );
 
 	describe( 'General reducer behaviors', () => {
@@ -120,7 +117,6 @@ describe( 'reducer', () => {
 				data,
 			} );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( `${ path }.version`, data.version );
 			expect( state ).toHaveProperty( `${ path }.mcId`, data.mcId );
 			expect( state ).toHaveProperty( `${ path }.adsId`, data.adsId );
@@ -152,7 +148,6 @@ describe( 'reducer', () => {
 			};
 			const state = reducer( prepareState(), action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, action.shippingRates );
 		} );
 
@@ -195,7 +190,6 @@ describe( 'reducer', () => {
 
 			const state = reducer( originalState, action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, [
 				{
 					id: '1',
@@ -245,7 +239,6 @@ describe( 'reducer', () => {
 
 			const state = reducer( originalState, action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, [
 				{
 					id: '1',
@@ -277,7 +270,6 @@ describe( 'reducer', () => {
 			};
 			const state = reducer( prepareState(), action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, action.shippingTimes );
 		} );
 
@@ -301,7 +293,6 @@ describe( 'reducer', () => {
 			};
 			const state = reducer( originalState, action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, [
 				{
 					countryCode: 'US',
@@ -339,7 +330,6 @@ describe( 'reducer', () => {
 			};
 			const state = reducer( originalState, action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, [
 				{
 					countryCode: 'CA',
@@ -362,19 +352,14 @@ describe( 'reducer', () => {
 			};
 			const state = reducer( prepareState(), action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, action.settings );
 		} );
 
 		it( 'should return with partially updated Merchant Center settings', () => {
-			const originalState = prepareState(
-				path,
-				{
-					existingSettingA: 'should be kept',
-					existingSettingB: 'should be updated from old value',
-				},
-				true
-			);
+			const originalState = prepareState( path, {
+				existingSettingA: 'should be kept',
+				existingSettingB: 'should be updated from old value',
+			} );
 			const action = {
 				type: TYPES.SAVE_SETTINGS,
 				settings: {
@@ -384,7 +369,6 @@ describe( 'reducer', () => {
 			};
 			const state = reducer( originalState, action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, {
 				existingSettingA: 'should be kept',
 				existingSettingB: 'should be updated to new value',
@@ -403,16 +387,14 @@ describe( 'reducer', () => {
 			};
 			const state = reducer( prepareState(), action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, action.account );
 		} );
 
 		it( 'should return with default Google Ads account connection when getting disconnect action', () => {
-			const originalState = prepareState( path, { id: 123456789 }, true );
+			const originalState = prepareState( path, { id: 123456789 } );
 			const action = { type: TYPES.DISCONNECT_ACCOUNTS_GOOGLE_ADS };
 			const state = reducer( originalState, action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, get( defaultState, path ) );
 		} );
 	} );
@@ -437,7 +419,6 @@ describe( 'reducer', () => {
 			};
 			const state = reducer( prepareState(), action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( 'mc.countries', data.countries );
 			expect( state ).toHaveProperty( 'mc.continents', data.continents );
 		} );
@@ -454,7 +435,6 @@ describe( 'reducer', () => {
 			};
 			const state = reducer( prepareState(), action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, action.adsCampaigns );
 		} );
 
@@ -468,8 +448,6 @@ describe( 'reducer', () => {
 				createdCampaign: { id: 456 },
 			} );
 
-			createdToInitialState.assertConsistentRef();
-			createdToLoadedState.assertConsistentRef();
 			expect( createdToInitialState ).toHaveProperty( path, [
 				{ id: 123 },
 			] );
@@ -501,7 +479,6 @@ describe( 'reducer', () => {
 			};
 			const state = reducer( originalState, action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, [
 				{
 					id: 123,
@@ -527,7 +504,6 @@ describe( 'reducer', () => {
 			const action = { type: TYPES.DELETE_ADS_CAMPAIGN, id: 456 };
 			const state = reducer( originalState, action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( path, [
 				{ id: 123 },
 				{ id: 789 },
@@ -542,7 +518,6 @@ describe( 'reducer', () => {
 			};
 			const state = reducer( prepareState(), action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( pathAllAds, action.adsCampaigns );
 		} );
 	} );
@@ -559,7 +534,6 @@ describe( 'reducer', () => {
 				assetGroups: groupsA,
 			} );
 
-			firstState.assertConsistentRef();
 			expect( firstState ).toHaveProperty( `${ path }.123`, groupsA );
 
 			// Store other asset groups individually.
@@ -569,7 +543,6 @@ describe( 'reducer', () => {
 				assetGroups: groupsB,
 			} );
 
-			secondState.assertConsistentRef();
 			expect( secondState ).toHaveProperty( `${ path }.123`, groupsA );
 			expect( secondState ).toHaveProperty( `${ path }.456`, groupsB );
 		} );
@@ -583,7 +556,6 @@ describe( 'reducer', () => {
 				assetGroup: groupA,
 			} );
 
-			firstState.assertConsistentRef();
 			expect( firstState ).toHaveProperty( `${ path }.123`, [ groupA ] );
 
 			const secondState = reducer( firstState, {
@@ -592,7 +564,6 @@ describe( 'reducer', () => {
 				assetGroup: groupB,
 			} );
 
-			secondState.assertConsistentRef();
 			expect( secondState ).toHaveProperty( `${ path }.123`, [
 				groupA,
 				groupB,
@@ -627,10 +598,6 @@ describe( 'reducer', () => {
 				query: { page: 2, per_page: 2, issue_type: 'account' },
 				data: { total: 5, issues: accountIssuesPage2 },
 			} );
-
-			accountIssuesState.assertConsistentRef();
-			productIssuesState.assertConsistentRef();
-			accountIssuesStatePage2.assertConsistentRef();
 
 			expect( accountIssuesState ).toHaveProperty( accountPath, {
 				total: 5,
@@ -682,10 +649,6 @@ describe( 'reducer', () => {
 					data: { total: 5, issues: [ '#5' ] },
 				} );
 
-				pageOneState.assertConsistentRef();
-				pageTwoState.assertConsistentRef();
-				pageThreeState.assertConsistentRef();
-
 				expect( pageOneState ).toHaveProperty( path, {
 					total: 5,
 					issues: [ '#1', '#2' ],
@@ -734,8 +697,6 @@ describe( 'reducer', () => {
 				},
 			} );
 
-			pageOneState.assertConsistentRef();
-			pageFourState.assertConsistentRef();
 			expect( pageOneState ).toHaveProperty( path, {
 				order: 'asc',
 				orderby: 'title',
@@ -769,10 +730,7 @@ describe( 'reducer', () => {
 					total: 7,
 					pages: { 1: [ '#1', '#2' ], 4: [ '#7' ] },
 				};
-				const originalState = prepareState( path, initValue, [
-					path,
-					`${ path }.pages`,
-				] );
+				const originalState = prepareState( path, initValue );
 				const action = {
 					type: TYPES.RECEIVE_MC_PRODUCT_FEED,
 					query: {
@@ -787,7 +745,6 @@ describe( 'reducer', () => {
 				};
 				const state = reducer( originalState, action );
 
-				state.assertConsistentRef();
 				expect( state ).toHaveProperty( path, {
 					...baseQuery,
 					[ key ]: value,
@@ -810,7 +767,6 @@ describe( 'reducer', () => {
 				data: '#1',
 			} );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( [ path, reportKey ], '#1' );
 		} );
 
@@ -827,8 +783,6 @@ describe( 'reducer', () => {
 				data: '#4',
 			} );
 
-			pageOneState.assertConsistentRef();
-			pageFourState.assertConsistentRef();
 			expect( pageOneState ).toHaveProperty( `${ path }.key1`, '#1' );
 			expect( pageFourState ).toHaveProperty( `${ path }.key1`, '#1' );
 			expect( pageFourState ).toHaveProperty( `${ path }.key4`, '#4' );
@@ -845,7 +799,6 @@ describe( 'reducer', () => {
 				tour,
 			} );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( [ path, tour.id ], tour );
 		} );
 
@@ -862,7 +815,6 @@ describe( 'reducer', () => {
 				tour: tourUpdated,
 			} );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( [ path, tour.id ], tourUpdated );
 		} );
 	} );
@@ -892,7 +844,6 @@ describe( 'reducer', () => {
 			};
 			const state = reducer( prepareState(), action );
 
-			state.assertConsistentRef();
 			expect( state ).toHaveProperty( `${ path }.mu_sg`, {
 				currency: recommendation.currency,
 				recommendations: recommendation.recommendations,
@@ -929,7 +880,6 @@ describe( 'reducer', () => {
 				const action = { type, [ key ]: payload };
 				const state = reducer( prepareState(), action );
 
-				state.assertConsistentRef();
 				expect( state ).toHaveProperty( path, payload );
 			}
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

For almost three years now, wp-data reducer changes have basically followed existing code that uses `setIn` or `chainState` functions to create the next state.

Considering that the need for these assertions should have gone away and that maintaining them and using them with tests are highly complex, we should be able to live without these assertions.

Ref:
- https://github.com/woocommerce/google-listings-and-ads/issues/270
- https://github.com/woocommerce/google-listings-and-ads/pull/1150

### Detailed test instructions:

1. Run `npm run test:js` to check if it can pass.
2. Evaluate whether the reasons for removing it are sufficient and sound.

### Changelog entry
