### PR TITLE
Clean up the leftover parameters used to support WooCommerce Navigation

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -76,9 +76,6 @@ addFilter(
 				container: GetStartedPage,
 				path: '/google/start',
 				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
-				navArgs: {
-					id: 'google-start',
-				},
 			},
 			{
 				breadcrumbs: [
@@ -104,9 +101,6 @@ addFilter(
 				container: Dashboard,
 				path: '/google/dashboard',
 				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
-				navArgs: {
-					id: 'google-dashboard',
-				},
 			},
 			{
 				breadcrumbs: [
@@ -116,9 +110,6 @@ addFilter(
 				container: Reports,
 				path: '/google/reports',
 				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
-				navArgs: {
-					id: 'google-reports',
-				},
 			},
 			{
 				breadcrumbs: [
@@ -128,9 +119,6 @@ addFilter(
 				container: ProductFeed,
 				path: '/google/product-feed',
 				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
-				navArgs: {
-					id: 'google-product-feed',
-				},
 			},
 			{
 				breadcrumbs: [
@@ -140,9 +128,6 @@ addFilter(
 				container: AttributeMapping,
 				path: '/google/attribute-mapping',
 				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
-				navArgs: {
-					id: 'google-attribute-mapping',
-				},
 			},
 			{
 				breadcrumbs: [
@@ -152,9 +137,6 @@ addFilter(
 				container: Settings,
 				path: '/google/settings',
 				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
-				navArgs: {
-					id: 'google-settings',
-				},
 			},
 			{
 				breadcrumbs: [
@@ -164,9 +146,6 @@ addFilter(
 				container: Shipping,
 				path: '/google/shipping',
 				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
-				navArgs: {
-					id: 'google-shipping',
-				},
 			},
 		];
 

--- a/src/Menu/AttributeMapping.php
+++ b/src/Menu/AttributeMapping.php
@@ -22,14 +22,10 @@ class AttributeMapping implements Service, Registerable {
 			function () {
 				wc_admin_register_page(
 					[
-						'title'    => __( 'Attribute Mapping', 'google-listings-and-ads' ),
-						'parent'   => 'google-listings-and-ads-category',
-						'path'     => '/google/attribute-mapping',
-						'id'       => 'google-attribute-mapping',
-						'nav_args' => [
-							'order'  => 40,
-							'parent' => 'google-listings-and-ads-category',
-						],
+						'title'  => __( 'Attribute Mapping', 'google-listings-and-ads' ),
+						'parent' => 'google-listings-and-ads-category',
+						'path'   => '/google/attribute-mapping',
+						'id'     => 'google-attribute-mapping',
 					]
 				);
 			}

--- a/src/Menu/ProductFeed.php
+++ b/src/Menu/ProductFeed.php
@@ -22,14 +22,10 @@ class ProductFeed implements Service, Registerable {
 			function () {
 				wc_admin_register_page(
 					[
-						'title'    => __( 'Product Feed', 'google-listings-and-ads' ),
-						'parent'   => 'google-listings-and-ads-category',
-						'path'     => '/google/product-feed',
-						'id'       => 'google-product-feed',
-						'nav_args' => [
-							'order'  => 30,
-							'parent' => 'google-listings-and-ads-category',
-						],
+						'title'  => __( 'Product Feed', 'google-listings-and-ads' ),
+						'parent' => 'google-listings-and-ads-category',
+						'path'   => '/google/product-feed',
+						'id'     => 'google-product-feed',
 					]
 				);
 			}

--- a/src/Menu/Reports.php
+++ b/src/Menu/Reports.php
@@ -22,14 +22,10 @@ class Reports implements Service, Registerable {
 			function () {
 				wc_admin_register_page(
 					[
-						'title'    => __( 'Reports', 'google-listings-and-ads' ),
-						'parent'   => 'google-listings-and-ads-category',
-						'path'     => '/google/reports',
-						'id'       => 'google-reports',
-						'nav_args' => [
-							'order'  => 20,
-							'parent' => 'google-listings-and-ads-category',
-						],
+						'title'  => __( 'Reports', 'google-listings-and-ads' ),
+						'parent' => 'google-listings-and-ads-category',
+						'path'   => '/google/reports',
+						'id'     => 'google-reports',
 					]
 				);
 			}

--- a/src/Menu/Settings.php
+++ b/src/Menu/Settings.php
@@ -22,14 +22,10 @@ class Settings implements Service, Registerable {
 			function () {
 				wc_admin_register_page(
 					[
-						'title'    => __( 'Settings', 'google-listings-and-ads' ),
-						'parent'   => 'google-listings-and-ads-category',
-						'path'     => '/google/settings',
-						'id'       => 'google-settings',
-						'nav_args' => [
-							'order'  => 50,
-							'parent' => 'google-listings-and-ads-category',
-						],
+						'title'  => __( 'Settings', 'google-listings-and-ads' ),
+						'parent' => 'google-listings-and-ads-category',
+						'path'   => '/google/settings',
+						'id'     => 'google-settings',
 					]
 				);
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Refer to #2406, it's no longer necessary to support WooCommerce Navigation feature, this PR cleans up the leftover parameters used to support the removed feature:
- `nav_args` parameter: https://github.com/woocommerce/woocommerce/pull/51559/files#diff-69a8b7c0a413b28dbe3e1b347b935a948d92c2dbbba5a7e8b0ef1018f54fbf49L62-L64
- `navArgs` parameter: https://github.com/woocommerce/woocommerce/pull/51559/files#diff-69a8b7c0a413b28dbe3e1b347b935a948d92c2dbbba5a7e8b0ef1018f54fbf49L117-L119

(Noticed these leftover parameters while working on the shipping improvement project)

### Detailed test instructions:

Check if all plugin menus are shown and pages can be visited as before.

### Changelog entry
