### PR TITLE
Add the conversion action details to the connection test page

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -492,6 +492,19 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 										<?php endforeach; ?>
 										)
 									</p>
+									<?php
+										$conversion_action = $options->get( OptionsInterface::ADS_CONVERSION_ACTION );
+										if ( ! empty( $conversion_action ) && is_array( $conversion_action ) ) :
+									?>
+									<p class="description" style="font-style: italic">
+										( Conversion Action --
+										<?php foreach ( $conversion_action as $name => $value ) : ?>
+											<?php echo "{$name} : \"{$value}\""; ?>
+										<?php endforeach; ?>
+										)
+									</p>
+									<?php endif; ?>
+									<br/>
 								<?php endif; ?>
 								<p class="description">
 									Begins/continues a multistep account-setup sequence.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the conversion action details to the Connection test page. When we go through onboarding and complete all the steps to connect the Ads account, a new conversion action is created. Which makes it possible to create multiple conversion actions if the steps are repeated. Since the data is serialized it's hard to debug which conversion action is currently being used to be able to match it up with the conversion action being used in the Google Ads dashboard.

### Detailed test instructions:
1. Go through the onboarding and complete all the ads account actions to ensure the conversion_action is created
2. Check the connection test page and confirm that it shows the full details about the current conversion action:
![image](https://github.com/user-attachments/assets/f2556efd-3d37-42f8-8b19-7bf9b607bb8b)
3. Disconnect the Ads account and confirm that the connection test page doesn't show any details about the conversion action.

### Changelog entry
* Dev - Add the conversion action details to the connection test page.

