### PR TITLE
Refactor `toScopeState` states and clarify the usage context of `GoogleAccountCard` and `GoogleComboAccountCard`

### DIFF
--- a/js/src/components/app-spinner/index.js
+++ b/js/src/components/app-spinner/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Spinner } from '@woocommerce/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -13,7 +14,11 @@ import './index.scss';
  */
 const AppSpinner = () => {
 	return (
-		<div className="app-spinner">
+		<div
+			className="app-spinner"
+			role="status"
+			aria-label={ __( 'Loading…', 'google-listings-and-ads' ) }
+		>
 			<Spinner />
 		</div>
 	);

--- a/js/src/components/google-account-card/connect-google-account-card.js
+++ b/js/src/components/google-account-card/connect-google-account-card.js
@@ -7,28 +7,28 @@ import { createInterpolateElement } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { glaData } from '~/constants';
 import AccountCard, { APPEARANCE } from '~/components/account-card';
 import AppButton from '~/components/app-button';
 import readMoreLink from './read-more-link';
 import useGoogleConnectFlow from './useGoogleConnectFlow';
 
 /**
- * @param {Object} props React props
- * @param {boolean} props.disabled
+ * Renders a card to connect to Google Account.
+ *
+ * Please note that this component is only used on the Reconnection page.
+ * For the onboarding flow, the `GoogleComboAccountCard` component is used instead.
+ *
  * @fires gla_google_account_connect_button_click with `{ action: 'authorization', context: 'reconnect' }`
- * @fires gla_google_account_connect_button_click with `{ action: 'authorization', context: 'setup-mc' }`
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/setup-and-configuration/#required-google-permissions' }`
  */
-const ConnectGoogleAccountCard = ( { disabled } ) => {
-	const pageName = glaData.mcSetupComplete ? 'reconnect' : 'setup-mc';
+const ConnectGoogleAccountCard = () => {
+	const pageName = 'reconnect';
 	const [ handleConnect, { loading, data } ] =
 		useGoogleConnectFlow( pageName );
 
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE }
-			disabled={ disabled }
 			alignIcon="top"
 			description={
 				<>
@@ -55,7 +55,6 @@ const ConnectGoogleAccountCard = ( { disabled } ) => {
 			indicator={
 				<AppButton
 					isSecondary
-					disabled={ disabled }
 					loading={ loading || data }
 					eventName="gla_google_account_connect_button_click"
 					eventProps={ {

--- a/js/src/components/google-account-card/google-account-card.js
+++ b/js/src/components/google-account-card/google-account-card.js
@@ -9,16 +9,13 @@ import ConnectedGoogleAccountCard from './connected-google-account-card';
 import ConnectGoogleAccountCard from './connect-google-account-card';
 
 /**
- * Renders the Google Account Card.
+ * Renders a card to connect, request full access, or display a connected Google account.
  *
- * Please note that this component is only used on the Settings and Reconnection pages.
+ * Please note that this component is only used on the Reconnection page.
  * For the onboarding flow, the `GoogleComboAccountCard` component is used instead.
  * Therefore, the `scope` is checked for reconnection requirements.
- *
- * @param {Object} props React props
- * @param {boolean} [props.disabled=false] Whether display the Card in disabled style.
  */
-export default function GoogleAccountCard( { disabled = false } ) {
+export default function GoogleAccountCard() {
 	const { google, scope, hasFinishedResolution } = useGoogleAccount();
 
 	if ( ! hasFinishedResolution ) {
@@ -39,5 +36,5 @@ export default function GoogleAccountCard( { disabled = false } ) {
 		);
 	}
 
-	return <ConnectGoogleAccountCard disabled={ disabled } />;
+	return <ConnectGoogleAccountCard />;
 }

--- a/js/src/components/google-account-card/google-account-card.js
+++ b/js/src/components/google-account-card/google-account-card.js
@@ -8,6 +8,16 @@ import RequestFullAccessGoogleAccountCard from './request-full-access-google-acc
 import ConnectedGoogleAccountCard from './connected-google-account-card';
 import ConnectGoogleAccountCard from './connect-google-account-card';
 
+/**
+ * Renders the Google Account Card.
+ *
+ * Please note that this component is only used on the Settings and Reconnection pages.
+ * For the onboarding flow, the `GoogleComboAccountCard` component is used instead.
+ * Therefore, the `scope` is checked for reconnection requirements.
+ *
+ * @param {Object} props React props
+ * @param {boolean} [props.disabled=false] Whether display the Card in disabled style.
+ */
 export default function GoogleAccountCard( { disabled = false } ) {
 	const { google, scope, hasFinishedResolution } = useGoogleAccount();
 
@@ -17,11 +27,11 @@ export default function GoogleAccountCard( { disabled = false } ) {
 
 	const isConnected = google?.active === 'yes';
 
-	if ( isConnected && scope.glaRequired ) {
+	if ( isConnected && scope.reconnectionRequired ) {
 		return <ConnectedGoogleAccountCard googleAccount={ google } />;
 	}
 
-	if ( isConnected && ! scope.glaRequired ) {
+	if ( isConnected && ! scope.reconnectionRequired ) {
 		return (
 			<RequestFullAccessGoogleAccountCard
 				additionalScopeEmail={ google.email }

--- a/js/src/components/google-account-card/google-account-card.test.js
+++ b/js/src/components/google-account-card/google-account-card.test.js
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import GoogleAccountCard from './google-account-card';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
+
+jest.mock( '~/hooks/useGoogleAccount', () =>
+	jest.fn().mockName( 'useGoogleAccount' )
+);
+
+jest.mock( './connected-google-account-card', () =>
+	jest
+		.fn()
+		.mockName( 'ConnectedGoogleAccountCard' )
+		.mockImplementation( () => (
+			<div>--Test--ConnectedGoogleAccountCard</div>
+		) )
+);
+
+describe( 'GoogleAccountCard', () => {
+	it( 'Should render a spinner when the Google account connection data is loading', () => {
+		useGoogleAccount.mockReturnValue( { hasFinishedResolution: false } );
+		const { rerender } = render( <GoogleAccountCard /> );
+
+		expect(
+			screen.getByRole( 'status', { name: /Loading/ } )
+		).toBeInTheDocument();
+
+		useGoogleAccount.mockReturnValue( { hasFinishedResolution: true } );
+		rerender( <GoogleAccountCard /> );
+
+		expect(
+			screen.queryByRole( 'status', { name: /Loading/ } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'Should render a card for connecting to Google account', () => {
+		useGoogleAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			google: { active: 'no' },
+		} );
+
+		render( <GoogleAccountCard /> );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Connect' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				/You will be prompted to give WooCommerce access to your Google account/
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'Should render a card for requesting all required access to Google account', () => {
+		useGoogleAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			google: { active: 'yes' },
+			scope: { reconnectionRequired: false },
+		} );
+		render( <GoogleAccountCard /> );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Allow full access' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				/You did not allow WooCommerce sufficient access to your Google account/
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'Should render a card for the connected Google account', () => {
+		useGoogleAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			google: { active: 'yes' },
+			scope: { reconnectionRequired: true },
+		} );
+		render( <GoogleAccountCard /> );
+		expect(
+			screen.getByText( '--Test--ConnectedGoogleAccountCard' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/js/src/components/google-ads-account-card/google-ads-account-card.test.js
+++ b/js/src/components/google-ads-account-card/google-ads-account-card.test.js
@@ -18,13 +18,6 @@ jest.mock( '~/hooks/useGoogleAdsAccountStatus', () => ( {
 	default: jest.fn().mockName( 'useGoogleAdsAccountStatus' ),
 } ) );
 
-jest.mock( '@woocommerce/components', () => ( {
-	...jest.requireActual( '@woocommerce/components' ),
-	Spinner: jest
-		.fn( () => <div role="status" aria-label="spinner" /> )
-		.mockName( 'Spinner' ),
-} ) );
-
 jest.mock( '~/hooks/useGoogleAdsAccount', () =>
 	jest.fn().mockName( 'useGoogleAdsAccount' ).mockReturnValue( {} )
 );
@@ -63,7 +56,7 @@ describe( 'GoogleAdsAccountCard', () => {
 		const { rerender } = render( <GoogleAdsAccountCard /> );
 
 		expect(
-			screen.queryByRole( 'status', { name: 'spinner' } )
+			screen.queryByRole( 'status', { name: /Loading/ } )
 		).toBeInTheDocument();
 
 		useGoogleAdsAccountStatus.mockReturnValue( {
@@ -73,7 +66,7 @@ describe( 'GoogleAdsAccountCard', () => {
 		rerender( <GoogleAdsAccountCard /> );
 
 		expect(
-			screen.queryByRole( 'status', { name: 'spinner' } )
+			screen.queryByRole( 'status', { name: /Loading/ } )
 		).not.toBeInTheDocument();
 	} );
 

--- a/js/src/components/google-combo-account-card/connect-google-combo-account-card.js
+++ b/js/src/components/google-combo-account-card/connect-google-combo-account-card.js
@@ -8,7 +8,6 @@ import { CheckboxControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { glaData } from '~/constants';
 import AccountCard, { APPEARANCE } from '~/components/account-card';
 import AppButton from '~/components/app-button';
 import {
@@ -18,16 +17,20 @@ import {
 import AppDocumentationLink from '../app-documentation-link';
 
 /**
+ * Renders a card to connect to Google Account.
+ *
+ * Please note that this component is only used on the onboarding flow.
+ *
  * @param {Object} props React props
- * @param {boolean} props.disabled
- * @fires gla_google_account_connect_button_click with `{ action: 'authorization', context: 'reconnect' }`
+ * @param {boolean} [props.disabled] Whether display the Card in disabled style.
+ *
  * @fires gla_google_account_connect_button_click with `{ action: 'authorization', context: 'setup-mc' }`
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/setup-and-configuration/#required-google-permissions' }`
  * @fires gla_documentation_link_click with `{ context: 'setup-mc-accounts', link_id: 'google-mc-terms-of-service', href: 'https://support.google.com/merchants/answer/160173' }`
  * @fires gla_documentation_link_click with `{ context: 'setup-ads', link_id: 'google-ads-terms-of-service', href: 'https://support.google.com/adspolicy/answer/54818' }`
  */
 const ConnectGoogleComboAccountCard = ( { disabled } ) => {
-	const pageName = glaData.mcSetupComplete ? 'reconnect' : 'setup-mc';
+	const pageName = 'setup-mc';
 	const [ handleConnect, { loading, data } ] =
 		useGoogleConnectFlow( pageName );
 	const [ termsAccepted, setTermsAccepted ] = useState( false );

--- a/js/src/components/google-combo-account-card/index.js
+++ b/js/src/components/google-combo-account-card/index.js
@@ -18,11 +18,11 @@ export default function GoogleComboAccountCard( { disabled = false } ) {
 
 	const isConnected = google?.active === 'yes';
 
-	if ( isConnected && scope.gmcRequired && scope.adsRequired ) {
+	if ( isConnected && scope.onboardingRequired ) {
 		return <ConnectedGoogleComboAccountCard />;
 	}
 
-	if ( isConnected && ( ! scope.gmcRequired || ! scope.adsRequired ) ) {
+	if ( isConnected && ! scope.onboardingRequired ) {
 		return (
 			<RequestFullAccessGoogleAccountCard
 				additionalScopeEmail={ google.email }

--- a/js/src/components/google-combo-account-card/index.js
+++ b/js/src/components/google-combo-account-card/index.js
@@ -9,6 +9,14 @@ import ConnectGoogleComboAccountCard from './connect-google-combo-account-card';
 import ConnectedGoogleComboAccountCard from './connected-google-combo-account-card';
 import './index.scss';
 
+/**
+ * Renders a card to connect, request full access, or display a connected Google account.
+ *
+ * Please note that this component is only used on the onboarding flow.
+ *
+ * @param {Object} props React props
+ * @param {boolean} [props.disabled=false] Whether display the Card in disabled style.
+ */
 export default function GoogleComboAccountCard( { disabled = false } ) {
 	const { google, scope, hasFinishedResolution } = useGoogleAccount();
 

--- a/js/src/components/google-combo-account-card/index.test.js
+++ b/js/src/components/google-combo-account-card/index.test.js
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import GoogleComboAccountCard from './';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
+
+jest.mock( '~/hooks/useGoogleAccount', () =>
+	jest.fn().mockName( 'useGoogleAccount' )
+);
+
+jest.mock( './connected-google-combo-account-card', () =>
+	jest
+		.fn()
+		.mockName( 'ConnectedGoogleComboAccountCard' )
+		.mockImplementation( () => (
+			<div>--Test--ConnectedGoogleComboAccountCard</div>
+		) )
+);
+
+describe( 'GoogleComboAccountCard', () => {
+	it( 'Should render a spinner when the Google account connection data is loading', () => {
+		useGoogleAccount.mockReturnValue( { hasFinishedResolution: false } );
+		const { rerender } = render( <GoogleComboAccountCard /> );
+
+		expect(
+			screen.getByRole( 'status', { name: /Loading/ } )
+		).toBeInTheDocument();
+
+		useGoogleAccount.mockReturnValue( { hasFinishedResolution: true } );
+		rerender( <GoogleComboAccountCard /> );
+
+		expect(
+			screen.queryByRole( 'status', { name: /Loading/ } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'Should render a card for connecting to Google account', async () => {
+		useGoogleAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			google: { active: 'no' },
+		} );
+
+		const user = userEvent.setup();
+		const { rerender } = render( <GoogleComboAccountCard disabled /> );
+		const checkbox = screen.getByRole( 'checkbox', { name: /I accept/ } );
+		const button = screen.getByRole( 'button', { name: 'Connect' } );
+		const text = screen.getByText(
+			/You will be prompted to give WooCommerce access to your Google account/
+		);
+
+		expect( text ).toBeInTheDocument();
+		expect( checkbox ).toBeDisabled();
+		expect( button ).toBeInTheDocument();
+
+		rerender( <GoogleComboAccountCard /> );
+
+		expect( text ).toBeInTheDocument();
+		expect( checkbox ).toBeEnabled();
+		expect( button ).toBeInTheDocument();
+
+		await user.click( checkbox );
+
+		expect( button ).toBeEnabled();
+	} );
+
+	it( 'Should render a card for requesting all required access to Google account', () => {
+		useGoogleAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			google: { active: 'yes' },
+			scope: { onboardingRequired: false },
+		} );
+		render( <GoogleComboAccountCard /> );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Allow full access' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				/You did not allow WooCommerce sufficient access to your Google account/
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'Should render a card for the connected Google account', () => {
+		useGoogleAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			google: { active: 'yes' },
+			scope: { onboardingRequired: true },
+		} );
+		render( <GoogleComboAccountCard /> );
+		expect(
+			screen.getByText( '--Test--ConnectedGoogleComboAccountCard' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/js/src/pages/settings/reconnect-google-account/reconnect-google-account.js
+++ b/js/src/pages/settings/reconnect-google-account/reconnect-google-account.js
@@ -29,7 +29,7 @@ export default function ReconnectGoogleAccount() {
 		: undefined;
 
 	const isCompletedReconnection =
-		isConnected && ! noAccess && scope.glaRequired;
+		isConnected && ! noAccess && scope.reconnectionRequired;
 
 	useEffect( () => {
 		if ( isCompletedReconnection ) {

--- a/js/src/utils/toScopeState.js
+++ b/js/src/utils/toScopeState.js
@@ -12,9 +12,11 @@ const SCOPE = {
  * @typedef {Object} ScopeState
  * @property {boolean} gmcRequired Whether has the required scopes of Google Merchant Center.
  * @property {boolean} adsRequired Whether has the required scopes of Google Ads.
- * @property {boolean} glaRequired Whether has the required scopes of GLA plugin based on the current GLA setup.
- *     If the user has completed Google Ads setup, all scopes are required,
- *     otherwise only Google Merchant Center scopes are required.
+ * @property {boolean} reconnectionRequired Whether has the required scopes to complete the reconnection process.
+ *   The reconnection process only happens when the user has previously completed
+ *   onboarding but this plugin has somehow lost access to the user's Google account.
+ *   If the user has previously completed Google Ads setup, all scopes are required,
+ *   otherwise only Google Merchant Center scopes are required.
  */
 
 /**
@@ -34,7 +36,7 @@ export default function toScopeState( adsSetupComplete, scopes = [] ) {
 		scopes.includes( SCOPE.CONTENT ) &&
 		scopes.includes( SCOPE.SITE_VERIFICATION_VERIFY_ONLY );
 
-	state.glaRequired = adsSetupComplete
+	state.reconnectionRequired = adsSetupComplete
 		? state.gmcRequired && state.adsRequired
 		: state.gmcRequired;
 

--- a/js/src/utils/toScopeState.js
+++ b/js/src/utils/toScopeState.js
@@ -12,6 +12,9 @@ const SCOPE = {
  * @typedef {Object} ScopeState
  * @property {boolean} gmcRequired Whether has the required scopes of Google Merchant Center.
  * @property {boolean} adsRequired Whether has the required scopes of Google Ads.
+ * @property {boolean} onboardingRequired Whether has the required scopes to continue the onboarding process.
+ *   All scopes are required because interconnections between this plugin, Google Ads
+ *   and Google Merchant Center, and domain claiming are set up during onboarding.
  * @property {boolean} reconnectionRequired Whether has the required scopes to complete the reconnection process.
  *   The reconnection process only happens when the user has previously completed
  *   onboarding but this plugin has somehow lost access to the user's Google account.
@@ -36,8 +39,11 @@ export default function toScopeState( adsSetupComplete, scopes = [] ) {
 		scopes.includes( SCOPE.CONTENT ) &&
 		scopes.includes( SCOPE.SITE_VERIFICATION_VERIFY_ONLY );
 
+	const allRequired = state.gmcRequired && state.adsRequired;
+
+	state.onboardingRequired = allRequired;
 	state.reconnectionRequired = adsSetupComplete
-		? state.gmcRequired && state.adsRequired
+		? allRequired
 		: state.gmcRequired;
 
 	return state;

--- a/js/src/utils/toScopeState.test.js
+++ b/js/src/utils/toScopeState.test.js
@@ -30,6 +30,7 @@ describe( 'toScopeState', () => {
 	let siteVerificationScopes;
 	let gmcScopes;
 	let adsScopes;
+	let contentAndAdsdScopes;
 	let allScopes;
 
 	beforeEach( () => {
@@ -37,6 +38,7 @@ describe( 'toScopeState', () => {
 		siteVerificationScopes = genScopes( 'site_verification_verify_only' );
 		gmcScopes = genScopes( 'content', 'site_verification_verify_only' );
 		adsScopes = genScopes( 'ad_words' );
+		contentAndAdsdScopes = genScopes( 'content', 'ad_words' );
 		allScopes = genScopes(
 			'content',
 			'site_verification_verify_only',
@@ -49,19 +51,19 @@ describe( 'toScopeState', () => {
 
 		expect( scopeState ).toHaveProperty( 'gmcRequired' );
 		expect( scopeState ).toHaveProperty( 'adsRequired' );
-		expect( scopeState ).toHaveProperty( 'glaRequired' );
+		expect( scopeState ).toHaveProperty( 'reconnectionRequired' );
 	} );
 
 	it( 'when the `scopes` parameter is not given, should get `false` for all results', () => {
 		expect( toScopeState( false ) ).toMatchObject( {
 			gmcRequired: false,
 			adsRequired: false,
-			glaRequired: false,
+			reconnectionRequired: false,
 		} );
 		expect( toScopeState( true ) ).toMatchObject( {
 			gmcRequired: false,
 			adsRequired: false,
-			glaRequired: false,
+			reconnectionRequired: false,
 		} );
 	} );
 
@@ -119,49 +121,59 @@ describe( 'toScopeState', () => {
 		}
 	);
 
-	describe( 'For `glaRequired`', () => {
+	describe( 'For `reconnectionRequired`', () => {
 		describe( 'if the parameter `adsSetupComplete` = false`', () => {
 			it( 'and the `scopes` contains GMC required scopes, should be `true`', () => {
-				expect( toScopeState( false, gmcScopes ).glaRequired ).toBe(
-					true
-				);
+				expect(
+					toScopeState( false, gmcScopes ).reconnectionRequired
+				).toBe( true );
 			} );
 
 			it( "and the `scopes` doesn't contains GMC required scopes, should be `false`", () => {
-				expect( toScopeState( false, [] ).glaRequired ).toBe( false );
-				expect( toScopeState( false, contentScopes ).glaRequired ).toBe(
+				expect( toScopeState( false, [] ).reconnectionRequired ).toBe(
 					false
 				);
 				expect(
-					toScopeState( false, siteVerificationScopes ).glaRequired
+					toScopeState( false, contentScopes ).reconnectionRequired
 				).toBe( false );
-				expect( toScopeState( false, adsScopes ).glaRequired ).toBe(
-					false
-				);
+				expect(
+					toScopeState( false, siteVerificationScopes )
+						.reconnectionRequired
+				).toBe( false );
+				expect(
+					toScopeState( false, adsScopes ).reconnectionRequired
+				).toBe( false );
+				expect(
+					toScopeState( false, contentAndAdsdScopes )
+						.reconnectionRequired
+				).toBe( false );
 			} );
 		} );
 
 		describe( 'if the parameter `adsSetupComplete` = true`', () => {
 			it( 'and the `scopes` contains all required scopes, should be `true`', () => {
-				expect( toScopeState( true, allScopes ).glaRequired ).toBe(
-					true
-				);
+				expect(
+					toScopeState( true, allScopes ).reconnectionRequired
+				).toBe( true );
 			} );
 
 			it( "and the `scopes` doesn't contains all required scopes, should be `false`", () => {
-				expect( toScopeState( true, [] ).glaRequired ).toBe( false );
-				expect( toScopeState( true, contentScopes ).glaRequired ).toBe(
+				expect( toScopeState( true, [] ).reconnectionRequired ).toBe(
 					false
 				);
 				expect(
-					toScopeState( true, siteVerificationScopes ).glaRequired
+					toScopeState( true, contentScopes ).reconnectionRequired
 				).toBe( false );
-				expect( toScopeState( true, adsScopes ).glaRequired ).toBe(
-					false
-				);
-				expect( toScopeState( true, gmcScopes ).glaRequired ).toBe(
-					false
-				);
+				expect(
+					toScopeState( true, siteVerificationScopes )
+						.reconnectionRequired
+				).toBe( false );
+				expect(
+					toScopeState( true, adsScopes ).reconnectionRequired
+				).toBe( false );
+				expect(
+					toScopeState( true, gmcScopes ).reconnectionRequired
+				).toBe( false );
 			} );
 		} );
 	} );

--- a/js/src/utils/toScopeState.test.js
+++ b/js/src/utils/toScopeState.test.js
@@ -51,6 +51,7 @@ describe( 'toScopeState', () => {
 
 		expect( scopeState ).toHaveProperty( 'gmcRequired' );
 		expect( scopeState ).toHaveProperty( 'adsRequired' );
+		expect( scopeState ).toHaveProperty( 'onboardingRequired' );
 		expect( scopeState ).toHaveProperty( 'reconnectionRequired' );
 	} );
 
@@ -58,11 +59,13 @@ describe( 'toScopeState', () => {
 		expect( toScopeState( false ) ).toMatchObject( {
 			gmcRequired: false,
 			adsRequired: false,
+			onboardingRequired: false,
 			reconnectionRequired: false,
 		} );
 		expect( toScopeState( true ) ).toMatchObject( {
 			gmcRequired: false,
 			adsRequired: false,
+			onboardingRequired: false,
 			reconnectionRequired: false,
 		} );
 	} );
@@ -116,6 +119,44 @@ describe( 'toScopeState', () => {
 				).toBe( false );
 				expect(
 					toScopeState( adsSetupComplete, gmcScopes ).adsRequired
+				).toBe( false );
+			} );
+		}
+	);
+
+	describe.each( [ [ false ], [ true ] ] )(
+		'For `onboardingRequired`, if the parameter `adsSetupComplete` = %p',
+		( adsSetupComplete ) => {
+			it( 'and the `scopes` contains all required scopes, should be `true`', () => {
+				expect(
+					toScopeState( adsSetupComplete, allScopes )
+						.onboardingRequired
+				).toBe( true );
+			} );
+
+			it( "and the `scopes` doesn't contains all required scopes, should be `false`", () => {
+				expect(
+					toScopeState( adsSetupComplete, [] ).onboardingRequired
+				).toBe( false );
+				expect(
+					toScopeState( adsSetupComplete, contentScopes )
+						.onboardingRequired
+				).toBe( false );
+				expect(
+					toScopeState( adsSetupComplete, siteVerificationScopes )
+						.onboardingRequired
+				).toBe( false );
+				expect(
+					toScopeState( adsSetupComplete, adsScopes )
+						.onboardingRequired
+				).toBe( false );
+				expect(
+					toScopeState( adsSetupComplete, gmcScopes )
+						.onboardingRequired
+				).toBe( false );
+				expect(
+					toScopeState( adsSetupComplete, contentAndAdsdScopes )
+						.onboardingRequired
 				).toBe( false );
 			} );
 		}

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -330,8 +330,8 @@ When a documentation link is clicked.
 #### Emitters
 - [`AppDocumentationLink`](../../js/src/components/app-documentation-link/index.js#L29)
 - [`ConnectAds`](../../js/src/components/google-ads-account-card/connect-ads/index.js#L32) with `{ context: 'setup-ads-connect-account', link_id: 'connect-sub-account', href: 'https://support.google.com/google-ads/answer/6139186' }`
-- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/setup-and-configuration/#required-google-permissions' }`
-- [`ConnectGoogleComboAccountCard`](../../js/src/components/google-combo-account-card/connect-google-combo-account-card.js#L29)
+- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L24) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/setup-and-configuration/#required-google-permissions' }`
+- [`ConnectGoogleComboAccountCard`](../../js/src/components/google-combo-account-card/connect-google-combo-account-card.js#L32)
 	- with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/setup-and-configuration/#required-google-permissions' }`
 	- with `{ context: 'setup-mc-accounts', link_id: 'google-mc-terms-of-service', href: 'https://support.google.com/merchants/answer/160173' }`
 	- with `{ context: 'setup-ads', link_id: 'google-ads-terms-of-service', href: 'https://support.google.com/adspolicy/answer/54818' }`
@@ -497,12 +497,8 @@ Clicking on the button to connect Google account.
 `action` | `string` | (`authorization`\|`scope`) 	- `authorization` is used when the plugin has not been authorized yet and requests Google account access and permission scopes from users.   - `scope` is used when requesting required permission scopes from users in order to proceed with more plugin functions. Added with the Partial OAuth feature (aka Incremental Authorization).
 #### Emitters
 - [`AuthorizeAds`](../../js/src/components/google-ads-account-card/authorize-ads.js#L20) with `{ action: 'scope', context: 'setup-ads' }`
-- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L23)
-	- with `{ action: 'authorization', context: 'reconnect' }`
-	- with `{ action: 'authorization', context: 'setup-mc' }`
-- [`ConnectGoogleComboAccountCard`](../../js/src/components/google-combo-account-card/connect-google-combo-account-card.js#L29)
-	- with `{ action: 'authorization', context: 'reconnect' }`
-	- with `{ action: 'authorization', context: 'setup-mc' }`
+- [`ConnectGoogleAccountCard`](../../js/src/components/google-account-card/connect-google-account-card.js#L24) with `{ action: 'authorization', context: 'reconnect' }`
+- [`ConnectGoogleComboAccountCard`](../../js/src/components/google-combo-account-card/connect-google-combo-account-card.js#L32) with `{ action: 'authorization', context: 'setup-mc' }`
 - [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26)
 	- with `{ action: 'scope', context: 'reconnect' }`
 	- with `{ action: 'scope', context: 'setup-mc' }`
@@ -604,7 +600,7 @@ A modal is closed.
 - [`AttributeMappingTable`](../../js/src/pages/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is closed
 - [`Dashboard`](../../js/src/pages/dashboard/index.js#L33) when CES modal is closed.
 - [`ReviewRequest`](../../js/src/pages/product-feed/review-request/index.js#L31) with `action: 'request-review-success' | 'maybe-later' | 'dismiss', context: REQUEST_REVIEW`
-- [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L157) with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss'`
+- [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L155) with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss'`
 
 ### [`gla_modal_content_link_click`](../../js/src/components/guide-page-content/index.js#L28)
 Clicking on a text link within the modal content
@@ -625,7 +621,7 @@ A modal is open
 #### Emitters
 - [`AttributeMappingTable`](../../js/src/pages/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is open with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal' }`
 - [`ReviewRequest`](../../js/src/pages/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
-- [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L157) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
+- [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 
 ### [`gla_onboarding_complete_button_click`](../../js/src/pages/onboarding/setup-stepper/skip-button.js#L17)
 Clicking on the skip paid ads button to complete the onboarding flow.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It's a pre-processing of the *Grant API Pull Access in Onboarding* project.

- Rename `glaRequired` to `reconnectionRequired` in the `toScopeState` util and related uses.
- Add a new state `onboardingRequired` to the `toScopeState` util and replace the related uses with it.
- Clarify the usage context of `GoogleAccountCard` and `GoogleComboAccountCard`.
   - `GoogleComboAccountCard` is only used on the onboarding flow.
   - `GoogleAccountCard` is only used on the Reconnection flow.
- Remove the no longer used `disabled` prop from `GoogleAccountCard` and `ConnectGoogleAccountCard`.

#### Why does it need to refactor `toScopeState` states?

With the change to the required completion of Google Ads account during onboarding, the original `glaRequired` state returned from `toScopeState` became outdated and misleading. Practical examples: https://github.com/woocommerce/google-listings-and-ads/pull/2644#pullrequestreview-2420088853 and https://github.com/woocommerce/google-listings-and-ads/pull/2644#discussion_r1833828891

https://github.com/woocommerce/google-listings-and-ads/blob/a524abb5c382612e1b9a4874dfdf639c6ab2b4fe/js/src/utils/toScopeState.js#L15-L17

https://github.com/woocommerce/google-listings-and-ads/blob/a524abb5c382612e1b9a4874dfdf639c6ab2b4fe/js/src/components/google-account-card/google-account-card.js#L20-L30

### Detailed test instructions:

#### Onboarding

1. Disconnect Google account via Connection Test tool
2. Go to the onboarding flow
3. Connect to Google account but grant only part of the asked permissions (a.k.a. scopes in Google's terminology)
4. Check if the following card is shown
   ![image](https://github.com/user-attachments/assets/4f54a6ae-f630-4e0d-aa75-5c3cc273db2d)
5. Click the "Allow full access" button to see if all the required permissions can be granted in the subsequent steps

#### Reconnection

1. Complete onboarding
2. Remove WooCommerce's access via Google's account management page
   Page location: **Manage your Google account > Data & privacy > Data from apps and services you use**
   ![image](https://github.com/user-attachments/assets/a9d84abb-7f61-499e-a804-f0510f475b0e)
3. Go to plugin's Dashboard page
4. Wait and see if it redirects to the Reconnection flow under the Setting page
    ![image](https://github.com/user-attachments/assets/d9634b0c-1f57-4622-bdb4-421d06e66229)
5. Connect to Google account but grant only part of the asked permissions
6. Check if the following card is shown
    ![image](https://github.com/user-attachments/assets/fb0fbd16-5d7b-48ae-8d67-4f6c807746a1)
7. Click the "Allow full access" button to see if all the required permissions can be granted in the subsequent steps

### Changelog entry
