### PR TITLE
Block Notifications when PULL mode is disabled

### DIFF
--- a/src/API/Site/Controllers/RestAPI/SyncController.php
+++ b/src/API/Site/Controllers/RestAPI/SyncController.php
@@ -221,7 +221,7 @@ class SyncController extends BaseOptionsController {
 
 	/**
 	 * Get the parameters from the request body.
-	 * Only the keys in SyncTrait::get_default_sync_mode() that contains boolean pull and/or push param are allowed.
+	 * Only the keys in NotificationsService::get_default_sync_mode() that contains boolean pull and/or push param are allowed.
 	 *
 	 * @param Request $request The request
 	 * @return array

--- a/src/API/Site/Controllers/RestAPI/SyncController.php
+++ b/src/API/Site/Controllers/RestAPI/SyncController.php
@@ -5,7 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestA
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
@@ -62,7 +62,11 @@ defined( 'ABSPATH' ) || exit;
  */
 class SyncController extends BaseOptionsController {
 
-	use SyncTrait;
+
+	/**
+	 * @var NotificationsService
+	 */
+	protected $notifications_service;
 
 	/**
 	 * The base for routes in this controller.
@@ -74,10 +78,12 @@ class SyncController extends BaseOptionsController {
 	/**
 	 * SyncController constructor.
 	 *
-	 * @param RESTServer $server
+	 * @param RESTServer           $server
+	 * @param NotificationsService $notifications_service
 	 */
-	public function __construct( RESTServer $server ) {
+	public function __construct( RESTServer $server, NotificationsService $notifications_service ) {
 		parent::__construct( $server );
+		$this->notifications_service = $notifications_service;
 	}
 
 	/**
@@ -111,7 +117,7 @@ class SyncController extends BaseOptionsController {
 	protected function get_sync_callback(): callable {
 		return function ( Request $request ) {
 			try {
-				$sync_mode = $this->get_current_sync_mode();
+				$sync_mode = $this->notifications_service->get_current_sync_mode();
 				return $this->prepare_item_for_response( $sync_mode, $request );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
@@ -127,7 +133,7 @@ class SyncController extends BaseOptionsController {
 	protected function get_update_sync_callback(): callable {
 		return function ( Request $request ) {
 			try {
-				$sync_mode     = $this->get_current_sync_mode();
+				$sync_mode     = $this->notifications_service->get_current_sync_mode();
 				$new_params    = $this->get_request_params( $request );
 				$new_sync_mode = array_replace_recursive( $sync_mode, $new_params );
 
@@ -227,7 +233,7 @@ class SyncController extends BaseOptionsController {
 			return [];
 		}
 
-		$params       = array_intersect_key( $request_params, $this->get_default_sync_mode() );
+		$params       = array_intersect_key( $request_params, $this->notifications_service->get_default_sync_mode() );
 		$valid_params = [];
 
 		foreach ( $params as $key => $param ) {

--- a/src/API/Site/Controllers/RestAPI/SyncController.php
+++ b/src/API/Site/Controllers/RestAPI/SyncController.php
@@ -111,7 +111,7 @@ class SyncController extends BaseOptionsController {
 	protected function get_sync_callback(): callable {
 		return function ( Request $request ) {
 			try {
-				$sync_mode = $this->get_current_sync_value();
+				$sync_mode = $this->get_current_sync_mode();
 				return $this->prepare_item_for_response( $sync_mode, $request );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
@@ -127,7 +127,7 @@ class SyncController extends BaseOptionsController {
 	protected function get_update_sync_callback(): callable {
 		return function ( Request $request ) {
 			try {
-				$sync_mode     = $this->get_current_sync_value();
+				$sync_mode     = $this->get_current_sync_mode();
 				$new_params    = $this->get_request_params( $request );
 				$new_sync_mode = array_replace_recursive( $sync_mode, $new_params );
 

--- a/src/API/Site/Controllers/RestAPI/SyncController.php
+++ b/src/API/Site/Controllers/RestAPI/SyncController.php
@@ -227,7 +227,7 @@ class SyncController extends BaseOptionsController {
 			return [];
 		}
 
-		$params       = array_intersect_key( $request_params, self::get_default_sync_mode() );
+		$params       = array_intersect_key( $request_params, $this->get_default_sync_mode() );
 		$valid_params = [];
 
 		foreach ( $params as $key => $param ) {

--- a/src/API/Site/Controllers/RestAPI/SyncController.php
+++ b/src/API/Site/Controllers/RestAPI/SyncController.php
@@ -215,7 +215,7 @@ class SyncController extends BaseOptionsController {
 
 	/**
 	 * Get the parameters from the request body.
-	 * Only the keys in self::DEFAULT_SYNC_MODE that contains boolean pull and/or push param are allowed.
+	 * Only the keys in SyncTrait::get_default_sync_mode() that contains boolean pull and/or push param are allowed.
 	 *
 	 * @param Request $request The request
 	 * @return array
@@ -227,7 +227,7 @@ class SyncController extends BaseOptionsController {
 			return [];
 		}
 
-		$params       = array_intersect_key( $request_params, self::DEFAULT_SYNC_MODE );
+		$params       = array_intersect_key( $request_params, self::get_default_sync_mode() );
 		$valid_params = [];
 
 		foreach ( $params as $key => $param ) {

--- a/src/API/Site/Controllers/RestAPI/SyncController.php
+++ b/src/API/Site/Controllers/RestAPI/SyncController.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestA
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
@@ -61,24 +62,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class SyncController extends BaseOptionsController {
 
-	private const DEFAULT_SYNC_MODE = [
-		'products' => [
-			'pull' => false,
-			'push' => false,
-		],
-		'coupons'  => [
-			'pull' => false,
-			'push' => false,
-		],
-		'shipping' => [
-			'pull' => false,
-			'push' => false,
-		],
-		'settings' => [
-			'pull' => false,
-			'push' => false,
-		],
-	];
+	use SyncTrait;
 
 	/**
 	 * The base for routes in this controller.
@@ -227,22 +211,6 @@ class SyncController extends BaseOptionsController {
 	 */
 	protected function get_update_sync_params(): array {
 		return $this->get_schema_properties();
-	}
-
-	/**
-	 * Get the current value for the API PULL Sync.
-	 * Notice that malformed data will be replaced by default data.
-	 *
-	 * @return array
-	 */
-	protected function get_current_sync_value(): array {
-		$sync_mode = $this->options->get( OptionsInterface::API_PULL_SYNC_MODE );
-
-		if ( ! is_array( $sync_mode ) ) {
-			$sync_mode = self::DEFAULT_SYNC_MODE;
-		}
-
-		return array_replace_recursive( self::DEFAULT_SYNC_MODE, $sync_mode );
 	}
 
 	/**

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -214,19 +214,19 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 */
 	protected function get_datatype_from_topic( string $topic ): string {
 		if ( in_array( $topic, self::PRODUCT_TOPICS, true ) ) {
-			return self::get_products_datatype();
+			return $this->get_products_datatype();
 		}
 
 		if ( in_array( $topic, self::COUPON_TOPICS, true ) ) {
-			return self::get_coupons_datatype();
+			return $this->get_coupons_datatype();
 		}
 
 		if ( in_array( $topic, self::SHIPPING_TOPICS, true ) ) {
-			return self::get_shipping_datatype();
+			return $this->get_shipping_datatype();
 		}
 
 		if ( in_array( $topic, self::SETTINGS_TOPICS, true ) ) {
-			return self::get_settings_datatype();
+			return $this->get_settings_datatype();
 		}
 
 		return $topic;

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Jetpack_Options;
 
 defined( 'ABSPATH' ) || exit;
@@ -230,5 +231,46 @@ class NotificationsService implements Service, OptionsAwareInterface {
 		}
 
 		return $topic;
+	}
+
+	/**
+	 * Get the current value for the API PULL / MC PUSH Sync mode.
+	 * Notice that malformed data will be replaced by default data.
+	 *
+	 * @return array
+	 */
+	public function get_current_sync_mode(): array {
+		$sync_mode = $this->options->get( OptionsInterface::API_PULL_SYNC_MODE );
+
+		if ( ! is_array( $sync_mode ) ) {
+			$sync_mode = $this->get_default_sync_mode();
+		}
+
+		$sync_mode = array_replace_recursive( $this->get_default_sync_mode(), $sync_mode );
+		return apply_filters( 'woocommerce_gla_sync_mode', $sync_mode );
+	}
+
+	/**
+	 * Check if API PULL is enabled for a specific data type.
+	 * Checking a non-existent data type will return false.
+	 *
+	 * @param string $data_type The data type to check.
+	 * @return bool
+	 */
+	public function is_pull_enabled_for_datatype( string $data_type ): bool {
+		$sync_modes = $this->get_current_sync_mode();
+		return (bool) apply_filters( 'woocommerce_gla_is_pull_enabled_for_datatype', $data_type, $sync_modes[ $data_type ]['pull'] ?? false );
+	}
+
+	/**
+	 * Check if MC PUSH is enabled for a specific data type.
+	 * Checking a non-existent data type will return false.
+	 *
+	 * @param string $data_type The data type to check.
+	 * @return bool
+	 */
+	public function is_push_enabled_for_datatype( string $data_type ): bool {
+		$sync_modes = $this->get_current_sync_mode();
+		return (bool) apply_filters( 'woocommerce_gla_is_push_enabled_for_datatype', $data_type, $sync_modes[ $data_type ]['push'] ?? false );
 	}
 }

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -214,19 +214,19 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 */
 	protected function get_datatype_from_topic( string $topic ): string {
 		if ( in_array( $topic, self::PRODUCT_TOPICS, true ) ) {
-			return self::DATATYPE_PRODUCTS;
+			return self::get_products_datatype();
 		}
 
 		if ( in_array( $topic, self::COUPON_TOPICS, true ) ) {
-			return self::DATATYPE_COUPONS;
+			return self::get_coupons_datatype();
 		}
 
 		if ( in_array( $topic, self::SHIPPING_TOPICS, true ) ) {
-			return self::DATATYPE_SHIPPING;
+			return self::get_shipping_datatype();
 		}
 
 		if ( in_array( $topic, self::SETTINGS_TOPICS, true ) ) {
-			return self::DATATYPE_SETTINGS;
+			return self::get_settings_datatype();
 		}
 
 		return $topic;

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -194,7 +194,7 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 */
 	public function is_ready( string $data_type = null, bool $with_health_check = true ): bool {
 		$is_ready = $this->options->is_wpcom_api_authorized() && $this->is_enabled() && $this->merchant_center->is_ready_for_syncing() && ( $with_health_check === false || $this->account_service->is_wpcom_api_status_healthy() );
-		return $is_ready && $this->is_pull_enabled_for_datatype( $data_type );
+		return $is_ready && ( is_null( $data_type ) || $this->is_pull_enabled_for_datatype( $data_type ) );
 	}
 
 	/**

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -48,20 +48,20 @@ class NotificationsService implements Service, OptionsAwareInterface {
 		self::TOPIC_SETTINGS_UPDATED,
 	];
 
-	public const PRODUCT_TOPICS =  [
+	public const PRODUCT_TOPICS = [
 		self::TOPIC_PRODUCT_CREATED,
 		self::TOPIC_PRODUCT_UPDATED,
-		self::TOPIC_PRODUCT_DELETED
+		self::TOPIC_PRODUCT_DELETED,
 	];
 
-	public const COUPON_TOPICS =  [
+	public const COUPON_TOPICS = [
 		self::TOPIC_COUPON_CREATED,
 		self::TOPIC_COUPON_UPDATED,
-		self::TOPIC_COUPON_DELETED
+		self::TOPIC_COUPON_DELETED,
 	];
 
-	public const SHIPPING_TOPICS =  [ self::TOPIC_SHIPPING_UPDATED ];
-	public const SETTINGS_TOPICS =  [ self::TOPIC_SETTINGS_UPDATED ];
+	public const SHIPPING_TOPICS = [ self::TOPIC_SHIPPING_UPDATED ];
+	public const SETTINGS_TOPICS = [ self::TOPIC_SETTINGS_UPDATED ];
 
 	/**
 	 * The url to send the notification
@@ -188,9 +188,9 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 * If the Notifications are ready
 	 * This happens when the WPCOM API is Authorized and the feature is enabled.
 	 *
-	 * @param bool $with_health_check If true. Performs a remote request to WPCOM API to get the status.
 	 * @param string|null $data_type The data type to check.
-	 * @return bool
+	 * @param bool        $with_health_check If true. Performs a remote request to WPCOM API to get the status.
+	 *        * @return bool
 	 */
 	public function is_ready( string $data_type = null, bool $with_health_check = true ): bool {
 		$is_ready = $this->options->is_wpcom_api_authorized() && $this->is_enabled() && $this->merchant_center->is_ready_for_syncing() && ( $with_health_check === false || $this->account_service->is_wpcom_api_status_healthy() );

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\WP;
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
@@ -23,6 +24,7 @@ defined( 'ABSPATH' ) || exit;
 class NotificationsService implements Service, OptionsAwareInterface {
 
 	use OptionsAwareTrait;
+	use SyncTrait;
 
 	// List of Topics to be used.
 	public const TOPIC_PRODUCT_CREATED  = 'product.create';
@@ -45,6 +47,21 @@ class NotificationsService implements Service, OptionsAwareInterface {
 		self::TOPIC_SHIPPING_UPDATED,
 		self::TOPIC_SETTINGS_UPDATED,
 	];
+
+	public const PRODUCT_TOPICS =  [
+		self::TOPIC_PRODUCT_CREATED,
+		self::TOPIC_PRODUCT_UPDATED,
+		self::TOPIC_PRODUCT_DELETED
+	];
+
+	public const COUPON_TOPICS =  [
+		self::TOPIC_COUPON_CREATED,
+		self::TOPIC_COUPON_UPDATED,
+		self::TOPIC_COUPON_DELETED
+	];
+
+	public const SHIPPING_TOPICS =  [ self::TOPIC_SHIPPING_UPDATED ];
+	public const SETTINGS_TOPICS =  [ self::TOPIC_SETTINGS_UPDATED ];
 
 	/**
 	 * The url to send the notification
@@ -100,7 +117,7 @@ class NotificationsService implements Service, OptionsAwareInterface {
 		 * @param int $item_id The item_id for the notification.
 		 * @param string $topic The topic for the notification.
 		 */
-		if ( ! apply_filters( 'woocommerce_gla_notify', $this->is_ready() && in_array( $topic, self::ALLOWED_TOPICS, true ), $item_id, $topic ) ) {
+		if ( ! apply_filters( 'woocommerce_gla_notify', $this->is_ready( $this->get_datatype_from_topic( $topic ) ) && in_array( $topic, self::ALLOWED_TOPICS, true ), $item_id, $topic ) ) {
 			$this->notification_error( $topic, 'Notification was not sent because the Notification Service is not ready or the topic is not valid.', $item_id );
 			return false;
 		}
@@ -172,10 +189,12 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 * This happens when the WPCOM API is Authorized and the feature is enabled.
 	 *
 	 * @param bool $with_health_check If true. Performs a remote request to WPCOM API to get the status.
+	 * @param string|null $data_type The data type to check.
 	 * @return bool
 	 */
-	public function is_ready( bool $with_health_check = true ): bool {
-		return $this->options->is_wpcom_api_authorized() && $this->is_enabled() && $this->merchant_center->is_ready_for_syncing() && ( $with_health_check === false || $this->account_service->is_wpcom_api_status_healthy() );
+	public function is_ready( string $data_type = null, bool $with_health_check = true ): bool {
+		$is_ready = $this->options->is_wpcom_api_authorized() && $this->is_enabled() && $this->merchant_center->is_ready_for_syncing() && ( $with_health_check === false || $this->account_service->is_wpcom_api_status_healthy() );
+		return $is_ready && $this->is_pull_enabled_for_datatype( $data_type );
 	}
 
 	/**
@@ -185,5 +204,31 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 */
 	public function is_enabled(): bool {
 		return apply_filters( 'woocommerce_gla_notifications_enabled', true );
+	}
+
+	/**
+	 * Get the DataType from a Notification Topic
+	 *
+	 * @param string $topic The topic.
+	 * @return string The DataType
+	 */
+	protected function get_datatype_from_topic( string $topic ): string {
+		if ( in_array( $topic, self::PRODUCT_TOPICS, true ) ) {
+			return self::DATATYPE_PRODUCTS;
+		}
+
+		if ( in_array( $topic, self::COUPON_TOPICS, true ) ) {
+			return self::DATATYPE_COUPONS;
+		}
+
+		if ( in_array( $topic, self::SHIPPING_TOPICS, true ) ) {
+			return self::DATATYPE_SHIPPING;
+		}
+
+		if ( in_array( $topic, self::SETTINGS_TOPICS, true ) ) {
+			return self::DATATYPE_SETTINGS;
+		}
+
+		return $topic;
 	}
 }

--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -259,7 +259,7 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 */
 	public function is_pull_enabled_for_datatype( string $data_type ): bool {
 		$sync_modes = $this->get_current_sync_mode();
-		return (bool) apply_filters( 'woocommerce_gla_is_pull_enabled_for_datatype', $data_type, $sync_modes[ $data_type ]['pull'] ?? false );
+		return (bool) apply_filters( 'woocommerce_gla_is_pull_enabled_for_datatype', $sync_modes[ $data_type ]['pull'] ?? false, $data_type );
 	}
 
 	/**
@@ -271,6 +271,6 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 */
 	public function is_push_enabled_for_datatype( string $data_type ): bool {
 		$sync_modes = $this->get_current_sync_mode();
-		return (bool) apply_filters( 'woocommerce_gla_is_push_enabled_for_datatype', $data_type, $sync_modes[ $data_type ]['push'] ?? false );
+		return (bool) apply_filters( 'woocommerce_gla_is_push_enabled_for_datatype', $sync_modes[ $data_type ]['push'] ?? false, $data_type );
 	}
 }

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\DeleteCouponEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
@@ -29,7 +28,6 @@ defined( 'ABSPATH' ) || exit();
 class SyncerHooks implements Service, Registerable {
 
 	use PluginHelper;
-	use SyncTrait;
 
 	protected const SCHEDULE_TYPE_UPDATE = 'update';
 
@@ -196,7 +194,7 @@ class SyncerHooks implements Service, Registerable {
 	protected function handle_update_coupon( WC_Coupon $coupon ) {
 		$coupon_id = $coupon->get_id();
 
-		if ( $this->notifications_service->is_ready( $this->get_coupons_datatype() ) ) {
+		if ( $this->notifications_service->is_ready( $this->notifications_service->get_coupons_datatype() ) ) {
 			$this->handle_update_coupon_notification( $coupon );
 		}
 
@@ -279,7 +277,7 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $coupon_id
 	 */
 	protected function handle_delete_coupon( int $coupon_id ) {
-		if ( $this->notifications_service->is_ready( $this->get_coupons_datatype() ) ) {
+		if ( $this->notifications_service->is_ready( $this->notifications_service->get_coupons_datatype() ) ) {
 			$this->maybe_send_delete_notification( $coupon_id );
 		}
 

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\DeleteCouponEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
@@ -28,6 +29,7 @@ defined( 'ABSPATH' ) || exit();
 class SyncerHooks implements Service, Registerable {
 
 	use PluginHelper;
+	use SyncTrait;
 
 	protected const SCHEDULE_TYPE_UPDATE = 'update';
 
@@ -194,7 +196,7 @@ class SyncerHooks implements Service, Registerable {
 	protected function handle_update_coupon( WC_Coupon $coupon ) {
 		$coupon_id = $coupon->get_id();
 
-		if ( $this->notifications_service->is_ready() ) {
+		if ( $this->notifications_service->is_ready( self::DATATYPE_COUPONS ) ) {
 			$this->handle_update_coupon_notification( $coupon );
 		}
 
@@ -277,7 +279,7 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $coupon_id
 	 */
 	protected function handle_delete_coupon( int $coupon_id ) {
-		if ( $this->notifications_service->is_ready() ) {
+		if ( $this->notifications_service->is_ready( self::DATATYPE_COUPONS ) ) {
 			$this->maybe_send_delete_notification( $coupon_id );
 		}
 

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -196,7 +196,7 @@ class SyncerHooks implements Service, Registerable {
 	protected function handle_update_coupon( WC_Coupon $coupon ) {
 		$coupon_id = $coupon->get_id();
 
-		if ( $this->notifications_service->is_ready( self::DATATYPE_COUPONS ) ) {
+		if ( $this->notifications_service->is_ready( self::get_coupons_datatype() ) ) {
 			$this->handle_update_coupon_notification( $coupon );
 		}
 
@@ -279,7 +279,7 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $coupon_id
 	 */
 	protected function handle_delete_coupon( int $coupon_id ) {
-		if ( $this->notifications_service->is_ready( self::DATATYPE_COUPONS ) ) {
+		if ( $this->notifications_service->is_ready( self::get_coupons_datatype() ) ) {
 			$this->maybe_send_delete_notification( $coupon_id );
 		}
 

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -196,7 +196,7 @@ class SyncerHooks implements Service, Registerable {
 	protected function handle_update_coupon( WC_Coupon $coupon ) {
 		$coupon_id = $coupon->get_id();
 
-		if ( $this->notifications_service->is_ready( self::get_coupons_datatype() ) ) {
+		if ( $this->notifications_service->is_ready( $this->get_coupons_datatype() ) ) {
 			$this->handle_update_coupon_notification( $coupon );
 		}
 
@@ -279,7 +279,7 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $coupon_id
 	 */
 	protected function handle_delete_coupon( int $coupon_id ) {
-		if ( $this->notifications_service->is_ready( self::get_coupons_datatype() ) ) {
+		if ( $this->notifications_service->is_ready( $this->get_coupons_datatype() ) ) {
 			$this->maybe_send_delete_notification( $coupon_id );
 		}
 

--- a/src/HelperTraits/SyncTrait.php
+++ b/src/HelperTraits/SyncTrait.php
@@ -1,0 +1,104 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\MigrateGTIN;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Exception;
+use WC_Product;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Trait with some helpers for API Pull and MC Push Sync modes.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits
+ */
+trait SyncTrait {
+
+	use OptionsAwareTrait;
+
+	public const PULL = 'pull';
+	public const PUSH = 'push';
+
+	public const DATATYPE_PRODUCTS = 'products';
+	public const DATATYPE_COUPONS  = 'coupons';
+	public const DATATYPE_SHIPPING = 'shipping';
+	public const DATATYPE_SETTINGS = 'settings';
+
+	public const DEFAULT_SYNC_MODE = [
+		self::DATATYPE_PRODUCTS => [
+			self::PULL => false,
+			self::PUSH => false,
+		],
+		self::DATATYPE_COUPONS => [
+			self::PULL => false,
+			self::PUSH => false,
+		],
+		self::DATATYPE_SHIPPING => [
+			self::PULL => false,
+			self::PUSH => false,
+		],
+		self::DATATYPE_SETTINGS => [
+			self::PULL => false,
+			self::PUSH => false,
+		],
+	];
+
+
+
+
+	/**
+	 * Get the current value for the API PULL Sync.
+	 * Notice that malformed data will be replaced by default data.
+	 *
+	 * @return array
+	 */
+	protected function get_current_sync_value(): array {
+		$sync_mode = $this->options->get(OptionsInterface::API_PULL_SYNC_MODE);
+
+		if (!is_array($sync_mode)) {
+			$sync_mode = self::DEFAULT_SYNC_MODE;
+		}
+
+		return array_replace_recursive(self::DEFAULT_SYNC_MODE, $sync_mode);
+	}
+
+	/**
+	 * Check if API PULL is enabled for a specific data type.
+	 *
+	 * Checking null data type returns true.
+	 * Checking a non-existent data type will return false.
+	 *
+	 * @param string|null $data_type The data type to check.
+	 * @return bool
+	 */
+	protected function is_pull_enabled_for_datatype( string $data_type = null ): bool {
+
+		if ( is_null( $data_type ) ) {
+			return true;
+		}
+
+		$sync_modes = $this->get_current_sync_value();
+
+		return apply_filters( 'woocommerce_gla_is_pull_enabled_for_datatype', $sync_modes[ $data_type ][self::PULL] ?? false );
+	}
+
+	/**
+	 * Check if MC PUSH is enabled for a specific data type.
+	 * @param string|null $data_type The data type to check.
+	 * @return bool
+	 */
+	protected function is_push_enabled_for_datatype( string $data_type = null ): bool {
+
+		if ( is_null( $data_type ) ) {
+			return true;
+		}
+
+		$sync_modes = $this->get_current_sync_value();
+
+		return apply_filters( 'woocommerce_gla_is_push_enabled_for_datatype', $sync_modes[ $data_type ][self::PUSH] ?? false  );
+	}
+}

--- a/src/HelperTraits/SyncTrait.php
+++ b/src/HelperTraits/SyncTrait.php
@@ -61,7 +61,7 @@ trait SyncTrait {
 	protected function get_default_sync_mode(): array {
 		$default_mode = [
 			'pull' => true,
-			'push' => true
+			'push' => true,
 		];
 
 		return [

--- a/src/HelperTraits/SyncTrait.php
+++ b/src/HelperTraits/SyncTrait.php
@@ -20,35 +20,42 @@ trait SyncTrait {
 
 	use OptionsAwareTrait;
 
-	public const PULL = 'pull';
-	public const PUSH = 'push';
+	protected function get_products_datatype() {
+		return 'products';
+	}
 
-	public const DATATYPE_PRODUCTS = 'products';
-	public const DATATYPE_COUPONS  = 'coupons';
-	public const DATATYPE_SHIPPING = 'shipping';
-	public const DATATYPE_SETTINGS = 'settings';
+	protected function get_coupons_datatype() {
+		return 'coupons';
+	}
 
-	public const DEFAULT_SYNC_MODE = [
-		self::DATATYPE_PRODUCTS => [
-			self::PULL => false,
-			self::PUSH => false,
-		],
-		self::DATATYPE_COUPONS => [
-			self::PULL => false,
-			self::PUSH => false,
-		],
-		self::DATATYPE_SHIPPING => [
-			self::PULL => false,
-			self::PUSH => false,
-		],
-		self::DATATYPE_SETTINGS => [
-			self::PULL => false,
-			self::PUSH => false,
-		],
-	];
+	protected function get_shipping_datatype() {
+		return 'shipping';
+	}
 
+	protected function get_settings_datatype() {
+		return 'settings';
+	}
 
-
+	protected function get_default_sync_mode() {
+		return [
+			$this->get_products_datatype() => [
+				'pull' => false,
+				'push' => false,
+			],
+			$this->get_coupons_datatype() => [
+				'pull' => false,
+				'push' => false,
+			],
+			$this->get_shipping_datatype() => [
+				'pull' => false,
+				'push' => false,
+			],
+			$this->get_settings_datatype() => [
+				'pull' => false,
+				'push' => false,
+			],
+		];
+	}
 
 	/**
 	 * Get the current value for the API PULL Sync.
@@ -60,10 +67,10 @@ trait SyncTrait {
 		$sync_mode = $this->options->get(OptionsInterface::API_PULL_SYNC_MODE);
 
 		if (!is_array($sync_mode)) {
-			$sync_mode = self::DEFAULT_SYNC_MODE;
+			$sync_mode = $this->get_default_sync_mode();
 		}
 
-		return array_replace_recursive(self::DEFAULT_SYNC_MODE, $sync_mode);
+		return array_replace_recursive($this->get_default_sync_mode(), $sync_mode);
 	}
 
 	/**
@@ -83,7 +90,7 @@ trait SyncTrait {
 
 		$sync_modes = $this->get_current_sync_value();
 
-		return apply_filters( 'woocommerce_gla_is_pull_enabled_for_datatype', $sync_modes[ $data_type ][self::PULL] ?? false );
+		return apply_filters( 'woocommerce_gla_is_pull_enabled_for_datatype', $sync_modes[ $data_type ]['pull'] ?? false );
 	}
 
 	/**
@@ -99,6 +106,6 @@ trait SyncTrait {
 
 		$sync_modes = $this->get_current_sync_value();
 
-		return apply_filters( 'woocommerce_gla_is_push_enabled_for_datatype', $sync_modes[ $data_type ][self::PUSH] ?? false  );
+		return apply_filters( 'woocommerce_gla_is_push_enabled_for_datatype', $sync_modes[ $data_type ]['push'] ?? false  );
 	}
 }

--- a/src/HelperTraits/SyncTrait.php
+++ b/src/HelperTraits/SyncTrait.php
@@ -3,9 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -14,8 +11,6 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits
  */
 trait SyncTrait {
-
-	use OptionsAwareTrait;
 
 	/**
 	 * Get the products datatype key
@@ -70,50 +65,5 @@ trait SyncTrait {
 			$this->get_shipping_datatype() => $default_mode,
 			$this->get_settings_datatype() => $default_mode,
 		];
-	}
-
-	/**
-	 * Get the current value for the API PULL / MC PUSH Sync mode.
-	 * Notice that malformed data will be replaced by default data.
-	 *
-	 * @return array
-	 */
-	protected function get_current_sync_mode(): array {
-		$sync_mode = $this->options->get( OptionsInterface::API_PULL_SYNC_MODE );
-
-		if ( ! is_array( $sync_mode ) ) {
-			$sync_mode = $this->get_default_sync_mode();
-		}
-
-		$sync_mode = array_replace_recursive( $this->get_default_sync_mode(), $sync_mode );
-		return apply_filters( 'woocommerce_gla_sync_mode', $sync_mode );
-	}
-
-	/**
-	 * Check if API PULL is enabled for a specific data type.
-	 * Checking a non-existent data type will return false.
-	 *
-	 * @param string $data_type The data type to check.
-	 * @return bool
-	 */
-	protected function is_pull_enabled_for_datatype( string $data_type ): bool {
-		$sync_modes = $this->get_current_sync_mode();
-		return (bool) apply_filters( 'woocommerce_gla_is_pull_enabled_for_datatype', $data_type, $sync_modes[ $data_type ]['pull'] ?? false );
-	}
-
-	/**
-	 * Check if MC PUSH is enabled for a specific data type.
-	 *
-	 * @param string|null $data_type The data type to check.
-	 * @return bool
-	 */
-	protected function is_push_enabled_for_datatype( string $data_type = null ): bool {
-		if ( is_null( $data_type ) ) {
-			return true;
-		}
-
-		$sync_modes = $this->get_current_sync_mode();
-
-		return (bool) apply_filters( 'woocommerce_gla_is_push_enabled_for_datatype', $data_type, $sync_modes[ $data_type ]['push'] ?? false );
 	}
 }

--- a/src/HelperTraits/SyncTrait.php
+++ b/src/HelperTraits/SyncTrait.php
@@ -73,19 +73,20 @@ trait SyncTrait {
 	}
 
 	/**
-	 * Get the current value for the API PULL Sync.
+	 * Get the current value for the API PULL / MC PUSH Sync mode.
 	 * Notice that malformed data will be replaced by default data.
 	 *
 	 * @return array
 	 */
-	protected function get_current_sync_value(): array {
+	protected function get_current_sync_mode(): array {
 		$sync_mode = $this->options->get( OptionsInterface::API_PULL_SYNC_MODE );
 
 		if ( ! is_array( $sync_mode ) ) {
 			$sync_mode = $this->get_default_sync_mode();
 		}
 
-		return array_replace_recursive( $this->get_default_sync_mode(), $sync_mode );
+		$sync_mode = array_replace_recursive( $this->get_default_sync_mode(), $sync_mode );
+		return apply_filters( 'woocommerce_gla_sync_mode', $sync_mode );
 	}
 
 	/**
@@ -102,7 +103,7 @@ trait SyncTrait {
 			return true;
 		}
 
-		$sync_modes = $this->get_current_sync_value();
+		$sync_modes = $this->get_current_sync_mode();
 
 		return (bool) apply_filters( 'woocommerce_gla_is_pull_enabled_for_datatype', $data_type, $sync_modes[ $data_type ]['pull'] ?? false );
 	}
@@ -118,7 +119,7 @@ trait SyncTrait {
 			return true;
 		}
 
-		$sync_modes = $this->get_current_sync_value();
+		$sync_modes = $this->get_current_sync_mode();
 
 		return (bool) apply_filters( 'woocommerce_gla_is_push_enabled_for_datatype', $data_type, $sync_modes[ $data_type ]['push'] ?? false );
 	}

--- a/src/HelperTraits/SyncTrait.php
+++ b/src/HelperTraits/SyncTrait.php
@@ -17,7 +17,7 @@ trait SyncTrait {
 	 *
 	 * @return string
 	 */
-	protected function get_products_datatype(): string {
+	public function get_products_datatype(): string {
 		return 'products';
 	}
 
@@ -26,7 +26,7 @@ trait SyncTrait {
 	 *
 	 * @return string
 	 */
-	protected function get_coupons_datatype(): string {
+	public function get_coupons_datatype(): string {
 		return 'coupons';
 	}
 
@@ -35,7 +35,7 @@ trait SyncTrait {
 	 *
 	 * @return string
 	 */
-	protected function get_shipping_datatype(): string {
+	public function get_shipping_datatype(): string {
 		return 'shipping';
 	}
 
@@ -44,7 +44,7 @@ trait SyncTrait {
 	 *
 	 * @return string
 	 */
-	protected function get_settings_datatype(): string {
+	public function get_settings_datatype(): string {
 		return 'settings';
 	}
 
@@ -53,7 +53,7 @@ trait SyncTrait {
 	 *
 	 * @return array[]
 	 */
-	protected function get_default_sync_mode(): array {
+	public function get_default_sync_mode(): array {
 		$default_mode = [
 			'pull' => true,
 			'push' => true,

--- a/src/HelperTraits/SyncTrait.php
+++ b/src/HelperTraits/SyncTrait.php
@@ -62,23 +62,16 @@ trait SyncTrait {
 	 * @return array[]
 	 */
 	protected function get_default_sync_mode(): array {
+		$default_mode = [
+			'pull' => true,
+			'push' => true
+		];
+
 		return [
-			$this->get_products_datatype() => [
-				'pull' => true,
-				'push' => true,
-			],
-			$this->get_coupons_datatype()  => [
-				'pull' => true,
-				'push' => true,
-			],
-			$this->get_shipping_datatype() => [
-				'pull' => true,
-				'push' => true,
-			],
-			$this->get_settings_datatype() => [
-				'pull' => true,
-				'push' => true,
-			],
+			$this->get_products_datatype() => $default_mode,
+			$this->get_coupons_datatype()  => $default_mode,
+			$this->get_shipping_datatype() => $default_mode,
+			$this->get_settings_datatype() => $default_mode,
 		];
 	}
 

--- a/src/HelperTraits/SyncTrait.php
+++ b/src/HelperTraits/SyncTrait.php
@@ -107,7 +107,7 @@ trait SyncTrait {
 
 		$sync_modes = $this->get_current_sync_value();
 
-		return apply_filters( 'woocommerce_gla_is_pull_enabled_for_datatype', $sync_modes[ $data_type ]['pull'] ?? false );
+		return (bool) apply_filters( 'woocommerce_gla_is_pull_enabled_for_datatype', $data_type, $sync_modes[ $data_type ]['pull'] ?? false );
 	}
 
 	/**
@@ -123,6 +123,6 @@ trait SyncTrait {
 
 		$sync_modes = $this->get_current_sync_value();
 
-		return apply_filters( 'woocommerce_gla_is_push_enabled_for_datatype', $sync_modes[ $data_type ]['push'] ?? false );
+		return (bool) apply_filters( 'woocommerce_gla_is_push_enabled_for_datatype', $data_type, $sync_modes[ $data_type ]['push'] ?? false );
 	}
 }

--- a/src/HelperTraits/SyncTrait.php
+++ b/src/HelperTraits/SyncTrait.php
@@ -3,11 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\MigrateGTIN;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
-use Exception;
-use WC_Product;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/src/HelperTraits/SyncTrait.php
+++ b/src/HelperTraits/SyncTrait.php
@@ -64,20 +64,20 @@ trait SyncTrait {
 	protected function get_default_sync_mode(): array {
 		return [
 			$this->get_products_datatype() => [
-				'pull' => false,
-				'push' => false,
+				'pull' => true,
+				'push' => true,
 			],
 			$this->get_coupons_datatype()  => [
-				'pull' => false,
-				'push' => false,
+				'pull' => true,
+				'push' => true,
 			],
 			$this->get_shipping_datatype() => [
-				'pull' => false,
-				'push' => false,
+				'pull' => true,
+				'push' => true,
 			],
 			$this->get_settings_datatype() => [
-				'pull' => false,
-				'push' => false,
+				'pull' => true,
+				'push' => true,
 			],
 		];
 	}

--- a/src/HelperTraits/SyncTrait.php
+++ b/src/HelperTraits/SyncTrait.php
@@ -20,29 +20,54 @@ trait SyncTrait {
 
 	use OptionsAwareTrait;
 
-	protected function get_products_datatype() {
+	/**
+	 * Get the products datatype key
+	 *
+	 * @return string
+	 */
+	protected function get_products_datatype(): string {
 		return 'products';
 	}
 
-	protected function get_coupons_datatype() {
+	/**
+	 * Get the coupons datatype key
+	 *
+	 * @return string
+	 */
+	protected function get_coupons_datatype(): string {
 		return 'coupons';
 	}
 
-	protected function get_shipping_datatype() {
+	/**
+	 * Get the shipping datatype key
+	 *
+	 * @return string
+	 */
+	protected function get_shipping_datatype(): string {
 		return 'shipping';
 	}
 
-	protected function get_settings_datatype() {
+	/**
+	 * Get the settings datatype key
+	 *
+	 * @return string
+	 */
+	protected function get_settings_datatype(): string {
 		return 'settings';
 	}
 
-	protected function get_default_sync_mode() {
+	/**
+	 * Get the default config for the sync mode.
+	 *
+	 * @return array[]
+	 */
+	protected function get_default_sync_mode(): array {
 		return [
 			$this->get_products_datatype() => [
 				'pull' => false,
 				'push' => false,
 			],
-			$this->get_coupons_datatype() => [
+			$this->get_coupons_datatype()  => [
 				'pull' => false,
 				'push' => false,
 			],
@@ -64,13 +89,13 @@ trait SyncTrait {
 	 * @return array
 	 */
 	protected function get_current_sync_value(): array {
-		$sync_mode = $this->options->get(OptionsInterface::API_PULL_SYNC_MODE);
+		$sync_mode = $this->options->get( OptionsInterface::API_PULL_SYNC_MODE );
 
-		if (!is_array($sync_mode)) {
+		if ( ! is_array( $sync_mode ) ) {
 			$sync_mode = $this->get_default_sync_mode();
 		}
 
-		return array_replace_recursive($this->get_default_sync_mode(), $sync_mode);
+		return array_replace_recursive( $this->get_default_sync_mode(), $sync_mode );
 	}
 
 	/**
@@ -83,7 +108,6 @@ trait SyncTrait {
 	 * @return bool
 	 */
 	protected function is_pull_enabled_for_datatype( string $data_type = null ): bool {
-
 		if ( is_null( $data_type ) ) {
 			return true;
 		}
@@ -95,17 +119,17 @@ trait SyncTrait {
 
 	/**
 	 * Check if MC PUSH is enabled for a specific data type.
+	 *
 	 * @param string|null $data_type The data type to check.
 	 * @return bool
 	 */
 	protected function is_push_enabled_for_datatype( string $data_type = null ): bool {
-
 		if ( is_null( $data_type ) ) {
 			return true;
 		}
 
 		$sync_modes = $this->get_current_sync_value();
 
-		return apply_filters( 'woocommerce_gla_is_push_enabled_for_datatype', $sync_modes[ $data_type ]['push'] ?? false  );
+		return apply_filters( 'woocommerce_gla_is_push_enabled_for_datatype', $sync_modes[ $data_type ]['push'] ?? false );
 	}
 }

--- a/src/HelperTraits/SyncTrait.php
+++ b/src/HelperTraits/SyncTrait.php
@@ -91,20 +91,13 @@ trait SyncTrait {
 
 	/**
 	 * Check if API PULL is enabled for a specific data type.
-	 *
-	 * Checking null data type returns true.
 	 * Checking a non-existent data type will return false.
 	 *
-	 * @param string|null $data_type The data type to check.
+	 * @param string $data_type The data type to check.
 	 * @return bool
 	 */
-	protected function is_pull_enabled_for_datatype( string $data_type = null ): bool {
-		if ( is_null( $data_type ) ) {
-			return true;
-		}
-
+	protected function is_pull_enabled_for_datatype( string $data_type ): bool {
 		$sync_modes = $this->get_current_sync_mode();
-
 		return (bool) apply_filters( 'woocommerce_gla_is_pull_enabled_for_datatype', $data_type, $sync_modes[ $data_type ]['pull'] ?? false );
 	}
 

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -53,6 +53,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCen
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SyncableProductsCountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\TargetAudienceController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestAPI\AuthController as RestAPIAuthController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\OAuthService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
@@ -144,7 +145,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( TourController::class );
 		$this->share( RestAPIAuthController::class, OAuthService::class, MerchantAccountService::class );
 		$this->share( GTINMigrationController::class, JobRepository::class );
-		$this->share( SyncController::class );
+		$this->share( SyncController::class, NotificationsService::class );
 	}
 
 	/**

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteProducts;
@@ -31,7 +30,6 @@ defined( 'ABSPATH' ) || exit;
 class SyncerHooks implements Service, Registerable {
 
 	use PluginHelper;
-	use SyncTrait;
 
 	protected const SCHEDULE_TYPE_UPDATE = 'update';
 	protected const SCHEDULE_TYPE_DELETE = 'delete';
@@ -211,7 +209,7 @@ class SyncerHooks implements Service, Registerable {
 			$product_id = $product->get_id();
 
 			// Avoid to handle variations directly. We handle them from the parent.
-			if ( $this->notifications_service->is_ready( self::get_products_datatype() ) && $notify ) {
+			if ( $this->notifications_service->is_ready( $this->notifications_service->get_products_datatype() ) && $notify ) {
 				$this->handle_update_product_notification( $product );
 			}
 
@@ -346,7 +344,7 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $product_id
 	 */
 	protected function handle_pre_delete_product( int $product_id ) {
-		if ( $this->notifications_service->is_ready( $this->get_products_datatype() ) ) {
+		if ( $this->notifications_service->is_ready( $this->notifications_service->get_products_datatype() ) ) {
 			/**
 			 * For deletions, we do send directly the notification instead of scheduling it.
 			 * This is because we want to avoid that the product is not in the database anymore when the scheduled action runs.

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteProducts;
@@ -30,6 +31,7 @@ defined( 'ABSPATH' ) || exit;
 class SyncerHooks implements Service, Registerable {
 
 	use PluginHelper;
+	use SyncTrait;
 
 	protected const SCHEDULE_TYPE_UPDATE = 'update';
 	protected const SCHEDULE_TYPE_DELETE = 'delete';
@@ -209,7 +211,7 @@ class SyncerHooks implements Service, Registerable {
 			$product_id = $product->get_id();
 
 			// Avoid to handle variations directly. We handle them from the parent.
-			if ( $this->notifications_service->is_ready() && $notify ) {
+			if ( $this->notifications_service->is_ready( self::DATATYPE_PRODUCTS ) && $notify ) {
 				$this->handle_update_product_notification( $product );
 			}
 
@@ -344,7 +346,7 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $product_id
 	 */
 	protected function handle_pre_delete_product( int $product_id ) {
-		if ( $this->notifications_service->is_ready() ) {
+		if ( $this->notifications_service->is_ready( self::DATATYPE_PRODUCTS ) ) {
 			/**
 			 * For deletions, we do send directly the notification instead of scheduling it.
 			 * This is because we want to avoid that the product is not in the database anymore when the scheduled action runs.

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -211,7 +211,7 @@ class SyncerHooks implements Service, Registerable {
 			$product_id = $product->get_id();
 
 			// Avoid to handle variations directly. We handle them from the parent.
-			if ( $this->notifications_service->is_ready( self::DATATYPE_PRODUCTS ) && $notify ) {
+			if ( $this->notifications_service->is_ready( self::get_products_datatype() ) && $notify ) {
 				$this->handle_update_product_notification( $product );
 			}
 
@@ -346,7 +346,7 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $product_id
 	 */
 	protected function handle_pre_delete_product( int $product_id ) {
-		if ( $this->notifications_service->is_ready( self::DATATYPE_PRODUCTS ) ) {
+		if ( $this->notifications_service->is_ready( $this->get_products_datatype() ) ) {
 			/**
 			 * For deletions, we do send directly the notification instead of scheduling it.
 			 * This is because we want to avoid that the product is not in the database anymore when the scheduled action runs.

--- a/src/Settings/SyncerHooks.php
+++ b/src/Settings/SyncerHooks.php
@@ -83,7 +83,7 @@ class SyncerHooks implements Service, Registerable {
 	 * Register the service.
 	 */
 	public function register(): void {
-		if ( ! $this->notifications_service->is_ready( self::DATATYPE_SETTINGS, false ) ) {
+		if ( ! $this->notifications_service->is_ready( self::get_settings_datatype(), false ) ) {
 			return;
 		}
 

--- a/src/Settings/SyncerHooks.php
+++ b/src/Settings/SyncerHooks.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Settings;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
@@ -22,8 +21,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 2.8.0
  */
 class SyncerHooks implements Service, Registerable {
-
-	use SyncTrait;
 
 	/**
 	 * @var NotificationsService $notifications_service
@@ -83,7 +80,7 @@ class SyncerHooks implements Service, Registerable {
 	 * Register the service.
 	 */
 	public function register(): void {
-		if ( ! $this->notifications_service->is_ready( self::get_settings_datatype(), false ) ) {
+		if ( ! $this->notifications_service->is_ready( $this->notifications_service->get_settings_datatype(), false ) ) {
 			return;
 		}
 

--- a/src/Settings/SyncerHooks.php
+++ b/src/Settings/SyncerHooks.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Settings;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
@@ -21,6 +22,8 @@ defined( 'ABSPATH' ) || exit;
  * @since 2.8.0
  */
 class SyncerHooks implements Service, Registerable {
+
+	use SyncTrait;
 
 	/**
 	 * @var NotificationsService $notifications_service
@@ -80,7 +83,7 @@ class SyncerHooks implements Service, Registerable {
 	 * Register the service.
 	 */
 	public function register(): void {
-		if ( ! $this->notifications_service->is_ready( false ) ) {
+		if ( ! $this->notifications_service->is_ready( self::DATATYPE_SETTINGS, false ) ) {
 			return;
 		}
 

--- a/src/Shipping/SyncerHooks.php
+++ b/src/Shipping/SyncerHooks.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
@@ -24,6 +25,8 @@ defined( 'ABSPATH' ) || exit;
  * @since 2.1.0
  */
 class SyncerHooks implements Service, Registerable {
+
+	use SyncTrait;
 
 	/**
 	 * This property is used to avoid scheduling duplicate jobs in the same request.
@@ -138,7 +141,7 @@ class SyncerHooks implements Service, Registerable {
 			return;
 		}
 
-		if ( $this->notifications_service->is_ready() ) {
+		if ( $this->notifications_service->is_ready( self::DATATYPE_SHIPPING ) ) {
 			$this->job_repository->get( ShippingNotificationJob::class )->schedule( [ 'topic' => NotificationsService::TOPIC_SHIPPING_UPDATED ] );
 		}
 

--- a/src/Shipping/SyncerHooks.php
+++ b/src/Shipping/SyncerHooks.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
@@ -25,8 +24,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 2.1.0
  */
 class SyncerHooks implements Service, Registerable {
-
-	use SyncTrait;
 
 	/**
 	 * This property is used to avoid scheduling duplicate jobs in the same request.
@@ -141,7 +138,7 @@ class SyncerHooks implements Service, Registerable {
 			return;
 		}
 
-		if ( $this->notifications_service->is_ready( self::get_shipping_datatype() ) ) {
+		if ( $this->notifications_service->is_ready( $this->notifications_service->get_shipping_datatype() ) ) {
 			$this->job_repository->get( ShippingNotificationJob::class )->schedule( [ 'topic' => NotificationsService::TOPIC_SHIPPING_UPDATED ] );
 		}
 

--- a/src/Shipping/SyncerHooks.php
+++ b/src/Shipping/SyncerHooks.php
@@ -141,7 +141,7 @@ class SyncerHooks implements Service, Registerable {
 			return;
 		}
 
-		if ( $this->notifications_service->is_ready( self::DATATYPE_SHIPPING ) ) {
+		if ( $this->notifications_service->is_ready( self::get_shipping_datatype() ) ) {
 			$this->job_repository->get( ShippingNotificationJob::class )->schedule( [ 'topic' => NotificationsService::TOPIC_SHIPPING_UPDATED ] );
 		}
 

--- a/tests/Unit/API/WP/NotificationsServiceTest.php
+++ b/tests/Unit/API/WP/NotificationsServiceTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\WP;
 
 use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -83,6 +84,7 @@ class NotificationsServiceTest extends UnitTest {
 		);
 
 		add_filter( 'woocommerce_gla_notifications_enabled', '__return_true' );
+		add_filter( 'woocommerce_gla_is_pull_enabled_for_datatype', '__return_true' );
 	}
 
 	/**
@@ -211,6 +213,19 @@ class NotificationsServiceTest extends UnitTest {
 		$this->assertFalse( $this->service->notify( 'product.create', 1 ) );
 		$this->assertEquals( did_action( 'woocommerce_gla_error' ), 1 );
 		remove_filter( 'woocommerce_gla_notifications_enabled', '__return_false' );
+	}
+
+	/**
+	 * Test notify() function logs an error when disabled for a datatype
+	 */
+	public function test_notify_show_error_when_disabled_for_datatype() {
+		$this->service = $this->get_mock();
+		remove_filter( 'woocommerce_gla_is_pull_enabled_for_datatype', '__return_true' );
+		add_filter( 'woocommerce_gla_is_pull_enabled_for_datatype', '__return_false' );
+		$this->service->expects( $this->never() )->method( 'do_request' );
+		$this->assertFalse( $this->service->notify( 'product.create', 1 ) );
+		$this->assertEquals( did_action( 'woocommerce_gla_error' ), 1 );
+		remove_filter( 'woocommerce_gla_is_pull_enabled_for_datatype', '__return_false' );
 	}
 
 	/**

--- a/tests/Unit/API/WP/NotificationsServiceTest.php
+++ b/tests/Unit/API/WP/NotificationsServiceTest.php
@@ -5,7 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\WP;
 
 use Automattic\WooCommerce\Admin\RemoteInboxNotifications\TransformerService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;

--- a/tests/Unit/API/WP/NotificationsServiceTest.php
+++ b/tests/Unit/API/WP/NotificationsServiceTest.php
@@ -226,7 +226,7 @@ class NotificationsServiceTest extends UnitTest {
 	public function test_is_ready_not_calling_status_api_if_with_health_check_is_false() {
 		$this->service = $this->get_mock( true, true, false );
 		$this->account->expects( $this->never() )->method( 'is_wpcom_api_status_healthy' );
-		$this->assertTrue( $this->service->is_ready( false ) );
+		$this->assertTrue( $this->service->is_ready( null, false ) );
 	}
 
 	public function test_is_ready_calling_status_api_if_with_health_check_is_true() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR blocks Notificacion Job Schedlue as well as Notifications when API PULL SYNC is disabled for a Data Type ( the settings for a specific Data Type inside are set as `pull: false` )

PUSH part will be done in a future PR

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Grant Data Fetch access in Settings page
2. Be sure your store country supports Coupon Sync (i.e India)
3. Be sure that in G4W - Shipping options you have "Automatically sync my store’s shipping settings to Google."


PRODUCTS PULL

1. verify your Sync Settings by request `GET wp-json/wc/gla/sync` products pull key should be `true`
2. Create a product
4. See `gla/jobs/notifications/products/process_item` scheduled. Run it
5. Verify that the notification happened in google-listings-and-ads logs. Should show something like: ` Notification - Item ID: 62 - Topic... product`
6. Update the product
7. See - `gla/jobs/notifications/products/process_item` scheduled. Run it
8. verify like you did in step 4
9. Permanently delete the product
10. See `gla/jobs/notifications/products/process_item` scheduled. Run it
11. verify like you did in step 4

COUPONS PULL

1. verify your Sync Settings by request `GET wp-json/wc/gla/sync` coupons pull key should be `true`
2. Create a coupon and set Google for WooCommerce  - Show coupon on Google
3. See `gla/jobs/notifications/coupons/process_item` scheduled. Run it
4. Verify that the notification happened in google-listings-and-ads logs. Should show something like: ` Notification - Item ID: 62 - Topic...coupon.`
5. Update the coupon
6. See - `gla/jobs/notifications/coupons/process_item` scheduled. Run it
7. verify like you did in step 4
8. Disable the coupon setting: Google for WooCommerce  -  Dont show coupon 
9. See `gla/jobs/notifications/coupons/process_item` scheduled. Run it
10. verify like you did in step 4


SETTINGS PULL

1. verify your Sync Settings by request `GET wp-json/wc/gla/sync` settings pull key should be `true`
2. Go to WooCommerce Settings and update something
3. See `gla/jobs/notifications/settings/process_item` scheduled. Run it
4. Verify that the notification happened in google-listings-and-ads logs. Should show something like: ` Notification - Item ID:  - Topic: settings.update - Data []`

SHIPPING PULL

1. Be sure that in G4W - Shipping options you have "Automatically sync my store’s shipping settings to Google."
2. verify your Sync Settings by request `GET wp-json/wc/gla/sync` shipping pull key should be `true`
3. Go to WooCommerce Settings - Shipping and update/add something. A zone for example 
4. See `gla/jobs/notifications/shipping/process_item` scheduled. Run it
5. Verify that the notification happened in google-listings-and-ads logs. Should show something like: ` Notification - Item ID:  - Topic: shipping.update - Data []`


API PULL DISABLED

Request `POST wp-json/wc/gla/sync with

```

{
    "products": {
        "pull": false
    },
    "coupons": {
        "pull": false
    },
    "settings": {
        "pull": false
    },
    "shipping": {
        "pull": false
    }
}
```

Verify again all the test steps. But checking that NO Job should be scheduled anymore and NO notification should take place as well 

ℹ️  Notice you can also check Notifications (not jobs) in connection test page under 
Send partner notification request to WPCOM section When you perform Notifications -  Response should be like: `Notification failed. Item: 68 - Topic: product.create`

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
