### PR TITLE
Pop up confirmation prompt on the Shipping page before saving changes

### DIFF
--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -53,6 +53,8 @@ const getSettings = ( values ) => {
 	return pick( values, settingsFieldNames );
 };
 
+const alwaysTrue = () => true;
+
 const { Fill, Slot } = createSlotFill( 'gla/SetupFreeListings/SubmitButton' );
 
 /**
@@ -71,6 +73,7 @@ const { Fill, Slot } = createSlotFill( 'gla/SetupFreeListings/SubmitButton' );
  * @param {(newValue: Object) => void} [props.onShippingRatesChange] Callback called with new data once shipping rates are changed. Forwarded from {@link Form.Props.onChange}.
  * @param {Array<ShippingTime>} props.shippingTimes Shipping times data, if not given AppSpinner will be rendered.
  * @param {(newValue: Object) => void} [props.onShippingTimesChange] Callback called with new data once shipping times are changed. Forwarded from {@link Form.Props.onChange}.
+ * @param {() => boolean | Promise<boolean>} [props.onRequestSubmit] Callback called before the form is submitted. If it returns false, the form will not be submitted.
  * @param {() => void} [props.onContinue] Callback called once continue button is clicked. Could be async. While it's being resolved the form would turn into a saving state.
  * @param {string} props.submitLabel Submit button label.
  */
@@ -84,6 +87,7 @@ const SetupFreeListings = ( {
 	onShippingRatesChange = noop,
 	shippingTimes,
 	onShippingTimesChange = noop,
+	onRequestSubmit = alwaysTrue,
 	onContinue = noop,
 	submitLabel,
 } ) => {
@@ -227,8 +231,11 @@ const SetupFreeListings = ( {
 			>
 				{ ( formContext ) => {
 					const { isValidForm, handleSubmit, adapter } = formContext;
-					const handleSubmitClick = ( event ) => {
+					const handleSubmitClick = async ( event ) => {
 						if ( isValidForm ) {
+							if ( ! ( await onRequestSubmit() ) ) {
+								return;
+							}
 							return handleSubmit( event );
 						}
 

--- a/js/src/pages/shipping/confirm-save-modal.js
+++ b/js/src/pages/shipping/confirm-save-modal.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '~/components/app-button';
+import AppModal from '~/components/app-modal';
+import styles from './confirm-save-modal.module.scss';
+
+/**
+ * Renders a modal to confirm before saving changes.
+ *
+ * @param {Object} props React props.
+ * @param {Function} props.onContinue Callback when the continue button is clicked.
+ * @param {Function} props.onRequestClose Callback when requesting to close the modal.
+ */
+export default function ConfirmSaveModal( { onContinue, onRequestClose } ) {
+	return (
+		<AppModal
+			className={ styles.confirmationModal }
+			title={ __( 'Before you save…', 'google-listings-and-ads' ) }
+			buttons={ [
+				<AppButton key="cancel" isSecondary onClick={ onRequestClose }>
+					{ __( `Don't save`, 'google-listings-and-ads' ) }
+				</AppButton>,
+				<AppButton key="continue" isPrimary onClick={ onContinue }>
+					{ __( 'Continue to save', 'google-listings-and-ads' ) }
+				</AppButton>,
+			] }
+			onRequestClose={ onRequestClose }
+		>
+			<p>
+				{ __(
+					'Results typically improve with time.',
+					'google-listings-and-ads'
+				) }
+			</p>
+			<p>
+				{ __(
+					'Changes will result in the loss of any optimisations learned over time.',
+					'google-listings-and-ads'
+				) }
+			</p>
+			<p>
+				{ __(
+					'We recommend allowing your listings to run for at least 14 days after set up without changing them for optimal performance.',
+					'google-listings-and-ads'
+				) }
+			</p>
+		</AppModal>
+	);
+}

--- a/js/src/pages/shipping/confirm-save-modal.module.scss
+++ b/js/src/pages/shipping/confirm-save-modal.module.scss
@@ -1,0 +1,5 @@
+.confirmationModal {
+	@include break-small {
+		max-width: $gla-width-medium-large;
+	}
+}

--- a/js/src/pages/shipping/index.js
+++ b/js/src/pages/shipping/index.js
@@ -12,6 +12,7 @@ import { isEqual } from 'lodash';
 import { useAppDispatch } from '~/data';
 import MainTabNav from '~/components/main-tab-nav';
 import SetupFreeListings from '~/components/free-listings/setup-free-listings';
+import ConfirmSaveModal from './confirm-save-modal';
 import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 import useSettings from '~/hooks/useSettings';
 import useNavigateAwayPromptEffect from '~/hooks/useNavigateAwayPromptEffect';
@@ -72,6 +73,8 @@ export default function Shipping() {
 	const [ shippingTimes, updateShippingTimes ] =
 		useState( savedShippingTimes );
 
+	const [ resolveConfirmation, setResolveConfirmation ] = useState( null );
+
 	// TODO: Consider making it less repetitive.
 	useEffect( () => updateSettings( savedSettings ), [ savedSettings ] );
 	useEffect(
@@ -123,6 +126,15 @@ export default function Shipping() {
 		),
 		didAnythingChanged
 	);
+
+	const handleRequestSubmit = () => {
+		return new Promise( ( resolve ) => {
+			setResolveConfirmation( () => ( shouldContinue ) => {
+				resolve( shouldContinue );
+				setResolveConfirmation( null );
+			} );
+		} );
+	};
 
 	const handleSetupFreeListingsContinue = async () => {
 		// TODO: Disable the form so the user won't be able to input any changes, which could be disregarded.
@@ -189,12 +201,19 @@ export default function Shipping() {
 				onShippingRatesChange={ updateShippingRates }
 				shippingTimes={ initialTimes }
 				onShippingTimesChange={ updateShippingTimes }
+				onRequestSubmit={ handleRequestSubmit }
 				onContinue={ handleSetupFreeListingsContinue }
 				submitLabel={ __( 'Save changes', 'google-listings-and-ads' ) }
 			/>
 			<Flex justify="flex-end">
 				<SetupFreeListings.SubmitButton />
 			</Flex>
+			{ resolveConfirmation && (
+				<ConfirmSaveModal
+					onContinue={ () => resolveConfirmation( true ) }
+					onRequestClose={ () => resolveConfirmation( false ) }
+				/>
+			) }
 		</>
 	);
 }

--- a/tests/e2e/specs/shipping.test.js
+++ b/tests/e2e/specs/shipping.test.js
@@ -15,7 +15,7 @@ test.use( { storageState: process.env.ADMINSTATE } );
 test.describe.configure( { mode: 'serial' } );
 
 /**
- * @type {import('../../utils/pages/shipping.js').default} shippingPage
+ * @type {import('../utils/pages/shipping.js').default} shippingPage
  */
 let shippingPage = null;
 
@@ -39,21 +39,27 @@ test.describe( 'Shipping', () => {
 		await page.close();
 	} );
 
-	test.skip( 'Should show confirmation modal before saving', async () => {
-		// TODO: This test case will be completed in a subsequent PR
+	test( 'Should show confirmation modal before saving', async () => {
+		const modal = shippingPage.getConfirmationModal();
+
 		await shippingPage.clickSaveChanges();
+		await expect( modal ).toBeVisible();
+
+		await shippingPage.getDontSaveButton().click();
+		await expect( modal ).not.toBeVisible();
 	} );
 
 	test( 'Check recommended shipping settings', async () => {
 		await shippingPage.checkRecommendShippingSettings();
 		await shippingPage.fillCountriesShippingTimeInput( '5', '10' );
-		const saveChangesButton = await shippingPage.getSaveChangesButton();
+		const saveChangesButton = shippingPage.getSaveChangesButton();
 		await expect( saveChangesButton ).toBeEnabled();
 	} );
 
 	test( 'Save changes', async () => {
 		const awaitForRequests = shippingPage.registerSavingRequests();
 		await shippingPage.clickSaveChanges();
+		await shippingPage.getContinueSaveButton().click();
 		const requests = await awaitForRequests;
 		const settingsResponse = await (
 			await requests[ 0 ].response()

--- a/tests/e2e/utils/pages/shipping.js
+++ b/tests/e2e/utils/pages/shipping.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Locator } from '@playwright/test';
+
+/**
  * Internal dependencies
  */
 import MockRequests from '../mock-requests';
@@ -23,6 +28,7 @@ export default class ShippingPage extends MockRequests {
 
 		await this.fulfillSettings( {
 			shipping_rate: 'flat',
+			shipping_time: 'flat',
 			tax_rate: 'destination',
 		} );
 
@@ -49,12 +55,43 @@ export default class ShippingPage extends MockRequests {
 	/**
 	 * Get Save Changes button.
 	 *
-	 * @return {Promise<import('@playwright/test').Locator>} Get Save Changes button.
+	 * @return {Locator} Get Save Changes button.
 	 */
-	async getSaveChangesButton() {
+	getSaveChangesButton() {
 		return this.page.getByRole( 'button', {
 			name: 'Save changes',
 			exact: true,
+		} );
+	}
+
+	/**
+	 * Get the "Don't save" button.
+	 *
+	 * @return {Locator} The button.
+	 */
+	getConfirmationModal() {
+		return this.page.getByRole( 'dialog', { name: 'Before you save…' } );
+	}
+
+	/**
+	 * Get the "Don't save" button in the confirmation modal.
+	 *
+	 * @return {Locator} The button.
+	 */
+	getDontSaveButton() {
+		return this.getConfirmationModal().getByRole( 'button', {
+			name: `Don't save`,
+		} );
+	}
+
+	/**
+	 * Get the "Continue to save" button in the confirmation modal.
+	 *
+	 * @return {Locator} The button.
+	 */
+	getContinueSaveButton() {
+		return this.getConfirmationModal().getByRole( 'button', {
+			name: 'Continue to save',
 		} );
 	}
 
@@ -64,8 +101,7 @@ export default class ShippingPage extends MockRequests {
 	 * @return {Promise<void>}
 	 */
 	async clickSaveChanges() {
-		const saveChangesButton = await this.getSaveChangesButton();
-		await saveChangesButton.click();
+		await this.getSaveChangesButton().click();
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project thread: pcTzPl-2Cf-p2

This PR implements the **📌 Add popup when saving** task of the project.

💡 Update for `src/Tracking/README.md` will be done by the conjunction PR for the feature branch.

### Screenshots:

https://github.com/user-attachments/assets/95b853bc-e6ac-4110-8f90-c0b93afd4109

### Detailed test instructions:

1. Go to step 2 of the onboarding flow
   - Check if clicking the "Continue" button can go to the next step without confirmation prompt
2. Go to the Shipping page
   - Check if clicking the "Save changes" button can pop up confirmation prompt
   - Click the "Don't save" button to see if it dismisses the save
   - Click the "Save changes" button to pop up confirmation prompt again
   - Click the "Continue to save" button to see if it continues saving 
3. View the E2E testing result: https://github.com/woocommerce/google-listings-and-ads/actions/runs/12687425268

### Changelog entry

> Tweak - Pop up confirmation prompt on the Shipping page before saving changes.
