### PR TITLE
Block Shipping, Products and Coupons when Sync Push is disabled

### DIFF
--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -3,10 +3,12 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -65,7 +67,9 @@ class Settings implements ContainerAwareInterface {
 	 * Sync the shipping settings with Google.
 	 */
 	public function sync_shipping() {
-		if ( ! $this->should_sync_shipping() ) {
+		/** @var MerchantCenterService $merchant_center */
+		$merchant_center = $this->container->get( MerchantCenterService::class );
+		if ( ! $this->should_sync_shipping() || ! $merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_SHIPPING ) ) {
 			return;
 		}
 

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -575,7 +575,44 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 				<hr />
 
 				<h2 class="title">Product Sync</h2>
+				<table class="form-table" role="presentation">
+					<tr>
+						<th><label>Products MC PUSH:</label></th>
+						<td>
+							<p>
 
+								<code><?php echo $this->enabled_or_disabled( $notification_service->is_push_enabled_for_datatype( NotificationsService::DATATYPE_PRODUCT ) ); ?></code>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<th><label>Coupons MC PUSH:</label></th>
+						<td>
+							<p>
+
+								<code><?php echo $this->enabled_or_disabled( $notification_service->is_push_enabled_for_datatype( NotificationsService::DATATYPE_COUPON ) ); ?></code>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<th><label>Shipping MC PUSH:</label></th>
+						<td>
+							<p>
+
+								<code><?php echo $this->enabled_or_disabled( $notification_service->is_push_enabled_for_datatype( NotificationsService::DATATYPE_SHIPPING ) ); ?></code>
+							</p>
+						</td>
+					</tr>
+					<tr>
+						<th><label>Settings MC PUSH:</label></th>
+						<td>
+							<p>
+
+								<code><?php echo $this->enabled_or_disabled( $notification_service->is_push_enabled_for_datatype( NotificationsService::DATATYPE_SETTINGS ) ); ?></code>
+							</p>
+						</td>
+					</tr>
+				</table>
 				<form action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" method="GET">
 					<table class="form-table" role="presentation">
 						<tr>
@@ -653,42 +690,6 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 					<input name="page" value="connection-test-admin-page" type="hidden" />
 					<input name="action" value="wcs-cleanup-products" type="hidden" />
 				</form>
-				<tr>
-					<th><label>Products Merchant Center PUSH:</label></th>
-					<td>
-						<p>
-
-							<code><?php echo $this->enabled_or_disabled( $notification_service->is_push_enabled_for_datatype( NotificationsService::DATATYPE_PRODUCT ) ); ?></code>
-						</p>
-					</td>
-				</tr>
-				<tr>
-					<th><label>Coupons Merchant Center PUSH:</label></th>
-					<td>
-						<p>
-
-							<code><?php echo $this->enabled_or_disabled( $notification_service->is_push_enabled_for_datatype( NotificationsService::DATATYPE_COUPON ) ); ?></code>
-						</p>
-					</td>
-				</tr>
-				<tr>
-					<th><label>Shipping Merchant Center PUSH:</label></th>
-					<td>
-						<p>
-
-							<code><?php echo $this->enabled_or_disabled( $notification_service->is_push_enabled_for_datatype( NotificationsService::DATATYPE_SHIPPING ) ); ?></code>
-						</p>
-					</td>
-				</tr>
-				<tr>
-					<th><label>Settings Merchant Center PUSH:</label></th>
-					<td>
-						<p>
-
-							<code><?php echo $this->enabled_or_disabled( $notification_service->is_push_enabled_for_datatype( NotificationsService::DATATYPE_SETTINGS ) ); ?></code>
-						</p>
-					</td>
-				</tr>
 				<form action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" method="GET">
 					<table class="form-table" role="presentation">
 						<tr>

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -136,6 +136,9 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 			$this->response .= 'Failed to connect to Google.';
 		}
 
+		$notification_service = new NotificationsService( $this->container->get( MerchantCenterService::class ), $this->container->get( AccountService::class ) );
+		$notification_service->set_options_object( $options );
+
 		?>
 		<div class="wrap">
 			<h2>Connection Test</h2>
@@ -650,6 +653,42 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 					<input name="page" value="connection-test-admin-page" type="hidden" />
 					<input name="action" value="wcs-cleanup-products" type="hidden" />
 				</form>
+				<tr>
+					<th><label>Products Merchant Center PUSH:</label></th>
+					<td>
+						<p>
+
+							<code><?php echo $this->enabled_or_disabled( $notification_service->is_push_enabled_for_datatype( NotificationsService::DATATYPE_PRODUCT ) ); ?></code>
+						</p>
+					</td>
+				</tr>
+				<tr>
+					<th><label>Coupons Merchant Center PUSH:</label></th>
+					<td>
+						<p>
+
+							<code><?php echo $this->enabled_or_disabled( $notification_service->is_push_enabled_for_datatype( NotificationsService::DATATYPE_COUPON ) ); ?></code>
+						</p>
+					</td>
+				</tr>
+				<tr>
+					<th><label>Shipping Merchant Center PUSH:</label></th>
+					<td>
+						<p>
+
+							<code><?php echo $this->enabled_or_disabled( $notification_service->is_push_enabled_for_datatype( NotificationsService::DATATYPE_SHIPPING ) ); ?></code>
+						</p>
+					</td>
+				</tr>
+				<tr>
+					<th><label>Settings Merchant Center PUSH:</label></th>
+					<td>
+						<p>
+
+							<code><?php echo $this->enabled_or_disabled( $notification_service->is_push_enabled_for_datatype( NotificationsService::DATATYPE_SETTINGS ) ); ?></code>
+						</p>
+					</td>
+				</tr>
 				<form action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" method="GET">
 					<table class="form-table" role="presentation">
 						<tr>
@@ -673,8 +712,6 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 				<?php
 				  $options = $this->container->get( OptionsInterface::class );
 				  $wp_api_status = $options->get( OptionsInterface::WPCOM_REST_API_STATUS );
-				  $notification_service = new NotificationsService( $this->container->get( MerchantCenterService::class ), $this->container->get( AccountService::class ) );
-				  $notification_service->set_options_object( $options );
 				?>
 				<h2 class="title">Partner API Pull Integration</h2>
 				<form action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" method="GET">

--- a/src/Coupon/CouponSyncer.php
+++ b/src/Coupon/CouponSyncer.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\DeleteCouponEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GooglePromotionService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\InvalidCouponEntry;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
@@ -21,6 +22,8 @@ defined( 'ABSPATH' ) || exit();
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Coupon
  */
 class CouponSyncer implements Service {
+
+	use SyncTrait;
 
 	public const FAILURE_THRESHOLD = 5;
 
@@ -476,16 +479,16 @@ class CouponSyncer implements Service {
 			);
 		}
 
-		if ( ! $this->merchant_center->should_push() ) {
+		if ( ! $this->merchant_center->should_push( $this->get_coupons_datatype() ) ) {
 			do_action(
 				'woocommerce_gla_error',
-				'Cannot push any coupons because they are being fetched automatically.',
+				'Cannot push any coupons because the syncing feature has been disabled on your store.',
 				__METHOD__
 			);
 
 			throw new CouponSyncerException(
 				__(
-					'Pushing Coupons will not run if the automatic data fetching is enabled. Please review your configuration in Google Listing and Ads settings.',
+					'Pushing Coupons will not run if the PUSH Sync functionality has been disabled.',
 					'google-listings-and-ads'
 				)
 			);

--- a/src/Coupon/CouponSyncer.php
+++ b/src/Coupon/CouponSyncer.php
@@ -2,10 +2,10 @@
 declare(strict_types = 1);
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Coupon;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\DeleteCouponEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GooglePromotionService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\InvalidCouponEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
@@ -22,8 +22,6 @@ defined( 'ABSPATH' ) || exit();
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Coupon
  */
 class CouponSyncer implements Service {
-
-	use SyncTrait;
 
 	public const FAILURE_THRESHOLD = 5;
 
@@ -479,7 +477,22 @@ class CouponSyncer implements Service {
 			);
 		}
 
-		if ( ! $this->merchant_center->should_push( $this->get_coupons_datatype() ) ) {
+		if ( ! $this->merchant_center->should_push() ) {
+			do_action(
+				'woocommerce_gla_error',
+				'Cannot push any coupons because your store is not ready for syncing.',
+				__METHOD__
+			);
+
+			throw new CouponSyncerException(
+				__(
+					'Pushing coupons will not run if the the store is not ready for syncing.',
+					'google-listings-and-ads'
+				)
+			);
+		}
+
+		if ( ! $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_COUPON ) ) {
 			do_action(
 				'woocommerce_gla_error',
 				'Cannot push any coupons because the syncing feature has been disabled on your store.',

--- a/src/Coupon/CouponSyncer.php
+++ b/src/Coupon/CouponSyncer.php
@@ -486,7 +486,7 @@ class CouponSyncer implements Service {
 
 			throw new CouponSyncerException(
 				__(
-					'Pushing coupons will not run if the the store is not ready for syncing.',
+					'Pushing coupons will not run if the store is not ready for syncing.',
 					'google-listings-and-ads'
 				)
 			);

--- a/src/Coupon/SyncerHooks.php
+++ b/src/Coupon/SyncerHooks.php
@@ -198,6 +198,11 @@ class SyncerHooks implements Service, Registerable {
 			$this->handle_update_coupon_notification( $coupon );
 		}
 
+		// Only proceed with coupon syncing if PUSH is enabled for this data type
+		if ( ! $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_COUPON ) ) {
+			return;
+		}
+
 		// Schedule an update job if product sync is enabled.
 		if ( $this->coupon_helper->is_sync_ready( $coupon ) ) {
 			$this->coupon_helper->mark_as_pending( $coupon );
@@ -241,6 +246,11 @@ class SyncerHooks implements Service, Registerable {
 	protected function handle_pre_delete_coupon( int $coupon_id ) {
 		$coupon = $this->wc->maybe_get_coupon( $coupon_id );
 
+		// Only proceed with coupon deletion if PUSH is enabled for this data type
+		if ( ! $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_COUPON ) ) {
+			return;
+		}
+
 		if ( $coupon instanceof WC_Coupon &&
 			$this->coupon_helper->is_coupon_synced( $coupon ) ) {
 			$this->delete_requests_map[ $coupon_id ] = new DeleteCouponEntry(
@@ -279,6 +289,11 @@ class SyncerHooks implements Service, Registerable {
 	protected function handle_delete_coupon( int $coupon_id ) {
 		if ( $this->notifications_service->is_ready( NotificationsService::DATATYPE_COUPON ) ) {
 			$this->maybe_send_delete_notification( $coupon_id );
+		}
+
+		// Only proceed with coupon deletion if PUSH is enabled for this data type
+		if ( ! $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_COUPON ) ) {
+			return;
 		}
 
 		if ( ! isset( $this->delete_requests_map[ $coupon_id ] ) ) {

--- a/src/Jobs/AbstractCouponSyncerJob.php
+++ b/src/Jobs/AbstractCouponSyncerJob.php
@@ -4,7 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
@@ -18,8 +18,6 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
 abstract class AbstractCouponSyncerJob extends AbstractActionSchedulerJob {
-
-	use SyncTrait;
 
 	/**
 	 * @var CouponHelper
@@ -75,6 +73,6 @@ abstract class AbstractCouponSyncerJob extends AbstractActionSchedulerJob {
 	 * @return bool Returns true if the job can be scheduled.
 	 */
 	public function can_schedule( $args = [] ): bool {
-		return ! $this->is_running( $args ) && $this->merchant_center->should_push( $this->get_coupons_datatype() );
+		return ! $this->is_running( $args ) && $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_COUPON );
 	}
 }

--- a/src/Jobs/AbstractCouponSyncerJob.php
+++ b/src/Jobs/AbstractCouponSyncerJob.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
@@ -17,6 +18,8 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
 abstract class AbstractCouponSyncerJob extends AbstractActionSchedulerJob {
+
+	use SyncTrait;
 
 	/**
 	 * @var CouponHelper
@@ -72,6 +75,6 @@ abstract class AbstractCouponSyncerJob extends AbstractActionSchedulerJob {
 	 * @return bool Returns true if the job can be scheduled.
 	 */
 	public function can_schedule( $args = [] ): bool {
-		return ! $this->is_running( $args ) && $this->merchant_center->should_push();
+		return ! $this->is_running( $args ) && $this->merchant_center->should_push( $this->get_coupons_datatype() );
 	}
 }

--- a/src/Jobs/AbstractProductSyncerBatchedJob.php
+++ b/src/Jobs/AbstractProductSyncerBatchedJob.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
@@ -18,6 +19,8 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
 abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSchedulerJob {
+
+	use SyncTrait;
 
 	/**
 	 * @var ProductSyncer
@@ -80,6 +83,6 @@ abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSche
 	 * @return bool Returns true if the job can be scheduled.
 	 */
 	public function can_schedule( $args = [] ): bool {
-		return ! $this->is_running( $args ) && $this->merchant_center->should_push();
+		return ! $this->is_running( $args ) && $this->merchant_center->should_push( $this->get_products_datatype() );
 	}
 }

--- a/src/Jobs/AbstractProductSyncerBatchedJob.php
+++ b/src/Jobs/AbstractProductSyncerBatchedJob.php
@@ -4,7 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
@@ -19,8 +19,6 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
 abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSchedulerJob {
-
-	use SyncTrait;
 
 	/**
 	 * @var ProductSyncer
@@ -83,6 +81,6 @@ abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSche
 	 * @return bool Returns true if the job can be scheduled.
 	 */
 	public function can_schedule( $args = [] ): bool {
-		return ! $this->is_running( $args ) && $this->merchant_center->should_push( $this->get_products_datatype() );
+		return ! $this->is_running( $args ) && $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_PRODUCT );
 	}
 }

--- a/src/Jobs/AbstractProductSyncerJob.php
+++ b/src/Jobs/AbstractProductSyncerJob.php
@@ -4,7 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -17,8 +17,6 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
 abstract class AbstractProductSyncerJob extends AbstractActionSchedulerJob {
-
-	use SyncTrait;
 
 	/**
 	 * @var ProductSyncer
@@ -65,6 +63,6 @@ abstract class AbstractProductSyncerJob extends AbstractActionSchedulerJob {
 	 * @return bool Returns true if the job can be scheduled.
 	 */
 	public function can_schedule( $args = [] ): bool {
-		return ! $this->is_running( $args ) && $this->merchant_center->should_push( $this->get_products_datatype() );
+		return ! $this->is_running( $args ) && $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_PRODUCT );
 	}
 }

--- a/src/Jobs/AbstractProductSyncerJob.php
+++ b/src/Jobs/AbstractProductSyncerJob.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -16,6 +17,8 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
 abstract class AbstractProductSyncerJob extends AbstractActionSchedulerJob {
+
+	use SyncTrait;
 
 	/**
 	 * @var ProductSyncer
@@ -62,6 +65,6 @@ abstract class AbstractProductSyncerJob extends AbstractActionSchedulerJob {
 	 * @return bool Returns true if the job can be scheduled.
 	 */
 	public function can_schedule( $args = [] ): bool {
-		return ! $this->is_running( $args ) && $this->merchant_center->should_push();
+		return ! $this->is_running( $args ) && $this->merchant_center->should_push( $this->get_products_datatype() );
 	}
 }

--- a/src/Jobs/UpdateShippingSettings.php
+++ b/src/Jobs/UpdateShippingSettings.php
@@ -5,7 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 
 defined( 'ABSPATH' ) || exit;
@@ -22,8 +22,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 2.1.0
  */
 class UpdateShippingSettings extends AbstractActionSchedulerJob {
-
-	use SyncTrait;
 
 	/**
 	 * @var MerchantCenterService
@@ -102,6 +100,6 @@ class UpdateShippingSettings extends AbstractActionSchedulerJob {
 	 */
 	protected function can_sync_shipping(): bool {
 		// Confirm that the Merchant Center account is connected, the user has chosen for the shipping rates to be synced from WooCommerce settings and the Push Sync is enabled for Shipping.
-		return $this->merchant_center->is_connected() && $this->google_settings->should_get_shipping_rates_from_woocommerce() && $this->is_push_enabled_for_datatype( $this->get_shipping_datatype() );
+		return $this->merchant_center->is_connected() && $this->google_settings->should_get_shipping_rates_from_woocommerce() && $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_SHIPPING );
 	}
 }

--- a/src/Jobs/UpdateShippingSettings.php
+++ b/src/Jobs/UpdateShippingSettings.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 
 defined( 'ABSPATH' ) || exit;
@@ -21,6 +22,9 @@ defined( 'ABSPATH' ) || exit;
  * @since 2.1.0
  */
 class UpdateShippingSettings extends AbstractActionSchedulerJob {
+
+	use SyncTrait;
+
 	/**
 	 * @var MerchantCenterService
 	 */
@@ -97,7 +101,7 @@ class UpdateShippingSettings extends AbstractActionSchedulerJob {
 	 * @return bool
 	 */
 	protected function can_sync_shipping(): bool {
-		// Confirm that the Merchant Center account is connected and the user has chosen for the shipping rates to be synced from WooCommerce settings.
-		return $this->merchant_center->is_connected() && $this->google_settings->should_get_shipping_rates_from_woocommerce();
+		// Confirm that the Merchant Center account is connected, the user has chosen for the shipping rates to be synced from WooCommerce settings and the Push Sync is enabled for Shipping.
+		return $this->merchant_center->is_connected() && $this->google_settings->should_get_shipping_rates_from_woocommerce() && $this->is_push_enabled_for_datatype( $this->get_shipping_datatype() );
 	}
 }

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -11,7 +11,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
@@ -56,7 +55,6 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	use ContainerAwareTrait;
 	use OptionsAwareTrait;
 	use PluginHelper;
-	use SyncTrait;
 
 	/**
 	 * MerchantCenterService constructor.
@@ -128,18 +126,28 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	}
 
 	/**
-	 * Whether we should push data into MC. Only if:
-	 * - MC is ready for syncing {@see is_ready_for_syncing}
-	 * - Notifications Service is not enabled
+	 * Whether we should push data into MC. Only is MC is ready for syncing.
 	 *
-	 * @param string|null $data_type The data type to check if the PUSH method is enabled.
+	 * @see is_ready_for_syncing
 	 * @return bool
 	 * @since 2.8.0
 	 */
-	public function should_push( string $data_type = null ): bool {
-		return $this->is_ready_for_syncing() && $this->is_push_enabled_for_datatype( $data_type );
+	public function should_push(): bool {
+		return $this->is_ready_for_syncing();
 	}
 
+	/**
+	 * Whether push is enabled for a specific data type.
+	 *
+	 * @param string $data_type The data type to check.
+	 * @return bool
+	 * @since x.x.x
+	 */
+	public function is_enabled_for_datatype( string $data_type ): bool {
+		/** @var NotificationsService $notifications_service */
+		$notifications_service = $this->container->get( NotificationsService::class );
+		return $notifications_service->is_push_enabled_for_datatype( $data_type );
+	}
 
 	/**
 	 * Get whether the country is supported by the Merchant Center.

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -138,10 +138,15 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 
 	/**
 	 * Whether push is enabled for a specific data type.
+	 * This method checks if push synchronization is enabled for a specific data type
+	 * (products, coupons, shipping, settings) in the Merchant Center.
+	 * 
+	 * This differs from should_push() which checks if the Merchant Center is ready
+	 * for syncing in general, while this method checks if a specific data type
+	 * has been enabled for push operations.
 	 *
 	 * @param string $data_type The data type to check.
-	 * @return bool
-	 * @since x.x.x
+	 * @return bool True if push is enabled for the specified data type.
 	 */
 	public function is_enabled_for_datatype( string $data_type ): bool {
 		/** @var NotificationsService $notifications_service */

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
@@ -55,6 +56,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	use ContainerAwareTrait;
 	use OptionsAwareTrait;
 	use PluginHelper;
+	use SyncTrait;
 
 	/**
 	 * MerchantCenterService constructor.
@@ -130,11 +132,12 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 * - MC is ready for syncing {@see is_ready_for_syncing}
 	 * - Notifications Service is not enabled
 	 *
+	 * @param string|null $data_type The data type to check if the PUSH method is enabled.
 	 * @return bool
 	 * @since 2.8.0
 	 */
-	public function should_push(): bool {
-		return $this->is_ready_for_syncing();
+	public function should_push( string $data_type = null ): bool {
+		return $this->is_ready_for_syncing() && $this->is_push_enabled_for_datatype( $data_type );
 	}
 
 

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -140,7 +140,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 * Whether push is enabled for a specific data type.
 	 * This method checks if push synchronization is enabled for a specific data type
 	 * (products, coupons, shipping, settings) in the Merchant Center.
-	 * 
+	 *
 	 * This differs from should_push() which checks if the Merchant Center is ready
 	 * for syncing in general, while this method checks if a specific data type
 	 * has been enabled for push operations.

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -372,7 +372,7 @@ class ProductSyncer implements Service {
 
 			throw new ProductSyncerException(
 				__(
-					'Pushing products will not run if the the store is not ready for syncing.',
+					'Pushing products will not run if the store is not ready for syncing.',
 					'google-listings-and-ads'
 				)
 			);

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntr
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
+use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -22,6 +23,8 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product
  */
 class ProductSyncer implements Service {
+
+	use SyncTrait;
 
 	public const FAILURE_THRESHOLD        = 5;         // Number of failed attempts allowed per FAILURE_THRESHOLD_WINDOW
 	public const FAILURE_THRESHOLD_WINDOW = '3 hours'; // PHP supported Date and Time format: https://www.php.net/manual/en/datetime.formats.php
@@ -362,16 +365,16 @@ class ProductSyncer implements Service {
 			throw new ProductSyncerException( __( 'Google Merchant Center has not been set up correctly. Please review your configuration.', 'google-listings-and-ads' ) );
 		}
 
-		if ( ! $this->merchant_center->should_push() ) {
+		if ( ! $this->merchant_center->should_push( $this->get_products_datatype() ) ) {
 			do_action(
 				'woocommerce_gla_error',
-				'Cannot push any products because they are being fetched automatically.',
+				'Cannot push any products because the syncing feature has been disabled on your store.',
 				__METHOD__
 			);
 
 			throw new ProductSyncerException(
 				__(
-					'Pushing products will not run if the automatic data fetching is enabled. Please review your configuration in Google Listing and Ads settings.',
+					'Pushing products will not run if the PUSH Sync functionality has been disabled.',
 					'google-listings-and-ads'
 				)
 			);

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -3,12 +3,12 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
-use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\SyncTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -23,8 +23,6 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Product
  */
 class ProductSyncer implements Service {
-
-	use SyncTrait;
 
 	public const FAILURE_THRESHOLD        = 5;         // Number of failed attempts allowed per FAILURE_THRESHOLD_WINDOW
 	public const FAILURE_THRESHOLD_WINDOW = '3 hours'; // PHP supported Date and Time format: https://www.php.net/manual/en/datetime.formats.php
@@ -365,7 +363,22 @@ class ProductSyncer implements Service {
 			throw new ProductSyncerException( __( 'Google Merchant Center has not been set up correctly. Please review your configuration.', 'google-listings-and-ads' ) );
 		}
 
-		if ( ! $this->merchant_center->should_push( $this->get_products_datatype() ) ) {
+		if ( ! $this->merchant_center->should_push() ) {
+			do_action(
+				'woocommerce_gla_error',
+				'Cannot push any products because your store is not ready for syncing.',
+				__METHOD__
+			);
+
+			throw new ProductSyncerException(
+				__(
+					'Pushing products will not run if the the store is not ready for syncing.',
+					'google-listings-and-ads'
+				)
+			);
+		}
+
+		if ( ! $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_PRODUCT ) ) {
 			do_action(
 				'woocommerce_gla_error',
 				'Cannot push any products because the syncing feature has been disabled on your store.',

--- a/src/Product/SyncerHooks.php
+++ b/src/Product/SyncerHooks.php
@@ -225,6 +225,11 @@ class SyncerHooks implements Service, Registerable {
 				continue;
 			}
 
+			// Only proceed with product syncing if PUSH is enabled for this data type
+			if ( ! $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_PRODUCT ) ) {
+				continue;
+			}
+
 			// Schedule an update job if product sync is enabled.
 			if ( $this->product_helper->is_sync_ready( $product ) ) {
 				$this->product_helper->mark_as_pending( $product );
@@ -294,6 +299,11 @@ class SyncerHooks implements Service, Registerable {
 	 * @param int $product_id
 	 */
 	protected function handle_delete_product( int $product_id ) {
+		// Only proceed with product deletion if PUSH is enabled for this data type
+		if ( ! $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_PRODUCT ) ) {
+			return;
+		}
+
 		if ( isset( $this->delete_requests_map[ $product_id ] ) ) {
 			$product_id_map = BatchProductIDRequestEntry::convert_to_id_map( $this->delete_requests_map[ $product_id ] )->get();
 			if ( ! empty( $product_id_map ) && ! $this->is_already_scheduled_to_delete( $product_id ) ) {
@@ -350,6 +360,11 @@ class SyncerHooks implements Service, Registerable {
 			 * This is because we want to avoid that the product is not in the database anymore when the scheduled action runs.
 			 */
 			$this->maybe_send_delete_notification( $product_id );
+		}
+
+		// Only proceed with product syncing if PUSH is enabled for this data type
+		if ( ! $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_PRODUCT ) ) {
+			return;
 		}
 
 		$product = $this->wc->maybe_get_product( $product_id );

--- a/src/Shipping/SyncerHooks.php
+++ b/src/Shipping/SyncerHooks.php
@@ -142,7 +142,9 @@ class SyncerHooks implements Service, Registerable {
 			$this->job_repository->get( ShippingNotificationJob::class )->schedule( [ 'topic' => NotificationsService::TOPIC_SHIPPING_UPDATED ] );
 		}
 
-		$this->job_repository->get( UpdateShippingSettings::class )->schedule();
+		if ( $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_SHIPPING ) ) {
+			$this->job_repository->get( UpdateShippingSettings::class )->schedule();
+		}
 
 		$this->already_scheduled = true;
 	}

--- a/tests/Unit/Coupon/CouponSyncerTest.php
+++ b/tests/Unit/Coupon/CouponSyncerTest.php
@@ -149,10 +149,13 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
 	public function test_update_throws_exception_when_mc_is_blocked() {
 		$coupon          = $this->create_ready_to_sync_coupon();
 		$merchant_center = $this->createMock( MerchantCenterService::class );
-		$merchant_center->expects( $this->any() )
+		$this->merchant_center->expects( $this->once() )
+			->method( 'is_ready_for_syncing' )
+			->willReturn( true );
+		$merchant_center->expects( $this->once() )
 			->method( 'should_push' )
 			->willReturn( true );
-		$merchant_center->expects( $this->any() )
+		$merchant_center->expects( $this->once() )
 			->method( 'is_enabled_for_datatype' )
 			->with( 'coupons' )
 			->willReturn( false );
@@ -166,10 +169,13 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
 	public function test_delete_throws_exception_when_mc_is_blocked() {
 		$coupon          = $this->create_ready_to_delete_coupon();
 		$merchant_center = $this->createMock( MerchantCenterService::class );
-		$merchant_center->expects( $this->any() )
+		$this->merchant_center->expects( $this->once() )
+			->method( 'is_ready_for_syncing' )
+			->willReturn( true );
+		$merchant_center->expects( $this->once() )
 			->method( 'should_push' )
 			->willReturn( true );
-		$merchant_center->expects( $this->any() )
+		$merchant_center->expects( $this->once() )
 			->method( 'is_enabled_for_datatype' )
 			->with( 'coupons' )
 			->willReturn( false );

--- a/tests/Unit/Coupon/CouponSyncerTest.php
+++ b/tests/Unit/Coupon/CouponSyncerTest.php
@@ -149,7 +149,7 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
 	public function test_update_throws_exception_when_mc_is_blocked() {
 		$coupon          = $this->create_ready_to_sync_coupon();
 		$merchant_center = $this->createMock( MerchantCenterService::class );
-		$merchant_center->expects( $this->once() )
+		$merchant_center->expects( $this->any() )
 			->method( 'should_push' )
 			->willReturn( true );
 		$merchant_center->expects( $this->any() )
@@ -166,7 +166,7 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
 	public function test_delete_throws_exception_when_mc_is_blocked() {
 		$coupon          = $this->create_ready_to_delete_coupon();
 		$merchant_center = $this->createMock( MerchantCenterService::class );
-		$merchant_center->expects( $this->once() )
+		$merchant_center->expects( $this->any() )
 			->method( 'should_push' )
 			->willReturn( true );
 		$merchant_center->expects( $this->any() )

--- a/tests/Unit/Coupon/CouponSyncerTest.php
+++ b/tests/Unit/Coupon/CouponSyncerTest.php
@@ -150,10 +150,11 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
 		$coupon          = $this->create_ready_to_sync_coupon();
 		$merchant_center = $this->createMock( MerchantCenterService::class );
 		$merchant_center->expects( $this->once() )
-			->method( 'is_ready_for_syncing' )
-			->willReturn( true );
-		$merchant_center->expects( $this->once() )
 			->method( 'should_push' )
+			->willReturn( true );
+		$merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->with( 'coupons' )
 			->willReturn( false );
 		$this->coupon_syncer = $this->get_coupon_syncer( [ 'merchant_center' => $merchant_center ] );
 
@@ -166,10 +167,11 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
 		$coupon          = $this->create_ready_to_delete_coupon();
 		$merchant_center = $this->createMock( MerchantCenterService::class );
 		$merchant_center->expects( $this->once() )
-			->method( 'is_ready_for_syncing' )
-			->willReturn( true );
-		$merchant_center->expects( $this->once() )
 			->method( 'should_push' )
+			->willReturn( true );
+		$merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->with( 'coupons' )
 			->willReturn( false );
 		$this->coupon_syncer = $this->get_coupon_syncer( [ 'merchant_center' => $merchant_center ] );
 
@@ -233,6 +235,10 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
 			->willReturn( true );
 		$this->merchant_center->expects( $this->any() )
 			->method( 'is_promotion_supported_country' )
+			->willReturn( true );
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->with( 'coupons' )
 			->willReturn( true );
 
 		$this->target_audience = $this->createMock( TargetAudience::class );

--- a/tests/Unit/Coupon/CouponSyncerTest.php
+++ b/tests/Unit/Coupon/CouponSyncerTest.php
@@ -149,7 +149,7 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
 	public function test_update_throws_exception_when_mc_is_blocked() {
 		$coupon          = $this->create_ready_to_sync_coupon();
 		$merchant_center = $this->createMock( MerchantCenterService::class );
-		$this->merchant_center->expects( $this->once() )
+		$merchant_center->expects( $this->once() )
 			->method( 'is_ready_for_syncing' )
 			->willReturn( true );
 		$merchant_center->expects( $this->once() )
@@ -169,7 +169,7 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
 	public function test_delete_throws_exception_when_mc_is_blocked() {
 		$coupon          = $this->create_ready_to_delete_coupon();
 		$merchant_center = $this->createMock( MerchantCenterService::class );
-		$this->merchant_center->expects( $this->once() )
+		$merchant_center->expects( $this->once() )
 			->method( 'is_ready_for_syncing' )
 			->willReturn( true );
 		$merchant_center->expects( $this->once() )

--- a/tests/Unit/Coupon/SyncerHooksTest.php
+++ b/tests/Unit/Coupon/SyncerHooksTest.php
@@ -356,6 +356,10 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 			->method( 'is_ready_for_syncing' )
 			->willReturn( $mc_status );
 
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->willReturn( $mc_status );
+
 		$this->notification_service->expects( $this->any() )
 			->method( 'is_ready' )
 			->willReturn( $notifications_status );

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -353,6 +353,6 @@ class UpdateAllProductsTest extends UnitTest {
 			->method( 'has_scheduled_action' )
 			->willReturn( false );
 
-		$this->job->can_schedule();
+		$this->assertFalse( $this->job->can_schedule() );
 	}
 }

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -344,6 +344,7 @@ class UpdateAllProductsTest extends UnitTest {
 	}
 
 	public function test_cannot_schedule_when_mc_push_is_blocked() {
+
 		$this->merchant_center
 			->method( 'is_enabled_for_datatype' )
 			->with( 'products' )
@@ -352,6 +353,16 @@ class UpdateAllProductsTest extends UnitTest {
 		$this->action_scheduler
 			->method( 'has_scheduled_action' )
 			->willReturn( false );
+
+		$this->job                = new UpdateAllProducts(
+			$this->action_scheduler,
+			$this->monitor,
+			$this->product_syncer,
+			$this->product_repository,
+			$this->product_helper,
+			$this->merchant_center,
+			$this->merchant_statuses
+		);
 
 		$this->assertFalse( $this->job->can_schedule() );
 	}

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -95,6 +95,11 @@ class UpdateAllProductsTest extends UnitTest {
 			->method( 'should_push' )
 			->willReturn( true );
 
+		$this->merchant_center
+			->method( 'is_enabled_for_datatype' )
+			->with( 'products' )
+			->willReturn( true );
+
 		/* adding a filter to make batch smaller for testing */
 		add_filter(
 			'woocommerce_gla_batched_job_size',
@@ -336,5 +341,18 @@ class UpdateAllProductsTest extends UnitTest {
 			->with( gmdate( 'U' ) + 100, self::CREATE_BATCH_HOOK, [ 1 ] );
 
 		$this->job->schedule_delayed( 100 );
+	}
+
+	public function test_cannot_schedule_when_mc_push_is_blocked() {
+		$this->merchant_center
+			->method( 'is_enabled_for_datatype' )
+			->with( 'products' )
+			->willReturn( false );
+
+		$this->action_scheduler
+			->method( 'has_scheduled_action' )
+			->willReturn( false );
+
+		$this->job->can_schedule();
 	}
 }

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -95,11 +95,6 @@ class UpdateAllProductsTest extends UnitTest {
 			->method( 'should_push' )
 			->willReturn( true );
 
-		$this->merchant_center
-			->method( 'is_enabled_for_datatype' )
-			->with( 'products' )
-			->willReturn( true );
-
 		/* adding a filter to make batch smaller for testing */
 		add_filter(
 			'woocommerce_gla_batched_job_size',
@@ -134,6 +129,10 @@ class UpdateAllProductsTest extends UnitTest {
 		$this->action_scheduler
 			->method( 'has_scheduled_action' )
 			->willReturn( false );
+
+		$this->merchant_center
+			->method( 'is_enabled_for_datatype' )
+			->willReturn( true );
 
 		/*
 		 * We expect only single call to `has_scheduled_action` when scheduling
@@ -170,6 +169,10 @@ class UpdateAllProductsTest extends UnitTest {
 				[ self::PROCESS_ITEM_HOOK, [ $filtered_product_list->get_product_ids() ] ]
 			);
 
+		$this->merchant_center
+			->method( 'is_enabled_for_datatype' )
+			->willReturn( true );
+
 		$this->job->schedule();
 
 		do_action( self::CREATE_BATCH_HOOK, 1 );
@@ -201,6 +204,10 @@ class UpdateAllProductsTest extends UnitTest {
 		$this->action_scheduler
 			->method( 'has_scheduled_action' )
 			->willReturn( false );
+
+		$this->merchant_center
+			->method( 'is_enabled_for_datatype' )
+			->willReturn( true );
 
 		$this->job->schedule();
 
@@ -236,6 +243,10 @@ class UpdateAllProductsTest extends UnitTest {
 			->method( 'has_scheduled_action' )
 			->willReturn( false );
 
+		$this->merchant_center
+			->method( 'is_enabled_for_datatype' )
+			->willReturn( true );
+
 		$this->job->schedule();
 
 		do_action( self::CREATE_BATCH_HOOK, 1 );
@@ -269,6 +280,10 @@ class UpdateAllProductsTest extends UnitTest {
 			->method( 'find_sync_ready_products' )
 			->withConsecutive( [ [], 2, 0 ], [ [], 2, 2 ], [ [], 2, 4 ] )
 			->willReturnOnConsecutiveCalls( $batch_a, $batch_b, $batch_c );
+
+		$this->merchant_center
+			->method( 'is_enabled_for_datatype' )
+			->willReturn( true );
 
 		$this->job->schedule();
 
@@ -340,29 +355,17 @@ class UpdateAllProductsTest extends UnitTest {
 			->method( 'schedule_single' )
 			->with( gmdate( 'U' ) + 100, self::CREATE_BATCH_HOOK, [ 1 ] );
 
+		$this->merchant_center
+			->method( 'is_enabled_for_datatype' )
+			->willReturn( true );
+
 		$this->job->schedule_delayed( 100 );
 	}
 
 	public function test_cannot_schedule_when_mc_push_is_blocked() {
-
 		$this->merchant_center
 			->method( 'is_enabled_for_datatype' )
-			->with( 'products' )
 			->willReturn( false );
-
-		$this->action_scheduler
-			->method( 'has_scheduled_action' )
-			->willReturn( false );
-
-		$this->job                = new UpdateAllProducts(
-			$this->action_scheduler,
-			$this->monitor,
-			$this->product_syncer,
-			$this->product_repository,
-			$this->product_helper,
-			$this->merchant_center,
-			$this->merchant_statuses
-		);
 
 		$this->assertFalse( $this->job->can_schedule() );
 	}

--- a/tests/Unit/Jobs/UpdateProductsTest.php
+++ b/tests/Unit/Jobs/UpdateProductsTest.php
@@ -59,12 +59,6 @@ class UpdateProductsTest extends UnitTest {
 		$this->product_syncer     = $this->createMock( ProductSyncer::class );
 		$this->product_repository = $this->createMock( ProductRepository::class );
 		$this->merchant_center    = $this->createMock( MerchantCenterService::class );
-
-		$this->merchant_center
-			->method( 'is_enabled_for_datatype' )
-			->with( 'products' )
-			->willReturn( true );
-
 		$this->job                = new UpdateProducts(
 			$this->action_scheduler,
 			$this->monitor,
@@ -106,6 +100,11 @@ class UpdateProductsTest extends UnitTest {
 		$this->action_scheduler
 			->method( 'has_scheduled_action' )
 			->willReturn( false );
+
+		$this->merchant_center
+			->method( 'is_enabled_for_datatype' )
+			->willReturn( true );
+
 		$this->merchant_center
 			->method( 'is_ready_for_syncing' )
 			->willReturn( true );
@@ -151,15 +150,7 @@ class UpdateProductsTest extends UnitTest {
 	}
 
 	public function test_cannot_schedule_when_mc_push_blocked() {
-		$this->merchant_center
-			->method( 'is_enabled_for_datatype' )
-			->with( 'products' )
-			->willReturn( false );
-
-		$this->action_scheduler
-			->method( 'has_scheduled_action' )
-			->willReturn( false );
-
+		$this->merchant_center->expects( $this->any() )->method( 'is_enabled_for_datatype' )->with( 'products' )->willReturn( false );
 		$this->assertFalse( $this->job->can_schedule() );
 	}
 }

--- a/tests/Unit/Jobs/UpdateProductsTest.php
+++ b/tests/Unit/Jobs/UpdateProductsTest.php
@@ -59,6 +59,12 @@ class UpdateProductsTest extends UnitTest {
 		$this->product_syncer     = $this->createMock( ProductSyncer::class );
 		$this->product_repository = $this->createMock( ProductRepository::class );
 		$this->merchant_center    = $this->createMock( MerchantCenterService::class );
+
+		$this->merchant_center
+			->method( 'is_ready_for_syncing' )
+			->with( 'products' )
+			->willReturn( true );
+
 		$this->job                = new UpdateProducts(
 			$this->action_scheduler,
 			$this->monitor,
@@ -142,5 +148,18 @@ class UpdateProductsTest extends UnitTest {
 		$this->product_syncer->expects( $this->once() )->method( 'update' )->with( $products );
 
 		$this->job->process_items( [] );
+	}
+
+	public function test_cannot_schedule_when_mc_push_blocked() {
+		$this->merchant_center
+			->method( 'is_ready_for_syncing' )
+			->with( 'products' )
+			->willReturn( false );
+
+		$this->action_scheduler
+			->method( 'has_scheduled_action' )
+			->willReturn( false );
+
+		$this->assertFalse( $this->job->can_schedule() );
 	}
 }

--- a/tests/Unit/Jobs/UpdateProductsTest.php
+++ b/tests/Unit/Jobs/UpdateProductsTest.php
@@ -61,7 +61,7 @@ class UpdateProductsTest extends UnitTest {
 		$this->merchant_center    = $this->createMock( MerchantCenterService::class );
 
 		$this->merchant_center
-			->method( 'is_ready_for_syncing' )
+			->method( 'is_enabled_for_datatype' )
 			->with( 'products' )
 			->willReturn( true );
 
@@ -152,7 +152,7 @@ class UpdateProductsTest extends UnitTest {
 
 	public function test_cannot_schedule_when_mc_push_blocked() {
 		$this->merchant_center
-			->method( 'is_ready_for_syncing' )
+			->method( 'is_enabled_for_datatype' )
 			->with( 'products' )
 			->willReturn( false );
 

--- a/tests/Unit/Jobs/UpdateShippingSettingsTest.php
+++ b/tests/Unit/Jobs/UpdateShippingSettingsTest.php
@@ -139,9 +139,6 @@ class UpdateShippingSettingsTest extends UnitTest {
 			->with( 'shipping' )
 			->willReturn( false );
 
-		$this->google_settings->expects( $this->never() )
-			->method( 'sync_shipping' );
-
 		$this->expectException( JobException::class );
 
 		do_action( $this->job->get_process_item_hook(), [] );

--- a/tests/Unit/Jobs/UpdateShippingSettingsTest.php
+++ b/tests/Unit/Jobs/UpdateShippingSettingsTest.php
@@ -38,6 +38,11 @@ class UpdateShippingSettingsTest extends UnitTest {
 		$this->merchant_center->expects( $this->any() )
 			->method( 'is_connected' )
 			->willReturn( true );
+
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->willReturn( true );
+
 		$this->google_settings->expects( $this->any() )
 			->method( 'should_get_shipping_rates_from_woocommerce' )
 			->willReturn( true );
@@ -83,6 +88,11 @@ class UpdateShippingSettingsTest extends UnitTest {
 		$this->merchant_center->expects( $this->any() )
 			->method( 'is_connected' )
 			->willReturn( true );
+
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->willReturn( true );
+
 		$this->google_settings->expects( $this->any() )
 			->method( 'should_get_shipping_rates_from_woocommerce' )
 			->willReturn( true );
@@ -132,7 +142,6 @@ class UpdateShippingSettingsTest extends UnitTest {
 
 		$this->merchant_center->expects( $this->any() )
 			->method( 'is_enabled_for_datatype' )
-			->with( 'shipping' )
 			->willReturn( false );
 
 		$this->google_settings->expects( $this->any() )
@@ -155,11 +164,7 @@ class UpdateShippingSettingsTest extends UnitTest {
 		$this->merchant_center  = $this->createMock( MerchantCenterService::class );
 		$this->google_settings  = $this->createMock( GoogleSettings::class );
 
-		$this->merchant_center->method( 'is_enabled_for_datatype' )
-			->with( 'shipping' )
-			->willReturn( true );
-
-		$this->job              = new UpdateShippingSettings( $this->action_scheduler, $this->monitor, $this->merchant_center, $this->google_settings );
+		$this->job = new UpdateShippingSettings( $this->action_scheduler, $this->monitor, $this->merchant_center, $this->google_settings );
 
 		$this->job->init();
 	}

--- a/tests/Unit/Jobs/UpdateShippingSettingsTest.php
+++ b/tests/Unit/Jobs/UpdateShippingSettingsTest.php
@@ -130,14 +130,14 @@ class UpdateShippingSettingsTest extends UnitTest {
 			->method( 'is_connected' )
 			->willReturn( true );
 
+		$this->google_settings->expects( $this->any() )
+			->method( 'should_get_shipping_rates_from_woocommerce' )
+			->willReturn( true );
+
 		$this->merchant_center->expects( $this->any() )
 			->method( 'is_enabled_for_datatype' )
 			->with( 'shipping' )
 			->willReturn( false );
-
-		$this->google_settings->expects( $this->any() )
-			->method( 'should_get_shipping_rates_from_woocommerce' )
-			->willReturn( true );
 
 		$this->google_settings->expects( $this->never() )
 			->method( 'sync_shipping' );
@@ -157,11 +157,6 @@ class UpdateShippingSettingsTest extends UnitTest {
 		$this->monitor          = $this->createMock( ActionSchedulerJobMonitor::class );
 		$this->merchant_center  = $this->createMock( MerchantCenterService::class );
 		$this->google_settings  = $this->createMock( GoogleSettings::class );
-
-		$this->merchant_center->expects( $this->any() )
-			->method( 'is_enabled_for_datatype' )
-			->with( 'shipping' )
-			->willReturn( true );
 
 		$this->job              = new UpdateShippingSettings( $this->action_scheduler, $this->monitor, $this->merchant_center, $this->google_settings );
 

--- a/tests/Unit/Jobs/UpdateShippingSettingsTest.php
+++ b/tests/Unit/Jobs/UpdateShippingSettingsTest.php
@@ -125,6 +125,28 @@ class UpdateShippingSettingsTest extends UnitTest {
 		do_action( $this->job->get_process_item_hook(), [] );
 	}
 
+	public function test_process_items_fails_if_push_sync_is_disabled() {
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_connected' )
+			->willReturn( true );
+
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->with( 'shipping' )
+			->willReturn( false );
+
+		$this->google_settings->expects( $this->any() )
+			->method( 'should_get_shipping_rates_from_woocommerce' )
+			->willReturn( true );
+
+		$this->google_settings->expects( $this->never() )
+			->method( 'sync_shipping' );
+
+		$this->expectException( JobException::class );
+
+		do_action( $this->job->get_process_item_hook(), [] );
+	}
+
 	/**
 	 * Runs before each test is executed.
 	 */
@@ -135,6 +157,12 @@ class UpdateShippingSettingsTest extends UnitTest {
 		$this->monitor          = $this->createMock( ActionSchedulerJobMonitor::class );
 		$this->merchant_center  = $this->createMock( MerchantCenterService::class );
 		$this->google_settings  = $this->createMock( GoogleSettings::class );
+
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->with( 'shipping' )
+			->willReturn( true );
+
 		$this->job              = new UpdateShippingSettings( $this->action_scheduler, $this->monitor, $this->merchant_center, $this->google_settings );
 
 		$this->job->init();

--- a/tests/Unit/Jobs/UpdateShippingSettingsTest.php
+++ b/tests/Unit/Jobs/UpdateShippingSettingsTest.php
@@ -155,6 +155,10 @@ class UpdateShippingSettingsTest extends UnitTest {
 		$this->merchant_center  = $this->createMock( MerchantCenterService::class );
 		$this->google_settings  = $this->createMock( GoogleSettings::class );
 
+		$this->merchant_center->method( 'is_enabled_for_datatype' )
+			->with( 'shipping' )
+			->willReturn( true );
+
 		$this->job              = new UpdateShippingSettings( $this->action_scheduler, $this->monitor, $this->merchant_center, $this->google_settings );
 
 		$this->job->init();

--- a/tests/Unit/Jobs/UpdateShippingSettingsTest.php
+++ b/tests/Unit/Jobs/UpdateShippingSettingsTest.php
@@ -130,14 +130,14 @@ class UpdateShippingSettingsTest extends UnitTest {
 			->method( 'is_connected' )
 			->willReturn( true );
 
-		$this->google_settings->expects( $this->any() )
-			->method( 'should_get_shipping_rates_from_woocommerce' )
-			->willReturn( true );
-
 		$this->merchant_center->expects( $this->any() )
 			->method( 'is_enabled_for_datatype' )
 			->with( 'shipping' )
 			->willReturn( false );
+
+		$this->google_settings->expects( $this->any() )
+			->method( 'should_get_shipping_rates_from_woocommerce' )
+			->willReturn( true );
 
 		$this->expectException( JobException::class );
 

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -551,10 +551,11 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 	public function test_update_throws_exception_when_mc_is_blocked() {
 		$merchant_center = $this->createMock( MerchantCenterService::class );
 		$merchant_center->expects( $this->once() )
-			->method( 'is_ready_for_syncing' )
-			->willReturn( true );
-		$merchant_center->expects( $this->once() )
 			->method( 'should_push' )
+			->willReturn( true );
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->with( 'products' )
 			->willReturn( false );
 		$this->product_syncer = $this->get_product_syncer( [ 'merchant_center' => $merchant_center ] );
 
@@ -566,10 +567,11 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 	public function test_update_by_batch_throws_exception_when_mc_is_blocked() {
 		$merchant_center = $this->createMock( MerchantCenterService::class );
 		$merchant_center->expects( $this->once() )
-			->method( 'is_ready_for_syncing' )
-			->willReturn( true );
-		$merchant_center->expects( $this->once() )
 			->method( 'should_push' )
+			->willReturn( true );
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->with( 'products' )
 			->willReturn( false );
 		$this->product_syncer = $this->get_product_syncer( [ 'merchant_center' => $merchant_center ] );
 
@@ -581,10 +583,11 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 	public function test_delete_throws_exception_when_mc_is_blocked() {
 		$merchant_center = $this->createMock( MerchantCenterService::class );
 		$merchant_center->expects( $this->once() )
-			->method( 'is_ready_for_syncing' )
-			->willReturn( true );
-		$merchant_center->expects( $this->once() )
 			->method( 'should_push' )
+			->willReturn( true );
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->with( 'products' )
 			->willReturn( false );
 		$this->product_syncer = $this->get_product_syncer( [ 'merchant_center' => $merchant_center ] );
 
@@ -596,10 +599,11 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 	public function test_delete_by_batch_throws_exception_when_mc_is_blocked() {
 		$merchant_center = $this->createMock( MerchantCenterService::class );
 		$merchant_center->expects( $this->once() )
-			->method( 'is_ready_for_syncing' )
-			->willReturn( true );
-		$merchant_center->expects( $this->once() )
 			->method( 'should_push' )
+			->willReturn( true );
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->with( 'products' )
 			->willReturn( false );
 		$this->product_syncer = $this->get_product_syncer( [ 'merchant_center' => $merchant_center ] );
 
@@ -644,6 +648,11 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 
 		$this->merchant_center->expects( $this->any() )
 			->method( 'should_push' )
+			->willReturn( true );
+
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->with( 'products' )
 			->willReturn( true );
 
 		$this->google_service = $this->createMock( GoogleProductService::class );

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -550,7 +550,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 
 	public function test_update_throws_exception_when_mc_is_blocked() {
 		$merchant_center = $this->createMock( MerchantCenterService::class );
-		$merchant_center->expects( $this->once() )
+		$merchant_center->expects( $this->any() )
 			->method( 'should_push' )
 			->willReturn( true );
 		$this->merchant_center->expects( $this->any() )
@@ -566,7 +566,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 
 	public function test_update_by_batch_throws_exception_when_mc_is_blocked() {
 		$merchant_center = $this->createMock( MerchantCenterService::class );
-		$merchant_center->expects( $this->once() )
+		$merchant_center->expects( $this->any() )
 			->method( 'should_push' )
 			->willReturn( true );
 		$this->merchant_center->expects( $this->any() )
@@ -582,7 +582,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 
 	public function test_delete_throws_exception_when_mc_is_blocked() {
 		$merchant_center = $this->createMock( MerchantCenterService::class );
-		$merchant_center->expects( $this->once() )
+		$merchant_center->expects( $this->any() )
 			->method( 'should_push' )
 			->willReturn( true );
 		$this->merchant_center->expects( $this->any() )
@@ -598,7 +598,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 
 	public function test_delete_by_batch_throws_exception_when_mc_is_blocked() {
 		$merchant_center = $this->createMock( MerchantCenterService::class );
-		$merchant_center->expects( $this->once() )
+		$merchant_center->expects( $this->any() )
 			->method( 'should_push' )
 			->willReturn( true );
 		$this->merchant_center->expects( $this->any() )

--- a/tests/Unit/Product/SyncerHooksTest.php
+++ b/tests/Unit/Product/SyncerHooksTest.php
@@ -572,6 +572,10 @@ class SyncerHooksTest extends ContainerAwareUnitTest {
 			->method( 'is_ready_for_syncing' )
 			->willReturn( $mc_status );
 
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->willReturn( $mc_status );
+
 		$this->notification_service->expects( $this->any() )
 			->method( 'is_ready' )
 			->willReturn( $notifications_status );

--- a/tests/Unit/Shipping/SyncerHooksTest.php
+++ b/tests/Unit/Shipping/SyncerHooksTest.php
@@ -208,7 +208,7 @@ class SyncerHooksTest extends UnitTest {
 		$zone->save();
 	}
 
-	public function test_saving_shipping_zone_doesnt_schedule_notifications_when_enabled() {
+	public function test_saving_shipping_zone_schedule_notifications_when_enabled() {
 		$this->mock_sync_ready_flags_and_register_hooks( true, true );
 
 		$this->notification_service->expects( $this->once() )
@@ -225,6 +225,28 @@ class SyncerHooksTest extends UnitTest {
 		$zone->add_location( 'GB', 'country' );
 		$zone->save();
 	}
+
+	public function test_saving_shipping_zone_schedules_when_datatypes_are_blocked() {
+		$this->mock_sync_ready_flags_and_register_hooks( true, true );
+
+		$this->notification_service->expects( $this->once() )
+			->method( 'is_push_enabled_for_datatype' )->willReturn( false );
+
+		$this->notification_service->expects( $this->once() )
+			->method( 'is_pull_enabled_for_datatype' )->willReturn( false );
+
+		$this->shipping_notification_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->update_shipping_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$zone = new WC_Shipping_Zone();
+		$zone->set_zone_name( 'GB' );
+		$zone->add_location( 'GB', 'country' );
+		$zone->save();
+	}
+
 
 	/**
 	 * Mocks the validation methods that allow/disallow the shipping settings to be synced.
@@ -281,6 +303,11 @@ class SyncerHooksTest extends UnitTest {
 					[ UpdateShippingSettings::class, $this->update_shipping_job ],
 				]
 			);
+
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->with( 'shipping' )
+			->willReturn( true );
 
 		add_filter( 'woocommerce_gla_notifications_enabled', '__return_false' );
 

--- a/tests/Unit/Shipping/SyncerHooksTest.php
+++ b/tests/Unit/Shipping/SyncerHooksTest.php
@@ -226,28 +226,6 @@ class SyncerHooksTest extends UnitTest {
 		$zone->save();
 	}
 
-	public function test_saving_shipping_zone_schedules_when_datatypes_are_blocked() {
-		$this->mock_sync_ready_flags_and_register_hooks( true, true );
-
-		$this->notification_service->expects( $this->once() )
-			->method( 'is_push_enabled_for_datatype' )->willReturn( false );
-
-		$this->notification_service->expects( $this->once() )
-			->method( 'is_pull_enabled_for_datatype' )->willReturn( false );
-
-		$this->shipping_notification_job->expects( $this->never() )
-			->method( 'schedule' );
-
-		$this->update_shipping_job->expects( $this->never() )
-			->method( 'schedule' );
-
-		$zone = new WC_Shipping_Zone();
-		$zone->set_zone_name( 'GB' );
-		$zone->add_location( 'GB', 'country' );
-		$zone->save();
-	}
-
-
 	/**
 	 * Mocks the validation methods that allow/disallow the shipping settings to be synced.
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Block Merchant Center Sync in case the Sync is disabled for the datatype

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout PR and have a completed onboarding. All the Sync Datatype for PUSH should be enabled
3. Create a product. Go to WoOCommere Scheduled actions and see `gla/jobs/update_products/process_item`. Run it 
4. Update the product.  Go to WoOCommere Scheduled actions and see `gla/jobs/update_products/process_item`. Run it 
5. Create a coupon and select "Show in Google" . Go to WoOCommere Scheduled actions and see `gla/jobs/update_coupon/process_item`. Run it 
6. Create a coupon and select "Show in Google".  Go to WoOCommere Scheduled actions and see `gla/jobs/update_coupon/process_item`. Run it 
7. Go to Google - Shipping tab and select "Automatically sync my store’s shipping settings to Google."
8. Go to WooCommerce - Settings - Shipping and create a Shipping Zone
9. Go to WooCommerce - Status - Scheduled Actions and see `gla/jobs/update_shipping_settings/process_item`
10. Deactivate Push Sync for Products, Coupons and Shipping 
11. Repeat step 3. No Job should be scheduled
12. Try to sync a product manually using the Connection Test Page. It should fail. "Error submitting product to Google: Pushing products will not run if the PUSH Sync functionality has been disabled."
13. Repeat steps 5.  No Job should be scheduled 
14. Repeat step 8. No Job should be scheduled 


### Additional details:

PT: pcTzPl-2yG-p2

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>