### PR TITLE
Eliminate the duplicate functions used to group shipping time data

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/shipping-time-setup/shipping-countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time-setup/shipping-countries-form.js
@@ -4,7 +4,7 @@
 import VerticalGapLayout from '~/components/vertical-gap-layout';
 import AddTimeButton from './add-time-button';
 import CountriesTimeInput from './countries-time-input';
-import getCountriesTimeArray from './getCountriesTimeArray';
+import getShippingTimesGroups from '~/utils/getShippingTimesGroups';
 
 /**
  * @typedef { import("~/data/actions").CountryCode } CountryCode
@@ -36,7 +36,7 @@ export default function ShippingCountriesForm( {
 	const remainingCount = remainingCountryCodes.length;
 
 	// Group countries with the same time.
-	const countriesTimeArray = getCountriesTimeArray( shippingTimes );
+	const countriesTimeArray = getShippingTimesGroups( shippingTimes );
 
 	// Prefill to-be-added time.
 	if ( countriesTimeArray.length === 0 ) {

--- a/js/src/components/free-listings/configure-product-listings/shipping-time-setup/shipping-countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time-setup/shipping-countries-form.js
@@ -9,7 +9,6 @@ import getShippingTimesGroups from '~/utils/getShippingTimesGroups';
 /**
  * @typedef { import("~/data/actions").CountryCode } CountryCode
  * @typedef { import("~/data/actions").ShippingTime } ShippingTime
- * @typedef { import("~/data/actions").AggregatedShippingTime } AggregatedShippingTime
  */
 
 /**

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -264,13 +264,13 @@ export function* fetchShippingTimes() {
  * @throws Will throw an error if the request failed.
  */
 export function* upsertShippingTimes( shippingTime ) {
-	const { countryCodes, time, maxTime } = shippingTime;
+	const { countries, time, maxTime } = shippingTime;
 
 	yield apiFetch( {
 		path: `${ API_NAMESPACE }/mc/shipping/times/batch`,
 		method: 'POST',
 		data: {
-			country_codes: countryCodes,
+			country_codes: countries,
 			time,
 			max_time: maxTime,
 		},

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -195,10 +195,10 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		}
 
 		case TYPES.UPSERT_SHIPPING_TIMES: {
-			const { countryCodes, time, maxTime } = action.shippingTime;
+			const { countries, time, maxTime } = action.shippingTime;
 			const times = [ ...state.mc.shipping.times ];
 
-			countryCodes.forEach( ( countryCode ) => {
+			countries.forEach( ( countryCode ) => {
 				const shippingTime = { countryCode, time, maxTime };
 				const idx = times.findIndex(
 					( el ) => el.countryCode === countryCode

--- a/js/src/data/test/reducer.test.js
+++ b/js/src/data/test/reducer.test.js
@@ -291,7 +291,7 @@ describe( 'reducer', () => {
 			const action = {
 				type: TYPES.UPSERT_SHIPPING_TIMES,
 				shippingTime: {
-					countryCodes: [ 'JP', 'CA' ],
+					countries: [ 'JP', 'CA' ],
 					time: 15,
 					maxTime: 30,
 				},

--- a/js/src/hooks/useSaveShippingTimes.js
+++ b/js/src/hooks/useSaveShippingTimes.js
@@ -10,11 +10,10 @@ import { useAppDispatch } from '~/data';
 import useShippingTimes from './useShippingTimes';
 import getDeletedShippingTimes from '~/utils/getDeletedShippingTimes';
 import getDifferentShippingTimes from '~/utils/getDifferentShippingTimes';
-import getShippingTimeMapKey from '~/utils/getShippingTimeMapKey';
+import getShippingTimesGroups from '~/utils/getShippingTimesGroups';
 
 /**
  * @typedef { import("~/data/actions").ShippingTime } ShippingTime
- * @typedef { import("~/data/actions").AggregatedShippingTime } AggregatedShippingTime
  */
 
 /**
@@ -35,28 +34,6 @@ const getDeletedCountryCodes = ( newShippingTimes, oldShippingTimes ) => {
 	return deletedShippingTimes.map(
 		( shippingTime ) => shippingTime.countryCode
 	);
-};
-
-/**
- * Get aggregated shipping time groups from shipping times.
- *
- * @param {Array<ShippingTime>} shippingTimes Array of shipping time.
- * @return {Array<AggregatedShippingTime>} Array of shipping time group.
- */
-const getShippingTimesGroups = ( shippingTimes ) => {
-	const timeGroupMap = new Map();
-	shippingTimes.forEach( ( { countryCode, time, maxTime } ) => {
-		const mapKey = getShippingTimeMapKey( time, maxTime );
-		const group = timeGroupMap.get( mapKey ) || {
-			countryCodes: [],
-			time,
-			maxTime,
-		};
-		group.countryCodes.push( countryCode );
-		timeGroupMap.set( mapKey, group );
-	} );
-
-	return Array.from( timeGroupMap.values() );
 };
 
 const useSaveShippingTimes = () => {

--- a/js/src/utils/getShippingTimeMapKey.js
+++ b/js/src/utils/getShippingTimeMapKey.js
@@ -1,5 +1,0 @@
-const getShippingTimeMapKey = ( time, maxtime ) => {
-	return `${ time }-${ maxtime }`;
-};
-
-export default getShippingTimeMapKey;

--- a/js/src/utils/getShippingTimesGroups.js
+++ b/js/src/utils/getShippingTimesGroups.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import getShippingTimeMapKey from '~/utils/getShippingTimeMapKey';
-
-/**
  * Groups shipping times based on time.
  *
  * Usage example:
@@ -52,7 +47,7 @@ const getShippingTimesGroups = ( shippingTimes ) => {
 
 	shippingTimes.forEach( ( shippingTime ) => {
 		const { countryCode, time, maxTime } = shippingTime;
-		const mapKey = getShippingTimeMapKey( time, maxTime );
+		const mapKey = `${ time }-${ maxTime }`;
 		const group = timeGroupMap.get( mapKey ) || {
 			countries: [],
 			time,

--- a/js/src/utils/getShippingTimesGroups.js
+++ b/js/src/utils/getShippingTimesGroups.js
@@ -27,7 +27,7 @@ import getShippingTimeMapKey from '~/utils/getShippingTimeMapKey';
  *     },
  * ]
  *
- * const result = getCountriesTimeArray( shippingTimes );
+ * const result = getShippingTimesGroups( shippingTimes );
  *
  * // result:
  * // [
@@ -47,7 +47,7 @@ import getShippingTimeMapKey from '~/utils/getShippingTimeMapKey';
  * @param {Array<ShippingTime>} shippingTimes Array of individual shipping times in the format of `{ countryCode, time }`.
  * @return {Array<AggregatedShippingTime>} Array of shipping times grouped by time.
  */
-const getCountriesTimeArray = ( shippingTimes ) => {
+const getShippingTimesGroups = ( shippingTimes ) => {
 	const timeGroupMap = new Map();
 
 	shippingTimes.forEach( ( shippingTime ) => {
@@ -65,7 +65,7 @@ const getCountriesTimeArray = ( shippingTimes ) => {
 	return Array.from( timeGroupMap.values() );
 };
 
-export default getCountriesTimeArray;
+export default getShippingTimesGroups;
 
 /**
  * @typedef { import("~/data/actions").ShippingTime } ShippingTime


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1426

This PR eliminates the duplicate functions used to group shipping time data.

- Move `getCountriesTimeArray` to the `utils` directory and rename to `getShippingTimesGroups`.
- Replace the `getShippingTimesGroups` function in the `useSaveShippingTimes` hook with the one in utils.
- Internalize the `getShippingTimeMapKey` util into `getShippingTimesGroups` util.
- Extra change: Remove an unreferenced `AggregatedShippingTime` type.

### Detailed test instructions:

1. Go to step 2 of the onboarding flow.
2. Check if the shipping times can be saved correctly.
3. Go to the free listings editing page.
4. Check if the shipping times can be saved correctly.

### Changelog entry

> Dev - Eliminate the duplicate functions used to group shipping time data.
