### PR TITLE
Update ubuntu image to 22.04 for QIT WF

### DIFF
--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -54,7 +54,7 @@ jobs:
     secrets: inherit
   qit-tests:
     name: Run QIT Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - name: Download artifact

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -54,7 +54,7 @@ jobs:
     secrets: inherit
   qit-tests:
     name: Run QIT Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Download artifact


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

PT: p7H4VZ-5d2-p2#comment-12564

In this PR we update the image to use in QIT Workflows to `ubuntu-latest`

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<img width="953" alt="Screenshot 2025-02-12 at 20 17 55" src="https://github.com/user-attachments/assets/08f12336-7e5f-46c5-916e-3253f9d0a1bb" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. See the QIT running in the new branch https://github.com/woocommerce/google-listings-and-ads/actions/runs/13306921922 using the last ubuntu version
2. Perform some QIT jobs against this branch and verify is running 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>