### PR TITLE
Refine the vertical gap for `Section` component

### DIFF
--- a/js/src/components/paid-ads/asset-group/asset-group-section.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-section.js
@@ -11,7 +11,6 @@ import { Tip } from '@wordpress/components';
 import { ASSET_FORM_KEY } from '~/constants';
 import { useAdaptiveFormContext } from '~/components/adaptive-form';
 import Section from '~/components/section';
-import VerticalGapLayout from '~/components/vertical-gap-layout';
 import FinalUrlCard from './final-url-card';
 import AssetGroupCard from './asset-group-card';
 import AppDocumentationLink from '~/components/app-documentation-link';
@@ -30,6 +29,7 @@ export default function AssetGroupSection() {
 	return (
 		<Section
 			className="gla-asset-group-section"
+			verticalGap={ 4 }
 			title={ createInterpolateElement(
 				__(
 					'Add additional assets <optional>(Optional)</optional>',
@@ -61,27 +61,25 @@ export default function AssetGroupSection() {
 				</>
 			}
 		>
-			<VerticalGapLayout size="medium">
-				<FinalUrlCard
-					initialFinalUrl={
-						adapter.baseAssetGroup[ ASSET_FORM_KEY.FINAL_URL ]
-					}
-					onAssetsChange={ adapter.resetAssetGroup }
-					// Currently, the PMax Assets feature in this extension doesn't offer the function
-					// to change the Final URL of the non-empty asset entity group, so it hides the
-					// reselect button in the card footer.
-					hideFooter={ ! adapter.isEmptyAssetEntityGroup }
-				/>
-				{ showTip && (
-					<Tip>
-						{ __(
-							'We auto-populated assets directly from your Final URL. We encourage you to edit or add more in order to best showcase your business.',
-							'google-listings-and-ads'
-						) }
-					</Tip>
-				) }
-				<AssetGroupCard />
-			</VerticalGapLayout>
+			<FinalUrlCard
+				initialFinalUrl={
+					adapter.baseAssetGroup[ ASSET_FORM_KEY.FINAL_URL ]
+				}
+				onAssetsChange={ adapter.resetAssetGroup }
+				// Currently, the PMax Assets feature in this extension doesn't offer the function
+				// to change the Final URL of the non-empty asset entity group, so it hides the
+				// reselect button in the card footer.
+				hideFooter={ ! adapter.isEmptyAssetEntityGroup }
+			/>
+			{ showTip && (
+				<Tip>
+					{ __(
+						'We auto-populated assets directly from your Final URL. We encourage you to edit or add more in order to best showcase your business.',
+						'google-listings-and-ads'
+					) }
+				</Tip>
+			) }
+			<AssetGroupCard />
 		</Section>
 	);
 }

--- a/js/src/components/paid-ads/budget-section/index.js
+++ b/js/src/components/paid-ads/budget-section/index.js
@@ -48,6 +48,7 @@ const BudgetSection = ( {
 	return (
 		<div className="gla-budget-section">
 			<Section
+				verticalGap={ 4 }
 				disabled={ disabled }
 				title={ __( 'Set your budget', 'google-listings-and-ads' ) }
 				description={

--- a/js/src/components/paid-ads/budget-section/index.scss
+++ b/js/src/components/paid-ads/budget-section/index.scss
@@ -1,10 +1,4 @@
 .gla-budget-section {
-	.gla-section__body {
-		display: flex;
-		flex-direction: column;
-		gap: $grid-unit-20;
-	}
-
 	&__card-body {
 		display: flex;
 		flex-direction: column;

--- a/js/src/components/section/index.js
+++ b/js/src/components/section/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { Flex } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -20,6 +21,7 @@ import './index.scss';
  * @param {JSX.Element} [props.children] Section content at the right side.
  * @param {boolean} [props.disabled] Whether display the whole section in disabled style.
  * @param {boolean} [props.disabledLeft] Whether display the left side of section in disabled style.
+ * @param {number} [props.verticalGap=6] Vertical gap between the children.
  */
 const Section = ( {
 	className,
@@ -29,6 +31,7 @@ const Section = ( {
 	children,
 	disabled,
 	disabledLeft,
+	verticalGap = 6,
 } ) => {
 	const sectionClassName = classnames(
 		'gla-section',
@@ -44,7 +47,13 @@ const Section = ( {
 				{ title && <h1>{ title }</h1> }
 				{ description }
 			</header>
-			<div className="gla-section__body">{ children }</div>
+			<Flex
+				className="gla-section__body"
+				direction="column"
+				gap={ verticalGap }
+			>
+				{ children }
+			</Flex>
 		</section>
 	);
 };

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -57,71 +57,69 @@ const ShippingRateSection = () => {
 				</div>
 			}
 		>
-			<VerticalGapLayout size="large">
-				<Section.Card>
-					<Section.Card.Body>
-						<VerticalGapLayout size="large">
-							{ ! hideAutomatticShippingRate && (
-								<AppRadioContentControl
-									{ ...inputProps }
-									label={ __(
-										'Automatically sync my store’s shipping settings to Google.',
-										'google-listings-and-ads'
-									) }
-									value="automatic"
-									collapsible
-								>
-									<RadioHelperText>
-										{ __(
-											'My current settings and any future changes to my store’s shipping rates and classes will be automatically synced to Google Merchant Center.',
-											'google-listings-and-ads'
-										) }
-									</RadioHelperText>
-								</AppRadioContentControl>
-							) }
+			<Section.Card>
+				<Section.Card.Body>
+					<VerticalGapLayout size="large">
+						{ ! hideAutomatticShippingRate && (
 							<AppRadioContentControl
 								{ ...inputProps }
 								label={ __(
-									'My shipping settings are simple. I can manually estimate flat shipping rates.',
+									'Automatically sync my store’s shipping settings to Google.',
 									'google-listings-and-ads'
 								) }
-								value="flat"
-								collapsible
-							/>
-							<AppRadioContentControl
-								{ ...inputProps }
-								label={ __(
-									'My shipping settings are complex. I will enter my shipping rates and times manually in Google Merchant Center.',
-									'google-listings-and-ads'
-								) }
-								value="manual"
+								value="automatic"
 								collapsible
 							>
 								<RadioHelperText>
-									{ createInterpolateElement(
-										__(
-											'I understand that if I don’t set this up manually in <link>Google Merchant Center</link>, my products will be disapproved by Google.',
-											'google-listings-and-ads'
-										),
-										{
-											link: (
-												<AppDocumentationLink
-													context="setup-mc-shipping"
-													linkId="shipping-manual"
-													href="https://www.google.com/retail/solutions/merchant-center/"
-												/>
-											),
-										}
+									{ __(
+										'My current settings and any future changes to my store’s shipping rates and classes will be automatically synced to Google Merchant Center.',
+										'google-listings-and-ads'
 									) }
 								</RadioHelperText>
 							</AppRadioContentControl>
-						</VerticalGapLayout>
-					</Section.Card.Body>
-				</Section.Card>
-				{ values.shipping_rate === 'flat' && (
-					<FlatShippingRatesInputCards />
-				) }
-			</VerticalGapLayout>
+						) }
+						<AppRadioContentControl
+							{ ...inputProps }
+							label={ __(
+								'My shipping settings are simple. I can manually estimate flat shipping rates.',
+								'google-listings-and-ads'
+							) }
+							value="flat"
+							collapsible
+						/>
+						<AppRadioContentControl
+							{ ...inputProps }
+							label={ __(
+								'My shipping settings are complex. I will enter my shipping rates and times manually in Google Merchant Center.',
+								'google-listings-and-ads'
+							) }
+							value="manual"
+							collapsible
+						>
+							<RadioHelperText>
+								{ createInterpolateElement(
+									__(
+										'I understand that if I don’t set this up manually in <link>Google Merchant Center</link>, my products will be disapproved by Google.',
+										'google-listings-and-ads'
+									),
+									{
+										link: (
+											<AppDocumentationLink
+												context="setup-mc-shipping"
+												linkId="shipping-manual"
+												href="https://www.google.com/retail/solutions/merchant-center/"
+											/>
+										),
+									}
+								) }
+							</RadioHelperText>
+						</AppRadioContentControl>
+					</VerticalGapLayout>
+				</Section.Card.Body>
+			</Section.Card>
+			{ values.shipping_rate === 'flat' && (
+				<FlatShippingRatesInputCards />
+			) }
 		</Section>
 	);
 };

--- a/js/src/components/stepper/step-content-footer/index.js
+++ b/js/src/components/stepper/step-content-footer/index.js
@@ -2,12 +2,11 @@
  * Internal dependencies
  */
 import Section from '~/components/section';
-import VerticalGapLayout from '~/components/vertical-gap-layout';
 
 const StepContentFooter = ( { children } ) => {
 	return (
-		<Section className="gla-step-content-footer">
-			<VerticalGapLayout size="xlarge">{ children }</VerticalGapLayout>
+		<Section className="gla-step-content-footer" verticalGap={ 10 }>
+			{ children }
 		</Section>
 	);
 };

--- a/js/src/components/vertical-gap-layout/index.js
+++ b/js/src/components/vertical-gap-layout/index.js
@@ -13,7 +13,6 @@ const sizeClassName = {
 	normal: false,
 	medium: 'gla-vertical-gap-layout__medium',
 	large: 'gla-vertical-gap-layout__large',
-	xlarge: 'gla-vertical-gap-layout__xlarge',
 	overlap: 'gla-vertical-gap-layout__overlap',
 };
 
@@ -22,11 +21,10 @@ const sizeClassName = {
  *
  * @param {Object} props React props.
  * @param {string} [props.className] Additional CSS class name to be appended.
- * @param {'normal'|'medium'|'large'|'xlarge'|'overlap'} [props.size='normal'] Indicate the gap between children.
+ * @param {'normal'|'medium'|'large'|'overlap'} [props.size='normal'] Indicate the gap between children.
  *     'normal': A normal gap.
  *     'medium': A medium gap.
  *     'large': A large gap.
- *     'xlarge': An extra large gap.
  *     'overlap': Overlap the back child on the front child with -1 pixel spacing.
  */
 const VerticalGapLayout = ( props ) => {

--- a/js/src/components/vertical-gap-layout/index.scss
+++ b/js/src/components/vertical-gap-layout/index.scss
@@ -11,10 +11,6 @@
 		gap: var(--main-gap);
 	}
 
-	&.gla-vertical-gap-layout__xlarge {
-		gap: var(--large-gap);
-	}
-
 	&.gla-vertical-gap-layout__overlap {
 		gap: 0;
 

--- a/js/src/pages/ads-onboarding/ads-stepper/setup-accounts.js
+++ b/js/src/pages/ads-onboarding/ads-stepper/setup-accounts.js
@@ -11,7 +11,6 @@ import StepContent from '~/components/stepper/step-content';
 import StepContentHeader from '~/components/stepper/step-content-header';
 import StepContentActions from '~/components/stepper/step-content-actions';
 import StepContentFooter from '~/components/stepper/step-content-footer';
-import VerticalGapLayout from '~/components/vertical-gap-layout';
 import { ConnectedGoogleAccountCard } from '~/components/google-account-card';
 import GoogleAdsAccountCard from '~/components/google-ads-account-card';
 import FreeAdCredit from '~/components/free-ad-credit';
@@ -52,18 +51,16 @@ const SetupAccounts = ( props ) => {
 					'google-listings-and-ads'
 				) }
 			>
-				<VerticalGapLayout size="large">
-					<ConnectedGoogleAccountCard
-						googleAccount={ google }
-						hideAccountSwitch
-						helper={ __(
-							'This Google account is connected to your store’s product feed.',
-							'google-listings-and-ads'
-						) }
-					/>
-					<GoogleAdsAccountCard />
-					<FreeAdCredit />
-				</VerticalGapLayout>
+				<ConnectedGoogleAccountCard
+					googleAccount={ google }
+					hideAccountSwitch
+					helper={ __(
+						'This Google account is connected to your store’s product feed.',
+						'google-listings-and-ads'
+					) }
+				/>
+				<GoogleAdsAccountCard />
+				<FreeAdCredit />
 			</Section>
 			<StepContentFooter>
 				<StepContentActions>

--- a/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
@@ -19,7 +19,6 @@ import StepContentFooter from '~/components/stepper/step-content-footer';
 import StepContentActions from '~/components/stepper/step-content-actions';
 import Section from '~/components/section';
 import AppDocumentationLink from '~/components/app-documentation-link';
-import VerticalGapLayout from '~/components/vertical-gap-layout';
 import WPComAccountCard from '~/components/wpcom-account-card';
 import GoogleComboAccountCard from '~/components/google-combo-account-card';
 import Faqs from './faqs';
@@ -151,12 +150,10 @@ const SetupAccounts = ( props ) => {
 					'google-listings-and-ads'
 				) }
 			>
-				<VerticalGapLayout size="large">
-					{ ! isJetpackActive && (
-						<WPComAccountCard jetpack={ jetpack } />
-					) }
-					<GoogleComboAccountCard disabled={ ! isJetpackActive } />
-				</VerticalGapLayout>
+				{ ! isJetpackActive && (
+					<WPComAccountCard jetpack={ jetpack } />
+				) }
+				<GoogleComboAccountCard disabled={ ! isJetpackActive } />
 			</Section>
 
 			<StepContentFooter>

--- a/js/src/pages/settings/linked-accounts.js
+++ b/js/src/pages/settings/linked-accounts.js
@@ -16,7 +16,6 @@ import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
 import AppButton from '~/components/app-button';
 import SpinnerCard from '~/components/spinner-card';
-import VerticalGapLayout from '~/components/vertical-gap-layout';
 import { ConnectedWPComAccountCard } from '~/components/wpcom-account-card';
 import { ConnectedGoogleAccountCard } from '~/components/google-account-card';
 import { ConnectedGoogleAdsAccountCard } from '~/components/google-ads-account-card';
@@ -87,7 +86,7 @@ export default function LinkedAccounts() {
 			{ isLoading ? (
 				<SpinnerCard />
 			) : (
-				<VerticalGapLayout size="large">
+				<>
 					<ConnectedWPComAccountCard jetpack={ jetpack } />
 					<ConnectedGoogleAccountCard
 						googleAccount={ google }
@@ -127,7 +126,7 @@ export default function LinkedAccounts() {
 							) }
 						</AppButton>
 					</Flex>
-				</VerticalGapLayout>
+				</>
 			) }
 		</LinkedAccountsSectionWrapper>
 	);

--- a/js/src/pages/settings/reconnect-wpcom-account/reconnect-wpcom-account.js
+++ b/js/src/pages/settings/reconnect-wpcom-account/reconnect-wpcom-account.js
@@ -13,7 +13,6 @@ import useJetpackAccount from '~/hooks/useJetpackAccount';
 import { getSettingsUrl } from '~/utils/urls';
 import AppSpinner from '~/components/app-spinner';
 import AccountCard from '~/components/account-card';
-import VerticalGapLayout from '~/components/vertical-gap-layout';
 import { ConnectWPComAccountCard } from '~/components/wpcom-account-card';
 import LinkedAccountsSectionWrapper from '../linked-accounts-section-wrapper';
 import './reconnect-wpcom-account.scss';
@@ -34,23 +33,21 @@ export default function ReconnectWPComAccount() {
 
 	return (
 		<LinkedAccountsSectionWrapper>
-			<VerticalGapLayout size="large">
-				<AccountCard
-					className="gla-wpcom-connection-lost-card"
-					isBorderless
-					size="small"
-					icon={ <Icon icon={ pluginsIcon } size={ 24 } /> }
-					title={ __(
-						'Your WordPress.com account has been disconnected.',
-						'google-listings-and-ads'
-					) }
-					helper={ __(
-						'Connect your WordPress.com account to ensure your products stay listed on Google. If you do not re-connect, your products can’t be automatically synced to Google, and any existing listings may be removed from Google.',
-						'google-listings-and-ads'
-					) }
-				/>
-				<ConnectWPComAccountCard />
-			</VerticalGapLayout>
+			<AccountCard
+				className="gla-wpcom-connection-lost-card"
+				isBorderless
+				size="small"
+				icon={ <Icon icon={ pluginsIcon } size={ 24 } /> }
+				title={ __(
+					'Your WordPress.com account has been disconnected.',
+					'google-listings-and-ads'
+				) }
+				helper={ __(
+					'Connect your WordPress.com account to ensure your products stay listed on Google. If you do not re-connect, your products can’t be automatically synced to Google, and any existing listings may be removed from Google.',
+					'google-listings-and-ads'
+				) }
+			/>
+			<ConnectWPComAccountCard />
 		</LinkedAccountsSectionWrapper>
 	);
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is one of the preliminaries for the shipping Improvements.

Considering the way the `Section` component is used, it can be summarized:

- When multiple subcomponents are presented in its body, the layout of subcomponents is always vertically oriented and requires gaps.
- Currently, this kind of layout is achieved by wrapping `VerticalGapLayout` or by additional CSS.

Therefore, it should be possible to lift the vertical layout and gap to the `Section` component instead of the above implementation.

To avoid too many file changes for subsequent PRs, this PR refines the vertical gap for `Section` component:

- Add the vertical gap prop to the `Section` component.
- Remove `VerticalGapLayout` layers that are no longer needed.
- Remove the vertical gap styling of the section body that is no longer needed.
- Remove the no-longer-used `'xlarge'` value from the size prop of `VerticalGapLayout` component.

💡 I will likely skip code review since this PR only includes developer-facing change.

### Detailed test instructions:

Compare before and after this change to check if the following pages are visually consistent in their layout:

- Onboarding flow
- Ads onboarding flow
- Edit free listings
- Add/edit campaign
- Settings, and its sub pages
   - Edit store address
   - Reconnect WordPress account flow
   - Reconnect Google account flow

### Changelog entry
