### PR TITLE
Refactor installer class to load dependencies when needed

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\FirstInstallInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\InstallableInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
@@ -19,8 +21,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds
  */
-class Installer implements OptionsAwareInterface, Service, Registerable {
+class Installer implements ContainerAwareInterface, OptionsAwareInterface, Registerable, Service {
 
+	use ContainerAwareTrait;
 	use OptionsAwareTrait;
 	use PluginHelper;
 

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -28,16 +28,6 @@ class Installer implements ContainerAwareInterface, OptionsAwareInterface, Regis
 	use PluginHelper;
 
 	/**
-	 * @var InstallableInterface[]
-	 */
-	protected $installables;
-
-	/**
-	 * @var FirstInstallInterface[]
-	 */
-	protected $first_installers;
-
-	/**
 	 * @var WP
 	 */
 	protected $wp;
@@ -45,14 +35,10 @@ class Installer implements ContainerAwareInterface, OptionsAwareInterface, Regis
 	/**
 	 * Installer constructor.
 	 *
-	 * @param InstallableInterface[]  $installables
-	 * @param FirstInstallInterface[] $first_installers
-	 * @param WP                      $wp
+	 * @param WP $wp
 	 */
-	public function __construct( array $installables, array $first_installers, WP $wp ) {
-		$this->installables     = $installables;
-		$this->first_installers = $first_installers;
-		$this->wp               = $wp;
+	public function __construct( WP $wp ) {
+		$this->wp = $wp;
 	}
 
 	/**
@@ -98,7 +84,10 @@ class Installer implements ContainerAwareInterface, OptionsAwareInterface, Regis
 		$old_version = $this->get_db_version();
 		$new_version = $this->get_version();
 
-		foreach ( $this->installables as $installable ) {
+		/** @var InstallableInterface[] */
+		$installables = $this->container->get( InstallableInterface::class );
+
+		foreach ( $installables as $installable ) {
 			$installable->install( $old_version, $new_version );
 		}
 	}
@@ -116,7 +105,10 @@ class Installer implements ContainerAwareInterface, OptionsAwareInterface, Regis
 	 * Runs on the first install of GLA.
 	 */
 	protected function first_install(): void {
-		foreach ( $this->first_installers as $installer ) {
+		/** @var FirstInstallInterface[] $first_installers */
+		$first_installers = $this->container->get( FirstInstallInterface::class );
+
+		foreach ( $first_installers as $installer ) {
 			$installer->first_install();
 		}
 	}

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\FirstInstallInterface;
@@ -24,7 +23,6 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 
 	use OptionsAwareTrait;
 	use PluginHelper;
-	use ValidateInterface;
 
 	/**
 	 * @var InstallableInterface[]
@@ -52,8 +50,6 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 		$this->installables     = $installables;
 		$this->first_installers = $first_installers;
 		$this->wp               = $wp;
-		$this->validate_installables();
-		$this->validate_first_installers();
 	}
 
 	/**
@@ -138,23 +134,5 @@ class Installer implements OptionsAwareInterface, Service, Registerable {
 	 */
 	protected function get_file_version(): string {
 		return $this->options->get( OptionsInterface::FILE_VERSION, '' );
-	}
-
-	/**
-	 * Validate that each of the installable items is of the correct interface.
-	 */
-	protected function validate_installables() {
-		foreach ( $this->installables as $installable ) {
-			$this->validate_instanceof( $installable, InstallableInterface::class );
-		}
-	}
-
-	/**
-	 * Validate that each of the first installers is of the correct interface.
-	 */
-	protected function validate_first_installers() {
-		foreach ( $this->first_installers as $installer ) {
-			$this->validate_instanceof( $installer, FirstInstallInterface::class );
-		}
 	}
 }

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -278,17 +278,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class, ImageUtility::class, wpdb::class, AdsAssetGroupAsset::class );
 
 		// Set up the installer.
-		$installer_definition = $this->share_with_tags(
-			Installer::class,
-			InstallableInterface::class,
-			FirstInstallInterface::class,
-			WP::class
-		);
-		$installer_definition->setConcrete(
-			function ( ...$arguments ) {
-				return new Installer( ...$arguments );
-			}
-		);
+		$this->share_with_tags( Installer::class, WP::class );
 
 		// Share utility classes
 		$this->share_with_tags( AddressUtility::class );

--- a/src/Internal/DependencyManagement/DBServiceProvider.php
+++ b/src/Internal/DependencyManagement/DBServiceProvider.php
@@ -50,6 +50,7 @@ class DBServiceProvider extends AbstractServiceProvider {
 	 */
 	protected $provides = [
 		AttributeMappingRulesTable::class => true,
+		AttributeMappingRulesQuery::class => true,
 		ShippingRateTable::class          => true,
 		ShippingRateQuery::class          => true,
 		ShippingTimeTable::class          => true,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes 2 main refactors to the Installer class.

##### 1. Remove validation
In the constructor we were explicitly passing all classes which implement `InstallableInterface` and then validating to check if they implemented the same interface. Since the container is responsible for passing the right dependencies we don't need to do another loop through those classes to validate them.

##### 2. Load dependencies when needed
Passing the dependencies in the constructor means it will call the constructor of all the dependencies, even when we don't use them. Since the Install class relies on a hook being called and some other additional conditions, we can retrieve the necessary classes from the container only when they are needed. This is a minor optimization in how the extension constructs itself, but together with other optimizations it will make a difference.

If we look at the before and after of a front end request we can see that it reduces the time spent resolving container dependencies.

Before:
![image](https://github.com/user-attachments/assets/a05a05a7-ac15-45f0-8b87-ec30acaf8f45)

After:
![image](https://github.com/user-attachments/assets/fb4d8a67-17d6-45df-b7ac-10c12564b304)


Since we changed the load order this was initially generating a fatal error:
```
PHP Fatal error:  Uncaught TypeError: Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager::__construct(): Argument #1 ($attribute_mapping_rules_query) must be of type Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery, string given in google-listings-and-ads/src/Product/Attributes/AttributeManager.php:69
```

This was because the `DBServiceProvider` wasn't registered as the provider of this class, so it wasn't resolving when loading in a different order.

### Detailed test instructions:

1. Use the snippet `add_filter( 'woocommerce_gla_force_run_install', '__return_true' );`
2. Remove the option `gla_db_version`
3. Remove the option `gla_install_version`
4. Refresh an admin page and confirm the options are re-added
5. Remove one of the DB tables like `wp_gla_budget_recommendations`
6. Refresh an admin page and confirm it's added again

### Changelog entry
* Tweak - Refactor installer class to load dependencies when needed.

