### PR TITLE
Fix error displayed when accessing campaign assets editing page without attached asset groups

### DIFF
--- a/js/src/pages/edit-paid-ads-campaign/index.js
+++ b/js/src/pages/edit-paid-ads-campaign/index.js
@@ -168,7 +168,7 @@ const EditPaidAdsCampaign = () => {
 		const hasChange =
 			allValues.amount !== campaign.amount ||
 			! isEqual(
-				assetEntityGroup.display_url_path,
+				assetEntityGroup?.display_url_path,
 				allValues.display_url_path
 			) ||
 			diffAssetOperations( assetEntityGroup, allValues ).length > 0;

--- a/js/src/pages/edit-paid-ads-campaign/index.js
+++ b/js/src/pages/edit-paid-ads-campaign/index.js
@@ -165,13 +165,21 @@ const EditPaidAdsCampaign = () => {
 	};
 
 	const handleOnChange = ( value, allValues ) => {
-		const hasChange =
-			allValues.amount !== campaign.amount ||
+		const isAmountChanged = allValues.amount !== campaign.amount;
+
+		const isDisplayUrlPathChanged =
+			!! assetEntityGroup &&
 			! isEqual(
-				assetEntityGroup?.display_url_path,
+				assetEntityGroup.display_url_path,
 				allValues.display_url_path
-			) ||
+			);
+
+		const hasAssetOperations =
+			!! assetEntityGroup &&
 			diffAssetOperations( assetEntityGroup, allValues ).length > 0;
+
+		const hasChange =
+			isAmountChanged || isDisplayUrlPathChanged || hasAssetOperations;
 
 		setDidChange( hasChange );
 	};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2791.

This PR fixes an issue that will display an error when accessing campaign asset editing page without attached asset groups.

### Screenshots:

Note that at the end of the video there is an error notice, which is not related to this PR. I will try to reproduce it and create a follow up issue for it.

https://github.com/user-attachments/assets/f7d28078-296b-48fc-90d5-bab5c8fd2d1d

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. In GLA, create a campaign without assets.
2. Go to [Google Ads](https://ads.google.com/aw/campaigns) to delete the empty asset group for the newly created campaign.
3. Back to GLA, refresh the web page, and go to edit the newly created campaign.
4. Click "Continue" to enter assets editing page
5. The assets editing page should open correctly
6. Add assets and click `Save changes`
7. Go to [Google Ads](https://ads.google.com/aw/campaigns), the asset group should be created with right assets.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Error displayed when accessing campaign assets editing page without attached asset groups
