### PR TITLE
Fix the issue of the saved max shipping time not showing after revisiting the free listings editing page

### DIFF
--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -195,11 +195,11 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		}
 
 		case TYPES.UPSERT_SHIPPING_TIMES: {
-			const { countryCodes, time } = action.shippingTime;
+			const { countryCodes, time, maxTime } = action.shippingTime;
 			const times = [ ...state.mc.shipping.times ];
 
 			countryCodes.forEach( ( countryCode ) => {
-				const shippingTime = { countryCode, time };
+				const shippingTime = { countryCode, time, maxTime };
 				const idx = times.findIndex(
 					( el ) => el.countryCode === countryCode
 				);

--- a/js/src/data/test/reducer.test.js
+++ b/js/src/data/test/reducer.test.js
@@ -261,10 +261,12 @@ describe( 'reducer', () => {
 					{
 						countryCode: 'US',
 						time: 7,
+						maxTime: 14,
 					},
 					{
 						countryCode: 'CA',
 						time: 12,
+						maxTime: 18,
 					},
 				],
 			};
@@ -278,10 +280,12 @@ describe( 'reducer', () => {
 				{
 					countryCode: 'US',
 					time: 7,
+					maxTime: 14,
 				},
 				{
 					countryCode: 'CA',
 					time: 12,
+					maxTime: 18,
 				},
 			] );
 			const action = {
@@ -289,6 +293,7 @@ describe( 'reducer', () => {
 				shippingTime: {
 					countryCodes: [ 'JP', 'CA' ],
 					time: 15,
+					maxTime: 30,
 				},
 			};
 			const state = reducer( originalState, action );
@@ -297,14 +302,17 @@ describe( 'reducer', () => {
 				{
 					countryCode: 'US',
 					time: 7,
+					maxTime: 14,
 				},
 				{
 					countryCode: 'CA',
 					time: 15,
+					maxTime: 30,
 				},
 				{
 					countryCode: 'JP',
 					time: 15,
+					maxTime: 30,
 				},
 			] );
 		} );
@@ -314,14 +322,17 @@ describe( 'reducer', () => {
 				{
 					countryCode: 'US',
 					time: 7,
+					maxTime: 14,
 				},
 				{
 					countryCode: 'CA',
 					time: 12,
+					maxTime: 18,
 				},
 				{
 					countryCode: 'JP',
 					time: 15,
+					maxTime: 30,
 				},
 			] );
 			const action = {
@@ -334,6 +345,7 @@ describe( 'reducer', () => {
 				{
 					countryCode: 'CA',
 					time: 12,
+					maxTime: 18,
 				},
 			] );
 		} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the issue of the saved max shipping time not showing after revisiting the free listings editing page.

https://github.com/user-attachments/assets/573b7f70-5ec3-41ec-95c8-0db9be5e8dba

### Screenshots:

https://github.com/user-attachments/assets/97fc9443-37e1-4fff-a10b-079120dc6470

### Detailed test instructions:

1. Go to edit free listings
2. Edit a max shipping time save it
3. Back to Dashboard by clicking the **<** button at the top-left side of the page 
   ![image](https://github.com/user-attachments/assets/74459538-4e1c-4ceb-a7a3-7c0c36b0ebf1)
4. Go to edit free listings again
5. Check if the saved max time is shown

### Changelog entry

> Fix - The saved max shipping time is not showing after revisiting the free listings editing page.
