### PR TITLE
Restrict Budget Metrics to positive numbers

### DIFF
--- a/src/API/Site/Controllers/Ads/BudgetMetricsController.php
+++ b/src/API/Site/Controllers/Ads/BudgetMetricsController.php
@@ -75,6 +75,7 @@ class BudgetMetricsController extends BaseController implements ContainerAwareIn
 			'budget'        => [
 				'description'       => __( 'Budget to fetch metrics for.', 'google-listings-and-ads' ),
 				'type'              => 'number',
+				'minimum'           => 0,
 				'sanitize_callback' => $this->get_sanitize_price_callback(),
 				'validate_callback' => 'rest_validate_request_arg',
 			],

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetMetricsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetMetricsControllerTest.php
@@ -139,4 +139,17 @@ class BudgetMetricsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'Missing parameter(s): country_codes', $response->get_data()['message'] );
 		$this->assertEquals( 400, $response->get_status() );
 	}
+
+	public function test_get_budget_recommendation_with_negative_budget_value() {
+		$budget_recommendation_params = [
+			'country_codes' => [ 'US' ],
+			'budget'        => -10,
+		];
+
+		$response = $this->do_request( self::ROUTE_BUDGET_METRICS, 'GET', $budget_recommendation_params );
+
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertEquals( 'Invalid parameter(s): budget', $response->get_data()['message'] );
+		$this->assertEquals( 400, $response->get_status() );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a followup to the comment for restricting [negative budgets](https://github.com/woocommerce/google-listings-and-ads/pull/2820#discussion_r2007274117). I acknowledged the comment but forgot to implement it before merging.

### Detailed test instructions:
1. Test API request `https://domain.test/wp-json/wc/gla/ads/campaigns/budget-metrics?country_codes[]=IE&budget=-10`
2. Ensure an error is returned:
```json
{
    "code": "rest_invalid_param",
    "message": "Invalid parameter(s): budget",
    "data": {
        "status": 400,
        "params": {
            "budget": "budget must be greater than or equal to 0"
        },
        "details": {
            "budget": {
                "code": "rest_out_of_bounds",
                "message": "budget must be greater than or equal to 0",
                "data": null
            }
        }
    }
}
```

### Changelog entry
* Tweak - Restrict Budget Metrics to positive numbers.
