### PR TITLE
Fix Ads Merchant Linking Failure Display Issue & Improve Retry Mechanism

### DIFF
--- a/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
+++ b/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
@@ -30,7 +30,7 @@ const ConnectExistingAccount = ( { onCreateClick } ) => {
 	const [ isLoading, setLoading ] = useState( false );
 	const { createNotice } = useDispatchCoreNotices();
 	const { fetchGoogleAdsAccountStatus } = useAppDispatch();
-	const isConnected = useGoogleAdsAccountReady();
+	const { isGoogleAdsReady } = useGoogleAdsAccountReady();
 	const {
 		googleAdsAccount,
 		hasFinishedResolution,
@@ -95,7 +95,7 @@ const ConnectExistingAccount = ( { onCreateClick } ) => {
 			);
 		}
 
-		if ( isConnected ) {
+		if ( isGoogleAdsReady ) {
 			return <ConnectedIconLabel />;
 		}
 

--- a/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.test.js
+++ b/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.test.js
@@ -94,7 +94,9 @@ describe( 'ConnectExistingAccount', () => {
 				refetchGoogleAdsAccount,
 			} );
 
-			useGoogleAdsAccountReady.mockReturnValue( true );
+			useGoogleAdsAccountReady.mockReturnValue( {
+				isGoogleAdsReady: true,
+			} );
 		} );
 
 		it( 'Should render the state in connected', () => {
@@ -127,7 +129,9 @@ describe( 'ConnectExistingAccount', () => {
 						refetchGoogleAdsAccount,
 					} );
 
-					useGoogleAdsAccountReady.mockReturnValue( false );
+					useGoogleAdsAccountReady.mockReturnValue( {
+						isGoogleAdsReady: false,
+					} );
 				} )
 			);
 

--- a/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.test.js
+++ b/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.test.js
@@ -96,6 +96,7 @@ describe( 'ConnectExistingAccount', () => {
 
 			useGoogleAdsAccountReady.mockReturnValue( {
 				isGoogleAdsReady: true,
+				isLinkedToMerchantCenter: true,
 			} );
 		} );
 
@@ -131,6 +132,7 @@ describe( 'ConnectExistingAccount', () => {
 
 					useGoogleAdsAccountReady.mockReturnValue( {
 						isGoogleAdsReady: false,
+						isLinkedToMerchantCenter: false,
 					} );
 				} )
 			);

--- a/js/src/components/google-combo-account-card/indicator.js
+++ b/js/src/components/google-combo-account-card/indicator.js
@@ -19,7 +19,7 @@ import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
  * @return {JSX.Element|null} Indicator component.
  */
 const Indicator = ( { showSpinner } ) => {
-	const isGoogleAdsConnected = useGoogleAdsAccountReady();
+	const { isGoogleAdsReady } = useGoogleAdsAccountReady();
 	const { isReady: isGoogleMCConnected } = useGoogleMCAccount();
 
 	if ( showSpinner ) {
@@ -30,7 +30,7 @@ const Indicator = ( { showSpinner } ) => {
 		);
 	}
 
-	if ( isGoogleAdsConnected && isGoogleMCConnected ) {
+	if ( isGoogleAdsReady && isGoogleMCConnected ) {
 		return <ConnectedIconLabel />;
 	}
 

--- a/js/src/hooks/useGoogleAdsAccountReady.js
+++ b/js/src/hooks/useGoogleAdsAccountReady.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import { GOOGLE_ADS_ACCOUNT_STATUS } from '~/constants';
 import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
 import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
 
@@ -12,6 +13,7 @@ import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
  */
 const useGoogleAdsAccountReady = () => {
 	const {
+		googleAdsAccount,
 		hasGoogleAdsConnection,
 		hasFinishedResolution: adsAccountResolved,
 	} = useGoogleAdsAccount();
@@ -25,7 +27,14 @@ const useGoogleAdsAccountReady = () => {
 		return null;
 	}
 
+	// A temorary fix to prevent the user from proceeding when the link merchant step failed but hasAccess is true.
+	const linkMerchantFailed =
+		hasAccess &&
+		step === 'link_merchant' &&
+		googleAdsAccount?.status === GOOGLE_ADS_ACCOUNT_STATUS.INCOMPLETE;
+
 	return (
+		! linkMerchantFailed &&
 		hasGoogleAdsConnection &&
 		hasAccess &&
 		[ '', 'billing', 'link_merchant' ].includes( step )

--- a/js/src/hooks/useGoogleAdsAccountReady.js
+++ b/js/src/hooks/useGoogleAdsAccountReady.js
@@ -27,7 +27,7 @@ const useGoogleAdsAccountReady = () => {
 		return null;
 	}
 
-	// A temorary fix to prevent the user from proceeding when the link merchant step failed but hasAccess is true.
+	// A temporary fix to prevent the user from proceeding when the link merchant step failed but hasAccess is true.
 	const linkMerchantFailed =
 		hasAccess &&
 		step === 'link_merchant' &&

--- a/js/src/hooks/useGoogleAdsAccountReady.js
+++ b/js/src/hooks/useGoogleAdsAccountReady.js
@@ -1,19 +1,28 @@
 /**
  * Internal dependencies
  */
-import { GOOGLE_ADS_ACCOUNT_STATUS } from '~/constants';
 import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
 import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
 
 /**
- * Hook to check if the Google Ads account is ready.
+ * @typedef {Object} GoogleAdsAccountReady
+ * @property {null|boolean} isGoogleAdsReady True if the Google Ads account is connected, claimed, and granted access. `null` if the state is not yet determined.
+ * @property {null|boolean} isLinkedToMerchantCenter True if the Google Ads account is linked to a Merchant Center account. `null` if the state is not yet determined.
+ */
+
+const notDetermined = {
+	isGoogleAdsReady: null,
+	isLinkedToMerchantCenter: null,
+};
+
+/**
+ * Hook to check if the Google Ads account is ready or connected to a Merchant Center account.
  * This is used to determine if the user can proceed to the next step.
  *
- * @return {boolean|null} Whether the Google Ads account is ready. `null` if the state is not yet determined.
+ * @return {GoogleAdsAccountReady} The state of the Google Ads account.
  */
 const useGoogleAdsAccountReady = () => {
 	const {
-		googleAdsAccount,
 		hasGoogleAdsConnection,
 		hasFinishedResolution: adsAccountResolved,
 	} = useGoogleAdsAccount();
@@ -24,21 +33,21 @@ const useGoogleAdsAccountReady = () => {
 	} = useGoogleAdsAccountStatus();
 
 	if ( ! adsAccountResolved || ! adsAccountStatusResolved ) {
-		return null;
+		return notDetermined;
 	}
 
-	// A temporary fix to prevent the user from proceeding when the link merchant step failed but hasAccess is true.
-	const linkMerchantFailed =
-		hasAccess &&
-		step === 'link_merchant' &&
-		googleAdsAccount?.status === GOOGLE_ADS_ACCOUNT_STATUS.INCOMPLETE;
+	const isLinkedToMerchantCenter =
+		hasAccess && [ '', 'billing' ].includes( step );
 
-	return (
-		! linkMerchantFailed &&
+	const isGoogleAdsReady =
 		hasGoogleAdsConnection &&
 		hasAccess &&
-		[ '', 'billing', 'link_merchant' ].includes( step )
-	);
+		[ '', 'billing', 'link_merchant' ].includes( step );
+
+	return {
+		isGoogleAdsReady,
+		isLinkedToMerchantCenter,
+	};
 };
 
 export default useGoogleAdsAccountReady;

--- a/js/src/hooks/useGoogleMCAccount.js
+++ b/js/src/hooks/useGoogleMCAccount.js
@@ -22,6 +22,7 @@ import {
  * @property {boolean} hasFinishedResolution Whether resolution has completed.
  * @property {boolean} isPreconditionReady Whether the precondition of continued connection processing is fulfilled.
  * @property {boolean} hasGoogleMCConnection Whether the user has a Google Merchant Center account connection established.
+ * @property {boolean} isLinkedToAds Whether the Google Merchant Center account is linked to a Google Ads account.
  * @property {boolean} isReady Whether the user has a Google Merchant Center account is in connected state.
  * @property {boolean} isWPComAppGranted Whether the user has granted Google's WPCOM app access to WooCommerce product data etc.
  */
@@ -53,6 +54,7 @@ const useGoogleMCAccount = () => {
 					// the precondition doesn't meet.
 					isPreconditionReady: false,
 					hasGoogleMCConnection: false,
+					isLinkedToAds: false,
 					isReady: false,
 					isWPComAppGranted: false,
 				};
@@ -71,8 +73,11 @@ const useGoogleMCAccount = () => {
 					GOOGLE_MC_ACCOUNT_STATUS.INCOMPLETE,
 				].includes( acc?.status );
 
+			const isLinkedToAds =
+				acc?.status === GOOGLE_MC_ACCOUNT_STATUS.CONNECTED;
+
 			const isReady =
-				acc?.status === GOOGLE_MC_ACCOUNT_STATUS.CONNECTED ||
+				isLinkedToAds ||
 				( acc?.status === GOOGLE_MC_ACCOUNT_STATUS.INCOMPLETE &&
 					acc?.step === 'link_ads' );
 
@@ -88,6 +93,7 @@ const useGoogleMCAccount = () => {
 				),
 				isPreconditionReady: true,
 				hasGoogleMCConnection,
+				isLinkedToAds,
 				isReady,
 				isWPComAppGranted,
 			};

--- a/js/src/pages/ads-onboarding/ads-stepper/setup-accounts.js
+++ b/js/src/pages/ads-onboarding/ads-stepper/setup-accounts.js
@@ -24,13 +24,13 @@ const SetupAccounts = ( props ) => {
 	const { onContinue = () => {} } = props;
 	const { google } = useGoogleAccount();
 	const { googleAdsAccount } = useGoogleAdsAccount();
-	const { isGoogleAdsReady } = useGoogleAdsAccountReady();
+	const { isLinkedToMerchantCenter } = useGoogleAdsAccountReady();
 
 	if ( ! google || ( google.active === 'yes' && ! googleAdsAccount ) ) {
 		return <AppSpinner />;
 	}
 
-	const isContinueButtonDisabled = ! isGoogleAdsReady;
+	const isContinueButtonDisabled = ! isLinkedToMerchantCenter;
 
 	return (
 		<StepContent>

--- a/js/src/pages/ads-onboarding/ads-stepper/setup-accounts.js
+++ b/js/src/pages/ads-onboarding/ads-stepper/setup-accounts.js
@@ -24,7 +24,7 @@ const SetupAccounts = ( props ) => {
 	const { onContinue = () => {} } = props;
 	const { google } = useGoogleAccount();
 	const { googleAdsAccount } = useGoogleAdsAccount();
-	const isGoogleAdsReady = useGoogleAdsAccountReady();
+	const { isGoogleAdsReady } = useGoogleAdsAccountReady();
 
 	if ( ! google || ( google.active === 'yes' && ! googleAdsAccount ) ) {
 		return <AppSpinner />;

--- a/js/src/pages/ads-onboarding/ads-stepper/setup-accounts.js
+++ b/js/src/pages/ads-onboarding/ads-stepper/setup-accounts.js
@@ -30,6 +30,12 @@ const SetupAccounts = ( props ) => {
 		return <AppSpinner />;
 	}
 
+	/**
+	 * Here it uses `isLinkedToMerchantCenter` rather than `isGoogleAdsReady`
+	 * state because the latter is still true when the linking process fails.
+	 * When `isLinkedToMerchantCenter` is true, it already means the connection
+	 * process of Ads account is completed.
+	 */
 	const isContinueButtonDisabled = ! isLinkedToMerchantCenter;
 
 	return (

--- a/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
@@ -92,7 +92,7 @@ const SetupAccounts = ( props ) => {
 	} = useGoogleMCAccount();
 	const { hasFinishedResolution } = useGoogleAdsAccount();
 	const isStoreAddressReady = useStoreAddressReady();
-	const isGoogleAdsReady = useGoogleAdsAccountReady();
+	const { isGoogleAdsReady } = useGoogleAdsAccountReady();
 	const { updateGoogleMCContactInformation } = useAppDispatch();
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 

--- a/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-accounts/index.js
@@ -87,12 +87,14 @@ const SetupAccounts = ( props ) => {
 	const {
 		googleMCAccount,
 		isPreconditionReady: isGMCPreconditionReady,
+		isLinkedToAds,
 		isReady: isGoogleMCReady,
 		isWPComAppGranted,
 	} = useGoogleMCAccount();
 	const { hasFinishedResolution } = useGoogleAdsAccount();
 	const isStoreAddressReady = useStoreAddressReady();
-	const { isGoogleAdsReady } = useGoogleAdsAccountReady();
+	const { isGoogleAdsReady, isLinkedToMerchantCenter } =
+		useGoogleAdsAccountReady();
 	const { updateGoogleMCContactInformation } = useAppDispatch();
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 
@@ -124,8 +126,21 @@ const SetupAccounts = ( props ) => {
 		return <AppSpinner />;
 	}
 
+	/**
+	 * Because the order in which Google Ads and Google Merchant Center accounts
+	 * are connected is not always in order, and the second connected one doesn't
+	 * ask the first one to refetch its new state, the states on the frontend may
+	 * not be up-to-date but remain in a mid-state.
+	 *
+	 * Therefore, here it checks if either of the two accounts can indicate that
+	 * the interlinking is complete.
+	 */
+	const isAdsAndMerchantCenterInterlinked =
+		isLinkedToMerchantCenter || isLinkedToAds;
+
 	const isContinueButtonDisabled = ! (
 		hasFinishedResolution &&
+		isAdsAndMerchantCenterInterlinked &&
 		isGoogleAdsReady &&
 		isGoogleMCReady &&
 		isWPComAppGranted &&

--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -129,7 +129,7 @@ class Ads implements OptionsAwareInterface {
 	 * @throws Exception When a link is unavailable.
 	 */
 	public function accept_merchant_link( int $merchant_id ) {
-		$link        = $this->get_merchant_link( $merchant_id, 3 );
+		$link        = $this->get_merchant_link( $merchant_id, 5 );
 		$link_status = $link->getStatus();
 		if ( $link_status === ProductLinkInvitationStatus::ACCEPTED ) {
 			return;
@@ -351,6 +351,7 @@ class Ads implements OptionsAwareInterface {
 		}
 
 		if ( $attempts_left > 0 ) {
+			sleep( 1 );
 			return $this->get_merchant_link( $merchant_id, $attempts_left - 1 );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2834.

This PR fixes an issue where the merchant linking step fails but incorrectly displays as "connected," allowing users to proceed with onboarding. This ultimately results in a "Resource not found" error when attempting to create a campaign. Additionally, this PR improves the retry mechanism when fetching the merchant link API.

**Changes**

- Add one more condition to determine link merchant failure
  - When `hasAceess` is `true` but `status` is `incomplete` and `step` is `link_merchant`.
- Increase retry attempts to 5 times when fetching the merchant link API.
- Add a 1 second delay between each retry to improve API stability.

### Screenshots:

https://github.com/user-attachments/assets/dc145cdf-dcc9-4ea8-953f-7016870e2fa0

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go through the onboarding process.
2. Create a new ads account. It will attempt to link a merchant account.
3. If linking fails, verify that it does not display as "connected", and ensure the Continue button is disabled.
    - To make the linking fails, try to revert the commit 85477379ef6610a90648f2d2a2179ec7d3d03815 that increase the retries and add a delay
    - Note that it happens frequently but not every time, so try again if the retries without delay passed
5. If linking succeeds, proceed to the campaign creation step without encountering the "Resource not found" error.

### Additional details

**Update:** I have solved the problem and attached a video above.

~I initially wanted to include screentshots or videos in the PR, but my account ended up reaching the account creation limit like below screenshot. I then created a new Google account for testing, but it still showed account creation limit reached.~

![Screenshot 2025-04-02 at 11 27 56](https://github.com/user-attachments/assets/66e4cd72-c194-4b6e-8d06-fccc2aa45f24)

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Ads merchant linking failure display issue & improve retry mechanism
