### PR TITLE
Show leaving prompt in Edit Ads Campaign if the form was modified.

### DIFF
--- a/js/src/pages/edit-paid-ads-campaign/index.js
+++ b/js/src/pages/edit-paid-ads-campaign/index.js
@@ -4,8 +4,8 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Stepper } from '@woocommerce/components';
 import { getQuery, getHistory, getNewPath } from '@woocommerce/navigation';
-import { useEffect } from '@wordpress/element';
-
+import { useEffect, useState } from '@wordpress/element';
+import { isEqual } from 'lodash';
 /**
  * Internal dependencies
  */
@@ -14,7 +14,9 @@ import useAdsCampaigns from '~/hooks/useAdsCampaigns';
 import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
 import { useAppDispatch } from '~/data';
 import { getDashboardUrl } from '~/utils/urls';
-import convertToAssetGroupUpdateBody from '~/components/paid-ads/convertToAssetGroupUpdateBody';
+import convertToAssetGroupUpdateBody, {
+	diffAssetOperations,
+} from '~/components/paid-ads/convertToAssetGroupUpdateBody';
 import TopBar from '~/components/stepper/top-bar';
 import HelpIconButton from '~/components/help-icon-button';
 import CampaignAssetsForm from '~/components/paid-ads/campaign-assets-form';
@@ -34,6 +36,7 @@ import {
 	recordStepContinueEvent,
 } from '~/utils/tracks';
 import useBudgetRecommendation from '~/hooks/useBudgetRecommendation';
+import useNavigateAwayPromptEffect from '~/hooks/useNavigateAwayPromptEffect';
 
 const eventName = 'gla_paid_campaign_step';
 const eventContext = 'edit-ads';
@@ -48,6 +51,15 @@ function getCurrentStep() {
 	return STEP.CAMPAIGN;
 }
 
+function isNotOurStep( location ) {
+	const allowList = new Set( [
+		getNewPath( { step: STEP.CAMPAIGN } ),
+		getNewPath( { step: STEP.ASSET_GROUP } ),
+	] );
+	const destination = location.pathname + location.search;
+	return ! allowList.has( destination );
+}
+
 /**
  * Renders the campaign editing page.
  *
@@ -56,6 +68,8 @@ function getCurrentStep() {
  */
 const EditPaidAdsCampaign = () => {
 	useLayout( 'full-content' );
+	const [ didChange, setDidChange ] = useState( false );
+	const [ isSubmit, setIsSubmit ] = useState( false );
 
 	const {
 		updateAdsCampaign,
@@ -81,6 +95,16 @@ const EditPaidAdsCampaign = () => {
 	}, [ campaign ] );
 
 	const step = getCurrentStep();
+
+	useNavigateAwayPromptEffect(
+		__(
+			'You have unsaved campaign data. Are you sure you want to leave?',
+			'google-listings-and-ads'
+		),
+		didChange && ! isSubmit,
+		isNotOurStep
+	);
+
 	const setStep = ( nextStep ) => {
 		const url = getNewPath( { ...getQuery(), step: nextStep } );
 		getHistory().push( url );
@@ -140,10 +164,22 @@ const EditPaidAdsCampaign = () => {
 		setStep( nextStep );
 	};
 
+	const handleOnChange = ( value, allValues ) => {
+		const hasChange =
+			allValues.amount !== campaign.amount ||
+			! isEqual(
+				assetEntityGroup.display_url_path,
+				allValues.display_url_path
+			) ||
+			diffAssetOperations( assetEntityGroup, allValues ).length > 0;
+
+		setDidChange( hasChange );
+	};
+
 	const handleSubmit = async ( values, enhancer ) => {
 		const { action } = enhancer.submitter.dataset;
 		const { amount } = values;
-
+		setIsSubmit( true );
 		try {
 			await updateAdsCampaign( campaign.id, { amount } );
 
@@ -165,6 +201,7 @@ const EditPaidAdsCampaign = () => {
 				invalidateResolvedAssetEntityGroups();
 			}
 		} catch ( e ) {
+			setIsSubmit( false );
 			enhancer.signalFailedSubmission();
 			return;
 		}
@@ -190,6 +227,7 @@ const EditPaidAdsCampaign = () => {
 				recommendedDailyBudget={ highestDailyBudget }
 				assetEntityGroup={ assetEntityGroup }
 				onSubmit={ handleSubmit }
+				onChange={ handleOnChange }
 			>
 				<Stepper
 					currentStep={ getCurrentStep() }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2090  .

This PR integrates the same logic as Edit Free Campaigns. To show a prompt when the user try to leave the page with changes in the form. 

Please check the issue #2090 for full context.

### Screenshots:

https://github.com/user-attachments/assets/3754f8e6-c6a4-405b-80b2-19f3a51940d3


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Enter in Edit Paid Campaign Page

-- You can leave when there are no changes -- 
3. Dont modify any data and confirm you can leave using WC Navigator in the header. 
4. Dont modify any data and confirm you can leave using browser back arrow. 
5. Dont modify any data and confirm you can leave using some link in the WordPress Menu.
6. Change something, try to go back. Verify the prompt shows. Then restore the change to what it was before. Confirm now you can leave without prompt.
7. You can navigate between steps 
8. You can save the form

-- Prompt shows when something changes -- 
9. Modify Daily average cost amount in the first step. 
10. Verify the prompt shows when you leave after change using steps 3,4 or 5.
11. Verify you can continue to next step without prompt.
12. Verify you can navigate between steps
13. You can save the form when something changes.
14. Enter again in edit paid campaign and change only values in the Assets step.
15. Verify steps 10-12 again with all the fields in assets.




### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Show leaving prompt in Edit Ads Campaign if the form was modified.
