### PR TITLE
Adjust some query and table functions

### DIFF
--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -318,10 +318,6 @@ abstract class Query implements QueryInterface {
 		}
 
 		if ( ! $get_count ) {
-			if ( empty( $this->groupby ) ) {
-				$pieces[] = "GROUP BY `{$this->table->get_name()}`.`{$this->table->get_primary_column()}`";
-			}
-
 			if ( $this->orderby ) {
 				$pieces[] = 'ORDER BY ' . implode( ', ', $this->orderby );
 			}

--- a/src/DB/Table.php
+++ b/src/DB/Table.php
@@ -52,7 +52,7 @@ abstract class Table implements TableInterface {
 	 */
 	public function exists(): bool {
 		$result = $this->wpdb->get_var(
-			"SHOW TABLES LIKE '{$this->get_sql_safe_name()}'" // phpcs:ignore WordPress.DB.PreparedSQL
+			"SHOW TABLES LIKE '{$this->wpdb->esc_like( $this->get_name() )}'" // phpcs:ignore WordPress.DB.PreparedSQL
 		);
 
 		return $result === $this->get_name();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As a result of the discussion in issue #500 there were three things to address:

1. Remove the GROUP BY (we already have a DB constraint handling this, if we didn't it would alter the count query results)
This was completed in this PR

2. Use esc_like when checking for an existing table
This was completed in this PR

3. Remove get_sql_safe_name and make sure we are placing the table name in backquotes in all locations
I decided to leave this in place for now as it isn't causing any harm. Ideally in the future we'd use `wpdb->prepare` for escaping the table names: https://make.wordpress.org/core/2022/10/08/escaping-table-and-field-names-with-wpdbprepare-in-wordpress-6-1/
However that's only available in WordPress 6.2, we would have to bump the minimum version for that.

Closes #500

### Detailed test instructions:
1. Add a snippet to log DB queries:
```php
// Log queries from gla.
add_filter(
	'query',
	function ( string $query ) {
		global $wpdb;

		if ( str_contains( strtolower( $query ), "{$wpdb->prefix}gla_" ) ) {
			wc_get_logger()->log(
				WC_Log_Levels::DEBUG,
				$query,
				[
					'source' => 'gla-db-queries',
				]
			);
		}

		return $query;
	}
);
```
2. Go to the Product Feed page to load issues from the table
3. Install this PR and reload the Product Feed page
4. Go to WooCommerce > Status > Logs and find a log file for `gla-db-queries`
5. Confirm we initially have the DB query with a GROUP BY:
```
SELECT * FROM `wp_gla_merchant_issues`
WHERE type = 'account' AND
severity IN ('error','critical')
GROUP BY `wp_gla_merchant_issues`.`id`
ORDER BY `type` ASC, `product` ASC, `issue` ASC
```
6. Confirm the DB query no longer has the GROUP BY after switching to this PR:
```
SELECT * FROM `wp_gla_merchant_issues`
WHERE type = 'account' AND
severity IN ('error','critical')
GROUP BY `wp_gla_merchant_issues`.`id`
```

The second change is harder to test because we don't use invalid characters in table names. But we can confirm tables are recreated after checking if they exist:
1. Drop one of the tables like `wp_gla_budget_recommendations`
2. Delete options:
    - `wp option delete gla_db_version`
    - `wp option delete gla_file_version`
3. Refresh one of the WP Admin pages
4. Confirm the database table has been recreated and populated

### Changelog entry
* Tweak - Adjust some query and table functions.