### PR TITLE
Adjust conditions for MCM

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
+use Automattic\WooCommerce\Admin\Marketing\MarketingChannels;
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Redirect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
@@ -429,7 +430,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		// Share Attribute Mapping related classes
 		$this->share_with_tags( AttributeMappingHelper::class );
 
-		if ( defined( 'WC_MCM_EXISTS' ) ) {
+		if ( class_exists( MarketingChannels::class ) ) {
 			$this->share_with_tags( GLAChannel::class, MerchantCenterService::class, AdsCampaign::class, Ads::class, MerchantStatuses::class, ProductSyncStats::class );
 			$this->share_with_tags( MarketingChannelRegistrar::class, GLAChannel::class, WC::class );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As laid out in the issue https://github.com/woocommerce/woocommerce/issues/53753
The conditions for registering Multi Channel Marketing channels has changed. This PR switches to using a `class_exists` check instead of a constant.

### Detailed test instructions:
1. Test with at least WC 9.5
2. Enable the snippet `add_filter( 'woocommerce_gla_enable_mcm', '__return_true' );`
3. Onboard with an ads account and make sure at least one campaign is created
4. Go to Marketing > Overview
5. Confirm that the channel is not showing
![image](https://github.com/user-attachments/assets/0a451178-144e-4087-a9af-c61d4c00aec4)
6. Check out this PR and reload the Marketing > Overview page
7. Confirm that the channels and campaigns are showing
![image](https://github.com/user-attachments/assets/25dafb0d-50c3-4a70-a96c-4e382f54ad6d)

### Changelog entry
* Tweak - Adjust conditions for MCM

