### PR TITLE
Remove a test assertion that occasionally causes PHPUnit tests to false positive

### DIFF
--- a/tests/Unit/Coupon/WCCouponAdapterTest.php
+++ b/tests/Unit/Coupon/WCCouponAdapterTest.php
@@ -195,18 +195,7 @@ class WCCouponAdapterTest extends UnitTest {
 		);
 		$adapted_coupon->disable_promotion( $coupon );
 		$dates = $adapted_coupon->getPromotionEffectiveTimePeriod();
-
-		$this->assertEquals(
-			new GoogleTimePeriod(
-				[
-					'startTime' => (string) $postdate,
-					'endTime'   => (string) $postdate,
-				]
-			),
-			$dates
-		);
-
-		$now = gmdate( DATE_ATOM );
+		$now   = gmdate( DATE_ATOM );
 
 		//phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$this->assertEquals( $postdate, $dates->startTime );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

https://github.com/woocommerce/google-listings-and-ads/blob/a524abb5c382612e1b9a4874dfdf639c6ab2b4fe/tests/Unit/Coupon/WCCouponAdapterTest.php#L199-L207

There was a previous version of the above test assertion, which was replaced with the below test assertions in PR #1245. However, it was accidentally added back in this rewritten version in PR #1260 when resolving code conflict, and for the same purpose as the one below.

https://github.com/woocommerce/google-listings-and-ads/blob/a524abb5c382612e1b9a4874dfdf639c6ab2b4fe/tests/Unit/Coupon/WCCouponAdapterTest.php#L212-L214

📌 This PR removes it again to avoid occasional failures like [this run of PHPUnit](https://github.com/woocommerce/google-listings-and-ads/actions/runs/13451910847/job/37587747080)

![image](https://github.com/user-attachments/assets/524a92ff-810c-46d7-8f76-429668b19808)

### Detailed test instructions:

1. View the test assertions to check
   - If they are indeed duplicating the purpose of the test
   - If the retained test assertions are preferable
2. Check if the PHPUnit testing can pass

### Changelog entry
