### PR TITLE
Remove unnecessary Sass imports of `@wordpress/base-styles`

### DIFF
--- a/js/src/css/index.scss
+++ b/js/src/css/index.scss
@@ -1,7 +1,3 @@
-// Default Styles Here
-@import "node_modules/@wordpress/base-styles/z-index";
-@import "node_modules/@wordpress/base-styles/default-custom-properties";
-
 // Import Gutenberg components that aren't already imported in the lowest WC Admin version we support
 @import "./shared/gutenberg-components";
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes unnecessary Sass imports of `@wordpress/base-styles`:
- [@wordpress/base-styles/z-index](https://github.com/WordPress/gutenberg/blob/%40wordpress/base-styles%404.49.0/packages/base-styles/_z-index.scss)
- [@wordpress/base-styles/default-custom-properties](https://github.com/WordPress/gutenberg/blob/%40wordpress/base-styles%404.49.0/packages/base-styles/_default-custom-properties.scss)

After externalizing `@wordpress/components` in #2056, it should no longer need to import `@wordpress/base-styles/z-index` because this codebase doesn't use `z-index()` in any .scss files.

I couldn't track back the reason for importing `@wordpress/base-styles/default-custom-properties`, but a plugin should be able to rely on the default WordPress Theme CSS variables provided by WordPress core instead of building the duplicated ones within plugin's CSS file.

![image](https://github.com/user-attachments/assets/0e88df9e-5834-47f7-9bdc-0931190a6c26)

Furthermore, removing it can fix the following Sass warning when building frontend code.

![image](https://github.com/user-attachments/assets/0d34de61-cea4-4f3a-9a18-0d89b95c5f3f)

### Detailed test instructions:

1. Confirm `npm run dev` can build frontend code without errors and the above Sass warning
2. Go to **User > Profile** and select the Default option for the **Admin Color Scheme** setting
3. View components that use the WordPress Theme CSS variables such as `--wp-admin-theme-color`
   - One of the most obvious examples is the `AppTabNav` component:
      ![image](https://github.com/user-attachments/assets/7b1380fd-9d1d-40eb-9001-0020bb1c57bc)
      https://github.com/woocommerce/google-listings-and-ads/blob/e6d95d8601a19ce39d2efdd6134a2b3e169b5ec3/js/src/components/app-tab-nav/index.scss#L36-L38
   - Check if the default colors defined by WordPress Theme CSS variables are applied correctly
      ![1](https://github.com/user-attachments/assets/e49af07b-6362-4275-81a3-2d1665e8761a)

### Changelog entry
