### PR TITLE
Supplement the implementation of API Pull for the Settings page

### DIFF
--- a/js/src/components/enable-new-product-sync-button.js
+++ b/js/src/components/enable-new-product-sync-button.js
@@ -31,7 +31,6 @@ const EnableNewProductSyncButton = ( params ) => {
 		try {
 			setLoading( true );
 			const d = await fetchRestAPIAuthorize();
-			setLoading( false );
 			window.location.href = d.auth_url;
 		} catch ( error ) {
 			setLoading( false );

--- a/js/src/components/enable-new-product-sync-button.js
+++ b/js/src/components/enable-new-product-sync-button.js
@@ -15,12 +15,22 @@ import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 
 /**
+ * Clicking on the button to start enabling the new product sync (API Pull).
+ *
+ * @event gla_enable_product_sync_click
+ * @property {string} [page] Indicates which page this event happened
+ * @property {string} [context] Indicates where or which the button triggered this event
+ */
+
+/**
  * Button to initiate auth process for WP Rest API
  *
- * @param {Object} params The component params
+ * @param {Object} props The component props to be forwarded to AppButton.
  * @return {JSX.Element} The button.
+ *
+ * @fires gla_enable_product_sync_click with `{ page: 'settings', context: 'banner' | 'mc_card' }`
  */
-const EnableNewProductSyncButton = ( params ) => {
+const EnableNewProductSyncButton = ( props ) => {
 	const { createNotice } = useDispatchCoreNotices();
 	const [ loading, setLoading ] = useState( false );
 	const nextPageName = glaData.mcSetupComplete ? 'settings' : 'setup-mc';
@@ -49,7 +59,8 @@ const EnableNewProductSyncButton = ( params ) => {
 			isSecondary
 			loading={ loading }
 			onClick={ handleEnableClick }
-			{ ...params }
+			eventName="gla_enable_product_sync_click"
+			{ ...props }
 		/>
 	);
 };

--- a/js/src/components/enable-new-product-sync-notice.js
+++ b/js/src/components/enable-new-product-sync-notice.js
@@ -42,8 +42,10 @@ const EnableNewProductSyncNotice = () => {
 				{
 					enableButton: (
 						<EnableNewProductSyncButton
-							eventName="gla_enable_product_sync_click"
-							eventProps={ { context: 'banner' } }
+							eventProps={ {
+								page: 'settings',
+								context: 'banner',
+							} }
 						/>
 					),
 					p: <p />,

--- a/js/src/components/google-mc-account-card/merchant-center-account-info-card.js
+++ b/js/src/components/google-mc-account-card/merchant-center-account-info-card.js
@@ -108,8 +108,7 @@ const MerchantCenterAccountInfoCard = ( { googleMCAccount } ) => {
 				showErrorNotificationsNotice ? (
 					<EnableNewProductSyncButton
 						text={ __( 'Grant access', 'google-listings-and-ads' ) }
-						eventName="gla_enable_product_sync_click"
-						eventProps={ { context: 'mc_card' } }
+						eventProps={ { page: 'settings', context: 'mc_card' } }
 					/>
 				) : (
 					<ConnectedIconLabel />

--- a/js/src/components/google-mc-account-card/merchant-center-account-info-card.js
+++ b/js/src/components/google-mc-account-card/merchant-center-account-info-card.js
@@ -31,12 +31,8 @@ import { getSettingsUrl } from '~/utils/urls';
  *
  * @param {Object} props React props.
  * @param {{ id: number }} props.googleMCAccount A data payload object containing the user's Google Merchant Center account ID.
- * @param {boolean} [props.hideNotificationService=true] Indicate whether hide the enable Notification service block at the card footer.
  */
-const MerchantCenterAccountInfoCard = ( {
-	googleMCAccount,
-	hideNotificationService = false,
-} ) => {
+const MerchantCenterAccountInfoCard = ( { googleMCAccount } ) => {
 	const { createNotice, removeNotice } = useDispatchCoreNotices();
 	const { invalidateResolution } = useAppDispatch();
 
@@ -83,15 +79,13 @@ const MerchantCenterAccountInfoCard = ( {
 		removeNotice( notice.id );
 	};
 
-	// Show the button if the status is "approved" and the Notification Service is not hidden.
+	// Show the button if the status is "approved".
 	const showDisconnectNotificationsButton =
-		! hideNotificationService &&
 		googleMCAccount.wpcom_rest_api_status ===
-			GOOGLE_WPCOM_APP_CONNECTED_STATUS.APPROVED;
+		GOOGLE_WPCOM_APP_CONNECTED_STATUS.APPROVED;
 
-	// Show the error if the status is set but is not "approved" and the Notification Service is not hidden.
+	// Show the error if the status is set but is not "approved".
 	const showErrorNotificationsNotice =
-		! hideNotificationService &&
 		googleMCAccount.wpcom_rest_api_status &&
 		googleMCAccount.notification_service_enabled &&
 		googleMCAccount.wpcom_rest_api_status !==

--- a/js/src/components/google-mc-account-card/merchant-center-account-info-card.js
+++ b/js/src/components/google-mc-account-card/merchant-center-account-info-card.js
@@ -25,9 +25,16 @@ import DisconnectModal, {
 	API_DATA_FETCH_FEATURE,
 } from '~/pages/settings/disconnect-modal';
 import { getSettingsUrl } from '~/utils/urls';
+import { recordGlaEvent } from '~/utils/tracks';
 
 /**
  * @typedef {import('~/data/types.js').GoogleMCAccount} GoogleMCAccount
+ */
+
+/**
+ * Clicking on the button to disable the new product sync (API Pull).
+ *
+ * @event gla_disable_product_sync_click
  */
 
 /**
@@ -35,6 +42,8 @@ import { getSettingsUrl } from '~/utils/urls';
  *
  * @param {Object} props React props.
  * @param {GoogleMCAccount} props.googleMCAccount A data payload object of Google Merchant Center account.
+ *
+ * @fires gla_disable_product_sync_click
  */
 const MerchantCenterAccountInfoCard = ( { googleMCAccount } ) => {
 	const { createNotice, removeNotice } = useDispatchCoreNotices();
@@ -59,6 +68,8 @@ const MerchantCenterAccountInfoCard = ( { googleMCAccount } ) => {
 	const domain = new URL( getSetting( 'homeUrl' ) ).host;
 
 	const disableNotifications = async () => {
+		recordGlaEvent( 'gla_disable_product_sync_click' );
+
 		const { notice } = await createNotice(
 			'info',
 			__(
@@ -154,7 +165,6 @@ const MerchantCenterAccountInfoCard = ( { googleMCAccount } ) => {
 							'Disable product data fetch',
 							'google-listings-and-ads'
 						) }
-						eventName="gla_disable_product_sync_click"
 						onClick={ openDisableDataFetchModal }
 					/>
 				</Section.Card.Footer>

--- a/js/src/components/google-mc-account-card/merchant-center-account-info-card.js
+++ b/js/src/components/google-mc-account-card/merchant-center-account-info-card.js
@@ -27,10 +27,14 @@ import DisconnectModal, {
 import { getSettingsUrl } from '~/utils/urls';
 
 /**
+ * @typedef {import('~/data/types.js').GoogleMCAccount} GoogleMCAccount
+ */
+
+/**
  * Renders a Google Merchant Center account card UI with connected account information.
  *
  * @param {Object} props React props.
- * @param {{ id: number }} props.googleMCAccount A data payload object containing the user's Google Merchant Center account ID.
+ * @param {GoogleMCAccount} props.googleMCAccount A data payload object of Google Merchant Center account.
  */
 const MerchantCenterAccountInfoCard = ( { googleMCAccount } ) => {
 	const { createNotice, removeNotice } = useDispatchCoreNotices();

--- a/js/src/data/selectors.js
+++ b/js/src/data/selectors.js
@@ -52,12 +52,6 @@ export const getSettings = ( state ) => {
  */
 
 /**
- * @typedef {Object} GoogleMCAccount
- * @property {number} id Account ID. It's 0 if not yet connected.
- * @property {string} status Connection status.
- */
-
-/**
  * @typedef {Object} Tour
  * @property {string} id The tour ID
  * @property {boolean} checked True if the tour was checked by the user.

--- a/js/src/data/types.js
+++ b/js/src/data/types.js
@@ -6,6 +6,14 @@
  */
 
 /**
+ * @typedef {Object} GoogleMCAccount
+ * @property {number} id Account ID. It's 0 if not yet connected.
+ * @property {string} status Connection status.
+ * @property {null|'approved'|'disapproved'|'error'|'disabled'} wpcom_rest_api_status The status of Google WPCOM app's access to WooCommerce products, coupons, shipping and settings.
+ * @property {boolean} notification_service_enabled Whether the service of notifying a partner of the shop data updates is enabled.
+ */
+
+/**
  * @typedef {Object} SuggestedAssets
  * @property {string} business_name The name of merchant's business or brand.
  * @property {string} final_url The page URL on merchant's website that people reach when they click the ad.

--- a/js/src/hooks/useGoogleMCAccount.js
+++ b/js/src/hooks/useGoogleMCAccount.js
@@ -11,7 +11,7 @@ import useGoogleAccount from './useGoogleAccount';
 import { GOOGLE_MC_ACCOUNT_STATUS } from '~/constants';
 
 /**
- * @typedef {import('~/data/selectors').GoogleMCAccount} GoogleMCAccount
+ * @typedef {import('~/data/types.js').GoogleMCAccount} GoogleMCAccount
  *
  * @typedef {Object} GoogleMCAccountPayload
  * @property {GoogleMCAccount|undefined} googleMCAccount The connection data of Google Merchant Center account associated with GLA.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -408,6 +408,16 @@ Triggered when store address "Edit in WooCommerce Settings" button is clicked.
 #### Emitters
 - [`StoreAddressCard`](../../js/src/components/contact-information/store-address-card.js#L49) Whenever "Edit in WooCommerce Settings" button is clicked.
 
+### [`gla_enable_product_sync_click`](../../js/src/components/enable-new-product-sync-button.js#L17)
+Clicking on the button to start enabling the new product sync (API Pull).
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`page` | `string` | Indicates which page this event happened
+`context` | `string` | Indicates where or which the button triggered this event
+#### Emitters
+- [`EnableNewProductSyncButton`](../../js/src/components/enable-new-product-sync-button.js#L33) with `{ page: 'settings', context: 'banner' | 'mc_card' }`
+
 ### [`gla_faq`](../../js/src/components/faqs-panel/index.js#L22)
 Clicking on faq item to collapse or expand it.
 #### Properties
@@ -468,10 +478,10 @@ Clicking on the link to view free ad credit value by country.
 #### Emitters
 - [`FreeAdCredit`](../../js/src/components/free-ad-credit/index.js#L27) with `{ context: 'setup-ads' }`.
 
-### [`gla_free_campaign_edited`](../../js/src/pages/shipping/index.js#L28)
+### [`gla_free_campaign_edited`](../../js/src/pages/shipping/index.js#L29)
 Saving changes of audience and/or shipping settings to the free listings.
 #### Emitters
-- [`exports`](../../js/src/pages/shipping/index.js#L44)
+- [`exports`](../../js/src/pages/shipping/index.js#L45)
 
 ### [`gla_google_account_connect_button_click`](../../js/src/utils/tracks.js#L175)
 Clicking on the button to connect Google account.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -305,6 +305,11 @@ Triggered when datepicker (date ranger picker) is updated,
 - [`ProductsReportFilters`](../../js/src/pages/reports/products/products-report-filters.js#L41)
 - [`ProgramsReportFilters`](../../js/src/pages/reports/programs/programs-report-filters.js#L43)
 
+### [`gla_disable_product_sync_click`](../../js/src/components/google-mc-account-card/merchant-center-account-info-card.js#L34)
+Clicking on the button to disable the new product sync (API Pull).
+#### Emitters
+- [`MerchantCenterAccountInfoCard`](../../js/src/components/google-mc-account-card/merchant-center-account-info-card.js#L48)
+
 ### [`gla_disconnected_accounts`](../../js/src/pages/settings/linked-accounts.js#L31)
 Accounts are disconnected from the Setting page
 #### Properties


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a preliminary change before granting API Pull access is added to the onboarding flow.

To avoid too many file changes for subsequent PRs, this PR changes a few things first:

- Remove the unused prop `hideNotificationService` from `MerchantCenterAccountInfoCard`.
   - The use of `hideNotificationService` has been removed by [PR #2639](https://github.com/woocommerce/google-listings-and-ads/pull/2639)
- Add the two missing properties to the `GoogleMCAccount` type.
- Stay with the loading state of `EnableNewProductSyncButton` during the page redirection.
- Adjust two event tracking and add their doc.
   - `gla_enable_product_sync_click`: Add the `page` event property to indicate which page the event happened to facilitate further breakdown after the onboarding page also triggers this tracking in a later PR.
   - `gla_disable_product_sync_click`: Change its trigger time to when the confirm button in the confirmation modal is clicked rather than when the button to open the confirmation modal is clicked.

### Detailed test instructions:

1. Open the Console tab in the browser DevTool
   - Configure it as below
     ![0](https://github.com/user-attachments/assets/27d7afcf-e91b-4fb2-9ba4-f3b9bd839442)
   - Run `localStorage.setItem( 'debug', 'wc-admin:*' )` to enable tracking debugging mode
2. Go to the Settings page.
3. Check if the functions to enable and disable the new product sync (API Pull) work well as before
4. View the Console tab in the browser DevTool and check if the following event tracking is triggered
   - ![1](https://github.com/user-attachments/assets/6a50224d-e56a-476d-8f88-ebd81b92d3f9)
   - ![2](https://github.com/user-attachments/assets/159d0798-8907-41ca-adcc-10354be86bf6)
   - ![3](https://github.com/user-attachments/assets/f18df6c2-1d51-4b55-a633-c409e4667b2e)

### Changelog entry

> Tweak - Supplement the implementation of API Pull for the Settings page.
