### PR TITLE
Fix Budget Recommendation data not populating on install

### DIFF
--- a/src/DB/Table/BudgetRecommendationTable.php
+++ b/src/DB/Table/BudgetRecommendationTable.php
@@ -104,7 +104,7 @@ SQL;
 		if ( file_exists( $path ) ) {
 			$csv = array_map(
 				function ( $row ) {
-					str_getcsv( $row, ',', '"', '\\' );
+					return str_getcsv( $row, ',', '"', '\\' );
 				},
 				file( $path )
 			);

--- a/tests/Unit/DB/Query/BudgetRecommendationQueryTest.php
+++ b/tests/Unit/DB/Query/BudgetRecommendationQueryTest.php
@@ -1,0 +1,63 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB\Query;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\BudgetRecommendationTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+
+/**
+ * BudgetRecommendationQueryTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB\Query
+ */
+class BudgetRecommendationQueryTest extends UnitTest {
+
+	/** @var BudgetRecommendationQuery $budget_recommendation_query */
+	protected $budget_recommendation_query;
+
+	/** @var BudgetRecommendationTable $budget_recommendation_table */
+	protected $budget_recommendation_table;
+
+	/** @var WP $wp */
+	protected $wp;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		global $wpdb;
+
+		parent::setUp();
+
+		$this->wp                          = new WP();
+		$this->budget_recommendation_table = new BudgetRecommendationTable( $this->wp, $wpdb );
+		$this->budget_recommendation_query = new BudgetRecommendationQuery( $wpdb, $this->budget_recommendation_table );
+
+		// Install DB table so we can test with actual pre populated data.
+		$this->budget_recommendation_table->install();
+	}
+
+	public function test_query_single_value() {
+		$this->budget_recommendation_query->where( 'currency', 'EUR' );
+		$this->budget_recommendation_query->where( 'country', 'IE' );
+
+		$results = $this->budget_recommendation_query->get_results();
+
+		$this->assertCount( 1, $results );
+		$this->assertEquals( 10, $results[0]['daily_budget'] );
+	}
+
+	public function test_query_multiple_values() {
+		$this->budget_recommendation_query->where( 'currency', 'USD' );
+		$this->budget_recommendation_query->where( 'country', [ 'US', 'CA' ], 'IN' );
+
+		$results = $this->budget_recommendation_query->get_results();
+
+		$this->assertCount( 2, $results );
+		$this->assertEquals( 15, $results[0]['daily_budget'] );
+		$this->assertEquals( 14, $results[1]['daily_budget'] );
+	}
+}

--- a/tests/Unit/DB/Query/BudgetRecommendationQueryTest.php
+++ b/tests/Unit/DB/Query/BudgetRecommendationQueryTest.php
@@ -53,11 +53,14 @@ class BudgetRecommendationQueryTest extends UnitTest {
 	public function test_query_multiple_values() {
 		$this->budget_recommendation_query->where( 'currency', 'USD' );
 		$this->budget_recommendation_query->where( 'country', [ 'US', 'CA' ], 'IN' );
+		$this->budget_recommendation_query->set_order( 'country' );
 
 		$results = $this->budget_recommendation_query->get_results();
 
 		$this->assertCount( 2, $results );
-		$this->assertEquals( 15, $results[0]['daily_budget'] );
-		$this->assertEquals( 14, $results[1]['daily_budget'] );
+		$this->assertEquals( 14, $results[0]['daily_budget'] );
+		$this->assertEquals( 'CA', $results[0]['country'] );
+		$this->assertEquals( 15, $results[1]['daily_budget'] );
+		$this->assertEquals( 'US', $results[1]['country'] );
 	}
 }

--- a/tests/Unit/DB/Table/BudgetRecommendationTableTest.php
+++ b/tests/Unit/DB/Table/BudgetRecommendationTableTest.php
@@ -100,4 +100,16 @@ class BudgetRecommendationTableTest extends UnitTest {
 
 		$this->mock_budget_recommendation->reload_data();
 	}
+
+	/**
+	 * Test installing the DB table to ensure there are no errors during install.
+	 */
+	public function test_db_install() {
+		global $wpdb;
+
+		$table = new BudgetRecommendationTable( new WP(), $wpdb );
+		$table->install();
+
+		$this->assertEmpty( $wpdb->last_error );
+	}
 }

--- a/tests/Unit/DB/Table/MerchantIssueTableTest.php
+++ b/tests/Unit/DB/Table/MerchantIssueTableTest.php
@@ -65,4 +65,16 @@ class MerchantIssueTableTest extends UnitTest {
 
 		$this->mock_merchant_issue->delete_specific_product_issues( [ 1 ] );
 	}
+
+	/**
+	 * Test installing the DB table to ensure there are no errors during install.
+	 */
+	public function test_db_install() {
+		global $wpdb;
+
+		$table = new MerchantIssueTable( new WP(), $wpdb );
+		$table->install();
+
+		$this->assertEmpty( $wpdb->last_error );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes an issue that was [introduced in PHP 8.4 compatibility code](https://github.com/woocommerce/google-listings-and-ads/commit/b6ba522871b845e48b8575bedad61bd027ebf665).

The budget recommendation was covered by unit testing, although it used mocked data, so it didn't catch the testing of actually installing the database table. Since we have database tables available during unit testing I added two types of tests:

1. Trigger the DB install code to run with the unit test DB and confirm it doesn't generate any errors
2. Query from the DB tables with pre-populated data (which expects the install / population process to have completed)

Closes #2730 

### Detailed test instructions:
1. Install extension from scratch 
3. Check the database table `wp_gla_budget_recommendations` is created and contains rows of imported data

Alternative way to test:
1. Drop / rename table `wp_gla_budget_recommendations`
2. Use this filter to force running the install code `add_filter( 'woocommerce_gla_force_run_install', '__return_true' );`
4. Ensure the DB table is recreated and populated

### Changelog entry
* Fix - Budget Recommendation data not populating on install.
