### PR TITLE
Add the process of granting API Pull access to the onboarding flow

### DIFF
--- a/js/src/components/account-card/index.scss
+++ b/js/src/components/account-card/index.scss
@@ -95,7 +95,6 @@
 	}
 
 	.components-notice.is-error {
-		margin: 0;
 		background-color: #f8ebea;
 	}
 

--- a/js/src/components/enable-new-product-sync-button.js
+++ b/js/src/components/enable-new-product-sync-button.js
@@ -26,7 +26,7 @@ import { handleApiError } from '~/utils/handleError';
  * @param {Object} props The component props to be forwarded to AppButton.
  * @return {JSX.Element} The button.
  *
- * @fires gla_enable_product_sync_click with `{ page: 'settings', context: 'banner' | 'mc_card' }`
+ * @fires gla_enable_product_sync_click with `{ page: 'setup-mc' | 'settings', context: 'banner' | 'mc_card' }`
  */
 const EnableNewProductSyncButton = ( props ) => {
 	const { fetchWPComAppAuthorizationUrl } = useAppDispatch();

--- a/js/src/components/google-account-card/authorize-wpcom-app-card.js
+++ b/js/src/components/google-account-card/authorize-wpcom-app-card.js
@@ -47,6 +47,7 @@ function getDetail( status ) {
  * Please note that the authorization process involves multiple external
  * services, this component may be technically ambiguous in these places:
  * - Component name
+ * - The directory where it is located
  * - The data source for its grant status
  * - The presenation on UI
  */

--- a/js/src/components/google-account-card/authorize-wpcom-app-card.js
+++ b/js/src/components/google-account-card/authorize-wpcom-app-card.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Notice } from '@wordpress/components';
+import { Flex, FlexBlock, Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -11,6 +11,7 @@ import AccountCard, { APPEARANCE } from '~/components/account-card';
 import LoadingLabel from '~/components/loading-label';
 import EnableNewProductSyncButton from '~/components/enable-new-product-sync-button';
 import { SwitchAccountButton } from '~/components/google-account-card';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import { GOOGLE_WPCOM_APP_CONNECTED_STATUS } from '~/constants';
 
@@ -19,7 +20,7 @@ function getDetail( status ) {
 		return (
 			<Notice status="warning" isDismissible={ false }>
 				{ __(
-					'Notice and status after the user denied the authorization.',
+					'Access was denied. Please make sure to grant Google access to your WooCommerce store to continue.',
 					'google-listings-and-ads'
 				) }
 			</Notice>
@@ -29,7 +30,7 @@ function getDetail( status ) {
 		return (
 			<Notice status="error" isDismissible={ false }>
 				{ __(
-					'Notice and status when an error occurs.',
+					'There was an error granting Google access to your WooCommerce store. Please try again, or contact support for further help.',
 					'google-listings-and-ads'
 				) }
 			</Notice>
@@ -52,6 +53,7 @@ function getDetail( status ) {
  * - The presenation on UI
  */
 export default function AuthorizeWPComAppCard() {
+	const { google } = useGoogleAccount();
 	const { googleMCAccount, hasFinishedResolution } = useGoogleMCAccount();
 
 	const getIndicator = () => {
@@ -73,14 +75,17 @@ export default function AuthorizeWPComAppCard() {
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE }
-			title={ __(
-				`Google's WordPress.com application`,
-				'google-listings-and-ads'
-			) }
-			description={ __(
-				'Granting access to the application is required in order to synchronize product data with Google through it.',
-				'google-listings-and-ads'
-			) }
+			description={
+				<Flex direction="column" gap={ 3 }>
+					<FlexBlock>{ google?.email }</FlexBlock>
+					<FlexBlock>
+						{ __(
+							'Granting Google access to your WooCommerce store is required in order to synchronize product data with Google.',
+							'google-listings-and-ads'
+						) }
+					</FlexBlock>
+				</Flex>
+			}
 			alignIcon={ alignment }
 			alignIndicator={ alignment }
 			expandedDetail={ Boolean( detail ) }

--- a/js/src/components/google-account-card/authorize-wpcom-app-card.js
+++ b/js/src/components/google-account-card/authorize-wpcom-app-card.js
@@ -74,6 +74,7 @@ export default function AuthorizeWPComAppCard() {
 
 	return (
 		<AccountCard
+			className="gla-authorize-wpcom-app-card"
 			appearance={ APPEARANCE.GOOGLE }
 			description={
 				<Flex direction="column" gap={ 3 }>

--- a/js/src/components/google-account-card/index.js
+++ b/js/src/components/google-account-card/index.js
@@ -1,6 +1,7 @@
 export { default } from './google-account-card';
 export { default as ConnectedGoogleAccountCard } from './connected-google-account-card';
 export { default as RequestFullAccessGoogleAccountCard } from './request-full-access-google-account-card';
+export { default as AuthorizeWPComAppCard } from './authorize-wpcom-app-card';
 export { default as SwitchAccountButton } from './switch-account-button';
 export { default as ReadMoreLink } from './read-more-link';
 export { default as useGoogleConnectFlow } from './useGoogleConnectFlow';

--- a/js/src/components/google-account-card/useSwitchGoogleAccount.js
+++ b/js/src/components/google-account-card/useSwitchGoogleAccount.js
@@ -2,24 +2,23 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { API_NAMESPACE } from '~/data/constants';
+import { useAppDispatch } from '~/data';
 import useGoogleAuthorization from '~/hooks/useGoogleAuthorization';
 import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
-import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 
 /**
- * A hook that returns a handler that initiates Google account disconnect and connect, to support switching to a different Google account.
- * This will also disconnect Google Merchant Center account, since Google Merchant Center account depends on Google account.
+ * Hook to initiates Google account disconnect and get Google OAuth URL to reconnect.
+ * It will also disconnect other connected accounts and WPCOM app to ensure a clean switch.
  *
  * The `handleSwitch` handler is meant to be used in button click handler. Upon button click, the handler will:
  *
  * 1. Display an info notice that the process is running and request the users to wait.
- * 2. Call `DELETE /mc/connection` API to disconnect the existing connected Google Merchant Center account.
- * 3. Call `DELETE /google/connect` API to disconnect the existing connected Google account.
+ * 2. Call `DELETE /connections` API to disconnect all the connected accounts and WPCOM app.
  * 4. Call `GET /google/connect` API to get the Google OAuth URL.
  * 5. Redirect the browser to the URL.
  * 6. If there is an error in the above process, it will display an error notice.
@@ -30,40 +29,14 @@ import useApiFetchCallback from '~/hooks/useApiFetchCallback';
  */
 const useSwitchGoogleAccount = () => {
 	const { createNotice, removeNotice } = useDispatchCoreNotices();
+	const { disconnectAllAccounts } = useAppDispatch();
+	const [ loading, setLoading ] = useState( false );
 
-	const [ fetchGoogleMCDisconnect, { loading: loadingGoogleMCDisconnect } ] =
-		useApiFetchCallback( {
-			path: `${ API_NAMESPACE }/mc/connection`,
-			method: 'DELETE',
-		} );
-
-	const [
-		fetchGoogleAdsDisconnect,
-		{ loading: loadingGoogleAdsDisconnect },
-	] = useApiFetchCallback( {
-		path: `${ API_NAMESPACE }/ads/connection`,
-		method: 'DELETE',
-	} );
-
-	/**
-	 * Note: we are manually calling `DELETE /google/connect` instead of using
-	 * `disconnectGoogleAccount` action from wp-data store
-	 * because `disconnectGoogleAccount` will cause a store update,
-	 * and the UI will display the Connect card for a brief moment,
-	 * before the browser redirects to the Google Auth page.
-	 */
-	const [ fetchGoogleDisconnect, { loading: loadingGoogleDisconnect } ] =
-		useApiFetchCallback( {
-			path: `${ API_NAMESPACE }/google/connect`,
-			method: 'DELETE',
-		} );
-
-	const [
-		fetchGoogleConnect,
-		{ loading: loadingGoogleConnect, data: dataGoogleConnect },
-	] = useGoogleAuthorization( 'setup-mc' );
+	const [ fetchGoogleConnect ] = useGoogleAuthorization( 'setup-mc' );
 
 	const handleSwitch = async () => {
+		setLoading( true );
+
 		const { notice } = await createNotice(
 			'info',
 			__(
@@ -73,29 +46,28 @@ const useSwitchGoogleAccount = () => {
 		);
 
 		try {
-			await fetchGoogleMCDisconnect();
-			await fetchGoogleAdsDisconnect();
-			await fetchGoogleDisconnect();
+			await disconnectAllAccounts();
+		} catch ( error ) {
+			setLoading( false );
+			removeNotice( notice.id );
+			return;
+		}
+
+		try {
 			const { url } = await fetchGoogleConnect();
 			window.location.href = url;
 		} catch ( error ) {
 			removeNotice( notice.id );
+
 			createNotice(
 				'error',
 				__(
-					'Unable to connect to a different Google account. Please try again later.',
+					'Unable to get the URL for Google authorization. Please refresh the page to restart the onboarding.',
 					'google-listings-and-ads'
 				)
 			);
 		}
 	};
-
-	const loading =
-		loadingGoogleMCDisconnect ||
-		loadingGoogleAdsDisconnect ||
-		loadingGoogleDisconnect ||
-		loadingGoogleConnect ||
-		dataGoogleConnect;
 
 	return [ handleSwitch, { loading } ];
 };

--- a/js/src/components/google-combo-account-card/connect-google-combo-account-card.js
+++ b/js/src/components/google-combo-account-card/connect-google-combo-account-card.js
@@ -80,7 +80,7 @@ const ConnectGoogleComboAccountCard = ( { disabled } ) => {
 			}
 			helper={ createInterpolateElement(
 				__(
-					'You will be prompted to give WooCommerce access to your Google account. Please check all the checkboxes to give WooCommerce all required permissions. <link>Read more</link>',
+					'You will be prompted to give WooCommerce access to your Google account and Google to your WooCommerce account. Please approve all access to give WooCommerce and Google all required permissions. <link>Read more</link>',
 					'google-listings-and-ads'
 				),
 				{

--- a/js/src/components/google-combo-account-card/index.js
+++ b/js/src/components/google-combo-account-card/index.js
@@ -2,9 +2,11 @@
  * Internal dependencies
  */
 import useGoogleAccount from '~/hooks/useGoogleAccount';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import AppSpinner from '~/components/app-spinner';
 import AccountCard from '~/components/account-card';
 import { RequestFullAccessGoogleAccountCard } from '~/components/google-account-card';
+import { AuthorizeWPComAppCard } from '~/components/wpcom-account-card';
 import ConnectGoogleComboAccountCard from './connect-google-combo-account-card';
 import ConnectedGoogleComboAccountCard from './connected-google-combo-account-card';
 import './index.scss';
@@ -18,24 +20,34 @@ import './index.scss';
  * @param {boolean} [props.disabled=false] Whether display the Card in disabled style.
  */
 export default function GoogleComboAccountCard( { disabled = false } ) {
-	const { google, scope, hasFinishedResolution } = useGoogleAccount();
+	const {
+		google,
+		scope,
+		hasFinishedResolution: hasResolvedGoogle,
+	} = useGoogleAccount();
+	const { isWPComAppGranted, hasFinishedResolution: hasResolvedGMC } =
+		useGoogleMCAccount();
 
-	if ( ! hasFinishedResolution ) {
+	if ( ! hasResolvedGoogle || ! hasResolvedGMC ) {
 		return <AccountCard description={ <AppSpinner /> } />;
 	}
 
 	const isConnected = google?.active === 'yes';
 
-	if ( isConnected && scope.onboardingRequired ) {
-		return <ConnectedGoogleComboAccountCard />;
-	}
+	if ( isConnected ) {
+		if ( ! scope.onboardingRequired ) {
+			return (
+				<RequestFullAccessGoogleAccountCard
+					additionalScopeEmail={ google.email }
+				/>
+			);
+		}
 
-	if ( isConnected && ! scope.onboardingRequired ) {
-		return (
-			<RequestFullAccessGoogleAccountCard
-				additionalScopeEmail={ google.email }
-			/>
-		);
+		if ( ! isWPComAppGranted ) {
+			return <AuthorizeWPComAppCard />;
+		}
+
+		return <ConnectedGoogleComboAccountCard />;
 	}
 
 	return <ConnectGoogleComboAccountCard disabled={ disabled } />;

--- a/js/src/components/google-combo-account-card/index.js
+++ b/js/src/components/google-combo-account-card/index.js
@@ -5,8 +5,10 @@ import useGoogleAccount from '~/hooks/useGoogleAccount';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import AppSpinner from '~/components/app-spinner';
 import AccountCard from '~/components/account-card';
-import { RequestFullAccessGoogleAccountCard } from '~/components/google-account-card';
-import { AuthorizeWPComAppCard } from '~/components/wpcom-account-card';
+import {
+	RequestFullAccessGoogleAccountCard,
+	AuthorizeWPComAppCard,
+} from '~/components/google-account-card';
 import ConnectGoogleComboAccountCard from './connect-google-combo-account-card';
 import ConnectedGoogleComboAccountCard from './connected-google-combo-account-card';
 import './index.scss';

--- a/js/src/components/google-combo-account-card/index.test.js
+++ b/js/src/components/google-combo-account-card/index.test.js
@@ -120,7 +120,9 @@ describe( 'GoogleComboAccountCard', () => {
 			screen.getByRole( 'button', { name: 'Grant access' } )
 		).toBeInTheDocument();
 		expect(
-			screen.getByText( /Granting access to the application is required/ )
+			screen.getByText(
+				/Granting Google access to your WooCommerce store is required/
+			)
 		).toBeInTheDocument();
 	} );
 

--- a/js/src/components/google-combo-account-card/index.test.js
+++ b/js/src/components/google-combo-account-card/index.test.js
@@ -111,6 +111,7 @@ describe( 'GoogleComboAccountCard', () => {
 		} );
 		useGoogleMCAccount.mockReturnValue( {
 			hasFinishedResolution: true,
+			googleMCAccount: {},
 			isWPComAppGranted: false,
 		} );
 		render( <GoogleComboAccountCard /> );

--- a/js/src/components/google-combo-account-card/index.test.js
+++ b/js/src/components/google-combo-account-card/index.test.js
@@ -10,9 +10,14 @@ import userEvent from '@testing-library/user-event';
  */
 import GoogleComboAccountCard from './';
 import useGoogleAccount from '~/hooks/useGoogleAccount';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 
 jest.mock( '~/hooks/useGoogleAccount', () =>
 	jest.fn().mockName( 'useGoogleAccount' )
+);
+
+jest.mock( '~/hooks/useGoogleMCAccount', () =>
+	jest.fn().mockName( 'useGoogleMCAccount' )
 );
 
 jest.mock( './connected-google-combo-account-card', () =>
@@ -25,8 +30,9 @@ jest.mock( './connected-google-combo-account-card', () =>
 );
 
 describe( 'GoogleComboAccountCard', () => {
-	it( 'Should render a spinner when the Google account connection data is loading', () => {
+	it( 'Should render a spinner when the Google or GMC account connection is loading', () => {
 		useGoogleAccount.mockReturnValue( { hasFinishedResolution: false } );
+		useGoogleMCAccount.mockReturnValue( { hasFinishedResolution: false } );
 		const { rerender } = render( <GoogleComboAccountCard /> );
 
 		expect(
@@ -34,6 +40,13 @@ describe( 'GoogleComboAccountCard', () => {
 		).toBeInTheDocument();
 
 		useGoogleAccount.mockReturnValue( { hasFinishedResolution: true } );
+		rerender( <GoogleComboAccountCard /> );
+
+		expect(
+			screen.getByRole( 'status', { name: /Loading/ } )
+		).toBeInTheDocument();
+
+		useGoogleMCAccount.mockReturnValue( { hasFinishedResolution: true } );
 		rerender( <GoogleComboAccountCard /> );
 
 		expect(
@@ -46,6 +59,7 @@ describe( 'GoogleComboAccountCard', () => {
 			hasFinishedResolution: true,
 			google: { active: 'no' },
 		} );
+		useGoogleMCAccount.mockReturnValue( { hasFinishedResolution: true } );
 
 		const user = userEvent.setup();
 		const { rerender } = render( <GoogleComboAccountCard disabled /> );
@@ -76,6 +90,7 @@ describe( 'GoogleComboAccountCard', () => {
 			google: { active: 'yes' },
 			scope: { onboardingRequired: false },
 		} );
+		useGoogleMCAccount.mockReturnValue( { hasFinishedResolution: true } );
 		render( <GoogleComboAccountCard /> );
 
 		expect(
@@ -88,13 +103,38 @@ describe( 'GoogleComboAccountCard', () => {
 		).toBeInTheDocument();
 	} );
 
+	it( 'Should render a card for re-asking to connect to WPComApp', () => {
+		useGoogleAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			google: { active: 'yes' },
+			scope: { onboardingRequired: true },
+		} );
+		useGoogleMCAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			isWPComAppGranted: false,
+		} );
+		render( <GoogleComboAccountCard /> );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Grant access' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( /Granting access to the application is required/ )
+		).toBeInTheDocument();
+	} );
+
 	it( 'Should render a card for the connected Google account', () => {
 		useGoogleAccount.mockReturnValue( {
 			hasFinishedResolution: true,
 			google: { active: 'yes' },
 			scope: { onboardingRequired: true },
 		} );
+		useGoogleMCAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			isWPComAppGranted: true,
+		} );
 		render( <GoogleComboAccountCard /> );
+
 		expect(
 			screen.getByText( '--Test--ConnectedGoogleComboAccountCard' )
 		).toBeInTheDocument();

--- a/js/src/components/wpcom-account-card/authorize-wpcom-app-card.js
+++ b/js/src/components/wpcom-account-card/authorize-wpcom-app-card.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -11,6 +12,32 @@ import LoadingLabel from '~/components/loading-label';
 import EnableNewProductSyncButton from '~/components/enable-new-product-sync-button';
 import { SwitchAccountButton } from '~/components/google-account-card';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+import { GOOGLE_WPCOM_APP_CONNECTED_STATUS } from '~/constants';
+
+function getDetail( status ) {
+	if ( status === GOOGLE_WPCOM_APP_CONNECTED_STATUS.DISAPPROVED ) {
+		return (
+			<Notice status="warning" isDismissible={ false }>
+				{ __(
+					'Notice and status after the user denied the authorization.',
+					'google-listings-and-ads'
+				) }
+			</Notice>
+		);
+	}
+	if ( status === GOOGLE_WPCOM_APP_CONNECTED_STATUS.ERROR ) {
+		return (
+			<Notice status="error" isDismissible={ false }>
+				{ __(
+					'Notice and status when an error occurs.',
+					'google-listings-and-ads'
+				) }
+			</Notice>
+		);
+	}
+
+	return null;
+}
 
 /**
  * Renders a card for asking the user to grant access to the WordPress.com app,
@@ -24,7 +51,7 @@ import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
  * - The presenation on UI
  */
 export default function AuthorizeWPComAppCard() {
-	const { hasFinishedResolution } = useGoogleMCAccount();
+	const { googleMCAccount, hasFinishedResolution } = useGoogleMCAccount();
 
 	const getIndicator = () => {
 		if ( ! hasFinishedResolution ) {
@@ -39,6 +66,9 @@ export default function AuthorizeWPComAppCard() {
 		);
 	};
 
+	const detail = getDetail( googleMCAccount.wpcom_rest_api_status );
+	const alignment = detail ? 'top' : undefined;
+
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE }
@@ -50,7 +80,11 @@ export default function AuthorizeWPComAppCard() {
 				'Granting access to the application is required in order to synchronize product data with Google through it.',
 				'google-listings-and-ads'
 			) }
+			alignIcon={ alignment }
+			alignIndicator={ alignment }
+			expandedDetail={ Boolean( detail ) }
 			indicator={ getIndicator() }
+			detail={ detail }
 			actions={ <SwitchAccountButton /> }
 		/>
 	);

--- a/js/src/components/wpcom-account-card/authorize-wpcom-app-card.js
+++ b/js/src/components/wpcom-account-card/authorize-wpcom-app-card.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import LoadingLabel from '~/components/loading-label';
+import EnableNewProductSyncButton from '~/components/enable-new-product-sync-button';
+import { SwitchAccountButton } from '~/components/google-account-card';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+
+/**
+ * Renders a card for asking the user to grant access to the WordPress.com app,
+ * which authorizes Google's shopping data integration API to fetch WooCommerce
+ * products etc through the app.
+ *
+ * Please note that the authorization process involves multiple external
+ * services, this component may be technically ambiguous in these places:
+ * - Component name
+ * - The data source for its grant status
+ * - The presenation on UI
+ */
+export default function AuthorizeWPComAppCard() {
+	const { hasFinishedResolution } = useGoogleMCAccount();
+
+	const getIndicator = () => {
+		if ( ! hasFinishedResolution ) {
+			return <LoadingLabel />;
+		}
+
+		return (
+			<EnableNewProductSyncButton
+				text={ __( 'Grant access', 'google-listings-and-ads' ) }
+				eventProps={ { page: 'setup-mc' } }
+			/>
+		);
+	};
+
+	return (
+		<AccountCard
+			appearance={ APPEARANCE.GOOGLE }
+			title={ __(
+				`Google's WordPress.com application`,
+				'google-listings-and-ads'
+			) }
+			description={ __(
+				'Granting access to the application is required in order to synchronize product data with Google through it.',
+				'google-listings-and-ads'
+			) }
+			indicator={ getIndicator() }
+			actions={ <SwitchAccountButton /> }
+		/>
+	);
+}

--- a/js/src/components/wpcom-account-card/index.js
+++ b/js/src/components/wpcom-account-card/index.js
@@ -1,3 +1,4 @@
 export { default } from './wpcom-account-card';
 export { default as ConnectWPComAccountCard } from './connect-wpcom-account-card';
 export { default as ConnectedWPComAccountCard } from './connected-wpcom-account-card';
+export { default as AuthorizeWPComAppCard } from './authorize-wpcom-app-card';

--- a/js/src/components/wpcom-account-card/index.js
+++ b/js/src/components/wpcom-account-card/index.js
@@ -1,4 +1,3 @@
 export { default } from './wpcom-account-card';
 export { default as ConnectWPComAccountCard } from './connect-wpcom-account-card';
 export { default as ConnectedWPComAccountCard } from './connected-wpcom-account-card';
-export { default as AuthorizeWPComAppCard } from './authorize-wpcom-app-card';

--- a/js/src/css/shared/_woocommerce-admin.scss
+++ b/js/src/css/shared/_woocommerce-admin.scss
@@ -75,6 +75,15 @@
 	.components-notice:not(.app-notice) {
 		margin-bottom: $grid-unit-15;
 	}
+
+	> .woocommerce-spinner:only-child {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		margin: auto;
+	}
 }
 
 // compatibility-code "WC >= 7.3" -- adding margin in the first question label.

--- a/js/src/hooks/useGoogleMCAccount.js
+++ b/js/src/hooks/useGoogleMCAccount.js
@@ -8,7 +8,10 @@ import { useSelect } from '@wordpress/data';
  */
 import { STORE_KEY } from '~/data/constants';
 import useGoogleAccount from './useGoogleAccount';
-import { GOOGLE_MC_ACCOUNT_STATUS } from '~/constants';
+import {
+	GOOGLE_MC_ACCOUNT_STATUS,
+	GOOGLE_WPCOM_APP_CONNECTED_STATUS,
+} from '~/constants';
 
 /**
  * @typedef {import('~/data/types.js').GoogleMCAccount} GoogleMCAccount
@@ -20,6 +23,7 @@ import { GOOGLE_MC_ACCOUNT_STATUS } from '~/constants';
  * @property {boolean} isPreconditionReady Whether the precondition of continued connection processing is fulfilled.
  * @property {boolean} hasGoogleMCConnection Whether the user has a Google Merchant Center account connection established.
  * @property {boolean} isReady Whether the user has a Google Merchant Center account is in connected state.
+ * @property {boolean} isWPComAppGranted Whether the user has granted Google's WPCOM app access to WooCommerce product data etc.
  */
 
 const googleMCAccountSelector = 'getGoogleMCAccount';
@@ -50,6 +54,7 @@ const useGoogleMCAccount = () => {
 					isPreconditionReady: false,
 					hasGoogleMCConnection: false,
 					isReady: false,
+					isWPComAppGranted: false,
 				};
 			}
 
@@ -71,6 +76,10 @@ const useGoogleMCAccount = () => {
 				( acc?.status === GOOGLE_MC_ACCOUNT_STATUS.INCOMPLETE &&
 					acc?.step === 'link_ads' );
 
+			const isWPComAppGranted =
+				acc?.wpcom_rest_api_status ===
+				GOOGLE_WPCOM_APP_CONNECTED_STATUS.APPROVED;
+
 			return {
 				googleMCAccount: acc,
 				isResolving: isResolvingGoogleMCAccount,
@@ -80,6 +89,7 @@ const useGoogleMCAccount = () => {
 				isPreconditionReady: true,
 				hasGoogleMCConnection,
 				isReady,
+				isWPComAppGranted,
 			};
 		},
 		[

--- a/js/src/pages/onboarding/index.js
+++ b/js/src/pages/onboarding/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import useLayout from '~/hooks/useLayout';
+import useUpdateRestAPIAuthorizeStatusByUrlQuery from '~/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery';
 import SetupTopBar from './setup-top-bar';
 import SetupStepper from './setup-stepper';
 
@@ -12,6 +13,7 @@ import SetupStepper from './setup-stepper';
  */
 const Onboarding = () => {
 	useLayout( 'full-page' );
+	useUpdateRestAPIAuthorizeStatusByUrlQuery();
 
 	return (
 		<>

--- a/js/src/pages/onboarding/index.js
+++ b/js/src/pages/onboarding/index.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import useLayout from '~/hooks/useLayout';
+import useAutoWPComAppAuthorization from './useAutoWPComAppAuthorization';
 import useUpdateRestAPIAuthorizeStatusByUrlQuery from '~/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery';
 import SetupTopBar from './setup-top-bar';
 import SetupStepper from './setup-stepper';
@@ -14,6 +15,14 @@ import SetupStepper from './setup-stepper';
 const Onboarding = () => {
 	useLayout( 'full-page' );
 	useUpdateRestAPIAuthorizeStatusByUrlQuery();
+
+	const canContinueRendering = useAutoWPComAppAuthorization();
+
+	// Render nothing as the requirement is to make it look like the redirections
+	// between Google authorization and WPCOM app authorization are seamless.
+	if ( ! canContinueRendering ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/js/src/pages/onboarding/index.js
+++ b/js/src/pages/onboarding/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Spinner } from '@woocommerce/components';
+
+/**
  * Internal dependencies
  */
 import useLayout from '~/hooks/useLayout';
@@ -18,10 +23,10 @@ const Onboarding = () => {
 
 	const canContinueRendering = useAutoWPComAppAuthorization();
 
-	// Render nothing as the requirement is to make it look like the redirections
+	// Render a spinner only as the requirement is to make it look like the redirections
 	// between Google authorization and WPCOM app authorization are seamless.
 	if ( ! canContinueRendering ) {
-		return null;
+		return <Spinner />;
 	}
 
 	return (

--- a/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
@@ -88,6 +88,7 @@ const SetupAccounts = ( props ) => {
 		googleMCAccount,
 		isPreconditionReady: isGMCPreconditionReady,
 		isReady: isGoogleMCReady,
+		isWPComAppGranted,
 	} = useGoogleMCAccount();
 	const { hasFinishedResolution } = useGoogleAdsAccount();
 	const isStoreAddressReady = useStoreAddressReady();
@@ -127,6 +128,7 @@ const SetupAccounts = ( props ) => {
 		hasFinishedResolution &&
 		isGoogleAdsReady &&
 		isGoogleMCReady &&
+		isWPComAppGranted &&
 		isStoreAddressReady
 	);
 

--- a/js/src/pages/onboarding/useAutoWPComAppAuthorization.js
+++ b/js/src/pages/onboarding/useAutoWPComAppAuthorization.js
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { getQuery } from '@woocommerce/navigation';
+import { useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useAppDispatch } from '~/data';
+import useJetpackAccount from '~/hooks/useJetpackAccount';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+
+/**
+ * Hook to automatically redirect the user to WPCOM app authorization once they
+ * are being redirected back from the Google authorization with all required access.
+ *
+ * Please note that this hook is a special business logic exclusive to the onboarding flow
+ * and should not be used elsewhere.
+ *
+ * @return {null|boolean} A state that indicates whether the caller can continue the subsequent process.
+ *   - `null` if it's still loading the required data for determining whether to do the redirection.
+ *   - `true` if it's ready to continue the subsequent process.
+ *   - `false` if it's processing the redirection and the caller should block the subsequent process.
+ */
+export default function useAutoWPComAppAuthorization() {
+	const { jetpack } = useJetpackAccount();
+	const { google, scope } = useGoogleAccount();
+	const { googleMCAccount, isWPComAppGranted } = useGoogleMCAccount();
+	const { fetchWPComAppAuthorizationUrl } = useAppDispatch();
+	const lockRef = useRef( null );
+
+	const query = getQuery();
+	const isBackFromGoogleAuth = query[ 'google-mc' ] === 'connected';
+
+	// This mechanism is only triggered when the user is being redirected back
+	// from Google authorization.
+	if ( ! isBackFromGoogleAuth ) {
+		return true;
+	}
+
+	// These data are fetched sequentially and conditionally in their hooks
+	// layer by layer. Each layer doesn't actually start fetching data from API
+	// until the data it depends on is available. Therefore, it needs to check
+	// the loading states layer by layer according to the dependencies.
+	const isLoadingJetpack = ! jetpack;
+	const isLoadingGoogle = jetpack?.active === 'yes' && ! google;
+	const isLoadingGMC =
+		google?.active === 'yes' && scope.gmcRequired && ! googleMCAccount;
+
+	if ( isLoadingJetpack || isLoadingGoogle || isLoadingGMC ) {
+		return null;
+	}
+
+	if ( scope.onboardingRequired && ! isWPComAppGranted ) {
+		// Make sure it only triggers the redirection one time.
+		if ( lockRef.current === null ) {
+			lockRef.current = false;
+
+			fetchWPComAppAuthorizationUrl()
+				.then( ( authUrl ) => {
+					window.location.href = authUrl;
+				} )
+				.catch( () => {
+					// Silently fall back to the subsequent process if any error occurs.
+					lockRef.current = true;
+				} );
+		}
+	} else {
+		lockRef.current = true;
+	}
+
+	return lockRef.current;
+}

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -231,6 +231,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		if (
 			$this->connected_account() &&
 			$this->container->get( AdsService::class )->connected_account() &&
+			$this->options->is_wpcom_api_authorized() &&
 			$this->is_mc_contact_information_setup()
 		) {
 			$step = 'product_listings';

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -413,7 +413,7 @@ Triggered when store address "Edit in WooCommerce Settings" button is clicked.
 #### Emitters
 - [`StoreAddressCard`](../../js/src/components/contact-information/store-address-card.js#L49) Whenever "Edit in WooCommerce Settings" button is clicked.
 
-### [`gla_enable_product_sync_click`](../../js/src/components/enable-new-product-sync-button.js#L17)
+### [`gla_enable_product_sync_click`](../../js/src/components/enable-new-product-sync-button.js#L15)
 Clicking on the button to start enabling the new product sync (API Pull).
 #### Properties
 | name | type | description |
@@ -421,7 +421,7 @@ Clicking on the button to start enabling the new product sync (API Pull).
 `page` | `string` | Indicates which page this event happened
 `context` | `string` | Indicates where or which the button triggered this event
 #### Emitters
-- [`EnableNewProductSyncButton`](../../js/src/components/enable-new-product-sync-button.js#L33) with `{ page: 'settings', context: 'banner' | 'mc_card' }`
+- [`EnableNewProductSyncButton`](../../js/src/components/enable-new-product-sync-button.js#L31) with `{ page: 'setup-mc' | 'settings', context: 'banner' | 'mc_card' }`
 
 ### [`gla_faq`](../../js/src/components/faqs-panel/index.js#L22)
 Clicking on faq item to collapse or expand it.

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -407,8 +407,29 @@ class MerchantCenterServiceTest extends UnitTest {
 		);
 	}
 
+	public function test_get_setup_status_step_accounts_not_yet_authorized_wpcom_api() {
+		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
+		$this->ads_service->method( 'connected_account' )->willReturn( true );
+		$this->contact_information->method( 'get_contact_information' )
+			->willReturn( $this->get_valid_business_info() );
+		$this->settings->method( 'get_store_address' )
+			->willReturn( $this->get_sample_address() );
+		$this->address_utility->method( 'compare_addresses' )
+			->willReturn( true );
+
+		$this->assertEquals(
+			[
+				'status' => 'incomplete',
+				'step'   => 'accounts',
+			],
+			$this->mc_service->get_setup_status()
+		);
+	}
+
 	public function test_get_setup_status_step_product_listings() {
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->options->method( 'is_wpcom_api_authorized' )->willReturn( true );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
 		$this->ads_service->method( 'connected_account' )->willReturn( true );
 		$this->options->method( 'get' )
@@ -441,6 +462,7 @@ class MerchantCenterServiceTest extends UnitTest {
 
 	public function test_get_setup_status_shipping_selected_rates() {
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->options->method( 'is_wpcom_api_authorized' )->willReturn( true );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
 		$this->ads_service->method( 'connected_account' )->willReturn( true );
 		$this->options->method( 'get' )
@@ -491,6 +513,7 @@ class MerchantCenterServiceTest extends UnitTest {
 
 	public function test_get_setup_status_step_paid_ads() {
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
+		$this->options->method( 'is_wpcom_api_authorized' )->willReturn( true );
 		$this->merchant_account_state->method( 'last_incomplete_step' )->willReturn( '' );
 		$this->ads_service->method( 'connected_account' )->willReturn( true );
 		$this->options->expects( $this->exactly( 3 ) )->method( 'get' )

--- a/tests/e2e/specs/notifications/notifications-banner.test.js
+++ b/tests/e2e/specs/notifications/notifications-banner.test.js
@@ -52,7 +52,7 @@ test.describe( 'Notifications Banner', () => {
 
 	test( 'Grant Access button is visible on Settings page when notifications service is enabled', async () => {
 		// Mock Merchant Center as connected
-		await settingsPage.mockMCConnected( 1234, true );
+		await settingsPage.mockMCConnected( 1234, true, null );
 		const button = settingsPage.getGrantAccessBtn();
 
 		await expect( button ).toBeVisible();
@@ -61,7 +61,7 @@ test.describe( 'Notifications Banner', () => {
 	test( 'When click on Grant Access button redirect to Auth page', async () => {
 		const mockAuthURL = 'https://example.com';
 		// Mock Merchant Center as connected
-		await settingsPage.mockMCConnected( 1234, true );
+		await settingsPage.mockMCConnected( 1234, true, null );
 		await settingsPage.fulfillRESTApiAuthorize( { auth_url: mockAuthURL } );
 		const button = settingsPage.getGrantAccessBtn();
 

--- a/tests/e2e/specs/onboarding/step-1-accounts.test.js
+++ b/tests/e2e/specs/onboarding/step-1-accounts.test.js
@@ -43,6 +43,8 @@ const ADS_ACCOUNTS = [
 	},
 ];
 
+let wpComAppAuthURL;
+
 test.describe( 'Set up accounts', () => {
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage();
@@ -149,7 +151,7 @@ test.describe( 'Set up accounts', () => {
 	} );
 
 	test.describe( 'Connect Google account', () => {
-		test.beforeAll( async () => {
+		test.beforeAll( async ( { baseURL } ) => {
 			// Mock Jetpack as not connected
 			await setUpAccountsPage.mockJetpackNotConnected();
 
@@ -158,6 +160,11 @@ test.describe( 'Set up accounts', () => {
 			// If not mocked will fail and render nothing,
 			// as Jetpack is mocked only on the client-side.
 			await setUpAccountsPage.mockGoogleNotConnected();
+
+			wpComAppAuthURL = baseURL + 'wpcom_app_auth';
+			await setUpAccountsPage.fulfillRESTApiAuthorize( {
+				auth_url: wpComAppAuthURL,
+			} );
 
 			await setUpAccountsPage.goto();
 		} );
@@ -224,6 +231,69 @@ test.describe( 'Set up accounts', () => {
 			expect( page.url() ).toMatch( baseURL + 'google_auth' );
 		} );
 
+		test( 'should seamlessly redirect to WPCOM app auth once being redirected back from Google auth with all required access', async () => {
+			await setUpAccountsPage.mockJetpackConnected();
+			await setUpAccountsPage.mockGoogleConnected();
+			await setUpAccountsPage.goto( { 'google-mc': 'connected' } );
+
+			// Expect the user to be redirected automatically
+			await page.waitForURL( wpComAppAuthURL );
+
+			expect( page.url() ).toMatch( wpComAppAuthURL );
+		} );
+
+		test( 'should be able to go to WPCOM app auth page', async () => {
+			await setUpAccountsPage.mockJetpackConnected();
+			await setUpAccountsPage.mockGoogleConnected();
+			await setUpAccountsPage.mockMCNotConnected();
+			await setUpAccountsPage.goto();
+
+			const card = setUpAccountsPage.getAuthorizeWPComAppCard();
+
+			await expect( card.getByText( 'mail@example.com' ) ).toBeVisible();
+			await expect(
+				card.getByText(
+					'Granting Google access to your WooCommerce store is required'
+				)
+			).toBeVisible();
+			await expect(
+				card.getByRole( 'button', {
+					name: 'Or, connect to a different',
+				} )
+			).toBeVisible();
+
+			await card.getByRole( 'button', { name: 'Grant access' } ).click();
+			await page.waitForURL( wpComAppAuthURL );
+
+			expect( page.url() ).toMatch( wpComAppAuthURL );
+		} );
+
+		test( 'Should show a corresponding message when the user denies WPCOM app auth', async () => {
+			await setUpAccountsPage.mockJetpackConnected();
+			await setUpAccountsPage.mockGoogleConnected();
+			await setUpAccountsPage.mockMCNotConnected( false, 'disapproved' );
+			await setUpAccountsPage.goto();
+
+			await expect(
+				setUpAccountsPage
+					.getAuthorizeWPComAppCard()
+					.getByText( 'Access was denied' )
+			).toBeVisible();
+		} );
+
+		test( 'Should show a corresponding message when an error occurs in WPCOM app auth', async () => {
+			await setUpAccountsPage.mockJetpackConnected();
+			await setUpAccountsPage.mockGoogleConnected();
+			await setUpAccountsPage.mockMCNotConnected( false, 'error' );
+			await setUpAccountsPage.goto();
+
+			await expect(
+				setUpAccountsPage
+					.getAuthorizeWPComAppCard()
+					.getByText( 'There was an error granting Google access' )
+			).toBeVisible();
+		} );
+
 		test( 'should create merchant center and ads account if does not exist for the user', async () => {
 			const once = setUpAccountsPage.withFulfillTimes( 1 );
 			const deferred = once.withFulfillDeferred();
@@ -238,7 +308,7 @@ test.describe( 'Set up accounts', () => {
 			await once.mockMCHasNoAccounts();
 			await once.mockAdsAccountDisconnected();
 			await once.mockAdsStatusDisconnected();
-			await once.mockMCNotConnected();
+			await once.mockMCNotConnected( false, 'approved' );
 
 			await setUpAccountsPage.goto();
 
@@ -274,7 +344,7 @@ test.describe( 'Set up accounts', () => {
 			await once.mockMCHasNoAccounts();
 			await once.mockAdsAccountDisconnected();
 			await once.mockAdsStatusDisconnected();
-			await once.mockMCNotConnected();
+			await once.mockMCNotConnected( false, 'approved' );
 
 			await setUpAccountsPage.goto();
 
@@ -342,7 +412,7 @@ test.describe( 'Set up accounts', () => {
 				setUpAccountsPage.mockAdsStatusClaimed(),
 
 				// Mock merchant center as not connected.
-				setUpAccountsPage.mockMCNotConnected(),
+				setUpAccountsPage.mockMCNotConnected( false, 'approved' ),
 			] );
 		} );
 
@@ -428,10 +498,10 @@ test.describe( 'Set up accounts', () => {
 					} ) => {
 						const host = new URL( baseURL ).host;
 
-						await Promise.all( [
-							// Mock Merchant Center as not connected
-							setUpAccountsPage.mockMCNotConnected(),
-						] );
+						await setUpAccountsPage.mockMCNotConnected(
+							false,
+							'approved'
+						);
 
 						await page.reload();
 
@@ -512,7 +582,7 @@ test.describe( 'Set up accounts', () => {
 					setUpAccountsPage.mockAdsAccountsResponse( ADS_ACCOUNTS ),
 
 					// Mock merchant center as not connected.
-					setUpAccountsPage.mockMCNotConnected(),
+					setUpAccountsPage.mockMCNotConnected( false, 'approved' ),
 
 					// Mock merchant center has accounts
 					setUpAccountsPage.mockMCHasAccounts(),
@@ -803,7 +873,7 @@ test.describe( 'Set up accounts', () => {
 			await setUpAccountsPage.mockAdsAccountConnected();
 			await setUpAccountsPage.mockAdsStatusClaimed();
 			await setUpAccountsPage.mockMCHasAccounts();
-			await setUpAccountsPage.mockMCNotConnected();
+			await setUpAccountsPage.mockMCNotConnected( false, 'approved' );
 
 			await setUpAccountsPage.goto();
 		} );
@@ -874,7 +944,7 @@ test.describe( 'Set up accounts', () => {
 		test.describe( 'When only Ads is connected', async () => {
 			test.beforeAll( async () => {
 				await setUpAccountsPage.mockAdsAccountConnected();
-				await setUpAccountsPage.mockMCNotConnected();
+				await setUpAccountsPage.mockMCNotConnected( false, 'approved' );
 				await setUpAccountsPage.mockContactInformation( {
 					wcAddressErrors: [],
 					isMCAddressDifferent: false,

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -643,14 +643,14 @@ export default class MockRequests {
 	/**
 	 * Mock MC as connected.
 	 *
-	 * @param {number} id
-	 * @param {boolean} notificationServiceEnabled
-	 * @param {null|'approved'|'error'|'dissaproved'} wpcomRestApiStatus
+	 * @param {number} [id=1234]
+	 * @param {boolean} [notificationServiceEnabled=false]
+	 * @param {null|'approved'|'error'|'disapproved'} [wpcomRestApiStatus='approved']
 	 */
 	async mockMCConnected(
 		id = 1234,
 		notificationServiceEnabled = false,
-		wpcomRestApiStatus = null
+		wpcomRestApiStatus = 'approved'
 	) {
 		await this.fulfillMCConnection( {
 			id,
@@ -662,11 +662,19 @@ export default class MockRequests {
 
 	/**
 	 * Mock MC as not connected.
+	 *
+	 * @param {boolean} [notificationServiceEnabled=false]
+	 * @param {null|'approved'|'error'|'disapproved'} [wpcomRestApiStatus=null]
 	 */
-	async mockMCNotConnected() {
+	async mockMCNotConnected(
+		notificationServiceEnabled = false,
+		wpcomRestApiStatus = null
+	) {
 		await this.fulfillMCConnection( {
 			id: 0,
 			status: 'disconnected',
+			notification_service_enabled: notificationServiceEnabled,
+			wpcom_rest_api_status: wpcomRestApiStatus,
 		} );
 	}
 

--- a/tests/e2e/utils/pages/onboarding/step-1-set-up-accounts.js
+++ b/tests/e2e/utils/pages/onboarding/step-1-set-up-accounts.js
@@ -28,13 +28,19 @@ export default class SetUpAccountsPage extends MockRequests {
 	/**
 	 * Go to the set up mc page.
 	 *
+	 * @param {Object} [searchParamsObject] Additional Search params to be added to the URL.
 	 * @return {Promise<void>}
 	 */
-	async goto() {
-		await this.page.goto(
-			'/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc',
-			{ waitUntil: LOAD_STATE.DOM_CONTENT_LOADED }
-		);
+	async goto( searchParamsObject ) {
+		const search = new URLSearchParams( {
+			page: 'wc-admin',
+			path: '/google/setup-mc',
+			...searchParamsObject,
+		} );
+
+		await this.page.goto( '/wp-admin/admin.php?' + search.toString(), {
+			waitUntil: LOAD_STATE.DOM_CONTENT_LOADED,
+		} );
 	}
 
 	/**
@@ -238,6 +244,15 @@ export default class SetUpAccountsPage extends MockRequests {
 		return this.page.locator(
 			'.gla-google-combo-service-account-card--google'
 		);
+	}
+
+	/**
+	 * Get WPCom app authorization card.
+	 *
+	 * @return {import('@playwright/test').Locator} Locator for WPCom app authorization card.
+	 */
+	getAuthorizeWPComAppCard() {
+		return this.page.locator( '.gla-authorize-wpcom-app-card' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project thread: pcTzPl-2Df-p2

The PR adds the process of granting API Pull access to step 1 of the onboarding flow.

### Screenshots:

#### 📹 Approve Google account and WPCOM app authorizations with all required access

This demonstrates the case where the user is automatically and seamlessly redirected to WPCOM app authorization once they are being redirected back from the Google authorization with all required access.

https://github.com/user-attachments/assets/b6d101d8-6387-4446-9df2-f3f154a025c5

#### 📹 Approve Google account authorization with partial access, and deny WPCOM app authorization on the first attempt

This demonstrates the case:

- The mid-state asks the user to grant all required access to their Google account
- The mid-state asks the user again to approve WPCOM app authorization

https://github.com/user-attachments/assets/7d589351-7b15-4f12-b3d3-60635dfd4b3f

#### 📷 The default mid-state UI without additional messages

User will see it in the following scenarios:

- User interrupted the onboarding process after completing the Google account connection and authorization, and then return to the onboarding process again.
- In any case the authorization URL in the automated and seamless process was not successfully obtained.

![image](https://github.com/user-attachments/assets/e671dc52-4efc-445a-ae0b-29524f29515a)

#### 📷 The mid-state UI after the user denied authorization

![image](https://github.com/user-attachments/assets/d52ee42f-e81e-4c10-9717-ff7f37a9b65c)

#### 📷 The mid-state UI after the user approved authorization with a mismatched WPCOM account

The user has connected a WPCOM account *A* before, and they approved authorization with another WPCOM account *B*

![image](https://github.com/user-attachments/assets/d39a8bd5-9c73-4afc-a08f-d58ebf738514)

### Detailed test instructions:

1. Use the Connection Test page to disconnect Google account and the authorization of Google's WPCOM app if they have been connected or granted
2.Make the test site publicly accessible
3. Go to step 1 of the onboarding flow
4. Connect to Google account with the all required permissions, and check if it automatically redirects you to WPCOM app authorization once you are being redirected back from the Google authorization
5. Approve WPCOM app authorization
6. After back to the onboarding flow, check if the connection setup of Google Merchant Center and Google Ads accounts are shown
7. Click the "Or, connect to a different Google account" button to and redo step 4
   - This step and the next step will verify if the WPCOM app is also disconnected as well
8. Deny WPCOM app authorization
9. After back to the onboarding flow, check if the Google account card is shown with the mid-state UI showing
   > Access was denied. Please make sure to grant Google access to your WooCommerce store to continue.
10. Click the "Grant access" button to see if it redirects you to the authorization of WPCOM app
11. Approve WPCOM app authorization
12. After back to the onboarding flow, check if the connection setup of Google Merchant Center and Google Ads accounts are shown
13. Complete the rest account connections and check to see if the "Continue" button at the bottom is enabled
14. Continue to step 2
15. Refresh the webpage to check if it starts from step 2
16. View the E2E testing result: https://github.com/woocommerce/google-listings-and-ads/actions/runs/13564482640/job/37914394871

### Changelog entry

> Add - During onboarding, it requires granting access to Google's WordPress.com application to synchronize product data with Google.
