### PR TITLE
Fix E2E tests in WC 9.6

### DIFF
--- a/tests/e2e/bin/test-env-setup.sh
+++ b/tests/e2e/bin/test-env-setup.sh
@@ -34,3 +34,6 @@ wp-env run tests-cli wp option update woocommerce_block_product_tour_shown 'yes'
 
 echo -e 'Set the variable product tour of classic product editor to not display \n'
 wp-env run tests-cli wp user meta update admin woocommerce_admin_variable_product_tour_shown '"yes"'
+
+echo -e 'Set the store as live \n'
+wp-env run tests-cli wp option update woocommerce_coming_soon 'no'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

[E2E tests were failing for 9.6.0-beta.2 
](https://github.com/woocommerce/google-listings-and-ads/actions/runs/12679101592)

The reason is that the store is in Coming Soon mode for Store pages. I adapted the Install Script to set the Store as Live

### Screenshots:

<img width="970" alt="Screenshot 2025-01-09 at 10 35 11" src="https://github.com/user-attachments/assets/c10b04d2-7e2b-442f-97ab-be6707d39d16" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. [See the tests passing against WC 9.6.0-beta.2](https://github.com/woocommerce/google-listings-and-ads/actions/runs/12687243053/job/35361216754)
2. [See the tests passing against WC latest](https://github.com/woocommerce/google-listings-and-ads/actions/runs/12687633530)


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Fix E2E tests in WC 9.6
