### PR TITLE
Feature/2826 price benchmark tab

### DIFF
--- a/js/src/components/main-tab-nav/main-tab-nav.js
+++ b/js/src/components/main-tab-nav/main-tab-nav.js
@@ -30,6 +30,11 @@ let tabs = [
 		href: getNewPath( {}, '/google/product-feed', {} ),
 	},
 	{
+		key: 'price-benchmark',
+		title: __( 'Price Benchmark', 'google-listings-and-ads' ),
+		href: getNewPath( {}, '/google/price-benchmark', {} ),
+	},
+	{
 		key: 'attribute-mapping',
 		title: __( 'Attributes', 'google-listings-and-ads' ),
 		href: getNewPath( {}, '/google/attribute-mapping', {} ),

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -60,6 +60,10 @@ const DEFAULT_STATE = {
 		reviewEligibleRegions: [],
 	},
 	mc_product_feed: null,
+	price_benchmark: {
+		suggestions: [],
+		adjustments: [],
+	},
 	report: {},
 	store_categories: [],
 	tours: {},

--- a/js/src/data/test/reducer.test.js
+++ b/js/src/data/test/reducer.test.js
@@ -63,6 +63,10 @@ describe( 'reducer', () => {
 				product: null,
 			},
 			mc_product_feed: null,
+			price_benchmark: {
+				suggestions: [],
+				adjustments: [],
+			},
 			report: {},
 			store_categories: [],
 			tours: {},

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -46,6 +46,12 @@ const AttributeMapping = lazy( () =>
 	)
 );
 
+const PriceBenchmark = lazy( () =>
+	import(
+		/* webpackChunkName: "price-benchmark" */ './pages/price-benchmark'
+	)
+);
+
 const Settings = lazy( () =>
 	import( /* webpackChunkName: "settings" */ './pages/settings' )
 );
@@ -118,6 +124,15 @@ addFilter(
 				],
 				container: ProductFeed,
 				path: '/google/product-feed',
+				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
+			},
+			{
+				breadcrumbs: [
+					...initialBreadcrumbs,
+					__( 'Price Benchmark', 'google-listings-and-ads' ),
+				],
+				container: PriceBenchmark,
+				path: '/google/price-benchmark',
 				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
 			},
 			{

--- a/js/src/pages/price-benchmark/PriceBenchmarkAdjustments.js
+++ b/js/src/pages/price-benchmark/PriceBenchmarkAdjustments.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { TablePlaceholder } from '@woocommerce/components';
+
+const TABLE_DATA_HEADERS = [
+	{
+		key: 'product',
+		label: __( 'Product', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'adjusted-price',
+		label: __( 'Adjusted Price', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'previous-price',
+		label: __( 'Previous Price', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'price-adjustments',
+		label: __( 'Price Adjustment', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'weekly-clicks',
+		label: __( 'Weekly Clicks', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'weekly-conversions',
+		label: __( 'Weekly Conv.', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'weekly-clicks-uplift',
+		label: __( 'Weekly Clicks Uplift', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'weekly-conv-uplift',
+		label: __( 'Weekly Conv. Uplift', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'actions',
+		label: __( 'Action', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+];
+
+const PriceBenchmarkSuggestions = () => {
+	return (
+		<TablePlaceholder
+			headers={ TABLE_DATA_HEADERS }
+			caption={ __(
+				'Loading the adjustment data…',
+				'google-listings-and-ads'
+			) }
+		/>
+	);
+};
+
+export default PriceBenchmarkSuggestions;

--- a/js/src/pages/price-benchmark/PriceBenchmarkSuggestions.js
+++ b/js/src/pages/price-benchmark/PriceBenchmarkSuggestions.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { TablePlaceholder } from '@woocommerce/components';
+import { __ } from '@wordpress/i18n';
+
+const TABLE_DATA_HEADERS = [
+	{
+		key: 'product',
+		label: __( 'Product', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'effectiveness',
+		label: __( 'Price Change Effectiveness', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'regular-price',
+		label: __( 'Regular Price', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'avg-google-price',
+		label: __( 'Avg. Price on Google', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'price-gap',
+		label: __( 'Price Gap', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'suggested-price',
+		label: __( 'Suggested Price', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+	{
+		key: 'actions',
+		label: __( 'Action', 'google-listings-and-ads' ),
+		isLeftAligned: true,
+		required: true,
+	},
+];
+
+const PriceBenchmarkSuggestions = () => {
+	return (
+		<TablePlaceholder
+			headers={ TABLE_DATA_HEADERS }
+			caption={ __(
+				'Loading the product data…',
+				'google-listings-and-ads'
+			) }
+		/>
+	);
+};
+
+export default PriceBenchmarkSuggestions;

--- a/js/src/pages/price-benchmark/constants.js
+++ b/js/src/pages/price-benchmark/constants.js
@@ -1,0 +1,2 @@
+export const TABLE_TYPE_SUGGESTIONS = 'suggestions';
+export const TABLE_TYPE_ADJUSTMENTS = 'adjustments';

--- a/js/src/pages/price-benchmark/index.js
+++ b/js/src/pages/price-benchmark/index.js
@@ -11,7 +11,6 @@ import MainTabNav from '~/components/main-tab-nav';
 import IssueTypeNavigation from './table-type-navigation';
 import PriceBenchmarkTable from './price-benchmark-table';
 import { TABLE_TYPE_SUGGESTIONS } from './constants';
-import './index.scss';
 
 const PriceBenchmark = () => {
 	const tableType = getQuery()?.tableType || TABLE_TYPE_SUGGESTIONS;

--- a/js/src/pages/price-benchmark/index.js
+++ b/js/src/pages/price-benchmark/index.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { getQuery } from '@woocommerce/navigation';
+import { Card } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import MainTabNav from '~/components/main-tab-nav';
+import IssueTypeNavigation from './table-type-navigation';
+import PriceBenchmarkTable from './price-benchmark-table';
+import { TABLE_TYPE_SUGGESTIONS } from './constants';
+import './index.scss';
+
+const PriceBenchmark = () => {
+	const tableType = getQuery()?.tableType || TABLE_TYPE_SUGGESTIONS;
+
+	return (
+		<div className="gla-price-benchmark">
+			<MainTabNav />
+			<Card>
+				<IssueTypeNavigation tableType={ tableType } />
+				<PriceBenchmarkTable tableType={ tableType } />
+			</Card>
+		</div>
+	);
+};
+
+export default PriceBenchmark;

--- a/js/src/pages/price-benchmark/price-benchmark-table.js
+++ b/js/src/pages/price-benchmark/price-benchmark-table.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { CardBody } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import PriceBenchmarkSuggestions from './PriceBenchmarkSuggestions';
+import PriceBenchmarkAdjustments from './PriceBenchmarkAdjustments';
+import { TABLE_TYPE_ADJUSTMENTS } from './constants';
+
+const PriceBenchmarkTable = ( { tableType } ) => {
+	return (
+		<CardBody size={ null }>
+			{ tableType === TABLE_TYPE_ADJUSTMENTS ? (
+				<PriceBenchmarkAdjustments />
+			) : (
+				<PriceBenchmarkSuggestions />
+			) }
+		</CardBody>
+	);
+};
+
+export default PriceBenchmarkTable;

--- a/js/src/pages/price-benchmark/table-type-navigation.js
+++ b/js/src/pages/price-benchmark/table-type-navigation.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { getNewPath } from '@woocommerce/navigation';
+
+/**
+ * Internal dependencies
+ */
+import AppTabNav from '~/components/app-tab-nav';
+import { TABLE_TYPE_SUGGESTIONS, TABLE_TYPE_ADJUSTMENTS } from './constants';
+
+const IssueTypeNavigation = ( { tableType } ) => {
+	const tabs = [
+		{
+			key: TABLE_TYPE_SUGGESTIONS,
+			title: __(
+				'Price Benchmark & Suggestions',
+				'google-listings-and-ads'
+			),
+			href: getNewPath(
+				{ tableType: TABLE_TYPE_SUGGESTIONS },
+				'/google/price-benchmark',
+				{}
+			),
+		},
+		{
+			key: TABLE_TYPE_ADJUSTMENTS,
+			title: __( 'Price Adjustments', 'google-listings-and-ads' ),
+			href: getNewPath(
+				{ tableType: TABLE_TYPE_ADJUSTMENTS },
+				'/google/price-benchmark',
+				{}
+			),
+		},
+	];
+
+	return <AppTabNav tabs={ tabs } selectedKey={ tableType } />;
+};
+
+export default IssueTypeNavigation;

--- a/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
+++ b/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { expect, test } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import { clearOnboardedMerchant } from '../../utils/api';
+import PriceBenchmarkPage from '../../utils/pages/price-benchmark';
+
+test.use( { storageState: process.env.ADMINSTATE } );
+
+test.describe.configure( { mode: 'serial' } );
+
+/**
+ * @type {import('../../utils/pages/price-benchmark').default} priceBenchmarkPage
+ */
+let priceBenchmarkPage = null;
+
+/**
+ * @type {import('@playwright/test').Page} page
+ */
+let page = null;
+
+test.describe( 'Price Benchmark Page', () => {
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		priceBenchmarkPage = new PriceBenchmarkPage( page );
+		await Promise.all( [ priceBenchmarkPage.mockRequests() ] );
+	} );
+
+	test.afterAll( async () => {
+		await clearOnboardedMerchant();
+		await page.close();
+	} );
+
+	test.describe( 'Has navigation', () => {
+		// Corrected: Added a function here
+		test( 'Goes to the Price Benchmark page', async () => {
+			// Added a test case
+			await priceBenchmarkPage.goto();
+
+			const expectedTabs = [
+				'Price Benchmark & Suggestions',
+				'Price Adjustments',
+			];
+
+			for ( const tabText of expectedTabs ) {
+				const tabLocator = page.locator(
+					`a[role="tab"]:has-text("${ tabText }")`
+				);
+				await expect( tabLocator ).toBeVisible();
+			}
+		} );
+	} );
+} );

--- a/tests/e2e/utils/pages/price-benchmark.js
+++ b/tests/e2e/utils/pages/price-benchmark.js
@@ -1,0 +1,69 @@
+/**
+ * Internal dependencies
+ */
+import { LOAD_STATE } from '../constants';
+import MockRequests from '../mock-requests';
+
+/**
+ * ProductFeed page object class.
+ */
+export default class PriceBenchmarkPage extends MockRequests {
+	/**
+	 * @param {import('@playwright/test').Page} page
+	 */
+	constructor( page ) {
+		super( page );
+		this.page = page;
+	}
+
+	/**
+	 * Go to the product feed page.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async goto() {
+		await this.page.goto(
+			'/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fprice-benchmark',
+			{ waitUntil: LOAD_STATE.DOM_CONTENT_LOADED }
+		);
+	}
+
+	/**
+	 * Mock all requests related to external accounts such as Merchant Center, Google, etc.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async mockRequests() {
+		await Promise.all( [
+			this.fulfillMCReview( {
+				cooldown: 0,
+				issues: [],
+				reviewEligibleRegions: [],
+				status: 'ONBOARDING',
+			} ),
+
+			this.fulfillAccountIssuesRequest( {
+				issues: [],
+				page: 1,
+				total: 0,
+				loading: false,
+			} ),
+
+			this.mockJetpackConnected(),
+			this.mockGoogleConnected(),
+			this.mockAdsAccountConnected(),
+		] );
+	}
+
+	/**
+	 * Get the active product value element.
+	 *
+	 * @return {import('@playwright/test').Locator} The active product value element.
+	 */
+	getActiveProductValueElement() {
+		return this.page
+			.locator( '.woocommerce-summary__item-label span >> text=Active' )
+			.locator( '../..' )
+			.locator( '.woocommerce-summary__item-value span' );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2826  .

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->
<img width="1346" alt="Screenshot 2025-04-03 at 3 27 10 PM" src="https://github.com/user-attachments/assets/2ffc9ed1-96f5-486f-9f8e-670f50344ed7" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to Marketing > Google for Woocommerce. Once the onboarding is completed, you shall be able to view `Price Benchmark` tab in admin.
2. By default `Price Benchmark & Suggestions` tab would be selected.
3. Clicking on `Price Adjustments` tab should switch the url to `tableType=adjustments`. Refreshing the page should keep the same tab selected.
4. Loading table placeholders are added for both `Price Benchmark & Suggestions` and `Price Adjustments` tabs.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
