### PR TITLE
Clear previous errors after completing sync

### DIFF
--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -105,10 +105,10 @@ class ProductHelper implements Service, HelperNotificationInterface {
 		$google_ids         = array_unique( array_merge( $current_google_ids, [ $google_product->getTargetCountry() => $google_product->getId() ] ) );
 		$this->meta_handler->update_google_ids( $product, $google_ids );
 
-		// check if product is synced completely and remove any previous errors if it is
+		// check if product is synced for main target country and remove any previous errors if it is
 		$synced_countries = array_keys( $google_ids );
 		$target_countries = $this->target_audience->get_target_countries();
-		if ( count( $synced_countries ) === count( $target_countries ) && empty( array_diff( $synced_countries, $target_countries ) ) ) {
+		if ( empty( array_diff( $synced_countries, $target_countries ) ) ) {
 			$this->meta_handler->delete_errors( $product );
 			$this->meta_handler->delete_failed_sync_attempts( $product );
 			$this->meta_handler->delete_sync_failed_at( $product );

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -100,7 +100,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	 *
 	 * @dataProvider return_test_products
 	 */
-	public function test_mark_as_synced_doesnt_delete_errors_unless_all_target_countries_synced( WC_Product $product ) {
+	public function test_mark_as_synced_deletes_errors_when_main_target_countries_synced( WC_Product $product ) {
 		$google_product = $this->generate_google_product_mock();
 
 		$this->target_audience->expects( $this->any() )
@@ -114,17 +114,33 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 
 		$this->product_helper->mark_as_synced( $product, $google_product );
 
-		$this->assertEquals( [ 'Error 1', 'Error 2' ], $this->product_meta->get_errors( $product ) );
-		$this->assertEquals( 1, $this->product_meta->get_failed_sync_attempts( $product ) );
-		$this->assertEquals( 12345, $this->product_meta->get_sync_failed_at( $product ) );
-
-		$google_product_2 = $this->generate_google_product_mock( null, 'AU' );
-
-		$this->product_helper->mark_as_synced( $product, $google_product_2 );
-
 		$this->assertEmpty( $this->product_meta->get_errors( $product ) );
 		$this->assertEmpty( $this->product_meta->get_failed_sync_attempts( $product ) );
 		$this->assertEmpty( $this->product_meta->get_sync_failed_at( $product ) );
+	}
+
+	/**
+	 * @param WC_Product $product
+	 *
+	 * @dataProvider return_test_products
+	 */
+	public function test_mark_as_synced_doesnt_delete_errors_unless_main_target_countries_synced( WC_Product $product ) {
+		$google_product = $this->generate_google_product_mock();
+
+		$this->target_audience->expects( $this->any() )
+			->method( 'get_target_countries' )
+			->willReturn( [ 'AU', 'CA' ] );
+
+		// add some random errors residue from previous sync attempts
+		$this->product_meta->update_errors( $product, [ 'Error 1', 'Error 2' ] );
+		$this->product_meta->update_failed_sync_attempts( $product, 1 );
+		$this->product_meta->update_sync_failed_at( $product, 12345 );
+
+		$this->product_helper->mark_as_synced( $product, $google_product );
+
+		$this->assertEquals( [ 'Error 1', 'Error 2' ], $this->product_meta->get_errors( $product ) );
+		$this->assertEquals( 1, $this->product_meta->get_failed_sync_attempts( $product ) );
+		$this->assertEquals( 12345, $this->product_meta->get_sync_failed_at( $product ) );
 	}
 
 	public function test_mark_as_synced_updates_both_variation_and_parent() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR clears out previous sync errors if the synced countries are all contained within the set of target countries. Previously the length of the arrays needed to match as well. This is no longer the case since we don't sync each target country individually anymore.

The unit tests were updated to reflect the new behaviour.

Closes #2737 

### Detailed test instructions:

1. On a site where we completed onboarding (and use a live URL so we are allowed to sync)
2. During onboarding make sure to select multiple target countries
3. Create a product with no description (complete all other requirements such as product image and price)
4. Save the product with Sync and Show status to trigger the sync
5. Wait for Action Scheduler to complete sync
6. Edit the product and confirm the error has shown up after sync attempt
![Image](https://github.com/user-attachments/assets/bebf230c-fbd1-43ad-9a9d-33d1d858c526)
7. View the product issues in the Product Feed page and confirm that the issue is showing up there as well
8. Update the product to add a description and complete all requirements so it can sync
9. Wait for the product sync to complete
10. Edit the product and confirm the errors don't show up in the product
11. View the product issues in the Product Feed page and confirm that the issue is not showing up there either
12. Clear the product status cache to reload it (tool in connection test page)
13. View the product issues table again and confirm that the error is still not there

### Changelog entry
* Fix - Clear previous errors after completing sync.
