### PR TITLE
Set specific flags for html_entity_decode

### DIFF
--- a/src/Ads/AccountService.php
+++ b/src/Ads/AccountService.php
@@ -78,7 +78,7 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		$status = [
 			'id'       => $id,
 			'currency' => $this->options->get( OptionsInterface::ADS_ACCOUNT_CURRENCY ),
-			'symbol'   => html_entity_decode( get_woocommerce_currency_symbol( $this->options->get( OptionsInterface::ADS_ACCOUNT_CURRENCY ) ) ),
+			'symbol'   => html_entity_decode( get_woocommerce_currency_symbol( $this->options->get( OptionsInterface::ADS_ACCOUNT_CURRENCY ) ), ENT_QUOTES ),
 			'status'   => $id ? 'connected' : 'disconnected',
 		];
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -427,7 +427,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			}
 
 			$product_issue_template = [
-				'product'              => html_entity_decode( $wc_product->get_name() ),
+				'product'              => html_entity_decode( $wc_product->get_name(), ENT_QUOTES ),
 				'product_id'           => $wc_product_id,
 				'created_at'           => $created_at,
 				'applicable_countries' => [],

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -624,7 +624,7 @@ class MerchantStatusesTest extends UnitTest {
 		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
 			[
 				[
-					'product'              => html_entity_decode( $product_1->get_name() ),
+					'product'              => html_entity_decode( $product_1->get_name(), ENT_QUOTES ),
 					'product_id'           => $product_1->get_id(),
 					'created_at'           => $this->merchant_statuses->get_cache_created_time()->format( 'Y-m-d H:i:s' ),
 					'applicable_countries' => json_encode( [ 'ES' ] ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR resolves the following warning notices:
> The default value of the $flags parameter for html_entity_decode() was changed from ENT_COMPAT to ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 in PHP 8.1. For cross-version compatibility, the $flags parameter should be explicitly set.

We only use the function `html_entity_decode` in two locations:
1. To decode currency symbols (generally we don't expect this to contain quotes, so the behaviour should remain the same regardless of PHP version)
2. For product names that show up in the issues table. We are already escaping these strings before inserting in the DB as well as decoding before displaying, so the change doesn't affect any behaviour

I was considering adding a unit test, but because the behaviour is identical, and what we are really concerned about is that the end display shows the product names without encoded entities, so instead I went with a manual visual test to confirm the behaviour remains consistent.

Closes #2770 

### Detailed test instructions:
1. Add a product with a name containing single and double quotes, ex: `Product "name" which shouldn't cause problems`
4. Make sure to leave some requirements out like adding a description or image so it ends up in the product issues table
5. Go to the connection test page and "Clear Status Cache"
6. Go to the Product Feed page and wait for the statuses to refresh
7. Check the DB table `wp_gla_merchant_issues` and confirm the product name column contains the quote characters as expected
8. View the product issues table on the product feed page and confirm the name contains the quotes as expected (can drop some rows from the DB table if there are too many to display)

![image](https://github.com/user-attachments/assets/5d6aaf65-bec6-4f16-97b4-dc200962b6c7)

### Changelog entry
* Tweak - Set specific flags for html_entity_decode.
