### PR TITLE
Improve a few E2E test cases

### DIFF
--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -400,7 +400,6 @@ test.describe( 'Set up Ads account', () => {
 			await page.waitForURL(
 				'/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&guide=campaign-creation-success',
 				{
-					timeout: 30000,
 					waitUntil: LOAD_STATE.DOM_CONTENT_LOADED,
 				}
 			);

--- a/tests/e2e/specs/onboarding/step-1-accounts.test.js
+++ b/tests/e2e/specs/onboarding/step-1-accounts.test.js
@@ -225,12 +225,14 @@ test.describe( 'Set up accounts', () => {
 		} );
 
 		test( 'should create merchant center and ads account if does not exist for the user', async () => {
+			const once = setUpAccountsPage.withFulfillTimes( 1 );
+			const deferred = once.withFulfillDeferred();
+
 			await setUpAccountsPage.mockJetpackConnected();
 			await setUpAccountsPage.mockGoogleConnected();
-			await setUpAccountsPage.mockAdsCreateAccount();
-			await setUpAccountsPage.mockMCCreateAccountWebsiteClaimed();
 
-			const once = setUpAccountsPage.withFulfillTimes( 1 );
+			await deferred.mockMCCreateAccountWebsiteClaimed();
+			await deferred.mockAdsCreateAccount();
 
 			await once.mockAdsHasNoAccounts();
 			await once.mockMCHasNoAccounts();
@@ -249,6 +251,12 @@ test.describe( 'Set up accounts', () => {
 						exact: true,
 					}
 				)
+			).toBeVisible();
+
+			deferred.continueFulfill();
+
+			await expect(
+				googleAccountCard.getByText( 'mail@example.com' )
 			).toBeVisible();
 		} );
 

--- a/tests/e2e/specs/onboarding/step-1-accounts.test.js
+++ b/tests/e2e/specs/onboarding/step-1-accounts.test.js
@@ -230,7 +230,7 @@ test.describe( 'Set up accounts', () => {
 			await setUpAccountsPage.mockAdsCreateAccount();
 			await setUpAccountsPage.mockMCCreateAccountWebsiteClaimed();
 
-			const once = setUpAccountsPage.fulfillTimes( 1 );
+			const once = setUpAccountsPage.withFulfillTimes( 1 );
 
 			await once.mockAdsHasNoAccounts();
 			await once.mockMCHasNoAccounts();
@@ -260,7 +260,7 @@ test.describe( 'Set up accounts', () => {
 			await setUpAccountsPage.mockAdsAccountIncomplete( 'claim_account' );
 			await setUpAccountsPage.mockAdsStatusNotClaimed();
 
-			const once = setUpAccountsPage.fulfillTimes( 1 );
+			const once = setUpAccountsPage.withFulfillTimes( 1 );
 
 			await once.mockAdsHasNoAccounts();
 			await once.mockMCHasNoAccounts();

--- a/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
+++ b/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
@@ -374,12 +374,18 @@ test.describe( 'Complete your campaign', () => {
 					} );
 
 					await newPage.close();
-					// return focus to the page.
-					await setupBudgetPage.focusBudget();
 					await setupBudgetPage.fulfillBillingStatusRequest( {
 						status: 'approved',
 					} );
-					await setupBudgetPage.awaitForBillingStatusRequest();
+
+					const requestPromise =
+						setupBudgetPage.awaitForBillingStatusRequest();
+
+					// Regain page focus to trigger a new request to update billing status.
+					await page.dispatchEvent( 'body', 'blur' );
+					await page.dispatchEvent( 'body', 'focus' );
+
+					await requestPromise;
 
 					const billingSetupSuccessSection =
 						setupBudgetPage.getBillingSetupSuccessSection();

--- a/tests/e2e/specs/settings/settings.test.js
+++ b/tests/e2e/specs/settings/settings.test.js
@@ -40,7 +40,7 @@ test.describe( 'Settings', () => {
 	test.describe( 'Tax rate setup', () => {
 		test( 'Should not show the setup when selling in regions unrelated to the US', async () => {
 			// Mock the country where the store is located as outside of the US.
-			const once = settingsPage.fulfillTimes( 1 );
+			const once = settingsPage.withFulfillTimes( 1 );
 			await once.fulfillRequest(
 				// Having`(\w+%2C)*` is because multiple option queries may be consolidated into a single request.
 				/\/wc-admin\/options\?options=(\w+%2C)*woocommerce_default_country\b/,

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -51,6 +51,23 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Defer the fulfillment of subsequent requests until calling the `continueFulfill` of the returned proxied instance.
+	 *
+	 * @return {this} A proxied instance intercepts the subsequent fulfillRequest calls to attach the `beforeFulfill` option.
+	 */
+	withFulfillDeferred() {
+		let continueFulfill;
+		const beforeFulfill = new Promise( ( resolve ) => {
+			continueFulfill = resolve;
+		} );
+
+		const proxiedInstance = proxyFulfill( this, { beforeFulfill } );
+		proxiedInstance.continueFulfill = continueFulfill;
+
+		return proxiedInstance;
+	}
+
+	/**
 	 * Fulfill a request with a payload.
 	 *
 	 * @param {RegExp|string} url The url to fulfill.
@@ -59,6 +76,7 @@ export default class MockRequests {
 	 * @param {Array} [methods] The HTTP methods in the request to be fulfill.
 	 * @param {Object} [options] Options to customize the request to be fulfill.
 	 * @param {number} [options.times] The number of times to fulfill the request.
+	 * @param {Promise<void>} [options.beforeFulfill] A promise that resolves before fulfilling the request.
 	 * @return {Promise<void>}
 	 */
 	async fulfillRequest(
@@ -73,12 +91,18 @@ export default class MockRequests {
 				methods.length === 0 ||
 				methods.includes( route.request().method() )
 			) {
-				return route.fulfill( {
+				const fulfillOptions = {
 					status,
 					contentType: 'application/json',
 					headers: { 'Access-Control-Allow-Origin': '*' },
 					body: JSON.stringify( payload ),
-				} );
+				};
+
+				const { beforeFulfill = Promise.resolve() } = options;
+
+				return beforeFulfill.then( () =>
+					route.fulfill( fulfillOptions )
+				);
 			}
 			return route.fallback();
 		};

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -1,3 +1,32 @@
+const proxyFulfill = ( instance, options ) => {
+	return new Proxy( instance.originalTarget || instance, {
+		get( target, property ) {
+			if ( property === 'originalTarget' ) {
+				return target;
+			}
+
+			if ( property === 'previousOptions' ) {
+				return options;
+			}
+
+			const value = Reflect.get( ...arguments );
+
+			if ( property === 'fulfillRequest' ) {
+				return function ( url, payload, status, methods ) {
+					const mergedOpts = {
+						...instance.previousOptions,
+						...options,
+					};
+					const args = [ url, payload, status, methods, mergedOpts ];
+					return value.apply( target, args );
+				};
+			}
+
+			return value;
+		},
+	} );
+};
+
 /**
  * Mock Requests
  *
@@ -17,34 +46,28 @@ export default class MockRequests {
 	 * @param {number} times The number of times to fulfill the request.
 	 * @return {this} A proxied instance intercepts the subsequent fulfillRequest calls to attach the `times` option.
 	 */
-	fulfillTimes( times ) {
-		return new Proxy( this, {
-			get( target, property ) {
-				const value = Reflect.get( ...arguments );
-
-				if ( property === 'fulfillRequest' ) {
-					return function ( url, payload, status, methods ) {
-						const args = [ url, payload, status, methods, times ];
-						return value.apply( target, args );
-					};
-				}
-
-				return value;
-			},
-		} );
+	withFulfillTimes( times ) {
+		return proxyFulfill( this, { times } );
 	}
 
 	/**
 	 * Fulfill a request with a payload.
 	 *
-	 * @param {RegExp|string} url      The url to fulfill.
-	 * @param {Object}        payload  The payload to send.
-	 * @param {number}        status   The HTTP status in the response.
-	 * @param {Array}         methods  The HTTP methods in the request to be fulfill.
-	 * @param {number}        [times]    The number of times to fulfill the request. Optional.
+	 * @param {RegExp|string} url The url to fulfill.
+	 * @param {Object} payload The payload to send.
+	 * @param {number} [status] The HTTP status in the response.
+	 * @param {Array} [methods] The HTTP methods in the request to be fulfill.
+	 * @param {Object} [options] Options to customize the request to be fulfill.
+	 * @param {number} [options.times] The number of times to fulfill the request.
 	 * @return {Promise<void>}
 	 */
-	async fulfillRequest( url, payload, status = 200, methods = [], times ) {
+	async fulfillRequest(
+		url,
+		payload,
+		status = 200,
+		methods = [],
+		options = {}
+	) {
 		const handler = async ( route ) => {
 			if (
 				methods.length === 0 ||
@@ -60,7 +83,7 @@ export default class MockRequests {
 			return route.fallback();
 		};
 
-		await this.page.route( url, handler, { times } );
+		await this.page.route( url, handler, { times: options.times } );
 	}
 
 	/**

--- a/tests/e2e/utils/pages/ads-onboarding/setup-budget.js
+++ b/tests/e2e/utils/pages/ads-onboarding/setup-budget.js
@@ -140,23 +140,16 @@ export default class SetupBudget extends MockRequests {
 	 * @return {Promise<Request>} The request.
 	 */
 	async awaitForCampaignCreationRequest( budget, targetLocations ) {
-		return this.page.waitForRequest(
-			( request ) => {
-				return (
-					request.url().includes( '/gla/ads/campaigns' ) &&
-					request.method() === 'POST' &&
-					request.postDataJSON().amount === parseInt( budget, 10 ) &&
-					targetLocations.every( ( item ) =>
-						request
-							.postDataJSON()
-							.targeted_locations.includes( item )
-					)
-				);
-			},
-			{
-				timeout: 35000,
-			}
-		);
+		return this.page.waitForRequest( ( request ) => {
+			return (
+				request.url().includes( '/gla/ads/campaigns' ) &&
+				request.method() === 'POST' &&
+				request.postDataJSON().amount === parseInt( budget, 10 ) &&
+				targetLocations.every( ( item ) =>
+					request.postDataJSON().targeted_locations.includes( item )
+				)
+			);
+		} );
 	}
 
 	/**

--- a/tests/e2e/utils/pages/ads-onboarding/setup-budget.js
+++ b/tests/e2e/utils/pages/ads-onboarding/setup-budget.js
@@ -100,16 +100,6 @@ export default class SetupBudget extends MockRequests {
 	}
 
 	/**
-	 * Focus the budget input.
-	 *
-	 * @return {Promise<void>}
-	 */
-	async focusBudget() {
-		const input = this.getBudgetInput();
-		await input.focus();
-	}
-
-	/**
 	 * Click set up billing button.
 	 *
 	 * @return {Promise<void>}
@@ -138,8 +128,7 @@ export default class SetupBudget extends MockRequests {
 		return this.page.waitForRequest(
 			( request ) =>
 				request.url().includes( '/gla/ads/billing-status' ) &&
-				request.method() === 'GET',
-			{ timeout: 35000 }
+				request.method() === 'GET'
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR improves a few E2E test cases:
- Fix the flaky E2E test which asserts the auto-creation of Google Ads and Merchant Center accounts.
   - It fails randomly and can usually pass after the first retry, but still often brings unwanted noise.
   - ![image](https://github.com/user-attachments/assets/10107f26-db80-4204-8ae0-c20940d4ba45)
   - Reference: https://github.com/woocommerce/google-listings-and-ads/actions/runs/12741983827/job/35509408880#step:10:89
- Speed up the E2E test which asserts the ad billing status change.
   - Will reduce execution time from about 26 seconds to less than 1 second.
   - Before
      ![image](https://github.com/user-attachments/assets/e74e8002-4182-41c9-8d9e-ec17c3e80e0f)
   - After
      ![image](https://github.com/user-attachments/assets/d132bc2c-5d51-45f6-84e4-c8d0af11ef74)
- Remove the `timeout` options that are no longer needed from E2E testing.

💡 I will be skipping code review since this PR only includes developer-facing only change.

### Detailed test instructions:

Confirm E2E tests can pass: https://github.com/woocommerce/google-listings-and-ads/actions/runs/12804583366

### Changelog entry
