### PR TITLE
Avoid the negative shipping rate leading to false onboarding completion and make its error message more explicit

### DIFF
--- a/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
@@ -9,7 +9,6 @@ import { noop } from 'lodash';
  * Internal dependencies
  */
 import useAdminUrl from '~/hooks/useAdminUrl';
-import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 import useAdsSetupCompleteCallback from '~/hooks/useAdsSetupCompleteCallback';
 import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 import AdsCampaign from '~/components/paid-ads/ads-campaign';
@@ -17,6 +16,7 @@ import CampaignAssetsForm from '~/components/paid-ads/campaign-assets-form';
 import AppButton from '~/components/app-button';
 import useGoogleAdsAccountBillingStatus from '~/hooks/useGoogleAdsAccountBillingStatus';
 import { getProductFeedUrl } from '~/utils/urls';
+import { handleApiError } from '~/utils/handleError';
 import { useAppDispatch } from '~/data';
 import { GUIDE_NAMES, GOOGLE_ADS_BILLING_STATUS } from '~/constants';
 import { ACTION_COMPLETE, ACTION_SKIP } from './constants';
@@ -41,7 +41,6 @@ import AppSpinner from '~/components/app-spinner';
 export default function SetupPaidAds() {
 	const adminUrl = useAdminUrl();
 	const [ completing, setCompleting ] = useState( null );
-	const { createNotice } = useDispatchCoreNotices();
 	const { data: countryCodes } = useTargetAudienceFinalCountryCodes();
 	const { highestDailyBudget, hasFinishedResolution } =
 		useBudgetRecommendation( countryCodes );
@@ -54,18 +53,19 @@ export default function SetupPaidAds() {
 
 	const finishOnboardingSetup = async ( onBeforeFinish = noop ) => {
 		try {
-			await onBeforeFinish();
 			await syncSettings();
+			await onBeforeFinish();
 		} catch ( e ) {
 			setCompleting( null );
 
-			createNotice(
-				'error',
+			handleApiError(
+				e,
 				__(
 					'Unable to complete your setup.',
 					'google-listings-and-ads'
 				)
 			);
+			return;
 		}
 
 		// Force reload WC admin page to initiate the relevant dependencies of the Dashboard page.

--- a/js/src/pages/shipping/index.js
+++ b/js/src/pages/shipping/index.js
@@ -23,6 +23,7 @@ import hasUnsavedShippingRates from './hasUnsavedShippingRates';
 import useSaveShippingRates from '~/hooks/useSaveShippingRates';
 import useSaveShippingTimes from '~/hooks/useSaveShippingTimes';
 import createErrorMessageForRejectedPromises from '~/utils/createErrorMessageForRejectedPromises';
+import { handleApiError } from '~/utils/handleError';
 import { recordGlaEvent } from '~/utils/tracks';
 
 /**
@@ -173,8 +174,9 @@ export default function Shipping() {
 
 			recordGlaEvent( 'gla_free_campaign_edited' );
 		} catch ( error ) {
-			createNotice(
-				'error',
+			handleApiError(
+				error,
+				__( 'Unable to save your changes.', 'google-listings-and-ads' ),
 				__(
 					'Something went wrong while saving your changes. Please try again later.',
 					'google-listings-and-ads'

--- a/src/Shipping/CountryRatesCollection.php
+++ b/src/Shipping/CountryRatesCollection.php
@@ -91,11 +91,14 @@ class CountryRatesCollection extends LocationRatesCollection {
 	/**
 	 * @param LocationRate $location_rate
 	 *
-	 * @throws InvalidValue If any of the location rates do not belong to the same country as the one provided for this class.
+	 * @throws InvalidValue If any of the location rates do not belong to the same country as the one provided for this class or if any of the rates are negative.
 	 */
 	protected function validate_rate( LocationRate $location_rate ) {
 		if ( $this->country !== $location_rate->get_location()->get_country() ) {
 			throw new InvalidValue( 'All location rates must be in the same country as the one provided for this collection.' );
+		}
+		if ( $location_rate->get_shipping_rate()->get_rate() < 0 ) {
+			throw new InvalidValue( 'Shipping rates cannot be negative.' );
 		}
 	}
 

--- a/tests/Unit/Shipping/CountryRatesCollectionTest.php
+++ b/tests/Unit/Shipping/CountryRatesCollectionTest.php
@@ -119,4 +119,14 @@ class CountryRatesCollectionTest extends UnitTest {
 
 		new CountryRatesCollection( 'US', $location_rates );
 	}
+
+	public function test_throws_exception_if_negative_rate_is_provided() {
+		$location_rates = [
+			new LocationRate( new ShippingLocation( 0, 'US' ), new ShippingRate( -1 ) ),
+		];
+
+		$this->expectException( InvalidValue::class );
+
+		new CountryRatesCollection( 'US', $location_rates );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2466

This PR avoids negative shipping rate leads to false onboarding completion and makes its error message more explicit.

- Update the PHP `CountryRatesCollection` class to throw `InvalidValue` when any shipping rates are negative.
- Avoid false onboarding completion when there are negative shipping rates and clarify the error message.
- Make the error message of the negative shipping rates more explicit on the shipping page.

### Detailed test instructions:

#### Preparation

1. Go to **WooCommerce > Settings > Shipping > Shipping zones**
2. Set up a zone with negative flat rate.
   ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17420811/9ec04b7c-2387-41a6-9367-3819820a33e9)

#### Onboarding

1. Start onboarding and proceed to step 2.
   1. Add the above configured zone to the Audience setting.
   2. Select the **Recommended:  Automatically sync my store’s shipping settings to Google** option for the shipping rates setting.
2. Proceed to step 3.
3. Click "Skip ads creation" or "Complete setup" button to see if it shows a proper error message and stop completing onboarding.
   ![image](https://github.com/user-attachments/assets/13973145-eb9d-4a21-ab09-e1570efa207c)
4. Switch back to the  **Shipping zones** setting page and update the shipping rate to a non-negative value.
5. Back to the onboarding and see if the flow can be completed.

#### Shipping page

1. Redo the test preparation.
2. Go to plugin's shipping page.
3. Click "Save changes" button to see if it shows a proper error message.
   ![image](https://github.com/user-attachments/assets/a0126e07-2b33-458a-866f-3f24bdd706c5)
4. Switch back to the  **Shipping zones** setting page and update the shipping rate to a non-negative value.
5. Back to plugin's shipping page and see if the saving can be completed.

### Changelog entry

> Fix - Avoid the negative shipping rate taken from WooCommerce settings leading to false onboarding completion and make its error message more explicit.
