### PR TITLE
Remove the starting `.` from all internal alias imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,8 +14,8 @@ module.exports = {
 		'\\.(png|jpg)$': '<rootDir>/tests/mocks/assets/imageMock.js',
 		'\\.svg$': '<rootDir>/tests/mocks/assets/svgrMock.js',
 		'\\.scss$': '<rootDir>/tests/mocks/assets/styleMock.js',
-		// Transform our `.~/` alias.
-		'^\\.~/(.*)$': '<rootDir>/js/src/$1',
+		// Transform our `~/` alias.
+		'^~/(.*)$': '<rootDir>/js/src/$1',
 		'@woocommerce/settings':
 			'<rootDir>/js/src/tests/dependencies/woocommerce/settings',
 		'@automattic/calypso-config':

--- a/js/src/attribute-mapping/attribute-mapping-category-control.js
+++ b/js/src/attribute-mapping/attribute-mapping-category-control.js
@@ -7,10 +7,10 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import useCategories from '.~/hooks/useCategories';
-import { CATEGORY_CONDITION_SELECT_TYPES } from '.~/constants';
-import SelectControl from '.~/wcdl/select-control';
-import AppSelectControl from '.~/components/app-select-control';
+import useCategories from '~/hooks/useCategories';
+import { CATEGORY_CONDITION_SELECT_TYPES } from '~/constants';
+import SelectControl from '~/wcdl/select-control';
+import AppSelectControl from '~/components/app-select-control';
 
 /**
  * Renders the selectors relative to the categories

--- a/js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-delete-rule-modal.js
@@ -8,10 +8,10 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppModal from '.~/components/app-modal';
-import AppButton from '.~/components/app-button';
-import { useAppDispatch } from '.~/data';
-import { recordGlaEvent } from '.~/utils/tracks';
+import AppModal from '~/components/app-modal';
+import AppButton from '~/components/app-button';
+import { useAppDispatch } from '~/data';
+import { recordGlaEvent } from '~/utils/tracks';
 
 /**
  * Deletes the rule successfully

--- a/js/src/attribute-mapping/attribute-mapping-field-sources-control.js
+++ b/js/src/attribute-mapping/attribute-mapping-field-sources-control.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppSelectControl from '.~/components/app-select-control';
+import AppSelectControl from '~/components/app-select-control';
 
 /**
  * Renders a selector for choosing the source field.

--- a/js/src/attribute-mapping/attribute-mapping-rule-modal.js
+++ b/js/src/attribute-mapping/attribute-mapping-rule-modal.js
@@ -8,19 +8,19 @@ import { isEqual, noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import Subsection from '.~/wcdl/subsection';
-import AppModal from '.~/components/app-modal';
-import AppButton from '.~/components/app-button';
-import AppSelectControl from '.~/components/app-select-control';
-import useMappingAttributes from '.~/hooks/useMappingAttributes';
-import useMappingAttributesSources from '.~/hooks/useMappingAttributesSources';
+import Subsection from '~/wcdl/subsection';
+import AppModal from '~/components/app-modal';
+import AppButton from '~/components/app-button';
+import AppSelectControl from '~/components/app-select-control';
+import useMappingAttributes from '~/hooks/useMappingAttributes';
+import useMappingAttributesSources from '~/hooks/useMappingAttributesSources';
 import AttributeMappingFieldSourcesControl from './attribute-mapping-field-sources-control';
 import AttributeMappingSourceTypeSelector from './attribute-mapping-source-type-selector';
-import AttributeMappingCategoryControl from '.~/attribute-mapping/attribute-mapping-category-control';
-import AppSpinner from '.~/components/app-spinner';
-import { useAppDispatch } from '.~/data';
-import { CATEGORY_CONDITION_SELECT_TYPES } from '.~/constants';
-import { recordGlaEvent } from '.~/utils/tracks';
+import AttributeMappingCategoryControl from '~/attribute-mapping/attribute-mapping-category-control';
+import AppSpinner from '~/components/app-spinner';
+import { useAppDispatch } from '~/data';
+import { CATEGORY_CONDITION_SELECT_TYPES } from '~/constants';
+import { recordGlaEvent } from '~/utils/tracks';
 
 /**
  * Updates the rule successfully

--- a/js/src/attribute-mapping/attribute-mapping-source-type-selector.js
+++ b/js/src/attribute-mapping/attribute-mapping-source-type-selector.js
@@ -8,12 +8,12 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import Subsection from '.~/wcdl/subsection';
-import AppRadioContentControl from '.~/components/app-radio-content-control';
-import AppInputControl from '.~/components/app-input-control';
-import AttributeMappingFieldSourcesControl from '.~/attribute-mapping/attribute-mapping-field-sources-control';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import HelpPopover from '.~/components/help-popover';
+import Subsection from '~/wcdl/subsection';
+import AppRadioContentControl from '~/components/app-radio-content-control';
+import AppInputControl from '~/components/app-input-control';
+import AttributeMappingFieldSourcesControl from '~/attribute-mapping/attribute-mapping-field-sources-control';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import HelpPopover from '~/components/help-popover';
 
 const SOURCE_TYPES = {
 	FIXED: 'fixed',

--- a/js/src/attribute-mapping/attribute-mapping-sync.js
+++ b/js/src/attribute-mapping/attribute-mapping-sync.js
@@ -9,10 +9,10 @@ import { format as formatDate } from '@wordpress/date';
 /**
  * Internal dependencies
  */
-import usePolling from '.~/hooks/usePolling';
-import { API_NAMESPACE } from '.~/data/constants';
-import { glaDateTimeFormat } from '.~/utils/date';
-import HelpPopover from '.~/components/help-popover';
+import usePolling from '~/hooks/usePolling';
+import { API_NAMESPACE } from '~/data/constants';
+import { glaDateTimeFormat } from '~/utils/date';
+import HelpPopover from '~/components/help-popover';
 
 const AttributeMappingSync = () => {
 	const { data, start } = usePolling( {

--- a/js/src/attribute-mapping/attribute-mapping-table-categories.js
+++ b/js/src/attribute-mapping/attribute-mapping-table-categories.js
@@ -6,12 +6,12 @@ import { _n, sprintf, __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppTooltip from '.~/components/app-tooltip';
+import AppTooltip from '~/components/app-tooltip';
 import {
 	CATEGORIES_TO_SHOW_IN_TOOLTIP,
 	CATEGORY_CONDITION_SELECT_TYPES,
-} from '.~/constants';
-import useCategories from '.~/hooks/useCategories';
+} from '~/constants';
+import useCategories from '~/hooks/useCategories';
 
 /**
  * Show a text with the number of categories

--- a/js/src/attribute-mapping/attribute-mapping-table.js
+++ b/js/src/attribute-mapping/attribute-mapping-table.js
@@ -9,18 +9,18 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Card from '.~/wcdl/section/card';
-import AppButton from '.~/components/app-button';
-import AppTableCardDiv from '.~/components/app-table-card-div';
-import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
+import Card from '~/wcdl/section/card';
+import AppButton from '~/components/app-button';
+import AppTableCardDiv from '~/components/app-table-card-div';
+import AppButtonModalTrigger from '~/components/app-button-modal-trigger';
 import AttributeMappingTableCategories from './attribute-mapping-table-categories';
 import AttributeMappingRuleModal from './attribute-mapping-rule-modal';
 import AttributeMappingDeleteRuleModal from './attribute-mapping-delete-rule-modal';
 import AttributeMappingSync from './attribute-mapping-sync';
-import useMappingAttributes from '.~/hooks/useMappingAttributes';
-import useMappingRules from '.~/hooks/useMappingRules';
-import usePagination from '.~/hooks/usePagination';
-import { recordGlaEvent, recordTablePageEvent } from '.~/utils/tracks';
+import useMappingAttributes from '~/hooks/useMappingAttributes';
+import useMappingRules from '~/hooks/useMappingRules';
+import usePagination from '~/hooks/usePagination';
+import { recordGlaEvent, recordTablePageEvent } from '~/utils/tracks';
 
 const PER_PAGE = 10;
 const ATTRIBUTE_MAPPING_TABLE_HEADERS = [

--- a/js/src/attribute-mapping/index.js
+++ b/js/src/attribute-mapping/index.js
@@ -6,11 +6,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import Section from '.~/wcdl/section';
+import Section from '~/wcdl/section';
 import AttributeMappingDescription from './attribute-mapping-description';
 import AttributeMappingTable from './attribute-mapping-table';
-import MainTabNav from '.~/components/main-tab-nav';
-import RebrandingTour from '.~/components/tours/rebranding-tour';
+import MainTabNav from '~/components/main-tab-nav';
+import RebrandingTour from '~/components/tours/rebranding-tour';
 import './index.scss';
 
 /**

--- a/js/src/attribute-mapping/index.test.js
+++ b/js/src/attribute-mapping/index.test.js
@@ -7,8 +7,8 @@ jest.mock( '@wordpress/date', () => {
 	};
 } );
 
-jest.mock( '.~/data/actions', () => ( {
-	...jest.requireActual( '.~/data/actions' ),
+jest.mock( '~/data/actions', () => ( {
+	...jest.requireActual( '~/data/actions' ),
 	createMappingRule: jest
 		.fn()
 		.mockName( 'createMappingRule' )
@@ -29,7 +29,7 @@ jest.mock( '.~/data/actions', () => ( {
 		} ),
 } ) );
 
-jest.mock( '.~/hooks/useAppSelectDispatch', () => ( {
+jest.mock( '~/hooks/useAppSelectDispatch', () => ( {
 	__esModule: true,
 	default: jest
 		.fn()
@@ -47,7 +47,7 @@ jest.mock( '.~/hooks/useAppSelectDispatch', () => ( {
 		} ),
 } ) );
 
-jest.mock( '.~/hooks/useMappingAttributes', () => ( {
+jest.mock( '~/hooks/useMappingAttributes', () => ( {
 	__esModule: true,
 	default: jest
 		.fn()
@@ -64,7 +64,7 @@ jest.mock( '.~/hooks/useMappingAttributes', () => ( {
 		} ),
 } ) );
 
-jest.mock( '.~/hooks/useMappingAttributesSources', () => ( {
+jest.mock( '~/hooks/useMappingAttributesSources', () => ( {
 	__esModule: true,
 	default: jest
 		.fn()
@@ -80,7 +80,7 @@ jest.mock( '.~/hooks/useMappingAttributesSources', () => ( {
 		} ),
 } ) );
 
-jest.mock( '.~/hooks/useMappingRules', () => ( {
+jest.mock( '~/hooks/useMappingRules', () => ( {
 	__esModule: true,
 	default: jest
 		.fn()
@@ -119,7 +119,7 @@ jest.mock( '.~/hooks/useMappingRules', () => ( {
 		} ),
 } ) );
 
-jest.mock( '.~/hooks/usePolling', () => ( {
+jest.mock( '~/hooks/usePolling', () => ( {
 	__esModule: true,
 	default: jest
 		.fn()
@@ -132,7 +132,7 @@ jest.mock( '.~/hooks/usePolling', () => ( {
 		} ),
 } ) );
 
-jest.mock( '.~/components/tours/rebranding-tour', () =>
+jest.mock( '~/components/tours/rebranding-tour', () =>
 	jest.fn().mockReturnValue( null ).mockName( 'RebrandingTour' )
 );
 
@@ -147,17 +147,17 @@ import userEvent from '@testing-library/user-event';
  * Internal dependencies
  */
 import AttributeMapping from './';
-import AttributeMappingTable from '.~/attribute-mapping/attribute-mapping-table';
-import AttributeMappingTableCategories from '.~/attribute-mapping/attribute-mapping-table-categories';
-import useMappingAttributes from '.~/hooks/useMappingAttributes';
+import AttributeMappingTable from '~/attribute-mapping/attribute-mapping-table';
+import AttributeMappingTableCategories from '~/attribute-mapping/attribute-mapping-table-categories';
+import useMappingAttributes from '~/hooks/useMappingAttributes';
 import {
 	createMappingRule,
 	deleteMappingRule,
 	updateMappingRule,
-} from '.~/data/actions';
-import AttributeMappingSync from '.~/attribute-mapping/attribute-mapping-sync';
-import usePolling from '.~/hooks/usePolling';
-import RebrandingTour from '.~/components/tours/rebranding-tour';
+} from '~/data/actions';
+import AttributeMappingSync from '~/attribute-mapping/attribute-mapping-sync';
+import usePolling from '~/hooks/usePolling';
+import RebrandingTour from '~/components/tours/rebranding-tour';
 
 describe( 'Attribute Mapping', () => {
 	test( 'Renders table', () => {

--- a/js/src/components/account-card/index.js
+++ b/js/src/components/account-card/index.js
@@ -8,13 +8,13 @@ import { Icon, store as storeIcon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import Section from '.~/wcdl/section';
-import Subsection from '.~/wcdl/subsection';
-import googleLogoURL from '.~/images/logo/gogole-g-logo.svg';
-import googleMCLogoURL from '.~/images/logo/google-merchant-center-logo.svg';
-import googleAdsLogoURL from '.~/images/logo/google-ads-logo.svg';
-import wpLogoURL from '.~/images/logo/wp-logo.svg';
-import finalUrlIconURL from '.~/images/final-url-icon.svg';
+import Section from '~/wcdl/section';
+import Subsection from '~/wcdl/subsection';
+import googleLogoURL from '~/images/logo/gogole-g-logo.svg';
+import googleMCLogoURL from '~/images/logo/google-merchant-center-logo.svg';
+import googleAdsLogoURL from '~/images/logo/google-ads-logo.svg';
+import wpLogoURL from '~/images/logo/wp-logo.svg';
+import finalUrlIconURL from '~/images/final-url-icon.svg';
 import './index.scss';
 
 /**

--- a/js/src/components/adaptive-form/adaptive-form.js
+++ b/js/src/components/adaptive-form/adaptive-form.js
@@ -15,7 +15,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import useIsMounted from '.~/hooks/useIsMounted';
+import useIsMounted from '~/hooks/useIsMounted';
 import { AdaptiveFormContext } from './adaptive-form-context';
 
 function isEvent( value ) {

--- a/js/src/components/ads-account-select-control/index.js
+++ b/js/src/components/ads-account-select-control/index.js
@@ -7,9 +7,9 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
 /**
  * Internal dependencies
  */
-import AppSelectControl from '.~/components/app-select-control';
-import useExistingGoogleAdsAccounts from '.~/hooks/useExistingGoogleAdsAccounts';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
+import AppSelectControl from '~/components/app-select-control';
+import useExistingGoogleAdsAccounts from '~/hooks/useExistingGoogleAdsAccounts';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
 
 /**
  * @param {Object} props The component props

--- a/js/src/components/app-button/index.js
+++ b/js/src/components/app-button/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { recordGlaEvent } from '.~/utils/tracks';
+import { recordGlaEvent } from '~/utils/tracks';
 import './index.scss';
 
 /**

--- a/js/src/components/app-icon-button/index.js
+++ b/js/src/components/app-icon-button/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 import './index.scss';
 
 const AppIconButton = ( props ) => {

--- a/js/src/components/app-input-control/index.js
+++ b/js/src/components/app-input-control/index.js
@@ -9,7 +9,7 @@ import { __experimentalInputControl as InputControl } from '@wordpress/component
 /**
  * Internal dependencies
  */
-import getCharacterCounter from '.~/utils/getCharacterCounter';
+import getCharacterCounter from '~/utils/getCharacterCounter';
 import './index.scss';
 
 const baseClassName = 'app-input-control';

--- a/js/src/components/app-input-link-control/index.js
+++ b/js/src/components/app-input-link-control/index.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import AppInputControl from '.~/components/app-input-control';
+import AppInputControl from '~/components/app-input-control';
 import './index.scss';
 
 /**

--- a/js/src/components/app-input-number-control/index.js
+++ b/js/src/components/app-input-number-control/index.js
@@ -6,10 +6,10 @@ import { useReducer } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppInputControl from '.~/components/app-input-control';
+import AppInputControl from '~/components/app-input-control';
 import parseStringToNumber from './parseStringToNumber';
-import useStoreNumberSettings from '.~/hooks/useStoreNumberSettings';
-import useNumberFormat from '.~/hooks/useNumberFormat';
+import useStoreNumberSettings from '~/hooks/useStoreNumberSettings';
+import useNumberFormat from '~/hooks/useNumberFormat';
 
 /**
  * Renders an AppInputControl that formats number value

--- a/js/src/components/app-input-price-control/index.js
+++ b/js/src/components/app-input-price-control/index.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import useStoreCurrency from '.~/hooks/useStoreCurrency';
-import AppInputNumberControl from '.~/components/app-input-number-control';
+import useStoreCurrency from '~/hooks/useStoreCurrency';
+import AppInputNumberControl from '~/components/app-input-number-control';
 
 /**
  * Renders an AppInputNumberControl that formats number value

--- a/js/src/components/app-table-card/index.js
+++ b/js/src/components/app-table-card/index.js
@@ -6,8 +6,8 @@ import { TableCard } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import AppTableCardDiv from '.~/components/app-table-card-div';
-import { recordGlaEvent } from '.~/utils/tracks';
+import AppTableCardDiv from '~/components/app-table-card-div';
+import { recordGlaEvent } from '~/utils/tracks';
 
 /**
  * Toggling display of table columns

--- a/js/src/components/conditional-section.js
+++ b/js/src/components/conditional-section.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import Section from '.~/wcdl/section';
-import AppSpinner from '.~/components/app-spinner';
+import Section from '~/wcdl/section';
+import AppSpinner from '~/components/app-spinner';
 
 /**
  * Component to conditionally render a section.

--- a/js/src/components/contact-information/contact-information-preview-card.js
+++ b/js/src/components/contact-information/contact-information-preview-card.js
@@ -8,8 +8,8 @@ import { getPath, getQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import AccountCard from '.~/components/account-card';
-import AppButton from '.~/components/app-button';
+import AccountCard from '~/components/account-card';
+import AppButton from '~/components/app-button';
 import './contact-information-preview-card.scss';
 
 /**
@@ -17,7 +17,7 @@ import './contact-information-preview-card.scss';
  * It adds loading & warning state to the regular `AccountCard`, and an edit button link.
  *
  * @param {Object} props React props
- * @param {import('.~/components/account-card').APPEARANCE}  props.appearance
+ * @param {import('~/components/account-card').APPEARANCE}  props.appearance
  * @param {string} props.editHref URL where Edit button should point to.
  * @param {string} props.editEventName Tracing event name used when the "Edit" button is clicked.
  * @param {boolean} props.loading Set to `true` if the card should be rendered in the loading state.

--- a/js/src/components/contact-information/contact-information-preview.js
+++ b/js/src/components/contact-information/contact-information-preview.js
@@ -6,9 +6,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getEditStoreAddressUrl } from '.~/utils/urls';
-import Section from '.~/wcdl/section';
-import AppDocumentationLink from '.~/components/app-documentation-link';
+import { getEditStoreAddressUrl } from '~/utils/urls';
+import Section from '~/wcdl/section';
+import AppDocumentationLink from '~/components/app-documentation-link';
 import { StoreAddressCardPreview } from './store-address-card';
 
 const learnMoreLinkId = 'contact-information-read-more';

--- a/js/src/components/contact-information/mapStoreAddressErrors.js
+++ b/js/src/components/contact-information/mapStoreAddressErrors.js
@@ -4,7 +4,7 @@
 import { __, _x, sprintf } from '@wordpress/i18n';
 
 /**
- * @typedef {import('.~/hooks/types.js').StoreAddress} StoreAddress
+ * @typedef {import('~/hooks/types.js').StoreAddress} StoreAddress
  */
 
 /**

--- a/js/src/components/contact-information/store-address-card.js
+++ b/js/src/components/contact-information/store-address-card.js
@@ -10,14 +10,14 @@ import { getPath, getQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import useStoreAddress from '.~/hooks/useStoreAddress';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import AppButton from '.~/components/app-button';
-import ValidationErrors from '.~/components/validation-errors';
+import useStoreAddress from '~/hooks/useStoreAddress';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import AppButton from '~/components/app-button';
+import ValidationErrors from '~/components/validation-errors';
 import ContactInformationPreviewCard from './contact-information-preview-card';
-import TrackableLink from '.~/components/trackable-link';
+import TrackableLink from '~/components/trackable-link';
 import mapStoreAddressErrors from './mapStoreAddressErrors';
-import { recordGlaEvent } from '.~/utils/tracks';
+import { recordGlaEvent } from '~/utils/tracks';
 import './store-address-card.scss';
 
 /**

--- a/js/src/components/country-names-plus-more.js
+++ b/js/src/components/country-names-plus-more.js
@@ -7,7 +7,7 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useCountryKeyNameMap from '.~/hooks/useCountryKeyNameMap';
+import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
 
 const defaultFirstN = 5;
 

--- a/js/src/components/customer-effort-score-prompt/index.js
+++ b/js/src/components/customer-effort-score-prompt/index.js
@@ -7,10 +7,10 @@ import { CustomerEffortScore } from '@woocommerce/customer-effort-score';
 /**
  * Internal dependencies
  */
-import { LOCAL_STORAGE_KEYS } from '.~/constants';
-import localStorage from '.~/utils/localStorage';
-import useEffectRemoveNotice from '.~/hooks/useEffectRemoveNotice';
-import { recordGlaEvent } from '.~/utils/tracks';
+import { LOCAL_STORAGE_KEYS } from '~/constants';
+import localStorage from '~/utils/localStorage';
+import useEffectRemoveNotice from '~/hooks/useEffectRemoveNotice';
+import { recordGlaEvent } from '~/utils/tracks';
 
 /**
  * CES prompt snackbar open

--- a/js/src/components/different-currency-notice.js
+++ b/js/src/components/different-currency-notice.js
@@ -8,10 +8,10 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import useStoreCurrency from '.~/hooks/useStoreCurrency';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import { GOOGLE_ADS_ACCOUNT_STATUS } from '.~/constants';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useStoreCurrency from '~/hooks/useStoreCurrency';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import { GOOGLE_ADS_ACCOUNT_STATUS } from '~/constants';
 
 /**
  * Shows warning {@link Notice}

--- a/js/src/components/edit-product-link/index.js
+++ b/js/src/components/edit-product-link/index.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { queueRecordGlaEvent } from '.~/utils/tracks';
+import { queueRecordGlaEvent } from '~/utils/tracks';
 
 const noop = () => {};
 

--- a/js/src/components/enable-new-product-sync-button.js
+++ b/js/src/components/enable-new-product-sync-button.js
@@ -8,11 +8,11 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import { glaData } from '.~/constants';
-import { API_NAMESPACE } from '.~/data/constants';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import AppButton from '~/components/app-button';
+import { glaData } from '~/constants';
+import { API_NAMESPACE } from '~/data/constants';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 
 /**
  * Button to initiate auth process for WP Rest API

--- a/js/src/components/enable-new-product-sync-notice.js
+++ b/js/src/components/enable-new-product-sync-notice.js
@@ -8,8 +8,8 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
-import EnableNewProductSyncButton from '.~/components/enable-new-product-sync-button';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+import EnableNewProductSyncButton from '~/components/enable-new-product-sync-button';
 
 /**
  * Shows info {@link Notice}

--- a/js/src/components/enable-new-product-sync-notice.test.js
+++ b/js/src/components/enable-new-product-sync-notice.test.js
@@ -7,10 +7,10 @@ import { render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import EnableNewProductSyncNotice from './enable-new-product-sync-notice';
 
-jest.mock( '.~/hooks/useGoogleMCAccount' );
+jest.mock( '~/hooks/useGoogleMCAccount' );
 
 describe( 'Enable New Product Sync Notice', () => {
 	it( 'should render the notice if the account has not switched to new product sync', () => {

--- a/js/src/components/faqs-panel/index.js
+++ b/js/src/components/faqs-panel/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { recordGlaEvent } from '.~/utils/tracks';
+import { recordGlaEvent } from '~/utils/tracks';
 import './index.scss';
 
 const getPanelToggleHandler = ( trackName, id, context ) => ( isOpened ) => {

--- a/js/src/components/free-ad-credit/country-modal/index.js
+++ b/js/src/components/free-ad-credit/country-modal/index.js
@@ -6,10 +6,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppModal from '.~/components/app-modal';
+import AppModal from '~/components/app-modal';
 import countryAmount from './countryAmount';
 import './index.scss';
-import useCountryKeyNameMap from '.~/hooks/useCountryKeyNameMap';
+import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
 
 const CountryModal = ( props ) => {
 	const map = useCountryKeyNameMap();

--- a/js/src/components/free-ad-credit/index.js
+++ b/js/src/components/free-ad-credit/index.js
@@ -8,9 +8,9 @@ import GridiconGift from 'gridicons/dist/gift';
 /**
  * Internal dependencies
  */
-import AppDocumentationLink from '.~/components/app-documentation-link';
+import AppDocumentationLink from '~/components/app-documentation-link';
 import './index.scss';
-import TrackableLink from '.~/components/trackable-link';
+import TrackableLink from '~/components/trackable-link';
 import CountryModal from './country-modal';
 
 /**

--- a/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
+++ b/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
@@ -6,13 +6,13 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useAdaptiveFormContext } from '.~/components/adaptive-form';
-import AppRadioContentControl from '.~/components/app-radio-content-control';
-import Section from '.~/wcdl/section';
-import Subsection from '.~/wcdl/subsection';
-import RadioHelperText from '.~/wcdl/radio-helper-text';
-import SupportedCountrySelect from '.~/components/supported-country-select';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import AppRadioContentControl from '~/components/app-radio-content-control';
+import Section from '~/wcdl/section';
+import Subsection from '~/wcdl/subsection';
+import RadioHelperText from '~/wcdl/radio-helper-text';
+import SupportedCountrySelect from '~/components/supported-country-select';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
 import './choose-audience-section.scss';
 
 /**

--- a/js/src/components/free-listings/configure-product-listings/hero/index.js
+++ b/js/src/components/free-listings/configure-product-listings/hero/index.js
@@ -6,8 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import StepContentHeader from '.~/components/stepper/step-content-header';
-import heroImageURL from '.~/images/google-free-listings.png';
+import StepContentHeader from '~/components/stepper/step-content-header';
+import heroImageURL from '~/images/google-free-listings.png';
 import './index.scss';
 
 /**

--- a/js/src/components/free-listings/configure-product-listings/shipping-time-section.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time-section.js
@@ -6,8 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import Section from '.~/wcdl/section';
-import AppDocumentationLink from '.~/components/app-documentation-link';
+import Section from '~/wcdl/section';
+import AppDocumentationLink from '~/components/app-documentation-link';
 import ShippingTimeSetup from './shipping-time/shipping-time-setup';
 
 /**

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.js
@@ -9,11 +9,11 @@ import { Flex, FlexItem } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import AppModal from '.~/components/app-modal';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import SupportedCountrySelect from '.~/components/supported-country-select';
-import validateShippingTimeGroup from '.~/utils/validateShippingTimeGroup';
+import AppButton from '~/components/app-button';
+import AppModal from '~/components/app-modal';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
+import SupportedCountrySelect from '~/components/supported-country-select';
+import validateShippingTimeGroup from '~/utils/validateShippingTimeGroup';
 import MinMaxShippingTimes from '../../min-max-shipping-times';
 
 /**
@@ -122,6 +122,6 @@ const AddTimeModal = ( { countries, onRequestClose, onSubmit } ) => {
 export default AddTimeModal;
 
 /**
- * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").AggregatedShippingTime } AggregatedShippingTime
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.test.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/add-time-modal/index.test.js
@@ -8,9 +8,9 @@ import { render, fireEvent, waitFor } from '@testing-library/react';
  * Internal dependencies
  */
 import AddTimeModal from './';
-import useMCCountryTreeOptions from '.~/components/supported-country-select/useMCCountryTreeOptions';
+import useMCCountryTreeOptions from '~/components/supported-country-select/useMCCountryTreeOptions';
 
-jest.mock( '.~/components/supported-country-select/useMCCountryTreeOptions' );
+jest.mock( '~/components/supported-country-select/useMCCountryTreeOptions' );
 
 describe( 'Add time Modal', () => {
 	it( 'The min and max shipping time inputs should be displayed, and both values should be submitted', async () => {

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/add-time-button/index.js
@@ -8,7 +8,7 @@ import GridiconPlusSmall from 'gridicons/dist/plus-small';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 import AddTimeModal from './add-time-modal';
 
 /**

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.js
@@ -9,11 +9,11 @@ import { Flex, FlexItem } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import AppModal from '.~/components/app-modal';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import SupportedCountrySelect from '.~/components/supported-country-select';
-import validateShippingTimeGroup from '.~/utils/validateShippingTimeGroup';
+import AppButton from '~/components/app-button';
+import AppModal from '~/components/app-modal';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
+import SupportedCountrySelect from '~/components/supported-country-select';
+import validateShippingTimeGroup from '~/utils/validateShippingTimeGroup';
 import MinMaxShippingTimes from '../../../min-max-shipping-times';
 import '../index.scss';
 
@@ -153,6 +153,6 @@ const EditTimeModal = ( {
 export default EditTimeModal;
 
 /**
- * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").AggregatedShippingTime } AggregatedShippingTime
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.test.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/edit-time-modal/index.test.js
@@ -8,9 +8,9 @@ import { render, fireEvent, waitFor } from '@testing-library/react';
  * Internal dependencies
  */
 import EditTimeModal from './';
-import useMCCountryTreeOptions from '.~/components/supported-country-select/useMCCountryTreeOptions';
+import useMCCountryTreeOptions from '~/components/supported-country-select/useMCCountryTreeOptions';
 
-jest.mock( '.~/components/supported-country-select/useMCCountryTreeOptions' );
+jest.mock( '~/components/supported-country-select/useMCCountryTreeOptions' );
 
 describe( 'Edit time Modal', () => {
 	it( 'The min and max shipping time inputs should be displayed, and both values should be submitted', async () => {

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/edit-time-button/index.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 import EditTimeModal from './edit-time-modal';
 import './index.scss';
 
@@ -66,6 +66,6 @@ const EditTimeButton = ( { audienceCountries, time, onChange, onDelete } ) => {
 export default EditTimeButton;
 
 /**
- * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").AggregatedShippingTime } AggregatedShippingTime
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/countries-time-input/index.js
@@ -6,8 +6,8 @@ import { Flex, FlexItem } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import AppSpinner from '.~/components/app-spinner';
-import ShippingTimeInputControlLabelText from '.~/components/shipping-time-input-control-label-text';
+import AppSpinner from '~/components/app-spinner';
+import ShippingTimeInputControlLabelText from '~/components/shipping-time-input-control-label-text';
 import EditTimeButton from './edit-time-button';
 import MinMaxShippingTimes from '../min-max-shipping-times';
 import './index.scss';
@@ -93,6 +93,6 @@ const CountriesTimeInput = ( {
 export default CountriesTimeInput;
 
 /**
- * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").AggregatedShippingTime } AggregatedShippingTime
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/getCountriesTimeArray.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/getCountriesTimeArray.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import getShippingTimeMapKey from '.~/utils/getShippingTimeMapKey';
+import getShippingTimeMapKey from '~/utils/getShippingTimeMapKey';
 
 /**
  * Groups shipping times based on time.
@@ -68,6 +68,6 @@ const getCountriesTimeArray = ( shippingTimes ) => {
 export default getCountriesTimeArray;
 
 /**
- * @typedef { import(".~/data/actions").ShippingTime } ShippingTime
- * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
+ * @typedef { import("~/data/actions").ShippingTime } ShippingTime
+ * @typedef { import("~/data/actions").AggregatedShippingTime } AggregatedShippingTime
  */

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/index.js
@@ -6,9 +6,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useAdaptiveFormContext } from '.~/components/adaptive-form';
-import Section from '.~/wcdl/section';
-import AppSpinner from '.~/components/app-spinner';
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import Section from '~/wcdl/section';
+import AppSpinner from '~/components/app-spinner';
 import ShippingCountriesForm from './shipping-countries-form';
 
 /**

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/shipping-countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/shipping-countries-form.js
@@ -1,15 +1,15 @@
 /**
  * Internal dependencies
  */
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
 import AddTimeButton from './add-time-button';
 import CountriesTimeInput from './countries-time-input';
 import getCountriesTimeArray from './getCountriesTimeArray';
 
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
- * @typedef { import(".~/data/actions").ShippingTime } ShippingTime
- * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").ShippingTime } ShippingTime
+ * @typedef { import("~/data/actions").AggregatedShippingTime } AggregatedShippingTime
  */
 
 /**

--- a/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time/shipping-time-setup/time-stepper/index.js
@@ -9,7 +9,7 @@ import { plus, reset } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import AppInputNumberControl from '.~/components/app-input-number-control';
+import AppInputNumberControl from '~/components/app-input-number-control';
 import './index.scss';
 
 const TimeStepper = ( {

--- a/js/src/components/free-listings/configure-product-listings/tax-rate.js
+++ b/js/src/components/free-listings/configure-product-listings/tax-rate.js
@@ -7,12 +7,12 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useAdaptiveFormContext } from '.~/components/adaptive-form';
-import Section from '.~/wcdl/section';
-import RadioHelperText from '.~/wcdl/radio-helper-text';
-import AppRadioContentControl from '.~/components/app-radio-content-control';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import Section from '~/wcdl/section';
+import RadioHelperText from '~/wcdl/radio-helper-text';
+import AppRadioContentControl from '~/components/app-radio-content-control';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
 
 /**
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-tax-rate', link_id: 'tax-rate-read-more', href: 'https://support.google.com/merchants/answer/160162' }`

--- a/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.js
+++ b/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import useStoreCountry from '.~/hooks/useStoreCountry';
+import useStoreCountry from '~/hooks/useStoreCountry';
 
 /**
- * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ * @typedef {import('~/data/actions').CountryCode} CountryCode
  */
 
 /**

--- a/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.test.js
+++ b/js/src/components/free-listings/configure-product-listings/useDisplayTaxRate.test.js
@@ -8,8 +8,8 @@ import { renderHook } from '@testing-library/react';
  */
 import useDisplayTaxRate from './useDisplayTaxRate';
 
-jest.mock( '.~/hooks/useStoreCountry', () => jest.fn() );
-const useStoreCountry = require( '.~/hooks/useStoreCountry' );
+jest.mock( '~/hooks/useStoreCountry', () => jest.fn() );
+const useStoreCountry = require( '~/hooks/useStoreCountry' );
 
 describe( 'useDisplayTaxRate', () => {
 	describe( 'when store country is a non-US country', () => {

--- a/js/src/components/free-listings/configure-product-listings/useSettings.js
+++ b/js/src/components/free-listings/configure-product-listings/useSettings.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data';
+import { STORE_KEY } from '~/data';
 
 /**
  * Returns an object `{ settings }` to be used in the Setup Free Listing page.

--- a/js/src/components/free-listings/setup-free-listings/form-content.js
+++ b/js/src/components/free-listings/setup-free-listings/form-content.js
@@ -6,19 +6,19 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useAdaptiveFormContext } from '.~/components/adaptive-form';
-import StepContent from '.~/components/stepper/step-content';
-import StepContentActions from '.~/components/stepper/step-content-actions';
-import StepContentFooter from '.~/components/stepper/step-content-footer';
-import TaxRate from '.~/components/free-listings/configure-product-listings/tax-rate';
-import useDisplayTaxRate from '.~/components/free-listings/configure-product-listings/useDisplayTaxRate';
-import ChooseAudienceSection from '.~/components/free-listings/choose-audience-section';
-import ShippingRateSection from '.~/components/shipping-rate-section';
-import ShippingTimeSection from '.~/components/free-listings/configure-product-listings/shipping-time-section';
-import AppButton from '.~/components/app-button';
-import ConditionalSection from '.~/components/conditional-section';
-import OrderValueConditionSection from '.~/components/order-value-condition-section';
-import isNonFreeShippingRate from '.~/utils/isNonFreeShippingRate';
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import StepContent from '~/components/stepper/step-content';
+import StepContentActions from '~/components/stepper/step-content-actions';
+import StepContentFooter from '~/components/stepper/step-content-footer';
+import TaxRate from '~/components/free-listings/configure-product-listings/tax-rate';
+import useDisplayTaxRate from '~/components/free-listings/configure-product-listings/useDisplayTaxRate';
+import ChooseAudienceSection from '~/components/free-listings/choose-audience-section';
+import ShippingRateSection from '~/components/shipping-rate-section';
+import ShippingTimeSection from '~/components/free-listings/configure-product-listings/shipping-time-section';
+import AppButton from '~/components/app-button';
+import ConditionalSection from '~/components/conditional-section';
+import OrderValueConditionSection from '~/components/order-value-condition-section';
+import isNonFreeShippingRate from '~/utils/isNonFreeShippingRate';
 
 /**
  * Form to configure free listigns.

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -8,21 +8,21 @@ import { pick, noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import useStoreCountry from '.~/hooks/useStoreCountry';
-import AppSpinner from '.~/components/app-spinner';
-import Hero from '.~/components/free-listings/configure-product-listings/hero';
-import AdaptiveForm from '.~/components/adaptive-form';
-import ValidationErrors from '.~/components/validation-errors';
-import checkErrors from '.~/components/free-listings/configure-product-listings/checkErrors';
-import getOfferFreeShippingInitialValue from '.~/utils/getOfferFreeShippingInitialValue';
-import isNonFreeShippingRate from '.~/utils/isNonFreeShippingRate';
+import useStoreCountry from '~/hooks/useStoreCountry';
+import AppSpinner from '~/components/app-spinner';
+import Hero from '~/components/free-listings/configure-product-listings/hero';
+import AdaptiveForm from '~/components/adaptive-form';
+import ValidationErrors from '~/components/validation-errors';
+import checkErrors from '~/components/free-listings/configure-product-listings/checkErrors';
+import getOfferFreeShippingInitialValue from '~/utils/getOfferFreeShippingInitialValue';
+import isNonFreeShippingRate from '~/utils/isNonFreeShippingRate';
 import FormContent from './form-content';
 
 /**
- * @typedef {import('.~/data/actions').TargetAudienceData } TargetAudienceData
- * @typedef {import('.~/data/actions').ShippingRate} ShippingRateFromServerSide
- * @typedef {import('.~/data/actions').ShippingTime} ShippingTime
- * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ * @typedef {import('~/data/actions').TargetAudienceData } TargetAudienceData
+ * @typedef {import('~/data/actions').ShippingRate} ShippingRateFromServerSide
+ * @typedef {import('~/data/actions').ShippingTime} ShippingTime
+ * @typedef {import('~/data/actions').CountryCode} CountryCode
  */
 
 const targetAudienceFields = [ 'locale', 'language', 'location', 'countries' ];

--- a/js/src/components/google-account-card/connect-google-account-card.js
+++ b/js/src/components/google-account-card/connect-google-account-card.js
@@ -7,9 +7,9 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import AppButton from '.~/components/app-button';
+import { glaData } from '~/constants';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import AppButton from '~/components/app-button';
 import readMoreLink from './read-more-link';
 import useGoogleConnectFlow from './useGoogleConnectFlow';
 

--- a/js/src/components/google-account-card/connected-google-account-card.js
+++ b/js/src/components/google-account-card/connected-google-account-card.js
@@ -1,9 +1,9 @@
 /**
  * Internal dependencies
  */
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import ConnectedIconLabel from '.~/components/connected-icon-label';
-import Section from '.~/wcdl/section';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import ConnectedIconLabel from '~/components/connected-icon-label';
+import Section from '~/wcdl/section';
 import SwitchAccountButton from './switch-account-button';
 
 /**

--- a/js/src/components/google-account-card/google-account-card.js
+++ b/js/src/components/google-account-card/google-account-card.js
@@ -1,9 +1,9 @@
 /**
  * Internal dependencies
  */
-import useGoogleAccount from '.~/hooks/useGoogleAccount';
-import AppSpinner from '.~/components/app-spinner';
-import AccountCard from '.~/components/account-card';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
+import AppSpinner from '~/components/app-spinner';
+import AccountCard from '~/components/account-card';
 import RequestFullAccessGoogleAccountCard from './request-full-access-google-account-card';
 import ConnectedGoogleAccountCard from './connected-google-account-card';
 import ConnectGoogleAccountCard from './connect-google-account-card';

--- a/js/src/components/google-account-card/read-more-link.js
+++ b/js/src/components/google-account-card/read-more-link.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import AppDocumentationLink from '.~/components/app-documentation-link';
+import AppDocumentationLink from '~/components/app-documentation-link';
 
 const ReadMoreLink = (
 	<AppDocumentationLink

--- a/js/src/components/google-account-card/request-full-access-google-account-card.js
+++ b/js/src/components/google-account-card/request-full-access-google-account-card.js
@@ -7,9 +7,9 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
-import AppButton from '.~/components/app-button';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
+import { glaData } from '~/constants';
+import AppButton from '~/components/app-button';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
 import readMoreLink from './read-more-link';
 import useGoogleConnectFlow from './useGoogleConnectFlow';
 import './request-full-access-google-account-card.scss';

--- a/js/src/components/google-account-card/switch-account-button.js
+++ b/js/src/components/google-account-card/switch-account-button.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 import useSwitchGoogleAccount from './useSwitchGoogleAccount';
 
 /**

--- a/js/src/components/google-account-card/useGoogleConnectFlow.js
+++ b/js/src/components/google-account-card/useGoogleConnectFlow.js
@@ -6,8 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import useGoogleAuthorization from '.~/hooks/useGoogleAuthorization';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useGoogleAuthorization from '~/hooks/useGoogleAuthorization';
 
 /**
  * A hook that returns a connect handler that initiates Google Connect with support for incremental OAuth process.

--- a/js/src/components/google-account-card/useSwitchGoogleAccount.js
+++ b/js/src/components/google-account-card/useSwitchGoogleAccount.js
@@ -6,10 +6,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { API_NAMESPACE } from '.~/data/constants';
-import useGoogleAuthorization from '.~/hooks/useGoogleAuthorization';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
+import { API_NAMESPACE } from '~/data/constants';
+import useGoogleAuthorization from '~/hooks/useGoogleAuthorization';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 
 /**
  * A hook that returns a handler that initiates Google account disconnect and connect, to support switching to a different Google account.

--- a/js/src/components/google-ads-account-card/authorize-ads.js
+++ b/js/src/components/google-ads-account-card/authorize-ads.js
@@ -6,11 +6,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import useGoogleAuthorization from '.~/hooks/useGoogleAuthorization';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import AppButton from '.~/components/app-button';
-import { glaData } from '.~/constants';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useGoogleAuthorization from '~/hooks/useGoogleAuthorization';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import AppButton from '~/components/app-button';
+import { glaData } from '~/constants';
 
 /**
  * @param {Object} props React props

--- a/js/src/components/google-ads-account-card/claim-account-button.js
+++ b/js/src/components/google-ads-account-card/claim-account-button.js
@@ -6,11 +6,11 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import getWindowFeatures from '.~/utils/getWindowFeatures';
-import { FILTER_ONBOARDING } from '.~/utils/tracks';
-import useGoogleAdsAccountStatus from '.~/hooks/useGoogleAdsAccountStatus';
-import useEventPropertiesFilter from '.~/hooks/useEventPropertiesFilter';
+import AppButton from '~/components/app-button';
+import getWindowFeatures from '~/utils/getWindowFeatures';
+import { FILTER_ONBOARDING } from '~/utils/tracks';
+import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
+import useEventPropertiesFilter from '~/hooks/useEventPropertiesFilter';
 
 /**
  * Clicking on the button to open the invitation page for claiming the newly created Google Ads account.

--- a/js/src/components/google-ads-account-card/claim-account-button.test.js
+++ b/js/src/components/google-ads-account-card/claim-account-button.test.js
@@ -10,11 +10,11 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import ClaimAccountButton from './claim-account-button';
-import useGoogleAdsAccountStatus from '.~/hooks/useGoogleAdsAccountStatus';
-import { FILTER_ONBOARDING } from '.~/utils/tracks';
-import expectComponentToRecordEventWithFilteredProperties from '.~/tests/expectComponentToRecordEventWithFilteredProperties';
+import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
+import { FILTER_ONBOARDING } from '~/utils/tracks';
+import expectComponentToRecordEventWithFilteredProperties from '~/tests/expectComponentToRecordEventWithFilteredProperties';
 
-jest.mock( '.~/hooks/useGoogleAdsAccountStatus', () =>
+jest.mock( '~/hooks/useGoogleAdsAccountStatus', () =>
 	jest.fn().mockName( 'useGoogleAdsAccountStatus' )
 );
 

--- a/js/src/components/google-ads-account-card/claim-account-modal.js
+++ b/js/src/components/google-ads-account-card/claim-account-modal.js
@@ -7,8 +7,8 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useGoogleAdsAccountStatus from '.~/hooks/useGoogleAdsAccountStatus';
-import AppModal from '.~/components/app-modal';
+import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
+import AppModal from '~/components/app-modal';
 import ClaimAccountButton from './claim-account-button';
 
 /**

--- a/js/src/components/google-ads-account-card/claim-account/index.js
+++ b/js/src/components/google-ads-account-card/claim-account/index.js
@@ -7,9 +7,9 @@ import { Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import Section from '.~/wcdl/section';
-import useWindowFocusCallbackIntervalEffect from '.~/hooks/useWindowFocusCallbackIntervalEffect';
+import { useAppDispatch } from '~/data';
+import Section from '~/wcdl/section';
+import useWindowFocusCallbackIntervalEffect from '~/hooks/useWindowFocusCallbackIntervalEffect';
 import DisconnectAccount from '../disconnect-account';
 import './index.scss';
 

--- a/js/src/components/google-ads-account-card/connect-ads/connect-button.js
+++ b/js/src/components/google-ads-account-card/connect-ads/connect-button.js
@@ -6,9 +6,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import useEventPropertiesFilter from '.~/hooks/useEventPropertiesFilter';
-import { FILTER_ONBOARDING } from '.~/utils/tracks';
+import AppButton from '~/components/app-button';
+import useEventPropertiesFilter from '~/hooks/useEventPropertiesFilter';
+import { FILTER_ONBOARDING } from '~/utils/tracks';
 
 /**
  * Clicking on the button to connect an existing Google Ads account.

--- a/js/src/components/google-ads-account-card/connect-ads/index.js
+++ b/js/src/components/google-ads-account-card/connect-ads/index.js
@@ -8,19 +8,19 @@ import { CardDivider } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import AppButton from '.~/components/app-button';
-import AppDocumentationLink from '.~/components/app-documentation-link';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import AppButton from '~/components/app-button';
+import AppDocumentationLink from '~/components/app-documentation-link';
 import ConnectButton from './connect-button';
-import ContentButtonLayout from '.~/components/content-button-layout';
-import LoadingLabel from '.~/components/loading-label';
-import Section from '.~/wcdl/section';
-import Subsection from '.~/wcdl/subsection';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import AdsAccountSelectControl from '.~/components/ads-account-select-control';
-import { useAppDispatch } from '.~/data';
+import ContentButtonLayout from '~/components/content-button-layout';
+import LoadingLabel from '~/components/loading-label';
+import Section from '~/wcdl/section';
+import Subsection from '~/wcdl/subsection';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import AdsAccountSelectControl from '~/components/ads-account-select-control';
+import { useAppDispatch } from '~/data';
 import './index.scss';
 
 /**

--- a/js/src/components/google-ads-account-card/connect-ads/index.test.js
+++ b/js/src/components/google-ads-account-card/connect-ads/index.test.js
@@ -10,27 +10,27 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import ConnectAds from './';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import { useAppDispatch } from '.~/data';
-import { FILTER_ONBOARDING } from '.~/utils/tracks';
-import expectComponentToRecordEventWithFilteredProperties from '.~/tests/expectComponentToRecordEventWithFilteredProperties';
-import useExistingGoogleAdsAccounts from '.~/hooks/useExistingGoogleAdsAccounts';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import { useAppDispatch } from '~/data';
+import { FILTER_ONBOARDING } from '~/utils/tracks';
+import expectComponentToRecordEventWithFilteredProperties from '~/tests/expectComponentToRecordEventWithFilteredProperties';
+import useExistingGoogleAdsAccounts from '~/hooks/useExistingGoogleAdsAccounts';
 
-jest.mock( '.~/hooks/useApiFetchCallback', () =>
+jest.mock( '~/hooks/useApiFetchCallback', () =>
 	jest.fn().mockName( 'useApiFetchCallback' )
 );
 
-jest.mock( '.~/hooks/useGoogleAdsAccount', () =>
+jest.mock( '~/hooks/useGoogleAdsAccount', () =>
 	jest.fn().mockName( 'useGoogleAdsAccount' )
 );
 
-jest.mock( '.~/hooks/useExistingGoogleAdsAccounts', () =>
+jest.mock( '~/hooks/useExistingGoogleAdsAccounts', () =>
 	jest.fn().mockName( 'useExistingGoogleAdsAccounts' )
 );
 
-jest.mock( '.~/data', () => ( {
-	...jest.requireActual( '.~/data' ),
+jest.mock( '~/data', () => ( {
+	...jest.requireActual( '~/data' ),
 	useAppDispatch: jest.fn(),
 } ) );
 

--- a/js/src/components/google-ads-account-card/connected-google-ads-account-card.js
+++ b/js/src/components/google-ads-account-card/connected-google-ads-account-card.js
@@ -6,10 +6,10 @@ import { ExternalLink } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import toAccountText from '.~/utils/toAccountText';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import ConnectedIconLabel from '.~/components/connected-icon-label';
-import Section from '.~/wcdl/section';
+import toAccountText from '~/utils/toAccountText';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import ConnectedIconLabel from '~/components/connected-icon-label';
+import Section from '~/wcdl/section';
 import DisconnectAccount from './disconnect-account';
 
 /**

--- a/js/src/components/google-ads-account-card/create-account-button.js
+++ b/js/src/components/google-ads-account-card/create-account-button.js
@@ -8,7 +8,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import TermsModal from './terms-modal';
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 
 /**
  * Renders a Google Ads account creaton button.

--- a/js/src/components/google-ads-account-card/create-account.js
+++ b/js/src/components/google-ads-account-card/create-account.js
@@ -7,16 +7,16 @@ import { useState, useEffect, Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import AppButton from '.~/components/app-button';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import AppButton from '~/components/app-button';
 import ClaimAccount from './claim-account';
 import ClaimAccountButton from './claim-account-button';
 import ClaimAccountModal from './claim-account-modal';
 import CreateAccountButton from './create-account-button';
-import Section from '.~/wcdl/section';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import useGoogleAdsAccountStatus from '.~/hooks/useGoogleAdsAccountStatus';
-import useUpsertAdsAccount from '.~/hooks/useUpsertAdsAccount';
+import Section from '~/wcdl/section';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
+import useUpsertAdsAccount from '~/hooks/useUpsertAdsAccount';
 
 const CreateAccount = ( props ) => {
 	const { allowShowExisting, onShowExisting } = props;

--- a/js/src/components/google-ads-account-card/disabled-card.js
+++ b/js/src/components/google-ads-account-card/disabled-card.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
 
 const DisabledCard = () => {
 	return <AccountCard disabled appearance={ APPEARANCE.GOOGLE_ADS } />;

--- a/js/src/components/google-ads-account-card/disconnect-account.js
+++ b/js/src/components/google-ads-account-card/disconnect-account.js
@@ -8,10 +8,10 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import AppButton from '.~/components/app-button';
-import useEventPropertiesFilter from '.~/hooks/useEventPropertiesFilter';
-import { FILTER_ONBOARDING } from '.~/utils/tracks';
+import { useAppDispatch } from '~/data';
+import AppButton from '~/components/app-button';
+import useEventPropertiesFilter from '~/hooks/useEventPropertiesFilter';
+import { FILTER_ONBOARDING } from '~/utils/tracks';
 
 /**
  * Clicking on the button to disconnect the Google Ads account.

--- a/js/src/components/google-ads-account-card/disconnect-account.test.js
+++ b/js/src/components/google-ads-account-card/disconnect-account.test.js
@@ -10,12 +10,12 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import DisconnectAccount from './disconnect-account';
-import { useAppDispatch } from '.~/data';
-import { FILTER_ONBOARDING } from '.~/utils/tracks';
-import expectComponentToRecordEventWithFilteredProperties from '.~/tests/expectComponentToRecordEventWithFilteredProperties';
+import { useAppDispatch } from '~/data';
+import { FILTER_ONBOARDING } from '~/utils/tracks';
+import expectComponentToRecordEventWithFilteredProperties from '~/tests/expectComponentToRecordEventWithFilteredProperties';
 
-jest.mock( '.~/data', () => ( {
-	...jest.requireActual( '.~/data' ),
+jest.mock( '~/data', () => ( {
+	...jest.requireActual( '~/data' ),
 	useAppDispatch: jest.fn(),
 } ) );
 

--- a/js/src/components/google-ads-account-card/google-ads-account-card.js
+++ b/js/src/components/google-ads-account-card/google-ads-account-card.js
@@ -7,16 +7,16 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { GOOGLE_ADS_ACCOUNT_STATUS } from '.~/constants';
-import SpinnerCard from '.~/components/spinner-card';
-import useGoogleAccount from '.~/hooks/useGoogleAccount';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
+import { GOOGLE_ADS_ACCOUNT_STATUS } from '~/constants';
+import SpinnerCard from '~/components/spinner-card';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
 import ConnectedGoogleAdsAccountCard from './connected-google-ads-account-card';
 import NonConnected from './non-connected';
 import AuthorizeAds from './authorize-ads';
 import DisabledCard from './disabled-card';
-import useGoogleAdsAccountStatus from '.~/hooks/useGoogleAdsAccountStatus';
-import showAdsConversionNotice from '.~/utils/showAdsConversionNotice';
+import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
+import showAdsConversionNotice from '~/utils/showAdsConversionNotice';
 
 export default function GoogleAdsAccountCard() {
 	const {

--- a/js/src/components/google-ads-account-card/google-ads-account-card.test.js
+++ b/js/src/components/google-ads-account-card/google-ads-account-card.test.js
@@ -8,12 +8,12 @@ import '@testing-library/jest-dom';
  * Internal dependencies
  */
 import GoogleAdsAccountCard from './google-ads-account-card';
-import useGoogleAdsAccountStatus from '.~/hooks/useGoogleAdsAccountStatus';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import useGoogleAccount from '.~/hooks/useGoogleAccount';
-import useExistingGoogleAdsAccounts from '.~/hooks/useExistingGoogleAdsAccounts';
+import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
+import useExistingGoogleAdsAccounts from '~/hooks/useExistingGoogleAdsAccounts';
 
-jest.mock( '.~/hooks/useGoogleAdsAccountStatus', () => ( {
+jest.mock( '~/hooks/useGoogleAdsAccountStatus', () => ( {
 	__esModule: true,
 	default: jest.fn().mockName( 'useGoogleAdsAccountStatus' ),
 } ) );
@@ -25,15 +25,15 @@ jest.mock( '@woocommerce/components', () => ( {
 		.mockName( 'Spinner' ),
 } ) );
 
-jest.mock( '.~/hooks/useGoogleAdsAccount', () =>
+jest.mock( '~/hooks/useGoogleAdsAccount', () =>
 	jest.fn().mockName( 'useGoogleAdsAccount' ).mockReturnValue( {} )
 );
 
-jest.mock( '.~/hooks/useGoogleAccount', () =>
+jest.mock( '~/hooks/useGoogleAccount', () =>
 	jest.fn().mockName( 'useGoogleAccount' ).mockReturnValue( {} )
 );
 
-jest.mock( '.~/hooks/useExistingGoogleAdsAccounts', () =>
+jest.mock( '~/hooks/useExistingGoogleAdsAccounts', () =>
 	jest.fn().mockName( 'useExistingGoogleAdsAccounts' ).mockReturnValue( {} )
 );
 

--- a/js/src/components/google-ads-account-card/non-connected.js
+++ b/js/src/components/google-ads-account-card/non-connected.js
@@ -6,11 +6,11 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import SpinnerCard from '.~/components/spinner-card';
+import SpinnerCard from '~/components/spinner-card';
 import CreateAccount from './create-account';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import useGoogleAdsAccountStatus from '.~/hooks/useGoogleAdsAccountStatus';
-import useExistingGoogleAdsAccounts from '.~/hooks/useExistingGoogleAdsAccounts';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
+import useExistingGoogleAdsAccounts from '~/hooks/useExistingGoogleAdsAccounts';
 import ConnectAds from './connect-ads';
 
 const NonConnected = () => {

--- a/js/src/components/google-ads-account-card/terms-modal/index.js
+++ b/js/src/components/google-ads-account-card/terms-modal/index.js
@@ -8,11 +8,11 @@ import { createInterpolateElement, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppModal from '.~/components/app-modal';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import AppButton from '.~/components/app-button';
-import useEventPropertiesFilter from '.~/hooks/useEventPropertiesFilter';
-import { FILTER_ONBOARDING } from '.~/utils/tracks';
+import AppModal from '~/components/app-modal';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import AppButton from '~/components/app-button';
+import useEventPropertiesFilter from '~/hooks/useEventPropertiesFilter';
+import { FILTER_ONBOARDING } from '~/utils/tracks';
 import './index.scss';
 
 /**

--- a/js/src/components/google-ads-account-card/terms-modal/index.test.js
+++ b/js/src/components/google-ads-account-card/terms-modal/index.test.js
@@ -10,8 +10,8 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import TermsModal from './';
-import { FILTER_ONBOARDING } from '.~/utils/tracks';
-import expectComponentToRecordEventWithFilteredProperties from '.~/tests/expectComponentToRecordEventWithFilteredProperties';
+import { FILTER_ONBOARDING } from '~/utils/tracks';
+import expectComponentToRecordEventWithFilteredProperties from '~/tests/expectComponentToRecordEventWithFilteredProperties';
 
 jest.mock( '@woocommerce/tracks', () => {
 	return {

--- a/js/src/components/google-combo-account-card/account-details.js
+++ b/js/src/components/google-combo-account-card/account-details.js
@@ -6,9 +6,9 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import useGoogleAccount from '.~/hooks/useGoogleAccount';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 
 /**
  * Account details.

--- a/js/src/components/google-combo-account-card/claim-ads-account/claim-ads-account.js
+++ b/js/src/components/google-combo-account-card/claim-ads-account/claim-ads-account.js
@@ -8,9 +8,9 @@ import { external as externalIcon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { ClaimAccountButton } from '.~/components/google-ads-account-card';
-import { useAppDispatch } from '.~/data';
-import useWindowFocusCallbackIntervalEffect from '.~/hooks/useWindowFocusCallbackIntervalEffect';
+import { ClaimAccountButton } from '~/components/google-ads-account-card';
+import { useAppDispatch } from '~/data';
+import useWindowFocusCallbackIntervalEffect from '~/hooks/useWindowFocusCallbackIntervalEffect';
 import './claim-ads-account.scss';
 
 /**

--- a/js/src/components/google-combo-account-card/connect-ads/confirm-create-modal.js
+++ b/js/src/components/google-combo-account-card/connect-ads/confirm-create-modal.js
@@ -6,9 +6,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppModal from '.~/components/app-modal';
-import AppButton from '.~/components/app-button';
-import WarningIcon from '.~/components/warning-icon';
+import AppModal from '~/components/app-modal';
+import AppButton from '~/components/app-button';
+import WarningIcon from '~/components/warning-icon';
 import './confirm-create-modal.scss';
 
 /**

--- a/js/src/components/google-combo-account-card/connect-ads/connect-ads.js
+++ b/js/src/components/google-combo-account-card/connect-ads/connect-ads.js
@@ -6,7 +6,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AccountCard from '.~/components/account-card';
+import AccountCard from '~/components/account-card';
 import ConfirmCreateModal from './confirm-create-modal';
 import ConnectExistingAccount from './connect-existing-account';
 import UpsertingAccount from './upserting-account';

--- a/js/src/components/google-combo-account-card/connect-ads/connect-existing-account-actions.js
+++ b/js/src/components/google-combo-account-card/connect-ads/connect-existing-account-actions.js
@@ -6,11 +6,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import { DisconnectAccountButton } from '.~/components/google-ads-account-card';
-import useExistingGoogleAdsAccounts from '.~/hooks/useExistingGoogleAdsAccounts';
-import useGoogleAdsAccountStatus from '.~/hooks/useGoogleAdsAccountStatus';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
+import AppButton from '~/components/app-button';
+import { DisconnectAccountButton } from '~/components/google-ads-account-card';
+import useExistingGoogleAdsAccounts from '~/hooks/useExistingGoogleAdsAccounts';
+import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
 
 /**
  * Footer component.

--- a/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
+++ b/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
@@ -7,17 +7,17 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AccountCard from '.~/components/account-card';
+import AccountCard from '~/components/account-card';
 import ConnectExistingAccountActions from './connect-existing-account-actions';
-import LoadingLabel from '.~/components/loading-label';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import { useAppDispatch } from '.~/data';
-import useGoogleAdsAccountReady from '.~/hooks/useGoogleAdsAccountReady';
-import AdsAccountSelectControl from '.~/components/ads-account-select-control';
-import ConnectedIconLabel from '.~/components/connected-icon-label';
-import { ConnectAccountButton } from '.~/components/google-ads-account-card';
+import LoadingLabel from '~/components/loading-label';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import { useAppDispatch } from '~/data';
+import useGoogleAdsAccountReady from '~/hooks/useGoogleAdsAccountReady';
+import AdsAccountSelectControl from '~/components/ads-account-select-control';
+import ConnectedIconLabel from '~/components/connected-icon-label';
+import { ConnectAccountButton } from '~/components/google-ads-account-card';
 
 /**
  * Renders an account card to connect to an existing Google Ads account.

--- a/js/src/components/google-combo-account-card/connect-ads/upserting-account.js
+++ b/js/src/components/google-combo-account-card/connect-ads/upserting-account.js
@@ -6,8 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AccountCard from '.~/components/account-card';
-import LoadingLabel from '.~/components/loading-label';
+import AccountCard from '~/components/account-card';
+import LoadingLabel from '~/components/loading-label';
 
 /**
  * Renders indication that the user is in the process of creating or connecting a Google Ads account.

--- a/js/src/components/google-combo-account-card/connect-google-combo-account-card.js
+++ b/js/src/components/google-combo-account-card/connect-google-combo-account-card.js
@@ -8,13 +8,13 @@ import { CheckboxControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import AppButton from '.~/components/app-button';
+import { glaData } from '~/constants';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import AppButton from '~/components/app-button';
 import {
 	ReadMoreLink,
 	useGoogleConnectFlow,
-} from '.~/components/google-account-card';
+} from '~/components/google-account-card';
 import AppDocumentationLink from '../app-documentation-link';
 
 /**

--- a/js/src/components/google-combo-account-card/connected-google-combo-account-card.js
+++ b/js/src/components/google-combo-account-card/connected-google-combo-account-card.js
@@ -7,27 +7,27 @@ import { useState, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
+import { useAppDispatch } from '~/data';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
 import ConnectAds from './connect-ads';
 import AccountDetails from './account-details';
 import ConnectedAdsAccountDetail from './connected-ads-account-detail';
 import Indicator from './indicator';
 import getAccountCreationTexts from './getAccountCreationTexts';
-import SpinnerCard from '.~/components/spinner-card';
-import { StoreAddressCard } from '.~/components/contact-information';
-import useAutoCreateAdsMCAccounts from '.~/hooks/useAutoCreateAdsMCAccounts';
-import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
-import useExistingGoogleMCAccounts from '.~/hooks/useExistingGoogleMCAccounts';
-import useCreateMCAccount from '.~/hooks/useCreateMCAccount';
-import { ConnectMC } from '.~/components/google-mc-account-card';
-import useExistingGoogleAdsAccounts from '.~/hooks/useExistingGoogleAdsAccounts';
-import AppButton from '.~/components/app-button';
-import { SwitchAccountButton } from '.~/components/google-account-card';
-import useGoogleAdsAccountStatus from '.~/hooks/useGoogleAdsAccountStatus';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import useUpsertAdsAccount from '.~/hooks/useUpsertAdsAccount';
-import showAdsConversionNotice from '.~/utils/showAdsConversionNotice';
+import SpinnerCard from '~/components/spinner-card';
+import { StoreAddressCard } from '~/components/contact-information';
+import useAutoCreateAdsMCAccounts from '~/hooks/useAutoCreateAdsMCAccounts';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+import useExistingGoogleMCAccounts from '~/hooks/useExistingGoogleMCAccounts';
+import useCreateMCAccount from '~/hooks/useCreateMCAccount';
+import { ConnectMC } from '~/components/google-mc-account-card';
+import useExistingGoogleAdsAccounts from '~/hooks/useExistingGoogleAdsAccounts';
+import AppButton from '~/components/app-button';
+import { SwitchAccountButton } from '~/components/google-account-card';
+import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useUpsertAdsAccount from '~/hooks/useUpsertAdsAccount';
+import showAdsConversionNotice from '~/utils/showAdsConversionNotice';
 import './connected-google-combo-account-card.scss';
 
 /**

--- a/js/src/components/google-combo-account-card/index.js
+++ b/js/src/components/google-combo-account-card/index.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import useGoogleAccount from '.~/hooks/useGoogleAccount';
-import AppSpinner from '.~/components/app-spinner';
-import AccountCard from '.~/components/account-card';
-import { RequestFullAccessGoogleAccountCard } from '.~/components/google-account-card';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
+import AppSpinner from '~/components/app-spinner';
+import AccountCard from '~/components/account-card';
+import { RequestFullAccessGoogleAccountCard } from '~/components/google-account-card';
 import ConnectGoogleComboAccountCard from './connect-google-combo-account-card';
 import ConnectedGoogleComboAccountCard from './connected-google-combo-account-card';
 import './index.scss';

--- a/js/src/components/google-combo-account-card/indicator.js
+++ b/js/src/components/google-combo-account-card/indicator.js
@@ -6,10 +6,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import ConnectedIconLabel from '.~/components/connected-icon-label';
-import LoadingLabel from '.~/components/loading-label';
-import useGoogleAdsAccountReady from '.~/hooks/useGoogleAdsAccountReady';
-import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
+import ConnectedIconLabel from '~/components/connected-icon-label';
+import LoadingLabel from '~/components/loading-label';
+import useGoogleAdsAccountReady from '~/hooks/useGoogleAdsAccountReady';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 
 /**
  * Account creation indicator.

--- a/js/src/components/google-mc-account-card/connect-mc/actions.js
+++ b/js/src/components/google-mc-account-card/connect-mc/actions.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
  */
 import CreateAccountButton from '../create-account-button';
 import DisconnectAccountButton from '../disconnect-account-button';
-import useExistingGoogleMCAccounts from '.~/hooks/useExistingGoogleMCAccounts';
+import useExistingGoogleMCAccounts from '~/hooks/useExistingGoogleMCAccounts';
 
 /**
  * Actions component.

--- a/js/src/components/google-mc-account-card/connect-mc/index.js
+++ b/js/src/components/google-mc-account-card/connect-mc/index.js
@@ -9,15 +9,15 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import MerchantCenterSelect from './merchant-center-select';
-import AppButton from '.~/components/app-button';
-import useConnectMCAccount from '.~/hooks/useConnectMCAccount';
+import AppButton from '~/components/app-button';
+import useConnectMCAccount from '~/hooks/useConnectMCAccount';
 import SwitchUrlCard from '../switch-url-card';
 import ReclaimUrlCard from '../reclaim-url-card';
-import LoadingLabel from '.~/components/loading-label';
-import ConnectedIconLabel from '.~/components/connected-icon-label';
-import AccountCard from '.~/components/account-card';
+import LoadingLabel from '~/components/loading-label';
+import ConnectedIconLabel from '~/components/connected-icon-label';
+import AccountCard from '~/components/account-card';
 import Actions from './actions';
-import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import CreatingCard from '../creating-card';
 
 /**

--- a/js/src/components/google-mc-account-card/connect-mc/merchant-center-select.js
+++ b/js/src/components/google-mc-account-card/connect-mc/merchant-center-select.js
@@ -7,10 +7,10 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
 /**
  * Internal dependencies
  */
-import MerchantCenterSelectControl from '.~/components/merchant-center-select-control';
-import useExistingGoogleMCAccounts from '.~/hooks/useExistingGoogleMCAccounts';
-import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
-import AppSelectControl from '.~/components/app-select-control';
+import MerchantCenterSelectControl from '~/components/merchant-center-select-control';
+import useExistingGoogleMCAccounts from '~/hooks/useExistingGoogleMCAccounts';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+import AppSelectControl from '~/components/app-select-control';
 
 /**
  * Renders the connected Merchant Center details, leveraging existing functionality

--- a/js/src/components/google-mc-account-card/create-account-button.js
+++ b/js/src/components/google-mc-account-card/create-account-button.js
@@ -7,10 +7,10 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 import WarningModal from './warning-modal';
 import TermsModal from './terms-modal';
-import useExistingGoogleMCAccounts from '.~/hooks/useExistingGoogleMCAccounts';
+import useExistingGoogleMCAccounts from '~/hooks/useExistingGoogleMCAccounts';
 import getMatchingDomainAccount from './getMatchingDomainAccount';
 
 const MODALS = Object.freeze( {

--- a/js/src/components/google-mc-account-card/creating-card.js
+++ b/js/src/components/google-mc-account-card/creating-card.js
@@ -7,8 +7,8 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
+import AppButton from '~/components/app-button';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
 
 const CreatingCard = ( props ) => {
 	const { retryAfter, onRetry = () => {} } = props;

--- a/js/src/components/google-mc-account-card/disconnect-account-button.js
+++ b/js/src/components/google-mc-account-card/disconnect-account-button.js
@@ -7,11 +7,11 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import { API_NAMESPACE } from '.~/data/constants';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import { useAppDispatch } from '.~/data';
+import AppButton from '~/components/app-button';
+import { API_NAMESPACE } from '~/data/constants';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import { useAppDispatch } from '~/data';
 
 /**
  * Clicking on the "connect to a different Google Merchant Center account" button.

--- a/js/src/components/google-mc-account-card/merchant-center-account-info-card.js
+++ b/js/src/components/google-mc-account-card/merchant-center-account-info-card.js
@@ -10,21 +10,21 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
 /**
  * Internal dependencies
  */
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import AppButton from '.~/components/app-button';
-import ConnectedIconLabel from '.~/components/connected-icon-label';
-import Section from '.~/wcdl/section';
-import { GOOGLE_WPCOM_APP_CONNECTED_STATUS } from '.~/constants';
-import { API_NAMESPACE } from '.~/data/constants';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import { useAppDispatch } from '.~/data';
-import EnableNewProductSyncButton from '.~/components/enable-new-product-sync-button';
-import AppNotice from '.~/components/app-notice';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import AppButton from '~/components/app-button';
+import ConnectedIconLabel from '~/components/connected-icon-label';
+import Section from '~/wcdl/section';
+import { GOOGLE_WPCOM_APP_CONNECTED_STATUS } from '~/constants';
+import { API_NAMESPACE } from '~/data/constants';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import { useAppDispatch } from '~/data';
+import EnableNewProductSyncButton from '~/components/enable-new-product-sync-button';
+import AppNotice from '~/components/app-notice';
 import DisconnectModal, {
 	API_DATA_FETCH_FEATURE,
-} from '.~/settings/disconnect-modal';
-import { getSettingsUrl } from '.~/utils/urls';
+} from '~/settings/disconnect-modal';
+import { getSettingsUrl } from '~/utils/urls';
 
 /**
  * Renders a Google Merchant Center account card UI with connected account information.

--- a/js/src/components/google-mc-account-card/reclaim-url-card/index.js
+++ b/js/src/components/google-mc-account-card/reclaim-url-card/index.js
@@ -12,17 +12,17 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
 /**
  * Internal dependencies
  */
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import AppButton from '.~/components/app-button';
-import Section from '.~/wcdl/section';
-import Subsection from '.~/wcdl/subsection';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import useExistingGoogleMCAccounts from '.~/hooks/useExistingGoogleMCAccounts';
-import { useAppDispatch } from '.~/data';
-import ContentButtonLayout from '.~/components/content-button-layout';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import AppButton from '~/components/app-button';
+import Section from '~/wcdl/section';
+import Subsection from '~/wcdl/subsection';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import useExistingGoogleMCAccounts from '~/hooks/useExistingGoogleMCAccounts';
+import { useAppDispatch } from '~/data';
+import ContentButtonLayout from '~/components/content-button-layout';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
 import './index.scss';
-import AppInputLinkControl from '.~/components/app-input-link-control';
+import AppInputLinkControl from '~/components/app-input-link-control';
 
 /**
  * Clicking on the button to reclaim URL for a Google Merchant Center account.

--- a/js/src/components/google-mc-account-card/switch-url-card/index.js
+++ b/js/src/components/google-mc-account-card/switch-url-card/index.js
@@ -10,16 +10,16 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import Section from '.~/wcdl/section';
-import Subsection from '.~/wcdl/subsection';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import { useAppDispatch } from '.~/data';
-import ContentButtonLayout from '.~/components/content-button-layout';
+import AppButton from '~/components/app-button';
+import Section from '~/wcdl/section';
+import Subsection from '~/wcdl/subsection';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import { useAppDispatch } from '~/data';
+import ContentButtonLayout from '~/components/content-button-layout';
 import ReclaimUrlCard from '../reclaim-url-card';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import AppInputLinkControl from '.~/components/app-input-link-control';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import AppInputLinkControl from '~/components/app-input-link-control';
 import './index.scss';
 
 /**

--- a/js/src/components/google-mc-account-card/terms-modal/index.js
+++ b/js/src/components/google-mc-account-card/terms-modal/index.js
@@ -8,9 +8,9 @@ import { createInterpolateElement, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppModal from '.~/components/app-modal';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import AppButton from '.~/components/app-button';
+import AppModal from '~/components/app-modal';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import AppButton from '~/components/app-button';
 import './index.scss';
 
 /**

--- a/js/src/components/google-mc-account-card/warning-modal/index.js
+++ b/js/src/components/google-mc-account-card/warning-modal/index.js
@@ -7,9 +7,9 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppModal from '.~/components/app-modal';
-import AppButton from '.~/components/app-button';
-import WarningIcon from '.~/components/warning-icon';
+import AppModal from '~/components/app-modal';
+import AppButton from '~/components/app-button';
+import WarningIcon from '~/components/warning-icon';
 import './index.scss';
 
 /**

--- a/js/src/components/gtin-migration-banner/gtin-migration-banner.js
+++ b/js/src/components/gtin-migration-banner/gtin-migration-banner.js
@@ -8,12 +8,12 @@ import { createInterpolateElement, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import TrackableLink from '.~/components/trackable-link';
-import AppButton from '.~/components/app-button';
-import AppModal from '.~/components/app-modal';
-import { recordGlaEvent } from '.~/utils/tracks';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import useGTINMigrationStatus from '.~/hooks/useGTINMigrationStatus';
+import TrackableLink from '~/components/trackable-link';
+import AppButton from '~/components/app-button';
+import AppModal from '~/components/app-modal';
+import { recordGlaEvent } from '~/utils/tracks';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useGTINMigrationStatus from '~/hooks/useGTINMigrationStatus';
 import './gtin-migration-banner.scss';
 
 const GTIN_MIGRATION_BANNER_CONTEXT = 'gtin_migration_banner';

--- a/js/src/components/guide-page-content/index.js
+++ b/js/src/components/guide-page-content/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import TrackableLink from '.~/components/trackable-link';
+import TrackableLink from '~/components/trackable-link';
 import './index.scss';
 
 /**

--- a/js/src/components/help-icon-button.js
+++ b/js/src/components/help-icon-button.js
@@ -7,7 +7,7 @@ import GridiconHelpOutline from 'gridicons/dist/help-outline';
 /**
  * Internal dependencies
  */
-import AppIconButton from '.~/components/app-icon-button';
+import AppIconButton from '~/components/app-icon-button';
 
 /**
  * "Help" button is clicked.
@@ -25,7 +25,7 @@ import AppIconButton from '.~/components/app-icon-button';
  *
  * @param {Object} props Props
  * @param {string} props.eventContext Context to be used in `gla_help_click` track event.
- * @return {import(".~/components/app-icon-button").default} The button.
+ * @return {import("~/components/app-icon-button").default} The button.
  */
 const HelpIconButton = ( props ) => {
 	const { eventContext, ...rest } = props;

--- a/js/src/components/help-popover/index.js
+++ b/js/src/components/help-popover/index.js
@@ -10,7 +10,7 @@ import GridiconHelpOutline from 'gridicons/dist/help-outline';
 /**
  * Internal dependencies
  */
-import { recordGlaEvent } from '.~/utils/tracks';
+import { recordGlaEvent } from '~/utils/tracks';
 import './index.scss';
 
 /**

--- a/js/src/components/main-tab-nav/main-tab-nav.js
+++ b/js/src/components/main-tab-nav/main-tab-nav.js
@@ -7,10 +7,10 @@ import { getNewPath, getPath } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
-import AppTabNav from '.~/components/app-tab-nav';
-import useMenuEffect from '.~/hooks/useMenuEffect';
-import GtinMigrationBanner from '.~/components/gtin-migration-banner';
+import { glaData } from '~/constants';
+import AppTabNav from '~/components/app-tab-nav';
+import useMenuEffect from '~/hooks/useMenuEffect';
+import GtinMigrationBanner from '~/components/gtin-migration-banner';
 
 let tabs = [
 	{

--- a/js/src/components/merchant-center-select-control/index.js
+++ b/js/src/components/merchant-center-select-control/index.js
@@ -6,8 +6,8 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import useExistingGoogleMCAccounts from '.~/hooks/useExistingGoogleMCAccounts';
-import AppSelectControl from '.~/components/app-select-control';
+import useExistingGoogleMCAccounts from '~/hooks/useExistingGoogleMCAccounts';
+import AppSelectControl from '~/components/app-select-control';
 
 /**
  * @param {Object} props The component props

--- a/js/src/components/merchant-center-select-control/index.test.js
+++ b/js/src/components/merchant-center-select-control/index.test.js
@@ -1,4 +1,4 @@
-jest.mock( '.~/hooks/useExistingGoogleMCAccounts', () => ( {
+jest.mock( '~/hooks/useExistingGoogleMCAccounts', () => ( {
 	__esModule: true,
 	default: jest
 		.fn()

--- a/js/src/components/order-value-condition-section/minimum-order-card/calculateValueFromGroupChange.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/calculateValueFromGroupChange.js
@@ -1,5 +1,5 @@
 /**
- * @typedef { import(".~/data/actions").ShippingRate } ShippingRate
+ * @typedef { import("~/data/actions").ShippingRate } ShippingRate
  * @typedef { import("./typedefs").MinimumOrderGroup } MinimumOrderGroup
  */
 

--- a/js/src/components/order-value-condition-section/minimum-order-card/groupShippingRatesByCurrencyFreeShippingThreshold.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/groupShippingRatesByCurrencyFreeShippingThreshold.js
@@ -1,5 +1,5 @@
 /**
- * @typedef { import(".~/data/actions").ShippingRate } ShippingRate
+ * @typedef { import("~/data/actions").ShippingRate } ShippingRate
  * @typedef { import("./typedefs").MinimumOrderGroup } MinimumOrderGroup
  */
 

--- a/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-card.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-card.js
@@ -5,19 +5,19 @@ import { __ } from '@wordpress/i18n';
 import GridiconPlusSmall from 'gridicons/dist/plus-small';
 
 /**
- * @typedef { import(".~/data/actions").ShippingRate } ShippingRate
+ * @typedef { import("~/data/actions").ShippingRate } ShippingRate
  */
 
 /**
  * Internal dependencies
  */
-import Section from '.~/wcdl/section';
-import AppButton from '.~/components/app-button';
-import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import { useAdaptiveFormInputProps } from '.~/components/adaptive-form';
-import OfferFreeShippingCheckbox from '.~/components/order-value-condition-section/offer-free-shipping-checkbox';
-import isNonFreeShippingRate from '.~/utils/isNonFreeShippingRate';
+import Section from '~/wcdl/section';
+import AppButton from '~/components/app-button';
+import AppButtonModalTrigger from '~/components/app-button-modal-trigger';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
+import { useAdaptiveFormInputProps } from '~/components/adaptive-form';
+import OfferFreeShippingCheckbox from '~/components/order-value-condition-section/offer-free-shipping-checkbox';
+import isNonFreeShippingRate from '~/utils/isNonFreeShippingRate';
 import MinimumOrderInputControl from './minimum-order-input-control';
 import { AddMinimumOrderFormModal } from './minimum-order-form-modals';
 import groupShippingRatesByCurrencyFreeShippingThreshold from './groupShippingRatesByCurrencyFreeShippingThreshold';

--- a/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-card.test.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-card.test.js
@@ -9,15 +9,15 @@ import userEvent from '@testing-library/user-event';
  * Internal dependencies
  */
 import MinimumOrderCard from './minimum-order-card';
-import * as adaptiveForm from '.~/components/adaptive-form';
+import * as adaptiveForm from '~/components/adaptive-form';
 
-jest.mock( '.~/hooks/useAppSelectDispatch' );
-jest.mock( '.~/hooks/useCountryKeyNameMap' );
-jest.mock( '.~/hooks/useStoreCurrency' );
-jest.mock( '.~/components/adaptive-form', () => {
+jest.mock( '~/hooks/useAppSelectDispatch' );
+jest.mock( '~/hooks/useCountryKeyNameMap' );
+jest.mock( '~/hooks/useStoreCurrency' );
+jest.mock( '~/components/adaptive-form', () => {
 	return {
 		__esModule: true,
-		...jest.requireActual( '.~/components/adaptive-form' ),
+		...jest.requireActual( '~/components/adaptive-form' ),
 	};
 } );
 

--- a/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-form-modals/add-minimum-order-form-modal.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-form-modals/add-minimum-order-form-modal.js
@@ -6,11 +6,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 import MinimumOrderFormModal from './minimum-order-form-modal';
 
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  * @typedef { import("../typedefs.js").MinimumOrderGroup } MinimumOrderGroup
  */
 

--- a/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-form-modals/edit-minimum-order-form-modal.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-form-modals/edit-minimum-order-form-modal.js
@@ -6,11 +6,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 import MinimumOrderFormModal from './minimum-order-form-modal';
 
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  * @typedef { import("../typedefs.js").MinimumOrderGroup } MinimumOrderGroup
  */
 

--- a/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-form-modals/minimum-order-form-modal.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-form-modals/minimum-order-form-modal.js
@@ -8,15 +8,15 @@ import { Form } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import AppModal from '.~/components/app-modal';
-import AppInputPriceControl from '.~/components/app-input-price-control';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import SupportedCountrySelect from '.~/components/supported-country-select';
+import AppModal from '~/components/app-modal';
+import AppInputPriceControl from '~/components/app-input-price-control';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
+import SupportedCountrySelect from '~/components/supported-country-select';
 import validateMinimumOrder from './validateMinimumOrder';
 
 /**
- * @typedef { import(".~/components/app-button").default } AppButton
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/components/app-button").default } AppButton
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  * @typedef { import("../typedefs.js").MinimumOrderGroup } MinimumOrderGroup
  */
 

--- a/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-input-control-label-text.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-input-control-label-text.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 
-import CountryNamesPlusMore from '.~/components/country-names-plus-more';
+import CountryNamesPlusMore from '~/components/country-names-plus-more';
 
 const MinimumOrderInputControlLabelText = ( props ) => {
 	const { countries } = props;

--- a/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-input-control.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-input-control.js
@@ -6,16 +6,16 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
-import AppInputPriceControl from '.~/components/app-input-price-control';
-import { useAdaptiveFormContext } from '.~/components/adaptive-form';
+import AppButton from '~/components/app-button';
+import AppButtonModalTrigger from '~/components/app-button-modal-trigger';
+import AppInputPriceControl from '~/components/app-input-price-control';
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
 import { EditMinimumOrderFormModal } from './minimum-order-form-modals';
 import MinimumOrderInputControlLabelText from './minimum-order-input-control-label-text';
 import './minimum-order-input-control.scss';
 
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  * @typedef { import("./typedefs").MinimumOrderGroup } MinimumOrderGroup
  */
 

--- a/js/src/components/order-value-condition-section/order-value-condition-section.js
+++ b/js/src/components/order-value-condition-section/order-value-condition-section.js
@@ -6,8 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import Section from '.~/wcdl/section';
-import { useAdaptiveFormInputProps } from '.~/components/adaptive-form';
+import Section from '~/wcdl/section';
+import { useAdaptiveFormInputProps } from '~/components/adaptive-form';
 import MinimumOrderCard from './minimum-order-card';
 
 const OrderValueConditionSection = () => {

--- a/js/src/components/paid-ads/add-paid-campaign-button.js
+++ b/js/src/components/paid-ads/add-paid-campaign-button.js
@@ -7,10 +7,10 @@ import { getHistory, getNewPath } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import { glaData } from '.~/constants';
-import { getCreateCampaignUrl } from '.~/utils/urls';
-import { recordGlaEvent } from '.~/utils/tracks';
+import AppButton from '~/components/app-button';
+import { glaData } from '~/constants';
+import { getCreateCampaignUrl } from '~/utils/urls';
+import { recordGlaEvent } from '~/utils/tracks';
 
 /**
  * "Add campaign" button is clicked.

--- a/js/src/components/paid-ads/ads-campaign/ads-campaign.js
+++ b/js/src/components/paid-ads/ads-campaign/ads-campaign.js
@@ -7,25 +7,25 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import StepContent from '.~/components/stepper/step-content';
-import StepContentHeader from '.~/components/stepper/step-content-header';
-import StepContentFooter from '.~/components/stepper/step-content-footer';
-import StepContentActions from '.~/components/stepper/step-content-actions';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import { useAdaptiveFormContext } from '.~/components/adaptive-form';
-import BillingCard from '.~/components/paid-ads/billing-card';
+import StepContent from '~/components/stepper/step-content';
+import StepContentHeader from '~/components/stepper/step-content-header';
+import StepContentFooter from '~/components/stepper/step-content-footer';
+import StepContentActions from '~/components/stepper/step-content-actions';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import BillingCard from '~/components/paid-ads/billing-card';
 import BudgetSection from '../budget-section';
 import { CampaignPreviewCard } from '../campaign-preview';
 import Faqs from './faqs';
 import PaidAdsFeaturesSection from './paid-ads-features-section';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
+import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 
 /**
- * @typedef {import('.~/components/adaptive-form/adaptive-form-context').AdaptiveFormContext} AdaptiveFormContext
+ * @typedef {import('~/components/adaptive-form/adaptive-form-context').AdaptiveFormContext} AdaptiveFormContext
  */
 
 /**
- * @typedef {import('.~/data/actions').Campaign} Campaign
+ * @typedef {import('~/data/actions').Campaign} Campaign
  */
 
 /**

--- a/js/src/components/paid-ads/ads-campaign/faqs.js
+++ b/js/src/components/paid-ads/ads-campaign/faqs.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import FaqsPanel from '.~/components/faqs-panel';
+import FaqsPanel from '~/components/faqs-panel';
 
 const faqItems = [
 	{

--- a/js/src/components/paid-ads/ads-campaign/paid-ads-features-section.js
+++ b/js/src/components/paid-ads/ads-campaign/paid-ads-features-section.js
@@ -9,11 +9,11 @@ import GridiconCheckmark from 'gridicons/dist/checkmark';
 /**
  * Internal dependencies
  */
-import Section from '.~/wcdl/section';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import CampaignPreview from '.~/components/paid-ads/campaign-preview';
-import FreeAdCredit from '.~/components/free-ad-credit';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
+import Section from '~/wcdl/section';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import CampaignPreview from '~/components/paid-ads/campaign-preview';
+import FreeAdCredit from '~/components/free-ad-credit';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
 import './paid-ads-features-section.scss';
 
 function FeatureList() {

--- a/js/src/components/paid-ads/asset-group/add-asset-item-button.js
+++ b/js/src/components/paid-ads/asset-group/add-asset-item-button.js
@@ -6,7 +6,7 @@ import GridiconPlusSmall from 'gridicons/dist/plus-small';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 import './add-asset-item-button.scss';
 
 export default function AddAssetItemButton( props ) {

--- a/js/src/components/paid-ads/asset-group/asset-field.js
+++ b/js/src/components/paid-ads/asset-group/asset-field.js
@@ -16,8 +16,8 @@ import { Pill } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import HelpPopover from '.~/components/help-popover';
+import AppButton from '~/components/app-button';
+import HelpPopover from '~/components/help-popover';
 import './asset-field.scss';
 
 /**

--- a/js/src/components/paid-ads/asset-group/asset-group-card.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-card.js
@@ -8,13 +8,13 @@ import { SelectControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { useAdaptiveFormContext } from '.~/components/adaptive-form';
-import AppInputControl from '.~/components/app-input-control';
-import ValidationErrors from '.~/components/validation-errors';
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import AppInputControl from '~/components/app-input-control';
+import ValidationErrors from '~/components/validation-errors';
 import ImagesSelector from './images-selector';
 import TextsEditor from './texts-editor';
 import AssetField from './asset-field';
-import { ASSET_FORM_KEY } from '.~/constants';
+import { ASSET_FORM_KEY } from '~/constants';
 import {
 	ASSET_IMAGE_SPECS,
 	ASSET_TEXT_SPECS,

--- a/js/src/components/paid-ads/asset-group/asset-group-section.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.js
@@ -8,13 +8,13 @@ import { Tip } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { ASSET_FORM_KEY } from '.~/constants';
-import { useAdaptiveFormContext } from '.~/components/adaptive-form';
-import Section from '.~/wcdl/section';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
+import { ASSET_FORM_KEY } from '~/constants';
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import Section from '~/wcdl/section';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
 import FinalUrlCard from './final-url-card';
 import AssetGroupCard from './asset-group-card';
-import AppDocumentationLink from '.~/components/app-documentation-link';
+import AppDocumentationLink from '~/components/app-documentation-link';
 import './asset-group-section.scss';
 
 /**

--- a/js/src/components/paid-ads/asset-group/asset-group-section.test.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.test.js
@@ -1,4 +1,4 @@
-jest.mock( '.~/components/adaptive-form', () => ( {
+jest.mock( '~/components/adaptive-form', () => ( {
 	useAdaptiveFormContext: jest
 		.fn()
 		.mockName( 'useAdaptiveFormContext' )
@@ -23,10 +23,10 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import AssetGroupSection from '.~/components/paid-ads/asset-group/asset-group-section';
-import { useAdaptiveFormContext } from '.~/components/adaptive-form';
+import AssetGroupSection from '~/components/paid-ads/asset-group/asset-group-section';
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
 
-jest.mock( '.~/components/paid-ads/asset-group/asset-group-card', () =>
+jest.mock( '~/components/paid-ads/asset-group/asset-group-card', () =>
 	jest.fn( ( props ) => <div { ...props } /> ).mockName( 'AssetGroupCard' )
 );
 

--- a/js/src/components/paid-ads/asset-group/asset-group.js
+++ b/js/src/components/paid-ads/asset-group/asset-group.js
@@ -6,23 +6,23 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ASSET_FORM_KEY } from '.~/constants';
-import { useAdaptiveFormContext } from '.~/components/adaptive-form';
-import StepContent from '.~/components/stepper/step-content';
-import StepContentHeader from '.~/components/stepper/step-content-header';
-import StepContentFooter from '.~/components/stepper/step-content-footer';
-import StepContentActions from '.~/components/stepper/step-content-actions';
-import AppButton from '.~/components/app-button';
+import { ASSET_FORM_KEY } from '~/constants';
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import StepContent from '~/components/stepper/step-content';
+import StepContentHeader from '~/components/stepper/step-content-header';
+import StepContentFooter from '~/components/stepper/step-content-footer';
+import StepContentActions from '~/components/stepper/step-content-actions';
+import AppButton from '~/components/app-button';
 import AssetGroupSection from './asset-group-section';
 import Faqs from './faqs';
-import { recordGlaEvent } from '.~/utils/tracks';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
+import { recordGlaEvent } from '~/utils/tracks';
+import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 
 export const ACTION_SUBMIT_CAMPAIGN_AND_ASSETS = 'submit-campaign-and-assets';
 export const ACTION_SUBMIT_CAMPAIGN_ONLY = 'submit-campaign-only';
 
 /**
- * @typedef {import('.~/data/actions').Campaign} Campaign
+ * @typedef {import('~/data/actions').Campaign} Campaign
  */
 
 /**

--- a/js/src/components/paid-ads/asset-group/assets-loader.js
+++ b/js/src/components/paid-ads/asset-group/assets-loader.js
@@ -10,14 +10,14 @@ import { Spinner } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import AppButton from '.~/components/app-button';
-import SelectControl from '.~/wcdl/select-control';
-import { API_NAMESPACE } from '.~/data/constants';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import AppButton from '~/components/app-button';
+import SelectControl from '~/wcdl/select-control';
+import { API_NAMESPACE } from '~/data/constants';
 import './assets-loader.scss';
 
 /**
- * @typedef {import('.~/data/types.js').SuggestedAssets} SuggestedAssets
+ * @typedef {import('~/data/types.js').SuggestedAssets} SuggestedAssets
  */
 
 function allowAllResults() {

--- a/js/src/components/paid-ads/asset-group/faqs.js
+++ b/js/src/components/paid-ads/asset-group/faqs.js
@@ -7,8 +7,8 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import FaqsPanel from '.~/components/faqs-panel';
-import AppDocumentationLink from '.~/components/app-documentation-link';
+import FaqsPanel from '~/components/faqs-panel';
+import AppDocumentationLink from '~/components/app-documentation-link';
 
 const faqItems = [
 	{

--- a/js/src/components/paid-ads/asset-group/final-url-card.js
+++ b/js/src/components/paid-ads/asset-group/final-url-card.js
@@ -9,15 +9,15 @@ import { ExternalLink } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { ASSET_GROUP_KEY } from '.~/constants';
-import Section from '.~/wcdl/section';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import AppButton from '.~/components/app-button';
+import { ASSET_GROUP_KEY } from '~/constants';
+import Section from '~/wcdl/section';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import AppButton from '~/components/app-button';
 import AssetsLoader from './assets-loader';
 import './final-url-card.scss';
 
 /**
- * @typedef {import('.~/data/types.js').SuggestedAssets} SuggestedAssets
+ * @typedef {import('~/data/types.js').SuggestedAssets} SuggestedAssets
  */
 
 /**

--- a/js/src/components/paid-ads/asset-group/images-selector.js
+++ b/js/src/components/paid-ads/asset-group/images-selector.js
@@ -9,9 +9,9 @@ import GridiconCrossCircle from 'gridicons/dist/cross-circle';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import useCroppedImageSelector from '.~/hooks/useCroppedImageSelector';
-import AppTooltip from '.~/components/app-tooltip';
+import AppButton from '~/components/app-button';
+import useCroppedImageSelector from '~/hooks/useCroppedImageSelector';
+import AppTooltip from '~/components/app-tooltip';
 import AddAssetItemButton from './add-asset-item-button';
 import './images-selector.scss';
 

--- a/js/src/components/paid-ads/asset-group/images-selector.test.js
+++ b/js/src/components/paid-ads/asset-group/images-selector.test.js
@@ -9,14 +9,14 @@ import userEvent from '@testing-library/user-event';
  * Internal dependencies
  */
 import ImagesSelector from './images-selector';
-import useCroppedImageSelector from '.~/hooks/useCroppedImageSelector';
-import AppTooltip from '.~/components/app-tooltip';
+import useCroppedImageSelector from '~/hooks/useCroppedImageSelector';
+import AppTooltip from '~/components/app-tooltip';
 
-jest.mock( '.~/hooks/useCroppedImageSelector', () =>
+jest.mock( '~/hooks/useCroppedImageSelector', () =>
 	jest.fn().mockName( 'useCroppedImageSelector' )
 );
 
-jest.mock( '.~/components/app-tooltip', () =>
+jest.mock( '~/components/app-tooltip', () =>
 	jest.fn( ( props ) => <div { ...props } /> ).mockName( 'AppTooltip' )
 );
 

--- a/js/src/components/paid-ads/asset-group/texts-editor.js
+++ b/js/src/components/paid-ads/asset-group/texts-editor.js
@@ -9,8 +9,8 @@ import GridiconCrossSmall from 'gridicons/dist/cross-small';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import AppInputControl from '.~/components/app-input-control';
+import AppButton from '~/components/app-button';
+import AppInputControl from '~/components/app-input-control';
 import AddAssetItemButton from './add-asset-item-button';
 import './texts-editor.scss';
 

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -8,10 +8,10 @@ import { Fragment, createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { ASSET_FORM_KEY } from '.~/constants';
+import { ASSET_FORM_KEY } from '~/constants';
 
 /**
- * @typedef {import('.~/components/types.js').AssetGroupFormValues} AssetGroupFormValues
+ * @typedef {import('~/components/types.js').AssetGroupFormValues} AssetGroupFormValues
  */
 
 const sharedMaxSymbol = Symbol( 'sharedMax' );

--- a/js/src/components/paid-ads/billing-card/billing-card.js
+++ b/js/src/components/paid-ads/billing-card/billing-card.js
@@ -8,11 +8,11 @@ import { Flex, FlexBlock } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import useGoogleAdsAccountBillingStatus from '.~/hooks/useGoogleAdsAccountBillingStatus';
-import SpinnerCard from '.~/components/spinner-card';
+import useGoogleAdsAccountBillingStatus from '~/hooks/useGoogleAdsAccountBillingStatus';
+import SpinnerCard from '~/components/spinner-card';
 import BillingSetupCard from './billing-setup-card';
 import fallbackBillingUrl from './fallbackBillingUrl';
-import { GOOGLE_ADS_BILLING_STATUS } from '.~/constants';
+import { GOOGLE_ADS_BILLING_STATUS } from '~/constants';
 import './billing-card.scss';
 
 const { APPROVED } = GOOGLE_ADS_BILLING_STATUS;

--- a/js/src/components/paid-ads/billing-card/billing-setup-card.js
+++ b/js/src/components/paid-ads/billing-card/billing-setup-card.js
@@ -9,14 +9,14 @@ import { external as externalIcon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import AppSpinner from '.~/components/app-spinner';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import Section from '.~/wcdl/section';
-import AppButton from '.~/components/app-button';
-import useEventPropertiesFilter from '.~/hooks/useEventPropertiesFilter';
+import AppSpinner from '~/components/app-spinner';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import Section from '~/wcdl/section';
+import AppButton from '~/components/app-button';
+import useEventPropertiesFilter from '~/hooks/useEventPropertiesFilter';
 import useAutoCheckBillingStatusEffect from './useAutoCheckBillingStatusEffect';
-import getWindowFeatures from '.~/utils/getWindowFeatures';
-import { FILTER_ONBOARDING, recordGlaEvent } from '.~/utils/tracks';
+import getWindowFeatures from '~/utils/getWindowFeatures';
+import { FILTER_ONBOARDING, recordGlaEvent } from '~/utils/tracks';
 import './billing-setup-card.scss';
 
 /**

--- a/js/src/components/paid-ads/billing-card/billing-setup-card.test.js
+++ b/js/src/components/paid-ads/billing-card/billing-setup-card.test.js
@@ -10,18 +10,18 @@ import { recordEvent } from '@woocommerce/tracks';
  * Internal dependencies
  */
 import BillingSetupCard from './billing-setup-card';
-import useWindowFocus from '.~/hooks/useWindowFocus';
-import { FILTER_ONBOARDING } from '.~/utils/tracks';
-import expectComponentToRecordEventWithFilteredProperties from '.~/tests/expectComponentToRecordEventWithFilteredProperties';
+import useWindowFocus from '~/hooks/useWindowFocus';
+import { FILTER_ONBOARDING } from '~/utils/tracks';
+import expectComponentToRecordEventWithFilteredProperties from '~/tests/expectComponentToRecordEventWithFilteredProperties';
 
-jest.mock( '.~/hooks/useGoogleAdsAccount', () =>
+jest.mock( '~/hooks/useGoogleAdsAccount', () =>
 	jest
 		.fn()
 		.mockName( 'useGoogleAdsAccount' )
 		.mockReturnValue( { googleAdsAccount: {} } )
 );
 
-jest.mock( '.~/hooks/useWindowFocus', () =>
+jest.mock( '~/hooks/useWindowFocus', () =>
 	jest.fn().mockName( 'useWindowFocus' ).mockReturnValue( true )
 );
 

--- a/js/src/components/paid-ads/billing-card/useAutoCheckBillingStatusEffect.js
+++ b/js/src/components/paid-ads/billing-card/useAutoCheckBillingStatusEffect.js
@@ -9,10 +9,10 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import useWindowFocusCallbackIntervalEffect from '.~/hooks/useWindowFocusCallbackIntervalEffect';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import { GOOGLE_ADS_BILLING_STATUS } from '.~/constants';
+import { useAppDispatch } from '~/data';
+import useWindowFocusCallbackIntervalEffect from '~/hooks/useWindowFocusCallbackIntervalEffect';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import { GOOGLE_ADS_BILLING_STATUS } from '~/constants';
 
 /**
  * Make API call to complete Google Ads account setup.

--- a/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
+++ b/js/src/components/paid-ads/budget-section/budget-recommendation/index.js
@@ -9,8 +9,8 @@ import GridiconNoticeOutline from 'gridicons/dist/notice-outline';
 /**
  * Internal dependencies
  */
-import useCountryKeyNameMap from '.~/hooks/useCountryKeyNameMap';
-import useBudgetRecommendation from '.~/hooks/useBudgetRecommendation';
+import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
+import useBudgetRecommendation from '~/hooks/useBudgetRecommendation';
 import './index.scss';
 
 function toRecommendationRange( isMultiple, ...values ) {

--- a/js/src/components/paid-ads/budget-section/index.js
+++ b/js/src/components/paid-ads/budget-section/index.js
@@ -6,15 +6,15 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import Section from '.~/wcdl/section';
+import Section from '~/wcdl/section';
 import getMonthlyMaxEstimated from './getMonthlyMaxEstimated';
 import './index.scss';
 import BudgetRecommendation from './budget-recommendation';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import AppInputPriceControl from '.~/components/app-input-price-control';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import AppInputPriceControl from '~/components/app-input-price-control';
 
 /**
- * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ * @typedef {import('~/data/actions').CountryCode} CountryCode
  */
 
 const nonInteractableProps = {

--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -7,16 +7,16 @@ import { isPlainObject } from 'lodash';
 /**
  * Internal dependencies
  */
-import { ASSET_GROUP_KEY, ASSET_FORM_KEY } from '.~/constants';
-import AdaptiveForm from '.~/components/adaptive-form';
-import validateCampaign from '.~/components/paid-ads/validateCampaign';
-import validateAssetGroup from '.~/components/paid-ads/validateAssetGroup';
-import useAdsCurrency from '.~/hooks/useAdsCurrency';
+import { ASSET_GROUP_KEY, ASSET_FORM_KEY } from '~/constants';
+import AdaptiveForm from '~/components/adaptive-form';
+import validateCampaign from '~/components/paid-ads/validateCampaign';
+import validateAssetGroup from '~/components/paid-ads/validateAssetGroup';
+import useAdsCurrency from '~/hooks/useAdsCurrency';
 
 /**
- * @typedef {import('.~/components/types.js').CampaignFormValues} CampaignFormValues
- * @typedef {import('.~/components/types.js').AssetGroupFormValues} AssetGroupFormValues
- * @typedef {import('.~/data/types.js').AssetEntityGroup} AssetEntityGroup
+ * @typedef {import('~/components/types.js').CampaignFormValues} CampaignFormValues
+ * @typedef {import('~/components/types.js').AssetGroupFormValues} AssetGroupFormValues
+ * @typedef {import('~/data/types.js').AssetEntityGroup} AssetEntityGroup
  */
 
 const emptyAssetGroup = {

--- a/js/src/components/paid-ads/campaign-preview/campaign-preview-card.js
+++ b/js/src/components/paid-ads/campaign-preview/campaign-preview-card.js
@@ -10,8 +10,8 @@ import GridiconChevronRight from 'gridicons/dist/chevron-right';
 /**
  * Internal dependencies
  */
-import Section from '.~/wcdl/section';
-import AppButton from '.~/components/app-button';
+import Section from '~/wcdl/section';
+import AppButton from '~/components/app-button';
 import CampaignPreview from './campaign-preview';
 import './campaign-preview-card.scss';
 

--- a/js/src/components/paid-ads/campaign-preview/campaign-preview.js
+++ b/js/src/components/paid-ads/campaign-preview/campaign-preview.js
@@ -16,18 +16,18 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
 /**
  * Internal dependencies
  */
-import useCountdown from '.~/hooks/useCountdown';
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
-import AppSpinner from '.~/components/app-spinner';
+import useCountdown from '~/hooks/useCountdown';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
+import AppSpinner from '~/components/app-spinner';
 import MockupShopping from './mockup-shopping';
 import MockupYouTube from './mockup-youtube';
 import MockupSearch from './mockup-search';
 import MockupGmail from './mockup-gmail';
 import MockupDisplay from './mockup-display';
 import MockupMap from './mockup-map';
-import productSampleImageURL from '.~/images/campaign-preview/product-sample-image.jpg';
-import shopSampleLogoURL from '.~/images/campaign-preview/shop-sample-logo.png';
-import { glaData } from '.~/constants';
+import productSampleImageURL from '~/images/campaign-preview/product-sample-image.jpg';
+import shopSampleLogoURL from '~/images/campaign-preview/shop-sample-logo.png';
+import { glaData } from '~/constants';
 import './campaign-preview.scss';
 
 /**

--- a/js/src/components/paid-ads/campaign-preview/mockup-display.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-display.js
@@ -9,7 +9,7 @@ import GridiconChevronRight from 'gridicons/dist/chevron-right';
  */
 import Placeholder from './components/placeholder';
 import ProductCover from './components/product-cover';
-import adCornerButtonsImageURL from '.~/images/campaign-preview/ad-corner-buttons-image.svg';
+import adCornerButtonsImageURL from '~/images/campaign-preview/ad-corner-buttons-image.svg';
 
 /**
  * @typedef { import("./index.js").AdPreviewData } AdPreviewData

--- a/js/src/components/paid-ads/campaign-preview/mockup-gmail.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-gmail.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import SearchBar from './components/search-bar';
 import ProductBanner from './components/product-banner';
 import Placeholder from './components/placeholder';
-import gmailLogoURL from '.~/images/campaign-preview/gmail-logo.svg';
+import gmailLogoURL from '~/images/campaign-preview/gmail-logo.svg';
 
 function MailItem() {
 	return (

--- a/js/src/components/paid-ads/campaign-preview/mockup-map.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-map.js
@@ -8,7 +8,7 @@ import GridiconLocation from 'gridicons/dist/location';
  */
 import SearchBar from './components/search-bar';
 import ProductBanner from './components/product-banner';
-import mapBackgroundURL from '.~/images/campaign-preview/map-background.png';
+import mapBackgroundURL from '~/images/campaign-preview/map-background.png';
 
 /**
  * @typedef { import("./index.js").AdPreviewData } AdPreviewData

--- a/js/src/components/paid-ads/campaign-preview/mockup-search.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-search.js
@@ -11,7 +11,7 @@ import Placeholder from './components/placeholder';
 import ScaledText from './components/scaled-text';
 import SearchBar from './components/search-bar';
 import ShopLogo from './components/shop-logo';
-import googleLogoURL from '.~/images/logo/google-logo.svg';
+import googleLogoURL from '~/images/logo/google-logo.svg';
 
 /**
  * @typedef { import("./index.js").AdPreviewData } AdPreviewData

--- a/js/src/components/paid-ads/campaign-preview/mockup-shopping.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-shopping.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import Placeholder from './components/placeholder';
 import ScaledText from './components/scaled-text';
 import ProductCover from './components/product-cover';
-import googleShoppingLogoURL from '.~/images/campaign-preview/google-shopping-logo.svg';
+import googleShoppingLogoURL from '~/images/campaign-preview/google-shopping-logo.svg';
 
 /**
  * @typedef { import("./index.js").AdPreviewData } AdPreviewData

--- a/js/src/components/paid-ads/campaign-preview/mockup-youtube.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-youtube.js
@@ -10,7 +10,7 @@ import GridiconExternal from 'gridicons/dist/external';
 import Placeholder from './components/placeholder';
 import ScaledText from './components/scaled-text';
 import ProductCover from './components/product-cover';
-import youTubeLogoURL from '.~/images/campaign-preview/youtube-logo.svg';
+import youTubeLogoURL from '~/images/campaign-preview/youtube-logo.svg';
 
 /**
  * @typedef { import("./index.js").AdPreviewData } AdPreviewData

--- a/js/src/components/paid-ads/continue-button.js
+++ b/js/src/components/paid-ads/continue-button.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 
 /**
  * Renders Continue button on paid ad campaign create and edit page.

--- a/js/src/components/paid-ads/convertToAssetGroupUpdateBody.js
+++ b/js/src/components/paid-ads/convertToAssetGroupUpdateBody.js
@@ -1,13 +1,13 @@
 /**
  * Internal dependencies
  */
-import { ASSET_KEY, ASSET_FORM_KEY } from '.~/constants';
+import { ASSET_KEY, ASSET_FORM_KEY } from '~/constants';
 
 /**
- * @typedef {import('.~/components/types.js').AssetGroupFormValues} AssetGroupFormValues
- * @typedef {import('.~/data/types.js').AssetEntityGroup} AssetEntityGroup
- * @typedef {import('.~/data/types.js').AssetOperations} AssetOperations
- * @typedef {import('.~/data/types.js').AssetEntityGroupUpdateBody} AssetEntityGroupUpdateBody
+ * @typedef {import('~/components/types.js').AssetGroupFormValues} AssetGroupFormValues
+ * @typedef {import('~/data/types.js').AssetEntityGroup} AssetEntityGroup
+ * @typedef {import('~/data/types.js').AssetOperations} AssetOperations
+ * @typedef {import('~/data/types.js').AssetEntityGroupUpdateBody} AssetEntityGroupUpdateBody
  */
 
 /**

--- a/js/src/components/paid-ads/convertToAssetGroupUpdateBody.test.js
+++ b/js/src/components/paid-ads/convertToAssetGroupUpdateBody.test.js
@@ -9,7 +9,7 @@ import { uniqueId } from 'lodash';
 import convertToAssetGroupUpdateBody, {
 	diffAssetOperations,
 } from './convertToAssetGroupUpdateBody';
-import { ASSET_KEY, ASSET_GROUP_KEY, ASSET_FORM_KEY } from '.~/constants';
+import { ASSET_KEY, ASSET_GROUP_KEY, ASSET_FORM_KEY } from '~/constants';
 
 function genId() {
 	return Number( uniqueId() );

--- a/js/src/components/paid-ads/validateAssetGroup.js
+++ b/js/src/components/paid-ads/validateAssetGroup.js
@@ -6,8 +6,8 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import getCharacterCounter from '.~/utils/getCharacterCounter';
-import { ASSET_FORM_KEY } from '.~/constants';
+import getCharacterCounter from '~/utils/getCharacterCounter';
+import { ASSET_FORM_KEY } from '~/constants';
 import {
 	ASSET_IMAGE_SPECS,
 	ASSET_TEXT_SPECS,
@@ -15,7 +15,7 @@ import {
 } from './assetSpecs';
 
 /**
- * @typedef {import('.~/components/types.js').AssetGroupFormValues} AssetGroupFormValues
+ * @typedef {import('~/components/types.js').AssetGroupFormValues} AssetGroupFormValues
  */
 
 /**

--- a/js/src/components/paid-ads/validateAssetGroup.test.js
+++ b/js/src/components/paid-ads/validateAssetGroup.test.js
@@ -7,7 +7,7 @@ import {
 	ASSET_TEXT_SPECS,
 	ASSET_DISPLAY_URL_PATH_SPECS,
 } from './assetSpecs';
-import { ASSET_FORM_KEY } from '.~/constants';
+import { ASSET_FORM_KEY } from '~/constants';
 
 /**
  * `validateAssetGroup` function returns an object, and if any checks are not passed,

--- a/js/src/components/paid-ads/validateCampaign.js
+++ b/js/src/components/paid-ads/validateCampaign.js
@@ -4,7 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
- * @typedef {import('.~/components/types.js').CampaignFormValues} CampaignFormValues
+ * @typedef {import('~/components/types.js').CampaignFormValues} CampaignFormValues
  */
 
 /**

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/estimated-shipping-rates-card.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/estimated-shipping-rates-card.js
@@ -7,19 +7,19 @@ import GridiconPlusSmall from 'gridicons/dist/plus-small';
 /**
  * Internal dependencies
  */
-import Section from '.~/wcdl/section';
-import AppButton from '.~/components/app-button';
-import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import useStoreCurrency from '.~/hooks/useStoreCurrency';
+import Section from '~/wcdl/section';
+import AppButton from '~/components/app-button';
+import AppButtonModalTrigger from '~/components/app-button-modal-trigger';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
+import useStoreCurrency from '~/hooks/useStoreCurrency';
 import groupShippingRatesByCurrencyRate from './groupShippingRatesByCurrencyRate';
 import ShippingRateInputControl from './shipping-rate-input-control';
 import { AddRateFormModal } from './rate-form-modals';
 import getHandlers from './getHandlers';
 
 /**
- * @typedef { import(".~/data/actions").ShippingRate } ShippingRate
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").ShippingRate } ShippingRate
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  */
 
 /**

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/getHandlers.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/getHandlers.js
@@ -1,11 +1,11 @@
 /**
  * Internal dependencies
  */
-import isNonFreeShippingRate from '.~/utils/isNonFreeShippingRate';
+import isNonFreeShippingRate from '~/utils/isNonFreeShippingRate';
 
 /**
- * @typedef { import(".~/data/actions").ShippingRate } ShippingRate
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").ShippingRate } ShippingRate
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  * @typedef { import("./typedefs").ShippingRateGroup } ShippingRateGroup
  */
 

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/groupShippingRatesByCurrencyRate.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/groupShippingRatesByCurrencyRate.js
@@ -1,5 +1,5 @@
 /**
- * @typedef { import(".~/data/actions").ShippingRate } ShippingRate
+ * @typedef { import("~/data/actions").ShippingRate } ShippingRate
  * @typedef { import("./typedefs").ShippingRateGroup } ShippingRateGroup
  */
 

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/add-rate-form-modal.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/add-rate-form-modal.js
@@ -7,11 +7,11 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 import RateFormModal from './rate-form-modal';
 
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  * @typedef { import("../typedefs.js").ShippingRateGroup } ShippingRateGroup
  */
 

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/edit-rate-form-modal.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/edit-rate-form-modal.js
@@ -7,11 +7,11 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 import RateFormModal from './rate-form-modal';
 
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  * @typedef { import("../typedefs.js").ShippingRateGroup } ShippingRateGroup
  */
 

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/rate-form-modal.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/rate-form-modals/rate-form-modal.js
@@ -10,14 +10,14 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import validateShippingRateGroup from './validateShippingRateGroup';
-import AppModal from '.~/components/app-modal';
-import AppInputPriceControl from '.~/components/app-input-price-control';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import SupportedCountrySelect from '.~/components/supported-country-select';
+import AppModal from '~/components/app-modal';
+import AppInputPriceControl from '~/components/app-input-price-control';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
+import SupportedCountrySelect from '~/components/supported-country-select';
 
 /**
- * @typedef { import(".~/components/app-button").default } AppButton
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/components/app-button").default } AppButton
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  * @typedef { import("../typedefs.js").ShippingRateGroup } ShippingRateGroup
  */
 

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/shipping-rate-input-control-label-text.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/shipping-rate-input-control-label-text.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 
-import CountryNamesPlusMore from '.~/components/country-names-plus-more';
+import CountryNamesPlusMore from '~/components/country-names-plus-more';
 
 const ShippingRateInputControlLabelText = ( props ) => {
 	const { countries } = props;

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/shipping-rate-input-control.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/shipping-rate-input-control.js
@@ -7,16 +7,16 @@ import { Pill } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import AppInputPriceControl from '.~/components/app-input-price-control';
-import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
-import AppButton from '.~/components/app-button';
+import AppInputPriceControl from '~/components/app-input-price-control';
+import AppButtonModalTrigger from '~/components/app-button-modal-trigger';
+import AppButton from '~/components/app-button';
 import { EditRateFormModal } from './rate-form-modals';
 import ShippingRateInputControlLabelText from './shipping-rate-input-control-label-text';
 import './shipping-rate-input-control.scss';
 
 /**
  * @typedef { import("./typedefs").ShippingRateGroup } ShippingRateGroup
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  */
 
 /**

--- a/js/src/components/shipping-rate-section/estimated-shipping-rates-card/typedefs.js
+++ b/js/src/components/shipping-rate-section/estimated-shipping-rates-card/typedefs.js
@@ -1,5 +1,5 @@
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  */
 
 /**

--- a/js/src/components/shipping-rate-section/flat-shipping-rates-input-cards.js
+++ b/js/src/components/shipping-rate-section/flat-shipping-rates-input-cards.js
@@ -4,7 +4,7 @@
 import {
 	useAdaptiveFormContext,
 	useAdaptiveFormInputProps,
-} from '.~/components/adaptive-form';
+} from '~/components/adaptive-form';
 import EstimatedShippingRatesCard from './estimated-shipping-rates-card';
 
 const FlatShippingRatesInputCards = () => {

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -7,15 +7,15 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useAdaptiveFormContext } from '.~/components/adaptive-form';
-import Section from '.~/wcdl/section';
-import AppRadioContentControl from '.~/components/app-radio-content-control';
-import RadioHelperText from '.~/wcdl/radio-helper-text';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import Section from '~/wcdl/section';
+import AppRadioContentControl from '~/components/app-radio-content-control';
+import RadioHelperText from '~/wcdl/radio-helper-text';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
 import FlatShippingRatesInputCards from './flat-shipping-rates-input-cards';
-import useSettings from '.~/components/free-listings/configure-product-listings/useSettings';
-import useMCSetup from '.~/hooks/useMCSetup';
+import useSettings from '~/components/free-listings/configure-product-listings/useSettings';
+import useMCSetup from '~/hooks/useMCSetup';
 
 /**
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`

--- a/js/src/components/shipping-rate-section/shipping-rate-section.test.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.test.js
@@ -7,14 +7,14 @@ import { render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import useSettings from '.~/components/free-listings/configure-product-listings/useSettings';
-import useMCSetup from '.~/hooks/useMCSetup';
+import useSettings from '~/components/free-listings/configure-product-listings/useSettings';
+import useMCSetup from '~/hooks/useMCSetup';
 import ShippingRateSection from './shipping-rate-section';
 //import FlatShippingRatesInputCards from './flat-shipping-rates-input-cards';
 
 jest.mock( './flat-shipping-rates-input-cards', () => () => <></> );
 
-jest.mock( '.~/components/adaptive-form', () => ( {
+jest.mock( '~/components/adaptive-form', () => ( {
 	useAdaptiveFormContext: jest
 		.fn()
 		.mockName( 'useAdaptiveFormContext' )
@@ -48,9 +48,9 @@ jest.mock( '.~/components/adaptive-form', () => ( {
 } ) );
 
 jest.mock(
-	'.~/components/free-listings/configure-product-listings/useSettings'
+	'~/components/free-listings/configure-product-listings/useSettings'
 );
-jest.mock( '.~/hooks/useMCSetup' );
+jest.mock( '~/hooks/useMCSetup' );
 
 describe( 'ShippingRateSection', () => {
 	it( 'shouldnt render automatic rates if there are not shipping rates and it is onboarding', () => {

--- a/js/src/components/shipping-time-input-control-label-text.js
+++ b/js/src/components/shipping-time-input-control-label-text.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 
-import CountryNamesPlusMore from '.~/components/country-names-plus-more';
+import CountryNamesPlusMore from '~/components/country-names-plus-more';
 
 const ShippingTimeInputControlLabelText = ( props ) => {
 	const { countries } = props;

--- a/js/src/components/spinner-card/index.js
+++ b/js/src/components/spinner-card/index.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import AppSpinner from '.~/components/app-spinner';
-import Section from '.~/wcdl/section';
+import AppSpinner from '~/components/app-spinner';
+import Section from '~/wcdl/section';
 
 const SpinnerCard = () => {
 	return (

--- a/js/src/components/stepper/step-content-footer/index.js
+++ b/js/src/components/stepper/step-content-footer/index.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import Section from '.~/wcdl/section';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
+import Section from '~/wcdl/section';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
 
 const StepContentFooter = ( { children } ) => {
 	return (

--- a/js/src/components/stepper/top-bar/index.js
+++ b/js/src/components/stepper/top-bar/index.js
@@ -15,7 +15,7 @@ import './index.scss';
  *
  * @param {Object} props
  * @param {string} props.title Title to indicate where the user is at.
- * @param {import(".~/components/app-button").default} props.helpButton Help button
+ * @param {import("~/components/app-button").default} props.helpButton Help button
  * @param {string} props.backHref Href for the back button.
  * @param {Function} props.onBackButtonClick
  */

--- a/js/src/components/supported-country-select/supported-country-select.js
+++ b/js/src/components/supported-country-select/supported-country-select.js
@@ -8,12 +8,12 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import TreeSelectControl from '.~/components/tree-select-control';
+import TreeSelectControl from '~/components/tree-select-control';
 import useMCCountryTreeOptions from './useMCCountryTreeOptions';
 import './supported-country-select.scss';
 
 /**
- * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ * @typedef {import('~/data/actions').CountryCode} CountryCode
  */
 
 /**

--- a/js/src/components/supported-country-select/useMCCountryTreeOptions.js
+++ b/js/src/components/supported-country-select/useMCCountryTreeOptions.js
@@ -6,11 +6,11 @@ import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
 
 /**
- * @typedef {import('.~/data/actions').CountryCode} CountryCode
- * @typedef {import('.~/components/tree-select-control').Option} Option
+ * @typedef {import('~/data/actions').CountryCode} CountryCode
+ * @typedef {import('~/components/tree-select-control').Option} Option
  */
 
 const EMPTY_ARRAY = [];

--- a/js/src/components/tours/campaign-assets-tour.js
+++ b/js/src/components/tours/campaign-assets-tour.js
@@ -8,7 +8,7 @@ import GridiconTrending from 'gridicons/dist/trending';
 /**
  * Internal dependencies
  */
-import useTour from '.~/hooks/useTour';
+import useTour from '~/hooks/useTour';
 import './campaign-assets-tour.scss';
 
 const TOUR_ID = 'dashboard-feature--campaign-assets';

--- a/js/src/components/tours/rebranding-tour.js
+++ b/js/src/components/tours/rebranding-tour.js
@@ -8,7 +8,7 @@ import { TourKit } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import useTour from '.~/hooks/useTour';
+import useTour from '~/hooks/useTour';
 import './rebranding-tour.scss';
 
 const TOUR_ID = 'rebranding-tour';

--- a/js/src/components/trackable-link/index.js
+++ b/js/src/components/trackable-link/index.js
@@ -6,7 +6,7 @@ import { Link } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import { recordGlaEvent } from '.~/utils/tracks';
+import { recordGlaEvent } from '~/utils/tracks';
 
 /**
  * A {@link module:@woocommerce/components~Link} component that will call `recordGlaEvent` with `eventName` and `eventProps` parameters upon click.

--- a/js/src/components/tree-select-control/control.test.js
+++ b/js/src/components/tree-select-control/control.test.js
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 /**
  * Internal dependencies
  */
-import Control from '.~/components/tree-select-control/control';
+import Control from '~/components/tree-select-control/control';
 
 describe( 'TreeSelectControl - Control Component', () => {
 	const onTagsChange = jest.fn().mockName( 'onTagsChange' );

--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -14,7 +14,7 @@ import {
 /**
  * Internal dependencies
  */
-import useIsEqualRefValue from '.~/hooks/useIsEqualRefValue';
+import useIsEqualRefValue from '~/hooks/useIsEqualRefValue';
 import Control from './control';
 import Options from './options';
 import './index.scss';

--- a/js/src/components/tree-select-control/options.js
+++ b/js/src/components/tree-select-control/options.js
@@ -10,7 +10,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import { ARROW_LEFT, ARROW_RIGHT, ROOT_VALUE } from './constants';
-import Checkbox from '.~/components/tree-select-control/checkbox';
+import Checkbox from '~/components/tree-select-control/checkbox';
 
 /**
  * @typedef {import('./index').InnerOption} InnerOption

--- a/js/src/components/tree-select-control/tags.js
+++ b/js/src/components/tree-select-control/tags.js
@@ -8,7 +8,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 
 /**
  * A list of tags to display selected items.

--- a/js/src/components/tree-select-control/tags.test.js
+++ b/js/src/components/tree-select-control/tags.test.js
@@ -6,7 +6,7 @@ import { fireEvent, render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import Tags from '.~/components/tree-select-control/tags';
+import Tags from '~/components/tree-select-control/tags';
 
 const tags = [
 	{ id: 'ES', label: 'Spain' },

--- a/js/src/components/types.js
+++ b/js/src/components/types.js
@@ -1,5 +1,5 @@
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  */
 
 /**

--- a/js/src/components/wpcom-account-card/connect-wpcom-account-card.js
+++ b/js/src/components/wpcom-account-card/connect-wpcom-account-card.js
@@ -7,12 +7,12 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
-import { API_NAMESPACE } from '.~/data/constants';
-import AppButton from '.~/components/app-button';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
+import { glaData } from '~/constants';
+import { API_NAMESPACE } from '~/data/constants';
+import AppButton from '~/components/app-button';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 
 /**
  * Clicking on the button to connect WordPress.com account.

--- a/js/src/components/wpcom-account-card/connected-wpcom-account-card.js
+++ b/js/src/components/wpcom-account-card/connected-wpcom-account-card.js
@@ -1,9 +1,9 @@
 /**
  * Internal dependencies
  */
-import getConnectedJetpackInfo from '.~/utils/getConnectedJetpackInfo';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import ConnectedIconLabel from '.~/components/connected-icon-label';
+import getConnectedJetpackInfo from '~/utils/getConnectedJetpackInfo';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import ConnectedIconLabel from '~/components/connected-icon-label';
 
 const ConnectedWPComAccountCard = ( { jetpack } ) => {
 	return (

--- a/js/src/css/shared/_woocommerce-admin.scss
+++ b/js/src/css/shared/_woocommerce-admin.scss
@@ -1,4 +1,4 @@
-// Used in .~/hooks/useLayout.js
+// Used in ~/hooks/useLayout.js
 .gla-full-content {
 	// #wpbody `margin-top` style is set onto DOM node directly in WC Admin.
 	// Here force override it to 0.
@@ -29,7 +29,7 @@
 	}
 }
 
-// Used in .~/hooks/useLayout.js
+// Used in ~/hooks/useLayout.js
 .gla-full-page {
 	// hack to fix the margin-top when width is between 600px and 782px.
 	// without this, the margin-top would be -32px,

--- a/js/src/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal/index.js
+++ b/js/src/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal/index.js
@@ -7,11 +7,11 @@ import { getHistory } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
-import AppButton from '.~/components/app-button';
-import AppModal from '.~/components/app-modal';
-import { getEditFreeListingsUrl, getEditCampaignUrl } from '.~/utils/urls';
-import { recordGlaEvent } from '.~/utils/tracks';
+import { FREE_LISTINGS_PROGRAM_ID } from '~/constants';
+import AppButton from '~/components/app-button';
+import AppModal from '~/components/app-modal';
+import { getEditFreeListingsUrl, getEditCampaignUrl } from '~/utils/urls';
+import { recordGlaEvent } from '~/utils/tracks';
 import './index.scss';
 
 /**

--- a/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
+++ b/js/src/dashboard/all-programs-table-card/edit-program-button/index.js
@@ -7,9 +7,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 import EditProgramPromptModal from './edit-program-prompt-modal';
-import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
+import AppButtonModalTrigger from '~/components/app-button-modal-trigger';
 
 const EditProgramButton = ( props ) => {
 	const { className, programId, ...buttonProps } = props;

--- a/js/src/dashboard/all-programs-table-card/free-listings-disabled-toggle.js
+++ b/js/src/dashboard/all-programs-table-card/free-listings-disabled-toggle.js
@@ -7,8 +7,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import './index.scss';
-import AppStandaloneToggleControl from '.~/components/app-standalone-toggle-control';
-import AppTooltip from '.~/components/app-tooltip';
+import AppStandaloneToggleControl from '~/components/app-standalone-toggle-control';
+import AppTooltip from '~/components/app-tooltip';
 
 const FreeListingsDisabledToggle = () => {
 	return (

--- a/js/src/dashboard/all-programs-table-card/index.js
+++ b/js/src/dashboard/all-programs-table-card/index.js
@@ -8,20 +8,20 @@ import { getQuery, onQueryChange } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import AppTableCard from '.~/components/app-table-card';
+import AppTableCard from '~/components/app-table-card';
 import RemoveProgramButton from './remove-program-button';
 import EditProgramButton from './edit-program-button';
 import './index.scss';
-import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
-import useCountryKeyNameMap from '.~/hooks/useCountryKeyNameMap';
-import useAdsCurrency from '.~/hooks/useAdsCurrency';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
-import AppSpinner from '.~/components/app-spinner';
-import { FREE_LISTINGS_PROGRAM_ID, CAMPAIGN_TYPE_PMAX } from '.~/constants';
-import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
+import useAdsCampaigns from '~/hooks/useAdsCampaigns';
+import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
+import useAdsCurrency from '~/hooks/useAdsCurrency';
+import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
+import AppSpinner from '~/components/app-spinner';
+import { FREE_LISTINGS_PROGRAM_ID, CAMPAIGN_TYPE_PMAX } from '~/constants';
+import AddPaidCampaignButton from '~/components/paid-ads/add-paid-campaign-button';
 import ProgramToggle from './program-toggle';
 import FreeListingsDisabledToggle from './free-listings-disabled-toggle';
-import CampaignAssetsTour from '.~/components/tours/campaign-assets-tour';
+import CampaignAssetsTour from '~/components/tours/campaign-assets-tour';
 
 const PROGRAMS_TABLE_CARD_CLASS_NAME = 'gla-all-programs-table-card';
 const CAMPAIGN_EDIT_BUTTON_CLASS_NAME = 'gla-campaign-edit-button';

--- a/js/src/dashboard/all-programs-table-card/index.test.js
+++ b/js/src/dashboard/all-programs-table-card/index.test.js
@@ -8,38 +8,38 @@ import { screen, within, render } from '@testing-library/react';
  * Internal dependencies
  */
 import AllProgramsTableCard from './';
-import CampaignAssetsTour from '.~/components/tours/campaign-assets-tour';
-import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
-import useAdsCurrency from '.~/hooks/useAdsCurrency';
+import CampaignAssetsTour from '~/components/tours/campaign-assets-tour';
+import useAdsCampaigns from '~/hooks/useAdsCampaigns';
+import useAdsCurrency from '~/hooks/useAdsCurrency';
 
-jest.mock( '.~/components/tours/campaign-assets-tour', () =>
+jest.mock( '~/components/tours/campaign-assets-tour', () =>
 	jest
 		.fn()
 		.mockReturnValue( <div role="dialog" aria-label="tour" /> )
 		.mockName( 'CampaignAssetsTour' )
 );
 
-jest.mock( '.~/hooks/useCountryKeyNameMap', () =>
+jest.mock( '~/hooks/useCountryKeyNameMap', () =>
 	jest
 		.fn()
 		.mockReturnValue( { US: 'United States (US)', JP: 'Japan' } )
 		.mockName( 'useCountryKeyNameMap' )
 );
 
-jest.mock( '.~/hooks/useAdsCurrency', () =>
+jest.mock( '~/hooks/useAdsCurrency', () =>
 	jest.fn().mockReturnValue( {
 		formatAmount: jest.fn().mockName( 'formatAmount' ),
 	} )
 );
 
-jest.mock( '.~/hooks/useTargetAudienceFinalCountryCodes', () =>
+jest.mock( '~/hooks/useTargetAudienceFinalCountryCodes', () =>
 	jest
 		.fn()
 		.mockReturnValue( { data: [ 'US', 'JP' ] } )
 		.mockName( 'useTargetAudienceFinalCountryCodes' )
 );
 
-jest.mock( '.~/hooks/useAdsCampaigns', () =>
+jest.mock( '~/hooks/useAdsCampaigns', () =>
 	jest.fn().mockName( 'useAdsCampaigns' )
 );
 

--- a/js/src/dashboard/all-programs-table-card/program-toggle/index.js
+++ b/js/src/dashboard/all-programs-table-card/program-toggle/index.js
@@ -6,8 +6,8 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import PauseProgramModal from './pause-program-modal';
-import { useAppDispatch } from '.~/data';
-import AppStandaloneToggleControl from '.~/components/app-standalone-toggle-control';
+import { useAppDispatch } from '~/data';
+import AppStandaloneToggleControl from '~/components/app-standalone-toggle-control';
 
 const ProgramToggle = ( props ) => {
 	const { program } = props;

--- a/js/src/dashboard/all-programs-table-card/program-toggle/pause-program-modal/index.js
+++ b/js/src/dashboard/all-programs-table-card/program-toggle/pause-program-modal/index.js
@@ -6,8 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import AppModal from '.~/components/app-modal';
+import AppButton from '~/components/app-button';
+import AppModal from '~/components/app-modal';
 import './index.scss';
 
 /**

--- a/js/src/dashboard/all-programs-table-card/remove-program-button/index.js
+++ b/js/src/dashboard/all-programs-table-card/remove-program-button/index.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 import RemoveProgramModal from './remove-program-modal';
 
 const RemoveProgramButton = ( props ) => {

--- a/js/src/dashboard/all-programs-table-card/remove-program-button/remove-program-modal/index.js
+++ b/js/src/dashboard/all-programs-table-card/remove-program-button/remove-program-modal/index.js
@@ -7,9 +7,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppModal from '.~/components/app-modal';
-import AppButton from '.~/components/app-button';
-import { useAppDispatch } from '.~/data';
+import AppModal from '~/components/app-modal';
+import AppButton from '~/components/app-button';
+import { useAppDispatch } from '~/data';
 import './index.scss';
 
 /**

--- a/js/src/dashboard/app-date-range-filter-picker/index.js
+++ b/js/src/dashboard/app-date-range-filter-picker/index.js
@@ -8,7 +8,7 @@ import { updateQueryString } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import getDateQuery from './getDateQuery';
-import { recordGlaEvent } from '.~/utils/tracks';
+import { recordGlaEvent } from '~/utils/tracks';
 
 const isoDateFormat = 'YYYY-MM-DD';
 

--- a/js/src/dashboard/campaign-creation-success-guide/index.js
+++ b/js/src/dashboard/campaign-creation-success-guide/index.js
@@ -11,19 +11,17 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import AppModal from '.~/components/app-modal';
-import GuidePageContent, {
-	ContentLink,
-} from '.~/components/guide-page-content';
-import { GUIDE_NAMES } from '.~/constants';
-import headerImageURL from '.~/images/success-guide-header.svg';
+import AppButton from '~/components/app-button';
+import AppModal from '~/components/app-modal';
+import GuidePageContent, { ContentLink } from '~/components/guide-page-content';
+import { GUIDE_NAMES } from '~/constants';
+import headerImageURL from '~/images/success-guide-header.svg';
 import {
 	CTA_CREATE_ANOTHER_CAMPAIGN,
 	CTA_CONFIRM,
 	CTA_DISMISS,
 } from '../constants';
-import { recordGlaEvent } from '.~/utils/tracks';
+import { recordGlaEvent } from '~/utils/tracks';
 import './index.scss';
 
 /**

--- a/js/src/dashboard/index.js
+++ b/js/src/dashboard/index.js
@@ -9,23 +9,23 @@ import { getNewPath, getQuery, getHistory } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import DifferentCurrencyNotice from '.~/components/different-currency-notice';
-import MainTabNav from '.~/components/main-tab-nav';
-import CustomerEffortScorePrompt from '.~/components/customer-effort-score-prompt';
+import AppButton from '~/components/app-button';
+import DifferentCurrencyNotice from '~/components/different-currency-notice';
+import MainTabNav from '~/components/main-tab-nav';
+import CustomerEffortScorePrompt from '~/components/customer-effort-score-prompt';
 import AppDateRangeFilterPicker from './app-date-range-filter-picker';
 import SummarySection from './summary-section';
 import CampaignCreationSuccessGuide from './campaign-creation-success-guide';
 import AllProgramsTableCard from './all-programs-table-card';
-import { glaData, GUIDE_NAMES } from '.~/constants';
-import { subpaths, getCreateCampaignUrl } from '.~/utils/urls';
-import isWCTracksEnabled from '.~/utils/isWCTracksEnabled';
-import EditFreeCampaign from '.~/edit-free-campaign';
-import EditPaidAdsCampaign from '.~/pages/edit-paid-ads-campaign';
-import CreatePaidAdsCampaign from '.~/pages/create-paid-ads-campaign';
+import { glaData, GUIDE_NAMES } from '~/constants';
+import { subpaths, getCreateCampaignUrl } from '~/utils/urls';
+import isWCTracksEnabled from '~/utils/isWCTracksEnabled';
+import EditFreeCampaign from '~/edit-free-campaign';
+import EditPaidAdsCampaign from '~/pages/edit-paid-ads-campaign';
+import CreatePaidAdsCampaign from '~/pages/create-paid-ads-campaign';
 import { CTA_CREATE_ANOTHER_CAMPAIGN, CTA_CONFIRM } from './constants';
-import { recordGlaEvent } from '.~/utils/tracks';
-import RebrandingTour from '.~/components/tours/rebranding-tour';
+import { recordGlaEvent } from '~/utils/tracks';
+import RebrandingTour from '~/components/tours/rebranding-tour';
 import './index.scss';
 
 /**

--- a/js/src/dashboard/index.test.js
+++ b/js/src/dashboard/index.test.js
@@ -1,4 +1,4 @@
-jest.mock( '.~/components/tours/rebranding-tour', () =>
+jest.mock( '~/components/tours/rebranding-tour', () =>
 	jest.fn().mockReturnValue( null ).mockName( 'RebrandingTour' )
 );
 
@@ -14,18 +14,18 @@ import { getQuery } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import Dashboard from './';
-import isWCTracksEnabled from '.~/utils/isWCTracksEnabled';
-import RebrandingTour from '.~/components/tours/rebranding-tour';
-import { GUIDE_NAMES } from '.~/constants';
+import isWCTracksEnabled from '~/utils/isWCTracksEnabled';
+import RebrandingTour from '~/components/tours/rebranding-tour';
+import { GUIDE_NAMES } from '~/constants';
 
-jest.mock( '.~/hooks/useGTINMigrationStatus', () =>
+jest.mock( '~/hooks/useGTINMigrationStatus', () =>
 	jest
 		.fn()
 		.mockReturnValue( [ 'completed', false, jest.fn() ] )
 		.mockName( 'useGTINMigrationStatus' )
 );
 
-jest.mock( '.~/components/different-currency-notice', () =>
+jest.mock( '~/components/different-currency-notice', () =>
 	jest.fn().mockName( 'DifferentCurrencyNotice' )
 );
 
@@ -50,13 +50,13 @@ jest.mock( '@woocommerce/navigation', () => {
 	};
 } );
 
-jest.mock( '.~/utils/isWCTracksEnabled', () => jest.fn() );
+jest.mock( '~/utils/isWCTracksEnabled', () => jest.fn() );
 
 const CAMPAIGN_CREATION_SUCCESS_GUIDE_TEXT =
 	"You've set up a Performance Max Campaign!";
 const CES_PROMPT_TEXT = 'How easy was it to create a Google Ad campaign?';
 
-jest.mock( '.~/components/customer-effort-score-prompt', () => () => (
+jest.mock( '~/components/customer-effort-score-prompt', () => () => (
 	<div>{ CES_PROMPT_TEXT }</div>
 ) );
 

--- a/js/src/dashboard/summary-section/index.js
+++ b/js/src/dashboard/summary-section/index.js
@@ -7,10 +7,10 @@ import { SummaryNumber } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import { REPORT_SOURCE_PAID, REPORT_SOURCE_FREE } from '.~/constants';
-import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
-import useAdsCurrency from '.~/hooks/useAdsCurrency';
-import useCurrencyFormat from '.~/hooks/useCurrencyFormat';
+import { REPORT_SOURCE_PAID, REPORT_SOURCE_FREE } from '~/constants';
+import useAdsCampaigns from '~/hooks/useAdsCampaigns';
+import useAdsCurrency from '~/hooks/useAdsCurrency';
+import useCurrencyFormat from '~/hooks/useCurrencyFormat';
 import usePerformance from './usePerformance';
 import PerformanceCard from './performance-card';
 import SummaryCard from './summary-card';

--- a/js/src/dashboard/summary-section/index.test.js
+++ b/js/src/dashboard/summary-section/index.test.js
@@ -7,7 +7,7 @@ import { render } from '@testing-library/react';
  * Internal dependencies
  */
 import SummarySection from './';
-import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
+import useAdsCampaigns from '~/hooks/useAdsCampaigns';
 
 // Mimic no data loaded.
 jest.mock( './usePerformance', () =>
@@ -17,13 +17,13 @@ jest.mock( './usePerformance', () =>
 		.mockReturnValue( { data: false, loaded: true } )
 );
 // Mock currency hooks not to require WooCommerce settings.
-jest.mock( '.~/hooks/useAdsCurrency', () =>
+jest.mock( '~/hooks/useAdsCurrency', () =>
 	jest.fn().mockReturnValue( {
 		formatAmount: jest.fn().mockName( 'formatAmount' ),
 	} )
 );
-jest.mock( '.~/hooks/useCurrencyFormat', () => jest.fn() );
-jest.mock( '.~/hooks/useAdsCampaigns', () =>
+jest.mock( '~/hooks/useCurrencyFormat', () => jest.fn() );
+jest.mock( '~/hooks/useAdsCampaigns', () =>
 	jest.fn().mockName( 'useAdsCampaigns' )
 );
 

--- a/js/src/dashboard/summary-section/paid-campaign-promotion-card.js
+++ b/js/src/dashboard/summary-section/paid-campaign-promotion-card.js
@@ -6,7 +6,7 @@ import { Spinner } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
 import PaidFeatures from './paid-features';
 
 function PaidCampaignPromotionCard() {

--- a/js/src/dashboard/summary-section/paid-features/free-ad-credit.js
+++ b/js/src/dashboard/summary-section/paid-features/free-ad-credit.js
@@ -8,7 +8,7 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppDocumentationLink from '.~/components/app-documentation-link';
+import AppDocumentationLink from '~/components/app-documentation-link';
 
 /**
  * Render the Free Ads Credit inside the Paid Features component.

--- a/js/src/dashboard/summary-section/paid-features/index.js
+++ b/js/src/dashboard/summary-section/paid-features/index.js
@@ -9,11 +9,11 @@ import GridiconCheckmark from 'gridicons/dist/checkmark';
 /**
  * Internal dependencies
  */
-import { ContentLink } from '.~/components/guide-page-content';
-import CampaignPreview from '.~/components/paid-ads/campaign-preview';
-import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
+import { ContentLink } from '~/components/guide-page-content';
+import CampaignPreview from '~/components/paid-ads/campaign-preview';
+import AddPaidCampaignButton from '~/components/paid-ads/add-paid-campaign-button';
 import FreeAdCredit from './free-ad-credit';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
 import './index.scss';
 
 function FeatureList() {

--- a/js/src/dashboard/summary-section/performance-card.js
+++ b/js/src/dashboard/summary-section/performance-card.js
@@ -5,7 +5,7 @@ import { SummaryList, SummaryListPlaceholder } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 
 /**
  * @typedef {import('@woocommerce/components').SummaryNumber} SummaryNumber

--- a/js/src/dashboard/summary-section/performance-card.test.js
+++ b/js/src/dashboard/summary-section/performance-card.test.js
@@ -6,7 +6,7 @@ import { render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import PerformanceCard from '.~/dashboard/summary-section/performance-card';
+import PerformanceCard from '~/dashboard/summary-section/performance-card';
 
 describe( 'Performance Card', () => {
 	it( 'Renders given no data message', () => {

--- a/js/src/dashboard/summary-section/summary-card.js
+++ b/js/src/dashboard/summary-section/summary-card.js
@@ -6,7 +6,7 @@ import { Card, CardHeader } from '@wordpress/components';
  * Internal dependencies
  */
 import './summary-card.scss';
-import Text from '.~/components/app-text';
+import Text from '~/components/app-text';
 
 /**
  * Returns a Card with the given content.

--- a/js/src/dashboard/summary-section/usePerformance.js
+++ b/js/src/dashboard/summary-section/usePerformance.js
@@ -6,9 +6,9 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data/constants';
-import { mapReportFieldsToPerformance } from '.~/data/utils';
-import useUrlQuery from '.~/hooks/useUrlQuery';
+import { STORE_KEY } from '~/data/constants';
+import { mapReportFieldsToPerformance } from '~/data/utils';
+import useUrlQuery from '~/hooks/useUrlQuery';
 
 /**
  * Get performance results by program type.
@@ -58,5 +58,5 @@ export default function usePerformance( type ) {
  */
 
 /**
- * @typedef { import(".~/data/utils").PerformanceData } PerformanceData
+ * @typedef { import("~/data/utils").PerformanceData } PerformanceData
  */

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -13,12 +13,12 @@ import {
 	REQUEST_ACTIONS,
 	EMPTY_ASSET_ENTITY_GROUP,
 } from './constants';
-import { handleApiError } from '.~/utils/handleError';
+import { handleApiError } from '~/utils/handleError';
 import { adaptAdsCampaign } from './adapters';
-import { isWCIos, isWCAndroid } from '.~/utils/isMobileApp';
+import { isWCIos, isWCAndroid } from '~/utils/isMobileApp';
 
 /**
- * @typedef {import('.~/data/types.js').AssetEntityGroupUpdateBody} AssetEntityGroupUpdateBody
+ * @typedef {import('~/data/types.js').AssetEntityGroupUpdateBody} AssetEntityGroupUpdateBody
  * @typedef {import('./selectors').Tour} Tour
  */
 

--- a/js/src/data/adapters.js
+++ b/js/src/data/adapters.js
@@ -1,12 +1,12 @@
 /**
  * Internal dependencies
  */
-import { ASSET_TEXT_SPECS } from '.~/components/paid-ads/assetSpecs';
-import getCharacterCounter from '.~/utils/getCharacterCounter';
+import { ASSET_TEXT_SPECS } from '~/components/paid-ads/assetSpecs';
+import getCharacterCounter from '~/utils/getCharacterCounter';
 
 /**
- * @typedef {import('.~/data/actions').Campaign} Campaign
- * @typedef {import('.~/data/types.js').AssetEntityGroup} AssetEntityGroup
+ * @typedef {import('~/data/actions').Campaign} Campaign
+ * @typedef {import('~/data/types.js').AssetEntityGroup} AssetEntityGroup
  */
 
 /**

--- a/js/src/data/adapters.test.js
+++ b/js/src/data/adapters.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { adaptAssetGroup } from './adapters';
-import { ASSET_KEY } from '.~/constants';
+import { ASSET_KEY } from '~/constants';
 
 describe( 'adaptAssetGroup', () => {
 	describe( 'Adapts the order of the multi-value text assets', () => {

--- a/js/src/data/constants.js
+++ b/js/src/data/constants.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { ASSET_GROUP_KEY } from '.~/constants';
+import { ASSET_GROUP_KEY } from '~/constants';
 
 export const STORE_KEY = 'wc/gla';
 export const API_NAMESPACE = '/wc/gla';

--- a/js/src/data/index.js
+++ b/js/src/data/index.js
@@ -8,7 +8,7 @@ import { getHistory } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
+import { glaData } from '~/constants';
 import { STORE_KEY } from './constants';
 import * as actions from './actions';
 import * as selectors from './selectors';
@@ -16,7 +16,7 @@ import * as resolvers from './resolvers';
 import { controls } from './controls';
 import reducer from './reducer';
 import { createErrorResponseCatcher } from './apiFetchMiddlewares';
-import { getReconnectAccountUrl } from '.~/utils/urls';
+import { getReconnectAccountUrl } from '~/utils/urls';
 
 registerStore( STORE_KEY, {
 	actions,

--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -12,11 +12,11 @@ import {
 	REPORT_SOURCE_PAID,
 	REPORT_SOURCE_FREE,
 	ISSUE_TYPE_ACCOUNT,
-} from '.~/constants';
+} from '~/constants';
 import TYPES from './action-types';
 import { API_NAMESPACE } from './constants';
 import { getReportKey, getCountryCodesKey } from './utils';
-import { handleApiError } from '.~/utils/handleError';
+import { handleApiError } from '~/utils/handleError';
 import { adaptAdsCampaign, adaptAssetGroup } from './adapters';
 import { fetchWithHeaders, awaitPromise } from './controls';
 
@@ -50,7 +50,7 @@ import {
 } from './actions';
 
 /**
- * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ * @typedef {import('~/data/actions').CountryCode} CountryCode
  */
 
 export function* getShippingRates() {

--- a/js/src/data/selectors.js
+++ b/js/src/data/selectors.js
@@ -16,9 +16,9 @@ import {
 } from './utils';
 
 /**
- * @typedef {import('.~/data/actions').CountryCode} CountryCode
- * @typedef {import('.~/data/types.js').GeneralState} GeneralState
- * @typedef {import('.~/data/types.js').AssetEntityGroup} AssetEntityGroup
+ * @typedef {import('~/data/actions').CountryCode} CountryCode
+ * @typedef {import('~/data/types.js').GeneralState} GeneralState
+ * @typedef {import('~/data/types.js').AssetEntityGroup} AssetEntityGroup
  */
 
 /**
@@ -146,7 +146,7 @@ export const getTargetAudience = ( state ) => {
 };
 
 /**
- * @typedef {import('.~/data/actions').Campaign} Campaign
+ * @typedef {import('~/data/actions').Campaign} Campaign
  */
 
 /**
@@ -183,7 +183,7 @@ export const getMCSetup = ( state ) => {
 };
 
 /**
- * @typedef {import('.~/data/actions').ProductStatistics } ProductStatistics
+ * @typedef {import('~/data/actions').ProductStatistics } ProductStatistics
  */
 
 /**

--- a/js/src/data/test/createAdsCampaign.test.js
+++ b/js/src/data/test/createAdsCampaign.test.js
@@ -7,7 +7,7 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
+import { useAppDispatch } from '~/data';
 
 jest.mock( '@wordpress/api-fetch', () => {
 	const impl = jest.fn().mockName( '@wordpress/api-fetch' );

--- a/js/src/data/test/disconnectAllAccounts.test.js
+++ b/js/src/data/test/disconnectAllAccounts.test.js
@@ -7,8 +7,8 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import { API_NAMESPACE } from '.~/data/constants';
+import { useAppDispatch } from '~/data';
+import { API_NAMESPACE } from '~/data/constants';
 
 jest.mock( '@wordpress/api-fetch', () => {
 	const impl = jest.fn().mockName( '@wordpress/api-fetch' );
@@ -16,8 +16,8 @@ jest.mock( '@wordpress/api-fetch', () => {
 	return impl;
 } );
 
-jest.mock( '.~/utils/handleError', () => {
-	const impl = jest.fn().mockName( '.~/utils/handleError' );
+jest.mock( '~/utils/handleError', () => {
+	const impl = jest.fn().mockName( '~/utils/handleError' );
 	return {
 		handleApiError: impl,
 	};

--- a/js/src/data/utils.js
+++ b/js/src/data/utils.js
@@ -7,10 +7,10 @@ import { getCurrentDates } from '@woocommerce/date';
 /**
  * Internal dependencies
  */
-import round from '.~/utils/round';
+import round from '~/utils/round';
 
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  */
 
 export const freeFields = [ 'clicks', 'impressions' ];

--- a/js/src/edit-free-campaign/hasUnsavedShippingRates.js
+++ b/js/src/edit-free-campaign/hasUnsavedShippingRates.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import getDifferentShippingRates from '.~/utils/getDifferentShippingRates';
+import getDifferentShippingRates from '~/utils/getDifferentShippingRates';
 
 /**
- * @typedef {import('.~/data/actions').ShippingRate} ShippingRate
+ * @typedef {import('~/data/actions').ShippingRate} ShippingRate
  */
 
 /**

--- a/js/src/edit-free-campaign/index.js
+++ b/js/src/edit-free-campaign/index.js
@@ -9,23 +9,23 @@ import { isEqual } from 'lodash';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import TopBar from '.~/components/stepper/top-bar';
-import SetupFreeListings from '.~/components/free-listings/setup-free-listings';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
-import useSettings from '.~/components/free-listings/configure-product-listings/useSettings';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import useLayout from '.~/hooks/useLayout';
-import useNavigateAwayPromptEffect from '.~/hooks/useNavigateAwayPromptEffect';
-import useShippingRates from '.~/hooks/useShippingRates';
-import useShippingTimes from '.~/hooks/useShippingTimes';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import HelpIconButton from '.~/components/help-icon-button';
+import { useAppDispatch } from '~/data';
+import TopBar from '~/components/stepper/top-bar';
+import SetupFreeListings from '~/components/free-listings/setup-free-listings';
+import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
+import useSettings from '~/components/free-listings/configure-product-listings/useSettings';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import useLayout from '~/hooks/useLayout';
+import useNavigateAwayPromptEffect from '~/hooks/useNavigateAwayPromptEffect';
+import useShippingRates from '~/hooks/useShippingRates';
+import useShippingTimes from '~/hooks/useShippingTimes';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import HelpIconButton from '~/components/help-icon-button';
 import hasUnsavedShippingRates from './hasUnsavedShippingRates';
-import useSaveShippingRates from '.~/hooks/useSaveShippingRates';
-import useSaveShippingTimes from '.~/hooks/useSaveShippingTimes';
-import createErrorMessageForRejectedPromises from '.~/utils/createErrorMessageForRejectedPromises';
-import { recordGlaEvent } from '.~/utils/tracks';
+import useSaveShippingRates from '~/hooks/useSaveShippingRates';
+import useSaveShippingTimes from '~/hooks/useSaveShippingTimes';
+import createErrorMessageForRejectedPromises from '~/utils/createErrorMessageForRejectedPromises';
+import { recordGlaEvent } from '~/utils/tracks';
 
 /**
  * Saving changes to the free campaign.

--- a/js/src/external-components/woocommerce/compare-filter/index.js
+++ b/js/src/external-components/woocommerce/compare-filter/index.js
@@ -24,7 +24,7 @@ import { CompareButton, Search } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import Text from '.~/components/app-text';
+import Text from '~/components/app-text';
 
 export { CompareButton };
 

--- a/js/src/get-started-page/benefits-card/index.js
+++ b/js/src/get-started-page/benefits-card/index.js
@@ -7,8 +7,8 @@ import { Card, CardBody, FlexItem } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import benefitsImageURL from '.~/images/get-started/benefits.png';
-import Text from '.~/components/app-text';
+import benefitsImageURL from '~/images/get-started/benefits.png';
+import Text from '~/components/app-text';
 import './index.scss';
 
 const BenefitsCard = () => {

--- a/js/src/get-started-page/customer-quotes-card/index.js
+++ b/js/src/get-started-page/customer-quotes-card/index.js
@@ -8,8 +8,8 @@ import { Flex, FlexBlock, Card, CardHeader } from '@wordpress/components';
  * Internal dependencies
  */
 import './index.scss';
-import quoteImageURL from '.~/images/get-started/img-quote.svg';
-import Text from '.~/components/app-text';
+import quoteImageURL from '~/images/get-started/img-quote.svg';
+import Text from '~/components/app-text';
 
 const Quote = ( { quote, name } ) => {
 	return (

--- a/js/src/get-started-page/faqs/index.js
+++ b/js/src/get-started-page/faqs/index.js
@@ -7,8 +7,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import FaqsPanel from '.~/components/faqs-panel';
-import AppDocumentationLink from '.~/components/app-documentation-link';
+import FaqsPanel from '~/components/faqs-panel';
+import AppDocumentationLink from '~/components/app-documentation-link';
 import './index.scss';
 
 const linkMc = (

--- a/js/src/get-started-page/features-card/index.js
+++ b/js/src/get-started-page/features-card/index.js
@@ -8,11 +8,11 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import freeListingsImageURL from '.~/images/get-started/img-free-listings.svg';
-import productPromotionImageURL from '.~/images/get-started/img-product-promotion.svg';
-import dashboardImageURL from '.~/images/get-started/img-dashboard.svg';
-import Text from '.~/components/app-text';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import freeListingsImageURL from '~/images/get-started/img-free-listings.svg';
+import productPromotionImageURL from '~/images/get-started/img-product-promotion.svg';
+import dashboardImageURL from '~/images/get-started/img-dashboard.svg';
+import Text from '~/components/app-text';
 import './index.scss';
 
 const LearnMoreLink = ( { linkId, href } ) => {

--- a/js/src/get-started-page/get-started-card/index.js
+++ b/js/src/get-started-page/get-started-card/index.js
@@ -8,13 +8,13 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import motivationImageURL from '.~/images/get-started/motivation.svg';
+import { glaData } from '~/constants';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import motivationImageURL from '~/images/get-started/motivation.svg';
 import './index.scss';
-import Text from '.~/components/app-text';
-import AppButton from '.~/components/app-button';
-import { getSetupMCUrl } from '.~/utils/urls';
+import Text from '~/components/app-text';
+import AppButton from '~/components/app-button';
+import { getSetupMCUrl } from '~/utils/urls';
 
 /**
  * @fires gla_setup_mc with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started' }`.

--- a/js/src/get-started-page/get-started-with-hero-card/index.js
+++ b/js/src/get-started-page/get-started-with-hero-card/index.js
@@ -8,13 +8,13 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
-import AppButton from '.~/components/app-button';
-import Text from '.~/components/app-text';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import { getSetupMCUrl } from '.~/utils/urls';
+import { glaData } from '~/constants';
+import AppButton from '~/components/app-button';
+import Text from '~/components/app-text';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import { getSetupMCUrl } from '~/utils/urls';
 import './index.scss';
-import heroUrl from '.~/images/get-started/hero.png';
+import heroUrl from '~/images/get-started/hero.png';
 
 /**
  * @fires gla_setup_mc with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started-with-hero' }`.

--- a/js/src/get-started-page/unsupported-notices/index.js
+++ b/js/src/get-started-page/unsupported-notices/index.js
@@ -10,10 +10,10 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useTargetAudience from '.~/hooks/useTargetAudience';
-import useStoreCountry from '.~/hooks/useStoreCountry';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import { glaData } from '.~/constants';
+import useTargetAudience from '~/hooks/useTargetAudience';
+import useStoreCountry from '~/hooks/useStoreCountry';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import { glaData } from '~/constants';
 import './index.scss';
 
 const ExternalIcon = () => (

--- a/js/src/hooks/useActiveIssueType.js
+++ b/js/src/hooks/useActiveIssueType.js
@@ -6,8 +6,8 @@ import { getQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '.~/constants';
-import useMCIssuesTotals from '.~/hooks/useMCIssuesTotals';
+import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '~/constants';
+import useMCIssuesTotals from '~/hooks/useMCIssuesTotals';
 
 /**
  * Gets the active Issue Type Filter based on the `issueType` query property.

--- a/js/src/hooks/useActiveIssueType.test.js
+++ b/js/src/hooks/useActiveIssueType.test.js
@@ -1,5 +1,5 @@
 jest.mock( '@woocommerce/navigation' );
-jest.mock( '.~/hooks/useMCIssuesTotals' );
+jest.mock( '~/hooks/useMCIssuesTotals' );
 
 /**
  * External dependencies
@@ -10,8 +10,8 @@ import { renderHook } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import useMCIssuesTotals from '.~/hooks/useMCIssuesTotals';
-import useActiveIssueType from '.~/hooks/useActiveIssueType';
+import useMCIssuesTotals from '~/hooks/useMCIssuesTotals';
+import useActiveIssueType from '~/hooks/useActiveIssueType';
 
 describe( 'useActiveIssueType', () => {
 	it( 'Returns "account" Issue type by default if it has issues', () => {

--- a/js/src/hooks/useAdsCampaigns.js
+++ b/js/src/hooks/useAdsCampaigns.js
@@ -6,14 +6,14 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data';
-import { glaData } from '.~/constants';
-import useIsEqualRefValue from '.~/hooks/useIsEqualRefValue';
+import { STORE_KEY } from '~/data';
+import { glaData } from '~/constants';
+import useIsEqualRefValue from '~/hooks/useIsEqualRefValue';
 
 const selectorName = 'getAdsCampaigns';
 
 /**
- * @typedef {import('.~/data/actions').Campaign} Campaign
+ * @typedef {import('~/data/actions').Campaign} Campaign
  *
  * @typedef {Object} AdsCampaignsPayload
  * @property {Array<Campaign>|null} data Current campaigns obtained from merchant's Google Ads account if connected. It will be `null` before load finished.

--- a/js/src/hooks/useAdsSetupCompleteCallback.js
+++ b/js/src/hooks/useAdsSetupCompleteCallback.js
@@ -8,8 +8,8 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import { useAppDispatch } from '~/data';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 
 export default function useAdsSetupCompleteCallback() {
 	const { createAdsCampaign } = useAppDispatch();

--- a/js/src/hooks/useApiFetchEffect.js
+++ b/js/src/hooks/useApiFetchEffect.js
@@ -6,8 +6,8 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import useIsEqualRefValue from '.~/hooks/useIsEqualRefValue';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import useIsEqualRefValue from '~/hooks/useIsEqualRefValue';
 
 /**
  * Calls apiFetch as a side effect. This uses useApiFetchCallback in a useEffect hook.

--- a/js/src/hooks/useAppSelectDispatch.js
+++ b/js/src/hooks/useAppSelectDispatch.js
@@ -7,9 +7,9 @@ import { useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data/constants';
-import { useAppDispatch } from '.~/data';
-import useIsEqualRefValue from '.~/hooks/useIsEqualRefValue';
+import { STORE_KEY } from '~/data/constants';
+import { useAppDispatch } from '~/data';
+import useIsEqualRefValue from '~/hooks/useIsEqualRefValue';
 
 const useAppSelectDispatch = ( selector, ...args ) => {
 	const { invalidateResolution } = useAppDispatch();

--- a/js/src/hooks/useAutoCreateAdsMCAccounts.js
+++ b/js/src/hooks/useAutoCreateAdsMCAccounts.js
@@ -10,12 +10,12 @@ import useGoogleAdsAccount from './useGoogleAdsAccount';
 import useExistingGoogleAdsAccounts from './useExistingGoogleAdsAccounts';
 import useGoogleMCAccount from './useGoogleMCAccount';
 import useExistingGoogleMCAccounts from './useExistingGoogleMCAccounts';
-import useUpsertAdsAccount from '.~/hooks/useUpsertAdsAccount';
+import useUpsertAdsAccount from '~/hooks/useUpsertAdsAccount';
 import {
 	CREATING_ADS_ACCOUNT,
 	CREATING_BOTH_ACCOUNTS,
 	CREATING_MC_ACCOUNT,
-} from '.~/components/google-combo-account-card/constants';
+} from '~/components/google-combo-account-card/constants';
 
 const useShouldCreateAdsAccount = () => {
 	const {

--- a/js/src/hooks/useBudgetRecommendation.js
+++ b/js/src/hooks/useBudgetRecommendation.js
@@ -6,11 +6,11 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data/constants';
-import getHighestBudget from '.~/utils/getHighestBudget';
+import { STORE_KEY } from '~/data/constants';
+import getHighestBudget from '~/utils/getHighestBudget';
 
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  */
 
 /**

--- a/js/src/hooks/useCategories.js
+++ b/js/src/hooks/useCategories.js
@@ -7,7 +7,7 @@ import { _x, __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useAppSelectDispatch from './useAppSelectDispatch';
-import { CATEGORIES_TO_SHOW_IN_TOOLTIP } from '.~/constants';
+import { CATEGORIES_TO_SHOW_IN_TOOLTIP } from '~/constants';
 
 const SEPARATOR = _x(
 	', ',

--- a/js/src/hooks/useConnectMCAccount.js
+++ b/js/src/hooks/useConnectMCAccount.js
@@ -6,9 +6,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import { useAppDispatch } from '.~/data';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import { useAppDispatch } from '~/data';
 
 const useConnectMCAccount = ( value ) => {
 	const { createNotice } = useDispatchCoreNotices();

--- a/js/src/hooks/useCreateMCAccount.js
+++ b/js/src/hooks/useCreateMCAccount.js
@@ -6,9 +6,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import { useAppDispatch } from '~/data';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 
 const useCreateMCAccount = () => {
 	const { createNotice } = useDispatchCoreNotices();

--- a/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
+++ b/js/src/hooks/useCroppedImageSelector/useCroppedImageSelector.js
@@ -10,7 +10,7 @@ import { useCallback, useRef } from '@wordpress/element';
 import './useCroppedImageSelector.scss';
 
 /**
- * @typedef {import('.~/hooks/types.js').ImageMedia} ImageMedia
+ * @typedef {import('~/hooks/types.js').ImageMedia} ImageMedia
  */
 
 /**

--- a/js/src/hooks/useEffectRemoveNotice.js
+++ b/js/src/hooks/useEffectRemoveNotice.js
@@ -7,8 +7,8 @@ import { dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import useNotices from '.~/hooks/useNotices';
-import { NOTICES_STORE_KEY } from '.~/data/constants';
+import useNotices from '~/hooks/useNotices';
+import { NOTICES_STORE_KEY } from '~/data/constants';
 
 /**
  * Search for a notice with specific label and remove it if the component is unmounted.

--- a/js/src/hooks/useEffectRemoveNotice.test.js
+++ b/js/src/hooks/useEffectRemoveNotice.test.js
@@ -7,12 +7,12 @@ import { renderHook } from '@testing-library/react';
  * Internal dependencies
  */
 import useEffectRemoveNotice from './useEffectRemoveNotice';
-import useNotices from '.~/hooks/useNotices';
-import { NOTICES_STORE_KEY } from '.~/data/constants';
+import useNotices from '~/hooks/useNotices';
+import { NOTICES_STORE_KEY } from '~/data/constants';
 
 const mockRemoveNotice = jest.fn();
 
-jest.mock( '.~/hooks/useNotices', () => {
+jest.mock( '~/hooks/useNotices', () => {
 	return jest.fn();
 } );
 

--- a/js/src/hooks/useEventPropertiesFilter.js
+++ b/js/src/hooks/useEventPropertiesFilter.js
@@ -8,7 +8,7 @@ import { pick, uniqueId } from 'lodash';
  * Internal dependencies
  */
 import useIsEqualRefValue from './useIsEqualRefValue';
-import { NAMESPACE, hooks, filterPropertiesMap } from '.~/utils/tracks';
+import { NAMESPACE, hooks, filterPropertiesMap } from '~/utils/tracks';
 
 /**
  * Hook to propagate event properties across multiple layers.

--- a/js/src/hooks/useEventPropertiesFilter.test.js
+++ b/js/src/hooks/useEventPropertiesFilter.test.js
@@ -7,7 +7,7 @@ import { renderHook } from '@testing-library/react';
  * Internal dependencies
  */
 import useEventPropertiesFilter from './useEventPropertiesFilter';
-import { filterPropertiesMap } from '.~/utils/tracks';
+import { filterPropertiesMap } from '~/utils/tracks';
 
 describe( 'useEventPropertiesFilter', () => {
 	const SETUP = 'test_filter_setup';

--- a/js/src/hooks/useExistingGoogleAdsAccounts.js
+++ b/js/src/hooks/useExistingGoogleAdsAccounts.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data/constants';
+import { STORE_KEY } from '~/data/constants';
 
 const useExistingGoogleAdsAccounts = () => {
 	return useSelect( ( select ) => {

--- a/js/src/hooks/useGTINMigrationStatus.js
+++ b/js/src/hooks/useGTINMigrationStatus.js
@@ -6,8 +6,8 @@ import { useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 
 const selectorName = 'getGtinMigrationStatus';
 

--- a/js/src/hooks/useGoogleAccount.js
+++ b/js/src/hooks/useGoogleAccount.js
@@ -6,9 +6,9 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
-import { STORE_KEY } from '.~/data/constants';
-import toScopeState from '.~/utils/toScopeState';
+import { glaData } from '~/constants';
+import { STORE_KEY } from '~/data/constants';
+import toScopeState from '~/utils/toScopeState';
 import useJetpackAccount from './useJetpackAccount';
 
 const useGoogleAccount = () => {

--- a/js/src/hooks/useGoogleAdsAccount.js
+++ b/js/src/hooks/useGoogleAdsAccount.js
@@ -7,9 +7,9 @@ import { useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data/constants';
-import { useAppDispatch } from '.~/data';
-import { GOOGLE_ADS_ACCOUNT_STATUS } from '.~/constants';
+import { STORE_KEY } from '~/data/constants';
+import { useAppDispatch } from '~/data';
+import { GOOGLE_ADS_ACCOUNT_STATUS } from '~/constants';
 import useGoogleAccount from './useGoogleAccount';
 
 const googleAdsAccountSelector = 'getGoogleAdsAccount';

--- a/js/src/hooks/useGoogleAdsAccountBillingStatus.js
+++ b/js/src/hooks/useGoogleAdsAccountBillingStatus.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data/constants';
+import { STORE_KEY } from '~/data/constants';
 
 const selectorName = 'getGoogleAdsAccountBillingStatus';
 

--- a/js/src/hooks/useGoogleAdsAccountReady.js
+++ b/js/src/hooks/useGoogleAdsAccountReady.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import useGoogleAdsAccountStatus from '.~/hooks/useGoogleAdsAccountStatus';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
 
 /**
  * Hook to check if the Google Ads account is ready.

--- a/js/src/hooks/useGoogleAdsAccountStatus.js
+++ b/js/src/hooks/useGoogleAdsAccountStatus.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data/constants';
+import { STORE_KEY } from '~/data/constants';
 
 const selectorName = 'getGoogleAdsAccountStatus';
 

--- a/js/src/hooks/useGoogleAuthorization.js
+++ b/js/src/hooks/useGoogleAuthorization.js
@@ -7,7 +7,7 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import { API_NAMESPACE } from '.~/data/constants';
+import { API_NAMESPACE } from '~/data/constants';
 import useApiFetchCallback from './useApiFetchCallback';
 
 /**

--- a/js/src/hooks/useGoogleMCAccount.js
+++ b/js/src/hooks/useGoogleMCAccount.js
@@ -6,12 +6,12 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data/constants';
+import { STORE_KEY } from '~/data/constants';
 import useGoogleAccount from './useGoogleAccount';
-import { GOOGLE_MC_ACCOUNT_STATUS } from '.~/constants';
+import { GOOGLE_MC_ACCOUNT_STATUS } from '~/constants';
 
 /**
- * @typedef {import('.~/data/selectors').GoogleMCAccount} GoogleMCAccount
+ * @typedef {import('~/data/selectors').GoogleMCAccount} GoogleMCAccount
  *
  * @typedef {Object} GoogleMCAccountPayload
  * @property {GoogleMCAccount|undefined} googleMCAccount The connection data of Google Merchant Center account associated with GLA.

--- a/js/src/hooks/useJetpackAccount.js
+++ b/js/src/hooks/useJetpackAccount.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data/constants';
+import { STORE_KEY } from '~/data/constants';
 
 const useJetpackAccount = () => {
 	return useSelect( ( select ) => {

--- a/js/src/hooks/useLayout.js
+++ b/js/src/hooks/useLayout.js
@@ -3,7 +3,7 @@
  */
 import { useEffect } from '@wordpress/element';
 
-// gla-* styles are defined in .~/css/shared/_woocommerce-admin.scss
+// gla-* styles are defined in ~/css/shared/_woocommerce-admin.scss
 const classNameDict = {
 	'full-page': [
 		'woocommerce-admin-full-screen',

--- a/js/src/hooks/useMCIssuesTotals.js
+++ b/js/src/hooks/useMCIssuesTotals.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '.~/constants';
-import useMCIssuesTypeFilter from '.~/hooks/useMCIssuesTypeFilter';
+import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '~/constants';
+import useMCIssuesTypeFilter from '~/hooks/useMCIssuesTypeFilter';
 
 const getTotal = ( issueTypes ) => {
 	const total = Object.values( issueTypes ).reduce(

--- a/js/src/hooks/useMCIssuesTotals.test.js
+++ b/js/src/hooks/useMCIssuesTotals.test.js
@@ -1,4 +1,4 @@
-jest.mock( '.~/hooks/useMCIssuesTypeFilter', () => ( {
+jest.mock( '~/hooks/useMCIssuesTypeFilter', () => ( {
 	__esModule: true,
 	default: jest
 		.fn()
@@ -21,9 +21,9 @@ import { renderHook } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import useMCIssuesTotals from '.~/hooks/useMCIssuesTotals';
-import useMCIssuesTypeFilter from '.~/hooks/useMCIssuesTypeFilter';
-import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '.~/constants';
+import useMCIssuesTotals from '~/hooks/useMCIssuesTotals';
+import useMCIssuesTypeFilter from '~/hooks/useMCIssuesTypeFilter';
+import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '~/constants';
 
 describe( 'useMCIssuesTotals', () => {
 	test.each( [ ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT ] )(

--- a/js/src/hooks/useMCIssuesTypeFilter.js
+++ b/js/src/hooks/useMCIssuesTypeFilter.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { ISSUE_TYPE_ACCOUNT, ISSUE_TABLE_PER_PAGE } from '.~/constants';
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+import { ISSUE_TYPE_ACCOUNT, ISSUE_TABLE_PER_PAGE } from '~/constants';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
 
 const defaultQuery = {
 	page: 1,

--- a/js/src/hooks/useMCIssuesTypeFilter.test.js
+++ b/js/src/hooks/useMCIssuesTypeFilter.test.js
@@ -1,4 +1,4 @@
-jest.mock( '.~/hooks/useAppSelectDispatch', () => ( {
+jest.mock( '~/hooks/useAppSelectDispatch', () => ( {
 	__esModule: true,
 	default: jest
 		.fn()
@@ -19,8 +19,8 @@ import { renderHook } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
-import useMCIssuesTypeFilter from '.~/hooks/useMCIssuesTypeFilter';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
+import useMCIssuesTypeFilter from '~/hooks/useMCIssuesTypeFilter';
 
 describe( 'useMCIssuesTypeFilter', () => {
 	test( 'Calls useAppSelectDispatch with `getMCIssues` and the right parameters', async () => {

--- a/js/src/hooks/useMCProductStatistics.js
+++ b/js/src/hooks/useMCProductStatistics.js
@@ -8,8 +8,8 @@ import { useEffect, useCallback } from '@wordpress/element';
  */
 import useAppSelectDispatch from './useAppSelectDispatch';
 import useCountdown from './useCountdown';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
-import { useAppDispatch } from '.~/data';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import { useAppDispatch } from '~/data';
 
 /**
  * Call `useAppSelectDispatch` with `"getMCProductStatistics"`.

--- a/js/src/hooks/useMCProductStatistics.test.js
+++ b/js/src/hooks/useMCProductStatistics.test.js
@@ -6,16 +6,16 @@ import { renderHook } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import useMCProductStatistics from '.~/hooks/useMCProductStatistics';
-import useCountdown from '.~/hooks/useCountdown';
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
-import { useAppDispatch } from '.~/data';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
+import useMCProductStatistics from '~/hooks/useMCProductStatistics';
+import useCountdown from '~/hooks/useCountdown';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
+import { useAppDispatch } from '~/data';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 
-jest.mock( '.~/hooks/useAppSelectDispatch' );
-jest.mock( '.~/hooks/useCountdown' );
-jest.mock( '.~/data' );
-jest.mock( '.~/hooks/useApiFetchCallback', () => ( {
+jest.mock( '~/hooks/useAppSelectDispatch' );
+jest.mock( '~/hooks/useCountdown' );
+jest.mock( '~/data' );
+jest.mock( '~/hooks/useApiFetchCallback', () => ( {
 	__esModule: true,
 	default: jest.fn().mockImplementation( () => {
 		return [ jest.fn(), null ];

--- a/js/src/hooks/useMappingAttributes.js
+++ b/js/src/hooks/useMappingAttributes.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
 
 /**
  * Returns the attributes available for mapping

--- a/js/src/hooks/useMappingAttributesSources.js
+++ b/js/src/hooks/useMappingAttributesSources.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
 
 /**
  * Returns available source data based on an attribute

--- a/js/src/hooks/useMappingRules.js
+++ b/js/src/hooks/useMappingRules.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
 
 /**
  * Returns the Attribute Mapping Rules

--- a/js/src/hooks/useMenuEffect.js
+++ b/js/src/hooks/useMenuEffect.js
@@ -16,7 +16,7 @@ const dashboardPage = {
 /**
  * Effect that highlights the GLA Dashboard menu entry in the WC menu.
  *
- * Should be called for every "root page" (`.~/pages/*`) that wants to open the GLA menu.
+ * Should be called for every "root page" (`~/pages/*`) that wants to open the GLA menu.
  *
  * The hook could be removed once make the plugin fully use the routing feature of WC,
  * and let this be done by proper matching of URL matchers from {@link /js/src/index.js}

--- a/js/src/hooks/useNotices.js
+++ b/js/src/hooks/useNotices.js
@@ -6,7 +6,7 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { NOTICES_STORE_KEY } from '.~/data/constants';
+import { NOTICES_STORE_KEY } from '~/data/constants';
 
 /**
  * @typedef {import('@wordpress/notices').Notice} Notice

--- a/js/src/hooks/usePagination.test.js
+++ b/js/src/hooks/usePagination.test.js
@@ -6,7 +6,7 @@ import { renderHook, act } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import usePagination from '.~/hooks/usePagination';
+import usePagination from '~/hooks/usePagination';
 
 describe( 'usePagination', () => {
 	it( 'returns the correct default page per each paginator key', () => {

--- a/js/src/hooks/usePolling.js
+++ b/js/src/hooks/usePolling.js
@@ -7,7 +7,7 @@ import { useEffect, useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import useApiFetchCallback from './useApiFetchCallback';
-import useCountdown from '.~/hooks/useCountdown';
+import useCountdown from '~/hooks/useCountdown';
 
 /**
  * A hook for polling to an API Endpoint on intervals

--- a/js/src/hooks/useSaveShippingRates.js
+++ b/js/src/hooks/useSaveShippingRates.js
@@ -6,13 +6,13 @@ import { useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import getDifferentShippingRates from '.~/utils/getDifferentShippingRates';
-import getDeletedShippingRates from '.~/utils/getDeletedShippingRates';
+import { useAppDispatch } from '~/data';
+import getDifferentShippingRates from '~/utils/getDifferentShippingRates';
+import getDeletedShippingRates from '~/utils/getDeletedShippingRates';
 import useShippingRates from './useShippingRates';
 
 /**
- * @typedef { import(".~/data/actions").ShippingRate } ShippingRate
+ * @typedef { import("~/data/actions").ShippingRate } ShippingRate
  */
 
 const getDeleteIds = ( newShippingRates, oldShippingRates ) => {

--- a/js/src/hooks/useSaveShippingTimes.js
+++ b/js/src/hooks/useSaveShippingTimes.js
@@ -6,15 +6,15 @@ import { useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
+import { useAppDispatch } from '~/data';
 import useShippingTimes from './useShippingTimes';
-import getDeletedShippingTimes from '.~/utils/getDeletedShippingTimes';
-import getDifferentShippingTimes from '.~/utils/getDifferentShippingTimes';
-import getShippingTimeMapKey from '.~/utils/getShippingTimeMapKey';
+import getDeletedShippingTimes from '~/utils/getDeletedShippingTimes';
+import getDifferentShippingTimes from '~/utils/getDifferentShippingTimes';
+import getShippingTimeMapKey from '~/utils/getShippingTimeMapKey';
 
 /**
- * @typedef { import(".~/data/actions").ShippingTime } ShippingTime
- * @typedef { import(".~/data/actions").AggregatedShippingTime } AggregatedShippingTime
+ * @typedef { import("~/data/actions").ShippingTime } ShippingTime
+ * @typedef { import("~/data/actions").AggregatedShippingTime } AggregatedShippingTime
  */
 
 /**

--- a/js/src/hooks/useStoreAddress.js
+++ b/js/src/hooks/useStoreAddress.js
@@ -5,7 +5,7 @@ import useAppSelectDispatch from './useAppSelectDispatch';
 import useCountryKeyNameMap from './useCountryKeyNameMap';
 
 /**
- * @typedef {import('.~/hooks/types.js').StoreAddress} StoreAddress
+ * @typedef {import('~/hooks/types.js').StoreAddress} StoreAddress
  */
 
 const emptyData = {

--- a/js/src/hooks/useStoreAddressReady.js
+++ b/js/src/hooks/useStoreAddressReady.js
@@ -6,8 +6,8 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
-import { STORE_KEY } from '.~/data/constants';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+import { STORE_KEY } from '~/data/constants';
 
 /**
  * Checks if the store address is synchronized with the Merchant Center (GMC) account address.

--- a/js/src/hooks/useStoreNumberSettings.js
+++ b/js/src/hooks/useStoreNumberSettings.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import useStoreCurrency from '.~/hooks/useStoreCurrency';
+import useStoreCurrency from '~/hooks/useStoreCurrency';
 
 /**
  * Get the store's number settings, which is based on the store's currency settings.

--- a/js/src/hooks/useTargetAudienceFinalCountryCodes.js
+++ b/js/src/hooks/useTargetAudienceFinalCountryCodes.js
@@ -6,11 +6,11 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data';
-import useMCCountries from '.~/hooks/useMCCountries';
+import { STORE_KEY } from '~/data';
+import useMCCountries from '~/hooks/useMCCountries';
 
 /**
- * @typedef {import('.~/data/actions').CountryCode} CountryCode
+ * @typedef {import('~/data/actions').CountryCode} CountryCode
  */
 
 /**

--- a/js/src/hooks/useTour.js
+++ b/js/src/hooks/useTour.js
@@ -6,8 +6,8 @@ import { useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+import { useAppDispatch } from '~/data';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
 
 /**
  * @typedef {Object} TourHook

--- a/js/src/hooks/useTour.test.js
+++ b/js/src/hooks/useTour.test.js
@@ -7,11 +7,11 @@ import { renderHook } from '@testing-library/react';
  * Internal dependencies
  */
 import useTour from './useTour';
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
-import { useAppDispatch } from '.~/data';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
+import { useAppDispatch } from '~/data';
 
-jest.mock( '.~/hooks/useAppSelectDispatch' );
-jest.mock( '.~/data', () => ( {
+jest.mock( '~/hooks/useAppSelectDispatch' );
+jest.mock( '~/data', () => ( {
 	useAppDispatch: jest.fn().mockName( 'useAppDispatch' ),
 } ) );
 

--- a/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.js
+++ b/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.js
@@ -7,10 +7,10 @@ import { getQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { GOOGLE_WPCOM_APP_CONNECTED_STATUS } from '.~/constants';
-import { useAppDispatch } from '.~/data';
-import { API_NAMESPACE } from '.~/data/constants';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
+import { GOOGLE_WPCOM_APP_CONNECTED_STATUS } from '~/constants';
+import { useAppDispatch } from '~/data';
+import { API_NAMESPACE } from '~/data/constants';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 
 /**
  * A hook that calls an API to update Google WPCOM app connected status.

--- a/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.test.js
+++ b/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.test.js
@@ -8,10 +8,10 @@ import { getQuery } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import useUpdateRestAPIAuthorizeStatusByUrlQuery from './useUpdateRestAPIAuthorizeStatusByUrlQuery';
-import useApiFetchCallback from '.~/hooks/useApiFetchCallback';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 
 jest.mock( '@woocommerce/navigation' );
-jest.mock( '.~/hooks/useApiFetchCallback' );
+jest.mock( '~/hooks/useApiFetchCallback' );
 
 describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 	let fetchUpdateRestAPIAuthorize;

--- a/js/src/hooks/useUpsertAdsAccount.js
+++ b/js/src/hooks/useUpsertAdsAccount.js
@@ -7,11 +7,11 @@ import { useCallback, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import { API_NAMESPACE } from '.~/data/constants';
+import { useAppDispatch } from '~/data';
+import { API_NAMESPACE } from '~/data/constants';
 import useGoogleAdsAccount from './useGoogleAdsAccount';
 import useApiFetchCallback from './useApiFetchCallback';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 
 /**
  * Set up a Google Ads account.

--- a/js/src/hooks/useUrlQuery.js
+++ b/js/src/hooks/useUrlQuery.js
@@ -6,7 +6,7 @@ import { getQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import useIsEqualRefValue from '.~/hooks/useIsEqualRefValue';
+import useIsEqualRefValue from '~/hooks/useIsEqualRefValue';
 
 /**
  * Get a memoized URL query object.

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -12,9 +12,9 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
  * Internal dependencies
  */
 import './css/index.scss';
-import withAdminPageShell from '.~/components/withAdminPageShell';
+import withAdminPageShell from '~/components/withAdminPageShell';
 import './data';
-import { addBaseEventProperties } from '.~/utils/tracks';
+import { addBaseEventProperties } from '~/utils/tracks';
 
 const Dashboard = lazy( () =>
 	import( /* webpackChunkName: "dashboard" */ './dashboard' )

--- a/js/src/index.test.js
+++ b/js/src/index.test.js
@@ -8,7 +8,7 @@ import { dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { pagePaths } from './';
-import { STORE_KEY } from '.~/data';
+import { STORE_KEY } from '~/data';
 
 jest.mock( '@woocommerce/settings', () => ( {
 	getSetting: jest.fn().mockName( 'getSetting' ),
@@ -77,7 +77,7 @@ describe( 'index', () => {
 		it( "When the `path` of `wcadmin_page_view` tracking event is one of this plugin's route paths, it should add base properties", () => {
 			expect( pagePaths.size ).toBeGreaterThan( 0 );
 
-			// Simulate that the version has been hydrated via the initialization of .~/data/index.js
+			// Simulate that the version has been hydrated via the initialization of ~/data/index.js
 			dispatch( STORE_KEY ).hydratePrefetchedData( { version: '1.2.3' } );
 
 			pagePaths.forEach( ( path ) => {

--- a/js/src/jsconfig.json
+++ b/js/src/jsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"baseUrl": ".",
 		"paths": {
-			".~/*": [ "./*" ]
+			"~/*": [ "./*" ]
 		}
 	}
 }

--- a/js/src/pages/create-paid-ads-campaign/index.js
+++ b/js/src/pages/create-paid-ads-campaign/index.js
@@ -10,30 +10,30 @@ import { getHistory } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import useLayout from '.~/hooks/useLayout';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
-import { useAppDispatch } from '.~/data';
-import { getDashboardUrl } from '.~/utils/urls';
-import convertToAssetGroupUpdateBody from '.~/components/paid-ads/convertToAssetGroupUpdateBody';
-import TopBar from '.~/components/stepper/top-bar';
-import ContinueButton from '.~/components/paid-ads/continue-button';
-import HelpIconButton from '.~/components/help-icon-button';
-import CampaignAssetsForm from '.~/components/paid-ads/campaign-assets-form';
-import AdsCampaign from '.~/components/paid-ads/ads-campaign';
+import useLayout from '~/hooks/useLayout';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
+import { useAppDispatch } from '~/data';
+import { getDashboardUrl } from '~/utils/urls';
+import convertToAssetGroupUpdateBody from '~/components/paid-ads/convertToAssetGroupUpdateBody';
+import TopBar from '~/components/stepper/top-bar';
+import ContinueButton from '~/components/paid-ads/continue-button';
+import HelpIconButton from '~/components/help-icon-button';
+import CampaignAssetsForm from '~/components/paid-ads/campaign-assets-form';
+import AdsCampaign from '~/components/paid-ads/ads-campaign';
 import AssetGroup, {
 	ACTION_SUBMIT_CAMPAIGN_AND_ASSETS,
-} from '.~/components/paid-ads/asset-group';
+} from '~/components/paid-ads/asset-group';
 import {
 	CAMPAIGN_STEP as STEP,
 	CAMPAIGN_STEP_NUMBER_MAP as STEP_NUMBER_MAP,
-} from '.~/constants';
-import { API_NAMESPACE } from '.~/data/constants';
+} from '~/constants';
+import { API_NAMESPACE } from '~/data/constants';
 import {
 	recordStepperChangeEvent,
 	recordStepContinueEvent,
-} from '.~/utils/tracks';
-import useBudgetRecommendation from '.~/hooks/useBudgetRecommendation';
+} from '~/utils/tracks';
+import useBudgetRecommendation from '~/hooks/useBudgetRecommendation';
 
 const eventName = 'gla_paid_campaign_step';
 const eventContext = 'create-ads';

--- a/js/src/pages/edit-paid-ads-campaign/index.js
+++ b/js/src/pages/edit-paid-ads-campaign/index.js
@@ -9,31 +9,31 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useLayout from '.~/hooks/useLayout';
-import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
-import { useAppDispatch } from '.~/data';
-import { getDashboardUrl } from '.~/utils/urls';
-import convertToAssetGroupUpdateBody from '.~/components/paid-ads/convertToAssetGroupUpdateBody';
-import TopBar from '.~/components/stepper/top-bar';
-import HelpIconButton from '.~/components/help-icon-button';
-import CampaignAssetsForm from '.~/components/paid-ads/campaign-assets-form';
-import AdsCampaign from '.~/components/paid-ads/ads-campaign';
-import ContinueButton from '.~/components/paid-ads/continue-button';
-import AppSpinner from '.~/components/app-spinner';
+import useLayout from '~/hooks/useLayout';
+import useAdsCampaigns from '~/hooks/useAdsCampaigns';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
+import { useAppDispatch } from '~/data';
+import { getDashboardUrl } from '~/utils/urls';
+import convertToAssetGroupUpdateBody from '~/components/paid-ads/convertToAssetGroupUpdateBody';
+import TopBar from '~/components/stepper/top-bar';
+import HelpIconButton from '~/components/help-icon-button';
+import CampaignAssetsForm from '~/components/paid-ads/campaign-assets-form';
+import AdsCampaign from '~/components/paid-ads/ads-campaign';
+import ContinueButton from '~/components/paid-ads/continue-button';
+import AppSpinner from '~/components/app-spinner';
 import AssetGroup, {
 	ACTION_SUBMIT_CAMPAIGN_AND_ASSETS,
-} from '.~/components/paid-ads/asset-group';
+} from '~/components/paid-ads/asset-group';
 import {
 	CAMPAIGN_STEP as STEP,
 	CAMPAIGN_STEP_NUMBER_MAP as STEP_NUMBER_MAP,
 	CAMPAIGN_TYPE_PMAX,
-} from '.~/constants';
+} from '~/constants';
 import {
 	recordStepperChangeEvent,
 	recordStepContinueEvent,
-} from '.~/utils/tracks';
-import useBudgetRecommendation from '.~/hooks/useBudgetRecommendation';
+} from '~/utils/tracks';
+import useBudgetRecommendation from '~/hooks/useBudgetRecommendation';
 
 const eventName = 'gla_paid_campaign_step';
 const eventContext = 'edit-ads';

--- a/js/src/pages/reports/index.js
+++ b/js/src/pages/reports/index.js
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { ProgramsReport, ProductsReport } from '.~/reports';
-import getSelectedReportKey from '.~/utils/getSelectedReportKey';
+import { ProgramsReport, ProductsReport } from '~/reports';
+import getSelectedReportKey from '~/utils/getSelectedReportKey';
 
 const Reports = () => {
 	const reportKey = getSelectedReportKey();

--- a/js/src/product-attributes/index.js
+++ b/js/src/product-attributes/index.js
@@ -6,7 +6,7 @@ import $ from 'jquery';
 /**
  * Internal dependencies
  */
-import { glaProductData } from '.~/constants';
+import { glaProductData } from '~/constants';
 import './custom-inputs';
 import './index.scss';
 

--- a/js/src/product-feed/constants.js
+++ b/js/src/product-feed/constants.js
@@ -6,10 +6,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import ErrorIcon from '.~/components/error-icon';
-import WarningIcon from '.~/components/warning-icon';
-import SuccessIcon from '.~/components/success-icon';
-import SyncIcon from '.~/components/sync-icon';
+import ErrorIcon from '~/components/error-icon';
+import WarningIcon from '~/components/warning-icon';
+import SuccessIcon from '~/components/success-icon';
+import SyncIcon from '~/components/sync-icon';
 
 const DISAPPROVED = {
 	status: (

--- a/js/src/product-feed/index.js
+++ b/js/src/product-feed/index.js
@@ -8,17 +8,17 @@ import { getQuery } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import MainTabNav from '.~/components/main-tab-nav';
+import MainTabNav from '~/components/main-tab-nav';
 import IssuesTableCard from './issues-table-card';
 import ProductFeedTableCard from './product-feed-table-card';
 import SubmissionSuccessGuide from './submission-success-guide';
-import CustomerEffortScorePrompt from '.~/components/customer-effort-score-prompt';
+import CustomerEffortScorePrompt from '~/components/customer-effort-score-prompt';
 import ProductStatistics from './product-statistics';
 import './index.scss';
-import { GUIDE_NAMES, LOCAL_STORAGE_KEYS } from '.~/constants';
-import localStorage from '.~/utils/localStorage';
-import isWCTracksEnabled from '.~/utils/isWCTracksEnabled';
-import RebrandingTour from '.~/components/tours/rebranding-tour';
+import { GUIDE_NAMES, LOCAL_STORAGE_KEYS } from '~/constants';
+import localStorage from '~/utils/localStorage';
+import isWCTracksEnabled from '~/utils/isWCTracksEnabled';
+import RebrandingTour from '~/components/tours/rebranding-tour';
 
 const ProductFeed = () => {
 	const [ canCESPromptOpen, setCESPromptOpen ] = useState( false );

--- a/js/src/product-feed/index.test.js
+++ b/js/src/product-feed/index.test.js
@@ -1,4 +1,4 @@
-jest.mock( '.~/components/tours/rebranding-tour', () =>
+jest.mock( '~/components/tours/rebranding-tour', () =>
 	jest.fn().mockReturnValue( null ).mockName( 'RebrandingTour' )
 );
 
@@ -13,10 +13,10 @@ import { getQuery } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import ProductFeed from './';
-import localStorage from '.~/utils/localStorage';
-import isWCTracksEnabled from '.~/utils/isWCTracksEnabled';
-import { GUIDE_NAMES } from '.~/constants';
-import RebrandingTour from '.~/components/tours/rebranding-tour';
+import localStorage from '~/utils/localStorage';
+import isWCTracksEnabled from '~/utils/isWCTracksEnabled';
+import { GUIDE_NAMES } from '~/constants';
+import RebrandingTour from '~/components/tours/rebranding-tour';
 
 jest.mock( '@woocommerce/navigation', () => {
 	return {
@@ -25,20 +25,20 @@ jest.mock( '@woocommerce/navigation', () => {
 	};
 } );
 
-jest.mock( '.~/utils/localStorage', () => {
+jest.mock( '~/utils/localStorage', () => {
 	return {
 		get: jest.fn(),
 		set: jest.fn(),
 	};
 } );
 
-jest.mock( '.~/utils/isWCTracksEnabled', () => jest.fn() );
+jest.mock( '~/utils/isWCTracksEnabled', () => jest.fn() );
 
 const SUBMISSION_SUCCESS_GUIDE_TEXT =
 	'You’ve successfully set up Google for WooCommerce! 🎉';
 const CES_PROMPT_TEXT = 'How easy was it to set up Google for WooCommerce?';
 
-jest.mock( '.~/components/customer-effort-score-prompt', () => () => (
+jest.mock( '~/components/customer-effort-score-prompt', () => () => (
 	<div>{ CES_PROMPT_TEXT }</div>
 ) );
 

--- a/js/src/product-feed/issues-table-card/index.js
+++ b/js/src/product-feed/issues-table-card/index.js
@@ -9,15 +9,15 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import AppTableCardDiv from '.~/components/app-table-card-div';
-import HelpPopover from '.~/components/help-popover';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import IssuesTable from '.~/product-feed/issues-table-card/issues-table';
-import IssuesTypeNavigation from '.~/product-feed/issues-table-card/issues-type-navigation';
-import ReviewRequest from '.~/product-feed/review-request';
-import useMCIssuesTotals from '.~/hooks/useMCIssuesTotals';
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
-import Text from '.~/components/app-text';
+import AppTableCardDiv from '~/components/app-table-card-div';
+import HelpPopover from '~/components/help-popover';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import IssuesTable from '~/product-feed/issues-table-card/issues-table';
+import IssuesTypeNavigation from '~/product-feed/issues-table-card/issues-type-navigation';
+import ReviewRequest from '~/product-feed/review-request';
+import useMCIssuesTotals from '~/hooks/useMCIssuesTotals';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
+import Text from '~/components/app-text';
 import './index.scss';
 
 const actions = (

--- a/js/src/product-feed/issues-table-card/index.test.js
+++ b/js/src/product-feed/issues-table-card/index.test.js
@@ -1,4 +1,4 @@
-jest.mock( '.~/hooks/useMCIssuesTypeFilter', () => ( {
+jest.mock( '~/hooks/useMCIssuesTypeFilter', () => ( {
 	__esModule: true,
 	default: jest
 		.fn()
@@ -24,7 +24,7 @@ import { render, screen } from '@testing-library/react';
  * Internal dependencies
  */
 import IssuesTableCard from './';
-import useMCIssuesTypeFilter from '.~/hooks/useMCIssuesTypeFilter';
+import useMCIssuesTypeFilter from '~/hooks/useMCIssuesTypeFilter';
 
 describe( 'Issues Table Card', () => {
 	it( 'Rendering when there are issues', () => {

--- a/js/src/product-feed/issues-table-card/issues-solved.js
+++ b/js/src/product-feed/issues-table-card/issues-solved.js
@@ -8,9 +8,9 @@ import { Dashicon } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import useActiveIssueType from '.~/hooks/useActiveIssueType';
-import { ISSUE_TYPE_PRODUCT, ISSUE_TYPE_ACCOUNT } from '.~/constants';
-import Text from '.~/components/app-text';
+import useActiveIssueType from '~/hooks/useActiveIssueType';
+import { ISSUE_TYPE_PRODUCT, ISSUE_TYPE_ACCOUNT } from '~/constants';
+import Text from '~/components/app-text';
 
 /**
  * This component renders a message when no issues of the

--- a/js/src/product-feed/issues-table-card/issues-solved.test.js
+++ b/js/src/product-feed/issues-table-card/issues-solved.test.js
@@ -1,5 +1,5 @@
-jest.mock( '.~/hooks/useMCIssuesTypeFilter' );
-jest.mock( '.~/hooks/useActiveIssueType' );
+jest.mock( '~/hooks/useMCIssuesTypeFilter' );
+jest.mock( '~/hooks/useActiveIssueType' );
 
 /**
  * External dependencies
@@ -9,9 +9,9 @@ import { render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import useMCIssuesTypeFilter from '.~/hooks/useMCIssuesTypeFilter';
-import useActiveIssueType from '.~/hooks/useActiveIssueType';
-import IssuesSolved from '.~/product-feed/issues-table-card/issues-solved';
+import useMCIssuesTypeFilter from '~/hooks/useMCIssuesTypeFilter';
+import useActiveIssueType from '~/hooks/useActiveIssueType';
+import IssuesSolved from '~/product-feed/issues-table-card/issues-solved';
 
 describe( 'Issues Solved Message', () => {
 	beforeEach( () => {

--- a/js/src/product-feed/issues-table-card/issues-table-data-modal.js
+++ b/js/src/product-feed/issues-table-card/issues-table-data-modal.js
@@ -7,8 +7,8 @@ import GridiconExternal from 'gridicons/dist/external';
 /**
  * Internal dependencies
  */
-import AppModal from '.~/components/app-modal';
-import AppButton from '.~/components/app-button';
+import AppModal from '~/components/app-modal';
+import AppButton from '~/components/app-button';
 
 /**
  * Renders a modal showing information about a Google Merchant Center issue

--- a/js/src/product-feed/issues-table-card/issues-table-data-modal.test.js
+++ b/js/src/product-feed/issues-table-card/issues-table-data-modal.test.js
@@ -1,4 +1,4 @@
-jest.mock( '.~/utils/tracks', () => {
+jest.mock( '~/utils/tracks', () => {
 	return {
 		recordGlaEvent: jest.fn(),
 	};
@@ -13,8 +13,8 @@ import '@testing-library/jest-dom';
  * Internal dependencies
  */
 import IssuesTableDataModal from './issues-table-data-modal';
-import mockIssue from '.~/tests/mock-issue';
-import { recordGlaEvent } from '.~/utils/tracks';
+import mockIssue from '~/tests/mock-issue';
+import { recordGlaEvent } from '~/utils/tracks';
 
 describe( 'Issues Data Table Modal', () => {
 	test( 'Render the issue details', () => {

--- a/js/src/product-feed/issues-table-card/issues-table-data.js
+++ b/js/src/product-feed/issues-table-card/issues-table-data.js
@@ -7,15 +7,15 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import WarningIcon from '.~/components/warning-icon';
-import ErrorIcon from '.~/components/error-icon';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import EditProductLink from '.~/components/edit-product-link';
-import AppButtonModalTrigger from '.~/components/app-button-modal-trigger';
+import AppButton from '~/components/app-button';
+import WarningIcon from '~/components/warning-icon';
+import ErrorIcon from '~/components/error-icon';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import EditProductLink from '~/components/edit-product-link';
+import AppButtonModalTrigger from '~/components/app-button-modal-trigger';
 import IssuesSolved from './issues-solved';
 import IssuesTableDataModal from './issues-table-data-modal';
-import { ISSUE_TYPE_PRODUCT } from '.~/constants';
+import { ISSUE_TYPE_PRODUCT } from '~/constants';
 import ISSUES_TABLE_DATA_HEADERS from './issues-table-data-headers';
 
 /**

--- a/js/src/product-feed/issues-table-card/issues-table-data.test.js
+++ b/js/src/product-feed/issues-table-card/issues-table-data.test.js
@@ -1,5 +1,5 @@
-jest.mock( '.~/hooks/useActiveIssueType' );
-jest.mock( '.~/utils/tracks', () => {
+jest.mock( '~/hooks/useActiveIssueType' );
+jest.mock( '~/utils/tracks', () => {
 	return {
 		recordGlaEvent: jest.fn(),
 	};
@@ -12,11 +12,11 @@ import '@testing-library/jest-dom';
 /**
  * Internal dependencies
  */
-import useActiveIssueType from '.~/hooks/useActiveIssueType';
-import mockIssue from '.~/tests/mock-issue';
+import useActiveIssueType from '~/hooks/useActiveIssueType';
+import mockIssue from '~/tests/mock-issue';
 import IssuesTableData from './issues-table-data';
-import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '.~/constants';
-import { recordGlaEvent } from '.~/utils/tracks';
+import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '~/constants';
+import { recordGlaEvent } from '~/utils/tracks';
 
 describe( 'Issues Table data', () => {
 	test( 'Render error if no data', () => {

--- a/js/src/product-feed/issues-table-card/issues-table.js
+++ b/js/src/product-feed/issues-table-card/issues-table.js
@@ -8,13 +8,13 @@ import { Pagination, TablePlaceholder } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
-import { ISSUE_TABLE_PER_PAGE } from '.~/constants';
+import { ISSUE_TABLE_PER_PAGE } from '~/constants';
 import ISSUES_TABLE_DATA_HEADERS from './issues-table-data-headers';
-import { recordTablePageEvent } from '.~/utils/tracks';
+import { recordTablePageEvent } from '~/utils/tracks';
 import IssuesTableData from './issues-table-data';
-import useMCIssuesTypeFilter from '.~/hooks/useMCIssuesTypeFilter';
-import usePagination from '.~/hooks/usePagination';
-import useActiveIssueType from '.~/hooks/useActiveIssueType';
+import useMCIssuesTypeFilter from '~/hooks/useMCIssuesTypeFilter';
+import usePagination from '~/hooks/usePagination';
+import useActiveIssueType from '~/hooks/useActiveIssueType';
 import './index.scss';
 
 /**

--- a/js/src/product-feed/issues-table-card/issues-table.test.js
+++ b/js/src/product-feed/issues-table-card/issues-table.test.js
@@ -1,5 +1,5 @@
-jest.mock( '.~/hooks/useActiveIssueType' );
-jest.mock( '.~/hooks/useMCIssuesTypeFilter', () => ( {
+jest.mock( '~/hooks/useActiveIssueType' );
+jest.mock( '~/hooks/useMCIssuesTypeFilter', () => ( {
 	__esModule: true,
 	default: jest.fn().mockName( 'useMCIssuesTypeFilter' ),
 } ) );
@@ -12,11 +12,11 @@ import { render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '.~/constants';
-import IssuesTable from '.~/product-feed/issues-table-card/issues-table';
-import useMCIssuesTypeFilter from '.~/hooks/useMCIssuesTypeFilter';
-import useActiveIssueType from '.~/hooks/useActiveIssueType';
-import mockIssue from '.~/tests/mock-issue';
+import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '~/constants';
+import IssuesTable from '~/product-feed/issues-table-card/issues-table';
+import useMCIssuesTypeFilter from '~/hooks/useMCIssuesTypeFilter';
+import useActiveIssueType from '~/hooks/useActiveIssueType';
+import mockIssue from '~/tests/mock-issue';
 
 describe( 'Issues Table', () => {
 	describe( 'Rendering correctly the table', () => {

--- a/js/src/product-feed/issues-table-card/issues-type-navigation.js
+++ b/js/src/product-feed/issues-table-card/issues-type-navigation.js
@@ -7,10 +7,10 @@ import { getNewPath } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '.~/constants';
-import AppTabNav from '.~/components/app-tab-nav';
-import useMCIssuesTotals from '.~/hooks/useMCIssuesTotals';
-import useActiveIssueType from '.~/hooks/useActiveIssueType';
+import { ISSUE_TYPE_ACCOUNT, ISSUE_TYPE_PRODUCT } from '~/constants';
+import AppTabNav from '~/components/app-tab-nav';
+import useMCIssuesTotals from '~/hooks/useMCIssuesTotals';
+import useActiveIssueType from '~/hooks/useActiveIssueType';
 
 /**
  * The issue navigation tabs. It uses `useMCIssuesTotals` for getting the issue totals

--- a/js/src/product-feed/issues-table-card/issues-type-navigation.test.js
+++ b/js/src/product-feed/issues-table-card/issues-type-navigation.test.js
@@ -1,4 +1,4 @@
-jest.mock( '.~/hooks/useMCIssuesTotals', () => ( {
+jest.mock( '~/hooks/useMCIssuesTotals', () => ( {
 	__esModule: true,
 	default: jest.fn().mockName( 'useMCIssuesTotals' ).mockReturnValue( {
 		account: 0,
@@ -16,8 +16,8 @@ import '@testing-library/jest-dom';
 /**
  * Internal dependencies
  */
-import IssuesTypeNavigation from '.~/product-feed/issues-table-card/issues-type-navigation';
-import useMCIssuesTotals from '.~/hooks/useMCIssuesTotals';
+import IssuesTypeNavigation from '~/product-feed/issues-table-card/issues-type-navigation';
+import useMCIssuesTotals from '~/hooks/useMCIssuesTotals';
 
 describe( 'Issues Type Navigation', () => {
 	describe( 'When totals are defined', () => {

--- a/js/src/product-feed/product-feed-table-card/edit-visibility-action.js
+++ b/js/src/product-feed/product-feed-table-card/edit-visibility-action.js
@@ -10,8 +10,8 @@ import { edit as editIcon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import AppTooltip from '.~/components/app-tooltip';
+import AppButton from '~/components/app-button';
+import AppTooltip from '~/components/app-tooltip';
 
 const tipText = __( 'Select channel visibility', 'google-listings-and-ads' );
 

--- a/js/src/product-feed/product-feed-table-card/index.js
+++ b/js/src/product-feed/product-feed-table-card/index.js
@@ -21,16 +21,16 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { recordGlaEvent, recordTablePageEvent } from '.~/utils/tracks';
-import AppTableCardDiv from '.~/components/app-table-card-div';
-import EditProductLink from '.~/components/edit-product-link';
+import { recordGlaEvent, recordTablePageEvent } from '~/utils/tracks';
+import AppTableCardDiv from '~/components/app-table-card-div';
+import EditProductLink from '~/components/edit-product-link';
 import './index.scss';
-import { useAppDispatch } from '.~/data';
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import { useAppDispatch } from '~/data';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 import EditVisibilityAction from './edit-visibility-action';
 import statusLabelMap from './statusLabelMap';
-import Text from '.~/components/app-text';
+import Text from '~/components/app-text';
 
 const PER_PAGE = 10;
 const EVENT_CONTEXT = 'product-feed';

--- a/js/src/product-feed/product-statistics/create-campaign-notice/index.js
+++ b/js/src/product-feed/product-statistics/create-campaign-notice/index.js
@@ -7,9 +7,9 @@ import { Flex, FlexItem } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
-import useMCProductStatistics from '.~/hooks/useMCProductStatistics';
-import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
+import AddPaidCampaignButton from '~/components/paid-ads/add-paid-campaign-button';
+import useMCProductStatistics from '~/hooks/useMCProductStatistics';
+import useAdsCampaigns from '~/hooks/useAdsCampaigns';
 import './index.scss';
 
 const CreateCampaignNotice = () => {

--- a/js/src/product-feed/product-statistics/index.js
+++ b/js/src/product-feed/product-statistics/index.js
@@ -19,15 +19,15 @@ import {
 /**
  * Internal dependencies
  */
-import useMCProductStatistics from '.~/hooks/useMCProductStatistics';
+import useMCProductStatistics from '~/hooks/useMCProductStatistics';
 import ProductStatusHelpPopover from './product-status-help-popover';
-import SyncStatus from '.~/product-feed/product-statistics/status-box/sync-status';
-import SyncProductStatistics from '.~/product-feed/product-statistics/status-box/sync-product-statistics';
-import FeedStatus from '.~/product-feed/product-statistics/status-box/feed-status';
-import AccountStatus from '.~/product-feed/product-statistics/status-box/account-status';
-import CreateCampaignNotice from '.~/product-feed/product-statistics/create-campaign-notice';
-import Text from '.~/components/app-text';
-import AppSpinner from '.~/components/app-spinner';
+import SyncStatus from '~/product-feed/product-statistics/status-box/sync-status';
+import SyncProductStatistics from '~/product-feed/product-statistics/status-box/sync-product-statistics';
+import FeedStatus from '~/product-feed/product-statistics/status-box/feed-status';
+import AccountStatus from '~/product-feed/product-statistics/status-box/account-status';
+import CreateCampaignNotice from '~/product-feed/product-statistics/create-campaign-notice';
+import Text from '~/components/app-text';
+import AppSpinner from '~/components/app-spinner';
 import './index.scss';
 
 const ProductStatistics = () => {

--- a/js/src/product-feed/product-statistics/index.test.js
+++ b/js/src/product-feed/product-statistics/index.test.js
@@ -8,11 +8,11 @@ import { render, screen } from '@testing-library/react';
  * Internal dependencies
  */
 import ProductStatistics from './';
-import useMCProductStatistics from '.~/hooks/useMCProductStatistics';
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+import useMCProductStatistics from '~/hooks/useMCProductStatistics';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
 
-jest.mock( '.~/hooks/useMCProductStatistics' );
-jest.mock( '.~/hooks/useAppSelectDispatch' );
+jest.mock( '~/hooks/useMCProductStatistics' );
+jest.mock( '~/hooks/useAppSelectDispatch' );
 
 const stats = {
 	loading: false,

--- a/js/src/product-feed/product-statistics/product-status-help-popover/index.js
+++ b/js/src/product-feed/product-statistics/product-status-help-popover/index.js
@@ -7,8 +7,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import HelpPopover from '.~/components/help-popover';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import HelpPopover from '~/components/help-popover';
 
 /**
  * @fires gla_documentation_link_click with `{ context: 'product-feed', link_id: 'product-sync-statuses', href: 'https://support.google.com/merchants/answer/160491' }`

--- a/js/src/product-feed/product-statistics/status-box/account-status.js
+++ b/js/src/product-feed/product-statistics/status-box/account-status.js
@@ -6,8 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import Status from '.~/product-feed/product-statistics/status-box/status';
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+import Status from '~/product-feed/product-statistics/status-box/status';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
 import { REVIEW_STATUSES } from '../../constants';
 
 /**

--- a/js/src/product-feed/product-statistics/status-box/account-status.test.js
+++ b/js/src/product-feed/product-statistics/status-box/account-status.test.js
@@ -8,10 +8,10 @@ import { render } from '@testing-library/react';
  * Internal dependencies
  */
 import { REVIEW_STATUSES } from '../../constants';
-import AccountStatus from '.~/product-feed/product-statistics/status-box/account-status';
+import AccountStatus from '~/product-feed/product-statistics/status-box/account-status';
 
-jest.mock( '.~/hooks/useAppSelectDispatch' );
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
+jest.mock( '~/hooks/useAppSelectDispatch' );
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
 
 describe( 'Account Status', () => {
 	it.each( Object.keys( REVIEW_STATUSES ) )(

--- a/js/src/product-feed/product-statistics/status-box/feed-status.js
+++ b/js/src/product-feed/product-statistics/status-box/feed-status.js
@@ -6,9 +6,9 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import useMCIssuesTotals from '.~/hooks/useMCIssuesTotals';
-import Status from '.~/product-feed/product-statistics/status-box/status';
-import SuccessIcon from '.~/components/success-icon';
+import useMCIssuesTotals from '~/hooks/useMCIssuesTotals';
+import Status from '~/product-feed/product-statistics/status-box/status';
+import SuccessIcon from '~/components/success-icon';
 
 /**
  * Returns the total number of issues to resolve

--- a/js/src/product-feed/product-statistics/status-box/sync-product-statistics.js
+++ b/js/src/product-feed/product-statistics/status-box/sync-product-statistics.js
@@ -6,12 +6,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import Status from '.~/product-feed/product-statistics/status-box/status';
-import ErrorIcon from '.~/components/error-icon';
-import AppButton from '.~/components/app-button';
+import Status from '~/product-feed/product-statistics/status-box/status';
+import ErrorIcon from '~/components/error-icon';
+import AppButton from '~/components/app-button';
 
 /**
- * @typedef {import('.~/data/actions').ProductStatistics } ProductStatistics
+ * @typedef {import('~/data/actions').ProductStatistics } ProductStatistics
  */
 
 /**

--- a/js/src/product-feed/product-statistics/status-box/sync-status.js
+++ b/js/src/product-feed/product-statistics/status-box/sync-status.js
@@ -7,15 +7,15 @@ import { format as formatDate } from '@wordpress/date';
 /**
  * Internal dependencies
  */
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
-import Status from '.~/product-feed/product-statistics/status-box/status';
-import SyncIcon from '.~/components/sync-icon';
-import SuccessIcon from '.~/components/success-icon';
-import getNumberOfSyncProducts from '.~/utils/getNumberOfSyncProducts';
-import { glaDateTimeFormat } from '.~/utils/date';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
+import Status from '~/product-feed/product-statistics/status-box/status';
+import SyncIcon from '~/components/sync-icon';
+import SuccessIcon from '~/components/success-icon';
+import getNumberOfSyncProducts from '~/utils/getNumberOfSyncProducts';
+import { glaDateTimeFormat } from '~/utils/date';
 
 /**
- * @typedef {import('.~/data/actions').ProductStatistics } ProductStatistics
+ * @typedef {import('~/data/actions').ProductStatistics } ProductStatistics
  */
 
 /**

--- a/js/src/product-feed/review-request/index.js
+++ b/js/src/product-feed/review-request/index.js
@@ -6,19 +6,19 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useActiveIssueType from '.~/hooks/useActiveIssueType';
+import useActiveIssueType from '~/hooks/useActiveIssueType';
 import ReviewRequestModal from './review-request-modal';
 import ReviewRequestNotice from './review-request-notice';
-import { ISSUE_TYPE_ACCOUNT, REQUEST_REVIEW } from '.~/constants';
+import { ISSUE_TYPE_ACCOUNT, REQUEST_REVIEW } from '~/constants';
 import { REVIEW_STATUSES } from '../constants';
-import useMCIssuesTypeFilter from '.~/hooks/useMCIssuesTypeFilter';
-import { recordGlaEvent } from '.~/utils/tracks';
+import useMCIssuesTypeFilter from '~/hooks/useMCIssuesTypeFilter';
+import { recordGlaEvent } from '~/utils/tracks';
 import './index.scss';
 
 const showNotice = ( status ) => !! REVIEW_STATUSES[ status ]?.title;
 
 /**
- * @typedef { import(".~/data/actions").AccountStatus } AccountStatus
+ * @typedef { import("~/data/actions").AccountStatus } AccountStatus
  */
 
 /**

--- a/js/src/product-feed/review-request/index.test.js
+++ b/js/src/product-feed/review-request/index.test.js
@@ -1,4 +1,4 @@
-jest.mock( '.~/hooks/useMCIssuesTypeFilter', () => ( {
+jest.mock( '~/hooks/useMCIssuesTypeFilter', () => ( {
 	__esModule: true,
 	default: jest
 		.fn()
@@ -9,8 +9,8 @@ jest.mock( '.~/hooks/useMCIssuesTypeFilter', () => ( {
 		} ),
 } ) );
 
-jest.mock( '.~/hooks/useActiveIssueType' );
-jest.mock( '.~/utils/tracks', () => {
+jest.mock( '~/hooks/useActiveIssueType' );
+jest.mock( '~/utils/tracks', () => {
 	return {
 		recordGlaEvent: jest.fn(),
 	};
@@ -24,9 +24,9 @@ import { fireEvent, screen, render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import useActiveIssueType from '.~/hooks/useActiveIssueType';
+import useActiveIssueType from '~/hooks/useActiveIssueType';
 import ReviewRequest from './';
-import { recordGlaEvent } from '.~/utils/tracks';
+import { recordGlaEvent } from '~/utils/tracks';
 
 function isNotRendering( accountState ) {
 	const { queryByTestId, queryByRole } = render(

--- a/js/src/product-feed/review-request/review-request-issues.js
+++ b/js/src/product-feed/review-request/review-request-issues.js
@@ -7,9 +7,9 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import Text from '.~/components/app-text';
-import { recordGlaEvent } from '.~/utils/tracks';
+import AppButton from '~/components/app-button';
+import Text from '~/components/app-text';
+import { recordGlaEvent } from '~/utils/tracks';
 
 const COLLAPSED_ISSUES_SIZE = 5;
 

--- a/js/src/product-feed/review-request/review-request-modal.js
+++ b/js/src/product-feed/review-request/review-request-modal.js
@@ -8,13 +8,13 @@ import { createInterpolateElement, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppModal from '.~/components/app-modal';
-import AppButton from '.~/components/app-button';
-import AppDocumentationLink from '.~/components/app-documentation-link';
+import AppModal from '~/components/app-modal';
+import AppButton from '~/components/app-button';
+import AppDocumentationLink from '~/components/app-documentation-link';
 import ReviewRequestIssues from './review-request-issues';
-import { useAppDispatch } from '.~/data';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import { recordGlaEvent } from '.~/utils/tracks';
+import { useAppDispatch } from '~/data';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import { recordGlaEvent } from '~/utils/tracks';
 
 /**
  * Triggered when request review button is clicked

--- a/js/src/product-feed/review-request/review-request-modal.test.js
+++ b/js/src/product-feed/review-request/review-request-modal.test.js
@@ -1,10 +1,10 @@
-jest.mock( '.~/utils/tracks', () => {
+jest.mock( '~/utils/tracks', () => {
 	return {
 		recordGlaEvent: jest.fn(),
 	};
 } );
 
-jest.mock( '.~/data', () => ( {
+jest.mock( '~/data', () => ( {
 	__esModule: true,
 	useAppDispatch: jest.fn( () => {
 		return {
@@ -21,8 +21,8 @@ import { act, fireEvent, render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import ReviewRequestModal from '.~/product-feed/review-request/review-request-modal';
-import { recordGlaEvent } from '.~/utils/tracks';
+import ReviewRequestModal from '~/product-feed/review-request/review-request-modal';
+import { recordGlaEvent } from '~/utils/tracks';
 
 const issues = [
 	{ code: '#1', issue: '#1' },

--- a/js/src/product-feed/review-request/review-request-notice.js
+++ b/js/src/product-feed/review-request/review-request-notice.js
@@ -8,10 +8,10 @@ import { Flex, FlexItem } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
+import AppButton from '~/components/app-button';
 import { REVIEW_STATUSES } from '../constants';
-import { glaData } from '.~/constants';
-import Text from '.~/components/app-text';
+import { glaData } from '~/constants';
+import Text from '~/components/app-text';
 
 const ReviewRequestNotice = ( {
 	account,

--- a/js/src/product-feed/review-request/review-request-notice.test.js
+++ b/js/src/product-feed/review-request/review-request-notice.test.js
@@ -7,7 +7,7 @@ import { format as formatDate } from '@wordpress/date';
 /**
  * Internal dependencies
  */
-import ReviewRequestNotice from '.~/product-feed/review-request/review-request-notice';
+import ReviewRequestNotice from '~/product-feed/review-request/review-request-notice';
 
 describe( 'Request Review Notice', () => {
 	it.each( [ 'DISAPPROVED', 'WARNING' ] )(

--- a/js/src/product-feed/submission-success-guide/index.js
+++ b/js/src/product-feed/submission-success-guide/index.js
@@ -12,18 +12,16 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import Guide from '.~/external-components/wordpress/guide';
-import GuidePageContent, {
-	ContentLink,
-} from '.~/components/guide-page-content';
-import AppButton from '.~/components/app-button';
-import AddPaidCampaignButton from '.~/components/paid-ads/add-paid-campaign-button';
-import { glaData, GUIDE_NAMES, LOCAL_STORAGE_KEYS } from '.~/constants';
-import localStorage from '.~/utils/localStorage';
-import { getProductFeedUrl } from '.~/utils/urls';
-import wooLogoURL from '.~/images/logo/woocommerce-logo.svg';
-import googleLogoURL from '.~/images/logo/google-logo.svg';
-import { recordGlaEvent } from '.~/utils/tracks';
+import Guide from '~/external-components/wordpress/guide';
+import GuidePageContent, { ContentLink } from '~/components/guide-page-content';
+import AppButton from '~/components/app-button';
+import AddPaidCampaignButton from '~/components/paid-ads/add-paid-campaign-button';
+import { glaData, GUIDE_NAMES, LOCAL_STORAGE_KEYS } from '~/constants';
+import localStorage from '~/utils/localStorage';
+import { getProductFeedUrl } from '~/utils/urls';
+import wooLogoURL from '~/images/logo/woocommerce-logo.svg';
+import googleLogoURL from '~/images/logo/google-logo.svg';
+import { recordGlaEvent } from '~/utils/tracks';
 import './index.scss';
 
 const EVENT_NAME = 'gla_modal_closed';

--- a/js/src/reports/chart-section.js
+++ b/js/src/reports/chart-section.js
@@ -9,8 +9,8 @@ import { getChartTypeForQuery } from '@woocommerce/date';
 /**
  * Internal dependencies
  */
-import useUrlQuery from '.~/hooks/useUrlQuery';
-import useStoreCurrency from '.~/hooks/useStoreCurrency';
+import useUrlQuery from '~/hooks/useUrlQuery';
+import useStoreCurrency from '~/hooks/useStoreCurrency';
 
 const emptyMessage = __(
 	'No data for the selected date range',

--- a/js/src/reports/compare-table-card.js
+++ b/js/src/reports/compare-table-card.js
@@ -10,9 +10,9 @@ import { onQueryChange } from '@woocommerce/navigation';
  * Internal dependencies
  */
 import { getIdsFromQuery } from './utils';
-import useUrlQuery from '.~/hooks/useUrlQuery';
-import AppButton from '.~/components/app-button';
-import AppTableCard from '.~/components/app-table-card';
+import useUrlQuery from '~/hooks/useUrlQuery';
+import AppButton from '~/components/app-button';
+import AppTableCard from '~/components/app-table-card';
 
 /**
  * All data table, with compare feature.
@@ -118,7 +118,7 @@ const CompareTableCard = ( {
 	 *
 	 * @param {Array<ReportData>} reportData Report data.
 	 *
-	 * @return {import('.~/components/app-table-card').Props.headers} All headers.
+	 * @return {import('~/components/app-table-card').Props.headers} All headers.
 	 */
 	const getHeaders = ( reportData ) => [
 		{

--- a/js/src/reports/index.js
+++ b/js/src/reports/index.js
@@ -19,8 +19,8 @@ export { default as ProductsReport } from './products';
  */
 
 /**
- * @typedef {import('.~/data/selectors').ReportSchema<ProductsReportData>} ProductsReportSchema
- * @typedef {import('.~/data/selectors').ReportSchema<ProgramsReportData>} ProgramsReportSchema
+ * @typedef {import('~/data/selectors').ReportSchema<ProductsReportData>} ProductsReportSchema
+ * @typedef {import('~/data/selectors').ReportSchema<ProgramsReportData>} ProgramsReportSchema
  */
 
 /**
@@ -63,6 +63,6 @@ export { default as ProductsReport } from './products';
  */
 
 /**
- * @typedef { import(".~/data/utils").ReportFieldsSchema } TotalsData
- * @typedef { import(".~/data/utils").PerformanceData } PerformanceData
+ * @typedef { import("~/data/utils").ReportFieldsSchema } TotalsData
+ * @typedef { import("~/data/utils").PerformanceData } PerformanceData
  */

--- a/js/src/reports/metric-number.js
+++ b/js/src/reports/metric-number.js
@@ -14,9 +14,9 @@ import GridiconInfoOutline from 'gridicons/dist/info-outline';
  * Internal dependencies
  */
 import './metric-number.scss';
-import AppTooltip from '.~/components/app-tooltip';
-import TrackableLink from '.~/components/trackable-link';
-import { MISSING_FREE_LISTINGS_DATA } from '.~/data/utils';
+import AppTooltip from '~/components/app-tooltip';
+import TrackableLink from '~/components/trackable-link';
+import { MISSING_FREE_LISTINGS_DATA } from '~/data/utils';
 
 const googleMCReportingDashboardURL =
 	'https://merchants.google.com/mc/reporting/dashboard';
@@ -33,7 +33,7 @@ const googleMCReportingDashboardURL =
  * @param {string} [props.href] An internal link to the report focused on this metric.
  * @param {boolean} [props.selected] Whether show a highlight style on this metric.
  * @param {Function} [props.onLinkClickCallback] A function to be called after a SummaryNumber, rendered as a link, is clicked.
- * @param {import('.~/data/utils').PerformanceMetrics} props.data Data as get from API.
+ * @param {import('~/data/utils').PerformanceMetrics} props.data Data as get from API.
  *
  * @return {SummaryNumber} Filled SummaryNumber.
  *

--- a/js/src/reports/products/filterConfig.js
+++ b/js/src/reports/products/filterConfig.js
@@ -12,7 +12,7 @@ import {
 	REPORT_SOURCE_PAID,
 	REPORT_SOURCE_FREE,
 	REPORT_SOURCE_DEFAULT,
-} from '.~/constants';
+} from '~/constants';
 import { getProductLabels, getVariationLabels } from './asyncRequests';
 
 // XXX: Should we register those filters somewhere?

--- a/js/src/reports/products/index.js
+++ b/js/src/reports/products/index.js
@@ -12,19 +12,19 @@ import {
 	REPORT_SOURCE_FREE,
 	REPORT_SOURCE_PAID,
 	REPORT_SOURCE_DEFAULT,
-} from '.~/constants';
+} from '~/constants';
 import useProductsReport from './useProductsReport';
 import useMetricsWithFormatter from '../useMetricsWithFormatter';
-import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
-import AppSpinner from '.~/components/app-spinner';
-import DifferentCurrencyNotice from '.~/components/different-currency-notice';
-import MainTabNav from '.~/components/main-tab-nav';
+import useAdsCampaigns from '~/hooks/useAdsCampaigns';
+import AppSpinner from '~/components/app-spinner';
+import DifferentCurrencyNotice from '~/components/different-currency-notice';
+import MainTabNav from '~/components/main-tab-nav';
 import ProductsReportFilters from './products-report-filters';
 import SummarySection from '../summary-section';
 import ChartSection from '../chart-section';
 import CompareProductsTableCard from './compare-products-table-card';
 import ReportsNavigation from '../reports-navigation';
-import RebrandingTour from '.~/components/tours/rebranding-tour';
+import RebrandingTour from '~/components/tours/rebranding-tour';
 
 /**
  * Available metrics and their human-readable labels.

--- a/js/src/reports/products/products-report-filters.js
+++ b/js/src/reports/products/products-report-filters.js
@@ -19,7 +19,7 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
  * Internal dependencies
  */
 import { productsFilter, advancedFilters } from './filterConfig';
-import { recordGlaEvent } from '.~/utils/tracks';
+import { recordGlaEvent } from '~/utils/tracks';
 
 const currency = getSetting( 'currency' );
 const siteLocale = getSetting( 'locale' ).siteLocale;

--- a/js/src/reports/products/useProductsReport.js
+++ b/js/src/reports/products/useProductsReport.js
@@ -6,9 +6,9 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data/constants';
-import { mapReportFieldsToPerformance } from '.~/data/utils';
-import useUrlQuery from '.~/hooks/useUrlQuery';
+import { STORE_KEY } from '~/data/constants';
+import { mapReportFieldsToPerformance } from '~/data/utils';
+import useUrlQuery from '~/hooks/useUrlQuery';
 
 const category = 'products';
 const emptyData = {

--- a/js/src/reports/programs/campaign-name-cell.js
+++ b/js/src/reports/programs/campaign-name-cell.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppTooltip from '.~/components/app-tooltip';
+import AppTooltip from '~/components/app-tooltip';
 import './campaign-name-cell.scss';
 
 /**

--- a/js/src/reports/programs/campaign-name-cell.test.js
+++ b/js/src/reports/programs/campaign-name-cell.test.js
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 /**
  * Internal dependencies
  */
-import CampaignNameCell from '.~/reports/programs/campaign-name-cell';
+import CampaignNameCell from '~/reports/programs/campaign-name-cell';
 
 describe( 'Notice Campaign Migration', () => {
 	it( 'Converted', async () => {

--- a/js/src/reports/programs/compare-programs-table-card.js
+++ b/js/src/reports/programs/compare-programs-table-card.js
@@ -8,7 +8,7 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import CompareTableCard from '../compare-table-card';
-import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
+import { FREE_LISTINGS_PROGRAM_ID } from '~/constants';
 import CampaignNameCell from './campaign-name-cell';
 
 const compareBy = 'programs';

--- a/js/src/reports/programs/filterConfig.js
+++ b/js/src/reports/programs/filterConfig.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getIdsFromQuery } from '../utils';
-import { FREE_LISTINGS_PROGRAM_ID, REPORT_PROGRAM_PARAM } from '.~/constants';
+import { FREE_LISTINGS_PROGRAM_ID, REPORT_PROGRAM_PARAM } from '~/constants';
 
 const freeListingsPrograms = [
 	{

--- a/js/src/reports/programs/filterConfig.test.js
+++ b/js/src/reports/programs/filterConfig.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { createProgramsFilterConfig } from './filterConfig';
-import { FREE_LISTINGS_PROGRAM_ID } from '.~/constants';
+import { FREE_LISTINGS_PROGRAM_ID } from '~/constants';
 
 function getAutocompleterOptions( config ) {
 	const filter = config.filters.find( ( el ) => el?.settings?.autocompleter );

--- a/js/src/reports/programs/index.js
+++ b/js/src/reports/programs/index.js
@@ -10,14 +10,14 @@ import { getQuery } from '@woocommerce/navigation';
  */
 import useProgramsReport, { usePerformanceReport } from './useProgramsReport';
 import useMetricsWithFormatter from '../useMetricsWithFormatter';
-import DifferentCurrencyNotice from '.~/components/different-currency-notice';
-import MainTabNav from '.~/components/main-tab-nav';
+import DifferentCurrencyNotice from '~/components/different-currency-notice';
+import MainTabNav from '~/components/main-tab-nav';
 import ProgramsReportFilters from './programs-report-filters';
 import SummarySection from '../summary-section';
 import ChartSection from '../chart-section';
 import CompareProgramsTableCard from './compare-programs-table-card';
 import ReportsNavigation from '../reports-navigation';
-import RebrandingTour from '.~/components/tours/rebranding-tour';
+import RebrandingTour from '~/components/tours/rebranding-tour';
 
 /**
  * Available metrics and their human-readable labels.

--- a/js/src/reports/programs/programs-report-filters.js
+++ b/js/src/reports/programs/programs-report-filters.js
@@ -19,10 +19,10 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
  * Internal dependencies
  */
 import { createProgramsFilterConfig } from './filterConfig';
-import useAdsCampaigns from '.~/hooks/useAdsCampaigns';
-import useStoreCurrency from '.~/hooks/useStoreCurrency';
-import ReportFilters from '.~/external-components/woocommerce/filters';
-import { recordGlaEvent } from '.~/utils/tracks';
+import useAdsCampaigns from '~/hooks/useAdsCampaigns';
+import useStoreCurrency from '~/hooks/useStoreCurrency';
+import ReportFilters from '~/external-components/woocommerce/filters';
+import { recordGlaEvent } from '~/utils/tracks';
 
 const siteLocale = getSetting( 'locale' ).siteLocale;
 const getProgramsFilter = createProgramsFilterConfig();

--- a/js/src/reports/programs/useProgramsReport.js
+++ b/js/src/reports/programs/useProgramsReport.js
@@ -7,19 +7,19 @@ import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '.~/data/constants';
+import { STORE_KEY } from '~/data/constants';
 import {
 	getIdsFromQuery,
 	aggregateIntervals,
 	sumToPerformance,
 	addBaseToPerformance,
 } from '../utils';
-import useUrlQuery from '.~/hooks/useUrlQuery';
+import useUrlQuery from '~/hooks/useUrlQuery';
 import {
 	FREE_LISTINGS_PROGRAM_ID,
 	REPORT_PROGRAM_PARAM,
 	glaData,
-} from '.~/constants';
+} from '~/constants';
 
 const category = 'programs';
 const emptyData = {
@@ -29,7 +29,7 @@ const emptyData = {
 	totals: {},
 };
 /**
- * @type {import('.~/data/selectors').ReportSchema}
+ * @type {import('~/data/selectors').ReportSchema}
  */
 const emptyReport = {
 	loaded: true,
@@ -78,8 +78,8 @@ function getReports( getReport, query, dateReference ) {
 }
 
 /**
- * @typedef { import(".~/data/utils").ReportFieldsSchema } ReportFieldsSchema
- * @typedef { import(".~/data/utils").PerformanceData } PerformanceData
+ * @typedef { import("~/data/utils").ReportFieldsSchema } ReportFieldsSchema
+ * @typedef { import("~/data/utils").PerformanceData } PerformanceData
  * @typedef { import("../index.js").ProgramsReportData } ProgramsReportData
  * @typedef { import("../index.js").ProgramsReportSchema } ProgramsReportSchema
  */

--- a/js/src/reports/reports-navigation.js
+++ b/js/src/reports/reports-navigation.js
@@ -7,8 +7,8 @@ import { getNewPath } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import AppSubNav from '.~/components/app-sub-nav';
-import getSelectedReportKey from '.~/utils/getSelectedReportKey';
+import AppSubNav from '~/components/app-sub-nav';
+import getSelectedReportKey from '~/utils/getSelectedReportKey';
 
 const tabs = [
 	{

--- a/js/src/reports/summary-section.js
+++ b/js/src/reports/summary-section.js
@@ -7,9 +7,9 @@ import { getNewPath } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import useUrlQuery from '.~/hooks/useUrlQuery';
+import useUrlQuery from '~/hooks/useUrlQuery';
 import MetricNumber from './metric-number';
-import { recordGlaEvent } from '.~/utils/tracks';
+import { recordGlaEvent } from '~/utils/tracks';
 
 const noValidData = {
 	value: null,
@@ -84,5 +84,5 @@ export default SummarySection;
 
 /**
  * @typedef {import("./index.js").Metric} Metric
- * @typedef {import(".~/data/utils").PerformanceData } PerformanceData
+ * @typedef {import("~/data/utils").PerformanceData } PerformanceData
  */

--- a/js/src/reports/useMetricsWithFormatter.js
+++ b/js/src/reports/useMetricsWithFormatter.js
@@ -7,8 +7,8 @@ import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useStoreCurrency from '.~/hooks/useStoreCurrency';
-import useAdsCurrency from '.~/hooks/useAdsCurrency';
+import useStoreCurrency from '~/hooks/useStoreCurrency';
+import useAdsCurrency from '~/hooks/useAdsCurrency';
 
 const unavailable = __( 'Unavailable', 'google-listings-and-ads' );
 

--- a/js/src/reports/useMetricsWithFormatter.test.js
+++ b/js/src/reports/useMetricsWithFormatter.test.js
@@ -22,7 +22,7 @@ jest.mock( '@woocommerce/settings', () => ( {
 		} ),
 } ) );
 
-jest.mock( '.~/hooks/useGoogleAdsAccount', () =>
+jest.mock( '~/hooks/useGoogleAdsAccount', () =>
 	jest
 		.fn()
 		.mockName( 'useGoogleAdsAccount' )

--- a/js/src/reports/utils.js
+++ b/js/src/reports/utils.js
@@ -5,7 +5,7 @@ import {
 	paidFields,
 	fieldsToPerformance,
 	MISSING_FREE_LISTINGS_DATA,
-} from '.~/data/utils';
+} from '~/data/utils';
 
 /**
  * Get an array of unique IDs from a comma-separated query parameter.

--- a/js/src/reports/utils.test.js
+++ b/js/src/reports/utils.test.js
@@ -5,7 +5,7 @@ import {
 	freeFields,
 	paidFields,
 	MISSING_FREE_LISTINGS_DATA,
-} from '.~/data/utils';
+} from '~/data/utils';
 import {
 	getIdsFromQuery,
 	aggregateIntervals,

--- a/js/src/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/settings/disconnect-modal/confirm-modal.js
@@ -8,10 +8,10 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import AppModal from '.~/components/app-modal';
-import AppButton from '.~/components/app-button';
-import WarningIcon from '.~/components/warning-icon';
-import { useAppDispatch } from '.~/data';
+import AppModal from '~/components/app-modal';
+import AppButton from '~/components/app-button';
+import WarningIcon from '~/components/warning-icon';
+import { useAppDispatch } from '~/data';
 import { ALL_ACCOUNTS, ADS_ACCOUNT, API_DATA_FETCH_FEATURE } from './constants';
 
 const textDict = {

--- a/js/src/settings/edit-store-address.js
+++ b/js/src/settings/edit-store-address.js
@@ -9,17 +9,17 @@ import { Flex } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { getSettingsUrl } from '.~/utils/urls';
-import { useAppDispatch } from '.~/data';
-import useLayout from '.~/hooks/useLayout';
-import useStoreAddress from '.~/hooks/useStoreAddress';
-import TopBar from '.~/components/stepper/top-bar';
-import HelpIconButton from '.~/components/help-icon-button';
-import Section from '.~/wcdl/section';
-import AppButton from '.~/components/app-button';
+import { getSettingsUrl } from '~/utils/urls';
+import { useAppDispatch } from '~/data';
+import useLayout from '~/hooks/useLayout';
+import useStoreAddress from '~/hooks/useStoreAddress';
+import TopBar from '~/components/stepper/top-bar';
+import HelpIconButton from '~/components/help-icon-button';
+import Section from '~/wcdl/section';
+import AppButton from '~/components/app-button';
 
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import { StoreAddressCard } from '.~/components/contact-information';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import { StoreAddressCard } from '~/components/contact-information';
 
 const learnMoreLinkId = 'contact-information-read-more';
 const learnMoreUrl =

--- a/js/src/settings/index.js
+++ b/js/src/settings/index.js
@@ -7,19 +7,19 @@ import { getQuery, getHistory } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { API_RESPONSE_CODES } from '.~/constants';
-import useMenuEffect from '.~/hooks/useMenuEffect';
-import useGoogleAccount from '.~/hooks/useGoogleAccount';
-import useUpdateRestAPIAuthorizeStatusByUrlQuery from '.~/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery';
-import { subpaths, getReconnectAccountUrl } from '.~/utils/urls';
-import { ContactInformationPreview } from '.~/components/contact-information';
+import { API_RESPONSE_CODES } from '~/constants';
+import useMenuEffect from '~/hooks/useMenuEffect';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
+import useUpdateRestAPIAuthorizeStatusByUrlQuery from '~/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery';
+import { subpaths, getReconnectAccountUrl } from '~/utils/urls';
+import { ContactInformationPreview } from '~/components/contact-information';
 import LinkedAccounts from './linked-accounts';
 import ReconnectWPComAccount from './reconnect-wpcom-account';
 import ReconnectGoogleAccount from './reconnect-google-account';
 import EditStoreAddress from './edit-store-address';
-import EnableNewProductSyncNotice from '.~/components/enable-new-product-sync-notice';
-import MainTabNav from '.~/components/main-tab-nav';
-import RebrandingTour from '.~/components/tours/rebranding-tour';
+import EnableNewProductSyncNotice from '~/components/enable-new-product-sync-notice';
+import MainTabNav from '~/components/main-tab-nav';
+import RebrandingTour from '~/components/tours/rebranding-tour';
 import './index.scss';
 
 const pageClassName = 'gla-settings';

--- a/js/src/settings/linked-accounts-section-wrapper.js
+++ b/js/src/settings/linked-accounts-section-wrapper.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import Section from '.~/wcdl/section';
+import Section from '~/wcdl/section';
 
 export default function LinkedAccountsSectionWrapper( props ) {
 	return (

--- a/js/src/settings/linked-accounts.js
+++ b/js/src/settings/linked-accounts.js
@@ -8,24 +8,24 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { getGetStartedUrl } from '.~/utils/urls';
-import useAdminUrl from '.~/hooks/useAdminUrl';
-import useJetpackAccount from '.~/hooks/useJetpackAccount';
-import useGoogleAccount from '.~/hooks/useGoogleAccount';
-import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import AppButton from '.~/components/app-button';
-import SpinnerCard from '.~/components/spinner-card';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import { ConnectedWPComAccountCard } from '.~/components/wpcom-account-card';
-import { ConnectedGoogleAccountCard } from '.~/components/google-account-card';
-import { ConnectedGoogleAdsAccountCard } from '.~/components/google-ads-account-card';
-import { MerchantCenterAccountInfoCard } from '.~/components/google-mc-account-card';
-import Section from '.~/wcdl/section';
+import { getGetStartedUrl } from '~/utils/urls';
+import useAdminUrl from '~/hooks/useAdminUrl';
+import useJetpackAccount from '~/hooks/useJetpackAccount';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import AppButton from '~/components/app-button';
+import SpinnerCard from '~/components/spinner-card';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
+import { ConnectedWPComAccountCard } from '~/components/wpcom-account-card';
+import { ConnectedGoogleAccountCard } from '~/components/google-account-card';
+import { ConnectedGoogleAdsAccountCard } from '~/components/google-ads-account-card';
+import { MerchantCenterAccountInfoCard } from '~/components/google-mc-account-card';
+import Section from '~/wcdl/section';
 import LinkedAccountsSectionWrapper from './linked-accounts-section-wrapper';
 import DisconnectModal, { ALL_ACCOUNTS, ADS_ACCOUNT } from './disconnect-modal';
-import { GOOGLE_ADS_ACCOUNT_STATUS } from '.~/constants';
-import { queueRecordGlaEvent } from '.~/utils/tracks';
+import { GOOGLE_ADS_ACCOUNT_STATUS } from '~/constants';
+import { queueRecordGlaEvent } from '~/utils/tracks';
 
 const { CONNECTED, INCOMPLETE } = GOOGLE_ADS_ACCOUNT_STATUS;
 

--- a/js/src/settings/reconnect-google-account/disconnect-google-account-card.js
+++ b/js/src/settings/reconnect-google-account/disconnect-google-account-card.js
@@ -9,11 +9,11 @@ import { getNewPath } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import useAdminUrl from '.~/hooks/useAdminUrl';
-import AppButton from '.~/components/app-button';
-import AccountCard, { APPEARANCE } from '.~/components/account-card';
-import Section from '.~/wcdl/section';
+import { useAppDispatch } from '~/data';
+import useAdminUrl from '~/hooks/useAdminUrl';
+import AppButton from '~/components/app-button';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import Section from '~/wcdl/section';
 import DisconnectModal, { ALL_ACCOUNTS } from '../disconnect-modal';
 
 export default function DisconnectGoogleAccountCard( { email } ) {

--- a/js/src/settings/reconnect-google-account/reconnect-google-account.js
+++ b/js/src/settings/reconnect-google-account/reconnect-google-account.js
@@ -8,13 +8,13 @@ import { getHistory } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
-import { getDashboardUrl } from '.~/utils/urls';
-import toScopeState from '.~/utils/toScopeState';
-import useAppSelectDispatch from '.~/hooks/useAppSelectDispatch';
-import Section from '.~/wcdl/section';
-import AppSpinner from '.~/components/app-spinner';
-import GoogleAccountCard from '.~/components/google-account-card';
+import { glaData } from '~/constants';
+import { getDashboardUrl } from '~/utils/urls';
+import toScopeState from '~/utils/toScopeState';
+import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
+import Section from '~/wcdl/section';
+import AppSpinner from '~/components/app-spinner';
+import GoogleAccountCard from '~/components/google-account-card';
 import DisconnectGoogleAccountCard from './disconnect-google-account-card';
 
 export default function ReconnectGoogleAccount() {

--- a/js/src/settings/reconnect-wpcom-account/reconnect-wpcom-account.js
+++ b/js/src/settings/reconnect-wpcom-account/reconnect-wpcom-account.js
@@ -9,12 +9,12 @@ import { Icon, plugins as pluginsIcon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import useJetpackAccount from '.~/hooks/useJetpackAccount';
-import { getSettingsUrl } from '.~/utils/urls';
-import AppSpinner from '.~/components/app-spinner';
-import AccountCard from '.~/components/account-card';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import { ConnectWPComAccountCard } from '.~/components/wpcom-account-card';
+import useJetpackAccount from '~/hooks/useJetpackAccount';
+import { getSettingsUrl } from '~/utils/urls';
+import AppSpinner from '~/components/app-spinner';
+import AccountCard from '~/components/account-card';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
+import { ConnectWPComAccountCard } from '~/components/wpcom-account-card';
 import LinkedAccountsSectionWrapper from '../linked-accounts-section-wrapper';
 import './reconnect-wpcom-account.scss';
 

--- a/js/src/setup-ads/ads-stepper/index.js
+++ b/js/src/setup-ads/ads-stepper/index.js
@@ -9,16 +9,16 @@ import { useState, useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import SetupAccounts from './setup-accounts';
-import AppSpinner from '.~/components/app-spinner';
-import useEventPropertiesFilter from '.~/hooks/useEventPropertiesFilter';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import useGoogleAdsAccountStatus from '.~/hooks/useGoogleAdsAccountStatus';
+import AppSpinner from '~/components/app-spinner';
+import useEventPropertiesFilter from '~/hooks/useEventPropertiesFilter';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
 import {
 	recordStepperChangeEvent,
 	recordStepContinueEvent,
 	FILTER_ONBOARDING,
 	CONTEXT_ADS_ONBOARDING,
-} from '.~/utils/tracks';
+} from '~/utils/tracks';
 import SetupPaidAds from './setup-paid-ads';
 
 /**

--- a/js/src/setup-ads/ads-stepper/index.test.js
+++ b/js/src/setup-ads/ads-stepper/index.test.js
@@ -4,7 +4,7 @@ jest.mock( '@woocommerce/tracks', () => {
 	};
 } );
 jest.mock( './setup-accounts', () => jest.fn().mockName( 'SetupAccounts' ) );
-jest.mock( '.~/components/paid-ads/ads-campaign', () =>
+jest.mock( '~/components/paid-ads/ads-campaign', () =>
 	jest.fn().mockName( 'AdsCampaign' )
 );
 

--- a/js/src/setup-ads/ads-stepper/setup-accounts/index.js
+++ b/js/src/setup-ads/ads-stepper/setup-accounts/index.js
@@ -6,20 +6,20 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import StepContent from '.~/components/stepper/step-content';
-import StepContentHeader from '.~/components/stepper/step-content-header';
-import StepContentActions from '.~/components/stepper/step-content-actions';
-import StepContentFooter from '.~/components/stepper/step-content-footer';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import { ConnectedGoogleAccountCard } from '.~/components/google-account-card';
-import GoogleAdsAccountCard from '.~/components/google-ads-account-card';
-import FreeAdCredit from '.~/components/free-ad-credit';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import useGoogleAccount from '.~/hooks/useGoogleAccount';
-import AppSpinner from '.~/components/app-spinner';
-import Section from '.~/wcdl/section';
-import useGoogleAdsAccountReady from '.~/hooks/useGoogleAdsAccountReady';
+import AppButton from '~/components/app-button';
+import StepContent from '~/components/stepper/step-content';
+import StepContentHeader from '~/components/stepper/step-content-header';
+import StepContentActions from '~/components/stepper/step-content-actions';
+import StepContentFooter from '~/components/stepper/step-content-footer';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
+import { ConnectedGoogleAccountCard } from '~/components/google-account-card';
+import GoogleAdsAccountCard from '~/components/google-ads-account-card';
+import FreeAdCredit from '~/components/free-ad-credit';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
+import AppSpinner from '~/components/app-spinner';
+import Section from '~/wcdl/section';
+import useGoogleAdsAccountReady from '~/hooks/useGoogleAdsAccountReady';
 
 const SetupAccounts = ( props ) => {
 	const { onContinue = () => {} } = props;

--- a/js/src/setup-ads/ads-stepper/setup-paid-ads.js
+++ b/js/src/setup-ads/ads-stepper/setup-paid-ads.js
@@ -9,18 +9,18 @@ import { getNewPath } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import AppButton from '.~/components/app-button';
-import AdsCampaign from '.~/components/paid-ads/ads-campaign';
-import useGoogleAdsAccountBillingStatus from '.~/hooks/useGoogleAdsAccountBillingStatus';
-import useAdminUrl from '.~/hooks/useAdminUrl';
-import useNavigateAwayPromptEffect from '.~/hooks/useNavigateAwayPromptEffect';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
-import useAdsSetupCompleteCallback from '.~/hooks/useAdsSetupCompleteCallback';
-import CampaignAssetsForm from '.~/components/paid-ads/campaign-assets-form';
-import { recordGlaEvent } from '.~/utils/tracks';
-import useBudgetRecommendation from '.~/hooks/useBudgetRecommendation';
-import AppSpinner from '.~/components/app-spinner';
-import { GOOGLE_ADS_BILLING_STATUS } from '.~/constants';
+import AppButton from '~/components/app-button';
+import AdsCampaign from '~/components/paid-ads/ads-campaign';
+import useGoogleAdsAccountBillingStatus from '~/hooks/useGoogleAdsAccountBillingStatus';
+import useAdminUrl from '~/hooks/useAdminUrl';
+import useNavigateAwayPromptEffect from '~/hooks/useNavigateAwayPromptEffect';
+import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
+import useAdsSetupCompleteCallback from '~/hooks/useAdsSetupCompleteCallback';
+import CampaignAssetsForm from '~/components/paid-ads/campaign-assets-form';
+import { recordGlaEvent } from '~/utils/tracks';
+import useBudgetRecommendation from '~/hooks/useBudgetRecommendation';
+import AppSpinner from '~/components/app-spinner';
+import { GOOGLE_ADS_BILLING_STATUS } from '~/constants';
 
 const { APPROVED } = GOOGLE_ADS_BILLING_STATUS;
 

--- a/js/src/setup-ads/index.js
+++ b/js/src/setup-ads/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import useLayout from '.~/hooks/useLayout';
+import useLayout from '~/hooks/useLayout';
 import SetupTopBar from './setup-top-bar';
 import AdsStepper from './ads-stepper';
 

--- a/js/src/setup-ads/setup-top-bar.js
+++ b/js/src/setup-ads/setup-top-bar.js
@@ -7,9 +7,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import TopBar from '.~/components/stepper/top-bar';
-import HelpIconButton from '.~/components/help-icon-button';
-import { recordGlaEvent } from '.~/utils/tracks';
+import TopBar from '~/components/stepper/top-bar';
+import HelpIconButton from '~/components/help-icon-button';
+import { recordGlaEvent } from '~/utils/tracks';
 
 /**
  * @fires gla_setup_ads with given `{ triggered_by: 'back-button', action: 'leave' }` when back button is clicked.

--- a/js/src/setup-mc/index.js
+++ b/js/src/setup-mc/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import useLayout from '.~/hooks/useLayout';
+import useLayout from '~/hooks/useLayout';
 import SetupTopBar from './setup-top-bar';
 import SetupStepper from './setup-stepper';
 

--- a/js/src/setup-mc/setup-stepper/index.js
+++ b/js/src/setup-mc/setup-stepper/index.js
@@ -6,9 +6,9 @@ import { getHistory, getNewPath } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import AppSpinner from '.~/components/app-spinner';
+import AppSpinner from '~/components/app-spinner';
 import SavedSetupStepper from './saved-setup-stepper';
-import useMCSetup from '.~/hooks/useMCSetup';
+import useMCSetup from '~/hooks/useMCSetup';
 import stepNameKeyMap from './stepNameKeyMap';
 
 const SetupStepper = () => {

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.js
@@ -8,18 +8,18 @@ import { useState, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import useEventPropertiesFilter from '.~/hooks/useEventPropertiesFilter';
+import { useAppDispatch } from '~/data';
+import useEventPropertiesFilter from '~/hooks/useEventPropertiesFilter';
 import useTargetAudienceWithSuggestions from './useTargetAudienceWithSuggestions';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
-import useSettings from '.~/components/free-listings/configure-product-listings/useSettings';
-import useShippingRates from '.~/hooks/useShippingRates';
-import useShippingTimes from '.~/hooks/useShippingTimes';
-import useSaveShippingRates from '.~/hooks/useSaveShippingRates';
-import useSaveShippingTimes from '.~/hooks/useSaveShippingTimes';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
+import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
+import useSettings from '~/components/free-listings/configure-product-listings/useSettings';
+import useShippingRates from '~/hooks/useShippingRates';
+import useShippingTimes from '~/hooks/useShippingTimes';
+import useSaveShippingRates from '~/hooks/useSaveShippingRates';
+import useSaveShippingTimes from '~/hooks/useSaveShippingTimes';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 import SetupAccounts from './setup-accounts';
-import SetupFreeListings from '.~/components/free-listings/setup-free-listings';
+import SetupFreeListings from '~/components/free-listings/setup-free-listings';
 import SetupPaidAds from './setup-paid-ads';
 import stepNameKeyMap from './stepNameKeyMap';
 import {
@@ -27,7 +27,7 @@ import {
 	recordStepContinueEvent,
 	FILTER_ONBOARDING,
 	CONTEXT_EXTENSION_ONBOARDING,
-} from '.~/utils/tracks';
+} from '~/utils/tracks';
 
 /**
  * @param {Object} props React props

--- a/js/src/setup-mc/setup-stepper/saved-setup-stepper.test.js
+++ b/js/src/setup-mc/setup-stepper/saved-setup-stepper.test.js
@@ -10,25 +10,25 @@ jest.mock( './useTargetAudienceWithSuggestions', () =>
 		.mockName( 'useTargetAudienceWithSuggestions' )
 		.mockReturnValue( {} )
 );
-jest.mock( '.~/hooks/useTargetAudienceFinalCountryCodes', () =>
+jest.mock( '~/hooks/useTargetAudienceFinalCountryCodes', () =>
 	jest
 		.fn()
 		.mockName( 'useTargetAudienceFinalCountryCodes' )
 		.mockReturnValue( {} )
 );
 jest.mock(
-	'.~/components/free-listings/configure-product-listings/useSettings',
+	'~/components/free-listings/configure-product-listings/useSettings',
 	() => jest.fn().mockName( 'useSettings' ).mockReturnValue( {} )
 );
-jest.mock( '.~/hooks/useShippingRates', () =>
+jest.mock( '~/hooks/useShippingRates', () =>
 	jest.fn().mockName( 'useShippingRates' ).mockReturnValue( {} )
 );
-jest.mock( '.~/hooks/useShippingTimes', () =>
+jest.mock( '~/hooks/useShippingTimes', () =>
 	jest.fn().mockName( 'useShippingTimes' ).mockReturnValue( {} )
 );
 
 jest.mock( './setup-accounts', () => jest.fn().mockName( 'SetupAccounts' ) );
-jest.mock( '.~/components/free-listings/setup-free-listings', () =>
+jest.mock( '~/components/free-listings/setup-free-listings', () =>
 	jest.fn().mockName( 'SetupFreeListings' )
 );
 jest.mock( './setup-paid-ads', () => jest.fn().mockName( 'SetupPaidAds' ) );
@@ -45,7 +45,7 @@ import { recordEvent } from '@woocommerce/tracks';
  */
 import SavedSetupStepper from './saved-setup-stepper';
 import SetupAccounts from './setup-accounts';
-import SetupFreeListings from '.~/components/free-listings/setup-free-listings';
+import SetupFreeListings from '~/components/free-listings/setup-free-listings';
 import SetupPaidAds from './setup-paid-ads';
 
 describe( 'SavedSetupStepper', () => {

--- a/js/src/setup-mc/setup-stepper/setup-accounts/faqs.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/faqs.js
@@ -7,8 +7,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import FaqsPanel from '.~/components/faqs-panel';
-import AppDocumentationLink from '.~/components/app-documentation-link';
+import FaqsPanel from '~/components/faqs-panel';
+import AppDocumentationLink from '~/components/app-documentation-link';
 
 const faqItems = [
 	{

--- a/js/src/setup-mc/setup-stepper/setup-accounts/index.js
+++ b/js/src/setup-mc/setup-stepper/setup-accounts/index.js
@@ -7,26 +7,26 @@ import { createInterpolateElement, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useAppDispatch } from '.~/data';
-import useJetpackAccount from '.~/hooks/useJetpackAccount';
-import useGoogleAccount from '.~/hooks/useGoogleAccount';
-import useGoogleMCAccount from '.~/hooks/useGoogleMCAccount';
-import AppButton from '.~/components/app-button';
-import AppSpinner from '.~/components/app-spinner';
-import StepContent from '.~/components/stepper/step-content';
-import StepContentHeader from '.~/components/stepper/step-content-header';
-import StepContentFooter from '.~/components/stepper/step-content-footer';
-import StepContentActions from '.~/components/stepper/step-content-actions';
-import Section from '.~/wcdl/section';
-import AppDocumentationLink from '.~/components/app-documentation-link';
-import VerticalGapLayout from '.~/components/vertical-gap-layout';
-import WPComAccountCard from '.~/components/wpcom-account-card';
-import GoogleComboAccountCard from '.~/components/google-combo-account-card';
+import { useAppDispatch } from '~/data';
+import useJetpackAccount from '~/hooks/useJetpackAccount';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+import AppButton from '~/components/app-button';
+import AppSpinner from '~/components/app-spinner';
+import StepContent from '~/components/stepper/step-content';
+import StepContentHeader from '~/components/stepper/step-content-header';
+import StepContentFooter from '~/components/stepper/step-content-footer';
+import StepContentActions from '~/components/stepper/step-content-actions';
+import Section from '~/wcdl/section';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
+import WPComAccountCard from '~/components/wpcom-account-card';
+import GoogleComboAccountCard from '~/components/google-combo-account-card';
 import Faqs from './faqs';
 import './index.scss';
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import useGoogleAdsAccountReady from '.~/hooks/useGoogleAdsAccountReady';
-import useStoreAddressReady from '.~/hooks/useStoreAddressReady';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleAdsAccountReady from '~/hooks/useGoogleAdsAccountReady';
+import useStoreAddressReady from '~/hooks/useStoreAddressReady';
 
 /**
  * Renders the disclaimer of Comparison Shopping Service (CSS).

--- a/js/src/setup-mc/setup-stepper/setup-paid-ads.js
+++ b/js/src/setup-mc/setup-stepper/setup-paid-ads.js
@@ -9,22 +9,22 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import useAdminUrl from '.~/hooks/useAdminUrl';
-import useDispatchCoreNotices from '.~/hooks/useDispatchCoreNotices';
-import useAdsSetupCompleteCallback from '.~/hooks/useAdsSetupCompleteCallback';
-import useTargetAudienceFinalCountryCodes from '.~/hooks/useTargetAudienceFinalCountryCodes';
-import AdsCampaign from '.~/components/paid-ads/ads-campaign';
-import CampaignAssetsForm from '.~/components/paid-ads/campaign-assets-form';
-import AppButton from '.~/components/app-button';
-import useGoogleAdsAccountBillingStatus from '.~/hooks/useGoogleAdsAccountBillingStatus';
-import { getProductFeedUrl } from '.~/utils/urls';
-import { API_NAMESPACE } from '.~/data/constants';
-import { GUIDE_NAMES, GOOGLE_ADS_BILLING_STATUS } from '.~/constants';
+import useAdminUrl from '~/hooks/useAdminUrl';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useAdsSetupCompleteCallback from '~/hooks/useAdsSetupCompleteCallback';
+import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
+import AdsCampaign from '~/components/paid-ads/ads-campaign';
+import CampaignAssetsForm from '~/components/paid-ads/campaign-assets-form';
+import AppButton from '~/components/app-button';
+import useGoogleAdsAccountBillingStatus from '~/hooks/useGoogleAdsAccountBillingStatus';
+import { getProductFeedUrl } from '~/utils/urls';
+import { API_NAMESPACE } from '~/data/constants';
+import { GUIDE_NAMES, GOOGLE_ADS_BILLING_STATUS } from '~/constants';
 import { ACTION_COMPLETE, ACTION_SKIP } from './constants';
 import SkipButton from './skip-button';
 import clientSession from './clientSession';
-import useBudgetRecommendation from '.~/hooks/useBudgetRecommendation';
-import AppSpinner from '.~/components/app-spinner';
+import useBudgetRecommendation from '~/hooks/useBudgetRecommendation';
+import AppSpinner from '~/components/app-spinner';
 
 /**
  * Clicking on the "Complete setup" button to complete the onboarding flow with paid ads.

--- a/js/src/setup-mc/setup-stepper/skip-button.js
+++ b/js/src/setup-mc/setup-stepper/skip-button.js
@@ -8,11 +8,11 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import useGoogleAdsAccount from '.~/hooks/useGoogleAdsAccount';
-import useGoogleAdsAccountBillingStatus from '.~/hooks/useGoogleAdsAccountBillingStatus';
-import AppButton from '.~/components/app-button';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleAdsAccountBillingStatus from '~/hooks/useGoogleAdsAccountBillingStatus';
+import AppButton from '~/components/app-button';
 import SkipPaidAdsConfirmationModal from './skip-paid-ads-confirmation-modal';
-import { recordGlaEvent } from '.~/utils/tracks';
+import { recordGlaEvent } from '~/utils/tracks';
 
 /**
  * Clicking on the skip paid ads button to complete the onboarding flow.

--- a/js/src/setup-mc/setup-stepper/skip-paid-ads-confirmation-modal.js
+++ b/js/src/setup-mc/setup-stepper/skip-paid-ads-confirmation-modal.js
@@ -6,9 +6,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import AppModal from '.~/components/app-modal';
-import AppButton from '.~/components/app-button';
-import AppDocumentationLink from '.~/components/app-documentation-link';
+import AppModal from '~/components/app-modal';
+import AppButton from '~/components/app-button';
+import AppDocumentationLink from '~/components/app-documentation-link';
 
 /**
  * @fires gla_documentation_link_click with `{ context: 'skip-paid-ads-modal', link_id: 'paid-ads-with-performance-max-campaigns-learn-more', href: 'https://support.google.com/google-ads/answer/10724817' }`

--- a/js/src/setup-mc/setup-stepper/useTargetAudienceWithSuggestions.js
+++ b/js/src/setup-mc/setup-stepper/useTargetAudienceWithSuggestions.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import { API_NAMESPACE } from '.~/data/constants';
-import useTargetAudience from '.~/hooks/useTargetAudience';
-import useMCCountries from '.~/hooks/useMCCountries';
-import useApiFetchEffect from '.~/hooks/useApiFetchEffect';
+import { API_NAMESPACE } from '~/data/constants';
+import useTargetAudience from '~/hooks/useTargetAudience';
+import useMCCountries from '~/hooks/useMCCountries';
+import useApiFetchEffect from '~/hooks/useApiFetchEffect';
 
 /**
  * @typedef {Object} TargetAudienceWithSuggestionsResult

--- a/js/src/setup-mc/setup-top-bar.js
+++ b/js/src/setup-mc/setup-top-bar.js
@@ -7,9 +7,9 @@ import { getNewPath } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import TopBar from '.~/components/stepper/top-bar';
-import HelpIconButton from '.~/components/help-icon-button';
-import { recordGlaEvent } from '.~/utils/tracks';
+import TopBar from '~/components/stepper/top-bar';
+import HelpIconButton from '~/components/help-icon-button';
+import { recordGlaEvent } from '~/utils/tracks';
 
 /**
  * @fires gla_setup_mc with `{ triggered_by: 'back-button', action: 'leave' }`.

--- a/js/src/tests/expectComponentToRecordEventWithFilteredProperties.js
+++ b/js/src/tests/expectComponentToRecordEventWithFilteredProperties.js
@@ -7,7 +7,7 @@ import { recordEvent } from '@woocommerce/tracks';
 /**
  * Internal dependencies
  */
-import useEventPropertiesFilter from '.~/hooks/useEventPropertiesFilter';
+import useEventPropertiesFilter from '~/hooks/useEventPropertiesFilter';
 
 /**
  * Expects a component to record an event with filtered event properties after performing the incoming action.

--- a/js/src/tests/jest-unit.setup.js
+++ b/js/src/tests/jest-unit.setup.js
@@ -26,7 +26,7 @@ global.wpNavMenuClassChange = jest.fn().mockName( 'wpNavMenuClassChange' );
 // mocked globally.
 //
 // Ref: https://github.com/WordPress/gutenberg/tree/trunk/packages/notices#usage
-jest.mock( '.~/hooks/useDispatchCoreNotices', () =>
+jest.mock( '~/hooks/useDispatchCoreNotices', () =>
 	jest
 		.fn()
 		.mockName( 'useDispatchCoreNotices' )

--- a/js/src/utils/createErrorMessageForRejectedPromises.js
+++ b/js/src/utils/createErrorMessageForRejectedPromises.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import createMessageForMultipleErrors from '.~/utils/createMessageForMultipleErrors';
+import createMessageForMultipleErrors from '~/utils/createMessageForMultipleErrors';
 
 /**
  * A function to create an error message for rejected promises.

--- a/js/src/utils/createErrorMessageForRejectedPromises.test.js
+++ b/js/src/utils/createErrorMessageForRejectedPromises.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import createErrorMessageForRejectedPromises from './createErrorMessageForRejectedPromises';
-import createMessageForMultipleErrors from '.~/utils/createMessageForMultipleErrors';
+import createMessageForMultipleErrors from '~/utils/createMessageForMultipleErrors';
 
 describe( 'createErrorMessageForRejectedPromises', () => {
 	const successPromise = () => new Promise( ( resolve ) => resolve( 'OK' ) );

--- a/js/src/utils/date.js
+++ b/js/src/utils/date.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
+import { glaData } from '~/constants';
 
 const glaDateTimeFormat =
 	glaData.dateFormat +

--- a/js/src/utils/getConnectedJetpackInfo.js
+++ b/js/src/utils/getConnectedJetpackInfo.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 
 /**
- * @typedef {import('.~/data/selectors').JetpackAccount} JetpackAccount
+ * @typedef {import('~/data/selectors').JetpackAccount} JetpackAccount
  */
 /**
  * Get a connected jetpack information for display on UI.

--- a/js/src/utils/getDeletedShippingRates.js
+++ b/js/src/utils/getDeletedShippingRates.js
@@ -4,7 +4,7 @@
 import { differenceWith } from 'lodash';
 
 /**
- * @typedef {import('.~/data/actions').ShippingRate} ShippingRate
+ * @typedef {import('~/data/actions').ShippingRate} ShippingRate
  */
 
 /**

--- a/js/src/utils/getDeletedShippingTimes.js
+++ b/js/src/utils/getDeletedShippingTimes.js
@@ -4,7 +4,7 @@
 import { differenceBy } from 'lodash';
 
 /**
- * @typedef {import('.~/data/actions').ShippingTime	} ShippingTime
+ * @typedef {import('~/data/actions').ShippingTime	} ShippingTime
  */
 
 /**

--- a/js/src/utils/getDifferentShippingRates.js
+++ b/js/src/utils/getDifferentShippingRates.js
@@ -4,7 +4,7 @@
 import { isEqual, differenceWith, at } from 'lodash';
 
 /**
- * @typedef {import('.~/data/actions').ShippingRate} ShippingRate
+ * @typedef {import('~/data/actions').ShippingRate} ShippingRate
  */
 
 /**

--- a/js/src/utils/getDifferentShippingTimes.js
+++ b/js/src/utils/getDifferentShippingTimes.js
@@ -4,7 +4,7 @@
 import { differenceWith, isEqual } from 'lodash';
 
 /**
- * @typedef {import('.~/data/actions').ShippingTime	} ShippingTime
+ * @typedef {import('~/data/actions').ShippingTime	} ShippingTime
  */
 
 /**

--- a/js/src/utils/getNumberOfSyncProducts.js
+++ b/js/src/utils/getNumberOfSyncProducts.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('.~/data/actions').ProductStatisticsDetails } ProductStatisticsDetails
+ * @typedef {import('~/data/actions').ProductStatisticsDetails } ProductStatisticsDetails
  */
 
 /**

--- a/js/src/utils/getOfferFreeShippingInitialValue.js
+++ b/js/src/utils/getOfferFreeShippingInitialValue.js
@@ -1,10 +1,10 @@
 /**
  * Internal dependencies
  */
-import isNonFreeShippingRate from '.~/utils/isNonFreeShippingRate';
+import isNonFreeShippingRate from '~/utils/isNonFreeShippingRate';
 
 /**
- * @typedef {import('.~/data/actions').ShippingRate} ShippingRate
+ * @typedef {import('~/data/actions').ShippingRate} ShippingRate
  */
 
 /**

--- a/js/src/utils/handleError.js
+++ b/js/src/utils/handleError.js
@@ -7,7 +7,7 @@ import { __, _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { NOTICES_STORE_KEY } from '.~/data/constants';
+import { NOTICES_STORE_KEY } from '~/data/constants';
 
 /**
  * @typedef {Object} ApiError

--- a/js/src/utils/isMobileApp.test.js
+++ b/js/src/utils/isMobileApp.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { isWCIos, isWCAndroid } from '.~/utils/isMobileApp';
+import { isWCIos, isWCAndroid } from '~/utils/isMobileApp';
 
 describe( 'isMobileApp', () => {
 	let navigatorGetter;

--- a/js/src/utils/isNonFreeShippingRate.js
+++ b/js/src/utils/isNonFreeShippingRate.js
@@ -1,5 +1,5 @@
 /**
- * @typedef { import(".~/data/actions").ShippingRate } ShippingRate
+ * @typedef { import("~/data/actions").ShippingRate } ShippingRate
  */
 
 /**

--- a/js/src/utils/isSameShippingRate.js
+++ b/js/src/utils/isSameShippingRate.js
@@ -1,5 +1,5 @@
 /**
- * @typedef { import(".~/data/actions").ShippingRate } ShippingRate
+ * @typedef { import("~/data/actions").ShippingRate } ShippingRate
  */
 
 /**

--- a/js/src/utils/showAdsConversionNotice.js
+++ b/js/src/utils/showAdsConversionNotice.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { GOOGLE_ADS_ACCOUNT_STATUS } from '.~/constants';
+import { GOOGLE_ADS_ACCOUNT_STATUS } from '~/constants';
 
 /**
  * Helper for determining whether to show the ads conversion notice based on the

--- a/js/src/utils/toScopeState.js
+++ b/js/src/utils/toScopeState.js
@@ -21,7 +21,7 @@ const SCOPE = {
  * Convert the authorization scopes to a state that whether the minimum required scopes for each function are met.
  *
  * @param {boolean} adsSetupComplete Whether Google Ads setup has been completed.
- *     It should be the `glaData.adsSetupComplete` value imported from {@link .~/constants.glaData}.
+ *     It should be the `glaData.adsSetupComplete` value imported from {@link ~/constants.glaData}.
  * @param {Array<string>} [scopes=[]] User authorized scopes returned from Google OAuth API.
  * @return {ScopeState} A state that whether the minimum required scopes for each function are met.
  */

--- a/js/src/utils/tracks.js
+++ b/js/src/utils/tracks.js
@@ -8,11 +8,11 @@ import { createHooks } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import { glaData } from '.~/constants';
-import { STORE_KEY } from '.~/data';
+import { glaData } from '~/constants';
+import { STORE_KEY } from '~/data';
 
 /**
- * @typedef { import(".~/data/actions").CountryCode } CountryCode
+ * @typedef { import("~/data/actions").CountryCode } CountryCode
  */
 
 export const hooks = createHooks();

--- a/js/src/utils/tracks.test.js
+++ b/js/src/utils/tracks.test.js
@@ -14,8 +14,8 @@ import { dispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { recordGlaEvent, queueRecordGlaEvent } from '.~/utils/tracks';
-import { STORE_KEY } from '.~/data';
+import { recordGlaEvent, queueRecordGlaEvent } from '~/utils/tracks';
+import { STORE_KEY } from '~/data';
 
 function updateMcId( mcId ) {
 	dispatch( STORE_KEY ).hydratePrefetchedData( { mcId } );
@@ -27,7 +27,7 @@ function updateAdsId( adsId ) {
 
 describe( 'tracks', () => {
 	beforeAll( () => {
-		// Simulate that the version has been hydrated via the initialization of .~/data/index.js
+		// Simulate that the version has been hydrated via the initialization of ~/data/index.js
 		dispatch( STORE_KEY ).hydratePrefetchedData( { version: '1.2.3' } );
 	} );
 

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -6,7 +6,7 @@ import { getNewPath } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
-import { API_RESPONSE_CODES } from '.~/constants';
+import { API_RESPONSE_CODES } from '~/constants';
 
 export const pagePaths = {
 	getStarted: '/google/start',

--- a/js/src/wcdl/section/card/title/index.js
+++ b/js/src/wcdl/section/card/title/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import Subsection from '.~/wcdl/subsection';
+import Subsection from '~/wcdl/subsection';
 import './index.scss';
 
 const Title = ( props ) => {

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -592,7 +592,7 @@ A modal is closed.
 - [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is closed
 - [`Dashboard`](../../js/src/dashboard/index.js#L34) when CES modal is closed.
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `action: 'request-review-success' | 'maybe-later' | 'dismiss', context: REQUEST_REVIEW`
-- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L159) with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss'`
+- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L157) with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss'`
 
 ### [`gla_modal_content_link_click`](../../js/src/components/guide-page-content/index.js#L28)
 Clicking on a text link within the modal content
@@ -613,7 +613,7 @@ A modal is open
 #### Emitters
 - [`AttributeMappingTable`](../../js/src/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is open with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal' }`
 - [`ReviewRequest`](../../js/src/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
-- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L159) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
+- [`SubmissionSuccessGuide`](../../js/src/product-feed/submission-success-guide/index.js#L157) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 
 ### [`gla_onboarding_complete_button_click`](../../js/src/setup-mc/setup-stepper/skip-button.js#L17)
 Clicking on the skip paid ads button to complete the onboarding flow.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,7 @@ const webpackConfig = {
 	resolve: {
 		...defaultConfig.resolve,
 		alias: {
-			'.~': path.resolve( process.cwd(), 'js/src/' ),
+			'~': path.join( __dirname, 'js/src' ),
 		},
 		fallback: {
 			/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the starting `.` from all internal alias imports.

In #192. it brought a better way to `import` modules with alias. However, a trick was introduced to make internal imports fall into the Internal dependencies section of the eslint rule `@woocommerce/dependency-group`. (see: https://github.com/woocommerce/google-listings-and-ads/pull/192#issuecomment-773299777)

Since `@woocommerce/eslint-plugin` [1.2.0](https://github.com/woocommerce/woocommerce/blob/9.4.3/packages/js/eslint-plugin/PREVIOUS_CHANGELOG.md#120), it supports internal dependencies starting with `~/`, so we can get rid of the trick.

💡 I will likely skip code review since this PR only includes developer-facing change.

### Detailed test instructions:

1. Confirm `npm run dev` can build frontend code without errors
2. Confirm `npm run lint:js` can pass
3. Confirm `npm run test:js` can pass
4. Confirm E2E tests can pass: https://github.com/woocommerce/google-listings-and-ads/actions/runs/12198402710

### Changelog entry
