### PR TITLE
Fix tests in WooCommerce 9.6

### DIFF
--- a/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
+++ b/tests/Unit/Product/AttributeMapping/AttributeMappingWCProductAdapterTest.php
@@ -192,8 +192,8 @@ class AttributeMappingWCProductAdapterTest extends UnitTest {
 		$adapted_product   = $this->generate_attribute_mapping_adapted_product( $rules );
 		$adapted_variation = $this->generate_attribute_mapping_adapted_product_variant( $rules );
 
-		$this->assertEquals( '1.1 kg', $adapted_product->getPattern() );
-		$this->assertEquals( '1.2 kg', $adapted_variation->getPattern() );
+		$this->assertEquals( '1.1 ' . get_option( 'woocommerce_weight_unit', 'lbs' ), $adapted_product->getPattern() );
+		$this->assertEquals( '1.2 ' . get_option( 'woocommerce_weight_unit', 'lbs' ), $adapted_variation->getPattern() );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -116,6 +116,9 @@ function load_plugins() {
 	require_once $wc_dir . '/woocommerce.php';
 	update_option( 'woocommerce_db_version', WC()->version );
 
+	// Be sure the WooCommerce features are loaded on the test environment
+	add_filter( 'woocommerce_admin_should_load_features', '__return_true' );
+
 	require $gla_dir . '/google-listings-and-ads.php';
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

[Tests are failing when using 9.6.0-beta.2 ](https://github.com/woocommerce/google-listings-and-ads/actions/runs/12672738051)

- One test regarding the default weight measure unit
- Another regarding the Features. That are not loaded anymore in our test environment.

That is because the code in https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Admin/Features/Features.php#L56

This PR adapts the test to fix those 2.


### Screenshots:

<img width="1277" alt="Screenshot 2025-01-08 at 21 34 53" src="https://github.com/user-attachments/assets/2fc62d8c-98c2-4d66-9bce-597cc11e2929" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. [See the test using 9.6.0-beta.2 passing against this branch ](https://github.com/woocommerce/google-listings-and-ads/actions/runs/12678666426/job/35336717102)
2.[See the test using latest passing against this branch ](https://github.com/woocommerce/google-listings-and-ads/actions/runs/12678628630/job/35336614816)

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Fix tests in WooCommerce 9.6
