### PR TITLE
Add the G4W settings to WC REST API

### DIFF
--- a/src/DB/Query/ShippingRateQuery.php
+++ b/src/DB/Query/ShippingRateQuery.php
@@ -67,4 +67,27 @@ class ShippingRateQuery extends Query {
 			$this->results
 		);
 	}
+
+	/**
+	 * Get all shipping rates.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @return array
+	 */
+	public function get_all_shipping_rates() {
+		$rates = $this->get_results();
+		$items = [];
+		foreach ( $rates as $rate ) {
+			$data = [
+				'country_code'            => $rate['country'],
+				'currency'                => $rate['rate'],
+				'free_shipping_threshold' => $rate['options']['free_shipping_threshold'] ?: $rate['options']['free_shipping_threshold'],
+			];
+
+			$items[ $rate['country'] ] = $data;
+		}
+
+		return $items;
+	}
 }

--- a/src/DB/Query/ShippingRateQuery.php
+++ b/src/DB/Query/ShippingRateQuery.php
@@ -81,7 +81,8 @@ class ShippingRateQuery extends Query {
 		foreach ( $rates as $rate ) {
 			$data = [
 				'country_code'            => $rate['country'],
-				'currency'                => $rate['rate'],
+				'currency'                => $rate['currency'],
+				'rate'                    => $rate['rate'],
 				'free_shipping_threshold' => $rate['options']['free_shipping_threshold'] ?: $rate['options']['free_shipping_threshold'],
 			];
 

--- a/src/DB/Query/ShippingRateQuery.php
+++ b/src/DB/Query/ShippingRateQuery.php
@@ -90,7 +90,7 @@ class ShippingRateQuery extends Query {
 			$data = [
 				'country_code'            => $rate['country'],
 				'currency'                => $rate['currency'],
-				'free_shipping_threshold' => $rate['options']['free_shipping_threshold'] ? $rate['options']['free_shipping_threshold'] : null,
+				'free_shipping_threshold' => isset( $rate['options']['free_shipping_threshold'] ) ? (float) $rate['options']['free_shipping_threshold'] : null,
 				'rate'                    => $rate['rate'],
 			];
 

--- a/src/DB/Query/ShippingRateQuery.php
+++ b/src/DB/Query/ShippingRateQuery.php
@@ -69,11 +69,19 @@ class ShippingRateQuery extends Query {
 	}
 
 	/**
-	 * Get all shipping rates.
+	 * Retrieves all available shipping rates and organizes them by country.
 	 *
-	 * @since 2.8.0
+	 * Fetches all shipping rate data using `get_results()`, processes it,
+	 * and returns an associative array in a format suitable for JSON responses.
 	 *
-	 * @return array
+	 * @since x.x.x
+	 *
+	 * @return array Associative array of shipping rates indexed by country codes.
+	 *               Each entry contains:
+	 *               - `country_code` (string): The country code.
+	 *               - `currency` (string): The currency code.
+	 *               - `free_shipping_threshold` (float | null): The minimum order amount required for free shipping.
+	 *               - `rate` (string): The cost of shipping in the respective currency.
 	 */
 	public function get_all_shipping_rates() {
 		$rates = $this->get_results();
@@ -82,8 +90,8 @@ class ShippingRateQuery extends Query {
 			$data = [
 				'country_code'            => $rate['country'],
 				'currency'                => $rate['currency'],
+				'free_shipping_threshold' => $rate['options']['free_shipping_threshold'] ? $rate['options']['free_shipping_threshold'] : null,
 				'rate'                    => $rate['rate'],
-				'free_shipping_threshold' => $rate['options']['free_shipping_threshold'] ?: $rate['options']['free_shipping_threshold'],
 			];
 
 			$items[ $rate['country'] ] = $data;

--- a/src/DB/Query/ShippingTimeQuery.php
+++ b/src/DB/Query/ShippingTimeQuery.php
@@ -45,11 +45,18 @@ class ShippingTimeQuery extends Query {
 	}
 
 	/**
-	 * Get all shipping times.
+	 * Retrieves all available shipping times and organizes them by country.
+	 *
+	 * Fetches all shipping time data using `get_results()`, processes it,
+	 * and returns an associative array in a format suitable for JSON responses.
 	 *
 	 * @since 2.8.0
 	 *
-	 * @return array
+	 * @return array Associative array of shipping times indexed by country codes.
+	 *               Each entry contains:
+	 *               - `country_code` (string): The country code.
+	 *               - `time` (string): The minimum shipping time.
+	 *               - `max_time` (string): The maximum shipping time.
 	 */
 	public function get_all_shipping_times() {
 		$times = $this->get_results();

--- a/src/Integration/WPCOMProxy.md
+++ b/src/Integration/WPCOMProxy.md
@@ -1,0 +1,70 @@
+# WPCOMProxy
+
+## `/settings/google-for-woocommerce` endpoint schema.
+
+Following is the desired and expected structure of `/settings/google-for-woocommerce?gla_syncable=1` response.
+
+```js
+[
+    {
+        "id": "gla_google_connected",
+        "label": "Google for WooCommerce: Is Google account connected?",
+        "value": ( true | false )
+    },
+    {
+        "id": "gla_jetpack_connected",
+        "label": "Google for WooCommerce: Is Jetpack connected?",
+        "value": ( true | false )
+    },
+    {
+        "id": "gla_language",
+        "label": "Google for WooCommerce: Store language",
+        "value": LANGUAGE_CODE,
+    },
+    {
+        "id": "gla_merchant_center",
+        "label": "Google for WooCommerce: Merchant Center settings",
+        "value": ( {
+            "shipping_rate": ( "flat" | "manual" | "automatic" ),
+            "shipping_time": ( "flat" | "manual" ),
+            "tax_rate": ( "destination" | "manual" )
+        } | null ) // `null` if the user did not set up it yet, or disconnected accounts.
+    },
+    {
+        "id": "gla_shipping_rates",
+        "label": "Google for WooCommerce: Shipping Rates",
+        "value": {
+            [ COUNTRY_CODE_1 ]: {
+                "country_code": COUNTRY_CODE_1,
+                "currency": AMOUNT_1,
+                "free_shipping_threshold": ( FREE_SHIPPING_THRESHOLD_1 | null ),
+            },
+			// …
+        }
+    },
+    {
+        "id": "gla_shipping_times",
+        "label": "Google for WooCommerce: Shipping Times",
+        "value": {
+            [ COUNTRY_CODE_1 ]: {
+                "country_code": COUNTRY_CODE_1,
+                "time": TIME,
+                "max_time": MAX_TIME
+            },
+			// …
+        }
+    },
+    {
+        "id": "gla_target_audience",
+        "label": "Google for WooCommerce: Target Audience",
+        "value": ( {
+            "location": ( "selected" | "all" ),
+            "countries": [
+                COUNTRY_CODE_1,
+                COUNTRY_CODE_2,
+				// …
+            ]
+        } | null ) // `null` if the user did not set up it yet, or disconnected accounts.
+    }
+]
+```

--- a/src/Integration/WPCOMProxy.md
+++ b/src/Integration/WPCOMProxy.md
@@ -36,8 +36,9 @@ Following is the desired and expected structure of `/settings/google-for-woocomm
         "value": {
             [ COUNTRY_CODE_1 ]: {
                 "country_code": COUNTRY_CODE_1,
-                "currency": AMOUNT_1,
+                "currency": CURRENCY_CODE_1,
                 "free_shipping_threshold": ( FREE_SHIPPING_THRESHOLD_1 | null ),
+                "rate": AMOUNT_1,
             },
             // …
         }

--- a/src/Integration/WPCOMProxy.md
+++ b/src/Integration/WPCOMProxy.md
@@ -12,11 +12,6 @@ Following is the desired and expected structure of `/settings/google-for-woocomm
         "value": ( true | false )
     },
     {
-        "id": "gla_jetpack_connected",
-        "label": "Google for WooCommerce: Is Jetpack connected?",
-        "value": ( true | false )
-    },
-    {
         "id": "gla_language",
         "label": "Google for WooCommerce: Store language",
         "value": LANGUAGE_CODE,

--- a/src/Integration/WPCOMProxy.md
+++ b/src/Integration/WPCOMProxy.md
@@ -28,7 +28,7 @@ Following is the desired and expected structure of `/settings/google-for-woocomm
             "shipping_rate": ( "flat" | "manual" | "automatic" ),
             "shipping_time": ( "flat" | "manual" ),
             "tax_rate": ( "destination" | "manual" )
-        } | null ) // `null` if the user did not set up it yet, or disconnected accounts.
+        } | null ) // `null` if the user has not set it up yet, or disconnected accounts.
     },
     {
         "id": "gla_shipping_rates",
@@ -39,7 +39,7 @@ Following is the desired and expected structure of `/settings/google-for-woocomm
                 "currency": AMOUNT_1,
                 "free_shipping_threshold": ( FREE_SHIPPING_THRESHOLD_1 | null ),
             },
-			// …
+            // …
         }
     },
     {
@@ -51,7 +51,7 @@ Following is the desired and expected structure of `/settings/google-for-woocomm
                 "time": TIME,
                 "max_time": MAX_TIME
             },
-			// …
+            // …
         }
     },
     {
@@ -62,9 +62,9 @@ Following is the desired and expected structure of `/settings/google-for-woocomm
             "countries": [
                 COUNTRY_CODE_1,
                 COUNTRY_CODE_2,
-				// …
+                // …
             ]
-        } | null ) // `null` if the user did not set up it yet, or disconnected accounts.
+        } | null ) // `null` if the user has not set it up yet, or disconnected accounts.
     }
 ]
 ```

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -268,7 +268,7 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 				$data[] = [
 					'id'         => 'gla_settings_placeholder',
 					'option_key' => 'gla_settings_placeholder',
-					'type'       => '_invalid_type_'
+					'type'       => '_invalid_type_',
 				];
 
 				/*
@@ -278,7 +278,6 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 				return $data;
 			}
 		);
-
 	}
 
 	/**

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Integration;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
@@ -29,6 +30,13 @@ defined( 'ABSPATH' ) || exit;
 class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 
 	use OptionsAwareTrait;
+
+	/**
+	 * The ShippingRateQuery object.
+	 *
+	 * @var ShippingRateQuery
+	 */
+	protected $shipping_rate_query;
 
 	/**
 	 * The ShippingTimeQuery object.
@@ -60,10 +68,12 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	/**
 	 * WPCOMProxy constructor.
 	 *
+	 * @param ShippingRateQuery $shipping_rate_query   The ShippingRateQuery object.
 	 * @param ShippingTimeQuery $shipping_time_query The ShippingTimeQuery object.
 	 * @param AttributeManager  $attribute_manager   The AttributeManager object.
 	 */
-	public function __construct( ShippingTimeQuery $shipping_time_query, AttributeManager $attribute_manager ) {
+	public function __construct( ShippingRateQuery $shipping_rate_query, ShippingTimeQuery $shipping_time_query, AttributeManager $attribute_manager ) {
+		$this->shipping_rate_query = $shipping_rate_query;
 		$this->shipping_time_query = $shipping_time_query;
 		$this->attribute_manager   = $attribute_manager;
 	}
@@ -197,17 +207,17 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 			return $locations;
 		} );
 
+		// Hack to make the settings group show up in the response.
 		add_filter( 'woocommerce_settings-' . self::SETTINGS_GROUP, function ( $data ) {
-			$data[] = [
-				'id'         => 'gla_target_audience',
-				'label'      => 'Google for WooCommerce: Target Audience',
-				'option_key' => OptionsInterface::TARGET_AUDIENCE,
-				'type'       => 'multiselect',
-				'default'	 => [],
-			];
+			// We need to add non-empty return value in the filter, to be able to pass the valid group check.
+			$data[] = ['id' => 'gla_settings_placeholder'];
+			// We do not provide a valid 'type', so the entry will be ignored in the response.
+
+			// This way `rest_request_after_callbacks` will get an empty data set.
 			return $data;
 		} );
-		// Add non-option settings to the WooCommerce REST API.
+
+		// Add non-option-conforming settings to the WooCommerce REST API.
 		add_filter(
 			'rest_request_after_callbacks',
 			/**
@@ -225,15 +235,39 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 				$data = $response->get_data();
 
 				$data[] = [
-					'id'    => 'gla_shipping_times',
-					'label' => 'Google for WooCommerce: Shipping Times',
-					'value' => $this->shipping_time_query->get_all_shipping_times(),
+					'id'    => 'gla_google_connected',
+					'label' => 'Google for WooCommerce: Is Google account connected?',
+					'value' => rest_sanitize_boolean( $this->options->get( OptionsInterface::GOOGLE_CONNECTED, false ) ),
 				];
-
+				$data[] = [
+					'id'    => 'gla_jetpack_connected',
+					'label' => 'Google for WooCommerce: Is Jetpack connected?',
+					'value' => rest_sanitize_boolean( $this->options->get( OptionsInterface::JETPACK_CONNECTED, false ) ),
+				];
 				$data[] = [
 					'id'    => 'gla_language',
 					'label' => 'Google for WooCommerce: Store language',
 					'value' => get_locale(),
+				];
+				$data[] = [
+					'id'    => 'gla_merchant_center',
+					'label' => 'Google for WooCommerce: Merchant Center settings',
+					'value' => $this->options->get( OptionsInterface::MERCHANT_CENTER, null ),
+				];
+				$data[] = [
+					'id'    => 'gla_shipping_rates',
+					'label' => 'Google for WooCommerce: Shipping Rates',
+					'value' => $this->shipping_rate_query->get_all_shipping_rates(),
+				];
+				$data[] = [
+					'id'    => 'gla_shipping_times',
+					'label' => 'Google for WooCommerce: Shipping Times',
+					'value' => $this->shipping_time_query->get_all_shipping_times(),
+				];
+				$data[] = [
+					'id'    => 'gla_target_audience',
+					'label' => 'Google for WooCommerce: Target Audience',
+					'value' => $this->options->get( OptionsInterface::TARGET_AUDIENCE, null ),
 				];
 
 				$response->set_data( array_values( $data ) );

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -174,7 +174,7 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 		add_filter(
 			'rest_request_after_callbacks',
 			/**
-			 * Prepare data for shipping methods.
+			 * Set data for settings & prepare data for shipping methods.
 			 *
 			 * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response The response object.
 			 * @param mixed                                             $handler  The handler.
@@ -184,6 +184,50 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 				if ( ! $this->is_gla_request( $request ) || ! $response instanceof WP_REST_Response ) {
 					return $response;
 				}
+
+				if ( $request->get_route() === '/wc/v3/settings/' . self::SETTINGS_GROUP ) {
+
+					$data = $response->get_data();
+
+					$data[] = [
+						'id'    => 'gla_google_connected',
+						'label' => 'Google for WooCommerce: Is Google account connected?',
+						'value' => rest_sanitize_boolean( $this->options->get( OptionsInterface::GOOGLE_CONNECTED, false ) ),
+					];
+					$data[] = [
+						'id'    => 'gla_jetpack_connected',
+						'label' => 'Google for WooCommerce: Is Jetpack connected?',
+						'value' => rest_sanitize_boolean( $this->options->get( OptionsInterface::JETPACK_CONNECTED, false ) ),
+					];
+					$data[] = [
+						'id'    => 'gla_language',
+						'label' => 'Google for WooCommerce: Store language',
+						'value' => get_locale(),
+					];
+					$data[] = [
+						'id'    => 'gla_merchant_center',
+						'label' => 'Google for WooCommerce: Merchant Center settings',
+						'value' => $this->options->get( OptionsInterface::MERCHANT_CENTER, null ),
+					];
+					$data[] = [
+						'id'    => 'gla_shipping_rates',
+						'label' => 'Google for WooCommerce: Shipping Rates',
+						'value' => $this->shipping_rate_query->get_all_shipping_rates(),
+					];
+					$data[] = [
+						'id'    => 'gla_shipping_times',
+						'label' => 'Google for WooCommerce: Shipping Times',
+						'value' => $this->shipping_time_query->get_all_shipping_times(),
+					];
+					$data[] = [
+						'id'    => 'gla_target_audience',
+						'label' => 'Google for WooCommerce: Target Audience',
+						'value' => $this->options->get( OptionsInterface::TARGET_AUDIENCE, null ),
+					];
+
+					$response->set_data( array_values( $data ) );
+				}
+
 				$response->set_data( $this->prepare_data( $response->get_data(), $request ) );
 				return $response;
 			},
@@ -211,72 +255,12 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 		add_filter( 'woocommerce_settings-' . self::SETTINGS_GROUP, function ( $data ) {
 			// We need to add non-empty return value in the filter, to be able to pass the valid group check.
 			$data[] = ['id' => 'gla_settings_placeholder'];
-			// We do not provide a valid 'type', so the entry will be ignored in the response.
+			// We do not provide any valid 'type', so the entry will be ignored in the response.
 
-			// This way `rest_request_after_callbacks` will get an empty data set.
+			// This way `rest_request_after_callbacks` will get an empty data set and could provide complete option- and non-option related settings.
 			return $data;
 		} );
 
-		// Add non-option-conforming settings to the WooCommerce REST API.
-		add_filter(
-			'rest_request_after_callbacks',
-			/**
-			 * Add the Google for WooCommerce and Ads settings to the settings/google-for-woocommerce response.
-			 *
-			 * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response The response object.
-			 * @param mixed                                             $handler  The handler.
-			 * @param WP_REST_Request                                   $request  The request object.
-			 */
-			function ( $response, $handler, $request ) {
-				if ( ! $response instanceof WP_REST_Response || $request->get_route() !== '/wc/v3/settings/' . self::SETTINGS_GROUP ) {
-					return $response;
-				}
-
-				$data = $response->get_data();
-
-				$data[] = [
-					'id'    => 'gla_google_connected',
-					'label' => 'Google for WooCommerce: Is Google account connected?',
-					'value' => rest_sanitize_boolean( $this->options->get( OptionsInterface::GOOGLE_CONNECTED, false ) ),
-				];
-				$data[] = [
-					'id'    => 'gla_jetpack_connected',
-					'label' => 'Google for WooCommerce: Is Jetpack connected?',
-					'value' => rest_sanitize_boolean( $this->options->get( OptionsInterface::JETPACK_CONNECTED, false ) ),
-				];
-				$data[] = [
-					'id'    => 'gla_language',
-					'label' => 'Google for WooCommerce: Store language',
-					'value' => get_locale(),
-				];
-				$data[] = [
-					'id'    => 'gla_merchant_center',
-					'label' => 'Google for WooCommerce: Merchant Center settings',
-					'value' => $this->options->get( OptionsInterface::MERCHANT_CENTER, null ),
-				];
-				$data[] = [
-					'id'    => 'gla_shipping_rates',
-					'label' => 'Google for WooCommerce: Shipping Rates',
-					'value' => $this->shipping_rate_query->get_all_shipping_rates(),
-				];
-				$data[] = [
-					'id'    => 'gla_shipping_times',
-					'label' => 'Google for WooCommerce: Shipping Times',
-					'value' => $this->shipping_time_query->get_all_shipping_times(),
-				];
-				$data[] = [
-					'id'    => 'gla_target_audience',
-					'label' => 'Google for WooCommerce: Target Audience',
-					'value' => $this->options->get( OptionsInterface::TARGET_AUDIENCE, null ),
-				];
-
-				$response->set_data( array_values( $data ) );
-
-				return $response;
-			},
-			10,
-			3
-		);
 	}
 
 	/**

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -260,11 +260,19 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 		add_filter(
 			'woocommerce_settings-' . self::SETTINGS_GROUP,
 			function ( $data ) {
-				// We need to add non-empty return value in the filter, to be able to pass the valid group check.
-				$data[] = [ 'id' => 'gla_settings_placeholder' ];
-				// We do not provide any valid 'type', so the entry will be ignored in the response.
+				/*
+				 * We need to add non-empty return value in the filter, to be able to pass the valid group check.
+				 * We do not provide any valid 'type', so the entry will be ignored
+				 * in the response by `WC_REST_Setting_Options_V2_Controller::get_items`
+				 */
+				$data[] = [
+					'option_key' => 'gla_settings_placeholder',
+				];
 
-				// This way `rest_request_after_callbacks` will get an empty data set and could provide complete option- and non-option related settings.
+				/*
+				 * This way `rest_request_after_callbacks` will get an empty data set
+				 * and could provide complete option- and non-option related settings.
+				 */
 				return $data;
 			}
 		);

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -53,6 +53,11 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	];
 
 	/**
+	 * The settings group for the REST API.
+	 * @var string
+	 */
+	protected const SETTINGS_GROUP = 'google-for-woocommerce';
+	/**
 	 * WPCOMProxy constructor.
 	 *
 	 * @param ShippingTimeQuery $shipping_time_query The ShippingTimeQuery object.
@@ -153,16 +158,13 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	}
 
 	/**
-	 * Register the `rest_request_after_callbacks` to add settings to `settings/general`.
-	 * Used for backward compatibility.
-	 *
-	 * @deprecated We created a dedicated settings group for google-for-woocommerce.
+	 * Register the `rest_request_after_callbacks`, to prepare shipping methods.
 	 */
 	protected function register_callbacks() {
 		add_filter(
 			'rest_request_after_callbacks',
 			/**
-			 * Add the Google for WooCommerce and Ads settings to the settings/general response.
+			 * Prepare data for shipping methods.
 			 *
 			 * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response The response object.
 			 * @param mixed                                             $handler  The handler.
@@ -172,31 +174,6 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 				if ( ! $this->is_gla_request( $request ) || ! $response instanceof WP_REST_Response ) {
 					return $response;
 				}
-
-				$data = $response->get_data();
-
-				if ( $request->get_route() === '/wc/v3/settings/general' ) {
-					$data[] = [
-						'id'    => 'gla_target_audience',
-						'label' => 'Google for WooCommerce: Target Audience',
-						'value' => $this->options->get( OptionsInterface::TARGET_AUDIENCE, [] ),
-					];
-
-					$data[] = [
-						'id'    => 'gla_shipping_times',
-						'label' => 'Google for WooCommerce: Shipping Times',
-						'value' => $this->shipping_time_query->get_all_shipping_times(),
-					];
-
-					$data[] = [
-						'id'    => 'gla_language',
-						'label' => 'Google for WooCommerce: Store language',
-						'value' => get_locale(),
-					];
-
-					$response->set_data( array_values( $data ) );
-				}
-
 				$response->set_data( $this->prepare_data( $response->get_data(), $request ) );
 				return $response;
 			},
@@ -213,14 +190,14 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	protected function add_g4w_settings() {
 		add_filter( 'woocommerce_settings_groups', function ( $locations ) {
 			$locations[] = array(
-				'id'          => 'google-for-woocommerce',
+				'id'          => self::SETTINGS_GROUP,
 				'label'       => 'Google for WooCommerce',
 				'description' => 'Settings of the Google for WooCommerce plugin.',
 			);
 			return $locations;
 		} );
 
-		add_filter( 'woocommerce_settings-google-for-woocommerce', function ( $data ) {
+		add_filter( 'woocommerce_settings-' . self::SETTINGS_GROUP, function ( $data ) {
 			$data[] = [
 				'id'         => 'gla_target_audience',
 				'label'      => 'Google for WooCommerce: Target Audience',
@@ -228,23 +205,44 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 				'type'       => 'multiselect',
 				'default'	 => [],
 			];
-
-			// Workaround option-less settings by adding a default value.
-			$data[] = [
-				'id'      => 'gla_shipping_times',
-				'label'   => 'Google for WooCommerce: Shipping Times',
-				'type'    => 'multiselect',
-				'default' => $this->shipping_time_query->get_all_shipping_times(),
-			];
-
-			$data[] = [
-				'id'      => 'gla_language',
-				'label'   => 'Google for WooCommerce: Store language',
-				'type'    => 'text',
-				'default' => get_locale(),
-			];
 			return $data;
 		} );
+		// Add non-option settings to the WooCommerce REST API.
+		add_filter(
+			'rest_request_after_callbacks',
+			/**
+			 * Add the Google for WooCommerce and Ads settings to the settings/google-for-woocommerce response.
+			 *
+			 * @param WP_REST_Response|WP_HTTP_Response|WP_Error|mixed $response The response object.
+			 * @param mixed                                             $handler  The handler.
+			 * @param WP_REST_Request                                   $request  The request object.
+			 */
+			function ( $response, $handler, $request ) {
+				if ( ! $response instanceof WP_REST_Response || $request->get_route() !== '/wc/v3/settings/' . self::SETTINGS_GROUP ) {
+					return $response;
+				}
+
+				$data = $response->get_data();
+
+				$data[] = [
+					'id'    => 'gla_shipping_times',
+					'label' => 'Google for WooCommerce: Shipping Times',
+					'value' => $this->shipping_time_query->get_all_shipping_times(),
+				];
+
+				$data[] = [
+					'id'    => 'gla_language',
+					'label' => 'Google for WooCommerce: Store language',
+					'value' => get_locale(),
+				];
+
+				$response->set_data( array_values( $data ) );
+
+				return $response;
+			},
+			10,
+			3
+		);
 	}
 
 	/**

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -21,7 +21,14 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class WPCOMProxy
  *
- * Initializes the hooks to filter the data sent to the WPCOM proxy depending on the query parameter gla_syncable.
+ * Prepares and filters data pulled by WPCOM proxy based on the `gla_syncable` query parameter.
+ *
+ * The `gla_syncable` parameter indicates that the request originates from the WPCOM proxy.
+ * It's not intended to provide security, as it does not expose any data
+ * that should be hidden from REST API users.
+ *
+ * Its primary purpose is to prevent global endpoints from being cluttered with additional data
+ * and to conceal undocumented implementation details of the integration between the G4W plugin and WPCOM proxy.
  *
  * @since 2.8.0
  *

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -262,11 +262,13 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 			function ( $data ) {
 				/*
 				 * We need to add non-empty return value in the filter, to be able to pass the valid group check.
-				 * We do not provide any valid 'type', so the entry will be ignored
+				 * We provide invalid 'type', so the entry will be ignored
 				 * in the response by `WC_REST_Setting_Options_V2_Controller::get_items`
 				 */
 				$data[] = [
+					'id'         => 'gla_settings_placeholder',
 					'option_key' => 'gla_settings_placeholder',
+					'type'       => '_invalid_type_'
 				];
 
 				/*

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -62,9 +62,11 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 
 	/**
 	 * The settings group for the REST API.
+	 *
 	 * @var string
 	 */
 	protected const SETTINGS_GROUP = 'google-for-woocommerce';
+
 	/**
 	 * WPCOMProxy constructor.
 	 *
@@ -242,24 +244,30 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	 * @return void
 	 */
 	protected function add_g4w_settings() {
-		add_filter( 'woocommerce_settings_groups', function ( $locations ) {
-			$locations[] = array(
-				'id'          => self::SETTINGS_GROUP,
-				'label'       => 'Google for WooCommerce',
-				'description' => 'Settings of the Google for WooCommerce plugin.',
-			);
-			return $locations;
-		} );
+		add_filter(
+			'woocommerce_settings_groups',
+			function ( $locations ) {
+				$locations[] = [
+					'id'          => self::SETTINGS_GROUP,
+					'label'       => 'Google for WooCommerce',
+					'description' => 'Settings of the Google for WooCommerce plugin.',
+				];
+				return $locations;
+			}
+		);
 
 		// Hack to make the settings group show up in the response.
-		add_filter( 'woocommerce_settings-' . self::SETTINGS_GROUP, function ( $data ) {
-			// We need to add non-empty return value in the filter, to be able to pass the valid group check.
-			$data[] = ['id' => 'gla_settings_placeholder'];
-			// We do not provide any valid 'type', so the entry will be ignored in the response.
+		add_filter(
+			'woocommerce_settings-' . self::SETTINGS_GROUP,
+			function ( $data ) {
+				// We need to add non-empty return value in the filter, to be able to pass the valid group check.
+				$data[] = [ 'id' => 'gla_settings_placeholder' ];
+				// We do not provide any valid 'type', so the entry will be ignored in the response.
 
-			// This way `rest_request_after_callbacks` will get an empty data set and could provide complete option- and non-option related settings.
-			return $data;
-		} );
+				// This way `rest_request_after_callbacks` will get an empty data set and could provide complete option- and non-option related settings.
+				return $data;
+			}
+		);
 
 	}
 

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -291,9 +291,11 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 			return $data;
 		}
 
-		foreach ( $data as $key => $value ) {
-			if ( preg_match( '/^\/wc\/v3\/shipping\/zones\/\d+\/methods/', $request->get_route() ) && isset( $value['settings'] ) && empty( $value['settings'] ) ) {
-				$data[ $key ]['settings'] = (object) $value['settings'];
+		if ( preg_match( '/^\/wc\/v3\/shipping\/zones\/\d+\/methods/', $request->get_route() ) ) {
+			foreach ( $data as $key => $value ) {
+				if ( isset( $value['settings'] ) && empty( $value['settings'] ) ) {
+					$data[ $key ]['settings'] = (object) $value['settings'];
+				}
 			}
 		}
 

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -204,11 +204,6 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 						'value' => rest_sanitize_boolean( $this->options->get( OptionsInterface::GOOGLE_CONNECTED, false ) ),
 					];
 					$data[] = [
-						'id'    => 'gla_jetpack_connected',
-						'label' => 'Google for WooCommerce: Is Jetpack connected?',
-						'value' => rest_sanitize_boolean( $this->options->get( OptionsInterface::JETPACK_CONNECTED, false ) ),
-					];
-					$data[] = [
 						'id'    => 'gla_language',
 						'label' => 'Google for WooCommerce: Store language',
 						'value' => get_locale(),

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -214,12 +214,12 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 					$data[] = [
 						'id'    => 'gla_shipping_rates',
 						'label' => 'Google for WooCommerce: Shipping Rates',
-						'value' => $this->shipping_rate_query->get_all_shipping_rates(),
+						'value' => (object) $this->shipping_rate_query->get_all_shipping_rates(),
 					];
 					$data[] = [
 						'id'    => 'gla_shipping_times',
 						'label' => 'Google for WooCommerce: Shipping Times',
-						'value' => $this->shipping_time_query->get_all_shipping_times(),
+						'value' => (object) $this->shipping_time_query->get_all_shipping_times(),
 					];
 					$data[] = [
 						'id'    => 'gla_target_audience',

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -117,6 +117,7 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 		);
 
 		$this->register_callbacks();
+		$this->add_g4w_settings();
 
 		foreach ( array_keys( self::$post_types_to_filter ) as $object_type ) {
 			$this->register_object_types_filter( $object_type );
@@ -152,7 +153,10 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	}
 
 	/**
-	 * Register the callbacks.
+	 * Register the `rest_request_after_callbacks` to add settings to `settings/general`.
+	 * Used for backward compatibility.
+	 *
+	 * @deprecated We created a dedicated settings group for google-for-woocommerce.
 	 */
 	protected function register_callbacks() {
 		add_filter(
@@ -199,6 +203,48 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 			10,
 			3
 		);
+	}
+
+	/**
+	 * Add the Google for WooCommerce settings to the WooCommerce REST API.
+	 *
+	 * @return void
+	 */
+	protected function add_g4w_settings() {
+		add_filter( 'woocommerce_settings_groups', function ( $locations ) {
+			$locations[] = array(
+				'id'          => 'google-for-woocommerce',
+				'label'       => 'Google for WooCommerce',
+				'description' => 'Settings of the Google for WooCommerce plugin.',
+			);
+			return $locations;
+		} );
+
+		add_filter( 'woocommerce_settings-google-for-woocommerce', function ( $data ) {
+			$data[] = [
+				'id'         => 'gla_target_audience',
+				'label'      => 'Google for WooCommerce: Target Audience',
+				'option_key' => OptionsInterface::TARGET_AUDIENCE,
+				'type'       => 'multiselect',
+				'default'	 => [],
+			];
+
+			// Workaround option-less settings by adding a default value.
+			$data[] = [
+				'id'      => 'gla_shipping_times',
+				'label'   => 'Google for WooCommerce: Shipping Times',
+				'type'    => 'multiselect',
+				'default' => $this->shipping_time_query->get_all_shipping_times(),
+			];
+
+			$data[] = [
+				'id'      => 'gla_language',
+				'label'   => 'Google for WooCommerce: Store language',
+				'type'    => 'text',
+				'default' => get_locale(),
+			];
+			return $data;
+		} );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/IntegrationServiceProvider.php
+++ b/src/Internal/DependencyManagement/IntegrationServiceProvider.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\IntegrationInitializer;
@@ -49,7 +50,7 @@ class IntegrationServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( WooCommerceProductBundles::class, AttributeManager::class );
 		$this->share_with_tags( WooCommercePreOrders::class, ProductHelper::class );
 		$this->conditionally_share_with_tags( JetpackWPCOM::class );
-		$this->share_with_tags( WPCOMProxy::class, ShippingTimeQuery::class, AttributeManager::class );
+		$this->share_with_tags( WPCOMProxy::class, ShippingRateQuery::class, ShippingTimeQuery::class, AttributeManager::class );
 
 		$this->share_with_tags(
 			IntegrationInitializer::class,

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -203,7 +203,7 @@ final class Options implements OptionsInterface, Service {
 	 *
 	 * @return string
 	 */
-	protected function prefix_name( string $name ): string {
+	public function prefix_name( string $name ): string {
 		return "{$this->get_slug()}_{$name}";
 	}
 

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -203,7 +203,7 @@ final class Options implements OptionsInterface, Service {
 	 *
 	 * @return string
 	 */
-	public function prefix_name( string $name ): string {
+	protected function prefix_name( string $name ): string {
 		return "{$this->get_slug()}_{$name}";
 	}
 

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -437,16 +437,39 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 		$this->assertEquals( $this->get_test_metadata( 'dont-sync-and-show' ), $this->format_metadata( $response_mapped[ $coupon_2->get_id() ]['meta_data'] ) );
 	}
 
-	public function test_get_settings() {
+	public function test_get_settings_without_gla_syncable_param() {
+		$response = $this->do_request( '/wc/v3/settings/general', 'GET' );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
+
+		$this->assertArrayNotHasKey( 'gla_google_connected', $response_mapped );
+		$this->assertArrayNotHasKey( 'gla_jetpack_connected', $response_mapped );
+		$this->assertArrayNotHasKey( 'gla_language', $response_mapped );
+		$this->assertArrayNotHasKey( 'gla_merchant_center', $response_mapped );
+		$this->assertArrayNotHasKey( 'gla_shipping_rates', $response_mapped );
+		$this->assertArrayNotHasKey( 'gla_shipping_times', $response_mapped );
+		$this->assertArrayNotHasKey( 'gla_target_audience', $response_mapped );
+	}
+
+	public function test_get_settings_with_gla_syncable_param() {
+		$response = $this->do_request( '/wc/v3/settings/general', 'GET', [ 'gla_syncable' => '1' ] );
+
 		$response = $this->do_request( '/wc/v3/settings/google-for-woocommerce', 'GET' );
 
 		$this->assertEquals( 200, $response->get_status() );
 
 		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
 
-		$this->assertArrayHasKey( 'gla_target_audience', $response_mapped );
-		$this->assertArrayHasKey( 'gla_shipping_times', $response_mapped );
+
+		$this->assertArrayHasKey( 'gla_google_connected', $response_mapped );
+		$this->assertArrayHasKey( 'gla_jetpack_connected', $response_mapped );
 		$this->assertArrayHasKey( 'gla_language', $response_mapped );
+		$this->assertArrayHasKey( 'gla_merchant_center', $response_mapped );
+		$this->assertArrayHasKey( 'gla_shipping_rates', $response_mapped );
+		$this->assertArrayHasKey( 'gla_shipping_times', $response_mapped );
+		$this->assertArrayHasKey( 'gla_target_audience', $response_mapped );
 	}
 
 	public function test_get_empty_settings_for_shipping_zone_methods_as_object() {

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -437,19 +437,8 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 		$this->assertEquals( $this->get_test_metadata( 'dont-sync-and-show' ), $this->format_metadata( $response_mapped[ $coupon_2->get_id() ]['meta_data'] ) );
 	}
 
-	public function test_get_settings_without_gla_syncable_param() {
-		$response = $this->do_request( '/wc/v3/settings/general', 'GET' );
-
-		$this->assertEquals( 200, $response->get_status() );
-
-		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
-
-		$this->assertArrayNotHasKey( 'gla_target_audience', $response_mapped );
-		$this->assertArrayNotHasKey( 'gla_shipping_times', $response_mapped );
-	}
-
-	public function test_get_settings_with_gla_syncable_param() {
-		$response = $this->do_request( '/wc/v3/settings/general', 'GET', [ 'gla_syncable' => '1' ] );
+	public function test_get_settings() {
+		$response = $this->do_request( '/wc/v3/settings/google-for-woocommerce', 'GET' );
 
 		$this->assertEquals( 200, $response->get_status() );
 
@@ -457,6 +446,7 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 
 		$this->assertArrayHasKey( 'gla_target_audience', $response_mapped );
 		$this->assertArrayHasKey( 'gla_shipping_times', $response_mapped );
+		$this->assertArrayHasKey( 'gla_language', $response_mapped );
 	}
 
 	public function test_get_empty_settings_for_shipping_zone_methods_as_object() {

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -2,6 +2,7 @@
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Integration;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper;
@@ -484,6 +485,7 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 		];
 
 		$proxy = new WPCOMProxy(
+			$this->container->get( ShippingRateQuery::class ),
 			$this->container->get( ShippingTimeQuery::class ),
 			$this->container->get( AttributeManager::class )
 		);

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -446,7 +446,6 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
 
 		$this->assertArrayNotHasKey( 'gla_google_connected', $response_mapped );
-		$this->assertArrayNotHasKey( 'gla_jetpack_connected', $response_mapped );
 		$this->assertArrayNotHasKey( 'gla_language', $response_mapped );
 		$this->assertArrayNotHasKey( 'gla_merchant_center', $response_mapped );
 		$this->assertArrayNotHasKey( 'gla_shipping_rates', $response_mapped );
@@ -462,7 +461,6 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
 
 		$this->assertArrayHasKey( 'gla_google_connected', $response_mapped );
-		$this->assertArrayHasKey( 'gla_jetpack_connected', $response_mapped );
 		$this->assertArrayHasKey( 'gla_language', $response_mapped );
 		$this->assertArrayHasKey( 'gla_merchant_center', $response_mapped );
 		$this->assertArrayHasKey( 'gla_shipping_rates', $response_mapped );

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -439,7 +439,7 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 	}
 
 	public function test_get_settings_without_gla_syncable_param() {
-		$response = $this->do_request( '/wc/v3/settings/general', 'GET' );
+		$response = $this->do_request( '/wc/v3/settings/google-for-woocommerce', 'GET' );
 
 		$this->assertEquals( 200, $response->get_status() );
 
@@ -455,14 +455,11 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 	}
 
 	public function test_get_settings_with_gla_syncable_param() {
-		$response = $this->do_request( '/wc/v3/settings/general', 'GET', [ 'gla_syncable' => '1' ] );
-
-		$response = $this->do_request( '/wc/v3/settings/google-for-woocommerce', 'GET' );
+		$response = $this->do_request( '/wc/v3/settings/google-for-woocommerce', 'GET', [ 'gla_syncable' => '1' ] );
 
 		$this->assertEquals( 200, $response->get_status() );
 
 		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
-
 
 		$this->assertArrayHasKey( 'gla_google_connected', $response_mapped );
 		$this->assertArrayHasKey( 'gla_jetpack_connected', $response_mapped );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- This PR adds `google-for-woocommerce` group to the WC REST API `/settings` endpoint and G4W specific settings to that group.
   Part of pcTzPl-2AM-p2
- Added some code docs about `gla_syncable` peeuvX-2ea-p2
- I also slightly tweaked the implementation of `prepare_data`, moving the endpoint check out side the loop.

### Screenshots:
![image](https://github.com/user-attachments/assets/50dccc48-d93e-4790-9727-53ea6721b04a)



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

0. Start with a fresh install, or disconnect all accounts
1. ```sh
   curl -X GET "https://yoursite.com/wp-json/wc/v3/settings/google-for-woocommerce"      -u 
   "restkey:restsecret"
   ```
   Check that the response is empty `200`.
2. ```sh
   curl -X GET "https://yoursite.com/wp-json/wc/v3/settings/google-for-woocommerce?gla_syncable=1"      -u 
   "restkey:restsecret"
   ```
3. Check that you get all keys, with empty/default values for the fresh install.
	```
	'gla_google_connected'
	'gla_jetpack_connected'
	'gla_language'
	'gla_merchant_center'
	'gla_shipping_rates'
	'gla_shipping_times'
	'gla_target_audience'
	```
   or for cleared accounts, that `*_connected` are set to `false`, `gla_shipping_*` are set to `[]`, and other settings as as they were set during onboarding.
4. Start onboarding, and after each step, redo the request, checking for updated values.
5. After finishing onboarding, go to `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings` and change the tax setting.
6. Resend the request and check that the change is reflected.
7. Go to `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fshipping` and change shipping settings
6. Resend the request and check that the change is reflected.



### Additional details:

1. In https://github.com/woocommerce/google-listings-and-ads/pull/2342 Jorge use `rest_request_after_callbacks` filter to add settings
	> Initially, my idea was to use the filter `woocommerce_settings- . $group_id` to add a new group of settings. However, this filter can only be used for Options (which should be fine for the target audience but not for the shipping times). Additionally, the filter `woocommerce_settings-` doesn't provide the Request Object param so I decided to use the filter `rest_request_after_callbacks` which makes it easier to verify if the request is made from the proxied endpoints.
	
	I think we can still use `woocommerce_settings*` filters to create the dedicated group. We could have added option-related settings in `woocommerce_settings-google-for-woocommerce` and even hacked to add non-option-related ones there as well (using the `$setting['default']` ). But that would require us to set `'type'` which will not be accurate, and would provide `link`s which are not working for our settings, etc. That's why I decided to add all settings in `rest_request_after_callbacks` in the same format that we used before.
	However, to make it work under ``woocommerce_settings-google-for-woocommerce`` it required [a bit of a hack](https://github.com/woocommerce/google-listings-and-ads/pull/2821/files#diff-0754aa1c2cb23cc7ac551b917d6800de2c34bb6f13ce10ee789799c6595fd846R264-R275).

2. Related to the discussion at peeuvX-2ea-p2, initially, I was thinking of making the `settings/google-for-woocommerce` return everything without the `gla_syncable` param, as I thought it would require a pretty convoluted implementation to return options from the ``woocommerce_settings-google-for-woocommerce`` filter, then conditionally remove it. However, I find a small hack that let us avoid that. So I kept everything behind `gla_syncable`, as it was before.
3. I added `gla_jetpack_connected` and `gla_google_connected` entries. They were not mentioned in the shared Google doc, but I believe that it could be useful to Google to check if a merchant disconnected their account. Plus, those could be considered onboarding inputs.
4. I'm not 100% sure if we should prefix `id`s with `gla_`. It was definitely useful for ones in `settings/general`, but now as everything is scoped under `/google-for-woocommerce`, it is a bit redundant. Also, as we already rebranded, we could use `g4w_` prefixes. I decided to keep it that way to make the old entries the same, but I'm open to opinions and to change it.
5. The structure of the minimum free order threshold is a bit different than in the initial Google Doc proposal. I kept it here like our internal structure to avoid glue-code for mapping it back and forth, therefore avoiding superficial room for bugs.  Google confirmed they are Ok with it (p1743358224845469-slack-C02BB3F30TG)



<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - `/settings/google-for-woocommerce` endpoint.
> Remove - `gla_` entries from `/settings/general`.