### PR TITLE
Add event tracking of how users process the WPCOM app authorization for the API Pull feature

### DIFF
--- a/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.js
+++ b/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { getQuery, getNewPath, getHistory } from '@woocommerce/navigation';
 
 /**
@@ -23,6 +23,7 @@ import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 const useUpdateRestAPIAuthorizeStatusByUrlQuery = () => {
 	const { google_wpcom_app_status: googleWPCOMAppStatus, nonce } = getQuery();
 	const { invalidateResolution } = useAppDispatch();
+	const lockRef = useRef( null );
 
 	const path = `${ API_NAMESPACE }/rest-api/authorize`;
 	const [ fetchUpdateRestAPIAuthorize ] = useApiFetchCallback( {
@@ -30,7 +31,7 @@ const useUpdateRestAPIAuthorizeStatusByUrlQuery = () => {
 		method: 'PUT',
 	} );
 
-	const handleUpdateRestAPIAuthorize = useCallback( async () => {
+	const handleUpdateRestAPIAuthorize = async () => {
 		try {
 			await fetchUpdateRestAPIAuthorize( {
 				data: {
@@ -54,25 +55,24 @@ const useUpdateRestAPIAuthorizeStatusByUrlQuery = () => {
 			nonce: undefined,
 		} );
 		getHistory().replace( url );
-	}, [
-		fetchUpdateRestAPIAuthorize,
-		googleWPCOMAppStatus,
-		invalidateResolution,
-		nonce,
-	] );
+	};
+
+	if ( lockRef.current === null ) {
+		lockRef.current = handleUpdateRestAPIAuthorize;
+	}
 
 	useEffect( () => {
-		async function updateStatus() {
-			await handleUpdateRestAPIAuthorize( googleWPCOMAppStatus );
-		}
-		if (
-			Object.values( GOOGLE_WPCOM_APP_CONNECTED_STATUS ).includes(
-				googleWPCOMAppStatus
-			)
-		) {
+		const isValidStatus = Object.values(
+			GOOGLE_WPCOM_APP_CONNECTED_STATUS
+		).includes( googleWPCOMAppStatus );
+
+		if ( isValidStatus && lockRef.current ) {
+			const updateStatus = lockRef.current;
+			lockRef.current = false;
+
 			updateStatus();
 		}
-	}, [ googleWPCOMAppStatus, handleUpdateRestAPIAuthorize ] );
+	}, [ googleWPCOMAppStatus ] );
 };
 
 export default useUpdateRestAPIAuthorizeStatusByUrlQuery;

--- a/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.js
+++ b/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.js
@@ -11,6 +11,18 @@ import { GOOGLE_WPCOM_APP_CONNECTED_STATUS } from '~/constants';
 import { useAppDispatch } from '~/data';
 import { API_NAMESPACE } from '~/data/constants';
 import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import { recordGlaEvent } from '~/utils/tracks';
+
+/**
+ * Being redirected back from WPCOM app authorization for the product sync (API Pull).
+ * This event is only recorded when the user is brought back to this plugin.
+ * It won't be recorded if they don't return to this plugin for any reason.
+ * (e.g., closing the browser tab).
+ *
+ * @event gla_product_sync_status_callback
+ * @property {string} page Indicates the page where this event happened
+ * @property {string} status The authorization status
+ */
 
 /**
  * A hook that calls an API to update Google WPCOM app connected status.
@@ -19,8 +31,12 @@ import useApiFetchCallback from '~/hooks/useApiFetchCallback';
  * redirect back to the merchant site, either the settings page or onboarding setup account page.
  * They will add a query param `google_wpcom_app_status` to the URL, we will store this status to
  * the DB by calling an API `PUT /wc/gla/rest-api/authorize`.
+ *
+ * @param {string} page The page where this hook is being used. It's used for tracking purposes.
+ *
+ * @fires gla_product_sync_status_callback with `{ page: 'setup-mc' | 'settings', status: 'approved' | 'disapproved' | 'error' }`
  */
-const useUpdateRestAPIAuthorizeStatusByUrlQuery = () => {
+const useUpdateRestAPIAuthorizeStatusByUrlQuery = ( page ) => {
 	const { google_wpcom_app_status: googleWPCOMAppStatus, nonce } = getQuery();
 	const { invalidateResolution } = useAppDispatch();
 	const lockRef = useRef( null );
@@ -32,6 +48,11 @@ const useUpdateRestAPIAuthorizeStatusByUrlQuery = () => {
 	} );
 
 	const handleUpdateRestAPIAuthorize = async () => {
+		recordGlaEvent( 'gla_product_sync_status_callback', {
+			page,
+			status: googleWPCOMAppStatus,
+		} );
+
 		try {
 			await fetchUpdateRestAPIAuthorize( {
 				data: {

--- a/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.test.js
+++ b/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.test.js
@@ -3,6 +3,7 @@
  */
 import { renderHook, waitFor } from '@testing-library/react';
 import { getQuery, getHistory } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -11,6 +12,9 @@ import useUpdateRestAPIAuthorizeStatusByUrlQuery from './useUpdateRestAPIAuthori
 import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 
 jest.mock( '@woocommerce/navigation' );
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn().mockName( 'recordEvent' ),
+} ) );
 jest.mock( '~/hooks/useApiFetchCallback' );
 
 describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
@@ -19,6 +23,8 @@ describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 	let consoleErrorSpy;
 
 	beforeEach( () => {
+		recordEvent.mockClear();
+
 		historyReplace = jest.fn().mockName( 'getHistory().replace' );
 		getHistory.mockReturnValue( { replace: historyReplace } );
 
@@ -130,7 +136,28 @@ describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 		} );
 		renderHook( () => useUpdateRestAPIAuthorizeStatusByUrlQuery() );
 		expect( fetchUpdateRestAPIAuthorize ).toHaveBeenCalledTimes( 0 );
+		expect( recordEvent ).toHaveBeenCalledTimes( 0 );
 	} );
+
+	it.each( [ 'approved', 'disapproved', 'error' ] )(
+		"Should record an event if the auth status is '%s'",
+		( status ) => {
+			getQuery.mockReturnValue( {
+				google_wpcom_app_status: status,
+				nonce: 'nonce-123',
+			} );
+
+			renderHook( () =>
+				useUpdateRestAPIAuthorizeStatusByUrlQuery( 'jest-testing' )
+			);
+
+			expect( recordEvent ).toHaveBeenCalledTimes( 1 );
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'gla_product_sync_status_callback',
+				{ page: 'jest-testing', status }
+			);
+		}
+	);
 
 	it( 'Should only call API one time', async () => {
 		getQuery.mockClear().mockReturnValue( {
@@ -140,8 +167,8 @@ describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 
 		expect( fetchUpdateRestAPIAuthorize ).not.toHaveBeenCalled();
 
-		const hook = renderHook( () =>
-			useUpdateRestAPIAuthorizeStatusByUrlQuery()
+		const hook = renderHook( ( page ) =>
+			useUpdateRestAPIAuthorizeStatusByUrlQuery( page )
 		);
 
 		hook.rerender();
@@ -150,5 +177,6 @@ describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 
 		await waitFor( () => expect( getQuery ).toHaveBeenCalledTimes( 4 ) );
 		expect( fetchUpdateRestAPIAuthorize ).toHaveBeenCalledTimes( 1 );
+		expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.test.js
+++ b/js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.test.js
@@ -131,4 +131,24 @@ describe( 'useUpdateRestAPIAuthorizeStatusByUrlQuery', () => {
 		renderHook( () => useUpdateRestAPIAuthorizeStatusByUrlQuery() );
 		expect( fetchUpdateRestAPIAuthorize ).toHaveBeenCalledTimes( 0 );
 	} );
+
+	it( 'Should only call API one time', async () => {
+		getQuery.mockClear().mockReturnValue( {
+			google_wpcom_app_status: 'approved',
+			nonce: 'nonce-123',
+		} );
+
+		expect( fetchUpdateRestAPIAuthorize ).not.toHaveBeenCalled();
+
+		const hook = renderHook( () =>
+			useUpdateRestAPIAuthorizeStatusByUrlQuery()
+		);
+
+		hook.rerender();
+		hook.rerender( 'jest-testing' );
+		hook.rerender();
+
+		await waitFor( () => expect( getQuery ).toHaveBeenCalledTimes( 4 ) );
+		expect( fetchUpdateRestAPIAuthorize ).toHaveBeenCalledTimes( 1 );
+	} );
 } );

--- a/js/src/pages/onboarding/index.js
+++ b/js/src/pages/onboarding/index.js
@@ -9,6 +9,7 @@ import { Spinner } from '@woocommerce/components';
 import useLayout from '~/hooks/useLayout';
 import useAutoWPComAppAuthorization from './useAutoWPComAppAuthorization';
 import useUpdateRestAPIAuthorizeStatusByUrlQuery from '~/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery';
+import { CONTEXT_EXTENSION_ONBOARDING } from '~/utils/tracks';
 import SetupTopBar from './setup-top-bar';
 import SetupStepper from './setup-stepper';
 
@@ -21,7 +22,9 @@ const Onboarding = () => {
 	useLayout( 'full-page' );
 	useUpdateRestAPIAuthorizeStatusByUrlQuery();
 
-	const canContinueRendering = useAutoWPComAppAuthorization();
+	const canContinueRendering = useAutoWPComAppAuthorization(
+		CONTEXT_EXTENSION_ONBOARDING
+	);
 
 	// Render a spinner only as the requirement is to make it look like the redirections
 	// between Google authorization and WPCOM app authorization are seamless.

--- a/js/src/pages/onboarding/index.js
+++ b/js/src/pages/onboarding/index.js
@@ -20,7 +20,7 @@ import SetupStepper from './setup-stepper';
  */
 const Onboarding = () => {
 	useLayout( 'full-page' );
-	useUpdateRestAPIAuthorizeStatusByUrlQuery();
+	useUpdateRestAPIAuthorizeStatusByUrlQuery( CONTEXT_EXTENSION_ONBOARDING );
 
 	const canContinueRendering = useAutoWPComAppAuthorization(
 		CONTEXT_EXTENSION_ONBOARDING

--- a/js/src/pages/onboarding/useAutoWPComAppAuthorization.js
+++ b/js/src/pages/onboarding/useAutoWPComAppAuthorization.js
@@ -11,6 +11,15 @@ import { useAppDispatch } from '~/data';
 import useJetpackAccount from '~/hooks/useJetpackAccount';
 import useGoogleAccount from '~/hooks/useGoogleAccount';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+import { recordGlaEvent } from '~/utils/tracks';
+
+/**
+ * Start the WPCOM app authorization process to enable the product sync (API Pull).
+ *
+ * @event gla_enable_product_sync
+ * @property {string} page Indicates the page where this event happened
+ * @property {string} context Indicates the origin that triggered this event
+ */
 
 /**
  * Hook to automatically redirect the user to WPCOM app authorization once they
@@ -19,12 +28,15 @@ import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
  * Please note that this hook is a special business logic exclusive to the onboarding flow
  * and should not be used elsewhere.
  *
+ * @param {string} page The page where this hook is being used. It's used for tracking purposes.
  * @return {null|boolean} A state that indicates whether the caller can continue the subsequent process.
  *   - `null` if it's still loading the required data for determining whether to do the redirection.
  *   - `true` if it's ready to continue the subsequent process.
  *   - `false` if it's processing the redirection and the caller should block the subsequent process.
+ *
+ * @fires gla_enable_product_sync with `{ page: 'setup-mc', context: 'auto-redirection' }`
  */
-export default function useAutoWPComAppAuthorization() {
+export default function useAutoWPComAppAuthorization( page ) {
 	const { jetpack } = useJetpackAccount();
 	const { google, scope } = useGoogleAccount();
 	const { googleMCAccount, isWPComAppGranted } = useGoogleMCAccount();
@@ -58,6 +70,11 @@ export default function useAutoWPComAppAuthorization() {
 		// Make sure it only triggers the redirection one time.
 		if ( lockRef.current === null ) {
 			lockRef.current = false;
+
+			recordGlaEvent( 'gla_enable_product_sync', {
+				page,
+				context: 'auto-redirection',
+			} );
 
 			fetchWPComAppAuthorizationUrl()
 				.then( ( authUrl ) => {

--- a/js/src/pages/onboarding/useAutoWPComAppAuthorization.test.js
+++ b/js/src/pages/onboarding/useAutoWPComAppAuthorization.test.js
@@ -3,6 +3,7 @@
  */
 import { renderHook, waitFor } from '@testing-library/react';
 import { getQuery } from '@woocommerce/navigation';
+import { recordEvent } from '@woocommerce/tracks';
 
 /**
  * Internal dependencies
@@ -14,6 +15,9 @@ import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import { useAppDispatch } from '~/data';
 
 jest.mock( '@woocommerce/navigation' );
+jest.mock( '@woocommerce/tracks', () => ( {
+	recordEvent: jest.fn().mockName( 'recordEvent' ),
+} ) );
 jest.mock( '~/hooks/useJetpackAccount' );
 jest.mock( '~/hooks/useGoogleAccount' );
 jest.mock( '~/hooks/useGoogleMCAccount' );
@@ -34,6 +38,7 @@ describe( 'useAutoWPComAppAuthorization', () => {
 
 	beforeEach( () => {
 		getQuery.mockClear().mockReturnValue( { 'google-mc': 'connected' } );
+		recordEvent.mockClear();
 		useJetpackAccount.mockReturnValue( { jetpack: { active: 'yes' } } );
 		useGoogleAccount.mockReturnValue( googleAccount );
 		useGoogleMCAccount.mockReturnValue( googleMCAccount );
@@ -168,20 +173,40 @@ describe( 'useAutoWPComAppAuthorization', () => {
 			expect( spyHref ).toHaveBeenCalledWith( 'https://jest/wpcom-auth' );
 		} );
 
+		it( 'Should record an event when starting the redirection to WPCom app authorization URL', () => {
+			expect( recordEvent ).not.toHaveBeenCalled();
+
+			renderHook( () => useAutoWPComAppAuthorization( 'jest-testing' ) );
+
+			expect( recordEvent ).toHaveBeenCalledTimes( 1 );
+			expect( recordEvent ).toHaveBeenCalledWith(
+				'gla_enable_product_sync',
+				{
+					page: 'jest-testing',
+					context: 'auto-redirection',
+				}
+			);
+		} );
+
 		it( 'Should only fetch and redirect to WPCom app authorization URL one time', async () => {
+			expect( recordEvent ).not.toHaveBeenCalled();
 			expect( fetchWPComAppAuthorizationUrl ).not.toHaveBeenCalled();
 			expect( spyHref ).not.toHaveBeenCalled();
 
-			const hook = renderHook( () => useAutoWPComAppAuthorization() );
+			const hook = renderHook( ( page ) =>
+				useAutoWPComAppAuthorization( page )
+			);
 
+			expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 			expect( fetchWPComAppAuthorizationUrl ).toHaveBeenCalledTimes( 1 );
 			await waitFor( () => expect( spyHref ).toHaveBeenCalledTimes( 1 ) );
 
 			hook.rerender();
-			hook.rerender();
+			hook.rerender( 'jest-testing' );
 			hook.rerender();
 
 			expect( getQuery ).toHaveBeenCalledTimes( 4 );
+			expect( recordEvent ).toHaveBeenCalledTimes( 1 );
 			expect( fetchWPComAppAuthorizationUrl ).toHaveBeenCalledTimes( 1 );
 			await waitFor( () => expect( spyHref ).toHaveBeenCalledTimes( 1 ) );
 		} );

--- a/js/src/pages/settings/index.js
+++ b/js/src/pages/settings/index.js
@@ -12,6 +12,7 @@ import useMenuEffect from '~/hooks/useMenuEffect';
 import useGoogleAccount from '~/hooks/useGoogleAccount';
 import useUpdateRestAPIAuthorizeStatusByUrlQuery from '~/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery';
 import { subpaths, getReconnectAccountUrl } from '~/utils/urls';
+import { CONTEXT_SETTINGS } from '~/utils/tracks';
 import { ContactInformationPreview } from '~/components/contact-information';
 import SetupTaxRate from './setup-tax-rate';
 import LinkedAccounts from './linked-accounts';
@@ -30,7 +31,7 @@ const Settings = () => {
 	// Make the component highlight GLA entry in the WC legacy menu.
 	useMenuEffect();
 
-	useUpdateRestAPIAuthorizeStatusByUrlQuery();
+	useUpdateRestAPIAuthorizeStatusByUrlQuery( CONTEXT_SETTINGS );
 
 	const { google } = useGoogleAccount();
 	const isReconnectGooglePage = subpath === subpaths.reconnectGoogleAccount;

--- a/js/src/utils/tracks.js
+++ b/js/src/utils/tracks.js
@@ -38,6 +38,7 @@ filterPropertiesMap.set( FILTER_ONBOARDING, [ 'context', 'step' ] );
  */
 export const CONTEXT_EXTENSION_ONBOARDING = 'setup-mc';
 export const CONTEXT_ADS_ONBOARDING = 'setup-ads';
+export const CONTEXT_SETTINGS = 'settings';
 
 /**
  * When table pagination is changed by entering page via "Go to page" input.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -289,7 +289,7 @@ Triggered when "continue" to edit program button is clicked.
 #### Emitters
 - [`EditProgramPromptModal`](../../js/src/pages/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal.js#L31) when "Continue to edit" is clicked.
 
-### [`gla_datepicker_update`](../../js/src/utils/tracks.js#L135)
+### [`gla_datepicker_update`](../../js/src/utils/tracks.js#L136)
 Triggered when datepicker (date ranger picker) is updated,
  with report name and data that comes from `DateRangeFilterPicker`'s `onRangeSelect` callback
 #### Properties
@@ -305,14 +305,14 @@ Triggered when datepicker (date ranger picker) is updated,
 - [`ProductsReportFilters`](../../js/src/pages/reports/products/products-report-filters.js#L41)
 - [`ProgramsReportFilters`](../../js/src/pages/reports/programs/programs-report-filters.js#L43)
 
-### [`gla_disconnected_accounts`](../../js/src/pages/settings/linked-accounts.js#L31)
+### [`gla_disconnected_accounts`](../../js/src/pages/settings/linked-accounts.js#L34)
 Accounts are disconnected from the Setting page
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | (`all-accounts`\|`ads-account`) - indicate which accounts have been disconnected.
 #### Emitters
-- [`exports`](../../js/src/pages/settings/linked-accounts.js#L41)
+- [`exports`](../../js/src/pages/settings/linked-accounts.js#L44)
 
 ### [`gla_documentation_link_click`](../../js/src/components/app-documentation-link/index.js#L6)
 When a documentation link is clicked.
@@ -408,6 +408,16 @@ Triggered when store address "Edit in WooCommerce Settings" button is clicked.
 #### Emitters
 - [`StoreAddressCard`](../../js/src/components/contact-information/store-address-card.js#L49) Whenever "Edit in WooCommerce Settings" button is clicked.
 
+### [`gla_enable_product_sync`](../../js/src/pages/onboarding/useAutoWPComAppAuthorization.js#L16)
+Start the WPCOM app authorization process to enable the product sync (API Pull).
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`page` | `string` | Indicates the page where this event happened
+`context` | `string` | Indicates the origin that triggered this event
+#### Emitters
+- [`exports`](../../js/src/pages/onboarding/useAutoWPComAppAuthorization.js#L39) with `{ page: 'setup-mc', context: 'auto-redirection' }`
+
 ### [`gla_enable_product_sync_click`](../../js/src/components/enable-new-product-sync-button.js#L15)
 Clicking on the button to start enabling the new product sync (API Pull).
 #### Properties
@@ -455,7 +465,7 @@ Clicking on faq item to collapse or expand it.
 	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-google-mc-account', action: 'expand' }`.
 	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-google-mc-account', action: 'collapse' }`.
 
-### [`gla_filter`](../../js/src/utils/tracks.js#L147)
+### [`gla_filter`](../../js/src/utils/tracks.js#L148)
 Triggered when changing products & variations filter,
  with data that comes from
  `FilterPicker`'s `onFilterSelect` callback.
@@ -483,7 +493,7 @@ Saving changes of audience and/or shipping settings to the free listings.
 #### Emitters
 - [`exports`](../../js/src/pages/shipping/index.js#L45)
 
-### [`gla_google_account_connect_button_click`](../../js/src/utils/tracks.js#L175)
+### [`gla_google_account_connect_button_click`](../../js/src/utils/tracks.js#L176)
 Clicking on the button to connect Google account.
 #### Properties
 | name | type | description |
@@ -503,7 +513,7 @@ Clicking on the "connect to a different Google account" button.
 #### Emitters
 - [`SwitchAccountButton`](../../js/src/components/google-account-card/switch-account-button.js#L25)
 
-### [`gla_google_mc_link_click`](../../js/src/utils/tracks.js#L185)
+### [`gla_google_mc_link_click`](../../js/src/utils/tracks.js#L186)
 Clicking on a Google Merchant Center link.
 #### Properties
 | name | type | description |
@@ -532,7 +542,7 @@ Clicking on the "Scan for assets" button.
 #### Emitters
 - [`exports`](../../js/src/components/paid-ads/asset-group/assets-loader.js#L96)
 
-### [`gla_launch_paid_campaign_button_click`](../../js/src/utils/tracks.js#L167)
+### [`gla_launch_paid_campaign_button_click`](../../js/src/utils/tracks.js#L168)
 Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign in the Google Ads setup flow.
 #### Properties
 | name | type | description |
@@ -584,7 +594,7 @@ Clicking on the "Yes, I want a new account" button in the warning modal for crea
 #### Emitters
 - [`WarningModal`](../../js/src/components/google-mc-account-card/warning-modal/index.js#L29)
 
-### [`gla_modal_closed`](../../js/src/utils/tracks.js#L241)
+### [`gla_modal_closed`](../../js/src/utils/tracks.js#L242)
 A modal is closed.
 #### Properties
 | name | type | description |
@@ -607,7 +617,7 @@ Clicking on a text link within the modal content
 #### Emitters
 - [`ContentLink`](../../js/src/components/guide-page-content/index.js#L46) with given `context, href`
 
-### [`gla_modal_open`](../../js/src/utils/tracks.js#L254)
+### [`gla_modal_open`](../../js/src/utils/tracks.js#L255)
 A modal is open
 #### Properties
 | name | type | description |
@@ -650,7 +660,7 @@ Clicking on the button to open the invitation page for claiming the newly create
 #### Emitters
 - [`ClaimAccountButton`](../../js/src/components/google-ads-account-card/claim-account-button.js#L32) When the user clicks on the button to claim the account.
 
-### [`gla_paid_campaign_step`](../../js/src/utils/tracks.js#L201)
+### [`gla_paid_campaign_step`](../../js/src/utils/tracks.js#L202)
 Triggered when moving to another step during creating/editing a campaign.
 #### Properties
 | name | type | description |
@@ -665,6 +675,19 @@ Triggered when moving to another step during creating/editing a campaign.
 - [`EditPaidAdsCampaign`](../../js/src/pages/edit-paid-ads-campaign/index.js#L69)
 	- with `{ context: 'edit-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
 	- with `{ context: 'edit-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
+
+### [`gla_product_sync_status_callback`](../../js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.js#L16)
+Being redirected back from WPCOM app authorization for the product sync (API Pull).
+ This event is only recorded when the user is brought back to this plugin.
+ It won't be recorded if they don't return to this plugin for any reason.
+ (e.g., closing the browser tab).
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`page` | `string` | Indicates the page where this event happened
+`status` | `string` | The authorization status
+#### Emitters
+- [`useUpdateRestAPIAuthorizeStatusByUrlQuery`](../../js/src/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery.js#L39) with `{ page: 'setup-mc' | 'settings', status: 'approved' | 'disapproved' | 'error' }`
 
 ### [`gla_request_review`](../../js/src/pages/product-feed/review-request/review-request-modal.js#L19)
 Triggered when request review button is clicked
@@ -695,7 +718,7 @@ Clicking on the "Or, select another page" button.
 #### Emitters
 - [`exports`](../../js/src/components/paid-ads/asset-group/final-url-card.js#L39)
 
-### [`gla_setup_ads`](../../js/src/utils/tracks.js#L193)
+### [`gla_setup_ads`](../../js/src/utils/tracks.js#L194)
 Triggered on events during ads onboarding
 #### Properties
 | name | type | description |
@@ -718,7 +741,7 @@ Clicking on faq items to collapse or expand it in the Onboarding Flow or creatin
 #### Emitters
 - [`Faqs`](../../js/src/components/paid-ads/ads-campaign/faqs.js#L88)
 
-### [`gla_setup_mc`](../../js/src/utils/tracks.js#L158)
+### [`gla_setup_mc`](../../js/src/utils/tracks.js#L159)
 Setup Merchant Center
 #### Properties
 | name | type | description |
@@ -759,7 +782,7 @@ Clicking on the submit button on the campaign creation or editing page.
 #### Emitters
 - [`exports`](../../js/src/components/paid-ads/asset-group/asset-group.js#L62)
 
-### [`gla_table_go_to_page`](../../js/src/utils/tracks.js#L42)
+### [`gla_table_go_to_page`](../../js/src/utils/tracks.js#L43)
 When table pagination is changed by entering page via "Go to page" input.
 #### Properties
 | name | type | description |
@@ -768,7 +791,7 @@ When table pagination is changed by entering page via "Go to page" input.
 `page` | `string` | Page number (starting at 1)
 #### Emitters
 - [`ProductFeedTableCard`](../../js/src/pages/product-feed/product-feed-table-card/index.js#L65) with `context: 'product-feed'`
-- [`recordTablePageEvent`](../../js/src/utils/tracks.js#L121) with the given `{ context, page }`.
+- [`recordTablePageEvent`](../../js/src/utils/tracks.js#L122) with the given `{ context, page }`.
 
 ### [`gla_table_header_toggle`](../../js/src/components/app-table-card/index.js#L12)
 Toggling display of table columns
@@ -782,7 +805,7 @@ Toggling display of table columns
 - [`AppTableCard`](../../js/src/components/app-table-card/index.js#L74) upon toggling column visibility
 - [`recordColumnToggleEvent`](../../js/src/components/app-table-card/index.js#L29) with given `report: trackEventReportId, column: toggled`
 
-### [`gla_table_page_click`](../../js/src/utils/tracks.js#L50)
+### [`gla_table_page_click`](../../js/src/utils/tracks.js#L51)
 When table pagination is clicked
 #### Properties
 | name | type | description |
@@ -791,7 +814,7 @@ When table pagination is clicked
 `direction` | `string` | Direction of page to be changed. `("next" \| "previous")`
 #### Emitters
 - [`ProductFeedTableCard`](../../js/src/pages/product-feed/product-feed-table-card/index.js#L65) with `context: 'product-feed'`
-- [`recordTablePageEvent`](../../js/src/utils/tracks.js#L121) with the given `{ context, direction }`.
+- [`recordTablePageEvent`](../../js/src/utils/tracks.js#L122) with the given `{ context, direction }`.
 
 ### [`gla_table_sort`](../../js/src/components/app-table-card/index.js#L38)
 Sorting table


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project thread: pcTzPl-2Df-p2

This PR adds event tracking to allow us to have insights into how users process the WPCOM app authorization.

- Record `gla_enable_product_sync` event when automatically starting the WPCOM app authorization process during onboarding
- Record `gla_product_sync_status_callback` event when being redirected back from WPCOM app authorization

### Detailed test instructions:

#### Preparation

1. Make the test site publicly accessible
1. Use the Connection Test page to clear the authorization status of Google's WPCOM app if it has been granted
1. Open the Console tab in the browser DevTool
   - Run `localStorage.setItem( 'debug', 'wc-admin:*' )` to enable tracking debugging mode 
   - Configure it as below
     ![0](https://github.com/user-attachments/assets/27d7afcf-e91b-4fb2-9ba4-f3b9bd839442)

#### Onboarding

1. Go to onboarding step 1 and disconnect all accounts if there are connected ones
1. Start connecting to Google account and authorize all required permissions
2. After being automatically redirected to WPCOM app authorization, check if the following event is recorded
   ![image](https://github.com/user-attachments/assets/71a6fb45-4dbc-4e03-bcc2-dc7e50ae3132)
1. Deny WPCOM app authorization
1. After being redirected back to the onboarding flow, check if the following event is recorded
   ![image](https://github.com/user-attachments/assets/a4300eaa-a07a-44fe-8a69-20ccc0e7276f)
1. Click the "Grant access" button to start WPCOM app authorization again
1. Approve WPCOM app authorization
1. After being redirected back to the onboarding flow, check if the following event is recorded
    ![image](https://github.com/user-attachments/assets/ade2e7d7-d3a8-408b-802c-cda1eec3de87)

#### Settings

1. Go to Settings page
1. Click the "Grant access" button to start WPCOM app authorization
1. Deny WPCOM app authorization
1. After being redirected back to the onboarding flow, check if the following event is recorded
   ![image](https://github.com/user-attachments/assets/f72c1dfc-e111-4b41-9ada-d04e155634eb)
1. Click the "Grant access" button to start WPCOM app authorization again
1. Approve WPCOM app authorization
1. After being redirected back to the onboarding flow, check if the following event is recorded
   ![image](https://github.com/user-attachments/assets/a60c76ae-b031-4b78-b166-1c43a09a815b)

### Changelog entry

> Add - Event tracking of how users process the WPCOM app authorization for the API Pull feature.
