### PR TITLE
[API PULL] POST method for SYNC endpoint

### DIFF
--- a/src/API/Site/Controllers/RestAPI/SyncController.php
+++ b/src/API/Site/Controllers/RestAPI/SyncController.php
@@ -199,8 +199,14 @@ class SyncController extends BaseOptionsController {
 	 */
 	protected function get_request_params( Request $request ): array {
 		$request_params = $request->get_json_params();
-		$params         = array_intersect_key( $request_params, self::DEFAULT_SYNC_MODE );
-		$valid_params   = [];
+
+		// JSON Data
+		if ( is_null( $request_params ) ) {
+			$request_params = json_decode( $request->get_body(), true );
+		}
+
+		$params       = array_intersect_key( $request_params, self::DEFAULT_SYNC_MODE );
+		$valid_params = [];
 
 		foreach ( $params as $key => $param ) {
 			if ( isset( $param['push'] ) && isset( $param['pull'] ) && is_bool( $param['push'] ) && is_bool( $param['pull'] ) ) {

--- a/src/API/Site/Controllers/RestAPI/SyncController.php
+++ b/src/API/Site/Controllers/RestAPI/SyncController.php
@@ -15,6 +15,46 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class SyncController
  *
+ * GET wp-json/wc/gla/sync
+ * POST wp-json/wc/gla/sync
+ * Body Params: @see get_schema_properties
+ *
+ * We support 4 data types Products, Coupons, Shipping and Settings.
+ * Each of this data types contains pull and push methods.
+ *
+ * Push: Legacy method pushing store data to Google Merchant Center using Google's API
+ * Pull: New method where Google fetches the data from the store.
+ *
+ * All the data types and methods are optional. When set, they update the current config.
+ *
+ * Examples
+ *
+ * POST wp-json/wc/gla/sync
+ *
+ * {
+ *     "products": {
+ *          "pull": true,
+ *          "push": false,
+ *     },
+ *     "settings": {
+ *         "pull": true,
+ *         "push": false,
+ *     }
+ * }
+ *
+ * Updates Only Products and Settings to enable Pull and disable Push. Rest of the data types will remain unchanged.
+ *
+ *
+ * POST wp-json/wc/gla/sync
+ *
+ *  {
+ *      "products": {
+ *           "pull": true,
+ *      }
+ *  }
+ *
+ * Updates Only Products to enable Pull. Rest of the data types and Products Pull method will remain unchanged.
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestAPI
  *
  * @since x.x.x
@@ -105,7 +145,8 @@ class SyncController extends BaseOptionsController {
 			try {
 				$sync_mode     = $this->get_current_sync_value();
 				$new_params    = $this->get_request_params( $request );
-				$new_sync_mode = wp_parse_args( $new_params, $sync_mode );
+				$new_sync_mode = array_replace_recursive( $sync_mode, $new_params );
+
 				$this->options->update( OptionsInterface::API_PULL_SYNC_MODE, $new_sync_mode );
 				return $this->prepare_item_for_response( $this->options->get( OptionsInterface::API_PULL_SYNC_MODE ), $request );
 			} catch ( Exception $e ) {
@@ -133,20 +174,24 @@ class SyncController extends BaseOptionsController {
 	protected function get_schema_properties(): array {
 		return [
 			'products' => [
-				'type'  => 'object',
-				'items' => $this->get_pull_push_schema_fields(),
+				'type'        => 'object',
+				'description' => 'Set pull and push sync method for Products.',
+				'items'       => $this->get_pull_push_schema_fields(),
 			],
 			'coupons'  => [
-				'type'  => 'object',
-				'items' => $this->get_pull_push_schema_fields(),
+				'type'        => 'object',
+				'description' => 'Set the config for Push and Pull methods for Coupons.',
+				'items'       => $this->get_pull_push_schema_fields(),
 			],
 			'shipping' => [
-				'type'  => 'object',
-				'items' => $this->get_pull_push_schema_fields(),
+				'type'        => 'object',
+				'description' => 'Set the config for Push and Pull methods for Shipping.',
+				'items'       => $this->get_pull_push_schema_fields(),
 			],
 			'settings' => [
-				'type'  => 'object',
-				'items' => $this->get_pull_push_schema_fields(),
+				'type'        => 'object',
+				'description' => 'Set the config for Push and Pull methods for Settings.',
+				'items'       => $this->get_pull_push_schema_fields(),
 			],
 		];
 	}
@@ -154,15 +199,23 @@ class SyncController extends BaseOptionsController {
 	/**
 	 * Get the item schema properties for the pull and push field.
 	 *
+	 * Push: Legacy method pushing store data to Google Merchant Center using Google's API
+	 * Pull: New method where Google fetches the data from the store.
+	 *
+	 * If true: Method is enabled
+	 * If false: Method is disabled
+	 *
 	 * @return array[]
 	 */
 	private function get_pull_push_schema_fields(): array {
 		return [
 			'push' => [
-				'type' => 'boolean',
+				'description' => 'Enable or disable Push method.',
+				'type'        => 'boolean',
 			],
 			'pull' => [
-				'type' => 'boolean',
+				'description' => 'Enable or disable Pull method.',
+				'type'        => 'boolean',
 			],
 		];
 	}
@@ -177,43 +230,45 @@ class SyncController extends BaseOptionsController {
 	}
 
 	/**
-	 * Get the current value for the API PULL Sync
+	 * Get the current value for the API PULL Sync.
+	 * Notice that malformed data will be replaced by default data.
 	 *
 	 * @return array
 	 */
 	protected function get_current_sync_value(): array {
 		$sync_mode = $this->options->get( OptionsInterface::API_PULL_SYNC_MODE );
+
 		if ( ! is_array( $sync_mode ) ) {
-			$sync_mode = [];
+			$sync_mode = self::DEFAULT_SYNC_MODE;
 		}
 
-		return wp_parse_args( $sync_mode, self::DEFAULT_SYNC_MODE );
+		return array_replace_recursive( self::DEFAULT_SYNC_MODE, $sync_mode );
 	}
 
 	/**
 	 * Get the parameters from the request body.
-	 * Only the keys in self::DEFAULT_SYNC_MODE that contains pull/push values as boolean are allowed as params.
+	 * Only the keys in self::DEFAULT_SYNC_MODE that contains boolean pull and/or push param are allowed.
 	 *
 	 * @param Request $request The request
 	 * @return array
 	 */
 	protected function get_request_params( Request $request ): array {
-		$request_params = $request->get_json_params();
+		$request_params = json_decode( $request->get_body(), true );
 
-		// JSON Data
 		if ( is_null( $request_params ) ) {
-			$request_params = json_decode( $request->get_body(), true );
+			return [];
 		}
 
 		$params       = array_intersect_key( $request_params, self::DEFAULT_SYNC_MODE );
 		$valid_params = [];
 
 		foreach ( $params as $key => $param ) {
-			if ( isset( $param['push'] ) && isset( $param['pull'] ) && is_bool( $param['push'] ) && is_bool( $param['pull'] ) ) {
-				$valid_params[ $key ] = [
-					'push' => $param['push'],
-					'pull' => $param['pull'],
-				];
+			if ( isset( $param['push'] ) && is_bool( $param['push'] ) ) {
+				$valid_params[ $key ]['push'] = $param['push'];
+			}
+
+			if ( isset( $param['pull'] ) && is_bool( $param['pull'] ) ) {
+				$valid_params[ $key ]['pull'] = $param['pull'];
 			}
 		}
 

--- a/src/API/Site/Controllers/RestAPI/SyncController.php
+++ b/src/API/Site/Controllers/RestAPI/SyncController.php
@@ -68,6 +68,12 @@ class SyncController extends BaseOptionsController {
 					'callback'            => $this->get_sync_callback(),
 					'permission_callback' => $this->get_permission_callback(),
 				],
+				[
+					'methods'             => TransportMethods::EDITABLE,
+					'callback'            => $this->get_update_sync_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+					'args'                => $this->get_update_sync_params(),
+				],
 				'schema' => $this->get_api_response_schema_callback(),
 			]
 		);
@@ -81,13 +87,27 @@ class SyncController extends BaseOptionsController {
 	protected function get_sync_callback(): callable {
 		return function ( Request $request ) {
 			try {
-				$sync_mode = $this->options->get( OptionsInterface::API_PULL_SYNC_MODE );
-				if ( ! is_array( $sync_mode ) ) {
-					$sync_mode = [];
-				}
-
-				$sync_mode = wp_parse_args( $sync_mode, self::DEFAULT_SYNC_MODE );
+				$sync_mode = $this->get_current_sync_value();
 				return $this->prepare_item_for_response( $sync_mode, $request );
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
+		};
+	}
+
+	/**
+	 * Get the callback function for updating the current sync mode for API PULL.
+	 *
+	 * @return callable
+	 */
+	protected function get_update_sync_callback(): callable {
+		return function ( Request $request ) {
+			try {
+				$sync_mode     = $this->get_current_sync_value();
+				$new_params    = $this->get_request_params( $request );
+				$new_sync_mode = wp_parse_args( $new_params, $sync_mode );
+				$this->options->update( OptionsInterface::API_PULL_SYNC_MODE, $new_sync_mode );
+				return $this->prepare_item_for_response( $this->options->get( OptionsInterface::API_PULL_SYNC_MODE ), $request );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}
@@ -113,19 +133,19 @@ class SyncController extends BaseOptionsController {
 	protected function get_schema_properties(): array {
 		return [
 			'products' => [
-				'type'  => 'array',
+				'type'  => 'object',
 				'items' => $this->get_pull_push_schema_fields(),
 			],
 			'coupons'  => [
-				'type'  => 'array',
+				'type'  => 'object',
 				'items' => $this->get_pull_push_schema_fields(),
 			],
 			'shipping' => [
-				'type'  => 'array',
+				'type'  => 'object',
 				'items' => $this->get_pull_push_schema_fields(),
 			],
 			'settings' => [
-				'type'  => 'array',
+				'type'  => 'object',
 				'items' => $this->get_pull_push_schema_fields(),
 			],
 		];
@@ -136,7 +156,7 @@ class SyncController extends BaseOptionsController {
 	 *
 	 * @return array[]
 	 */
-	private function get_pull_push_schema_fields() {
+	private function get_pull_push_schema_fields(): array {
 		return [
 			'push' => [
 				'type' => 'boolean',
@@ -145,5 +165,52 @@ class SyncController extends BaseOptionsController {
 				'type' => 'boolean',
 			],
 		];
+	}
+
+	/**
+	 * Get the query params for the update sync request.
+	 *
+	 * @return array
+	 */
+	protected function get_update_sync_params(): array {
+		return $this->get_schema_properties();
+	}
+
+	/**
+	 * Get the current value for the API PULL Sync
+	 *
+	 * @return array
+	 */
+	protected function get_current_sync_value(): array {
+		$sync_mode = $this->options->get( OptionsInterface::API_PULL_SYNC_MODE );
+		if ( ! is_array( $sync_mode ) ) {
+			$sync_mode = [];
+		}
+
+		return wp_parse_args( $sync_mode, self::DEFAULT_SYNC_MODE );
+	}
+
+	/**
+	 * Get the parameters from the request body.
+	 * Only the keys in self::DEFAULT_SYNC_MODE that contains pull/push values as boolean are allowed as params.
+	 *
+	 * @param Request $request The request
+	 * @return array
+	 */
+	protected function get_request_params( Request $request ): array {
+		$request_params = $request->get_json_params();
+		$params         = array_intersect_key( $request_params, self::DEFAULT_SYNC_MODE );
+		$valid_params   = [];
+
+		foreach ( $params as $key => $param ) {
+			if ( isset( $param['push'] ) && isset( $param['pull'] ) && is_bool( $param['push'] ) && is_bool( $param['pull'] ) ) {
+				$valid_params[ $key ] = [
+					'push' => $param['push'],
+					'pull' => $param['pull'],
+				];
+			}
+		}
+
+		return $valid_params;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In this PR we create POST method for the SYNC endpoint `/wp-json/wc/gla/sync` and save it inside `wp_options.gla_api_pull_sync_mode`

PT: pcTzPl-2yG-p2

### Screenshots:

<img width="1278" alt="Screenshot 2025-02-18 at 11 48 32" src="https://github.com/user-attachments/assets/98de74c4-3943-40f7-b4f0-675d0aeb6704" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Request POST wp-json/wc/gla/sync with some valid values and some random values (a mix with good values and wrong keys and wrong values) 
2. Verify that only the valid keys and values are updated in the options table. Everything is optional. Invalid or missing datatypes or methods won't be updated.  


Examples

1. Updates all data types
```
'products' => [
			'pull' => bool,
			'push' => bool,
		],
		'coupons'  => [
			'pull' => bool,
			'push' => bool,
		],
		'shipping' => [
			'pull' => bool,
			'push' => bool,
		],
		'settings' => [
			'pull' => bool,
			'push' => bool,
		],
```

2. Updates products data type
```
'products' => [
			'pull' => bool,
			'push' => bool,
		],
]
```

2. Updates products pull method

```
'products' => [
			'pull' => bool
]		],
```


### Additional details:

Didn't add yet `gla_syncable` as a required param because anyone can really add it as a param in the request to bypass the check ...  so it doesn't make much difference to use it as a protection layer. Also even if we protect the API anyone can just update the options table for changing the modes. So for now I just keep the auth access as `can_manage` as we do for other endpoints.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>