### PR TITLE
Fix the issue of not being able to reconnect to the auto-selected Google ads account during onboarding

### DIFF
--- a/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
+++ b/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
@@ -77,8 +77,7 @@ const ConnectExistingAccount = ( { onCreateClick } ) => {
 		 * Prevent the `value` from staying on the unclaimed and disconnected account ID.
 		 * Please note that the reset works because the `AdsAccountSelectControl` happens to
 		 * switch between two different `AppSelectControls` so that `autoSelectFirstOption`
-		 * can be triggered again. Otherwise, it would need to specify `key={ Boolean(value) }`
-		 * in the `<AdsAccountSelectControl>` use of this component.
+		 * can be triggered again.
 		 */
 		setValue( undefined );
 	};
@@ -124,6 +123,10 @@ const ConnectExistingAccount = ( { onCreateClick } ) => {
 			indicator={ getIndicator() }
 			detail={
 				<AdsAccountSelectControl
+					// Setting `key` is to ensure that `autoSelectFirstOption` will be
+					// triggered after disconnecting, so that the automatically selected
+					// account can call back to this component.
+					key={ Boolean( value ) }
 					value={ value }
 					onChange={ setValue }
 					autoSelectFirstOption

--- a/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.test.js
+++ b/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.test.js
@@ -1,0 +1,161 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import ConnectExistingAccount from './connect-existing-account';
+import { useAppDispatch } from '~/data';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleAdsAccountReady from '~/hooks/useGoogleAdsAccountReady';
+
+jest.mock( '~/data', () => ( {
+	...jest.requireActual( '~/data' ),
+	useAppDispatch: jest.fn(),
+} ) );
+
+jest.mock( '~/hooks/useApiFetchCallback', () =>
+	jest
+		.fn()
+		.mockName( 'useApiFetchCallback' )
+		.mockReturnValue( [ jest.fn().mockName( 'connectGoogleAdsAccount' ) ] )
+);
+
+jest.mock( '~/hooks/useGoogleAdsAccount', () =>
+	jest.fn().mockName( 'useGoogleAdsAccount' )
+);
+
+jest.mock( '~/hooks/useGoogleAdsAccountReady', () =>
+	jest.fn().mockName( 'useGoogleAdsAccountReady' )
+);
+
+jest.mock( '~/hooks/useExistingGoogleAdsAccounts', () =>
+	jest
+		.fn()
+		.mockName( 'useExistingGoogleAdsAccounts' )
+		.mockReturnValue( {
+			existingAccounts: [
+				{ id: 123, name: 'Account one' },
+				{ id: 456, name: 'Account two' },
+			],
+		} )
+);
+
+jest.mock( '~/hooks/useGoogleAdsAccountStatus', () =>
+	jest
+		.fn()
+		.mockName( 'useGoogleAdsAccountStatus' )
+		.mockReturnValue( { hasAccess: true } )
+);
+
+describe( 'ConnectExistingAccount', () => {
+	let connectGoogleAdsAccount;
+	let fetchGoogleAdsAccountStatus;
+	let disconnectGoogleAdsAccount;
+
+	beforeEach( () => {
+		connectGoogleAdsAccount = jest
+			.fn()
+			.mockName( 'fetchConnectAdsAccount' );
+
+		fetchGoogleAdsAccountStatus = jest
+			.fn()
+			.mockName( 'fetchGoogleAdsAccountStatus' );
+
+		disconnectGoogleAdsAccount = jest
+			.fn()
+			.mockName( 'disconnectGoogleAdsAccount' )
+			.mockReturnValue( Promise.resolve() );
+
+		useApiFetchCallback.mockReturnValue( [ connectGoogleAdsAccount ] );
+		useAppDispatch.mockReturnValue( {
+			fetchGoogleAdsAccountStatus,
+			disconnectGoogleAdsAccount,
+		} );
+	} );
+
+	describe( 'Initial with the connected state', () => {
+		let refetchGoogleAdsAccount;
+
+		beforeEach( () => {
+			refetchGoogleAdsAccount = jest
+				.fn()
+				.mockName( 'refetchGoogleAdsAccount' );
+
+			useGoogleAdsAccount.mockReturnValue( {
+				hasFinishedResolution: true,
+				hasGoogleAdsConnection: true,
+				googleAdsAccount: { id: 123 },
+				refetchGoogleAdsAccount,
+			} );
+
+			useGoogleAdsAccountReady.mockReturnValue( true );
+		} );
+
+		it( 'Should render the state in connected', () => {
+			render( <ConnectExistingAccount /> );
+
+			expect( screen.getByRole( 'combobox' ) ).toHaveAttribute(
+				'readonly'
+			);
+			expect( screen.getByText( 'Connected' ) ).toBeInTheDocument();
+			expect(
+				screen.getByRole( 'button', {
+					name: 'Or, connect to a different Google Ads account',
+				} )
+			).toBeInTheDocument();
+
+			expect(
+				screen.queryByRole( 'button', { name: 'Connect' } )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'Should be able to reconnect to the auto-selected account after disconnecting', async () => {
+			const user = userEvent.setup();
+
+			disconnectGoogleAdsAccount.mockReturnValue(
+				Promise.resolve().then( () => {
+					useGoogleAdsAccount.mockReturnValue( {
+						hasFinishedResolution: true,
+						hasGoogleAdsConnection: false,
+						googleAdsAccount: { id: 0 },
+						refetchGoogleAdsAccount,
+					} );
+
+					useGoogleAdsAccountReady.mockReturnValue( false );
+				} )
+			);
+
+			render( <ConnectExistingAccount /> );
+
+			await user.click(
+				screen.getByRole( 'button', {
+					name: 'Or, connect to a different Google Ads account',
+				} )
+			);
+
+			expect( disconnectGoogleAdsAccount ).toHaveBeenCalledTimes( 1 );
+			expect( connectGoogleAdsAccount ).toHaveBeenCalledTimes( 0 );
+			expect( fetchGoogleAdsAccountStatus ).toHaveBeenCalledTimes( 0 );
+			expect( refetchGoogleAdsAccount ).toHaveBeenCalledTimes( 0 );
+			expect( useApiFetchCallback ).toHaveBeenLastCalledWith( {
+				path: '/wc/gla/ads/accounts',
+				method: 'POST',
+				data: { id: 123 },
+			} );
+
+			await user.click(
+				screen.getByRole( 'button', { name: 'Connect' } )
+			);
+
+			expect( connectGoogleAdsAccount ).toHaveBeenCalledTimes( 1 );
+			expect( fetchGoogleAdsAccountStatus ).toHaveBeenCalledTimes( 1 );
+			expect( refetchGoogleAdsAccount ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2805

This PR fixes the problem and also add the relevant test cases.

### Screenshots:

https://github.com/user-attachments/assets/a1374bde-995d-4e6a-a7f5-d22948da0b31

### Detailed test instructions:

1. Go to step 1 of the onboarding flow.
2. Connect to the first existing Google Ads account.
3. Disconnect the Google Ads account.
4. Without interacting with the account select control, Check if it can reconnect to the first existing Google Ads account again.

### Changelog entry

> Fix - It may be unable to connect to the auto-selected Google Ads account after disconnecting during onboarding.
