### PR TITLE
Avoid getting stuck in loading state when it fails to fetch WPCOM app auth URL during onboarding

### DIFF
--- a/js/src/pages/onboarding/useAutoWPComAppAuthorization.js
+++ b/js/src/pages/onboarding/useAutoWPComAppAuthorization.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getQuery } from '@woocommerce/navigation';
-import { useRef } from '@wordpress/element';
+import { useRef, useReducer } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,6 +30,7 @@ export default function useAutoWPComAppAuthorization() {
 	const { googleMCAccount, isWPComAppGranted } = useGoogleMCAccount();
 	const { fetchWPComAppAuthorizationUrl } = useAppDispatch();
 	const lockRef = useRef( null );
+	const [ , forceUpdate ] = useReducer( ( x ) => x + 1, 0 );
 
 	const query = getQuery();
 	const isBackFromGoogleAuth = query[ 'google-mc' ] === 'connected';
@@ -65,6 +66,7 @@ export default function useAutoWPComAppAuthorization() {
 				.catch( () => {
 					// Silently fall back to the subsequent process if any error occurs.
 					lockRef.current = true;
+					forceUpdate();
 				} );
 		}
 	} else {

--- a/js/src/pages/onboarding/useAutoWPComAppAuthorization.test.js
+++ b/js/src/pages/onboarding/useAutoWPComAppAuthorization.test.js
@@ -1,0 +1,197 @@
+/**
+ * External dependencies
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { getQuery } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import useAutoWPComAppAuthorization from './useAutoWPComAppAuthorization';
+import useJetpackAccount from '~/hooks/useJetpackAccount';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+import { useAppDispatch } from '~/data';
+
+jest.mock( '@woocommerce/navigation' );
+jest.mock( '~/hooks/useJetpackAccount' );
+jest.mock( '~/hooks/useGoogleAccount' );
+jest.mock( '~/hooks/useGoogleMCAccount' );
+jest.mock( '~/data', () => ( {
+	...jest.requireActual( '~/data' ),
+	useAppDispatch: jest.fn(),
+} ) );
+
+const googleAccount = {
+	google: { active: 'yes' },
+	scope: { gmcRequired: true, onboardingRequired: true },
+};
+
+const googleMCAccount = { googleMCAccount: {}, isWPComAppGranted: true };
+
+describe( 'useAutoWPComAppAuthorization', () => {
+	let fetchWPComAppAuthorizationUrl;
+
+	beforeEach( () => {
+		getQuery.mockClear().mockReturnValue( { 'google-mc': 'connected' } );
+		useJetpackAccount.mockReturnValue( { jetpack: { active: 'yes' } } );
+		useGoogleAccount.mockReturnValue( googleAccount );
+		useGoogleMCAccount.mockReturnValue( googleMCAccount );
+
+		fetchWPComAppAuthorizationUrl = jest
+			.fn()
+			.mockName( 'fetchWPComAppAuthorizationUrl' )
+			.mockResolvedValue( 'https://jest/wpcom-auth' );
+		useAppDispatch.mockReturnValue( { fetchWPComAppAuthorizationUrl } );
+	} );
+
+	describe( 'Should return `null`', () => {
+		it( 'When Jetpack account is loading', () => {
+			useJetpackAccount.mockReturnValue( { jetpack: null } );
+			const hook = renderHook( () => useAutoWPComAppAuthorization() );
+
+			expect( hook.result.current ).toBeNull();
+			expect( fetchWPComAppAuthorizationUrl ).not.toHaveBeenCalled();
+		} );
+
+		it( 'When Google account is loading', () => {
+			useGoogleAccount.mockReturnValue( { google: null } );
+			const hook = renderHook( () => useAutoWPComAppAuthorization() );
+
+			expect( hook.result.current ).toBeNull();
+			expect( fetchWPComAppAuthorizationUrl ).not.toHaveBeenCalled();
+		} );
+
+		it( 'When Google Merchant Center account is loading', () => {
+			useGoogleMCAccount.mockReturnValue( { googleMCAccount: null } );
+			const hook = renderHook( () => useAutoWPComAppAuthorization() );
+
+			expect( hook.result.current ).toBeNull();
+			expect( fetchWPComAppAuthorizationUrl ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Should return `true`', () => {
+		it( 'When not being redirected back from Google authorization', () => {
+			getQuery.mockReturnValue( {} );
+			const hook = renderHook( () => useAutoWPComAppAuthorization() );
+
+			expect( hook.result.current ).toBe( true );
+			expect( fetchWPComAppAuthorizationUrl ).not.toHaveBeenCalled();
+		} );
+
+		it( 'When Jetpack account is not connected', () => {
+			useJetpackAccount.mockReturnValue( { jetpack: { active: 'no' } } );
+			const hook = renderHook( () => useAutoWPComAppAuthorization() );
+
+			expect( hook.result.current ).toBe( true );
+			expect( fetchWPComAppAuthorizationUrl ).not.toHaveBeenCalled();
+		} );
+
+		it( 'When Google account is not connected', () => {
+			useGoogleAccount.mockReturnValue( {
+				...googleAccount,
+				google: { active: 'no' },
+			} );
+			const hook = renderHook( () => useAutoWPComAppAuthorization() );
+
+			expect( hook.result.current ).toBe( true );
+			expect( fetchWPComAppAuthorizationUrl ).not.toHaveBeenCalled();
+		} );
+
+		it( 'When access to Google Merchant Center is insufficient', () => {
+			useGoogleAccount.mockReturnValue( {
+				...googleAccount,
+				scope: { gmcRequired: false },
+			} );
+			const hook = renderHook( () => useAutoWPComAppAuthorization() );
+
+			expect( hook.result.current ).toBe( true );
+			expect( fetchWPComAppAuthorizationUrl ).not.toHaveBeenCalled();
+		} );
+
+		it( 'When all required access to Google account is insufficient', () => {
+			useGoogleAccount.mockReturnValue( {
+				...googleAccount,
+				scope: { gmcRequired: true, onboardingRequired: false },
+			} );
+			useGoogleMCAccount.mockReturnValue( {
+				...googleMCAccount,
+				isWPComAppGranted: false,
+			} );
+			const hook = renderHook( () => useAutoWPComAppAuthorization() );
+
+			expect( hook.result.current ).toBe( true );
+			expect( fetchWPComAppAuthorizationUrl ).not.toHaveBeenCalled();
+		} );
+
+		it( 'When WPCom app authorization is already granted', () => {
+			const hook = renderHook( () => useAutoWPComAppAuthorization() );
+
+			expect( hook.result.current ).toBe( true );
+			expect( fetchWPComAppAuthorizationUrl ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'WPCom app authorization is not granted and being redirected back from Google authorization', () => {
+		let originalLocation;
+		let spyHref;
+
+		beforeEach( () => {
+			useGoogleMCAccount.mockReturnValue( {
+				...googleMCAccount,
+				isWPComAppGranted: false,
+			} );
+
+			originalLocation = global.location;
+			Object.defineProperty( global, 'location', {
+				value: new URL( 'http://localhost' ),
+				writable: true,
+			} );
+			spyHref = jest.spyOn( global.location, 'href', 'set' );
+		} );
+
+		afterEach( () => {
+			global.location = originalLocation;
+		} );
+
+		it( 'Should return `false`', () => {
+			const hook = renderHook( () => useAutoWPComAppAuthorization() );
+
+			expect( hook.result.current ).toBe( false );
+		} );
+
+		it( 'Should redirect to WPCom app authorization URL', async () => {
+			renderHook( () => useAutoWPComAppAuthorization() );
+
+			await waitFor( () => expect( spyHref ).toHaveBeenCalledTimes( 1 ) );
+			expect( spyHref ).toHaveBeenCalledWith( 'https://jest/wpcom-auth' );
+		} );
+
+		it( 'Should only fetch and redirect to WPCom app authorization URL one time', async () => {
+			expect( fetchWPComAppAuthorizationUrl ).not.toHaveBeenCalled();
+			expect( spyHref ).not.toHaveBeenCalled();
+
+			const hook = renderHook( () => useAutoWPComAppAuthorization() );
+
+			expect( fetchWPComAppAuthorizationUrl ).toHaveBeenCalledTimes( 1 );
+			await waitFor( () => expect( spyHref ).toHaveBeenCalledTimes( 1 ) );
+
+			hook.rerender();
+			hook.rerender();
+			hook.rerender();
+
+			expect( getQuery ).toHaveBeenCalledTimes( 4 );
+			expect( fetchWPComAppAuthorizationUrl ).toHaveBeenCalledTimes( 1 );
+			await waitFor( () => expect( spyHref ).toHaveBeenCalledTimes( 1 ) );
+		} );
+
+		it( 'When an error occurs while fetching the URL, it should trigger a hook update and change the return value from `false` to `true`', async () => {
+			fetchWPComAppAuthorizationUrl.mockRejectedValue( new Error() );
+			const hook = renderHook( () => useAutoWPComAppAuthorization() );
+
+			expect( hook.result.current ).toBe( false );
+			await waitFor( () => expect( hook.result.current ).toBe( true ) );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project thread: pcTzPl-2Df-p2

This PR fixes the issue of getting stuck on loading state when it fails to fetch WPCOM app auth URL during onboarding.

https://github.com/user-attachments/assets/f2ec4536-c64a-460d-972b-9130717af0a5

### Screenshots:

https://github.com/user-attachments/assets/f4379789-72f4-43f0-a5d6-d12ac287ec3c

### Detailed test instructions:

1. Locally insert code between [lines 95-96 of AuthController.php](https://github.com/woocommerce/google-listings-and-ads/blob/3559b763024fac5c7906b011c9e5a341c8ddd026/src/API/Site/Controllers/RestAPI/AuthController.php#L95-L96) to simulate API failure.
   ```php
   return $this->response_from_exception( new Exception( 'Test' ) );
   ```
2. Make the test site publicly accessible
3. Use the Connection Test page to clear the authorization status of Google's WPCOM app if it has been granted
4. Go to onboarding step 1 and disconnect all accounts if there are connected ones
5. Open browser DevTool and switch to Network tab
6. Start connecting to Google account and authorize all required permissions
7. After being redirected back from Google account authorization
   - Check if the request to `rest-api/authorize` API failed as simulated
   - Check if the following UI is present instead of a blank page with a forever loading spinner
      ![image](https://github.com/user-attachments/assets/3df35afa-6f84-40ed-9975-d18941dc479e)

### Additional details:

Setting `changelog: dev` label rather than `changelog: fix` is because the issue only exists in a feature branch and has not been released.

### Changelog entry
