### PR TITLE
Sync shipping max times to Google Merchant Center

### DIFF
--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -3,8 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery as RateQuery;
-use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery as TimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -206,7 +206,7 @@ class Settings {
 		static $times = null;
 
 		if ( null === $times ) {
-			$time_query = $this->container->get( TimeQuery::class );
+			$time_query = $this->container->get( ShippingTimeQuery::class );
 			$times      = array_column( $time_query->get_results(), 'time', 'country' );
 		}
 
@@ -219,7 +219,7 @@ class Settings {
 	 * @return array
 	 */
 	protected function get_shipping_rates_from_database(): array {
-		$rate_query = $this->container->get( RateQuery::class );
+		$rate_query = $this->container->get( ShippingRateQuery::class );
 
 		return $rate_query->get_results();
 	}

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -207,7 +207,7 @@ class Settings {
 
 		if ( null === $times ) {
 			$time_query = $this->container->get( ShippingTimeQuery::class );
-			$times      = array_column( $time_query->get_results(), 'time', 'country' );
+			$times      = $time_query->get_all_shipping_times();
 		}
 
 		return $times;

--- a/src/DB/Query/ShippingTimeQuery.php
+++ b/src/DB/Query/ShippingTimeQuery.php
@@ -58,6 +58,7 @@ class ShippingTimeQuery extends Query {
 			$data = [
 				'country_code' => $time['country'],
 				'time'         => $time['time'],
+				'max_time'     => $time['max_time'] ?: $time['time'],
 			];
 
 			$items[ $time['country'] ] = $data;

--- a/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
@@ -66,8 +66,8 @@ abstract class AbstractShippingSettingsAdapter extends GoogleShippingSettings {
 		$time = new DeliveryTime();
 		$time->setMinHandlingTimeInDays( 0 );
 		$time->setMaxHandlingTimeInDays( 0 );
-		$time->setMinTransitTimeInDays( (int) $this->delivery_times[ $country ] );
-		$time->setMaxTransitTimeInDays( (int) $this->delivery_times[ $country ] );
+		$time->setMinTransitTimeInDays( (int) $this->delivery_times[ $country ]['time'] );
+		$time->setMaxTransitTimeInDays( (int) $this->delivery_times[ $country ]['max_time'] );
 
 		return $time;
 	}

--- a/tests/Unit/Shipping/GoogleAdapter/DBShippingSettingsAdapterTest.php
+++ b/tests/Unit/Shipping/GoogleAdapter/DBShippingSettingsAdapterTest.php
@@ -31,8 +31,14 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 			[
 				'currency'       => 'USD',
 				'delivery_times' => [
-					'US' => 1,
-					'AU' => 2,
+					'US' => [
+						'time'     => 1,
+						'max_time' => 3,
+					],
+					'AU' => [
+						'time'     => 2,
+						'max_time' => 4,
+					],
 				],
 				'db_rates'       => $db_rates,
 			]
@@ -52,12 +58,12 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 				$this->assertEquals( 'USD', $service->getRateGroups()[0]->getSingleValue()->getFlatRate()->getCurrency() );
 				$this->assertEquals( 10, $service->getRateGroups()[0]->getSingleValue()->getFlatRate()->getValue() );
 				$this->assertEquals( 1, $service->getDeliveryTime()->getMinTransitTimeInDays() );
-				$this->assertEquals( 1, $service->getDeliveryTime()->getMaxTransitTimeInDays() );
+				$this->assertEquals( 3, $service->getDeliveryTime()->getMaxTransitTimeInDays() );
 			} elseif ( 'AU' === $service->getDeliveryCountry() ) {
 				$this->assertEquals( 'USD', $service->getRateGroups()[0]->getSingleValue()->getFlatRate()->getCurrency() );
 				$this->assertEquals( 50, $service->getRateGroups()[0]->getSingleValue()->getFlatRate()->getValue() );
 				$this->assertEquals( 2, $service->getDeliveryTime()->getMinTransitTimeInDays() );
-				$this->assertEquals( 2, $service->getDeliveryTime()->getMaxTransitTimeInDays() );
+				$this->assertEquals( 4, $service->getDeliveryTime()->getMaxTransitTimeInDays() );
 			}
 		}
 	}
@@ -74,7 +80,12 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 		$settings = new DBShippingSettingsAdapter(
 			[
 				'currency'       => 'USD',
-				'delivery_times' => [ 'US' => 1 ],
+				'delivery_times' => [
+					'US' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
 				'db_rates'       => $db_rates,
 			]
 		);
@@ -96,7 +107,12 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 		$settings = new DBShippingSettingsAdapter(
 			[
 				'currency'       => 'USD',
-				'delivery_times' => [ 'US' => 1 ],
+				'delivery_times' => [
+					'US' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
 				'db_rates'       => $db_rates,
 			]
 		);
@@ -120,7 +136,12 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 		$settings = new DBShippingSettingsAdapter(
 			[
 				'currency'       => 'USD',
-				'delivery_times' => [ 'US' => 1 ],
+				'delivery_times' => [
+					'US' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
 				'db_rates'       => $db_rates,
 			]
 		);
@@ -146,7 +167,12 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 		$settings = new DBShippingSettingsAdapter(
 			[
 				'currency'       => 'USD',
-				'delivery_times' => [ 'US' => 1 ],
+				'delivery_times' => [
+					'US' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
 				'db_rates'       => $db_rates,
 			]
 		);
@@ -172,7 +198,12 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 		new DBShippingSettingsAdapter(
 			[
 				'currency'       => 'USD',
-				'delivery_times' => [ 'US' => 1 ],
+				'delivery_times' => [
+					'US' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
 			]
 		);
 	}
@@ -182,7 +213,12 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 
 		new DBShippingSettingsAdapter(
 			[
-				'delivery_times' => [ 'US' => 1 ],
+				'delivery_times' => [
+					'US' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
 				'db_rates'       => [
 					[
 						'country' => 'US',

--- a/tests/Unit/Shipping/GoogleAdapter/WCShippingSettingsAdapterTest.php
+++ b/tests/Unit/Shipping/GoogleAdapter/WCShippingSettingsAdapterTest.php
@@ -36,7 +36,12 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 				'rates_collections' => [
 					new CountryRatesCollection( 'US', [ $location_rate_1 ] ),
 				],
-				'delivery_times'    => [ 'US' => 2 ],
+				'delivery_times'    => [
+					'US' => [
+						'time'     => 2,
+						'max_time' => 3,
+					],
+				],
 			]
 		);
 
@@ -57,7 +62,12 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 				'rates_collections' => [
 					new CountryRatesCollection( 'US', [ $location_rate_1 ] ),
 				],
-				'delivery_times'    => [ 'US' => 2 ],
+				'delivery_times'    => [
+					'US' => [
+						'time'     => 2,
+						'max_time' => 3,
+					],
+				],
 			]
 		);
 
@@ -84,8 +94,14 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 					new CountryRatesCollection( 'AU', [ $location_rate_3 ] ),
 				],
 				'delivery_times'    => [
-					'AU' => 1,
-					'US' => 2,
+					'AU' => [
+						'time'     => 1,
+						'max_time' => 2,
+					],
+					'US' => [
+						'time'     => 2,
+						'max_time' => 3,
+					],
 				],
 			]
 		);
@@ -138,8 +154,14 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 					new CountryRatesCollection( 'AU', [ $location_rate_3 ] ),
 				],
 				'delivery_times'    => [
-					'AU' => 1,
-					'US' => 2,
+					'AU' => [
+						'time'     => 1,
+						'max_time' => 2,
+					],
+					'US' => [
+						'time'     => 2,
+						'max_time' => 3,
+					],
 				],
 			]
 		);
@@ -206,8 +228,14 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 					new CountryRatesCollection( 'AU', [ $location_rate_2 ] ),
 				],
 				'delivery_times'    => [
-					'AU' => 5,
-					'US' => 10,
+					'AU' => [
+						'time'     => 5,
+						'max_time' => 6,
+					],
+					'US' => [
+						'time'     => 10,
+						'max_time' => 10,
+					],
 				],
 			]
 		);
@@ -238,7 +266,7 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 		$au_service  = $au_services[ array_key_first( $au_services ) ];
 		$this->assertInstanceOf( DeliveryTime::class, $au_service->getDeliveryTime() );
 		$this->assertEquals( 5, $au_service->getDeliveryTime()->getMinTransitTimeInDays() );
-		$this->assertEquals( 5, $au_service->getDeliveryTime()->getMaxTransitTimeInDays() );
+		$this->assertEquals( 6, $au_service->getDeliveryTime()->getMaxTransitTimeInDays() );
 	}
 
 	public function test_sets_the_currency_provided() {
@@ -253,8 +281,14 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 					new CountryRatesCollection( 'AU', [ $location_rate_2 ] ),
 				],
 				'delivery_times'    => [
-					'AU' => 5,
-					'US' => 10,
+					'AU' => [
+						'time'     => 5,
+						'max_time' => 6,
+					],
+					'US' => [
+						'time'     => 10,
+						'max_time' => 10,
+					],
 				],
 			]
 		);
@@ -270,7 +304,12 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 		new WCShippingSettingsAdapter(
 			[
 				'currency'       => 'USD',
-				'delivery_times' => [ 'US' => 1 ],
+				'delivery_times' => [
+					'US' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
 			]
 		);
 	}
@@ -281,7 +320,12 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 		new WCShippingSettingsAdapter(
 			[
 				'rates_collections' => [ new CountryRatesCollection( 'US', [] ) ],
-				'delivery_times'    => [ 'US' => 1 ],
+				'delivery_times'    => [
+					'US' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
 			]
 		);
 	}
@@ -310,7 +354,12 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 					new CountryRatesCollection( 'US', [ $location_rate_1 ] ),
 					new CountryRatesCollection( 'AU', [ $location_rate_2 ] ),
 				],
-				'delivery_times'    => [ 'AU' => 1 ],
+				'delivery_times'    => [
+					'AU' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
 			]
 		);
 	}
@@ -321,7 +370,12 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 		new WCShippingSettingsAdapter(
 			[
 				'currency'          => 'USD',
-				'delivery_times'    => [ 'US' => 1 ],
+				'delivery_times'    => [
+					'US' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
 				'rates_collections' => [ new \stdClass() ],
 			]
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the max shipping time in two locations:

- When syncing to Google Merchant Center
- When returning settings for the API Pull implementation

Considering that the ShippingTimeQuery already had a function `get_all_shipping_times`. I made sure the code is consistent to always use this helper function so we only have to format the shipping times once.

Closes #2759 

### Detailed test instructions:
1. Use a site that is onboarded and connected to a Merchant Center account
2. Go to Marketing > Google for WooCommerce > Dashboard and click on edit Free Listings
3. Select the option "My shipping settings are simple. I can manually estimate flat shipping rates"
4. Set some shipping times to have different min / max values
![image](https://github.com/user-attachments/assets/184469ff-03db-4649-820d-daaaddcad198)
5. Save the values and wait for them to sync
6. Check the Merchant Center account and go to the Shipping and Returns tab
7. Confirm the min and max values are set as expected
![image](https://github.com/user-attachments/assets/70647558-0919-4994-8a0a-6b98ab234d6c)

##### Test API pull settings endpoint
1. Send an API request to `https://domain.test/wp-json/wc/v3/settings/general?gla_syncable=1`
2. For testing, [include any authentication headers or use a snippet to authorize requests](https://github.com/woocommerce/google-listings-and-ads/wiki/Testing-GLA-endpoints-with-Postman)
3. Confirm that the shipping times have both min and max times set:
```json
    {
        "id": "gla_shipping_times",
        "label": "Google for WooCommerce: Shipping Times",
        "value": {
            "IE": {
                "country_code": "IE",
                "time": "1",
                "max_time": "3"
            },
            "GB": {
                "country_code": "GB",
                "time": "2",
                "max_time": "4"
            }
        }
    }
```

### Additional details:
### Changelog entry
* Fix - Sync shipping max times to Google Merchant Center.
