### PR TITLE
Extract the API call of WPCOM app authorization URL and clean up authorization URL queries after being redirected back

### DIFF
--- a/js/src/components/enable-new-product-sync-button.js
+++ b/js/src/components/enable-new-product-sync-button.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 import { useState } from '@wordpress/element';
 
 /**
@@ -10,9 +9,8 @@ import { useState } from '@wordpress/element';
  */
 import AppButton from '~/components/app-button';
 import { glaData } from '~/constants';
-import { API_NAMESPACE } from '~/data/constants';
-import useApiFetchCallback from '~/hooks/useApiFetchCallback';
-import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import { useAppDispatch } from '~/data';
+import { handleApiError } from '~/utils/handleError';
 
 /**
  * Clicking on the button to start enabling the new product sync (API Pull).
@@ -31,23 +29,21 @@ import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
  * @fires gla_enable_product_sync_click with `{ page: 'settings', context: 'banner' | 'mc_card' }`
  */
 const EnableNewProductSyncButton = ( props ) => {
-	const { createNotice } = useDispatchCoreNotices();
+	const { fetchWPComAppAuthorizationUrl } = useAppDispatch();
 	const [ loading, setLoading ] = useState( false );
 	const nextPageName = glaData.mcSetupComplete ? 'settings' : 'setup-mc';
-	const query = { next_page_name: nextPageName };
-	const path = addQueryArgs( `${ API_NAMESPACE }/rest-api/authorize`, query );
-	const [ fetchRestAPIAuthorize ] = useApiFetchCallback( { path } );
+
 	const handleEnableClick = async () => {
 		try {
 			setLoading( true );
-			const d = await fetchRestAPIAuthorize();
-			window.location.href = d.auth_url;
+			const authUrl = await fetchWPComAppAuthorizationUrl( nextPageName );
+			window.location.href = authUrl;
 		} catch ( error ) {
 			setLoading( false );
-			createNotice(
-				'error',
+			handleApiError(
+				error,
 				__(
-					'Unable to enable new product sync. Please try again later.',
+					'Unable to enable new product sync.',
 					'google-listings-and-ads'
 				)
 			);

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { apiFetch } from '@wordpress/data-controls';
+import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -395,6 +396,21 @@ export function* fetchGoogleAccount() {
 			)
 		);
 	}
+}
+
+/**
+ * Fetch the URL for the user to grant Google's WPCOM app access to WooCommerce product data etc.
+ *
+ * @param {'settings'|'setup-mc'} nextPageName The name of the next page to redirect to after authorization.
+ * @return {string} The URL for the user to continue authorization.
+ * @throws Will throw an error if the request failed.
+ */
+export function* fetchWPComAppAuthorizationUrl( nextPageName ) {
+	const query = { next_page_name: nextPageName };
+	const path = addQueryArgs( `${ API_NAMESPACE }/rest-api/authorize`, query );
+
+	const response = yield apiFetch( { path } );
+	return response.auth_url;
 }
 
 export function receiveGoogleAccountAccess( data ) {

--- a/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.js
+++ b/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useCallback, useEffect } from '@wordpress/element';
-import { getQuery } from '@woocommerce/navigation';
+import { getQuery, getNewPath, getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -47,6 +47,13 @@ const useUpdateRestAPIAuthorizeStatusByUrlQuery = () => {
 			// eslint-disable-next-line no-console
 			console.error( e.message );
 		}
+
+		// Clean up authorization URL queries anyway
+		const url = getNewPath( {
+			google_wpcom_app_status: undefined,
+			nonce: undefined,
+		} );
+		getHistory().replace( url );
 	}, [
 		fetchUpdateRestAPIAuthorize,
 		googleWPCOMAppStatus,

--- a/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.test.js
+++ b/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.test.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { renderHook } from '@testing-library/react';
-import { getQuery } from '@woocommerce/navigation';
+import { renderHook, waitFor } from '@testing-library/react';
+import { getQuery, getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -14,10 +14,14 @@ jest.mock( '@woocommerce/navigation' );
 jest.mock( '~/hooks/useApiFetchCallback' );
 
 describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
+	let historyReplace;
 	let fetchUpdateRestAPIAuthorize;
 	let consoleErrorSpy;
 
 	beforeEach( () => {
+		historyReplace = jest.fn().mockName( 'getHistory().replace' );
+		getHistory.mockReturnValue( { replace: historyReplace } );
+
 		fetchUpdateRestAPIAuthorize = jest.fn();
 		useApiFetchCallback.mockImplementation( () => [
 			fetchUpdateRestAPIAuthorize,
@@ -65,7 +69,7 @@ describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 		} );
 	} );
 
-	it( 'should call fetchUpdateRestAPIAuthorize if query param is approved', () => {
+	it( 'should call fetchUpdateRestAPIAuthorize if query param is approved', async () => {
 		getQuery.mockReturnValue( {
 			google_wpcom_app_status: 'approved',
 			nonce: 'nonce-123',
@@ -78,9 +82,12 @@ describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 				nonce: 'nonce-123',
 			},
 		} );
+		await waitFor( () => {
+			expect( historyReplace ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 
-	it( 'should call fetchUpdateRestAPIAuthorize if query param is disapproved', () => {
+	it( 'should call fetchUpdateRestAPIAuthorize if query param is disapproved', async () => {
 		getQuery.mockReturnValue( {
 			google_wpcom_app_status: 'disapproved',
 			nonce: 'nonce-123',
@@ -93,9 +100,12 @@ describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 				nonce: 'nonce-123',
 			},
 		} );
+		await waitFor( () => {
+			expect( historyReplace ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 
-	it( 'should call fetchUpdateRestAPIAuthorize if query param is error', () => {
+	it( 'should call fetchUpdateRestAPIAuthorize if query param is error', async () => {
 		getQuery.mockReturnValue( {
 			google_wpcom_app_status: 'error',
 			nonce: 'nonce-123',
@@ -107,6 +117,9 @@ describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 				status: 'error',
 				nonce: 'nonce-123',
 			},
+		} );
+		await waitFor( () => {
+			expect( historyReplace ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project thread: pcTzPl-2Df-p2

It's a pre-processing of the *Grant API Pull Access in Onboarding* project.

- Replace the fetch call in `EnableNewProductSyncButton` with the `fetchWPComAppAuthorizationUrl` action.
   - In the subsequent PR, the authorization URL will be automatically fetched and redirected during onboarding under certain conditions, so the API call function is extracted in advance.
- Adjust `useUpdateRestAPIAuthorizeStatusByUrlQuery` to clean up authorization URL queries after updating the authorization status of Google's WPCOM app.
   - Avoid triggering the API call in `useUpdateRestAPIAuthorizeStatusByUrlQuery` again when the user refresh the webpage.

### Detailed test instructions:

1. Make the test site publicly accessible
2. Use the Connection Test page to clear the authorization status of Google's WPCOM app if it has been granted
3. Go to Settings page
4. Click the "Get early access" button on the notification at the top of the page and see if it brings you to the authorization flow on WordPress.com
5. After approving and being brought back to the onboarding flow for this plugin, check if the page URL doesn't include `google_wpcom_app_status` and `nonce` in its query

### Changelog entry
