### PR TITLE
Resolve some of the plugin check errors and warnings

### DIFF
--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -457,7 +457,7 @@ function update_autoloads( string $file, array $composer_autoload, array $packag
 	if ( $modified ) {
 		file_put_contents(
 			$file,
-			wp_json_encode( $json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
+			json_encode( $json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
 		);
 	}
 }

--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -457,7 +457,7 @@ function update_autoloads( string $file, array $composer_autoload, array $packag
 	if ( $modified ) {
 		file_put_contents(
 			$file,
-			json_encode( $json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
+			wp_json_encode( $json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
 		);
 	}
 }

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -16,6 +16,9 @@
  * WC tested up to: 9.6
  * Woo:
  *
+ * License: GPLv3
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ *
  * @package WooCommerce\Admin
  */
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -85,16 +85,6 @@
 		</properties>
 	</rule>
 
-	<!-- We'd rather use native functions -->
-	<rule ref="WordPress.WP.AlternativeFunctions">
-		<properties>
-			<property name="exclude" type="array">
-				<element value="json_encode"/>
-				<element value="rand"/>
-			</property>
-		</properties>
-	</rule>
-
 	<!-- We're judicious in our usage of meta queries -->
 	<rule ref="WordPress.DB.SlowDBQuery">
 		<properties>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -108,6 +108,7 @@
 	<file>./bin</file>
 	<file>./views</file>
 	<file>./google-listings-and-ads.php</file>
+	<file>./uninstall.php</file>
 
 	<!-- Show progress and sniff codes in all reports -->
 	<arg value="ps"/>

--- a/src/API/Google/AdsConversionAction.php
+++ b/src/API/Google/AdsConversionAction.php
@@ -57,7 +57,7 @@ class AdsConversionAction implements OptionsAwareInterface {
 	 */
 	public function create_conversion_action(): array {
 		try {
-			$unique = sprintf( '%04x', mt_rand( 0, 0xffff ) );
+			$unique = sprintf( '%04x', wp_rand( 0, 0xffff ) );
 
 			$conversion_action_operation = new ConversionActionOperation();
 			$conversion_action_operation->setCreate(

--- a/src/API/Google/Connection.php
+++ b/src/API/Google/Connection.php
@@ -52,7 +52,7 @@ class Connection implements ContainerAwareInterface, OptionsAwareInterface {
 			$result = $client->post(
 				$this->get_connection_url(),
 				[
-					'body' => json_encode( $post_body ),
+					'body' => wp_json_encode( $post_body ),
 				]
 			);
 

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -131,7 +131,7 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 			$result = $client->post(
 				$this->get_manager_url( 'create-merchant' ),
 				[
-					'body' => json_encode(
+					'body' => wp_json_encode(
 						[
 							'name'       => $name,
 							'websiteUrl' => $site_url,
@@ -198,7 +198,7 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 			$result = $client->post(
 				$this->get_manager_url( 'link-merchant' ),
 				[
-					'body' => json_encode(
+					'body' => wp_json_encode(
 						[
 							'accountId' => $this->options->get_merchant_id(),
 						]
@@ -240,7 +240,7 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 			$result = $client->post(
 				$this->get_manager_url( 'claim-website' ),
 				[
-					'body' => json_encode(
+					'body' => wp_json_encode(
 						[
 							'accountId' => $this->options->get_merchant_id(),
 							'overwrite' => $overwrite,
@@ -299,7 +299,7 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 			$result = $client->post(
 				$this->get_manager_url( $country . '/create-customer' ),
 				[
-					'body' => json_encode(
+					'body' => wp_json_encode(
 						[
 							'descriptive_name' => $this->new_account_name(),
 							'currency_code'    => get_woocommerce_currency(),
@@ -358,7 +358,7 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 			$result = $client->post(
 				$this->get_manager_url( 'link-customer' ),
 				[
-					'body' => json_encode(
+					'body' => wp_json_encode(
 						[
 							'client_customer' => $id,
 						]
@@ -429,7 +429,7 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 			$result = $client->post(
 				$this->get_tos_url( $service ),
 				[
-					'body' => json_encode(
+					'body' => wp_json_encode(
 						[
 							'email' => $email,
 						]

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -126,7 +126,7 @@ class NotificationsService implements Service, OptionsAwareInterface {
 
 		do_action(
 			'woocommerce_gla_debug_message',
-			sprintf( 'Notification - Item ID: %s - Topic: %s - Data %s', $item_id, $topic, json_encode( $data ) ),
+			sprintf( 'Notification - Item ID: %s - Topic: %s - Data %s', $item_id, $topic, wp_json_encode( $data ) ),
 			__METHOD__
 		);
 

--- a/src/Assets/ScriptAsset.php
+++ b/src/Assets/ScriptAsset.php
@@ -124,7 +124,7 @@ class ScriptAsset extends BaseAsset {
 			}
 
 			foreach ( $this->inline_scripts as $variable_name => $data_array ) {
-				$inline_script = "var $variable_name = " . json_encode( $data_array );
+				$inline_script = "var $variable_name = " . wp_json_encode( $data_array );
 				wp_add_inline_script( $this->handle, $inline_script, 'before' );
 			}
 

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -770,7 +770,7 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 								<th><label>Errors:</label></th>
 								<td>
 									<p>
-										<code><?php echo isset( $this->integration_status_response['errors'] ) ? wp_kses_post( json_encode( $this->integration_status_response['errors'] ) ) ?? '' : '-'; ?></code>
+										<code><?php echo isset( $this->integration_status_response['errors'] ) ? wp_kses_post( wp_json_encode( $this->integration_status_response['errors'] ) ) ?? '' : '-'; ?></code>
 									</p>
 								</td>
 							</tr>

--- a/src/Coupon/CouponSyncer.php
+++ b/src/Coupon/CouponSyncer.php
@@ -142,7 +142,7 @@ class CouponSyncer implements Service {
 				sprintf(
 					'Skipping coupon (ID: %s) because it does not pass validation: %s',
 					$coupon->get_id(),
-					json_encode( $validation_result )
+					wp_json_encode( $validation_result )
 				),
 				__METHOD__
 			);
@@ -156,7 +156,7 @@ class CouponSyncer implements Service {
 				sprintf(
 					'Start to upload coupon (ID: %s) as promotion structure: %s',
 					$coupon->get_id(),
-					json_encode( $adapted_coupon )
+					wp_json_encode( $adapted_coupon )
 				),
 				__METHOD__
 			);
@@ -172,7 +172,7 @@ class CouponSyncer implements Service {
 				'woocommerce_gla_debug_message',
 				sprintf(
 					"Submitted promotion:\n%s",
-					json_encode( $adapted_coupon )
+					wp_json_encode( $adapted_coupon )
 				),
 				__METHOD__
 			);
@@ -195,7 +195,7 @@ class CouponSyncer implements Service {
 				'woocommerce_gla_debug_message',
 				sprintf(
 					"Promotion failed to sync with Merchant Center:\n%s",
-					json_encode( $invalid_promotion )
+					wp_json_encode( $invalid_promotion )
 				),
 				__METHOD__
 			);
@@ -261,7 +261,7 @@ class CouponSyncer implements Service {
 					sprintf(
 						'Start to delete coupon (ID: %s) as promotion structure: %s',
 						$coupon->get_wc_coupon_id(),
-						json_encode( $adapted_coupon )
+						wp_json_encode( $adapted_coupon )
 					),
 					__METHOD__
 				);
@@ -310,7 +310,7 @@ class CouponSyncer implements Service {
 				sprintf(
 					"Failed to delete %s promotions from Merchant Center:\n%s",
 					count( $invalid_promotions ),
-					json_encode( $invalid_promotions )
+					wp_json_encode( $invalid_promotions )
 				),
 				__METHOD__
 			);
@@ -329,7 +329,7 @@ class CouponSyncer implements Service {
 			sprintf(
 				"Deleted %s promoitons:\n%s",
 				count( $deleted_promotions ),
-				json_encode( $deleted_promotions )
+				wp_json_encode( $deleted_promotions )
 			),
 			__METHOD__
 		);

--- a/src/DB/Migration/Migration20211228T1640692399.php
+++ b/src/DB/Migration/Migration20211228T1640692399.php
@@ -65,7 +65,7 @@ class Migration20211228T1640692399 extends AbstractMigration {
 
 			if ( isset( $mc_settings['offers_free_shipping'] ) && false !== boolval( $mc_settings['offers_free_shipping'] ) && isset( $mc_settings['free_shipping_threshold'] ) ) {
 				// Move the free shipping threshold from the options to the shipping rate table.
-				$options_json = json_encode( [ 'free_shipping_threshold' => (float) $mc_settings['free_shipping_threshold'] ] );
+				$options_json = wp_json_encode( [ 'free_shipping_threshold' => (float) $mc_settings['free_shipping_threshold'] ] );
 
 				// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 				// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/src/DB/Query/ShippingRateQuery.php
+++ b/src/DB/Query/ShippingRateQuery.php
@@ -46,7 +46,7 @@ class ShippingRateQuery extends Query {
 				throw InvalidQuery::invalid_value( $column );
 			}
 
-			$value = json_encode( $value );
+			$value = wp_json_encode( $value );
 		}
 
 		return $value;

--- a/src/DB/Table/AttributeMappingRulesTable.php
+++ b/src/DB/Table/AttributeMappingRulesTable.php
@@ -22,7 +22,7 @@ class AttributeMappingRulesTable extends Table {
 	 * @return string
 	 */
 	protected function get_install_query(): string {
-		return <<< SQL
+		return "
 CREATE TABLE `{$this->get_sql_safe_name()}` (
     `id` bigint(20) NOT NULL AUTO_INCREMENT,
     `attribute` varchar(255) NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     `categories` text NOT NULL,
     PRIMARY KEY `id` (`id`)
 ) {$this->get_collation()};
-SQL;
+";
 	}
 
 	/**

--- a/src/DB/Table/BudgetRecommendationTable.php
+++ b/src/DB/Table/BudgetRecommendationTable.php
@@ -29,7 +29,7 @@ class BudgetRecommendationTable extends Table {
 	 * @return string
 	 */
 	protected function get_install_query(): string {
-		return <<< SQL
+		return "
 CREATE TABLE `{$this->get_sql_safe_name()}` (
     id bigint(20) NOT NULL AUTO_INCREMENT,
     currency varchar(3) NOT NULL,
@@ -38,7 +38,7 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     PRIMARY KEY (id),
     UNIQUE KEY country_currency (country, currency)
 ) {$this->get_collation()};
-SQL;
+";
 	}
 
 	/**

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -23,7 +23,7 @@ class MerchantIssueTable extends Table {
 	 * @return string
 	 */
 	protected function get_install_query(): string {
-		return <<< SQL
+		return "
 CREATE TABLE `{$this->get_sql_safe_name()}` (
     `id` bigint(20) NOT NULL AUTO_INCREMENT,
     `product_id` bigint(20) NOT NULL,
@@ -39,7 +39,7 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     `created_at` datetime NOT NULL,
     PRIMARY KEY `id` (`id`)
 ) {$this->get_collation()};
-SQL;
+";
 	}
 
 	/**

--- a/src/DB/Table/ShippingRateTable.php
+++ b/src/DB/Table/ShippingRateTable.php
@@ -22,7 +22,7 @@ class ShippingRateTable extends Table {
 	 * @return string
 	 */
 	protected function get_install_query(): string {
-		return <<< SQL
+		return "
 CREATE TABLE `{$this->get_sql_safe_name()}` (
     id bigint(20) NOT NULL AUTO_INCREMENT,
     country varchar(2) NOT NULL,
@@ -33,7 +33,7 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     KEY country (country),
     KEY currency (currency)
 ) {$this->get_collation()};
-SQL;
+";
 	}
 
 	/**

--- a/src/DB/Table/ShippingTimeTable.php
+++ b/src/DB/Table/ShippingTimeTable.php
@@ -22,7 +22,7 @@ class ShippingTimeTable extends Table {
 	 * @return string
 	 */
 	protected function get_install_query(): string {
-		return <<< SQL
+		return "
 CREATE TABLE `{$this->get_sql_safe_name()}` (
     id bigint(20) NOT NULL AUTO_INCREMENT,
     country varchar(2) NOT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
     PRIMARY KEY (id),
     KEY country (country)
 ) {$this->get_collation()};
-SQL;
+";
 	}
 
 	/**

--- a/src/Jobs/ActionSchedulerJobMonitor.php
+++ b/src/Jobs/ActionSchedulerJobMonitor.php
@@ -206,7 +206,7 @@ class ActionSchedulerJobMonitor implements Service {
 	 * @since 1.7.0
 	 */
 	protected static function get_job_hash( string $hook, ?array $args = null ): string {
-		return hash( 'crc32b', $hook . json_encode( $args ) );
+		return hash( 'crc32b', $hook . wp_json_encode( $args ) );
 	}
 
 	/**

--- a/src/Jobs/Notifications/AbstractItemNotificationJob.php
+++ b/src/Jobs/Notifications/AbstractItemNotificationJob.php
@@ -44,7 +44,7 @@ abstract class AbstractItemNotificationJob extends AbstractNotificationJob {
 		} catch ( InvalidValue $e ) {
 			do_action(
 				'woocommerce_gla_error',
-				sprintf( 'Error sending Notification for - Item ID: %s - Topic: %s - Data %s. Product was deleted from the database before the notification was sent.', $item, $topic, json_encode( $data ) ),
+				sprintf( 'Error sending Notification for - Item ID: %s - Topic: %s - Data %s. Product was deleted from the database before the notification was sent.', $item, $topic, wp_json_encode( $data ) ),
 				__METHOD__
 			);
 		}

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -514,7 +514,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		$account_issues = array_map(
 			function ( $issue ) {
 				sort( $issue['applicable_countries'] );
-				$issue['applicable_countries'] = json_encode(
+				$issue['applicable_countries'] = wp_json_encode(
 					array_unique(
 						$issue['applicable_countries']
 					)
@@ -567,7 +567,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		ksort( $product_issues );
 		$product_issues = array_map(
 			function ( $unique_key, $issue ) {
-				$issue['applicable_countries'] = json_encode( $this->product_issue_countries[ $unique_key ] );
+				$issue['applicable_countries'] = wp_json_encode( $this->product_issue_countries[ $unique_key ] );
 				return $issue;
 			},
 			array_keys( $product_issues ),

--- a/src/Notes/LeaveReviewActionTrait.php
+++ b/src/Notes/LeaveReviewActionTrait.php
@@ -28,7 +28,7 @@ trait LeaveReviewActionTrait {
 		$note->add_action(
 			'leave-review',
 			__( 'Leave a review', 'google-listings-and-ads' ),
-			rand( 0, 1 ) ? $wp_link : $wc_link
+			wp_rand( 0, 1 ) ? $wp_link : $wc_link
 		);
 	}
 }

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -229,7 +229,7 @@ class BatchProductHelper implements Service {
 
 					do_action(
 						'woocommerce_gla_debug_message',
-						sprintf( 'Skipping product (ID: %s) because it does not pass validation: %s', $product->get_id(), json_encode( $validation_result ) ),
+						sprintf( 'Skipping product (ID: %s) because it does not pass validation: %s', $product->get_id(), wp_json_encode( $validation_result ) ),
 						__METHOD__
 					);
 

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -149,7 +149,7 @@ class ProductSyncer implements Service {
 			sprintf(
 				"Submitted %s products:\n%s",
 				count( $updated_products ),
-				json_encode( $updated_products )
+				wp_json_encode( $updated_products )
 			),
 			__METHOD__
 		);
@@ -159,7 +159,7 @@ class ProductSyncer implements Service {
 				sprintf(
 					"%s products failed to sync with Merchant Center:\n%s",
 					count( $invalid_products ),
-					json_encode( $invalid_products )
+					wp_json_encode( $invalid_products )
 				),
 				__METHOD__
 			);
@@ -235,7 +235,7 @@ class ProductSyncer implements Service {
 			sprintf(
 				"Deleted %s products:\n%s",
 				count( $deleted_products ),
-				json_encode( $deleted_products ),
+				wp_json_encode( $deleted_products ),
 			),
 			__METHOD__
 		);
@@ -245,7 +245,7 @@ class ProductSyncer implements Service {
 				sprintf(
 					"Failed to delete %s products from Merchant Center:\n%s",
 					count( $invalid_products ),
-					json_encode( $invalid_products )
+					wp_json_encode( $invalid_products )
 				),
 				__METHOD__
 			);

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -207,7 +207,7 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 				sprintf(
 					'Product category (ID: %s): %s.',
 					$base_product_id,
-					json_encode( $google_product_types )
+					wp_json_encode( $google_product_types )
 				),
 				__METHOD__
 			);

--- a/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
@@ -139,7 +139,7 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	 * @return GoogleShippingService
 	 */
 	protected function create_shipping_service( string $country, string $currency, float $rate ): GoogleShippingService {
-		$unique  = sprintf( '%04x', mt_rand( 0, 0xffff ) );
+		$unique  = sprintf( '%04x', wp_rand( 0, 0xffff ) );
 		$service = new GoogleShippingService();
 		$service->setActive( true );
 		$service->setDeliveryCountry( $country );

--- a/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
@@ -147,7 +147,7 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 		$name    = sprintf(
 		/* translators: %1 is a random 4-digit string, %2 is the country code  */
 			__( '[%1$s] Google for WooCommerce generated service - %2$s', 'google-listings-and-ads' ),
-			sprintf( '%04x', mt_rand( 0, 0xffff ) ),
+			sprintf( '%04x', wp_rand( 0, 0xffff ) ),
 			$country
 		);
 

--- a/tests/Tools/HelperTrait/CouponTrait.php
+++ b/tests/Tools/HelperTrait/CouponTrait.php
@@ -27,7 +27,7 @@ trait CouponTrait {
 
 		$coupon->expects( $this->any() )
 			->method( 'get_id' )
-			->willReturn( rand() );
+			->willReturn( wp_rand() );
 
 		return $coupon;
 	}
@@ -39,7 +39,7 @@ trait CouponTrait {
 	 */
 	public function create_simple_coupon() {
 		$coupon = new WC_Coupon();
-		$coupon->set_code( sprintf( 'simple_coupon_%d', rand() ) );
+		$coupon->set_code( sprintf( 'simple_coupon_%d', wp_rand() ) );
 		$coupon->set_amount( 10 );
 		$coupon->set_discount_type( 'percent' );
 		$coupon->set_free_shipping( true );
@@ -108,7 +108,7 @@ trait CouponTrait {
 		$promotion = $this->createMock( GooglePromotion::class );
 
 		$target_country = $target_country ?: $this->get_sample_target_country();
-		$promotion_id   = $coupon_id ?: rand();
+		$promotion_id   = $coupon_id ?: wp_rand();
 
 		$promotion->expects( $this->any() )
 			->method( 'getPromotionId' )

--- a/tests/Tools/HelperTrait/GuzzleClientTrait.php
+++ b/tests/Tools/HelperTrait/GuzzleClientTrait.php
@@ -40,7 +40,7 @@ trait GuzzleClientTrait {
 	 */
 	protected function generate_request_mock( $response, string $type = 'get', int $code = 200 ) {
 		$body = $this->createMock( StreamInterface::class );
-		$body->method( 'getContents' )->willReturn( json_encode( $response ) );
+		$body->method( 'getContents' )->willReturn( wp_json_encode( $response ) );
 
 		$result = $this->createMock( ResponseInterface::class );
 		$result->method( 'getBody' )->willReturn( $body );
@@ -61,8 +61,8 @@ trait GuzzleClientTrait {
 		$body->method( 'getContents' )
 			->will(
 				$this->onConsecutiveCalls(
-					json_encode( [ 'status' => 'accepted' ] ),
-					json_encode( $response )
+					wp_json_encode( [ 'status' => 'accepted' ] ),
+					wp_json_encode( $response )
 				)
 			);
 
@@ -87,8 +87,8 @@ trait GuzzleClientTrait {
 		$body->method( 'getContents' )
 			->will(
 				$this->onConsecutiveCalls(
-					json_encode( [ 'status' => 'accepted' ] ),
-					json_encode( $response )
+					wp_json_encode( [ 'status' => 'accepted' ] ),
+					wp_json_encode( $response )
 				)
 			);
 
@@ -151,7 +151,7 @@ trait GuzzleClientTrait {
 	 */
 	protected function generate_exception_mock( string $message, int $code ): BadResponseException {
 		$body = $this->createMock( StreamInterface::class );
-		$body->method( 'getContents' )->willReturn( json_encode( [ 'message' => $message ] ) );
+		$body->method( 'getContents' )->willReturn( wp_json_encode( [ 'message' => $message ] ) );
 
 		$request  = $this->createMock( RequestInterface::class );
 		$response = $this->createMock( ResponseInterface::class );

--- a/tests/Tools/HelperTrait/ProductTrait.php
+++ b/tests/Tools/HelperTrait/ProductTrait.php
@@ -28,7 +28,7 @@ trait ProductTrait {
 	 */
 	public function generate_variable_product_mock( int $number_of_variations = 3 ) {
 		$product = $this->createMock( WC_Product_Variable::class );
-		$id      = rand();
+		$id      = wp_rand();
 
 		$children = [];
 		for ( $i = 0; $i < $number_of_variations; $i++ ) {
@@ -36,7 +36,7 @@ trait ProductTrait {
 
 			$child->expects( $this->any() )
 				->method( 'get_id' )
-				->willReturn( rand() );
+				->willReturn( wp_rand() );
 			$child->expects( $this->any() )
 				->method( 'get_parent_id' )
 				->willReturn( $id );
@@ -75,7 +75,7 @@ trait ProductTrait {
 		$product = $this->createMock( GoogleProduct::class );
 
 		$target_country = $target_country ?: $this->get_sample_target_country();
-		$id             = $id ?: "online:en:{$target_country}:gla_" . rand();
+		$id             = $id ?: "online:en:{$target_country}:gla_" . wp_rand();
 
 		$product->expects( $this->any() )
 				->method( 'getId' )
@@ -99,7 +99,7 @@ trait ProductTrait {
 
 		$product->expects( $this->any() )
 				->method( 'get_id' )
-				->willReturn( $product_id ?: rand() );
+				->willReturn( $product_id ?: wp_rand() );
 
 		$product->expects( $this->any() )
 				->method( 'get_type' )
@@ -118,10 +118,10 @@ trait ProductTrait {
 
 		$product->expects( $this->any() )
 				->method( 'get_id' )
-				->willReturn( rand() );
+				->willReturn( wp_rand() );
 		$product->expects( $this->any() )
 				->method( 'get_parent_id' )
-				->willReturn( rand() );
+				->willReturn( wp_rand() );
 		$product->expects( $this->any() )
 				->method( 'get_type' )
 				->willReturn( 'variation' );
@@ -137,7 +137,7 @@ trait ProductTrait {
 	public function generate_google_id( $product ): string {
 		$product_id = $product;
 		if ( $product instanceof WC_Product ) {
-			$product_id = $product->get_id() ?: rand();
+			$product_id = $product->get_id() ?: wp_rand();
 		}
 
 		return 'online:en:' . $this->get_sample_target_country() . ':gla_' . $product_id;

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsSyncControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsSyncControllerTest.php
@@ -78,7 +78,7 @@ class SettingsSyncControllerTest extends RESTControllerUnitTest {
 			->method( 'sync_taxes' )
 			->willThrowException(
 				new Exception(
-					json_encode(
+					wp_json_encode(
 						[
 							'code'    => 400,
 							'message' => 'error',

--- a/tests/Unit/Coupon/WCCouponAdapterTest.php
+++ b/tests/Unit/Coupon/WCCouponAdapterTest.php
@@ -216,8 +216,8 @@ class WCCouponAdapterTest extends UnitTest {
 	}
 
 	public function test_product_id_restrictions() {
-		$product_id_1 = rand();
-		$product_id_2 = rand();
+		$product_id_1 = wp_rand();
+		$product_id_2 = wp_rand();
 		$coupon       = $this->create_ready_to_sync_coupon();
 		$coupon->set_product_ids( [ $product_id_1 ] );
 		$coupon->set_excluded_product_ids( [ $product_id_2 ] );

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -627,7 +627,7 @@ class MerchantStatusesTest extends UnitTest {
 					'product'              => html_entity_decode( $product_1->get_name() ),
 					'product_id'           => $product_1->get_id(),
 					'created_at'           => $this->merchant_statuses->get_cache_created_time()->format( 'Y-m-d H:i:s' ),
-					'applicable_countries' => json_encode( [ 'ES' ] ),
+					'applicable_countries' => wp_json_encode( [ 'ES' ] ),
 					'source'               => 'mc',
 					'code'                 => $product_status->getItemLevelIssues()[0]->getCode(),
 					'issue'                => $product_status->getItemLevelIssues()[0]->getDescription(),

--- a/tests/Unit/Product/Attributes/AttributeManagerTest.php
+++ b/tests/Unit/Product/Attributes/AttributeManagerTest.php
@@ -82,7 +82,7 @@ class AttributeManagerTest extends ContainerAwareUnitTest {
 	public function test_get_throws_exception_if_attribute_id_invalid() {
 		$product = WC_Helper_Product::create_simple_product();
 		$this->expectException( InvalidValue::class );
-		$this->attribute_manager->get( $product, 'some_random_string' . rand() );
+		$this->attribute_manager->get( $product, 'some_random_string' . wp_rand() );
 	}
 
 	public function test_get_throws_exception_if_attribute_inapplicable_to_product() {
@@ -147,7 +147,7 @@ class AttributeManagerTest extends ContainerAwareUnitTest {
 	public function test_delete_throws_exception_if_attribute_id_invalid() {
 		$product = WC_Helper_Product::create_simple_product();
 		$this->expectException( InvalidValue::class );
-		$this->attribute_manager->delete( $product, 'some_random_string' . rand() );
+		$this->attribute_manager->delete( $product, 'some_random_string' . wp_rand() );
 	}
 
 	public function test_delete_throws_exception_if_attribute_inapplicable_to_product() {

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -495,10 +495,7 @@ class WCProductAdapterTest extends UnitTest {
 			]
 		);
 
-		$expected_description = <<<DESCRIPTION
-Parent description.
-Variation description.
-DESCRIPTION;
+		$expected_description = "Parent description.\nVariation description.";
 
 		$this->assertEquals( $expected_description, $adapted_product->getDescription() );
 	}
@@ -519,10 +516,7 @@ DESCRIPTION;
 			]
 		);
 
-		$expected_description = <<<DESCRIPTION
-Parent short description.
-Variation description.
-DESCRIPTION;
+		$expected_description = "Parent short description.\nVariation description.";
 
 		$this->assertEquals( $expected_description, $adapted_product->getDescription() );
 	}

--- a/tests/Unit/Shipping/ZoneLocationsParserTest.php
+++ b/tests/Unit/Shipping/ZoneLocationsParserTest.php
@@ -298,7 +298,7 @@ class ZoneLocationsParserTest extends UnitTest {
 			->method( 'find_country_id_by_code' )
 			->willReturnCallback(
 				function () {
-					return rand();
+					return wp_rand();
 				}
 			);
 
@@ -319,7 +319,7 @@ class ZoneLocationsParserTest extends UnitTest {
 					if ( -1 !== $return_value ) {
 						return $return_value;
 					}
-					return rand();
+					return wp_rand();
 				}
 			);
 	}

--- a/tests/Unit/View/PHPViewFactoryTest.php
+++ b/tests/Unit/View/PHPViewFactoryTest.php
@@ -29,7 +29,7 @@ class PHPViewFactoryTest extends UnitTest {
 
 	public function test_create_view_fails_if_non_existing_view_file() {
 		$this->expectException( ViewException::class );
-		$this->view_factory->create( '/tmp/imaginary-folder/non-existing-view' . md5( (string) rand() ) );
+		$this->view_factory->create( '/tmp/imaginary-folder/non-existing-view' . md5( (string) wp_rand() ) );
 	}
 
 	/**

--- a/tests/Unit/View/PHPViewTest.php
+++ b/tests/Unit/View/PHPViewTest.php
@@ -29,15 +29,13 @@ class PHPViewTest extends UnitTest {
 	public function test_view_render_with_partial() {
 		$view = new PHPView( $this->get_data_file_path( 'test-php-view.php' ), $this->view_factory );
 
-		$expected = <<<VIEW
-Variable value is: Test
+		$expected = 'Variable value is: Test
 Raw variable value is: <strong>Test Raw HTML</strong>
 Boolean variable value is: 1
 Array variable value is: Value 1, Value 2
 Partial variable value is: Test partial
 Partial with no context:
-Partial variable value is: Test
-VIEW;
+Partial variable value is: Test';
 
 		$this->assertEquals(
 			$expected,

--- a/tests/Unit/View/PHPViewTest.php
+++ b/tests/Unit/View/PHPViewTest.php
@@ -23,7 +23,7 @@ class PHPViewTest extends UnitTest {
 
 	public function test_view_construct_fails_if_non_existing_view_file() {
 		$this->expectException( ViewException::class );
-		new PHPView( '/tmp/imaginary-folder/non-existing-view' . md5( (string) rand() ), $this->view_factory );
+		new PHPView( '/tmp/imaginary-folder/non-existing-view' . md5( (string) wp_rand() ), $this->view_factory );
 	}
 
 	public function test_view_render_with_partial() {

--- a/tests/phpcs.xml.dist
+++ b/tests/phpcs.xml.dist
@@ -89,16 +89,6 @@
 		</properties>
 	</rule>
 
-	<!-- We'd rather use native functions -->
-	<rule ref="WordPress.WP.AlternativeFunctions">
-		<properties>
-			<property name="exclude" type="array">
-				<element value="json_encode"/>
-				<element value="rand"/>
-			</property>
-		</properties>
-	</rule>
-
 	<!-- We're judicious in our usage of meta queries -->
 	<rule ref="WordPress.DB.SlowDBQuery">
 		<properties>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR resolves a substantial amount of the errors and warnings which are identified in the [WordPress.org plugin check](https://wordpress.org/plugins/plugin-check/).

Changes resolve the following errors:
- Use of heredoc and nowdoc syntax ("<<<") is not allowed; use standard strings or inline HTML instead
- json_encode() is discouraged. Use wp_json_encode() instead.
- rand() or mt_rand() is discouraged. Use the far less predictable wp_rand() instead.
- Missing "License" in Plugin Header. Please update your Plugin Header with a valid GPLv2 (or later) compatible license.

> [!Note]
> We are ignoring the following errors/warnings:
> - `WordPress.Security.EscapeOutput.ExceptionNotEscaped` - Exceptions can be escaped late when output, not when they are thrown, we have a specific exclusion for this in the phpcs.xml file
> - `trademarked_term` Plugin naming has been done in discussion with trademark owners
> - Caching in uninstall.php - only gets run once when uninstalling, we have a specific exclusion for this in the phpcs.xml file
>
> We can address these at a later date if these rules ever become fully required.


### Detailed test instructions:
1. Build a zip file from this branch `composer install && nvm use && npm run build`
2. Install the zip file on a test site
3. Install [plugin check](https://wordpress.org/plugins/plugin-check/)
4. Go to Tools > Plugin Check and run the check for the selected plugin
5. Confirm the amount of errors is now reduced there should be about 50 less down to @ 250
6. Check for any errors left if they are in the ignore list above

#### Linting php
1. Run `npm run lint:php`
2. Run `npm run lint:php-tests`
3. Confirm we don't get any errors with the revised linting rules

### Changelog entry
* Tweak - Resolve some of the plugin check errors and warnings.