### PR TITLE
Grant API auth before MC connect

### DIFF
--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -475,15 +475,35 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 	}
 
 	/**
-	 * Get the Google Shopping Data Integration auth endpoint URL
+	 * Get the URL for the Google Shopping Data Integration auth endpoint.
 	 *
 	 * @return string
 	 */
 	public function get_sdi_auth_endpoint(): string {
+		return $this->get_sdi_endpoint() . 'oauth/redirect:generate';
+	}
+
+	/**
+	 * Get the URL for the Google SDI merchant update endpoint.
+	 *
+	 * @return string
+	 */
+	public function get_sdi_merchant_update_endpoint(): string {
+		return $this->get_sdi_endpoint()
+			. 'account:connect?merchant_id='
+			. $this->options->get_merchant_id();
+	}
+
+	/**
+	 * Get the base endpoint to the Google Shopping Data Integration (SDI).
+	 *
+	 * @return string
+	 */
+	protected function get_sdi_endpoint(): string {
 		return $this->container->get( 'connect_server_root' )
-				. 'google/google-sdi/v1/credentials/partners/WOO_COMMERCE/merchants/'
-				. $this->strip_url_protocol( $this->get_site_url() )
-				. '/oauth/redirect:generate';
+			. 'google/google-sdi/v1/credentials/partners/WOO_COMMERCE/merchants/'
+			. $this->strip_url_protocol( $this->get_site_url() )
+			. '/';
 	}
 
 	/**
@@ -593,6 +613,40 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 
 			throw new Exception(
 				$this->client_exception_message( $e, __( 'Error authenticating Google Partner APP.', 'google-listings-and-ads' ) ),
+				$e->getCode()
+			);
+		}
+	}
+
+	/**
+	 * Performs a request to Google Shopping Data Integration (SDI) to update the merchant center account.
+	 *
+	 * @return array An array with the JSON response from the WCS server.
+	 * @throws NotFoundExceptionInterface  When the container was not found.
+	 * @throws ContainerExceptionInterface When an error happens while retrieving the container.
+	 * @throws Exception When the response status is not successful.
+	 * @see google-sdi in google/services inside WCS
+	 */
+	public function update_sdi_merchant_account() {
+		try {
+			/** @var Client $client */
+			$client   = $this->container->get( Client::class );
+			$result   = $client->get( $this->get_sdi_merchant_update_endpoint() );
+			$response = json_decode( $result->getBody()->getContents(), true );
+
+			if ( 200 !== $result->getStatusCode() ) {
+				do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
+				$error = $response['message'] ?? __( 'Invalid response when updating merchant account in Google partner app.', 'google-listings-and-ads' );
+				throw new Exception( $error, $result->getStatusCode() );
+			}
+
+			return $response;
+
+		} catch ( ClientExceptionInterface $e ) {
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
+
+			throw new Exception(
+				$this->client_exception_message( $e, __( 'Error updating merchant account in Google Partner APP.', 'google-listings-and-ads' ) ),
 				$e->getCode()
 			);
 		}

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -480,7 +480,15 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 	 * @return string
 	 */
 	public function get_sdi_auth_endpoint(): string {
-		return $this->get_sdi_endpoint() . 'oauth/redirect:generate';
+		$endpoint = $this->get_sdi_endpoint() . 'oauth/redirect:generate';
+
+		// Add merchant ID for cases where we've already completed onboarding.
+		$merchant_id = $this->options->get_merchant_id();
+		if ( $merchant_id ) {
+			$endpoint .= "?merchant_id={$merchant_id}";
+		}
+
+		return $endpoint;
 	}
 
 	/**

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -483,8 +483,7 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 		return $this->container->get( 'connect_server_root' )
 				. 'google/google-sdi/v1/credentials/partners/WOO_COMMERCE/merchants/'
 				. $this->strip_url_protocol( $this->get_site_url() )
-				. '/oauth/redirect:generate'
-				. '?merchant_id=' . $this->options->get_merchant_id();
+				. '/oauth/redirect:generate';
 	}
 
 	/**

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -497,9 +497,7 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 	 * @return string
 	 */
 	public function get_sdi_merchant_update_endpoint(): string {
-		return $this->get_sdi_endpoint()
-			. 'account:connect?merchant_id='
-			. $this->options->get_merchant_id();
+		return $this->get_sdi_endpoint() . 'account:connect';
 	}
 
 	/**
@@ -629,27 +627,40 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 	/**
 	 * Performs a request to Google Shopping Data Integration (SDI) to update the merchant center account.
 	 *
-	 * @return array An array with the JSON response from the WCS server.
 	 * @throws NotFoundExceptionInterface  When the container was not found.
 	 * @throws ContainerExceptionInterface When an error happens while retrieving the container.
-	 * @throws Exception When the response status is not successful.
+	 * @throws Exception When the response status is not successful, or merchant ID is not set.
 	 * @see google-sdi in google/services inside WCS
 	 */
 	public function update_sdi_merchant_account() {
 		try {
-			/** @var Client $client */
-			$client   = $this->container->get( Client::class );
-			$result   = $client->get( $this->get_sdi_merchant_update_endpoint() );
-			$response = json_decode( $result->getBody()->getContents(), true );
-
-			if ( 200 !== $result->getStatusCode() ) {
-				do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
-				$error = $response['message'] ?? __( 'Invalid response when updating merchant account in Google partner app.', 'google-listings-and-ads' );
-				throw new Exception( $error, $result->getStatusCode() );
+			if ( ! $this->options->get_merchant_id() ) {
+				throw new Exception( __( 'Merchant ID must be set before updating in SDI.', 'google-listings-and-ads' ) );
 			}
 
-			return $response;
+			/** @var Client $client */
+			$client = $this->container->get( Client::class );
+			$result = $client->post(
+				$this->get_sdi_merchant_update_endpoint(),
+				[
+					'body' => wp_json_encode(
+						[
+							'merchant_center_id' => $this->options->get_merchant_id(),
+						]
+					),
+				]
+			);
 
+			// Check the status, since an empty response is returned upon success.
+			if ( 200 !== $result->getStatusCode() ) {
+				$response = json_decode( $result->getBody()->getContents(), true );
+				do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
+
+				throw new Exception(
+					__( 'Invalid response when updating merchant account in Google Partner APP.', 'google-listings-and-ads' ),
+					$result->getStatusCode()
+				);
+			}
 		} catch ( ClientExceptionInterface $e ) {
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 

--- a/src/API/WP/OAuthService.php
+++ b/src/API/WP/OAuthService.php
@@ -81,7 +81,17 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 	public function get_auth_url( string $path ): string {
 		$google_data = $this->get_data_from_google();
 
-		$store_url = urlencode_deep( admin_url( "admin.php?page=wc-admin&path={$path}" ) );
+		$store_url = urlencode_deep(
+			/**
+			 * Filters the store URL to return to after the WPCOM REST API permissions have been granted.
+			 *
+			 * @param string $url WC Admin path to redirect to.
+			 */
+			apply_filters(
+				'woocommerce_gla_wpcom_return_url',
+				admin_url( "admin.php?page=wc-admin&path={$path}" )
+			)
+		);
 
 		$state = $this->base64url_encode(
 			build_query(

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -347,6 +347,9 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 							$merchant->claimwebsite();
 						}
 						break;
+					case 'sdi_update':
+						$middleware->update_sdi_merchant_account();
+						break;
 					case 'link_ads':
 						// Continue to next step if Ads account is not connected yet.
 						if ( ! $this->options->get_ads_id() ) {

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -27,7 +27,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use Exception;
 use Jetpack_Options;
 

--- a/src/Options/MerchantAccountState.php
+++ b/src/Options/MerchantAccountState.php
@@ -30,7 +30,7 @@ class MerchantAccountState extends AccountState {
 	 * @return string[]
 	 */
 	protected function account_creation_steps(): array {
-		return [ 'set_id', 'verify', 'link', 'claim', 'link_ads' ];
+		return [ 'set_id', 'verify', 'link', 'claim', 'sdi_update', 'link_ads' ];
 	}
 
 	/**

--- a/tests/Tools/HelperTrait/GuzzleClientTrait.php
+++ b/tests/Tools/HelperTrait/GuzzleClientTrait.php
@@ -46,7 +46,7 @@ trait GuzzleClientTrait {
 		$result->method( 'getBody' )->willReturn( $body );
 		$result->method( 'getStatusCode' )->willReturn( $code );
 
-		$this->client->method( $type )->willReturn( $result );
+		$this->client->expects( $this->once() )->method( $type )->willReturn( $result );
 	}
 
 	/**

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -399,7 +399,7 @@ class MiddlewareTest extends UnitTest {
 	public function test_get_sdi_auth_endpoint() {
 		$this->assertEquals(
 			$this->middleware->get_sdi_auth_endpoint(),
-			'https://connect-server.test/google/google-sdi/v1/credentials/partners/WOO_COMMERCE/merchants/example.org/oauth/redirect:generate?merchant_id=0'
+			'https://connect-server.test/google/google-sdi/v1/credentials/partners/WOO_COMMERCE/merchants/example.org/oauth/redirect:generate'
 		);
 	}
 

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -441,4 +441,39 @@ class MiddlewareTest extends UnitTest {
 		$this->middleware->get_sdi_auth_params();
 		$this->assertEquals( 1, did_action( 'woocommerce_gla_guzzle_client_exception' ) );
 	}
+
+	public function test_update_sdi_merchant_account_no_merchant() {
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Merchant ID must be set before updating in SDI.' );
+		$this->middleware->update_sdi_merchant_account();
+	}
+
+	public function test_update_sdi_merchant_account_invalid_response() {
+		$this->options->method( 'get_merchant_id' )->willReturn( self::TEST_MERCHANT_ID );
+		$this->generate_request_mock( [], 'post', 400 );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Invalid response when updating merchant account in Google Partner APP.' );
+		$this->expectExceptionCode( 400 );
+
+		$this->middleware->update_sdi_merchant_account();
+	}
+
+	public function test_update_sdi_merchant_account_exception() {
+		$this->options->method( 'get_merchant_id' )->willReturn( self::TEST_MERCHANT_ID );
+		$this->generate_request_mock_exception( 'Some exception.', 'post', 400 );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Error updating merchant account in Google Partner APP.' );
+		$this->expectExceptionCode( 400 );
+
+		$this->middleware->update_sdi_merchant_account();
+	}
+
+	public function test_update_sdi_merchant_account() {
+		$this->options->method( 'get_merchant_id' )->willReturn( self::TEST_MERCHANT_ID );
+		$this->generate_request_mock( null, 'post', 200 );
+
+		$this->middleware->update_sdi_merchant_account();
+	}
 }

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -403,6 +403,15 @@ class MiddlewareTest extends UnitTest {
 		);
 	}
 
+	public function test_get_sdi_auth_endpoint_with_merchant_id() {
+		$this->options->method( 'get_merchant_id' )->willReturn( self::TEST_MERCHANT_ID );
+
+		$this->assertEquals(
+			$this->middleware->get_sdi_auth_endpoint(),
+			'https://connect-server.test/google/google-sdi/v1/credentials/partners/WOO_COMMERCE/merchants/example.org/oauth/redirect:generate?merchant_id=' . self::TEST_MERCHANT_ID
+		);
+	}
+
 	public function test_get_sdi_auth_params() {
 		$expected_response = [
 			'clientId'    => self::TEST_MERCHANT_ID,

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -622,6 +622,25 @@ class AccountServiceTest extends UnitTest {
 		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->switch_url( self::TEST_ACCOUNT_ID ) );
 	}
 
+	public function test_setup_account_step_sdi_update() {
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->any() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'sdi_update' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->middleware->expects( $this->once() )
+			->method( 'update_sdi_merchant_account' );
+
+		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->setup_account( self::TEST_ACCOUNT_ID ) );
+	}
+
 	public function test_setup_account_step_link_ads() {
 		$this->options->expects( $this->any() )
 			->method( 'get_ads_id' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the requirement to connect the Merchant Center account first, before being able to grant the WPCOM API authentication. The following steps were implemented in this PR:

- Remove Merchant Center ID when requesting redirect URL
- Adjust Connection Test to support granting auth permissions
- Adjust unit tests to support the same


### Detailed test instructions:

#### Test API Pull grant for already existing users:
1. Start with a site that is fully onboarded (before using this PR)
2. Switch to this PR so we can test granting permissions
3. Go to the Google for WooCommerce > Settings page
4. Click on the "Get early access" button to start the flow to grant permissions
5. Confirm the process completes

> [!Note]
> There isn't really any way to confirm that the code is passing the Merchant ID here. So the best we can do is temporarily add some troubleshooting code to confirm it's included:
```diff
			$client   = $this->container->get( Client::class );
+			error_log( 'SDI Auth endpoint: ' . $this->get_sdi_auth_endpoint() );
			$result   = $client->get( $this->get_sdi_auth_endpoint() );
```
Make sure to have error logging enabled to a file so we can check the log entry, ex:
```
[20-Feb-2025 16:38:29 UTC] SDI Auth endpoint: https://api.woocommerce.com/google/google-sdi/v1/credentials/partners/WOO_COMMERCE/merchants/domain.test/oauth/redirect:generate?merchant_id=112113145
```

#### Test API Pull grant for new users:
1. Start with a site where everything is disconnected
2. Make sure to leave the WP.com connection connected, or reconnect it
3. We don't have the UI ready so we will test granting the API Pull auth through the connection test page
4. Go to the section "Partner API Pull Integration" and click the Grant access button
5. Go through the flow (if you have the logging enabled from above it should record the same URL without a `merchant_id`
6. Complete the flow and make sure we don't get any errors
7. Go through the onboarding and connect the MC account in the process
8. Go back to the connection test page and check the completed steps for the MC account, it should include the step `sdi_update`
![image](https://github.com/user-attachments/assets/0cea9f03-404d-4ef2-9ac6-7756c9dc6263)
9. Scroll down to the section "Partner API Pull Integration" and confirm everything is ready and approved
![image](https://github.com/user-attachments/assets/dd6da7e3-aad6-4e41-aafc-2c2ee4257f94)


### Additional details:
Project Thread: pcTzPl-2FJ-p2

### Changelog entry
* Tweak - Grant API auth before MC connect.