### PR TITLE
Reorganizes the frontend code related to the calls of settings APIs

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -325,10 +325,10 @@ export function* fetchSettings() {
 }
 
 /**
- * Save the the MC settings.
+ * Save the plugin settings.
  *
- * @param {SettingsData} settings settings
- * @return {Object} Action object to save target audience.
+ * @param {SettingsData} settings Plugin settings
+ * @return {Object} Action object to save the plugin settings.
  */
 export function* saveSettings( settings ) {
 	yield apiFetch( {

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -343,6 +343,18 @@ export function* saveSettings( settings ) {
 	};
 }
 
+/**
+ * Sync the shipping and tax rate settings to Google Merchant Center.
+ *
+ * @throws Will throw an error if the request failed.
+ */
+export function* syncSettings() {
+	yield apiFetch( {
+		path: `${ API_NAMESPACE }/mc/settings/sync`,
+		method: 'POST',
+	} );
+}
+
 export function* fetchJetpackAccount() {
 	try {
 		const response = yield apiFetch( {

--- a/js/src/hooks/useSettings.js
+++ b/js/src/hooks/useSettings.js
@@ -6,21 +6,25 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { STORE_KEY } from '~/data';
+import { STORE_KEY, useAppDispatch } from '~/data';
 
 /**
- * Returns an object `{ settings }` to be used in the Setup Free Listing page.
+ * Returns an object `{ settings, saveSettings }` to be used in the Setup Free Listing page.
  *
  * `settings` is the saved values retrieved from API.
+ * `saveSettings` action to save the plugin settings.
  */
 const useSettings = () => {
-	return useSelect( ( select ) => {
-		const settings = select( STORE_KEY ).getSettings();
+	const { saveSettings } = useAppDispatch();
 
-		return {
-			settings,
-		};
+	const settings = useSelect( ( select ) => {
+		return select( STORE_KEY ).getSettings();
 	}, [] );
+
+	return {
+		settings,
+		saveSettings,
+	};
 };
 
 export default useSettings;

--- a/js/src/hooks/useSettings.js
+++ b/js/src/hooks/useSettings.js
@@ -9,13 +9,15 @@ import { useSelect } from '@wordpress/data';
 import { STORE_KEY, useAppDispatch } from '~/data';
 
 /**
- * Returns an object `{ settings, saveSettings }` to be used in the Setup Free Listing page.
+ * Returns an object `{ settings, saveSettings, syncSettings }` to
+ * be used in the Setup Free Listing page.
  *
  * `settings` is the saved values retrieved from API.
  * `saveSettings` action to save the plugin settings.
+ * `syncSettings` action to sync the shipping and tax rate settings to Google Merchant Center.
  */
 const useSettings = () => {
-	const { saveSettings } = useAppDispatch();
+	const { saveSettings, syncSettings } = useAppDispatch();
 
 	const settings = useSelect( ( select ) => {
 		return select( STORE_KEY ).getSettings();
@@ -24,6 +26,7 @@ const useSettings = () => {
 	return {
 		settings,
 		saveSettings,
+		syncSettings,
 	};
 };
 

--- a/js/src/pages/edit-free-listings/index.js
+++ b/js/src/pages/edit-free-listings/index.js
@@ -49,8 +49,8 @@ const EditFreeListings = () => {
 	const { targetAudience: savedTargetAudience, getFinalCountries } =
 		useTargetAudienceFinalCountryCodes();
 
-	const { settings: savedSettings } = useSettings();
-	const { saveTargetAudience, saveSettings } = useAppDispatch();
+	const { settings: savedSettings, saveSettings } = useSettings();
+	const { saveTargetAudience } = useAppDispatch();
 	const { saveShippingRates } = useSaveShippingRates();
 	const { saveShippingTimes } = useSaveShippingTimes();
 

--- a/js/src/pages/edit-free-listings/index.js
+++ b/js/src/pages/edit-free-listings/index.js
@@ -14,7 +14,6 @@ import TopBar from '~/components/stepper/top-bar';
 import SetupFreeListings from '~/components/free-listings/setup-free-listings';
 import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 import useSettings from '~/hooks/useSettings';
-import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 import useLayout from '~/hooks/useLayout';
 import useNavigateAwayPromptEffect from '~/hooks/useNavigateAwayPromptEffect';
 import useShippingRates from '~/hooks/useShippingRates';
@@ -49,7 +48,12 @@ const EditFreeListings = () => {
 	const { targetAudience: savedTargetAudience, getFinalCountries } =
 		useTargetAudienceFinalCountryCodes();
 
-	const { settings: savedSettings, saveSettings } = useSettings();
+	const {
+		settings: savedSettings,
+		saveSettings,
+		syncSettings,
+	} = useSettings();
+
 	const { saveTargetAudience } = useAppDispatch();
 	const { saveShippingRates } = useSaveShippingRates();
 	const { saveShippingTimes } = useSaveShippingTimes();
@@ -87,10 +91,6 @@ const EditFreeListings = () => {
 		[ savedShippingTimes ]
 	);
 
-	const [ fetchSettingsSync ] = useApiFetchCallback( {
-		path: `/wc/gla/mc/settings/sync`,
-		method: 'POST',
-	} );
 	const { createNotice } = useDispatchCoreNotices();
 
 	// Check what've changed to show prompt, and send requests only to save changed things.
@@ -155,7 +155,7 @@ const EditFreeListings = () => {
 			);
 
 			// Sync data once our changes are saved, even partially succesfully.
-			await fetchSettingsSync();
+			await syncSettings();
 
 			if ( errorMessage ) {
 				createNotice( 'error', errorMessage );

--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
@@ -38,7 +38,7 @@ import {
 const SavedSetupStepper = ( { savedStep } ) => {
 	const [ step, setStep ] = useState( savedStep );
 
-	const { settings } = useSettings();
+	const { settings, saveSettings } = useSettings();
 	const { data: suggestedAudience } = useTargetAudienceWithSuggestions();
 	const { targetAudience, getFinalCountries } =
 		useTargetAudienceFinalCountryCodes();
@@ -51,7 +51,7 @@ const SavedSetupStepper = ( { savedStep } ) => {
 		data: shippingTimes,
 	} = useShippingTimes();
 
-	const { saveTargetAudience, saveSettings } = useAppDispatch();
+	const { saveTargetAudience } = useAppDispatch();
 	const { saveShippingRates } = useSaveShippingRates();
 	const { saveShippingTimes } = useSaveShippingTimes();
 	const { createNotice } = useDispatchCoreNotices();

--- a/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
 import { useState } from '@wordpress/element';
 import { noop } from 'lodash';
 
@@ -18,7 +17,7 @@ import CampaignAssetsForm from '~/components/paid-ads/campaign-assets-form';
 import AppButton from '~/components/app-button';
 import useGoogleAdsAccountBillingStatus from '~/hooks/useGoogleAdsAccountBillingStatus';
 import { getProductFeedUrl } from '~/utils/urls';
-import { API_NAMESPACE } from '~/data/constants';
+import { useAppDispatch } from '~/data';
 import { GUIDE_NAMES, GOOGLE_ADS_BILLING_STATUS } from '~/constants';
 import { ACTION_COMPLETE, ACTION_SKIP } from './constants';
 import SkipButton from './skip-button';
@@ -48,6 +47,7 @@ export default function SetupPaidAds() {
 		useBudgetRecommendation( countryCodes );
 	const [ handleSetupComplete ] = useAdsSetupCompleteCallback();
 	const { billingStatus } = useGoogleAdsAccountBillingStatus();
+	const { syncSettings } = useAppDispatch();
 
 	const isBillingCompleted =
 		billingStatus?.status === GOOGLE_ADS_BILLING_STATUS.APPROVED;
@@ -55,10 +55,7 @@ export default function SetupPaidAds() {
 	const finishOnboardingSetup = async ( onBeforeFinish = noop ) => {
 		try {
 			await onBeforeFinish();
-			await apiFetch( {
-				path: `${ API_NAMESPACE }/mc/settings/sync`,
-				method: 'POST',
-			} );
+			await syncSettings();
 		} catch ( e ) {
 			setCompleting( null );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is one of the preliminaries for the shipping Improvements.

To avoid too many file changes for subsequent PRs, this PR reorganizes the code related to the calls of settings APIs:

- Add the `saveSettings` action as one of the return values to the `useSettings` hook and update the related uses.
   - Since they are always used together, and there will be a third use case in the subsequent PR.
- Create a new action `syncSettings`, add it as one of the return values to the `useSettings` hook and update the related uses.
   - There will be a third use case of calling to `mc/settings/sync` API in the subsequent PR.
   - They are often used together.
- Correct the JSDoc description for the `saveSettings` action.

### Detailed test instructions:

1. Go to step 2 of the onboarding flow
   1. Open the Network tab of browser's DevTool
   2. Change the **Shipping rates** setting
      ![image](https://github.com/user-attachments/assets/bd1c4e88-2bde-4998-a44b-43f1ccb863ec)
   3. Inspect Network tab. Check if there is a request issued to `wc/gla/mc/settings` API  and if the request is successful
   4. Select the **Preserve log** option on the Network tab
   5. Continue to complete the onboarding flow
   6. Inspect Network tab. Check if there is a request issued to `wc/gla/mc/settings/sync` API  and if the request is successful
2. Go to edit free listing page
   1. Open the Network tab of browser's DevTool
   2. Change the **Tax rate** or **Shipping rates** setting
   3. Save changes
   4. Inspect Network tab.
   5. Check if there is a request issued to `wc/gla/mc/settings` API  and if the request is successful
   6. Check if there is a request issued to `wc/gla/mc/settings/sync` API  and if the request is successful
      ![image](https://github.com/user-attachments/assets/1bd5560a-f6d2-4b99-aaeb-d153e3187402)

### Changelog entry
