### PR TITLE
Update the `caniuse-lite` package to the latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "google-listings-and-ads",
-			"version": "2.9.3",
+			"version": "2.9.6",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@woocommerce/components": "^12.3.0",
@@ -14998,9 +14998,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001646",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001646.tgz",
-			"integrity": "sha512-dRg00gudiBDDTmUhClSdv3hqRfpbOnU28IpI1T6PBTLWa+kOj0681C8uML3PifYfREuBrVjDGhL3adYpBT6spw==",
+			"version": "1.0.30001696",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
+			"integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The following warning shows when running `npm start` and `npm run test:js`. This PR updates the `caniuse-lite` package to the latest to avoid the warnings.

```
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```

### Detailed test instructions:

1. `npm install`
2. `npm start` and `npm run test:js` to check if the warning doesn't appear anymore.

### Changelog entry
