### PR TITLE
Fetch budget recommendations from the Google Ads API

### DIFF
--- a/src/API/Google/BudgetRecommendations.php
+++ b/src/API/Google/BudgetRecommendations.php
@@ -91,12 +91,8 @@ class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInt
 					continue;
 				}
 
-				// Return recommended budget for the first country.
-				$recommended = $this->select_recommended_budget( $campaign_budget_recommendation );
-				if ( $recommended ) {
-					$recommended['country'] = reset( $country_codes );
-					return [ $recommended ];
-				}
+				// Parse all the returned recommendations and assign to the first country.
+				return $this->parse_recommendations( $campaign_budget_recommendation, reset( $country_codes ) );
 			}
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
@@ -106,13 +102,14 @@ class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInt
 	}
 
 	/**
-	 * Select the suggested budget recommendation and return metrics.
+	 * Return all budget recommendations including metrics.
 	 *
-	 * @param CampaignBudgetRecommendation $recommendation
+	 * @param CampaignBudgetRecommendation $recommendation  Collection of recommendation options.
+	 * @param string                       $country_code    Primary country code.
 	 *
-	 * @return array|null Suggested recommendation (including metrics).
+	 * @return array|null Recommendations (including metrics).
 	 */
-	protected function select_recommended_budget( CampaignBudgetRecommendation $recommendation ): ?array {
+	protected function parse_recommendations( CampaignBudgetRecommendation $recommendation, string $country_code ): ?array {
 		// Map all available budget options.
 		$options = [];
 		foreach ( $recommendation->getBudgetOptions() as $budget_option ) {
@@ -137,7 +134,36 @@ class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInt
 		$numbers = array_map( 'floatval', array_keys( $options ) );
 		$closest = $this->find_closest( $this->from_micro( $recommendation->getRecommendedBudgetAmountMicros() ), $numbers );
 
-		return $options[ (string) $closest ] ?: null;
+		// Add each option and assign it's level
+		$recommendations = [];
+		foreach ( $options as $option ) {
+			if ( $option['daily_budget'] === $closest ) {
+				$level = 'recommended';
+				$index = 0;
+			} elseif ( $option['daily_budget'] > $closest ) {
+				$level = 'high';
+				$index = 1;
+			} else {
+				$level = 'low';
+				$index = 2;
+			}
+
+			$recommendations[ $index ] = array_merge(
+				$option,
+				[
+					'country' => $country_code,
+					'level'   => $level,
+				]
+			);
+		}
+
+		if ( empty( $recommendations ) ) {
+			return null;
+		}
+
+		// Sort recommendations in the order: recommended, high, low.
+		ksort( $recommendations );
+		return $recommendations;
 	}
 
 	/**

--- a/src/API/Google/BudgetRecommendations.php
+++ b/src/API/Google/BudgetRecommendations.php
@@ -59,6 +59,14 @@ class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInt
 	 * @return array|null List of recommendations (including metrics).
 	 */
 	public function get_recommendations( array $country_codes ): ?array {
+		$cache_key = strtolower( join( '-', $country_codes ) );
+		$transient = $this->transients->get( TransientsInterface::ADS_RECOMMENDATIONS );
+
+		// Check if we have the budget recommendations cached in the transient.
+		if ( $transient && ! empty( $transient[ $cache_key ] ) ) {
+			return $transient[ $cache_key ];
+		}
+
 		$location_ids = $this->get_location_ids( $country_codes );
 
 		$request = new GenerateRecommendationsRequest(
@@ -93,7 +101,9 @@ class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInt
 				}
 
 				// Parse all the returned recommendations and assign to the first country.
-				return $this->parse_recommendations( $campaign_budget_recommendation, reset( $country_codes ) );
+				$recommendations = $this->parse_recommendations( $campaign_budget_recommendation, reset( $country_codes ) );
+				$this->transients->set( TransientsInterface::ADS_RECOMMENDATIONS, [ $cache_key => $recommendations ], HOUR_IN_SECONDS * 12 );
+				return $recommendations;
 			}
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );

--- a/src/API/Google/BudgetRecommendations.php
+++ b/src/API/Google/BudgetRecommendations.php
@@ -67,6 +67,7 @@ class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInt
 				'recommendation_types'     => [ RecommendationType::CAMPAIGN_BUDGET ],
 				'advertising_channel_type' => AdvertisingChannelType::PERFORMANCE_MAX,
 				'positive_locations_ids'   => array_keys( $location_ids ),
+				'country_codes'            => $country_codes,
 				'bidding_info'             => new BiddingInfo(
 					[
 						'bidding_strategy_type' => BiddingStrategyType::MAXIMIZE_CONVERSION_VALUE,

--- a/src/API/Google/BudgetRecommendations.php
+++ b/src/API/Google/BudgetRecommendations.php
@@ -90,7 +90,7 @@ class BudgetRecommendations implements OptionsAwareInterface {
 				$recommended = $this->select_recommended_budget( $campaign_budget_recommendation );
 				if ( $recommended ) {
 					$recommended['country'] = reset( $country_codes );
-					return $recommended;
+					return [ $recommended ];
 				}
 			}
 		} catch ( ApiException $e ) {

--- a/src/API/Google/BudgetRecommendations.php
+++ b/src/API/Google/BudgetRecommendations.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\MicroTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsCountryQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
@@ -19,7 +20,7 @@ use Google\ApiCore\ApiException;
 
 /**
  * Class BudgetRecommendations
- * https://developers.google.com/google-ads/api/docs/performance-max/overview
+ * https://developers.google.com/google-ads/api/rest/reference/rest/v18/Recommendation#CampaignBudgetRecommendation
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */
@@ -53,25 +54,14 @@ class BudgetRecommendations implements OptionsAwareInterface {
 	 * @return array|null Recommendations, including metrics.
 	 */
 	public function get_recommendations( array $country_codes ): ?array {
-		/*
-			TODO: Location ID's need to be fetched with a query:
-			SELECT
-				geo_target_constant.canonical_name,
-				geo_target_constant.id,
-				geo_target_constant.name,
-				geo_target_constant.country_code,
-				geo_target_constant.target_type
-			FROM geo_target_constant
-			WHERE geo_target_constant.country_code IN "US,CA"
-			AND geo_target_constant.target_type = "Country"
-		*/
+		$location_ids = $this->get_location_ids( $country_codes );
 
 		$request = new GenerateRecommendationsRequest(
 			[
 				'customer_id'              => $this->options->get_ads_id(),
 				'recommendation_types'     => [ RecommendationType::CAMPAIGN_BUDGET ],
 				'advertising_channel_type' => AdvertisingChannelType::PERFORMANCE_MAX,
-				// TODO: add 'positive_locations_ids'   => '',
+				'positive_locations_ids'   => array_keys( $location_ids ),
 				'bidding_info'             => new BiddingInfo(
 					[
 						'bidding_strategy_type' => BiddingStrategyType::MAXIMIZE_CONVERSION_VALUE,
@@ -121,7 +111,11 @@ class BudgetRecommendations implements OptionsAwareInterface {
 		// Map all available budget options.
 		$options = [];
 		foreach ( $recommendation->getBudgetOptions() as $budget_option ) {
-			$amount  = $this->from_micro( $budget_option->getBudgetAmountMicros() );
+			$amount = $this->from_micro( $budget_option->getBudgetAmountMicros() );
+			if ( ! $amount ) {
+				continue;
+			}
+
 			$metrics = $budget_option->getImpact()->getPotentialMetrics();
 
 			$options[ (string) $amount ] = [
@@ -162,5 +156,33 @@ class BudgetRecommendations implements OptionsAwareInterface {
 		);
 
 		return reset( $numbers );
+	}
+
+	/**
+	 * Fetch location IDs from country codes.
+	 *
+	 * @param array $country_codes List of country codes to fetch.
+	 *
+	 * @return array Mapped array of location IDs to country codes.
+	 */
+	protected function get_location_ids( array $country_codes ): array {
+		try {
+			$location_results = ( new AdsCountryQuery() )
+				->set_client( $this->client, $this->options->get_ads_id() )
+				->where( 'geo_target_constant.country_code', $country_codes, 'IN' )
+				->get_results();
+
+			$locations = [];
+			foreach ( $location_results->iterateAllElements() as $row ) {
+				$location                        = $row->getGeoTargetConstant();
+				$locations[ $location->getId() ] = $location->getCountryCode();
+			}
+
+			return $locations;
+		} catch ( ApiException $e ) {
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
+		}
+
+		return [];
 	}
 }

--- a/src/API/Google/BudgetRecommendations.php
+++ b/src/API/Google/BudgetRecommendations.php
@@ -138,13 +138,13 @@ class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInt
 		$recommendations = [];
 		foreach ( $options as $option ) {
 			if ( $option['daily_budget'] === $closest ) {
-				$level = 'recommended';
+				$level = __( 'Recommended', 'google-listings-and-ads' );
 				$index = 0;
 			} elseif ( $option['daily_budget'] > $closest ) {
-				$level = 'high';
+				$level = __( 'High', 'google-listings-and-ads' );
 				$index = 1;
 			} else {
-				$level = 'low';
+				$level = __( 'Low', 'google-listings-and-ads' );
 				$index = 2;
 			}
 

--- a/src/API/Google/BudgetRecommendations.php
+++ b/src/API/Google/BudgetRecommendations.php
@@ -8,6 +8,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsCountryQuery
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Google\Ads\GoogleAds\V18\Enums\AdvertisingChannelTypeEnum\AdvertisingChannelType;
 use Google\Ads\GoogleAds\V18\Enums\BiddingStrategyTypeEnum\BiddingStrategyType;
@@ -24,11 +27,12 @@ use Google\ApiCore\ApiException;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */
-class BudgetRecommendations implements OptionsAwareInterface {
+class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInterface {
 
 	use MicroTrait;
 	use OptionsAwareTrait;
 	use PluginHelper;
+	use TransientsAwareTrait;
 
 	/**
 	 * The Google Ads Client.
@@ -167,7 +171,16 @@ class BudgetRecommendations implements OptionsAwareInterface {
 	 * @return array Mapped array of location IDs to country codes.
 	 */
 	protected function get_location_ids( array $country_codes ): array {
+		$cache_key = strtolower( join( '-', $country_codes ) );
+		$transient = $this->transients->get( TransientsInterface::ADS_LOCATION_IDS );
+
+		// Check if we have the location ID's cached in the transient.
+		if ( $transient && ! empty( $transient[ $cache_key ] ) ) {
+			return $transient[ $cache_key ];
+		}
+
 		try {
+			// Query the location ID's from the Google Ads API.
 			$location_results = ( new AdsCountryQuery() )
 				->set_client( $this->client, $this->options->get_ads_id() )
 				->where( 'geo_target_constant.country_code', $country_codes, 'IN' )
@@ -178,6 +191,8 @@ class BudgetRecommendations implements OptionsAwareInterface {
 				$location                        = $row->getGeoTargetConstant();
 				$locations[ $location->getId() ] = $location->getCountryCode();
 			}
+
+			$this->transients->set( TransientsInterface::ADS_LOCATION_IDS, [ $cache_key => $locations ] );
 
 			return $locations;
 		} catch ( ApiException $e ) {

--- a/src/API/Google/BudgetRecommendations.php
+++ b/src/API/Google/BudgetRecommendations.php
@@ -48,10 +48,11 @@ class BudgetRecommendations implements OptionsAwareInterface {
 
 	/**
 	 * Fetch budget recommendations (with metrics) from Google Ads API.
+	 * This function will only return a single recommendation in the list, with the first country code.
 	 *
 	 * @param array $country_codes List of countries to include.
 	 *
-	 * @return array|null Recommendations, including metrics.
+	 * @return array|null List of recommendations (including metrics).
 	 */
 	public function get_recommendations( array $country_codes ): ?array {
 		$location_ids = $this->get_location_ids( $country_codes );
@@ -105,7 +106,7 @@ class BudgetRecommendations implements OptionsAwareInterface {
 	 *
 	 * @param CampaignBudgetRecommendation $recommendation
 	 *
-	 * @return array|null Recommendations, including metrics.
+	 * @return array|null Suggested recommendation (including metrics).
 	 */
 	protected function select_recommended_budget( CampaignBudgetRecommendation $recommendation ): ?array {
 		// Map all available budget options.

--- a/src/API/Google/BudgetRecommendations.php
+++ b/src/API/Google/BudgetRecommendations.php
@@ -1,0 +1,166 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\MicroTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Google\Ads\GoogleAds\V18\Enums\AdvertisingChannelTypeEnum\AdvertisingChannelType;
+use Google\Ads\GoogleAds\V18\Enums\BiddingStrategyTypeEnum\BiddingStrategyType;
+use Google\Ads\GoogleAds\V18\Enums\RecommendationTypeEnum\RecommendationType;
+use Google\Ads\GoogleAds\V18\Resources\Recommendation\CampaignBudgetRecommendation;
+use Google\Ads\GoogleAds\V18\Services\GenerateRecommendationsRequest;
+use Google\Ads\GoogleAds\V18\Services\GenerateRecommendationsRequest\AssetGroupInfo;
+use Google\Ads\GoogleAds\V18\Services\GenerateRecommendationsRequest\BiddingInfo;
+use Google\ApiCore\ApiException;
+
+/**
+ * Class BudgetRecommendations
+ * https://developers.google.com/google-ads/api/docs/performance-max/overview
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
+ */
+class BudgetRecommendations implements OptionsAwareInterface {
+
+	use MicroTrait;
+	use OptionsAwareTrait;
+	use PluginHelper;
+
+	/**
+	 * The Google Ads Client.
+	 *
+	 * @var GoogleAdsClient
+	 */
+	protected $client;
+
+	/**
+	 * BudgetRecommendations constructor.
+	 *
+	 * @param GoogleAdsClient $client
+	 */
+	public function __construct( GoogleAdsClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * Fetch budget recommendations (with metrics) from Google Ads API.
+	 *
+	 * @param array $country_codes List of countries to include.
+	 *
+	 * @return array|null Recommendations, including metrics.
+	 */
+	public function get_recommendations( array $country_codes ): ?array {
+		/*
+			TODO: Location ID's need to be fetched with a query:
+			SELECT
+				geo_target_constant.canonical_name,
+				geo_target_constant.id,
+				geo_target_constant.name,
+				geo_target_constant.country_code,
+				geo_target_constant.target_type
+			FROM geo_target_constant
+			WHERE geo_target_constant.country_code IN "US,CA"
+			AND geo_target_constant.target_type = "Country"
+		*/
+
+		$request = new GenerateRecommendationsRequest(
+			[
+				'customer_id'              => $this->options->get_ads_id(),
+				'recommendation_types'     => [ RecommendationType::CAMPAIGN_BUDGET ],
+				'advertising_channel_type' => AdvertisingChannelType::PERFORMANCE_MAX,
+				// TODO: add 'positive_locations_ids'   => '',
+				'bidding_info'             => new BiddingInfo(
+					[
+						'bidding_strategy_type' => BiddingStrategyType::MAXIMIZE_CONVERSION_VALUE,
+					]
+				),
+				'asset_group_info'         => [
+					new AssetGroupInfo(
+						[
+							'final_url' => $this->get_site_url(),
+						],
+					),
+				],
+			]
+		);
+
+		try {
+			$response = $this->client->getRecommendationServiceClient()->generateRecommendations( $request );
+
+			foreach ( $response->getRecommendations() as $recommendation ) {
+				$campaign_budget_recommendation = $recommendation->getCampaignBudgetRecommendation();
+				if ( ! $campaign_budget_recommendation ) {
+					continue;
+				}
+
+				// Return recommended budget for the first country.
+				$recommended = $this->select_recommended_budget( $campaign_budget_recommendation );
+				if ( $recommended ) {
+					$recommended['country'] = reset( $country_codes );
+					return $recommended;
+				}
+			}
+		} catch ( ApiException $e ) {
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Select the suggested budget recommendation and return metrics.
+	 *
+	 * @param CampaignBudgetRecommendation $recommendation
+	 *
+	 * @return array|null Recommendations, including metrics.
+	 */
+	protected function select_recommended_budget( CampaignBudgetRecommendation $recommendation ): ?array {
+		// Map all available budget options.
+		$options = [];
+		foreach ( $recommendation->getBudgetOptions() as $budget_option ) {
+			$amount  = $this->from_micro( $budget_option->getBudgetAmountMicros() );
+			$metrics = $budget_option->getImpact()->getPotentialMetrics();
+
+			$options[ (string) $amount ] = [
+				'daily_budget' => $amount,
+				'metrics'      => [
+					'cost'              => $this->from_micro( $metrics->getCostMicros() ),
+					'conversions'       => $metrics->getConversions(),
+					'conversions_value' => $metrics->getConversionsValue(),
+				],
+			];
+		}
+
+		// Find closest match based on recommended amount.
+		$numbers = array_map( 'floatval', array_keys( $options ) );
+		$closest = $this->find_closest( $this->from_micro( $recommendation->getRecommendedBudgetAmountMicros() ), $numbers );
+
+		return $options[ (string) $closest ] ?: null;
+	}
+
+	/**
+	 * Find closest matching number in an array of numbers.
+	 *
+	 * @param float $number  Number to search for.
+	 * @param array $numbers List of numbers to search in.
+	 *
+	 * @return float|null Closest number found.
+	 */
+	protected function find_closest( float $number, array $numbers ): ?float {
+		if ( empty( $numbers ) ) {
+			return null;
+		}
+
+		usort(
+			$numbers,
+			function ( $a, $b ) use ( $number ) {
+				return abs( $number - (float) $a ) <=> abs( $number - (float) $b );
+			}
+		);
+
+		return reset( $numbers );
+	}
+}

--- a/src/API/Google/Query/AdsCountryQuery.php
+++ b/src/API/Google/Query/AdsCountryQuery.php
@@ -1,0 +1,30 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsCountryQuery
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query
+ */
+class AdsCountryQuery extends AdsQuery {
+
+	/**
+	 * AdsCountryQuery constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'geo_target_constant' );
+		$this->columns(
+			[
+				'geo_target_constant.id',
+				'geo_target_constant.country_code',
+				'geo_target_constant.target_type',
+			]
+		);
+
+		$this->where( 'geo_target_constant.target_type', 'Country' );
+	}
+}

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -115,8 +115,8 @@ class BudgetRecommendationController extends BaseController implements Container
 			if ( $fallback_recommendations ) {
 				$fallback_budget = $fallback_recommendations[0]['daily_budget'] ?? 0;
 
-				// Swap recommended if fallback is higher.
-				if ( ! empty( $recommendations[0]['daily_budget'] ) && $recommendations[0]['daily_budget'] < $fallback_budget ) {
+				// Swap recommended if not set or if fallback is higher.
+				if ( empty( $recommendations[0] ) || ( ! empty( $recommendations[0]['daily_budget'] ) && $recommendations[0]['daily_budget'] < $fallback_budget ) ) {
 					$recommendations[0] = $fallback_recommendations[0];
 
 					// Remove high recommendation if fallback is higher.

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -104,11 +104,7 @@ class BudgetRecommendationController extends BaseController implements Container
 				);
 			}
 
-			$query           = $this->container->get( BudgetRecommendationQuery::class );
-			$recommendations = $query
-				->where( 'country', $country_codes, 'IN' )
-				->where( 'currency', $currency )
-				->get_results();
+			$recommendations = $this->get_fallback_recommendations( $country_codes, $currency );
 
 			if ( ! $recommendations ) {
 				return new Response(
@@ -121,24 +117,44 @@ class BudgetRecommendationController extends BaseController implements Container
 				);
 			}
 
-			$returned_recommendations = array_map(
-				function ( $recommendation ) {
-					return [
-						'country'      => $recommendation['country'],
-						'daily_budget' => (int) $recommendation['daily_budget'],
-					];
-				},
-				$recommendations
-			);
-
 			return $this->prepare_item_for_response(
 				[
 					'currency'        => $currency,
-					'recommendations' => $returned_recommendations,
+					'recommendations' => $recommendations,
 				],
 				$request
 			);
 		};
+	}
+
+	/**
+	 * Returns fallback recommendationa from database table.
+	 *
+	 * @param array  $country_codes List of countries to include.
+	 * @param string $currency      Currency to use for recommendations.
+	 *
+	 * @return array|null Recommendation for each included country.
+	 */
+	protected function get_fallback_recommendations( array $country_codes, string $currency ): ?array {
+		$query           = $this->container->get( BudgetRecommendationQuery::class );
+		$recommendations = $query
+			->where( 'country', $country_codes, 'IN' )
+			->where( 'currency', $currency )
+			->get_results();
+
+		if ( ! $recommendations ) {
+			return null;
+		}
+
+		return array_map(
+			function ( $recommendation ) {
+				return [
+					'country'      => $recommendation['country'],
+					'daily_budget' => (int) $recommendation['daily_budget'],
+				];
+			},
+			$recommendations
+		);
 	}
 
 	/**

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -113,7 +113,7 @@ class BudgetRecommendationController extends BaseController implements Container
 			// Fetch fallback recommendations from the database.
 			$fallback_recommendations = $this->get_fallback_recommendations( $country_codes, $currency );
 			if ( $fallback_recommendations ) {
-				$recommendations = array_merge( $recommendations, $fallback_recommendations );
+				$recommendations = array_merge( $recommendations ?: [], $fallback_recommendations );
 			}
 
 			if ( ! $recommendations ) {

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -110,14 +110,14 @@ class BudgetRecommendationController extends BaseController implements Container
 			$budget_recommendations = $this->container->get( BudgetRecommendations::class );
 			$recommendations        = $budget_recommendations->get_recommendations( $country_codes );
 
-			// Fetch fallback recommendations from the database.
-			$fallback_recommendations = $this->get_fallback_recommendations( $country_codes, $currency );
-			if ( $fallback_recommendations ) {
-				$fallback_budget = $fallback_recommendations[0]['daily_budget'] ?? 0;
+			// Fetch fallback recommendation from the database.
+			$fallback_recommendation = $this->get_fallback_recommendation( $country_codes, $currency );
+			if ( $fallback_recommendation ) {
+				$fallback_budget = $fallback_recommendation[0]['daily_budget'] ?? 0;
 
 				// Swap recommended if not set or if fallback is higher.
 				if ( empty( $recommendations[0] ) || ( ! empty( $recommendations[0]['daily_budget'] ) && $recommendations[0]['daily_budget'] < $fallback_budget ) ) {
-					$recommendations[0] = $fallback_recommendations[0];
+					$recommendations[0] = $fallback_recommendation[0];
 
 					// Remove high recommendation if fallback is higher.
 					if ( ! empty( $recommendations[1]['daily_budget'] ) && $recommendations[1]['daily_budget'] < $fallback_budget ) {
@@ -153,14 +153,14 @@ class BudgetRecommendationController extends BaseController implements Container
 	}
 
 	/**
-	 * Returns fallback recommendationa from database table.
+	 * Returns a fallback recommendation from the database for the primary country (first in the list).
 	 *
 	 * @param array  $country_codes List of countries to include.
 	 * @param string $currency      Currency to use for recommendations.
 	 *
-	 * @return array|null Recommendation for each included country.
+	 * @return array|null Recommendation for the primary country.
 	 */
-	protected function get_fallback_recommendations( array $country_codes, string $currency ): ?array {
+	protected function get_fallback_recommendation( array $country_codes, string $currency ): ?array {
 		$query           = $this->container->get( BudgetRecommendationQuery::class );
 		$primary_country = reset( $country_codes );
 		$recommendations = $query

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -193,6 +193,10 @@ class BudgetRecommendationController extends BaseController implements Container
 							'type'        => 'number',
 							'description' => __( 'The recommended daily budget for a country.', 'google-listings-and-ads' ),
 						],
+						'level'        => [
+							'type'        => 'string',
+							'description' => __( 'Label for the recommendation level: High, Recommended, Low', 'google-listings-and-ads' ),
+						],
 						'metrics'      => [
 							'type'       => 'object',
 							'properties' => [

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -8,6 +8,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseControl
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\CountryCodeTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ISO3166AwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use WP_REST_Request as Request;
@@ -18,16 +20,15 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class BudgetRecommendationController
  *
+ * ContainerAware used for:
+ * - BudgetRecommendationQuery
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads
  */
-class BudgetRecommendationController extends BaseController implements ISO3166AwareInterface {
+class BudgetRecommendationController extends BaseController implements ContainerAwareInterface, ISO3166AwareInterface {
 
+	use ContainerAwareTrait;
 	use CountryCodeTrait;
-
-	/**
-	 * @var BudgetRecommendationQuery
-	 */
-	protected $budget_recommendation_query;
 
 	/**
 	 * @var Ads
@@ -37,14 +38,12 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 	/**
 	 * BudgetRecommendationController constructor.
 	 *
-	 * @param RESTServer                $rest_server
-	 * @param BudgetRecommendationQuery $budget_recommendation_query
-	 * @param Ads                       $ads
+	 * @param RESTServer $rest_server
+	 * @param Ads        $ads
 	 */
-	public function __construct( RESTServer $rest_server, BudgetRecommendationQuery $budget_recommendation_query, Ads $ads ) {
+	public function __construct( RESTServer $rest_server, Ads $ads ) {
 		parent::__construct( $rest_server );
-		$this->budget_recommendation_query = $budget_recommendation_query;
-		$this->ads                         = $ads;
+		$this->ads = $ads;
 	}
 
 	/**
@@ -105,8 +104,8 @@ class BudgetRecommendationController extends BaseController implements ISO3166Aw
 				);
 			}
 
-			$recommendations = $this
-				->budget_recommendation_query
+			$query           = $this->container->get( BudgetRecommendationQuery::class );
+			$recommendations = $query
 				->where( 'country', $country_codes, 'IN' )
 				->where( 'currency', $currency )
 				->get_results();

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -110,9 +110,10 @@ class BudgetRecommendationController extends BaseController implements Container
 			$budget_recommendations = $this->container->get( BudgetRecommendations::class );
 			$recommendations        = $budget_recommendations->get_recommendations( $country_codes );
 
-			// Fetch fallback recommendations if none returned by the Google Ads API.
-			if ( ! $recommendations ) {
-				$recommendations = $this->get_fallback_recommendations( $country_codes, $currency );
+			// Fetch fallback recommendations from the database.
+			$fallback_recommendations = $this->get_fallback_recommendations( $country_codes, $currency );
+			if ( $fallback_recommendations ) {
+				$recommendations = array_merge( $recommendations, $fallback_recommendations );
 			}
 
 			if ( ! $recommendations ) {
@@ -146,8 +147,9 @@ class BudgetRecommendationController extends BaseController implements Container
 	 */
 	protected function get_fallback_recommendations( array $country_codes, string $currency ): ?array {
 		$query           = $this->container->get( BudgetRecommendationQuery::class );
+		$primary_country = reset( $country_codes );
 		$recommendations = $query
-			->where( 'country', $country_codes, 'IN' )
+			->where( 'country', $primary_country )
 			->where( 'currency', $currency )
 			->get_results();
 
@@ -158,8 +160,9 @@ class BudgetRecommendationController extends BaseController implements Container
 		return array_map(
 			function ( $recommendation ) {
 				return [
-					'country'      => $recommendation['country'],
 					'daily_budget' => (int) $recommendation['daily_budget'],
+					'country'      => $recommendation['country'],
+					'level'        => __( 'Fallback', 'google-listings-and-ads' ),
 				];
 			},
 			$recommendations

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -113,7 +113,22 @@ class BudgetRecommendationController extends BaseController implements Container
 			// Fetch fallback recommendations from the database.
 			$fallback_recommendations = $this->get_fallback_recommendations( $country_codes, $currency );
 			if ( $fallback_recommendations ) {
-				$recommendations = array_merge( $recommendations ?: [], $fallback_recommendations );
+				$fallback_budget = $fallback_recommendations[0]['daily_budget'] ?? 0;
+
+				// Swap recommended if fallback is higher.
+				if ( ! empty( $recommendations[0]['daily_budget'] ) && $recommendations[0]['daily_budget'] < $fallback_budget ) {
+					$recommendations[0] = $fallback_recommendations[0];
+
+					// Remove high recommendation if fallback is higher.
+					if ( ! empty( $recommendations[1]['daily_budget'] ) && $recommendations[1]['daily_budget'] < $fallback_budget ) {
+						unset( $recommendations[1] );
+					}
+
+					// Remove low recommendation if fallback is higher.
+					if ( ! empty( $recommendations[2]['daily_budget'] ) && $recommendations[2]['daily_budget'] < $fallback_budget ) {
+						unset( $recommendations[2] );
+					}
+				}
 			}
 
 			if ( ! $recommendations ) {
@@ -162,7 +177,7 @@ class BudgetRecommendationController extends BaseController implements Container
 				return [
 					'daily_budget' => (int) $recommendation['daily_budget'],
 					'country'      => $recommendation['country'],
-					'level'        => __( 'Fallback', 'google-listings-and-ads' ),
+					'level'        => __( 'Recommended', 'google-listings-and-ads' ),
 				];
 			},
 			$recommendations

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\CountryCodeTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
@@ -21,6 +22,7 @@ defined( 'ABSPATH' ) || exit;
  * Class BudgetRecommendationController
  *
  * ContainerAware used for:
+ * - BudgetRecommendations
  * - BudgetRecommendationQuery
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads
@@ -104,7 +106,14 @@ class BudgetRecommendationController extends BaseController implements Container
 				);
 			}
 
-			$recommendations = $this->get_fallback_recommendations( $country_codes, $currency );
+			// Try to fetch recommendations from the Google Ads API.
+			$budget_recommendations = $this->container->get( BudgetRecommendations::class );
+			$recommendations        = $budget_recommendations->get_recommendations( $country_codes );
+
+			// Fetch fallback recommendations if none returned by the Google Ads API.
+			if ( ! $recommendations ) {
+				$recommendations = $this->get_fallback_recommendations( $country_codes, $currency );
+			}
 
 			if ( ! $recommendations ) {
 				return new Response(
@@ -183,6 +192,26 @@ class BudgetRecommendationController extends BaseController implements Container
 						'daily_budget' => [
 							'type'        => 'number',
 							'description' => __( 'The recommended daily budget for a country.', 'google-listings-and-ads' ),
+						],
+						'metrics'      => [
+							'type'       => 'object',
+							'properties' => [
+								'cost'              => [
+									'type'        => 'number',
+									'description' => __( 'Estimated average amount you will spend weekly during the month.', 'google-listings-and-ads' ),
+									'context'     => [ 'view' ],
+								],
+								'conversions'       => [
+									'type'        => 'number',
+									'description' => __( 'Estimated number of conversions (unit sales) for a typical week.', 'google-listings-and-ads' ),
+									'context'     => [ 'view' ],
+								],
+								'conversions_value' => [
+									'type'        => 'number',
+									'description' => __( 'Estimated total value of all the conversions (sales volume) your campaign will generate in a week.', 'google-listings-and-ads' ),
+									'context'     => [ 'view' ],
+								],
+							],
 						],
 					],
 				],

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -175,7 +175,7 @@ class BudgetRecommendationController extends BaseController implements Container
 		return array_map(
 			function ( $recommendation ) {
 				return [
-					'daily_budget' => (int) $recommendation['daily_budget'],
+					'daily_budget' => (float) $recommendation['daily_budget'],
 					'country'      => $recommendation['country'],
 					'level'        => __( 'Recommended', 'google-listings-and-ads' ),
 				];

--- a/src/Google/Ads/ServiceClientFactoryTrait.php
+++ b/src/Google/Ads/ServiceClientFactoryTrait.php
@@ -31,6 +31,7 @@ use Google\Ads\GoogleAds\V18\Services\Client\CustomerUserAccessServiceClient;
 use Google\Ads\GoogleAds\V18\Services\Client\GeoTargetConstantServiceClient;
 use Google\Ads\GoogleAds\V18\Services\Client\GoogleAdsServiceClient;
 use Google\Ads\GoogleAds\V18\Services\Client\ProductLinkInvitationServiceClient;
+use Google\Ads\GoogleAds\V18\Services\Client\RecommendationServiceClient;
 
 /**
  * Contains service client factory methods.
@@ -200,5 +201,12 @@ trait ServiceClientFactoryTrait {
 	 */
 	public function getProductLinkInvitationServiceClient(): ProductLinkInvitationServiceClient {
 		return new ProductLinkInvitationServiceClient( $this->getGoogleAdsClientOptions() );
+	}
+
+	/**
+	 * @return RecommendationServiceClient
+	 */
+	public function getRecommendationServiceClient(): RecommendationServiceClient {
+		return new RecommendationServiceClient( $this->getGoogleAdsClientOptions() );
 	}
 }

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -76,6 +76,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\Options;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\Transients;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMapping\AttributeMappingHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
@@ -199,7 +200,6 @@ class CoreServiceProvider extends AbstractServiceProvider {
 
 		// Share our interfaces, possibly with concrete objects.
 		$this->share_concrete( AssetsHandlerInterface::class, AssetsHandler::class );
-		$this->share_concrete( TransientsInterface::class, Transients::class );
 		$this->share_concrete(
 			TracksInterface::class,
 			$this->share_with_tags( Tracks::class, TracksProxy::class )
@@ -210,6 +210,12 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()
 			->inflector( OptionsAwareInterface::class )
 			->invokeMethod( 'set_options_object', [ OptionsInterface::class ] );
+
+		// Set up Transients, and inflect classes that need transients.
+		$this->share_concrete( TransientsInterface::class, Transients::class );
+		$this->getContainer()
+			->inflector( TransientsAwareInterface::class )
+			->invokeMethod( 'set_transients_object', [ TransientsInterface::class ] );
 
 		// Share helper classes, and inflect classes that need it.
 		$this->share_with_tags( GoogleHelper::class, WC::class );

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsConversionAction;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsReport;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroupAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAsset;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
@@ -84,6 +85,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		AdsReport::class              => true,
 		AdsAssetGroupAsset::class     => true,
 		AdsAsset::class               => true,
+		BudgetRecommendations::class  => true,
 		'connect_server_root'         => true,
 		Connection::class             => true,
 		GoogleProductService::class   => true,
@@ -117,6 +119,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( AdsCampaignLabel::class, GoogleAdsClient::class );
 		$this->share( AdsConversionAction::class, GoogleAdsClient::class );
 		$this->share( AdsReport::class, GoogleAdsClient::class );
+		$this->share( BudgetRecommendations::class, GoogleAdsClient::class );
 
 		$this->share( Merchant::class, ShoppingContent::class );
 		$this->share( MerchantMetrics::class, ShoppingContent::class, GoogleAdsClient::class, WP::class, TransientsInterface::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -15,7 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroup;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AccountController as AdsAccountController;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\BudgetRecommendationController as AdsBudgetRecommendationController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\BudgetRecommendationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\CampaignController as AdsCampaignController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\ReportsController as AdsReportsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\SetupCompleteController;
@@ -55,7 +55,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestAPI\Aut
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\OAuthService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
-use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\RequestReviewStatuses;
@@ -111,6 +110,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( AdsCampaignController::class, AdsCampaign::class );
 		$this->share( AdsAssetGroupController::class, AdsAssetGroup::class );
 		$this->share( AdsReportsController::class );
+		$this->share( BudgetRecommendationController::class, Ads::class );
 		$this->share( GoogleAccountController::class, Connection::class );
 		$this->share( JetpackAccountController::class, Manager::class, Middleware::class );
 		$this->share( MerchantCenterProductStatsController::class, MerchantStatuses::class, ProductSyncStats::class );
@@ -118,7 +118,6 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( MerchantCenterProductFeedController::class, ProductFeedQueryHelper::class );
 		$this->share( MerchantCenterProductVisibilityController::class, ProductHelper::class, MerchantIssueQuery::class );
 		$this->share( MerchantCenterContactInformationController::class, ContactInformation::class, Settings::class, AddressUtility::class );
-		$this->share( AdsBudgetRecommendationController::class, BudgetRecommendationQuery::class, Ads::class );
 		$this->share( PhoneVerificationController::class, PhoneVerification::class );
 		$this->share( MerchantCenterAccountController::class, MerchantAccountService::class );
 		$this->share( MerchantCenterRequestReviewController::class, Middleware::class, Merchant::class, RequestReviewStatuses::class, TransientsInterface::class );

--- a/src/Options/TransientsAwareInterface.php
+++ b/src/Options/TransientsAwareInterface.php
@@ -1,0 +1,23 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface TransientsAwareInterface
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Options
+ */
+interface TransientsAwareInterface {
+
+	/**
+	 * Set the Transients object.
+	 *
+	 * @param TransientsInterface $transients
+	 *
+	 * @return void
+	 */
+	public function set_transients_object( TransientsInterface $transients ): void;
+}

--- a/src/Options/TransientsAwareTrait.php
+++ b/src/Options/TransientsAwareTrait.php
@@ -1,0 +1,30 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Trait TransientsAwareTrait
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Options
+ */
+trait TransientsAwareTrait {
+
+	/**
+	 * The Transients object.
+	 *
+	 * @var TransientsInterface
+	 */
+	protected $transients;
+
+	/**
+	 * Set the Transients object.
+	 *
+	 * @param TransientsInterface $transients
+	 */
+	public function set_transients_object( TransientsInterface $transients ): void {
+		$this->transients = $transients;
+	}
+}

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
 interface TransientsInterface {
 
 	public const ADS_CAMPAIGN_COUNT   = 'ads_campaign_count';
+	public const ADS_LOCATION_IDS     = 'ads_location_ids';
 	public const ADS_METRICS          = 'ads_metrics';
 	public const FREE_LISTING_METRICS = 'free_listing_metrics';
 	public const MC_ACCOUNT_REVIEW    = 'mc_account_review';
@@ -21,6 +22,7 @@ interface TransientsInterface {
 
 	public const VALID_OPTIONS = [
 		self::ADS_CAMPAIGN_COUNT   => true,
+		self::ADS_LOCATION_IDS     => true,
 		self::ADS_METRICS          => true,
 		self::FREE_LISTING_METRICS => true,
 		self::MC_ACCOUNT_REVIEW    => true,

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -13,6 +13,7 @@ interface TransientsInterface {
 	public const ADS_CAMPAIGN_COUNT   = 'ads_campaign_count';
 	public const ADS_LOCATION_IDS     = 'ads_location_ids';
 	public const ADS_METRICS          = 'ads_metrics';
+	public const ADS_RECOMMENDATIONS  = 'ads_recommendations';
 	public const FREE_LISTING_METRICS = 'free_listing_metrics';
 	public const MC_ACCOUNT_REVIEW    = 'mc_account_review';
 	public const MC_IS_SUBACCOUNT     = 'mc_is_subaccount';
@@ -24,6 +25,7 @@ interface TransientsInterface {
 		self::ADS_CAMPAIGN_COUNT   => true,
 		self::ADS_LOCATION_IDS     => true,
 		self::ADS_METRICS          => true,
+		self::ADS_RECOMMENDATIONS  => true,
 		self::FREE_LISTING_METRICS => true,
 		self::MC_ACCOUNT_REVIEW    => true,
 		self::MC_IS_SUBACCOUNT     => true,

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -1083,10 +1083,15 @@ trait GoogleAdsClientTrait {
 	 * Generates a list of mocked recommendations.
 	 *
 	 * @param array $mocked_list
+	 * @param mixed $return_other_recommendation_type
 	 */
-	protected function generate_recommendations_mock( array $mocked_list ) {
+	protected function generate_recommendations_mock( array $mocked_list, $return_other_recommendation_type = false ) {
 		if ( empty( $mocked_list ) ) {
 			$recommendation_list = [];
+		} elseif ( $return_other_recommendation_type ) {
+			$recommendation = $this->createMock( Recommendation::class );
+			$recommendation->method( 'getCampaignBudgetRecommendation' )->willReturn( null );
+			$recommendation_list = [ $recommendation ];
 		} else {
 			$budget_options = [];
 			foreach ( $mocked_list as $mock ) {

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -41,9 +41,11 @@ use Google\Ads\GoogleAds\V18\Resources\CustomerUserAccess;
 use Google\Ads\GoogleAds\V18\Resources\ShoppingPerformanceView;
 use Google\Ads\GoogleAds\V18\Services\Client\ConversionActionServiceClient;
 use Google\Ads\GoogleAds\V18\Services\Client\CustomerServiceClient;
-use Google\Ads\GoogleAds\V18\Services\Client\ProductLinkInvitationServiceClient;
-use Google\Ads\GoogleAds\V18\Services\GoogleAdsRow;
 use Google\Ads\GoogleAds\V18\Services\Client\GoogleAdsServiceClient;
+use Google\Ads\GoogleAds\V18\Services\Client\ProductLinkInvitationServiceClient;
+use Google\Ads\GoogleAds\V18\Services\Client\RecommendationServiceClient;
+use Google\Ads\GoogleAds\V18\Services\GenerateRecommendationsResponse;
+use Google\Ads\GoogleAds\V18\Services\GoogleAdsRow;
 use Google\Ads\GoogleAds\V18\Services\ListAccessibleCustomersResponse;
 use Google\Ads\GoogleAds\V18\Services\MutateCampaignResult;
 use Google\Ads\GoogleAds\V18\Services\MutateLabelResult;
@@ -79,6 +81,9 @@ trait GoogleAdsClientTrait {
 	/** @var MockObject|GoogleAdsClient $client */
 	protected $client;
 
+	/** @var MockObject|RecommendationServiceClient $recommendation_service */
+	protected $recommendation_service;
+
 	/** @var MockObject|GoogleAdsServiceClient $service_client */
 	protected $service_client;
 
@@ -100,6 +105,9 @@ trait GoogleAdsClientTrait {
 
 		$this->conversion_action_service = $this->createMock( ConversionActionServiceClient::class );
 		$this->client->method( 'getConversionActionServiceClient' )->willReturn( $this->conversion_action_service );
+
+		$this->recommendation_service = $this->createMock( RecommendationServiceClient::class );
+		$this->client->method( 'getRecommendationServiceClient' )->willReturn( $this->recommendation_service );
 	}
 
 	/**
@@ -1063,5 +1071,26 @@ trait GoogleAdsClientTrait {
 		}
 
 		return $asset_group_asset_operations;
+	}
+
+	/**
+	 * Generates a list of mocked recommendations.
+	 *
+	 * @param array $mocked_list
+	 */
+	protected function generate_recommendations_mock( array $mocked_list ) {
+		$recommendations = $this->createMock( GenerateRecommendationsResponse::class );
+		$recommendations->method( 'getRecommendations' )->willReturn( $mocked_list );
+
+		$this->recommendation_service->method( 'generateRecommendations' )->willReturn( $recommendations );
+	}
+
+	/**
+	 * Generates a mocked exception when recommendations are requested.
+	 *
+	 * @param ApiException $exception
+	 */
+	protected function generate_recommendations_mock_exception( ApiException $exception ) {
+		$this->recommendation_service->method( 'generateRecommendations' )->willThrowException( $exception );
 	}
 }

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -38,6 +38,7 @@ use Google\Ads\GoogleAds\V18\Resources\Campaign\ShoppingSetting;
 use Google\Ads\GoogleAds\V18\Resources\ConversionAction;
 use Google\Ads\GoogleAds\V18\Resources\Customer;
 use Google\Ads\GoogleAds\V18\Resources\CustomerUserAccess;
+use Google\Ads\GoogleAds\V18\Resources\GeoTargetConstant;
 use Google\Ads\GoogleAds\V18\Resources\ShoppingPerformanceView;
 use Google\Ads\GoogleAds\V18\Services\Client\ConversionActionServiceClient;
 use Google\Ads\GoogleAds\V18\Services\Client\CustomerServiceClient;
@@ -62,7 +63,6 @@ use Google\Ads\GoogleAds\V18\Services\SearchGoogleAdsResponse;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\Page;
 use Google\ApiCore\PagedListResponse;
-
 /**
  * Trait GoogleAdsClient
  *
@@ -1092,5 +1092,22 @@ trait GoogleAdsClientTrait {
 	 */
 	protected function generate_recommendations_mock_exception( ApiException $exception ) {
 		$this->recommendation_service->method( 'generateRecommendations' )->willThrowException( $exception );
+	}
+
+	/**
+	 * Generates a mocked response for location IDs.
+	 *
+	 * @param array $locations List of locations.
+	 */
+	protected function generate_location_ids_mock( array $locations ) {
+		foreach ( $locations as $id => $location ) {
+			$geo_target = $this->createMock( GeoTargetConstant::class );
+			$geo_target->method( 'getId' )->willReturn( $id );
+			$geo_target->method( 'getCountryCode' )->willReturn( $location );
+
+			$locations[ $id ] = ( new GoogleAdsRow() )->setGeoTargetConstant( $geo_target );
+		}
+
+		$this->generate_ads_query_mock( array_values( $locations ) );
 	}
 }

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -1107,7 +1107,7 @@ trait GoogleAdsClientTrait {
 
 			$budget_recommendation = $this->createMock( CampaignBudgetRecommendation::class );
 			$budget_recommendation->method( 'getBudgetOptions' )->willReturn( $budget_options );
-			$budget_recommendation->method( 'getRecommendedBudgetAmountMicros' )->willReturn( $mocked_list[0]['daily_budget'] );
+			$budget_recommendation->method( 'getRecommendedBudgetAmountMicros' )->willReturn( $this->to_micro( $mocked_list[0]['daily_budget'] ) );
 
 			$recommendation = $this->createMock( Recommendation::class );
 			$recommendation->method( 'getCampaignBudgetRecommendation' )->willReturn( $budget_recommendation );

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -39,6 +39,11 @@ use Google\Ads\GoogleAds\V18\Resources\ConversionAction;
 use Google\Ads\GoogleAds\V18\Resources\Customer;
 use Google\Ads\GoogleAds\V18\Resources\CustomerUserAccess;
 use Google\Ads\GoogleAds\V18\Resources\GeoTargetConstant;
+use Google\Ads\GoogleAds\V18\Resources\Recommendation;
+use Google\Ads\GoogleAds\V18\Resources\Recommendation\CampaignBudgetRecommendation;
+use Google\Ads\GoogleAds\V18\Resources\Recommendation\CampaignBudgetRecommendation\CampaignBudgetRecommendationOption;
+use Google\Ads\GoogleAds\V18\Resources\Recommendation\RecommendationImpact;
+use Google\Ads\GoogleAds\V18\Resources\Recommendation\RecommendationMetrics;
 use Google\Ads\GoogleAds\V18\Resources\ShoppingPerformanceView;
 use Google\Ads\GoogleAds\V18\Services\Client\ConversionActionServiceClient;
 use Google\Ads\GoogleAds\V18\Services\Client\CustomerServiceClient;
@@ -63,6 +68,7 @@ use Google\Ads\GoogleAds\V18\Services\SearchGoogleAdsResponse;
 use Google\ApiCore\ApiException;
 use Google\ApiCore\Page;
 use Google\ApiCore\PagedListResponse;
+
 /**
  * Trait GoogleAdsClient
  *
@@ -1079,8 +1085,37 @@ trait GoogleAdsClientTrait {
 	 * @param array $mocked_list
 	 */
 	protected function generate_recommendations_mock( array $mocked_list ) {
+		if ( empty( $mocked_list ) ) {
+			$recommendation_list = [];
+		} else {
+			$budget_options = [];
+			foreach ( $mocked_list as $mock ) {
+				$metrics = $this->createMock( RecommendationMetrics::class );
+				$metrics->method( 'getCostMicros' )->willReturn( $this->to_micro( $mock['metrics']['cost'] ) );
+				$metrics->method( 'getConversions' )->willReturn( $mock['metrics']['conversions'] );
+				$metrics->method( 'getConversionsValue' )->willReturn( $mock['metrics']['conversions_value'] );
+
+				$impact = $this->createMock( RecommendationImpact::class );
+				$impact->method( 'getPotentialMetrics' )->willReturn( $metrics );
+
+				$budget_option = $this->createMock( CampaignBudgetRecommendationOption::class );
+				$budget_option->method( 'getBudgetAmountMicros' )->willReturn( $this->to_micro( $mock['daily_budget'] ) );
+				$budget_option->method( 'getImpact' )->willReturn( $impact );
+
+				$budget_options[] = $budget_option;
+			}
+
+			$budget_recommendation = $this->createMock( CampaignBudgetRecommendation::class );
+			$budget_recommendation->method( 'getBudgetOptions' )->willReturn( $budget_options );
+			$budget_recommendation->method( 'getRecommendedBudgetAmountMicros' )->willReturn( $mocked_list[0]['daily_budget'] );
+
+			$recommendation = $this->createMock( Recommendation::class );
+			$recommendation->method( 'getCampaignBudgetRecommendation' )->willReturn( $budget_recommendation );
+			$recommendation_list = [ $recommendation ];
+		}
+
 		$recommendations = $this->createMock( GenerateRecommendationsResponse::class );
-		$recommendations->method( 'getRecommendations' )->willReturn( $mocked_list );
+		$recommendations->method( 'getRecommendations' )->willReturn( $recommendation_list );
 
 		$this->recommendation_service->method( 'generateRecommendations' )->willReturn( $recommendations );
 	}

--- a/tests/Unit/API/Google/BudgetRecommendationsTest.php
+++ b/tests/Unit/API/Google/BudgetRecommendationsTest.php
@@ -119,6 +119,34 @@ class BudgetRecommendationsTest extends UnitTest {
 		$this->assertEquals( 1, did_action( 'woocommerce_gla_ads_client_exception' ) );
 	}
 
+	public function test_get_recommendations_location_id_exception() {
+		$this->generate_ads_query_mock_exception(
+			new ApiException( 'failed location IDs', 8 )
+		);
+		$this->generate_recommendations_mock( [] );
+
+		$this->assertNull( $this->recommendations->get_recommendations( [ 'US' ] ) );
+		$this->assertEquals( 1, did_action( 'woocommerce_gla_ads_client_exception' ) );
+	}
+
+	public function test_get_recommendations_with_zeros() {
+		$recommendations = [
+			[
+				'daily_budget' => 0,
+				'metrics'      => [
+					'cost'              => 0,
+					'conversions'       => 0,
+					'conversions_value' => 0,
+				],
+			],
+		];
+
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
+		$this->generate_recommendations_mock( $recommendations );
+
+		$this->assertNull( $this->recommendations->get_recommendations( [ 'US' ] ) );
+	}
+
 	public function test_get_recommendations() {
 		$recommendations = [
 			self::TEST_RECOMMENDATION,

--- a/tests/Unit/API/Google/BudgetRecommendationsTest.php
+++ b/tests/Unit/API/Google/BudgetRecommendationsTest.php
@@ -31,7 +31,17 @@ class BudgetRecommendationsTest extends UnitTest {
 	/** @var BudgetRecommendations $recommendations */
 	protected $recommendations;
 
-	protected const TEST_ADS_ID = 1234567890;
+	protected const TEST_ADS_ID         = 1234567890;
+	protected const TEST_RECOMMENDATION = [
+		'daily_budget' => 12,
+		'metrics'      => [
+			'cost'              => 84,
+			'conversions'       => 6.1,
+			'conversions_value' => 243.88,
+		],
+		'country'      => 'US',
+		'level'        => 'Recommended',
+	];
 
 	/**
 	 * Runs before each test is executed.
@@ -47,6 +57,46 @@ class BudgetRecommendationsTest extends UnitTest {
 		$this->recommendations = new BudgetRecommendations( $this->client );
 		$this->recommendations->set_options_object( $this->options );
 		$this->recommendations->set_transients_object( $this->transients );
+	}
+
+	public function test_get_recommendations_cached() {
+		$recommendations = [
+			'us' => self::TEST_RECOMMENDATION,
+		];
+
+		$this->transients->expects( $this->once() )
+			->method( 'get' )
+			->with( TransientsInterface::ADS_RECOMMENDATIONS )
+			->willReturn( $recommendations );
+
+		$this->assertEquals( $recommendations['us'], $this->recommendations->get_recommendations( [ 'US' ] ) );
+	}
+
+	public function test_get_recommendations_cached_locations() {
+		$recommendations = [ self::TEST_RECOMMENDATION ];
+
+		$invoked_count = $this->exactly( 2 );
+		$this->transients->expects( $invoked_count )
+			->method( 'get' )
+			->willReturnCallback(
+				function ( string $transient ) use ( $invoked_count ) {
+					if ( 1 === $invoked_count->getInvocationCount() && $transient === TransientsInterface::ADS_RECOMMENDATIONS ) {
+						return false;
+					}
+
+					if ( 2 === $invoked_count->getInvocationCount() && $transient === TransientsInterface::ADS_LOCATION_IDS ) {
+						return [
+							'us' => [
+								111 => 'US',
+							],
+						];
+					}
+				}
+			);
+
+		$this->generate_recommendations_mock( $recommendations );
+
+		$this->assertEquals( $recommendations, $this->recommendations->get_recommendations( [ 'US' ] ) );
 	}
 
 	public function test_get_recommendations_empty_set() {

--- a/tests/Unit/API/Google/BudgetRecommendationsTest.php
+++ b/tests/Unit/API/Google/BudgetRecommendationsTest.php
@@ -108,6 +108,13 @@ class BudgetRecommendationsTest extends UnitTest {
 		$this->assertNull( $this->recommendations->get_recommendations( [ 'US' ] ) );
 	}
 
+	public function test_get_recommendations_with_other_recommendation_type() {
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
+
+		$this->generate_recommendations_mock( [ self::TEST_RECOMMENDATION ], true );
+		$this->assertNull( $this->recommendations->get_recommendations( [ 'US' ] ) );
+	}
+
 	public function test_get_recommendations_exception() {
 		$this->generate_location_ids_mock( [ 111 => 'US' ] );
 

--- a/tests/Unit/API/Google/BudgetRecommendationsTest.php
+++ b/tests/Unit/API/Google/BudgetRecommendationsTest.php
@@ -57,6 +57,8 @@ class BudgetRecommendationsTest extends UnitTest {
 		$this->recommendations = new BudgetRecommendations( $this->client );
 		$this->recommendations->set_options_object( $this->options );
 		$this->recommendations->set_transients_object( $this->transients );
+
+		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
 	}
 
 	public function test_get_recommendations_cached() {
@@ -102,8 +104,6 @@ class BudgetRecommendationsTest extends UnitTest {
 	public function test_get_recommendations_empty_set() {
 		$this->generate_location_ids_mock( [ 111 => 'US' ] );
 
-		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
-
 		$this->generate_recommendations_mock( [] );
 		$this->assertNull( $this->recommendations->get_recommendations( [ 'US' ] ) );
 	}
@@ -111,13 +111,42 @@ class BudgetRecommendationsTest extends UnitTest {
 	public function test_get_recommendations_exception() {
 		$this->generate_location_ids_mock( [ 111 => 'US' ] );
 
-		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
-
 		$this->generate_recommendations_mock_exception(
 			new ApiException( 'failed', 7 )
 		);
 
 		$this->assertNull( $this->recommendations->get_recommendations( [ 'US' ] ) );
 		$this->assertEquals( 1, did_action( 'woocommerce_gla_ads_client_exception' ) );
+	}
+
+	public function test_get_recommendations() {
+		$recommendations = [
+			self::TEST_RECOMMENDATION,
+			[
+				'daily_budget' => 14.4,
+				'metrics'      => [
+					'cost'              => 100.8,
+					'conversions'       => 6.5,
+					'conversions_value' => 258.72,
+				],
+				'country'      => 'US',
+				'level'        => 'High',
+			],
+			[
+				'daily_budget' => 9.6,
+				'metrics'      => [
+					'cost'              => 67.2,
+					'conversions'       => 5.7,
+					'conversions_value' => 226.13,
+				],
+				'country'      => 'US',
+				'level'        => 'Low',
+			],
+		];
+
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
+		$this->generate_recommendations_mock( $recommendations );
+
+		$this->assertEquals( $recommendations, $this->recommendations->get_recommendations( [ 'US' ] ) );
 	}
 }

--- a/tests/Unit/API/Google/BudgetRecommendationsTest.php
+++ b/tests/Unit/API/Google/BudgetRecommendationsTest.php
@@ -1,0 +1,79 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
+use Google\ApiCore\ApiException;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class BudgetRecommendationsTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ */
+class BudgetRecommendationsTest extends UnitTest {
+
+	use GoogleAdsClientTrait;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var MockObject|TransientsInterface $transients */
+	protected $transients;
+
+	/** @var BudgetRecommendations $recommendations */
+	protected $recommendations;
+
+	protected const TEST_ADS_ID = 1234567890;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->ads_client_setup();
+
+		$this->options    = $this->createMock( OptionsInterface::class );
+		$this->transients = $this->createMock( TransientsInterface::class );
+
+		$this->recommendations = new BudgetRecommendations( $this->client );
+		$this->recommendations->set_options_object( $this->options );
+		$this->recommendations->set_transients_object( $this->transients );
+	}
+
+	public function test_get_recommendations_empty_set() {
+		$this->transients->expects( $this->once() )
+			->method( 'get' )
+			->with( TransientsInterface::ADS_LOCATION_IDS )
+			->willReturn( [ 'us' => [ 111 => 'US' ] ] );
+
+		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
+
+		$this->generate_recommendations_mock( [] );
+		$this->assertNull( $this->recommendations->get_recommendations( [ 'US' ] ) );
+	}
+
+	public function test_get_recommendations_exception() {
+		$this->transients->expects( $this->once() )
+			->method( 'get' )
+			->with( TransientsInterface::ADS_LOCATION_IDS )
+			->willReturn( [ 'us' => [ 111 => 'US' ] ] );
+
+		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
+
+		$this->generate_recommendations_mock_exception(
+			new ApiException( 'failed', 7 )
+		);
+
+		$this->assertNull( $this->recommendations->get_recommendations( [ 'US' ] ) );
+		$this->assertEquals( 1, did_action( 'woocommerce_gla_ads_client_exception' ) );
+	}
+}

--- a/tests/Unit/API/Google/BudgetRecommendationsTest.php
+++ b/tests/Unit/API/Google/BudgetRecommendationsTest.php
@@ -50,10 +50,7 @@ class BudgetRecommendationsTest extends UnitTest {
 	}
 
 	public function test_get_recommendations_empty_set() {
-		$this->transients->expects( $this->once() )
-			->method( 'get' )
-			->with( TransientsInterface::ADS_LOCATION_IDS )
-			->willReturn( [ 'us' => [ 111 => 'US' ] ] );
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
 
 		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
 
@@ -62,10 +59,7 @@ class BudgetRecommendationsTest extends UnitTest {
 	}
 
 	public function test_get_recommendations_exception() {
-		$this->transients->expects( $this->once() )
-			->method( 'get' )
-			->with( TransientsInterface::ADS_LOCATION_IDS )
-			->willReturn( [ 'us' => [ 111 => 'US' ] ] );
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
 
 		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
 

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -62,25 +62,13 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 
 	public function test_get_budget_recommendation() {
 		$budget_recommendation_params = [
-			'country_codes' => [ 'JP', 'TW', 'GB', 'US' ],
+			'country_codes' => [ 'TW', 'GB', 'US' ],
 		];
 
 		$budget_recommendation_data = [
 			[
-				'country'      => 'US',
-				'daily_budget' => '330',
-			],
-			[
-				'country'      => 'GB',
-				'daily_budget' => '245',
-			],
-			[
 				'country'      => 'TW',
-				'daily_budget' => '95',
-			],
-			[
-				'country'      => 'JP',
-				'daily_budget' => '110',
+				'daily_budget' => '330',
 			],
 		];
 
@@ -89,23 +77,8 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 			'recommendations' => [
 				[
 					'daily_budget' => 330,
-					'country'      => 'US',
-					'level'        => 'Fallback',
-				],
-				[
-					'daily_budget' => 245,
-					'country'      => 'GB',
-					'level'        => 'Fallback',
-				],
-				[
-					'daily_budget' => 95,
 					'country'      => 'TW',
-					'level'        => 'Fallback',
-				],
-				[
-					'daily_budget' => 110,
-					'country'      => 'JP',
-					'level'        => 'Fallback',
+					'level'        => 'Recommended',
 				],
 			],
 		];

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -38,6 +38,38 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 	protected $controller;
 
 	protected const ROUTE_BUDGET_RECOMMENDATION = '/wc/gla/ads/campaigns/budget-recommendation';
+	protected const RECOMMENDATION_DATA         = [
+		[
+			'daily_budget' => 12,
+			'metrics'      => [
+				'cost'              => 84,
+				'conversions'       => 6.1,
+				'conversions_value' => 243.88,
+			],
+			'country'      => 'GB',
+			'level'        => 'Recommended',
+		],
+		[
+			'daily_budget' => 14.4,
+			'metrics'      => [
+				'cost'              => 100.8,
+				'conversions'       => 6.5,
+				'conversions_value' => 258.72,
+			],
+			'country'      => 'GB',
+			'level'        => 'High',
+		],
+		[
+			'daily_budget' => 9.6,
+			'metrics'      => [
+				'cost'              => 67.2,
+				'conversions'       => 5.7,
+				'conversions_value' => 226.13,
+			],
+			'country'      => 'GB',
+			'level'        => 'Low',
+		],
+	];
 
 	public function setUp(): void {
 		parent::setUp();
@@ -76,7 +108,7 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 			'currency'        => 'TWD',
 			'recommendations' => [
 				[
-					'daily_budget' => 330,
+					'daily_budget' => 330.0,
 					'country'      => 'TW',
 					'level'        => 'Recommended',
 				],
@@ -90,6 +122,128 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		$this->budget_recommendation_query->expects( $this->once() )
 			->method( 'get_results' )
 			->willReturn( $budget_recommendation_data );
+
+		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
+
+		$this->assertSame( $expected_response_data, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_budget_recommendation_with_metrics() {
+		$budget_recommendation_params = [
+			'country_codes' => [ 'GB', 'US' ],
+		];
+
+		$expected_response_data = [
+			'currency'        => 'GBP',
+			'recommendations' => self::RECOMMENDATION_DATA,
+		];
+
+		$this->ads->expects( $this->once() )
+			->method( 'get_ads_currency' )
+			->willReturn( 'GBP' );
+
+		$this->budget_recommendations->expects( $this->once() )
+			->method( 'get_recommendations' )
+			->willReturn( self::RECOMMENDATION_DATA );
+
+		$this->budget_recommendation_query->expects( $this->once() )
+			->method( 'get_results' )
+			->willReturn( null );
+
+		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
+
+		$this->assertSame( $expected_response_data, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_budget_recommendation_with_fallback_higher() {
+		$budget_recommendation_params = [
+			'country_codes' => [ 'GB', 'US' ],
+		];
+
+		$fallback_data = [
+			[
+				'daily_budget' => '15',
+				'country'      => 'GB',
+				'level'        => 'Recommended',
+			],
+		];
+
+		$expected_response_data = [
+			'currency'        => 'GBP',
+			'recommendations' => [
+				[
+					'daily_budget' => 15.0,
+					'country'      => 'GB',
+					'level'        => 'Recommended',
+				],
+			],
+		];
+
+		$this->ads->expects( $this->once() )
+			->method( 'get_ads_currency' )
+			->willReturn( 'GBP' );
+
+		$this->budget_recommendations->expects( $this->once() )
+			->method( 'get_recommendations' )
+			->willReturn( self::RECOMMENDATION_DATA );
+
+		$this->budget_recommendation_query->expects( $this->once() )
+			->method( 'get_results' )
+			->willReturn( $fallback_data );
+
+		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
+
+		$this->assertSame( $expected_response_data, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_budget_recommendation_with_fallback_lower_than_highest_recommendation() {
+		$budget_recommendation_params = [
+			'country_codes' => [ 'GB', 'US' ],
+		];
+
+		$fallback_data = [
+			[
+				'daily_budget' => '13.2',
+				'country'      => 'GB',
+				'level'        => 'Recommended',
+			],
+		];
+
+		$expected_response_data = [
+			'currency'        => 'GBP',
+			'recommendations' => [
+				[
+					'daily_budget' => 13.2,
+					'country'      => 'GB',
+					'level'        => 'Recommended',
+				],
+				[
+					'daily_budget' => 14.4,
+					'metrics'      => [
+						'cost'              => 100.8,
+						'conversions'       => 6.5,
+						'conversions_value' => 258.72,
+					],
+					'country'      => 'GB',
+					'level'        => 'High',
+				],
+			],
+		];
+
+		$this->ads->expects( $this->once() )
+			->method( 'get_ads_currency' )
+			->willReturn( 'GBP' );
+
+		$this->budget_recommendations->expects( $this->once() )
+			->method( 'get_recommendations' )
+			->willReturn( self::RECOMMENDATION_DATA );
+
+		$this->budget_recommendation_query->expects( $this->once() )
+			->method( 'get_results' )
+			->willReturn( $fallback_data );
 
 		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
 

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -3,6 +3,7 @@
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\BudgetRecommendationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
@@ -27,6 +28,9 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 	/** @var MockObject|BudgetRecommendationQuery $budget_recommendation_query */
 	protected $budget_recommendation_query;
 
+	/** @var MockObject|BudgetRecommendations $budget_recommendations */
+	protected $budget_recommendations;
+
 	/** @var MockObject|ISO3166DataProvider $iso_provider */
 	protected $iso_provider;
 
@@ -42,11 +46,13 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		$this->budget_recommendation_query->method( 'where' )
 			->willReturn( $this->budget_recommendation_query );
 
-		$this->iso_provider = $this->createMock( ISO3166DataProvider::class );
-		$this->ads          = $this->createMock( Ads::class );
+		$this->iso_provider           = $this->createMock( ISO3166DataProvider::class );
+		$this->ads                    = $this->createMock( Ads::class );
+		$this->budget_recommendations = $this->createMock( BudgetRecommendations::class );
 
 		$this->container = new Container();
 		$this->container->addShared( BudgetRecommendationQuery::class, $this->budget_recommendation_query );
+		$this->container->addShared( BudgetRecommendations::class, $this->budget_recommendations );
 
 		$this->controller = new BudgetRecommendationController( $this->server, $this->ads );
 		$this->controller->register();

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\BudgetRecommendationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -16,6 +17,9 @@ use PHPUnit\Framework\MockObject\MockObject;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
  */
 class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
+
+	/** @var Container $container */
+	protected $container;
 
 	/** @var MockObject|Ads $ads */
 	protected $ads;
@@ -41,8 +45,12 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		$this->iso_provider = $this->createMock( ISO3166DataProvider::class );
 		$this->ads          = $this->createMock( Ads::class );
 
-		$this->controller = new BudgetRecommendationController( $this->server, $this->budget_recommendation_query, $this->ads );
+		$this->container = new Container();
+		$this->container->addShared( BudgetRecommendationQuery::class, $this->budget_recommendation_query );
+
+		$this->controller = new BudgetRecommendationController( $this->server, $this->ads );
 		$this->controller->register();
+		$this->controller->set_container( $this->container );
 		$this->controller->set_iso3166_provider( $this->iso_provider );
 	}
 

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -88,20 +88,24 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 			'currency'        => 'TWD',
 			'recommendations' => [
 				[
-					'country'      => 'US',
 					'daily_budget' => 330,
+					'country'      => 'US',
+					'level'        => 'Fallback',
 				],
 				[
-					'country'      => 'GB',
 					'daily_budget' => 245,
+					'country'      => 'GB',
+					'level'        => 'Fallback',
 				],
 				[
-					'country'      => 'TW',
 					'daily_budget' => 95,
+					'country'      => 'TW',
+					'level'        => 'Fallback',
 				],
 				[
-					'country'      => 'JP',
 					'daily_budget' => 110,
+					'country'      => 'JP',
+					'level'        => 'Fallback',
 				],
 			],
 		];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Initial implementation for fetching Budget Recommendations from the Ads API.

This covers both getting recommendations from the Google Ads API, as well as the pre-existing fallback from the database table. Note that if the recommendations from the Ads API are lower they will be replaced by the fallback. This only happens when the recommended budget is lower than the fallback budget. So we can end up with a situation where the high recommendation is still included with the fallback. Or where the low option is still included if the recommended rate hasn't been swapped.

Caching was also implemented since it can take a while occasionally to get back results from the API.
1. Caching of country locations do not have an expiry time (as country ID's shouldn't change)
2. Caching of the recommended rates returned from the API are retained for 12 hours

We still need to implement fetching metrics for the fallback rate. But since that is similar to fetching metrics for a custom budget I'm leaving that out for this PR and the fallback recommendation will be returned without metrics.

Unit testing was added to fully cover both the `BudgetRecommendations` fetching from the Ads API as well as the `BudgetRecommendationController`.

### Detailed test instructions:

1. Reinstall composer dependencies `rm -rf vendor && composer install` 
4. Test API request `https://domain.test/wp-json/wc/gla/ads/campaigns/budget-recommendation?country_codes[]=IE`
5. Observe multiple recommendation results being returned:
```json
{
    "currency": "EUR",
    "recommendations": [
        {
            "daily_budget": 12,
            "metrics": {
                "cost": 84,
                "conversions": 6.1,
                "conversions_value": 243.88968735282847
            },
            "country": "IE",
            "level": "Recommended"
        },
        {
            "daily_budget": 14.399999,
            "metrics": {
                "cost": 100.799993,
                "conversions": 6.5,
                "conversions_value": 258.7239827235049
            },
            "country": "IE",
            "level": "High"
        },
        {
            "daily_budget": 9.6,
            "metrics": {
                "cost": 67.2,
                "conversions": 5.7,
                "conversions_value": 226.13979597572018
            },
            "country": "IE",
            "level": "Low"
        }
    ]
}
```
6. They should be ordered in the following order: recommended, high, low , fallback (the current UI will always take the first recommendation)
7. Adjust the fallback rate in the table `wp_gla_budget_recommendations` so it is higher than all the returned rates (ex: 20)
8. Repeat the request and expect to see only the fallback rate (still without metrics):
```json
{
    "currency": "EUR",
    "recommendations": [
        {
            "daily_budget": 20,
            "country": "IE",
            "level": "Recommended"
        }
    ]
}
```
9. Adjust the fallback rate in the table `wp_gla_budget_recommendations` so it is higher than the recommended amount but still lower than the high recommendation (ex: 13)
10. Repeat the request and expect to see a mix of fallback and API rates:
```json
{
    "currency": "EUR",
    "recommendations": [
        {
            "daily_budget": 13,
            "country": "IE",
            "level": "Recommended"
        },
        {
            "daily_budget": 14.399999,
            "metrics": {
                "cost": 100.799993,
                "conversions": 6.5,
                "conversions_value": 258.7239827235049
            },
            "country": "IE",
            "level": "High"
        }
    ]
}
```
11. Adjust the fallback rate in the table `wp_gla_budget_recommendations` so it is lower than the recommended amount but still higher than the lowest option (ex: 11)
12. Repeat the request and expect to see the full result returned from the API:
```json
{
    "currency": "EUR",
    "recommendations": [
        {
            "daily_budget": 12,
            "metrics": {
                "cost": 84,
                "conversions": 6.1,
                "conversions_value": 243.88968735282847
            },
            "country": "IE",
            "level": "Recommended"
        },
        {
            "daily_budget": 14.399999,
            "metrics": {
                "cost": 100.799993,
                "conversions": 6.5,
                "conversions_value": 258.7239827235049
            },
            "country": "IE",
            "level": "High"
        },
        {
            "daily_budget": 9.6,
            "metrics": {
                "cost": 67.2,
                "conversions": 5.7,
                "conversions_value": 226.13979597572018
            },
            "country": "IE",
            "level": "Low"
        }
    ]
}
```

> [!Note]
> Initially I was always getting lower rates than the fallback, but today I tried with a new account after creating the first campaign. It's now returning higher rates. If your fallback rate is always higher than this can be adjusted for the right country/currency in the table `wp_gla_budget_recommendations` which allows different combinations to be tested.
> While we handle fallback rates as floats, the DB table still has the type as `int(11)` so we are unable to enter a decimal value in the DB table.

### Additional details:
Project Thread: pcTzPl-2Hb-p2

### Changelog entry
* Add - Fetch budget recommendations from the Google Ads API.