### PR TITLE
Add Budget Metrics endpoint for fetching metrics with a custom budget

### DIFF
--- a/src/API/Google/BudgetMetrics.php
+++ b/src/API/Google/BudgetMetrics.php
@@ -108,7 +108,14 @@ class BudgetMetrics implements OptionsAwareInterface, TransientsAwareInterface {
 
 				// Parse the metrics for the given budget.
 				$metrics = $this->parse_metrics( $campaign_budget_recommendation, $budget );
-				$this->transients->set( TransientsInterface::ADS_BUDGET_METRICS, [ $cache_key => $metrics ], HOUR_IN_SECONDS * 12 );
+
+				// Merge with previously cached metrics.
+				if ( ! is_array( $transient ) ) {
+					$transient = [];
+				}
+				$transient[ $cache_key ] = $metrics;
+				$this->transients->set( TransientsInterface::ADS_BUDGET_METRICS, $transient, HOUR_IN_SECONDS * 12 );
+
 				return $metrics;
 			}
 		} catch ( ApiException $e ) {

--- a/src/API/Google/BudgetMetrics.php
+++ b/src/API/Google/BudgetMetrics.php
@@ -136,7 +136,7 @@ class BudgetMetrics implements OptionsAwareInterface, TransientsAwareInterface {
 	protected function parse_metrics( CampaignBudgetRecommendation $recommendation, float $budget ): ?array {
 		foreach ( $recommendation->getBudgetOptions() as $budget_option ) {
 			$amount = $this->from_micro( $budget_option->getBudgetAmountMicros() );
-			if ( $amount === $budget ) {
+			if ( abs( $amount - $budget ) < 0.00001 ) {
 				$metrics = $budget_option->getImpact()->getPotentialMetrics();
 
 				return [

--- a/src/API/Google/BudgetMetrics.php
+++ b/src/API/Google/BudgetMetrics.php
@@ -1,0 +1,145 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\MicroTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\LocationIDTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Google\Ads\GoogleAds\V18\Enums\AdvertisingChannelTypeEnum\AdvertisingChannelType;
+use Google\Ads\GoogleAds\V18\Enums\BiddingStrategyTypeEnum\BiddingStrategyType;
+use Google\Ads\GoogleAds\V18\Enums\RecommendationTypeEnum\RecommendationType;
+use Google\Ads\GoogleAds\V18\Resources\Recommendation\CampaignBudgetRecommendation;
+use Google\Ads\GoogleAds\V18\Services\GenerateRecommendationsRequest;
+use Google\Ads\GoogleAds\V18\Services\GenerateRecommendationsRequest\AssetGroupInfo;
+use Google\Ads\GoogleAds\V18\Services\GenerateRecommendationsRequest\BiddingInfo;
+use Google\Ads\GoogleAds\V18\Services\GenerateRecommendationsRequest\BudgetInfo;
+use Google\ApiCore\ApiException;
+
+/**
+ * Class BudgetMetrics
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
+ */
+class BudgetMetrics implements OptionsAwareInterface, TransientsAwareInterface {
+
+	use MicroTrait;
+	use OptionsAwareTrait;
+	use PluginHelper;
+	use TransientsAwareTrait;
+	use LocationIDTrait;
+
+	/**
+	 * The Google Ads Client.
+	 *
+	 * @var GoogleAdsClient
+	 */
+	protected $client;
+
+	/**
+	 * BudgetMetrics constructor.
+	 *
+	 * @param GoogleAdsClient $client
+	 */
+	public function __construct( GoogleAdsClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * Fetch budget metrics from Google Ads API.
+	 *
+	 * @param float $budget        Budget to fetch metrics for.
+	 * @param array $country_codes List of countries to include.
+	 *
+	 * @return array|null List of metrics.
+	 */
+	public function get_metrics( float $budget, array $country_codes ): ?array {
+		$cache_key = strtolower( join( '-', $country_codes ) . '-' . $budget );
+		$transient = $this->transients->get( TransientsInterface::ADS_BUDGET_METRICS );
+
+		// Check if we have the budget metrics cached in the transient.
+		if ( $transient && ! empty( $transient[ $cache_key ] ) ) {
+			return $transient[ $cache_key ];
+		}
+
+		$location_ids = $this->get_location_ids( $country_codes );
+
+		$request = new GenerateRecommendationsRequest(
+			[
+				'customer_id'              => $this->options->get_ads_id(),
+				'recommendation_types'     => [ RecommendationType::CAMPAIGN_BUDGET ],
+				'advertising_channel_type' => AdvertisingChannelType::PERFORMANCE_MAX,
+				'positive_locations_ids'   => array_keys( $location_ids ),
+				'country_codes'            => $country_codes,
+				'bidding_info'             => new BiddingInfo(
+					[
+						'bidding_strategy_type' => BiddingStrategyType::MAXIMIZE_CONVERSION_VALUE,
+					]
+				),
+				'budget_info'              => new BudgetInfo(
+					[
+						'current_budget' => $this->to_micro( $budget ),
+					],
+				),
+				'asset_group_info'         => [
+					new AssetGroupInfo(
+						[
+							'final_url' => $this->get_site_url(),
+						],
+					),
+				],
+			]
+		);
+
+		try {
+			$response = $this->client->getRecommendationServiceClient()->generateRecommendations( $request );
+
+			foreach ( $response->getRecommendations() as $recommendation ) {
+				$campaign_budget_recommendation = $recommendation->getCampaignBudgetRecommendation();
+				if ( ! $campaign_budget_recommendation ) {
+					continue;
+				}
+
+				// Parse the metrics for the given budget.
+				$metrics = $this->parse_metrics( $campaign_budget_recommendation, $budget );
+				$this->transients->set( TransientsInterface::ADS_BUDGET_METRICS, [ $cache_key => $metrics ], HOUR_IN_SECONDS * 12 );
+				return $metrics;
+			}
+		} catch ( ApiException $e ) {
+			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Parse metrics for the given budget.
+	 *
+	 * @param CampaignBudgetRecommendation $recommendation Collection of recommendation options.
+	 * @param float                        $budget         Budget to fetch metrics for.
+	 *
+	 * @return array|null Metrics for the given budget.
+	 */
+	protected function parse_metrics( CampaignBudgetRecommendation $recommendation, float $budget ): ?array {
+		foreach ( $recommendation->getBudgetOptions() as $budget_option ) {
+			$amount = $this->from_micro( $budget_option->getBudgetAmountMicros() );
+			if ( $amount === $budget ) {
+				$metrics = $budget_option->getImpact()->getPotentialMetrics();
+
+				return [
+					'cost'              => $this->from_micro( $metrics->getCostMicros() ),
+					'conversions'       => $metrics->getConversions(),
+					'conversions_value' => $metrics->getConversionsValue(),
+				];
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/API/Google/BudgetRecommendations.php
+++ b/src/API/Google/BudgetRecommendations.php
@@ -3,8 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\LocationIDTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\MicroTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsCountryQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
@@ -33,6 +33,7 @@ class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInt
 	use OptionsAwareTrait;
 	use PluginHelper;
 	use TransientsAwareTrait;
+	use LocationIDTrait;
 
 	/**
 	 * The Google Ads Client.
@@ -198,44 +199,5 @@ class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInt
 		);
 
 		return reset( $numbers );
-	}
-
-	/**
-	 * Fetch location IDs from country codes.
-	 *
-	 * @param array $country_codes List of country codes to fetch.
-	 *
-	 * @return array Mapped array of location IDs to country codes.
-	 */
-	protected function get_location_ids( array $country_codes ): array {
-		$cache_key = strtolower( join( '-', $country_codes ) );
-		$transient = $this->transients->get( TransientsInterface::ADS_LOCATION_IDS );
-
-		// Check if we have the location ID's cached in the transient.
-		if ( $transient && ! empty( $transient[ $cache_key ] ) ) {
-			return $transient[ $cache_key ];
-		}
-
-		try {
-			// Query the location ID's from the Google Ads API.
-			$location_results = ( new AdsCountryQuery() )
-				->set_client( $this->client, $this->options->get_ads_id() )
-				->where( 'geo_target_constant.country_code', $country_codes, 'IN' )
-				->get_results();
-
-			$locations = [];
-			foreach ( $location_results->iterateAllElements() as $row ) {
-				$location                        = $row->getGeoTargetConstant();
-				$locations[ $location->getId() ] = $location->getCountryCode();
-			}
-
-			$this->transients->set( TransientsInterface::ADS_LOCATION_IDS, [ $cache_key => $locations ] );
-
-			return $locations;
-		} catch ( ApiException $e ) {
-			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
-		}
-
-		return [];
 	}
 }

--- a/src/API/Site/Controllers/Ads/BudgetMetricsController.php
+++ b/src/API/Site/Controllers/Ads/BudgetMetricsController.php
@@ -167,25 +167,22 @@ class BudgetMetricsController extends BaseController implements ContainerAwareIn
 				'context'     => [ 'view' ],
 			],
 			'metrics'  => [
-				'type'  => 'array',
-				'items' => [
-					'type'       => 'object',
-					'properties' => [
-						'cost'              => [
-							'type'        => 'number',
-							'description' => __( 'Estimated average amount you will spend weekly during the month.', 'google-listings-and-ads' ),
-							'context'     => [ 'view' ],
-						],
-						'conversions'       => [
-							'type'        => 'number',
-							'description' => __( 'Estimated number of conversions (unit sales) for a typical week.', 'google-listings-and-ads' ),
-							'context'     => [ 'view' ],
-						],
-						'conversions_value' => [
-							'type'        => 'number',
-							'description' => __( 'Estimated total value of all the conversions (sales volume) your campaign will generate in a week.', 'google-listings-and-ads' ),
-							'context'     => [ 'view' ],
-						],
+				'type'       => 'object',
+				'properties' => [
+					'cost'              => [
+						'type'        => 'number',
+						'description' => __( 'Estimated average amount you will spend weekly during the month.', 'google-listings-and-ads' ),
+						'context'     => [ 'view' ],
+					],
+					'conversions'       => [
+						'type'        => 'number',
+						'description' => __( 'Estimated number of conversions (unit sales) for a typical week.', 'google-listings-and-ads' ),
+						'context'     => [ 'view' ],
+					],
+					'conversions_value' => [
+						'type'        => 'number',
+						'description' => __( 'Estimated total value of all the conversions (sales volume) your campaign will generate in a week.', 'google-listings-and-ads' ),
+						'context'     => [ 'view' ],
 					],
 				],
 			],

--- a/src/API/Site/Controllers/Ads/BudgetMetricsController.php
+++ b/src/API/Site/Controllers/Ads/BudgetMetricsController.php
@@ -1,0 +1,205 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\CountryCodeTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ISO3166AwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class BudgetMetricsController
+ *
+ * ContainerAware used for:
+ * - BudgetMetrics
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads
+ */
+class BudgetMetricsController extends BaseController implements ContainerAwareInterface, ISO3166AwareInterface {
+
+	use ContainerAwareTrait;
+	use CountryCodeTrait;
+
+	/**
+	 * @var Ads
+	 */
+	protected $ads;
+
+	/**
+	 * BudgetMetricsController constructor.
+	 *
+	 * @param RESTServer $rest_server
+	 * @param Ads        $ads
+	 */
+	public function __construct( RESTServer $rest_server, Ads $ads ) {
+		parent::__construct( $rest_server );
+		$this->ads = $ads;
+	}
+
+	/**
+	 * Register rest routes with WordPress.
+	 */
+	public function register_routes(): void {
+		$this->register_route(
+			'ads/campaigns/budget-metrics',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_budget_metrics_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+					'args'                => $this->get_collection_params(),
+				],
+				'schema' => $this->get_api_response_schema_callback(),
+			]
+		);
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params(): array {
+		return [
+			'context'       => $this->get_context_param( [ 'default' => 'view' ] ),
+			'budget'        => [
+				'description'       => __( 'Budget to fetch metrics for.', 'google-listings-and-ads' ),
+				'type'              => 'number',
+				'sanitize_callback' => $this->get_sanitize_price_callback(),
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'country_codes' => [
+				'description'       => __( 'List of country codes to fetch metrics for.', 'google-listings-and-ads' ),
+				'type'              => 'array',
+				'sanitize_callback' => $this->get_country_code_sanitize_callback(),
+				'validate_callback' => $this->get_country_code_validate_callback(),
+				'items'             => [
+					'type' => 'string',
+				],
+				'required'          => true,
+				'minItems'          => 1,
+			],
+		];
+	}
+
+	/**
+	 * @return callable
+	 */
+	protected function get_budget_metrics_callback(): callable {
+		return function ( Request $request ) {
+			$country_codes = $request->get_param( 'country_codes' );
+			$budget        = $request->get_param( 'budget' );
+			$currency      = $this->ads->get_ads_currency();
+			$country       = reset( $country_codes );
+
+			if ( ! $currency ) {
+				return new Response(
+					[
+						'message'       => __( 'No currency available for the Ads account.', 'google-listings-and-ads' ),
+						'budget'        => $budget,
+						'currency'      => $currency,
+						'country_codes' => $country_codes,
+					],
+					400
+				);
+			}
+
+			// Fetch metrics from the Google Ads API.
+			$budget_metrics = $this->container->get( BudgetMetrics::class );
+			$metrics        = $budget_metrics->get_metrics( $budget, $country_codes );
+
+			if ( ! $metrics ) {
+				return new Response(
+					[
+						'message'       => __( 'Cannot find any budget metrics.', 'google-listings-and-ads' ),
+						'budget'        => $budget,
+						'currency'      => $currency,
+						'country_codes' => $country_codes,
+					],
+					404
+				);
+			}
+
+			return $this->prepare_item_for_response(
+				[
+					'currency' => $currency,
+					'budget'   => $budget,
+					'country'  => $country,
+					'metrics'  => $metrics,
+				],
+				$request
+			);
+		};
+	}
+
+	/**
+	 * Get the item schema for the controller.
+	 *
+	 * @return array
+	 */
+	protected function get_schema_properties(): array {
+		return [
+			'currency' => [
+				'type'              => 'string',
+				'description'       => __( 'The currency to use for the metrics.', 'google-listings-and-ads' ),
+				'context'           => [ 'view' ],
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'budget'   => [
+				'type'              => 'number',
+				'description'       => __( 'Budget we requested metrics for.', 'google-listings-and-ads' ),
+				'context'           => [ 'view' ],
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'country'  => [
+				'type'        => 'string',
+				'description' => __( 'Country code in ISO 3166-1 alpha-2 format.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+			],
+			'metrics'  => [
+				'type'  => 'array',
+				'items' => [
+					'type'       => 'object',
+					'properties' => [
+						'cost'              => [
+							'type'        => 'number',
+							'description' => __( 'Estimated average amount you will spend weekly during the month.', 'google-listings-and-ads' ),
+							'context'     => [ 'view' ],
+						],
+						'conversions'       => [
+							'type'        => 'number',
+							'description' => __( 'Estimated number of conversions (unit sales) for a typical week.', 'google-listings-and-ads' ),
+							'context'     => [ 'view' ],
+						],
+						'conversions_value' => [
+							'type'        => 'number',
+							'description' => __( 'Estimated total value of all the conversions (sales volume) your campaign will generate in a week.', 'google-listings-and-ads' ),
+							'context'     => [ 'view' ],
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * Used for building the API response schema.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'budget-metrics';
+	}
+}

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\CountryCodeTrait;
@@ -22,6 +23,7 @@ defined( 'ABSPATH' ) || exit;
  * Class BudgetRecommendationController
  *
  * ContainerAware used for:
+ * - BudgetMetrics
  * - BudgetRecommendations
  * - BudgetRecommendationQuery
  *
@@ -118,6 +120,13 @@ class BudgetRecommendationController extends BaseController implements Container
 				// Swap recommended if not set or if fallback is higher.
 				if ( empty( $recommendations[0] ) || ( ! empty( $recommendations[0]['daily_budget'] ) && $recommendations[0]['daily_budget'] < $fallback_budget ) ) {
 					$recommendations[0] = $fallback_recommendation[0];
+
+					// Fetch metrics from the API for the fallback budget (only when we are going to use the fallback).
+					$budget_metrics   = $this->container->get( BudgetMetrics::class );
+					$fallback_metrics = $budget_metrics->get_metrics( $fallback_budget, $country_codes );
+					if ( $fallback_metrics ) {
+						$recommendations[0]['metrics'] = $fallback_metrics;
+					}
 
 					// Remove high recommendation if fallback is higher.
 					if ( ! empty( $recommendations[1]['daily_budget'] ) && $recommendations[1]['daily_budget'] < $fallback_budget ) {

--- a/src/API/Site/Controllers/BaseController.php
+++ b/src/API/Site/Controllers/BaseController.php
@@ -198,7 +198,7 @@ abstract class BaseController extends WC_REST_Controller implements Registerable
 	 */
 	protected function get_sanitize_price_callback(): callable {
 		return function ( $price ) {
-			return preg_match( '/^[0-9]{0,10}(\.[0-9]{0,8})?$/', $price ) ? (float) $price : false;
+			return preg_match( '/^[0-9]{0,10}(\.[0-9]{0,8})?$/', (string) $price ) ? (float) $price : false;
 		};
 	}
 

--- a/src/API/Site/Controllers/BaseController.php
+++ b/src/API/Site/Controllers/BaseController.php
@@ -187,6 +187,22 @@ abstract class BaseController extends WC_REST_Controller implements Registerable
 	}
 
 	/**
+	 * Get the callback to sanitize a price value.
+	 *
+	 * Supports positive integers and floats.
+	 * Maximum number length is 10 digits + 8 decimals.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return callable
+	 */
+	protected function get_sanitize_price_callback(): callable {
+		return function ( $price ) {
+			return preg_match( '/^[0-9]{0,10}(\.[0-9]{0,8})?$/', $price ) ? (float) $price : false;
+		};
+	}
+
+	/**
 	 * Get the item schema properties for the controller.
 	 *
 	 * @return array

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsConversionAction;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsReport;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroupAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAsset;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
@@ -85,6 +86,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		AdsReport::class              => true,
 		AdsAssetGroupAsset::class     => true,
 		AdsAsset::class               => true,
+		BudgetMetrics::class          => true,
 		BudgetRecommendations::class  => true,
 		'connect_server_root'         => true,
 		Connection::class             => true,
@@ -119,6 +121,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( AdsCampaignLabel::class, GoogleAdsClient::class );
 		$this->share( AdsConversionAction::class, GoogleAdsClient::class );
 		$this->share( AdsReport::class, GoogleAdsClient::class );
+		$this->share( BudgetMetrics::class, GoogleAdsClient::class );
 		$this->share( BudgetRecommendations::class, GoogleAdsClient::class );
 
 		$this->share( Merchant::class, ShoppingContent::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroup;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AccountController as AdsAccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\BudgetMetricsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\BudgetRecommendationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\CampaignController as AdsCampaignController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\ReportsController as AdsReportsController;
@@ -110,6 +111,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( AdsCampaignController::class, AdsCampaign::class );
 		$this->share( AdsAssetGroupController::class, AdsAssetGroup::class );
 		$this->share( AdsReportsController::class );
+		$this->share( BudgetMetricsController::class, Ads::class );
 		$this->share( BudgetRecommendationController::class, Ads::class );
 		$this->share( GoogleAccountController::class, Connection::class );
 		$this->share( JetpackAccountController::class, Manager::class, Middleware::class );

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
  */
 interface TransientsInterface {
 
+	public const ADS_BUDGET_METRICS   = 'ads_budget_metrics';
 	public const ADS_CAMPAIGN_COUNT   = 'ads_campaign_count';
 	public const ADS_LOCATION_IDS     = 'ads_location_ids';
 	public const ADS_METRICS          = 'ads_metrics';
@@ -22,6 +23,7 @@ interface TransientsInterface {
 	public const WPCOM_API_STATUS     = 'wpcom_api_status';
 
 	public const VALID_OPTIONS = [
+		self::ADS_BUDGET_METRICS   => true,
 		self::ADS_CAMPAIGN_COUNT   => true,
 		self::ADS_LOCATION_IDS     => true,
 		self::ADS_METRICS          => true,

--- a/tests/Unit/API/Google/BudgetMetricsTest.php
+++ b/tests/Unit/API/Google/BudgetMetricsTest.php
@@ -156,6 +156,24 @@ class BudgetMetricsTest extends UnitTest {
 		$this->assertNull( $this->metrics->get_metrics( 12, [ 'US' ] ) );
 	}
 
+	public function test_get_metrics_with_float_inaccuracies() {
+		$metrics = [
+			[
+				'daily_budget' => 16.3999998,
+				'metrics'      => [
+					'cost'              => 114.799986,
+					'conversions'       => 6.7,
+					'conversions_value' => 267.87,
+				],
+			],
+		];
+
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
+		$this->generate_recommendations_mock( $metrics );
+
+		$this->assertEquals( $metrics[0]['metrics'], $this->metrics->get_metrics( 16.4, [ 'US' ] ) );
+	}
+
 	public function test_get_metrics() {
 		$this->generate_location_ids_mock( [ 111 => 'US' ] );
 		$this->generate_recommendations_mock(

--- a/tests/Unit/API/Google/BudgetMetricsTest.php
+++ b/tests/Unit/API/Google/BudgetMetricsTest.php
@@ -1,0 +1,172 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
+use Google\ApiCore\ApiException;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class BudgetMetricsTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ */
+class BudgetMetricsTest extends UnitTest {
+
+	use GoogleAdsClientTrait;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var MockObject|TransientsInterface $transients */
+	protected $transients;
+
+	/** @var BudgetMetrics $metrics */
+	protected $metrics;
+
+	protected const TEST_ADS_ID  = 1234567890;
+	protected const TEST_METRICS = [
+		'cost'              => 84,
+		'conversions'       => 6.1,
+		'conversions_value' => 243.88,
+	];
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->ads_client_setup();
+
+		$this->options    = $this->createMock( OptionsInterface::class );
+		$this->transients = $this->createMock( TransientsInterface::class );
+
+		$this->metrics = new BudgetMetrics( $this->client );
+		$this->metrics->set_options_object( $this->options );
+		$this->metrics->set_transients_object( $this->transients );
+
+		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
+	}
+
+	public function test_get_metrics_cached() {
+		$metrics = [
+			'us-12' => self::TEST_METRICS,
+		];
+
+		$this->transients->expects( $this->once() )
+			->method( 'get' )
+			->with( TransientsInterface::ADS_BUDGET_METRICS )
+			->willReturn( $metrics );
+
+		$this->assertEquals( $metrics['us-12'], $this->metrics->get_metrics( 12, [ 'US' ] ) );
+	}
+
+	public function test_get_metrics_cached_locations() {
+		$metrics = [ self::TEST_METRICS ];
+
+		$invoked_count = $this->exactly( 2 );
+		$this->transients->expects( $invoked_count )
+			->method( 'get' )
+			->willReturnCallback(
+				function ( string $transient ) use ( $invoked_count ) {
+					if ( 1 === $invoked_count->getInvocationCount() && $transient === TransientsInterface::ADS_BUDGET_METRICS ) {
+						return false;
+					}
+
+					if ( 2 === $invoked_count->getInvocationCount() && $transient === TransientsInterface::ADS_LOCATION_IDS ) {
+						return [
+							'us' => [
+								111 => 'US',
+							],
+						];
+					}
+				}
+			);
+
+		$this->generate_recommendations_mock(
+			[
+				[
+					'daily_budget' => 12.5,
+					'metrics'      => self::TEST_METRICS,
+				],
+			]
+		);
+
+		$this->assertEquals( self::TEST_METRICS, $this->metrics->get_metrics( 12.5, [ 'US' ] ) );
+	}
+
+	public function test_get_metrics_empty_set() {
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
+
+		$this->generate_recommendations_mock( [] );
+		$this->assertNull( $this->metrics->get_metrics( 12, [ 'US' ] ) );
+	}
+
+	public function test_get_metrics_with_other_recommendation_type() {
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
+
+		$this->generate_recommendations_mock( [ self::TEST_METRICS ], true );
+		$this->assertNull( $this->metrics->get_metrics( 12, [ 'US' ] ) );
+	}
+
+	public function test_get_metrics_exception() {
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
+
+		$this->generate_recommendations_mock_exception(
+			new ApiException( 'failed', 7 )
+		);
+
+		$this->assertNull( $this->metrics->get_metrics( 12, [ 'US' ] ) );
+		$this->assertEquals( 1, did_action( 'woocommerce_gla_ads_client_exception' ) );
+	}
+
+	public function test_get_metrics_location_id_exception() {
+		$this->generate_ads_query_mock_exception(
+			new ApiException( 'failed location IDs', 8 )
+		);
+		$this->generate_recommendations_mock( [] );
+
+		$this->assertNull( $this->metrics->get_metrics( 12, [ 'US' ] ) );
+		$this->assertEquals( 1, did_action( 'woocommerce_gla_ads_client_exception' ) );
+	}
+
+	public function test_get_metrics_with_different_budget() {
+		$metrics = [
+			[
+				'daily_budget' => 5,
+				'metrics'      => [
+					'cost'              => 35,
+					'conversions'       => 10,
+					'conversions_value' => 48.12,
+				],
+			],
+		];
+
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
+		$this->generate_recommendations_mock( $metrics );
+
+		$this->assertNull( $this->metrics->get_metrics( 12, [ 'US' ] ) );
+	}
+
+	public function test_get_metrics() {
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
+		$this->generate_recommendations_mock(
+			[
+				[
+					'daily_budget' => 12,
+					'metrics'      => self::TEST_METRICS,
+				],
+			]
+		);
+
+		$this->assertEquals( self::TEST_METRICS, $this->metrics->get_metrics( 12, [ 'US' ] ) );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetMetricsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetMetricsControllerTest.php
@@ -1,0 +1,142 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\BudgetMetricsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class BudgetMetricsControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ */
+class BudgetMetricsControllerTest extends RESTControllerUnitTest {
+
+	/** @var Container $container */
+	protected $container;
+
+	/** @var MockObject|Ads $ads */
+	protected $ads;
+
+	/** @var MockObject|BudgetMetrics $budget_metrics */
+	protected $budget_metrics;
+
+	/** @var MockObject|ISO3166DataProvider $iso_provider */
+	protected $iso_provider;
+
+	/** @var BudgetMetricsController $controller */
+	protected $controller;
+
+	protected const ROUTE_BUDGET_METRICS = '/wc/gla/ads/campaigns/budget-metrics';
+	protected const METRICS_DATA         = [
+		'cost'              => 84,
+		'conversions'       => 6.1,
+		'conversions_value' => 243.88,
+	];
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->iso_provider   = $this->createMock( ISO3166DataProvider::class );
+		$this->ads            = $this->createMock( Ads::class );
+		$this->budget_metrics = $this->createMock( BudgetMetrics::class );
+
+		$this->container = new Container();
+		$this->container->addShared( BudgetMetrics::class, $this->budget_metrics );
+
+		$this->controller = new BudgetMetricsController( $this->server, $this->ads );
+		$this->controller->register();
+		$this->controller->set_container( $this->container );
+		$this->controller->set_iso3166_provider( $this->iso_provider );
+	}
+
+	public function test_get_budget_metrics() {
+		$budget_metrics_params = [
+			'country_codes' => [ 'US' ],
+			'budget'        => 12.25,
+		];
+
+		$expected_response_data = [
+			'currency' => 'USD',
+			'budget'   => 12.25,
+			'country'  => 'US',
+			'metrics'  => self::METRICS_DATA,
+		];
+
+		$this->ads->expects( $this->once() )
+			->method( 'get_ads_currency' )
+			->willReturn( 'USD' );
+
+		$this->budget_metrics->expects( $this->once() )
+			->method( 'get_metrics' )
+			->with( 12.25, [ 'US' ] )
+			->willReturn( self::METRICS_DATA );
+
+		$response = $this->do_request( self::ROUTE_BUDGET_METRICS, 'GET', $budget_metrics_params );
+
+		$this->assertSame( $expected_response_data, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_budget_metrics_no_currency() {
+		$budget_metrics_params = [
+			'country_codes' => [ 'US' ],
+			'budget'        => 12.4,
+		];
+
+		$response = $this->do_request( self::ROUTE_BUDGET_METRICS, 'GET', $budget_metrics_params );
+
+		$this->assertEquals(
+			[
+				'message'       => 'No currency available for the Ads account.',
+				'budget'        => 12.4,
+				'currency'      => '',
+				'country_codes' => [ 'US' ],
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_get_budget_metrics_no_metrics() {
+		$budget_metrics_params = [
+			'country_codes' => [ 'US' ],
+			'budget'        => 12.5,
+		];
+
+		$expected_response_data = [
+			'message'       => 'Cannot find any budget metrics.',
+			'budget'        => 12.5,
+			'currency'      => 'USD',
+			'country_codes' => [ 'US' ],
+		];
+
+		$this->ads->expects( $this->once() )
+			->method( 'get_ads_currency' )
+			->willReturn( 'USD' );
+
+		$this->budget_metrics->expects( $this->once() )
+			->method( 'get_metrics' )
+			->with( 12.5, [ 'US' ] )
+			->willReturn( null );
+
+		$response = $this->do_request( self::ROUTE_BUDGET_METRICS, 'GET', $budget_metrics_params );
+
+		$this->assertSame( $expected_response_data, $response->get_data() );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	public function test_get_budget_metrics_without_query_parameters() {
+		$response = $this->do_request( self::ROUTE_BUDGET_METRICS, 'GET', [] );
+
+		$this->assertEquals( 'rest_missing_callback_param', $response->get_data()['code'] );
+		$this->assertEquals( 'Missing parameter(s): country_codes', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\BudgetRecommendationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
@@ -30,6 +31,9 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 
 	/** @var MockObject|BudgetRecommendations $budget_recommendations */
 	protected $budget_recommendations;
+
+	/** @var MockObject|BudgetMetrics $budget_metrics */
+	protected $budget_metrics;
 
 	/** @var MockObject|ISO3166DataProvider $iso_provider */
 	protected $iso_provider;
@@ -81,10 +85,12 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		$this->iso_provider           = $this->createMock( ISO3166DataProvider::class );
 		$this->ads                    = $this->createMock( Ads::class );
 		$this->budget_recommendations = $this->createMock( BudgetRecommendations::class );
+		$this->budget_metrics         = $this->createMock( BudgetMetrics::class );
 
 		$this->container = new Container();
 		$this->container->addShared( BudgetRecommendationQuery::class, $this->budget_recommendation_query );
 		$this->container->addShared( BudgetRecommendations::class, $this->budget_recommendations );
+		$this->container->addShared( BudgetMetrics::class, $this->budget_metrics );
 
 		$this->controller = new BudgetRecommendationController( $this->server, $this->ads );
 		$this->controller->register();
@@ -212,6 +218,70 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 			],
 		];
 
+		$fallback_metrics = [
+			'cost'              => 92.4,
+			'conversions'       => 6.3,
+			'conversions_value' => 250.56,
+		];
+
+		$expected_response_data = [
+			'currency'        => 'GBP',
+			'recommendations' => [
+				[
+					'daily_budget' => 13.2,
+					'country'      => 'GB',
+					'level'        => 'Recommended',
+					'metrics'      => $fallback_metrics,
+				],
+				[
+					'daily_budget' => 14.4,
+					'metrics'      => [
+						'cost'              => 100.8,
+						'conversions'       => 6.5,
+						'conversions_value' => 258.72,
+					],
+					'country'      => 'GB',
+					'level'        => 'High',
+				],
+			],
+		];
+
+		$this->ads->expects( $this->once() )
+			->method( 'get_ads_currency' )
+			->willReturn( 'GBP' );
+
+		$this->budget_recommendations->expects( $this->once() )
+			->method( 'get_recommendations' )
+			->willReturn( self::RECOMMENDATION_DATA );
+
+		$this->budget_recommendation_query->expects( $this->once() )
+			->method( 'get_results' )
+			->willReturn( $fallback_data );
+
+		$this->budget_metrics->expects( $this->once() )
+			->method( 'get_metrics' )
+			->with( 13.2, [ 'GB', 'US' ] )
+			->willReturn( $fallback_metrics );
+
+		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
+
+		$this->assertSame( $expected_response_data, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_budget_recommendation_with_fallback_lower_than_highest_recommendation_no_metrics() {
+		$budget_recommendation_params = [
+			'country_codes' => [ 'GB', 'US' ],
+		];
+
+		$fallback_data = [
+			[
+				'daily_budget' => '13.2',
+				'country'      => 'GB',
+				'level'        => 'Recommended',
+			],
+		];
+
 		$expected_response_data = [
 			'currency'        => 'GBP',
 			'recommendations' => [
@@ -244,6 +314,11 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		$this->budget_recommendation_query->expects( $this->once() )
 			->method( 'get_results' )
 			->willReturn( $fallback_data );
+
+		$this->budget_metrics->expects( $this->once() )
+			->method( 'get_metrics' )
+			->with( 13.2, [ 'GB', 'US' ] )
+			->willReturn( null );
 
 		$response = $this->do_request( self::ROUTE_BUDGET_RECOMMENDATION, 'GET', $budget_recommendation_params );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a follow up to #2795 

This allows for fetching a Campaign Budget Recommendation to extract the metrics when specifying a specific budget.

Since it was quite similar to the changed for fetching Budget Recommendations from the API, CoPilot was able to generate the unit tests (with a minor set of corrections needed).

### Detailed test instructions:
1. Reinstall composer dependencies `rm -rf vendor && composer install`
2. Test API request `https://domain.test/wp-json/wc/gla/ads/campaigns/budget-metrics?country_codes[]=IE&budget=16.77`
3. Ensure a single set of metrics is returned (cost is for a whole week so it should be 7 x budget):
```json
{
    "currency": "EUR",
    "budget": 16.77,
    "country": "IE",
    "metrics": {
        "cost": 117.39,
        "conversions": 6.8,
        "conversions_value": 270.65197389217025
    }
}
```
4. Repeat the call and it should respond much faster as it will be pulling from the cache
5. Adjust the fallback rate in the table `wp_gla_budget_recommendations` so it is higher than the recommended amount but still lower than the high recommendation (ex: 13)
6. Send API request to fetch recommendations `https://domain.test/wp-json/wc/gla/ads/campaigns/budget-recommendation?country_codes[]=IE`
7. Ensure the fallback rate has metrics returned (to confirm it got the right metrics, the cost should be 7 x fallback budget):
```json
{
    "currency": "EUR",
    "recommendations": [
        {
            "daily_budget": 13,
            "country": "IE",
            "level": "Recommended",
            "metrics": {
                "cost": 91,
                "conversions": 6.2,
                "conversions_value": 248.78137720487214
            }
        },
        {
            "daily_budget": 14.4,
            "metrics": {
                "cost": 100.8,
                "conversions": 6.4,
                "conversions_value": 257.03656077956504
            },
            "country": "IE",
            "level": "High"
        }
    ]
}
```


### Additional details:
Project Thread: pcTzPl-2Hb-p2

### Changelog entry
* Add - Budget Metrics endpoint for fetching metrics with a custom budget.

