### PR TITLE
Make the names of PHP classes, interfaces and traits in code comments consistent with the actual names

### DIFF
--- a/src/API/Google/AdsAssetGroupAsset.php
+++ b/src/API/Google/AdsAssetGroupAsset.php
@@ -56,7 +56,7 @@ class AdsAssetGroupAsset implements OptionsAwareInterface {
 	protected static $temporary_id = -4;
 
 	/**
-	 * AdsAssetGroup constructor.
+	 * AdsAssetGroupAsset constructor.
 	 *
 	 * @param GoogleAdsClient $client
 	 * @param AdsAsset        $asset

--- a/src/API/Google/Query/AdsAccountAccessQuery.php
+++ b/src/API/Google/Query/AdsAccountAccessQuery.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 class AdsAccountAccessQuery extends AdsQuery {
 
 	/**
-	 * Query constructor.
+	 * AdsAccountAccessQuery constructor.
 	 */
 	public function __construct() {
 		parent::__construct( 'customer_user_access' );

--- a/src/API/Google/Query/AdsAccountQuery.php
+++ b/src/API/Google/Query/AdsAccountQuery.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 class AdsAccountQuery extends AdsQuery {
 
 	/**
-	 * Query constructor.
+	 * AdsAccountQuery constructor.
 	 */
 	public function __construct() {
 		parent::__construct( 'customer' );

--- a/src/API/Google/Query/AdsAssetGroupAssetQuery.php
+++ b/src/API/Google/Query/AdsAssetGroupAssetQuery.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 class AdsAssetGroupAssetQuery extends AdsQuery {
 
 	/**
-	 * Query constructor.
+	 * AdsAssetGroupAssetQuery constructor.
 	 */
 	public function __construct() {
 		parent::__construct( 'asset_group_asset' );

--- a/src/API/Google/Query/AdsAssetGroupQuery.php
+++ b/src/API/Google/Query/AdsAssetGroupQuery.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 class AdsAssetGroupQuery extends AdsQuery {
 
 	/**
-	 * Query constructor.
+	 * AdsAssetGroupQuery constructor.
 	 *
 	 * @param array $search_args List of search args, such as pageSize.
 	 */

--- a/src/API/Google/Query/AdsBillingStatusQuery.php
+++ b/src/API/Google/Query/AdsBillingStatusQuery.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 class AdsBillingStatusQuery extends AdsQuery {
 
 	/**
-	 * Query constructor.
+	 * AdsBillingStatusQuery constructor.
 	 */
 	public function __construct() {
 		parent::__construct( 'billing_setup' );

--- a/src/API/Google/Query/AdsCampaignBudgetQuery.php
+++ b/src/API/Google/Query/AdsCampaignBudgetQuery.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 class AdsCampaignBudgetQuery extends AdsQuery {
 
 	/**
-	 * Query constructor.
+	 * AdsCampaignBudgetQuery constructor.
 	 */
 	public function __construct() {
 		parent::__construct( 'campaign' );

--- a/src/API/Google/Query/AdsCampaignCriterionQuery.php
+++ b/src/API/Google/Query/AdsCampaignCriterionQuery.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 class AdsCampaignCriterionQuery extends AdsQuery {
 
 	/**
-	 * Query constructor.
+	 * AdsCampaignCriterionQuery constructor.
 	 */
 	public function __construct() {
 		parent::__construct( 'campaign_criterion' );

--- a/src/API/Google/Query/AdsCampaignLabelQuery.php
+++ b/src/API/Google/Query/AdsCampaignLabelQuery.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 class AdsCampaignLabelQuery extends AdsQuery {
 
 	/**
-	 * Query constructor.
+	 * AdsCampaignLabelQuery constructor.
 	 */
 	public function __construct() {
 		parent::__construct( 'label' );

--- a/src/API/Google/Query/AdsCampaignQuery.php
+++ b/src/API/Google/Query/AdsCampaignQuery.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 class AdsCampaignQuery extends AdsQuery {
 
 	/**
-	 * Query constructor.
+	 * AdsCampaignQuery constructor.
 	 */
 	public function __construct() {
 		parent::__construct( 'campaign' );

--- a/src/API/Google/Query/AdsConversionActionQuery.php
+++ b/src/API/Google/Query/AdsConversionActionQuery.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 class AdsConversionActionQuery extends AdsQuery {
 
 	/**
-	 * Query constructor.
+	 * AdsConversionActionQuery constructor.
 	 */
 	public function __construct() {
 		parent::__construct( 'conversion_action' );

--- a/src/API/Google/Query/AdsProductLinkInvitationQuery.php
+++ b/src/API/Google/Query/AdsProductLinkInvitationQuery.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 class AdsProductLinkInvitationQuery extends AdsQuery {
 
 	/**
-	 * Query constructor.
+	 * AdsProductLinkInvitationQuery constructor.
 	 */
 	public function __construct() {
 		parent::__construct( 'product_link_invitation' );

--- a/src/API/Google/Query/AdsReportQuery.php
+++ b/src/API/Google/Query/AdsReportQuery.php
@@ -17,7 +17,7 @@ abstract class AdsReportQuery extends AdsQuery {
 	use ReportQueryTrait;
 
 	/**
-	 * Query constructor.
+	 * AdsReportQuery constructor.
 	 * Uses the resource ShoppingPerformanceView.
 	 *
 	 * @param array $args Query arguments.

--- a/src/API/Google/Query/MerchantProductViewReportQuery.php
+++ b/src/API/Google/Query/MerchantProductViewReportQuery.php
@@ -15,7 +15,7 @@ class MerchantProductViewReportQuery extends MerchantQuery {
 	use ReportQueryTrait;
 
 	/**
-	 * Query constructor.
+	 * MerchantProductViewReportQuery constructor.
 	 *
 	 * @param array $args Query arguments.
 	 */

--- a/src/API/Google/Query/MerchantReportQuery.php
+++ b/src/API/Google/Query/MerchantReportQuery.php
@@ -15,7 +15,7 @@ abstract class MerchantReportQuery extends MerchantQuery {
 	use ReportQueryTrait;
 
 	/**
-	 * Query constructor.
+	 * MerchantReportQuery constructor.
 	 *
 	 * @param array $args Query arguments.
 	 */

--- a/src/API/Site/Controllers/AttributeMapping/AttributeMappingDataController.php
+++ b/src/API/Site/Controllers/AttributeMapping/AttributeMappingDataController.php
@@ -27,7 +27,7 @@ class AttributeMappingDataController extends BaseOptionsController {
 
 
 	/**
-	 * AttributeMappingController constructor.
+	 * AttributeMappingDataController constructor.
 	 *
 	 * @param RESTServer             $server
 	 * @param AttributeMappingHelper $attribute_mapping_helper

--- a/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php
+++ b/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php
@@ -33,7 +33,7 @@ class AttributeMappingRulesController extends BaseOptionsController {
 	private AttributeMappingHelper $attribute_mapping_helper;
 
 	/**
-	 * AttributeMappingController constructor.
+	 * AttributeMappingRulesController constructor.
 	 *
 	 * @param RESTServer                 $server
 	 * @param AttributeMappingHelper     $attribute_mapping_helper

--- a/src/API/Site/Controllers/Google/AccountController.php
+++ b/src/API/Site/Controllers/Google/AccountController.php
@@ -38,7 +38,7 @@ class AccountController extends BaseController {
 	];
 
 	/**
-	 * BaseController constructor.
+	 * AccountController constructor.
 	 *
 	 * @param RESTServer $server
 	 * @param Connection $connection

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -51,7 +51,7 @@ class AccountController extends BaseOptionsController {
 	];
 
 	/**
-	 * BaseController constructor.
+	 * AccountController constructor.
 	 *
 	 * @param RESTServer $server
 	 * @param Manager    $manager

--- a/src/API/Site/Controllers/MerchantCenter/PolicyComplianceCheckController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PolicyComplianceCheckController.php
@@ -31,7 +31,7 @@ class PolicyComplianceCheckController extends BaseController {
 	protected $policy_compliance_check;
 
 	/**
-	 * BaseController constructor.
+	 * PolicyComplianceCheckController constructor.
 	 *
 	 * @param RESTServer            $server
 	 * @param PolicyComplianceCheck $policy_compliance_check

--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -17,7 +17,7 @@ use Exception;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class IssuesController
+ * Class RequestReviewController
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
  */

--- a/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php
@@ -29,7 +29,7 @@ class SettingsSyncController extends BaseController {
 	protected $settings;
 
 	/**
-	 * BaseController constructor.
+	 * SettingsSyncController constructor.
 	 *
 	 * @param RESTServer $server
 	 * @param Settings   $settings

--- a/src/API/Site/Controllers/MerchantCenter/ShippingTimeController.php
+++ b/src/API/Site/Controllers/MerchantCenter/ShippingTimeController.php
@@ -37,7 +37,7 @@ class ShippingTimeController extends BaseController implements ISO3166AwareInter
 	protected $route_base = 'mc/shipping/times';
 
 	/**
-	 * BaseController constructor.
+	 * ShippingTimeController constructor.
 	 *
 	 * @param ContainerInterface $container
 	 */

--- a/src/API/Site/Controllers/MerchantCenter/SupportedCountriesController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SupportedCountriesController.php
@@ -37,7 +37,7 @@ class SupportedCountriesController extends BaseController {
 	protected $google_helper;
 
 	/**
-	 * BaseController constructor.
+	 * SupportedCountriesController constructor.
 	 *
 	 * @param RESTServer   $server
 	 * @param WC           $wc

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -69,7 +69,7 @@ class NotificationsService implements Service, OptionsAwareInterface {
 
 
 	/**
-	 * Class constructor
+	 * NotificationsService constructor
 	 *
 	 * @param MerchantCenterService $merchant_center
 	 * @param AccountService        $account_service

--- a/src/Admin/BulkEdit/CouponBulkEdit.php
+++ b/src/Admin/BulkEdit/CouponBulkEdit.php
@@ -44,7 +44,7 @@ class CouponBulkEdit implements BulkEditInterface, Registerable {
 	protected $target_audience;
 
 	/**
-	 * AbstractMetaBox constructor.
+	 * CouponBulkEdit constructor.
 	 *
 	 * @param CouponMetaHandler     $meta_handler
 	 * @param MerchantCenterService $merchant_center

--- a/src/Admin/Input/SelectWithTextInput.php
+++ b/src/Admin/Input/SelectWithTextInput.php
@@ -16,7 +16,7 @@ class SelectWithTextInput extends Input {
 	public const SELECT_INPUT_KEY = '_gla_select';
 
 	/**
-	 * Select constructor.
+	 * SelectWithTextInput constructor.
 	 */
 	public function __construct() {
 		$select_input = ( new Select() )->set_id( self::SELECT_INPUT_KEY )

--- a/src/Admin/Product/Attributes/Input/SizeSystemInput.php
+++ b/src/Admin/Product/Attributes/Input/SizeSystemInput.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class SizeSystemInput extends Select {
 
 	/**
-	 * SizeInput constructor.
+	 * SizeSystemInput constructor.
 	 */
 	public function __construct() {
 		parent::__construct();

--- a/src/Admin/Redirect.php
+++ b/src/Admin/Redirect.php
@@ -39,7 +39,7 @@ class Redirect implements Activateable, Service, Registerable, OptionsAwareInter
 	protected $wp;
 
 	/**
-	 * Installer constructor.
+	 * Redirect constructor.
 	 *
 	 * @param WP $wp
 	 */

--- a/src/Container.php
+++ b/src/Container.php
@@ -61,7 +61,7 @@ final class Container implements ContainerInterface {
 	private $container;
 
 	/**
-	 * Class constructor.
+	 * Container constructor.
 	 *
 	 * @param LeagueContainer|null $container
 	 */

--- a/src/DB/Migration/MigrationVersion141.php
+++ b/src/DB/Migration/MigrationVersion141.php
@@ -9,7 +9,7 @@ use wpdb;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class MigrationVersion1_4_1
+ * Class MigrationVersion141
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration
  *

--- a/src/DB/Query/AttributeMappingRulesQuery.php
+++ b/src/DB/Query/AttributeMappingRulesQuery.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class AttributeMappingRulesQuery extends Query {
 
 	/**
-	 * Query constructor.
+	 * AttributeMappingRulesQuery constructor.
 	 *
 	 * @param wpdb                       $wpdb
 	 * @param AttributeMappingRulesTable $table

--- a/src/DB/Query/BudgetRecommendationQuery.php
+++ b/src/DB/Query/BudgetRecommendationQuery.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 class BudgetRecommendationQuery extends Query {
 
 	/**
-	 * Query constructor.
+	 * BudgetRecommendationQuery constructor.
 	 *
 	 * @param wpdb                      $wpdb
 	 * @param BudgetRecommendationTable $table

--- a/src/DB/Query/MerchantIssueQuery.php
+++ b/src/DB/Query/MerchantIssueQuery.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 class MerchantIssueQuery extends Query {
 
 	/**
-	 * Query constructor.
+	 * MerchantIssueQuery constructor.
 	 *
 	 * @param wpdb               $wpdb
 	 * @param MerchantIssueTable $table

--- a/src/DB/Query/ShippingRateQuery.php
+++ b/src/DB/Query/ShippingRateQuery.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 class ShippingRateQuery extends Query {
 
 	/**
-	 * Query constructor.
+	 * ShippingRateQuery constructor.
 	 *
 	 * @param wpdb              $wpdb
 	 * @param ShippingRateTable $table

--- a/src/DB/Query/ShippingTimeQuery.php
+++ b/src/DB/Query/ShippingTimeQuery.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 class ShippingTimeQuery extends Query {
 
 	/**
-	 * Query constructor.
+	 * ShippingTimeQuery constructor.
 	 *
 	 * @param wpdb              $wpdb
 	 * @param ShippingTimeTable $table

--- a/src/DB/TableInterface.php
+++ b/src/DB/TableInterface.php
@@ -6,7 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\DB;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Interface DBTableInterface
+ * Interface TableInterface
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\DB
  */

--- a/src/Exception/InvalidQuery.php
+++ b/src/Exception/InvalidQuery.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class InvalidColumn
+ * Class InvalidQuery
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Exception
  */

--- a/src/Google/Ads/GoogleAdsClient.php
+++ b/src/Google/Ads/GoogleAdsClient.php
@@ -24,7 +24,7 @@ class GoogleAdsClient {
 	private $httpClient = null;
 
 	/**
-	 * Default constructor
+	 * GoogleAdsClient constructor
 	 *
 	 * @param string $endpoint Endpoint URL to send requests to.
 	 */

--- a/src/Google/BatchProductIDRequestEntry.php
+++ b/src/Google/BatchProductIDRequestEntry.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Value\ProductIDMap;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class BatchDeleteProductRequestEntry
+ * Class BatchProductIDRequestEntry
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Google
  */
@@ -24,7 +24,7 @@ class BatchProductIDRequestEntry {
 	protected $product_id;
 
 	/**
-	 * BatchDeleteProductRequestEntry constructor.
+	 * BatchProductIDRequestEntry constructor.
 	 *
 	 * @param int    $wc_product_id
 	 * @param string $product_id

--- a/src/Google/DeleteCouponEntry.php
+++ b/src/Google/DeleteCouponEntry.php
@@ -31,7 +31,7 @@ class DeleteCouponEntry {
 	protected $synced_google_ids;
 
 	/**
-	 * BatchProductRequestEntry constructor.
+	 * DeleteCouponEntry constructor.
 	 *
 	 * @param int             $wc_coupon_id
 	 * @param GooglePromotion $google_promotion

--- a/src/Jobs/AbstractCouponSyncerJob.php
+++ b/src/Jobs/AbstractCouponSyncerJob.php
@@ -39,7 +39,7 @@ abstract class AbstractCouponSyncerJob extends AbstractActionSchedulerJob {
 	protected $merchant_center;
 
 	/**
-	 * SyncProducts constructor.
+	 * AbstractCouponSyncerJob constructor.
 	 *
 	 * @param ActionSchedulerInterface  $action_scheduler
 	 * @param ActionSchedulerJobMonitor $monitor

--- a/src/Jobs/AbstractProductSyncerBatchedJob.php
+++ b/src/Jobs/AbstractProductSyncerBatchedJob.php
@@ -45,7 +45,7 @@ abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSche
 	protected $merchant_statuses;
 
 	/**
-	 * SyncProducts constructor.
+	 * AbstractProductSyncerBatchedJob constructor.
 	 *
 	 * @param ActionSchedulerInterface  $action_scheduler
 	 * @param ActionSchedulerJobMonitor $monitor

--- a/src/Jobs/AbstractProductSyncerJob.php
+++ b/src/Jobs/AbstractProductSyncerJob.php
@@ -33,7 +33,7 @@ abstract class AbstractProductSyncerJob extends AbstractActionSchedulerJob {
 	protected $merchant_center;
 
 	/**
-	 * SyncProducts constructor.
+	 * AbstractProductSyncerJob constructor.
 	 *
 	 * @param ActionSchedulerInterface  $action_scheduler
 	 * @param ActionSchedulerJobMonitor $monitor

--- a/src/Jobs/ActionSchedulerJobMonitor.php
+++ b/src/Jobs/ActionSchedulerJobMonitor.php
@@ -30,7 +30,7 @@ class ActionSchedulerJobMonitor implements Service {
 	protected $monitored_hooks = [];
 
 	/**
-	 * ActionSchedulerInterface constructor.
+	 * ActionSchedulerJobMonitor constructor.
 	 *
 	 * @param ActionSchedulerInterface $action_scheduler
 	 */

--- a/src/Jobs/MigrateGTIN.php
+++ b/src/Jobs/MigrateGTIN.php
@@ -44,7 +44,7 @@ class MigrateGTIN extends AbstractBatchedActionSchedulerJob implements OptionsAw
 
 
 	/**
-	 * Job constructor.
+	 * MigrateGTIN constructor.
 	 *
 	 * @param ActionSchedulerInterface  $action_scheduler
 	 * @param ActionSchedulerJobMonitor $monitor

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -40,7 +40,7 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 	protected $merchant_statuses;
 
 	/**
-	 * UpdateShippingSettings constructor.
+	 * UpdateMerchantProductStatuses constructor.
 	 *
 	 * @param ActionSchedulerInterface  $action_scheduler
 	 * @param ActionSchedulerJobMonitor $monitor

--- a/src/Menu/AttributeMapping.php
+++ b/src/Menu/AttributeMapping.php
@@ -7,7 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 
 /**
- * Class ProductFeed
+ * Class AttributeMapping
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Menu
  */

--- a/src/MerchantCenter/PolicyComplianceCheck.php
+++ b/src/MerchantCenter/PolicyComplianceCheck.php
@@ -41,7 +41,7 @@ class PolicyComplianceCheck implements Service {
 	protected $target_audience;
 
 	/**
-	 * BaseController constructor.
+	 * PolicyComplianceCheck constructor.
 	 *
 	 * @param WC             $wc
 	 * @param GoogleHelper   $google_helper

--- a/src/Notes/NoteInitializer.php
+++ b/src/Notes/NoteInitializer.php
@@ -44,7 +44,7 @@ class NoteInitializer implements Activateable, Deactivateable, InstallableInterf
 	protected $action_scheduler;
 
 	/**
-	 * Cron constructor.
+	 * NoteInitializer constructor.
 	 *
 	 * @param ActionSchedulerInterface $action_scheduler
 	 */

--- a/src/Product/ProductFilter.php
+++ b/src/Product/ProductFilter.php
@@ -22,7 +22,7 @@ class ProductFilter implements Service {
 	protected $product_helper;
 
 	/**
-	 * ProductRepository constructor.
+	 * ProductFilter constructor.
 	 *
 	 * @param ProductHelper $product_helper
 	 */

--- a/src/Shipping/LocationRatesCollection.php
+++ b/src/Shipping/LocationRatesCollection.php
@@ -21,7 +21,7 @@ abstract class LocationRatesCollection {
 	protected $location_rates = [];
 
 	/**
-	 * RatesCollection constructor.
+	 * LocationRatesCollection constructor.
 	 *
 	 * @param LocationRate[] $location_rates
 	 */

--- a/src/Tracking/TracksAwareTrait.php
+++ b/src/Tracking/TracksAwareTrait.php
@@ -4,7 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tracking;
 
 /**
- * Trait TracksAwareness
+ * Trait TracksAwareTrait
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tracking
  */

--- a/src/Utility/ImageUtility.php
+++ b/src/Utility/ImageUtility.php
@@ -21,7 +21,7 @@ class ImageUtility implements Service {
 	protected WP $wp;
 
 	/**
-	 * AssetSuggestionsService constructor.
+	 * ImageUtility constructor.
 	 *
 	 * @param WP $wp WP Proxy.
 	 */

--- a/src/Utility/WPCLIMigrationGTIN.php
+++ b/src/Utility/WPCLIMigrationGTIN.php
@@ -15,7 +15,7 @@ use WP_CLI;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class WP_CLI_GTIN_Migration
+ * Class WPCLIMigrationGTIN
  * Creates a set of utility commands in WP CLI for GTIN Migration
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Utility

--- a/src/Value/ChannelVisibility.php
+++ b/src/Value/ChannelVisibility.php
@@ -28,7 +28,7 @@ class ChannelVisibility implements CastableValueInterface, ValueInterface {
 	protected $visibility;
 
 	/**
-	 * PositiveInteger constructor.
+	 * ChannelVisibility constructor.
 	 *
 	 * @param string $visibility The value.
 	 *

--- a/src/Value/NotificationStatus.php
+++ b/src/Value/NotificationStatus.php
@@ -36,7 +36,7 @@ class NotificationStatus implements ValueInterface {
 	protected $status;
 
 	/**
-	 * SyncStatus constructor.
+	 * NotificationStatus constructor.
 	 *
 	 * @param string $status The value.
 	 *

--- a/tests/Unit/API/Google/MerchantMetricsTest.php
+++ b/tests/Unit/API/Google/MerchantMetricsTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class MerchantTest
+ * Class MerchantMetricsTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
  */

--- a/tests/Unit/API/Site/Controllers/Ads/AssetGroupControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetGroupControllerTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Exception;
 
 /**
- * Class AssetSuggestionsControllerTest
+ * Class AssetGroupControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
  */

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ContactInformationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ContactInformationControllerTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class PhoneNumberControllerTest
+ * Class ContactInformationControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
  */

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PhoneVerificationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PhoneVerificationControllerTest.php
@@ -11,7 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Value\PhoneNumber;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
- * Class PhoneNumberControllerTest
+ * Class PhoneVerificationControllerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter
  */

--- a/tests/Unit/Coupon/CouponMetaHandlerTest.php
+++ b/tests/Unit/Coupon/CouponMetaHandlerTest.php
@@ -11,7 +11,7 @@ use WC_Coupon;
 use WP_UnitTestCase;
 
 /**
- * Class ProductMetaHandlerTest
+ * Class CouponMetaHandlerTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Coupon
  */

--- a/tests/Unit/Coupon/WCCouponAdapterTest.php
+++ b/tests/Unit/Coupon/WCCouponAdapterTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 use WC_Helper_Product;
 
 /**
- * Class WCProductAdapterTest
+ * Class WCCouponAdapterTest
  *
  * @group Coupons
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Coupon

--- a/tests/Unit/DB/Table/BudgetRecommendationTableTest.php
+++ b/tests/Unit/DB/Table/BudgetRecommendationTableTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use wpdb;
 
 /**
- * Class MigratorTest
+ * Class BudgetRecommendationTableTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB\Table
  */

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -21,7 +21,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductT
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
- * Class UpdateProductsTest
+ * Class UpdateAllProductsTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
  */

--- a/tests/Unit/MerchantCenter/ValidateAddressTest.php
+++ b/tests/Unit/MerchantCenter/ValidateAddressTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class ContactInformationTest
+ * Class ValidateAddressTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter
  */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes the names of PHP classes, interfaces and traits in code comments consistent with the actual names, especially since some names are completely irrelevant.

(Noticed these inconsistencies while working on the shipping improvement project)

💡 I will likely skip code review since this PR only includes developer-facing change.

### Detailed test instructions:

Check if the updated names are consistent with the actual ones.

### Changelog entry
