### PR TITLE
Allow mapping of a Google ID without a prefix

### DIFF
--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -310,10 +310,11 @@ class ProductHelper implements Service, HelperNotificationInterface {
 		$mc_product_id_tokens = explode( ':', $mc_product_id );
 		$mc_product_id        = end( $mc_product_id_tokens );
 
+		// Support a fully numeric ID both with and without the `gla_` prefix.
 		$wc_product_id = 0;
-		$pattern       = '/' . preg_quote( $this->get_slug(), '/' ) . '_(\d+)$/';
+		$pattern       = '/^(' . preg_quote( $this->get_slug(), '/' ) . '_)?(\d+)$/';
 		if ( preg_match( $pattern, $mc_product_id, $matches ) ) {
-			$wc_product_id = (int) $matches[1];
+			$wc_product_id = (int) $matches[2];
 		}
 
 		/**

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -487,6 +487,31 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertEquals( 1234567, $product_id );
 	}
 
+	/**
+	 * Confirm we support converting a product ID without the `gla_` prefix.
+	 */
+	public function test_get_wc_product_id_without_prefix() {
+		$google_id  = 'online:en:US:1234567';
+		$product_id = $this->product_helper->get_wc_product_id( $google_id );
+
+		$this->assertEquals( 1234567, $product_id );
+	}
+
+	/**
+	 * If we don't add the prefix confirm it only accepts a fully numeric ID.
+	 */
+	public function test_get_wc_product_id_without_prefix_only_numeric() {
+		$google_id  = 'online:en:US:123abc';
+		$product_id = $this->product_helper->get_wc_product_id( $google_id );
+
+		$this->assertEquals( 0, $product_id );
+
+		$google_id  = 'online:en:US:abc123';
+		$product_id = $this->product_helper->get_wc_product_id( $google_id );
+
+		$this->assertEquals( 0, $product_id );
+	}
+
 	public function test_get_wc_product_id_returns_zero_if_no_id_matches() {
 		$google_id  = 'online:en:US:gla_invalid_id_1';
 		$product_id = $this->product_helper->get_wc_product_id( $google_id );

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -480,11 +480,21 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertEquals( [ 'US' => 'online:en:US:gla_1' ], $this->product_helper->get_synced_google_product_ids( $product ) );
 	}
 
+	/**
+	 * Test a legitimate Google product ID both with and without namespacing.
+	 *
+	 * @return void
+	 */
 	public function test_get_wc_product_id() {
 		$google_id  = 'online:en:US:gla_1234567';
 		$product_id = $this->product_helper->get_wc_product_id( $google_id );
 
 		$this->assertEquals( 1234567, $product_id );
+
+		$google_id  = 'gla_4567890';
+		$product_id = $this->product_helper->get_wc_product_id( $google_id );
+
+		$this->assertEquals( 4567890, $product_id );
 	}
 
 	/**
@@ -512,7 +522,15 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertEquals( 0, $product_id );
 	}
 
+	/**
+	 * Confirm `gla_` prefix must be at the beginning and followed by a numeric ID.
+	 */
 	public function test_get_wc_product_id_returns_zero_if_no_id_matches() {
+		$google_id  = 'online:en:US:invalid_gla_123';
+		$product_id = $this->product_helper->get_wc_product_id( $google_id );
+
+		$this->assertEquals( 0, $product_id );
+
 		$google_id  = 'online:en:US:gla_invalid_id_1';
 		$product_id = $this->product_helper->get_wc_product_id( $google_id );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes the prefix when fetching status from the Merchant Center as optional. We do want to make sure that the ID is a strictly numeric ID otherwise it's not accepted. In the previous regex we searched till end of string with `$`, but didn't force it to search from the start of the string with `^`. This meant that it was possible to a map an ID like `foo_gla_12345`. We fixed this in the PR to ensure it scans the whole string for a matching pattern:

- `gla_` + numeric ID
- numeric ID

Any other patterns will result in an unmapped ID. I've added additional unit tests to cover all these variations.

Closes #2768 

### Detailed test instructions:
1. Add the snippet from the documentation: https://woocommerce.com/document/google-listings-and-ads/faqs/#how-do-i-remove-the-gla-prefix-from-synced-products
2. Setup the extension to sync some products to Merchant Center
3. Use the Connection Test helper to clear the product statuses 
4. Refresh the product feed page
5. Wait for the statuses to reload and confirm that we have products that are a different status then `unsynced`

### Changelog entry
* Tweak - Allow mapping of a Google ID without a prefix.