### PR TITLE
Add an admin service provider for WP Admin requests

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -9,8 +9,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminScriptWithBuiltDepen
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminStyleAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\Asset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\ViewFactory;
@@ -29,11 +27,10 @@ use Automattic\WooCommerce\Admin\PageController;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Pages
  */
-class Admin implements Service, Registerable, Conditional, OptionsAwareInterface {
+class Admin implements OptionsAwareInterface, Registerable, Service {
 
-	use AdminConditional;
-	use PluginHelper;
 	use OptionsAwareTrait;
+	use PluginHelper;
 
 	/**
 	 * @var AssetsHandlerInterface

--- a/src/Admin/BulkEdit/BulkEditInitializer.php
+++ b/src/Admin/BulkEdit/BulkEditInitializer.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\BulkEdit;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use WP_Post;
@@ -16,8 +15,6 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin\BulkEdit
  */
 class BulkEditInitializer implements Service, Registerable {
-
-	use AdminConditional;
 
 	/**
 	 * Register a service.

--- a/src/Admin/MetaBox/AbstractMetaBox.php
+++ b/src/Admin/MetaBox/AbstractMetaBox.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\ViewHelperTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\View\ViewException;
 use WP_Post;
 
@@ -18,7 +17,6 @@ defined( 'ABSPATH' ) || exit;
  */
 abstract class AbstractMetaBox implements MetaBoxInterface {
 
-	use AdminConditional;
 	use ViewHelperTrait;
 
 	protected const VIEW_PATH = 'meta-box';

--- a/src/Admin/MetaBox/MetaBoxInterface.php
+++ b/src/Admin/MetaBox/MetaBoxInterface.php
@@ -3,13 +3,12 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Renderable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 
 defined( 'ABSPATH' ) || exit;
 
-interface MetaBoxInterface extends Service, Conditional, Renderable {
+interface MetaBoxInterface extends Renderable, Service {
 	public const SCREEN_PRODUCT = 'product';
 	public const SCREEN_COUPON  = 'shop_coupon';
 

--- a/src/Admin/Redirect.php
+++ b/src/Admin/Redirect.php
@@ -74,9 +74,9 @@ class Redirect implements Activateable, Service, Registerable, OptionsAwareInter
 
 		if (
 			// Only redirect to onboarding when activated on its own. Either with a link...
-			isset( $_GET['action'] ) && 'activate' === $_GET['action'] // phpcs:ignore WordPress.Security.NonceVerification
+			( isset( $_GET['action'] ) && 'activate' === $_GET['action'] ) // phpcs:ignore WordPress.Security.NonceVerification
 			// ...or with a bulk action.
-			|| isset( $_POST['checked'] ) && is_array( $_POST['checked'] ) && 1 === count( $_POST['checked'] ) // phpcs:ignore WordPress.Security.NonceVerification
+			|| ( isset( $_POST['checked'] ) && is_array( $_POST['checked'] ) && 1 === count( $_POST['checked'] ) ) // phpcs:ignore WordPress.Security.NonceVerification
 		) {
 			$this->options->update( self::OPTION, 'yes' );
 		}

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -18,8 +18,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\GTINMigrationUtilities;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
@@ -46,9 +44,8 @@ use WP_REST_Request as Request;
 /**
  * Main class for Connection Test.
  */
-class ConnectionTest implements Conditional, ContainerAwareInterface, Service, Registerable {
+class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 
-	use AdminConditional;
 	use ContainerAwareTrait;
 	use GTINMigrationUtilities;
 	use PluginHelper;

--- a/src/Container.php
+++ b/src/Container.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\GoogleListingsAndAds;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\AdminServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\CoreServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\DBServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\GoogleServiceProvider;
@@ -52,6 +53,7 @@ final class Container implements ContainerInterface {
 		JobServiceProvider::class,
 		IntegrationServiceProvider::class,
 		DBServiceProvider::class,
+		AdminServiceProvider::class,
 	];
 
 	/**

--- a/src/Container.php
+++ b/src/Container.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\CoreServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\DBServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\GoogleServiceProvider;
@@ -72,7 +73,13 @@ final class Container implements ContainerInterface {
 			->invokeMethod( 'set_container', [ ContainerInterface::class ] );
 
 		foreach ( $this->service_providers as $service_provider_class ) {
-			$this->container->addServiceProvider( new $service_provider_class() );
+			$service_provider = new $service_provider_class();
+			$implements       = class_implements( $service_provider );
+			if ( array_key_exists( Conditional::class, $implements ) && ! $service_provider->is_needed() ) {
+				continue;
+			}
+
+			$this->container->addServiceProvider( $service_provider );
 		}
 	}
 

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\ConnectionTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
@@ -33,6 +34,7 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 	 */
 	protected $provides = [
 		AttributeMapping::class    => true,
+		ConnectionTest::class      => true,
 		Dashboard::class           => true,
 		GetStarted::class          => true,
 		ProductFeed::class         => true,
@@ -52,14 +54,16 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 	 * @return void
 	 */
 	public function register(): void {
-		$this->conditionally_share_with_tags( AttributeMapping::class );
-		$this->conditionally_share_with_tags( Dashboard::class );
-		$this->conditionally_share_with_tags( GetStarted::class );
-		$this->conditionally_share_with_tags( ProductFeed::class );
-		$this->conditionally_share_with_tags( Reports::class );
-		$this->conditionally_share_with_tags( Settings::class );
-		$this->conditionally_share_with_tags( SetupAds::class );
-		$this->conditionally_share_with_tags( SetupMerchantCenter::class );
-		$this->conditionally_share_with_tags( Shipping::class );
+		$this->share_with_tags( ConnectionTest::class );
+
+		$this->share_with_tags( AttributeMapping::class );
+		$this->share_with_tags( Dashboard::class );
+		$this->share_with_tags( GetStarted::class );
+		$this->share_with_tags( ProductFeed::class );
+		$this->share_with_tags( Reports::class );
+		$this->share_with_tags( Settings::class );
+		$this->share_with_tags( SetupAds::class );
+		$this->share_with_tags( SetupMerchantCenter::class );
+		$this->share_with_tags( Shipping::class );
 	}
 }

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -3,6 +3,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\ConnectionTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
@@ -16,6 +19,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupAds;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupMerchantCenter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Shipping;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
 
 /**
  * Class AdminServiceProvider
@@ -33,6 +38,7 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 	 * @var array
 	 */
 	protected $provides = [
+		Admin::class               => true,
 		AttributeMapping::class    => true,
 		ConnectionTest::class      => true,
 		Dashboard::class           => true,
@@ -54,6 +60,15 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 	 * @return void
 	 */
 	public function register(): void {
+		$this->share_with_tags(
+			Admin::class,
+			AssetsHandlerInterface::class,
+			PHPViewFactory::class,
+			MerchantCenterService::class,
+			AdsService::class
+		);
+		$this->share_with_tags( PHPViewFactory::class );
+
 		$this->share_with_tags( ConnectionTest::class );
 
 		$this->share_with_tags( AttributeMapping::class );

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -4,10 +4,16 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\ChannelVisibilityMetaBox;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\CouponChannelVisibilityMetaBox;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInitializer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Redirect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\ConnectionTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
@@ -21,6 +27,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupAds;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupMerchantCenter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Shipping;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
 
@@ -45,6 +54,8 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 		ConnectionTest::class      => true,
 		Dashboard::class           => true,
 		GetStarted::class          => true,
+		MetaBoxInterface::class    => true,
+		MetaBoxInitializer::class  => true,
 		ProductFeed::class         => true,
 		Redirect::class            => true,
 		Reports::class             => true,
@@ -72,6 +83,11 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 		);
 		$this->share_with_tags( PHPViewFactory::class );
 		$this->share_with_tags( Redirect::class, WP::class );
+
+		// Share admin meta boxes
+		$this->share_with_tags( ChannelVisibilityMetaBox::class, Admin::class, ProductMetaHandler::class, ProductHelper::class, MerchantCenterService::class );
+		$this->share_with_tags( CouponChannelVisibilityMetaBox::class, Admin::class, CouponMetaHandler::class, CouponHelper::class, MerchantCenterService::class, TargetAudience::class );
+		$this->share_with_tags( MetaBoxInitializer::class, Admin::class, MetaBoxInterface::class );
 
 		$this->share_with_tags( ConnectionTest::class );
 

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -4,6 +4,8 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\BulkEdit\BulkEditInitializer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\BulkEdit\CouponBulkEdit;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\ChannelVisibilityMetaBox;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\CouponChannelVisibilityMetaBox;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInitializer;
@@ -51,7 +53,9 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 	protected $provides = [
 		Admin::class               => true,
 		AttributeMapping::class    => true,
+		BulkEditInitializer::class => true,
 		ConnectionTest::class      => true,
+		CouponBulkEdit::class      => true,
 		Dashboard::class           => true,
 		GetStarted::class          => true,
 		MetaBoxInterface::class    => true,
@@ -83,6 +87,10 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 		);
 		$this->share_with_tags( PHPViewFactory::class );
 		$this->share_with_tags( Redirect::class, WP::class );
+
+		// Share bulk edit views
+		$this->share_with_tags( CouponBulkEdit::class, CouponMetaHandler::class, MerchantCenterService::class, TargetAudience::class );
+		$this->share_with_tags( BulkEditInitializer::class );
 
 		// Share admin meta boxes
 		$this->share_with_tags( ChannelVisibilityMetaBox::class, Admin::class, ProductMetaHandler::class, ProductHelper::class, MerchantCenterService::class );

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -6,6 +6,15 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Menu\AttributeMapping;
+use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Dashboard;
+use Automattic\WooCommerce\GoogleListingsAndAds\Menu\GetStarted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Menu\ProductFeed;
+use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Reports;
+use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Settings;
+use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupAds;
+use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupMerchantCenter;
+use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Shipping;
 
 /**
  * Class AdminServiceProvider
@@ -23,7 +32,16 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 	 * @var array
 	 */
 	protected $provides = [
-		Service::class => true,
+		AttributeMapping::class    => true,
+		Dashboard::class           => true,
+		GetStarted::class          => true,
+		ProductFeed::class         => true,
+		Reports::class             => true,
+		Settings::class            => true,
+		SetupAds::class            => true,
+		SetupMerchantCenter::class => true,
+		Shipping::class            => true,
+		Service::class             => true,
 	];
 
 	/**
@@ -34,5 +52,14 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 	 * @return void
 	 */
 	public function register(): void {
+		$this->conditionally_share_with_tags( AttributeMapping::class );
+		$this->conditionally_share_with_tags( Dashboard::class );
+		$this->conditionally_share_with_tags( GetStarted::class );
+		$this->conditionally_share_with_tags( ProductFeed::class );
+		$this->conditionally_share_with_tags( Reports::class );
+		$this->conditionally_share_with_tags( Settings::class );
+		$this->conditionally_share_with_tags( SetupAds::class );
+		$this->conditionally_share_with_tags( SetupMerchantCenter::class );
+		$this->conditionally_share_with_tags( Shipping::class );
 	}
 }

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -1,0 +1,38 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+
+/**
+ * Class AdminServiceProvider
+ * Provides services which are only required for the WP admin dashboard.
+ *
+ * Note: These services will not be available in a REST API request.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement
+ */
+class AdminServiceProvider extends AbstractServiceProvider implements Conditional {
+
+	use AdminConditional;
+
+	/**
+	 * @var array
+	 */
+	protected $provides = [
+		Service::class => true,
+	];
+
+	/**
+	 * Use the register method to register items with the container via the
+	 * protected $this->container property or the `getContainer` method
+	 * from the ContainerAwareTrait.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+	}
+}

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Redirect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\ConnectionTest;
@@ -20,6 +21,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupAds;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupMerchantCenter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Shipping;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
 
 /**
@@ -44,6 +46,7 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 		Dashboard::class           => true,
 		GetStarted::class          => true,
 		ProductFeed::class         => true,
+		Redirect::class            => true,
 		Reports::class             => true,
 		Settings::class            => true,
 		SetupAds::class            => true,
@@ -68,6 +71,7 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 			AdsService::class
 		);
 		$this->share_with_tags( PHPViewFactory::class );
+		$this->share_with_tags( Redirect::class, WP::class );
 
 		$this->share_with_tags( ConnectionTest::class );
 

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -6,8 +6,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 use Automattic\WooCommerce\Admin\Marketing\MarketingChannels;
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
-use Automattic\WooCommerce\GoogleListingsAndAds\Admin\BulkEdit\BulkEditInitializer;
-use Automattic\WooCommerce\GoogleListingsAndAds\Admin\BulkEdit\CouponBulkEdit;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesTab;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\VariationsAttributes;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\ChannelVisibilityBlock;
@@ -130,11 +128,9 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		Installer::class                 => true,
 		AddressUtility::class            => true,
 		AssetsHandlerInterface::class    => true,
-		BulkEditInitializer::class       => true,
 		ContactInformationNote::class    => true,
 		CompleteSetupTask::class         => true,
 		CompleteSetupNote::class         => true,
-		CouponBulkEdit::class            => true,
 		CouponHelper::class              => true,
 		CouponMetaHandler::class         => true,
 		CouponSyncer::class              => true,
@@ -337,10 +333,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()
 			->inflector( TracksAwareInterface::class )
 			->invokeMethod( 'set_tracks', [ TracksInterface::class ] );
-
-		// Share bulk edit views
-		$this->conditionally_share_with_tags( CouponBulkEdit::class, CouponMetaHandler::class, MerchantCenterService::class, TargetAudience::class );
-		$this->conditionally_share_with_tags( BulkEditInitializer::class );
 
 		// Share other classes.
 		$this->share_with_tags( ActivatedEvents::class, $_SERVER );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 
 use Automattic\WooCommerce\Admin\Marketing\MarketingChannels;
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
-use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Redirect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\BulkEdit\BulkEditInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\BulkEdit\CouponBulkEdit;
@@ -133,7 +132,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 	 */
 	protected $provides = [
 		Installer::class                 => true,
-		Redirect::class                  => true,
 		AddressUtility::class            => true,
 		AssetsHandlerInterface::class    => true,
 		BulkEditInitializer::class       => true,
@@ -263,7 +261,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( ISOUtility::class, ISO3166DataProvider::class );
 
 		// Share our regular service classes.
-		$this->conditionally_share_with_tags( Redirect::class, WP::class );
 		$this->share_with_tags( TrackerSnapshot::class );
 		$this->share_with_tags( EventTracking::class );
 		$this->share_with_tags( RESTControllers::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -54,8 +54,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\ViewFactory;
 use Automattic\WooCommerce\GoogleListingsAndAds\Installer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DeprecatedFilters;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\InstallTimestamp;
-use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\FirstInstallInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\InstallableInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\Logging\DebugLogger;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\AttributeMapping;

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -32,7 +32,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\RESTControllers;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\OAuthService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\ConnectionTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
@@ -277,7 +276,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( TrackerSnapshot::class );
 		$this->share_with_tags( EventTracking::class );
 		$this->share_with_tags( RESTControllers::class );
-		$this->conditionally_share_with_tags( ConnectionTest::class );
 		$this->share_with_tags( CompleteSetupTask::class );
 		$this->conditionally_share_with_tags( GlobalSiteTag::class, AssetsHandlerInterface::class, GoogleGtagJs::class, ProductHelper::class, WC::class, WP::class );
 		$this->share_with_tags( SiteVerificationMeta::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -118,7 +118,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ImageUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ISOUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\WPCLIMigrationGTIN;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
-use Automattic\WooCommerce\GoogleListingsAndAds\View\PHPViewFactory;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use wpdb;
 
@@ -135,7 +134,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 	protected $provides = [
 		Installer::class                 => true,
 		Redirect::class                  => true,
-		Admin::class                     => true,
 		AddressUtility::class            => true,
 		AssetsHandlerInterface::class    => true,
 		BulkEditInitializer::class       => true,
@@ -265,13 +263,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( ISOUtility::class, ISO3166DataProvider::class );
 
 		// Share our regular service classes.
-		$this->conditionally_share_with_tags(
-			Admin::class,
-			AssetsHandlerInterface::class,
-			PHPViewFactory::class,
-			MerchantCenterService::class,
-			AdsService::class
-		);
 		$this->conditionally_share_with_tags( Redirect::class, WP::class );
 		$this->share_with_tags( TrackerSnapshot::class );
 		$this->share_with_tags( EventTracking::class );
@@ -364,8 +355,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		// Share bulk edit views
 		$this->conditionally_share_with_tags( CouponBulkEdit::class, CouponMetaHandler::class, MerchantCenterService::class, TargetAudience::class );
 		$this->conditionally_share_with_tags( BulkEditInitializer::class );
-
-		$this->share_with_tags( PHPViewFactory::class );
 
 		// Share other classes.
 		$this->share_with_tags( ActivatedEvents::class, $_SERVER );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -8,10 +8,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\BulkEdit\BulkEditInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\BulkEdit\CouponBulkEdit;
-use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\ChannelVisibilityMetaBox;
-use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\CouponChannelVisibilityMetaBox;
-use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInitializer;
-use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\AttributesTab;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\Attributes\VariationsAttributes;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Product\ChannelVisibilityBlock;
@@ -167,8 +163,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		BatchProductHelper::class        => true,
 		ProductFilter::class             => true,
 		ProductRepository::class         => true,
-		MetaBoxInterface::class          => true,
-		MetaBoxInitializer::class        => true,
 		ViewFactory::class               => true,
 		DebugLogger::class               => true,
 		MerchantStatuses::class          => true,
@@ -343,11 +337,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()
 			->inflector( TracksAwareInterface::class )
 			->invokeMethod( 'set_tracks', [ TracksInterface::class ] );
-
-		// Share admin meta boxes
-		$this->conditionally_share_with_tags( ChannelVisibilityMetaBox::class, Admin::class, ProductMetaHandler::class, ProductHelper::class, MerchantCenterService::class );
-		$this->conditionally_share_with_tags( CouponChannelVisibilityMetaBox::class, Admin::class, CouponMetaHandler::class, CouponHelper::class, MerchantCenterService::class, TargetAudience::class );
-		$this->conditionally_share_with_tags( MetaBoxInitializer::class, Admin::class, MetaBoxInterface::class );
 
 		// Share bulk edit views
 		$this->conditionally_share_with_tags( CouponBulkEdit::class, CouponMetaHandler::class, MerchantCenterService::class, TargetAudience::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -56,15 +56,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DeprecatedFilters;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\InstallTimestamp;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ProductSyncStats;
 use Automattic\WooCommerce\GoogleListingsAndAds\Logging\DebugLogger;
-use Automattic\WooCommerce\GoogleListingsAndAds\Menu\AttributeMapping;
-use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Dashboard;
-use Automattic\WooCommerce\GoogleListingsAndAds\Menu\GetStarted;
-use Automattic\WooCommerce\GoogleListingsAndAds\Menu\ProductFeed;
-use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Reports;
-use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Settings;
-use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupAds;
-use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupMerchantCenter;
-use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Shipping;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService as MerchantAccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
@@ -147,7 +138,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		Redirect::class                  => true,
 		Admin::class                     => true,
 		AddressUtility::class            => true,
-		Reports::class                   => true,
 		AssetsHandlerInterface::class    => true,
 		BulkEditInitializer::class       => true,
 		ContactInformationNote::class    => true,
@@ -157,24 +147,17 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		CouponHelper::class              => true,
 		CouponMetaHandler::class         => true,
 		CouponSyncer::class              => true,
-		Dashboard::class                 => true,
 		DateTimeUtility::class           => true,
 		EventTracking::class             => true,
-		GetStarted::class                => true,
 		GlobalSiteTag::class             => true,
 		ISOUtility::class                => true,
 		SiteVerificationEvents::class    => true,
 		OptionsInterface::class          => true,
 		TransientsInterface::class       => true,
-		ProductFeed::class               => true,
 		ReconnectWordPressNote::class    => true,
 		ReviewAfterClicksNote::class     => true,
 		RESTControllers::class           => true,
 		Service::class                   => true,
-		Settings::class                  => true,
-		Shipping::class                  => true,
-		SetupAds::class                  => true,
-		SetupMerchantCenter::class       => true,
 		SetupCampaignNote::class         => true,
 		SetupCampaign2Note::class        => true,
 		SetupCouponSharingNote::class    => true,
@@ -214,7 +197,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		ShippingZone::class              => true,
 		AdsAccountService::class         => true,
 		MerchantAccountService::class    => true,
-		AttributeMapping::class          => true,
 		MarketingChannelRegistrar::class => true,
 		OAuthService::class              => true,
 		WPCLIMigrationGTIN::class        => true,
@@ -292,15 +274,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			AdsService::class
 		);
 		$this->conditionally_share_with_tags( Redirect::class, WP::class );
-		$this->conditionally_share_with_tags( GetStarted::class );
-		$this->conditionally_share_with_tags( SetupMerchantCenter::class );
-		$this->conditionally_share_with_tags( SetupAds::class );
-		$this->conditionally_share_with_tags( Dashboard::class );
-		$this->conditionally_share_with_tags( Reports::class );
-		$this->conditionally_share_with_tags( ProductFeed::class );
-		$this->conditionally_share_with_tags( AttributeMapping::class );
-		$this->conditionally_share_with_tags( Settings::class );
-		$this->conditionally_share_with_tags( Shipping::class );
 		$this->share_with_tags( TrackerSnapshot::class );
 		$this->share_with_tags( EventTracking::class );
 		$this->share_with_tags( RESTControllers::class );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Instead of adding AdminConditional to a large list of service classes, this PR instead ads a conditional ServiceProvider which only registers if the AdminConditional is true. This allows us to move all the specific service classes which handle functionality for WP Admin page requests into a separate service provider.

Note: This service provider won't be loaded for frontend or REST API requests.

When viewing the profile of a frontend request we can see a slight improvement on amount of classes the container has to load.

Before:
![image](https://github.com/user-attachments/assets/fb7bd588-b5a5-4c09-a7d0-270bb75b8fe0)

After:
![image](https://github.com/user-attachments/assets/c236f6b0-4308-45e0-9f6d-27fe1f18fdd6)

If we compare this with the previous release we can see a bigger performance improvement:
![image](https://github.com/user-attachments/assets/ba997284-eee9-4693-b96a-1c85b42906cd)


### Detailed test instructions:
##### Test ConnectionTest
1. Visit the connection test page directly: `/wp-admin/admin.php?page=connection-test-admin-page`
2. Test some status calls to confirm requests are working

##### Test Admin view
1. Make sure onboarding is complete (so syncing is available)
2. Go to edit a product and view the "Google for WooCommerce" product data tab
3. Confirm all views for the fields are rendered correctly

##### Test menu pages
1. Make sure onboarding is complete
2. Visit the Marketing > Google for WooCommerce > Dashboard
3. Ensure that each of the pages continues loading

##### Test redirect
1. Make sure onboarding is not complete
4. Deactivate plugin
5. Activate plugin
6. Confirm we are redirected to `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fstart`
7. Try to load the dashboard at `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard`
8. Confirm we are redirected to the start page
9. Complete onboarding and try going directly to the start page `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fstart`
10. Confirm we are redirected to the dashboard page

##### Test metaboxes
1. Make sure onboarding is completed
2. Go to edit a product and confirm the Channel Visibility meta box is visible
3. Toggle sync and show setting and update product
5. Confirm toggled value is persistent
6. Go to Marketing > Coupons and edit a coupon
7. Confirm the Channel Visitibility meta box is visible

##### Test Bulk editing coupons
1. Set base country to one that supports coupons ex: USA
2. Make sure onboarding is complete
3. Go to Marketing > Coupons and add several coupons
4. Select all coupons and use the Bulk action "edit"
5. Toggle Google Visibility and update
6. Check each individual coupon and confirm the visibility was updated


### Changelog entry
* Tweak - Add an admin service provider for WP Admin requests.
