### PR TITLE
Bump the minimum supported WordPress version to 6.1 to align with the minimum supported WooCommerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you have a WooCommerce.com account, you can [start a chat or open a ticket on
 
 We aim to support the latest two minor versions of WordPress, WooCommerce, and PHP. (L-2 policy)
 
--   WordPress 5.9+
+-   WordPress 6.1+
 -   WooCommerce 7.9+
 -   PHP 7.4+ (64 bits)
 

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -7,7 +7,7 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
- * Requires at least: 5.9
+ * Requires at least: 6.1
  * Tested up to: 6.7
  * Requires PHP: 7.4
  * Requires PHP Architecture: 64 bits

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
 	<!-- Set the minimum WP version -->
-	<config name="minimum_supported_wp_version" value="5.3"/>
+	<config name="minimum_supported_wp_version" value="6.1"/>
 
 	<rule ref="WordPress">
 		<!-- We don't require conforming to WP file naming -->

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Google for WooCommerce ===
 Contributors: automattic, google, woocommerce
 Tags: woocommerce, google, product feed, ads, listings
-Requires at least: 5.9
+Requires at least: 6.1
 Tested up to: 6.7
 Requires PHP: 7.4
 Requires PHP Architecture: 64 Bits
@@ -51,7 +51,7 @@ Once you’re running Google Ads campaigns, the Google tag feature in the extens
 
 = Minimum Requirements =
 
-* WordPress 5.9 or greater
+* WordPress 6.1 or greater
 * WooCommerce 7.9 or greater
 * PHP version 7.4 or greater
 * PHP Architecture 64 bits

--- a/tests/phpcs.xml.dist
+++ b/tests/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
 	<!-- Set the minimum WP version -->
-	<config name="minimum_supported_wp_version" value="5.3"/>
+	<config name="minimum_supported_wp_version" value="6.1"/>
 
 	<rule ref="WordPress">
 		<!-- We don't require conforming to WP file naming -->


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #2723, the minimum supported WooCommerce was updated to 7.9, and the minimum WordPress it supports is 6.1, so this PR aligns the minimum supported WordPress version to the same.

See: https://github.com/woocommerce/woocommerce/blob/7.9.0/plugins/woocommerce/woocommerce.php#L11

### Detailed test instructions:

Search the codebase to see if there are any WordPress versions noted that have not been updated together.

### Changelog entry

> Update - Drop support for WordPress < 6.1.
