### PR TITLE
Add the process of granting API Pull access to the onboarding flow

### DIFF
--- a/js/src/components/connected-icon-label/index.js
+++ b/js/src/components/connected-icon-label/index.js
@@ -11,9 +11,17 @@ import GridiconCheckmarkCircle from 'gridicons/dist/checkmark-circle';
  */
 import './index.scss';
 
-const ConnectedIconLabel = ( props ) => {
-	const { className } = props;
-
+/**
+ * Renders a text with a leading checkmark circle icon.
+ *
+ * @param {Object} props React props.
+ * @param {string} [props.className] Additional CSS class name to be appended.
+ * @param {string} [props.text] The text to be displayed.
+ */
+const ConnectedIconLabel = ( {
+	className,
+	text = __( 'Connected', 'google-listings-and-ads' ),
+} ) => {
 	return (
 		<Flex
 			className={ classnames( 'gla-connected-icon-label', className ) }
@@ -23,9 +31,7 @@ const ConnectedIconLabel = ( props ) => {
 			<FlexItem>
 				<GridiconCheckmarkCircle />
 			</FlexItem>
-			<FlexItem>
-				{ __( 'Connected', 'google-listings-and-ads' ) }
-			</FlexItem>
+			<FlexItem>{ text }</FlexItem>
 		</Flex>
 	);
 };

--- a/js/src/components/enable-new-product-sync-button.js
+++ b/js/src/components/enable-new-product-sync-button.js
@@ -28,7 +28,7 @@ import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
  * @param {Object} props The component props to be forwarded to AppButton.
  * @return {JSX.Element} The button.
  *
- * @fires gla_enable_product_sync_click with `{ page: 'settings', context: 'banner' | 'mc_card' }`
+ * @fires gla_enable_product_sync_click with `{ page: 'setup-mc' | 'settings', context: 'banner' | 'mc_card' }`
  */
 const EnableNewProductSyncButton = ( props ) => {
 	const { createNotice } = useDispatchCoreNotices();

--- a/js/src/components/google-combo-account-card/connected-google-combo-account-card.js
+++ b/js/src/components/google-combo-account-card/connected-google-combo-account-card.js
@@ -20,7 +20,10 @@ import useAutoCreateAdsMCAccounts from '~/hooks/useAutoCreateAdsMCAccounts';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import useExistingGoogleMCAccounts from '~/hooks/useExistingGoogleMCAccounts';
 import useCreateMCAccount from '~/hooks/useCreateMCAccount';
-import { ConnectMC } from '~/components/google-mc-account-card';
+import {
+	ConnectMC,
+	WPComAppAuthorizationCard,
+} from '~/components/google-mc-account-card';
 import useExistingGoogleAdsAccounts from '~/hooks/useExistingGoogleAdsAccounts';
 import AppButton from '~/components/app-button';
 import { SwitchAccountButton } from '~/components/google-account-card';
@@ -179,7 +182,7 @@ const ConnectedGoogleComboAccountCard = () => {
 	const showConversionMeasurementNotice =
 		showAdsConversionNotice( googleAdsAccount );
 
-	const showAddressCard = hasFinishedResolution && isGoogleMCReady;
+	const isGoogleMCResolvedAndReady = hasFinishedResolution && isGoogleMCReady;
 
 	return (
 		<div className="gla-google-combo-account-card-wrapper">
@@ -216,8 +219,8 @@ const ConnectedGoogleComboAccountCard = () => {
 					className="gla-google-combo-account-card gla-google-combo-service-account-card--mc"
 				/>
 			) }
-
-			{ showAddressCard && <StoreAddressCard /> }
+			{ isGoogleMCResolvedAndReady && <WPComAppAuthorizationCard /> }
+			{ isGoogleMCResolvedAndReady && <StoreAddressCard /> }
 		</div>
 	);
 };

--- a/js/src/components/google-mc-account-card/index.js
+++ b/js/src/components/google-mc-account-card/index.js
@@ -1,2 +1,3 @@
 export { default as ConnectMC } from './connect-mc';
 export { default as MerchantCenterAccountInfoCard } from './merchant-center-account-info-card';
+export { default as WPComAppAuthorizationCard } from './wpcom-app-authorization-card';

--- a/js/src/components/google-mc-account-card/wpcom-app-authorization-card.js
+++ b/js/src/components/google-mc-account-card/wpcom-app-authorization-card.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import ConnectedIconLabel from '~/components/connected-icon-label';
+import LoadingLabel from '~/components/loading-label';
+import EnableNewProductSyncButton from '~/components/enable-new-product-sync-button';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+
+/**
+ * Renders a card for asking the user to grant access to the WordPress.com app,
+ * which authorizes Google's shopping data integration API to fetch WooCommerce
+ * products etc through the app.
+ *
+ * Please note that the authorization process involves multiple external
+ * services, this component may be technically ambiguous in these places:
+ * - Component name
+ * - The directory where it is located
+ * - The data source for its grant status
+ * - The presenation on UI
+ */
+export default function WPComAppAuthorizationCard() {
+	const { hasFinishedResolution, isWPComAppGranted } = useGoogleMCAccount();
+
+	const getIndicator = () => {
+		if ( ! hasFinishedResolution ) {
+			return <LoadingLabel />;
+		}
+
+		if ( isWPComAppGranted ) {
+			return (
+				<ConnectedIconLabel
+					text={ __( 'Access granted', 'google-listings-and-ads' ) }
+				/>
+			);
+		}
+
+		return (
+			<EnableNewProductSyncButton
+				text={ __( 'Grant access', 'google-listings-and-ads' ) }
+				eventProps={ { page: 'setup-mc' } }
+			/>
+		);
+	};
+
+	return (
+		<AccountCard
+			appearance={ APPEARANCE.GOOGLE_MERCHANT_CENTER }
+			title={ __(
+				`Google's WordPress.com application`,
+				'google-listings-and-ads'
+			) }
+			description={ __(
+				'Granting access to the application is required in order to synchronize product data with Google through it.',
+				'google-listings-and-ads'
+			) }
+			indicator={ getIndicator() }
+		/>
+	);
+}

--- a/js/src/hooks/useGoogleMCAccount.js
+++ b/js/src/hooks/useGoogleMCAccount.js
@@ -8,7 +8,10 @@ import { useSelect } from '@wordpress/data';
  */
 import { STORE_KEY } from '~/data/constants';
 import useGoogleAccount from './useGoogleAccount';
-import { GOOGLE_MC_ACCOUNT_STATUS } from '~/constants';
+import {
+	GOOGLE_MC_ACCOUNT_STATUS,
+	GOOGLE_WPCOM_APP_CONNECTED_STATUS,
+} from '~/constants';
 
 /**
  * @typedef {import('~/data/types.js').GoogleMCAccount} GoogleMCAccount
@@ -20,6 +23,7 @@ import { GOOGLE_MC_ACCOUNT_STATUS } from '~/constants';
  * @property {boolean} isPreconditionReady Whether the precondition of continued connection processing is fulfilled.
  * @property {boolean} hasGoogleMCConnection Whether the user has a Google Merchant Center account connection established.
  * @property {boolean} isReady Whether the user has a Google Merchant Center account is in connected state.
+ * @property {boolean} isWPComAppGranted Whether the user has granted Google's WPCOM app access to WooCommerce product data etc.
  */
 
 const googleMCAccountSelector = 'getGoogleMCAccount';
@@ -50,6 +54,7 @@ const useGoogleMCAccount = () => {
 					isPreconditionReady: false,
 					hasGoogleMCConnection: false,
 					isReady: false,
+					isWPComAppGranted: false,
 				};
 			}
 
@@ -71,6 +76,10 @@ const useGoogleMCAccount = () => {
 				( acc?.status === GOOGLE_MC_ACCOUNT_STATUS.INCOMPLETE &&
 					acc?.step === 'link_ads' );
 
+			const isWPComAppGranted =
+				acc?.wpcom_rest_api_status ===
+				GOOGLE_WPCOM_APP_CONNECTED_STATUS.APPROVED;
+
 			return {
 				googleMCAccount: acc,
 				isResolving: isResolvingGoogleMCAccount,
@@ -80,6 +89,7 @@ const useGoogleMCAccount = () => {
 				isPreconditionReady: true,
 				hasGoogleMCConnection,
 				isReady,
+				isWPComAppGranted,
 			};
 		},
 		[

--- a/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.js
+++ b/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useCallback, useEffect } from '@wordpress/element';
-import { getQuery } from '@woocommerce/navigation';
+import { getQuery, getNewPath, getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -47,6 +47,13 @@ const useUpdateRestAPIAuthorizeStatusByUrlQuery = () => {
 			// eslint-disable-next-line no-console
 			console.error( e.message );
 		}
+
+		// Clean up authorization URL queries anyway
+		const url = getNewPath( {
+			google_wpcom_app_status: undefined,
+			nonce: undefined,
+		} );
+		getHistory().replace( url );
 	}, [
 		fetchUpdateRestAPIAuthorize,
 		googleWPCOMAppStatus,

--- a/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.test.js
+++ b/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.test.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { renderHook } from '@testing-library/react';
-import { getQuery } from '@woocommerce/navigation';
+import { renderHook, waitFor } from '@testing-library/react';
+import { getQuery, getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -14,10 +14,14 @@ jest.mock( '@woocommerce/navigation' );
 jest.mock( '~/hooks/useApiFetchCallback' );
 
 describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
+	let historyReplace;
 	let fetchUpdateRestAPIAuthorize;
 	let consoleErrorSpy;
 
 	beforeEach( () => {
+		historyReplace = jest.fn().mockName( 'getHistory().replace' );
+		getHistory.mockReturnValue( { replace: historyReplace } );
+
 		fetchUpdateRestAPIAuthorize = jest.fn();
 		useApiFetchCallback.mockImplementation( () => [
 			fetchUpdateRestAPIAuthorize,
@@ -65,7 +69,7 @@ describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 		} );
 	} );
 
-	it( 'should call fetchUpdateRestAPIAuthorize if query param is approved', () => {
+	it( 'should call fetchUpdateRestAPIAuthorize if query param is approved', async () => {
 		getQuery.mockReturnValue( {
 			google_wpcom_app_status: 'approved',
 			nonce: 'nonce-123',
@@ -78,9 +82,12 @@ describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 				nonce: 'nonce-123',
 			},
 		} );
+		await waitFor( () => {
+			expect( historyReplace ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 
-	it( 'should call fetchUpdateRestAPIAuthorize if query param is disapproved', () => {
+	it( 'should call fetchUpdateRestAPIAuthorize if query param is disapproved', async () => {
 		getQuery.mockReturnValue( {
 			google_wpcom_app_status: 'disapproved',
 			nonce: 'nonce-123',
@@ -93,9 +100,12 @@ describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 				nonce: 'nonce-123',
 			},
 		} );
+		await waitFor( () => {
+			expect( historyReplace ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 
-	it( 'should call fetchUpdateRestAPIAuthorize if query param is error', () => {
+	it( 'should call fetchUpdateRestAPIAuthorize if query param is error', async () => {
 		getQuery.mockReturnValue( {
 			google_wpcom_app_status: 'error',
 			nonce: 'nonce-123',
@@ -107,6 +117,9 @@ describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 				status: 'error',
 				nonce: 'nonce-123',
 			},
+		} );
+		await waitFor( () => {
+			expect( historyReplace ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 

--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
@@ -18,6 +18,7 @@ import useShippingTimes from '~/hooks/useShippingTimes';
 import useSaveShippingRates from '~/hooks/useSaveShippingRates';
 import useSaveShippingTimes from '~/hooks/useSaveShippingTimes';
 import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useUpdateRestAPIAuthorizeStatusByUrlQuery from '~/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery';
 import SetupAccounts from './setup-accounts';
 import SetupListings from './setup-listings';
 import SetupPaidAds from './setup-paid-ads';
@@ -36,6 +37,8 @@ import {
  * @fires gla_setup_mc with `{ triggered_by: 'stepper-step1-button' | 'stepper-step2-button', action: 'go-to-step1' | 'go-to-step2' }`.
  */
 const SavedSetupStepper = ( { savedStep } ) => {
+	useUpdateRestAPIAuthorizeStatusByUrlQuery();
+
 	const [ step, setStep ] = useState( savedStep );
 
 	const { settings, saveSettings } = useSettings();

--- a/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
@@ -88,6 +88,7 @@ const SetupAccounts = ( props ) => {
 		googleMCAccount,
 		isPreconditionReady: isGMCPreconditionReady,
 		isReady: isGoogleMCReady,
+		isWPComAppGranted,
 	} = useGoogleMCAccount();
 	const { hasFinishedResolution } = useGoogleAdsAccount();
 	const isStoreAddressReady = useStoreAddressReady();
@@ -127,6 +128,7 @@ const SetupAccounts = ( props ) => {
 		hasFinishedResolution &&
 		isGoogleAdsReady &&
 		isGoogleMCReady &&
+		isWPComAppGranted &&
 		isStoreAddressReady
 	);
 

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -231,6 +231,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		if (
 			$this->connected_account() &&
 			$this->container->get( AdsService::class )->connected_account() &&
+			$this->options->is_wpcom_api_authorized() &&
 			$this->is_mc_contact_information_setup()
 		) {
 			$step = 'product_listings';

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -421,7 +421,7 @@ Clicking on the button to start enabling the new product sync (API Pull).
 `page` | `string` | Indicates which page this event happened
 `context` | `string` | Indicates where or which the button triggered this event
 #### Emitters
-- [`EnableNewProductSyncButton`](../../js/src/components/enable-new-product-sync-button.js#L33) with `{ page: 'settings', context: 'banner' | 'mc_card' }`
+- [`EnableNewProductSyncButton`](../../js/src/components/enable-new-product-sync-button.js#L33) with `{ page: 'setup-mc' | 'settings', context: 'banner' | 'mc_card' }`
 
 ### [`gla_faq`](../../js/src/components/faqs-panel/index.js#L22)
 Clicking on faq item to collapse or expand it.
@@ -738,7 +738,7 @@ Setup Merchant Center
 #### Emitters
 - [`GetStartedCard`](../../js/src/pages/get-started/get-started-card/index.js#L23) with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started' }`.
 - [`GetStartedWithHeroCard`](../../js/src/pages/get-started/get-started-with-hero-card/index.js#L23) with `{ triggered_by: 'start-onboarding-button', action: 'go-to-onboarding', context: 'get-started-with-hero' }`.
-- [`SavedSetupStepper`](../../js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js#L38)
+- [`SavedSetupStepper`](../../js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js#L39)
 	- with `{ triggered_by: 'step1-continue-button' | 'step2-continue-button', action: 'go-to-step2' | 'go-to-step3' }`.
 	- with `{ triggered_by: 'stepper-step1-button' | 'stepper-step2-button', action: 'go-to-step1' | 'go-to-step2' }`.
 - [`SetupTopBar`](../../js/src/pages/onboarding/setup-top-bar.js#L17) with `{ triggered_by: 'back-button', action: 'leave' }`.

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -407,8 +407,29 @@ class MerchantCenterServiceTest extends UnitTest {
 		);
 	}
 
+	public function test_get_setup_status_step_accounts_not_yet_authorized_wpcom_api() {
+		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
+		$this->ads_service->method( 'connected_account' )->willReturn( true );
+		$this->contact_information->method( 'get_contact_information' )
+			->willReturn( $this->get_valid_business_info() );
+		$this->settings->method( 'get_store_address' )
+			->willReturn( $this->get_sample_address() );
+		$this->address_utility->method( 'compare_addresses' )
+			->willReturn( true );
+
+		$this->assertEquals(
+			[
+				'status' => 'incomplete',
+				'step'   => 'accounts',
+			],
+			$this->mc_service->get_setup_status()
+		);
+	}
+
 	public function test_get_setup_status_step_product_listings() {
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->options->method( 'is_wpcom_api_authorized' )->willReturn( true );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
 		$this->ads_service->method( 'connected_account' )->willReturn( true );
 		$this->options->method( 'get' )
@@ -441,6 +462,7 @@ class MerchantCenterServiceTest extends UnitTest {
 
 	public function test_get_setup_status_shipping_selected_rates() {
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->options->method( 'is_wpcom_api_authorized' )->willReturn( true );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
 		$this->ads_service->method( 'connected_account' )->willReturn( true );
 		$this->options->method( 'get' )
@@ -491,6 +513,7 @@ class MerchantCenterServiceTest extends UnitTest {
 
 	public function test_get_setup_status_step_paid_ads() {
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->options->method( 'is_wpcom_api_authorized' )->willReturn( true );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
 		$this->ads_service->method( 'connected_account' )->willReturn( true );
 		$this->options->expects( $this->exactly( 3 ) )->method( 'get' )

--- a/tests/e2e/specs/onboarding/step-1-accounts.test.js
+++ b/tests/e2e/specs/onboarding/step-1-accounts.test.js
@@ -932,7 +932,7 @@ test.describe( 'Set up accounts', () => {
 		test.describe( 'When all accounts are connected and store address is fulfilled', async () => {
 			test.beforeAll( async () => {
 				await setUpAccountsPage.mockAdsAccountConnected();
-				await setUpAccountsPage.mockMCConnected();
+				await setUpAccountsPage.mockMCConnected( 1, true, 'approved' );
 				await setUpAccountsPage.mockAdsStatusClaimed();
 				await setUpAccountsPage.mockContactInformation( {} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project thread: pcTzPl-2Df-p2

The PR adds the process of granting API Pull access to step 1 of the onboarding flow.

In addition, it adjusts `useUpdateRestAPIAuthorizeStatusByUrlQuery` to clean up authorization URL queries after updating the authorization status of Google's WPCOM app.

💡 Since the design document is still not available and the current decision is to develop it first, there is no UI or copy to refer to.

### Screenshots:

https://github.com/user-attachments/assets/7b18882b-9f23-4856-b77a-50458a5c2d61

### Detailed test instructions:

1. Make the test site publicly accessible
2. Use the Connection Test page to clear the authorization status of Google's WPCOM app if it has been granted
3. Go to step 1 of the onboarding flow
4. Complete the connection of all accounts
5. Check to see if the "Continue" button at the bottom is still disabled
6. Refresh the webpage to check if it starts from step 1
7. Check if the "Google's WordPress.com application" card is shown
8. Click on the "Grant access" button to see if it brings you to the authorization flow on WordPress.com
9. After approving and being brought back to the onboarding flow for this plugin, check if the status on the "Google's WordPress.com application" card changes to “Access granted”
10. Check if the page URL doesn't include `google_wpcom_app_status` and `nonce` in its query
11. Check to see if the "Continue" button at the bottom is enabled
12. Continue to step 2
13. Refresh the webpage to check if it starts from step 2

### Changelog entry

> Add - During onboarding, it requires granting access to Google's WordPress.com application to synchronize product data with Google.
