### PR TITLE
Add support for getting price benchmarks & suggestions from the Content API 

### DIFF
--- a/src/API/Google/MerchantPriceBenchmarks.php
+++ b/src/API/Google/MerchantPriceBenchmarks.php
@@ -66,7 +66,7 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 	 */
 	public function get_price_insights_product_view(): array {
 		try {
-			$response = ( new MerchantPriceSuggestionsQuery() )
+			$response = ( new MerchantPriceSuggestionsQuery( [] ) )
 			->set_client( $this->service, $this->options->get_merchant_id() )
 			->get_results();
 

--- a/src/API/Google/MerchantPriceBenchmarks.php
+++ b/src/API/Google/MerchantPriceBenchmarks.php
@@ -44,7 +44,7 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 	 */
 	public function get_benchmark_data(): array {
 		try {
-			$response = ( new MerchantPriceBenchmarksQuery() )
+			$response = ( new MerchantPriceBenchmarksQuery( [] ) )
 			->set_client( $this->service, $this->options->get_merchant_id() )
 			->get_results();
 

--- a/src/API/Google/MerchantPriceBenchmarks.php
+++ b/src/API/Google/MerchantPriceBenchmarks.php
@@ -68,7 +68,7 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 	 *
 	 * @throws Exception If the merchant price suggestions data can't be retrieved.
 	 */
-	public function get_price_insights_product_view( array $args ): array {
+	public function get_price_insights( array $args ): array {
 		try {
 			$response = ( new MerchantPriceSuggestionsQuery( $args ) )
 			->set_client( $this->service, $this->options->get_merchant_id() )

--- a/src/API/Google/MerchantPriceBenchmarks.php
+++ b/src/API/Google/MerchantPriceBenchmarks.php
@@ -1,0 +1,91 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantPriceBenchmarksQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantPriceSuggestionsQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent;
+use Exception;
+
+/**
+ * Class MerchantPriceBenchmarks
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
+ */
+class MerchantPriceBenchmarks implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/**
+	 * The shopping service.
+	 *
+	 * @var ShoppingContent
+	 */
+	protected $service;
+
+	/**
+	 * Product helper class.
+	 *
+	 * @var ProductHelper
+	 */
+	protected $product_helper;
+
+	/**
+	 * Merchant Report constructor.
+	 *
+	 * @param ShoppingContent $service
+	 * @param ProductHelper   $product_helper
+	 */
+	public function __construct( ShoppingContent $service, ProductHelper $product_helper ) {
+		$this->service        = $service;
+		$this->product_helper = $product_helper;
+	}
+
+	/**
+	 * Get MerchantPriceBenchmarksQuery Query response.
+	 *
+	 * @return array Associative array with product statuses and the next page token.
+	 *
+	 * @throws Exception If the merchant price benchmarks report data can't be retrieved.
+	 */
+	public function get_benchmark_data(): array {
+		try {
+			$response = ( new MerchantPriceBenchmarksQuery() )
+			->set_client( $this->service, $this->options->get_merchant_id() )
+			->get_results();
+
+			$results = $response->getResults() ?? [];
+
+			return $results;
+		} catch ( GoogleException $e ) {
+			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
+			throw new Exception( __( 'Unable to retrieve Merchant Price Benchmarks.', 'google-listings-and-ads' ) . $e->getMessage(), $e->getCode() );
+		}
+	}
+
+	/**
+	 * Get MerchantPriceSuggestions Query response.
+	 *
+	 * @return array Associative array with product statuses and the next page token.
+	 *
+	 * @throws Exception If the merchant price suggestions data can't be retrieved.
+	 */
+	public function get_price_insights_product_view(): array {
+		try {
+			$response = ( new MerchantPriceSuggestionsQuery() )
+			->set_client( $this->service, $this->options->get_merchant_id() )
+			->get_results();
+
+			$results = $response->getResults() ?? [];
+
+			return $results;
+		} catch ( GoogleException $e ) {
+			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
+			throw new Exception( __( 'Unable to retrieve Merchant Price Benchmarks.', 'google-listings-and-ads' ) . $e->getMessage(), $e->getCode() );
+		}
+	}
+}

--- a/src/API/Google/MerchantPriceBenchmarks.php
+++ b/src/API/Google/MerchantPriceBenchmarks.php
@@ -7,7 +7,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantPriceBe
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantPriceSuggestionsQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent;
 use Exception;
 
@@ -28,21 +27,12 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 	protected $service;
 
 	/**
-	 * Product helper class.
-	 *
-	 * @var ProductHelper
-	 */
-	protected $product_helper;
-
-	/**
 	 * Merchant Report constructor.
 	 *
 	 * @param ShoppingContent $service
-	 * @param ProductHelper   $product_helper
 	 */
-	public function __construct( ShoppingContent $service, ProductHelper $product_helper ) {
-		$this->service        = $service;
-		$this->product_helper = $product_helper;
+	public function __construct( ShoppingContent $service ) {
+		$this->service = $service;
 	}
 
 	/**

--- a/src/API/Google/MerchantPriceBenchmarks.php
+++ b/src/API/Google/MerchantPriceBenchmarks.php
@@ -40,9 +40,9 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 	 *
 	 * @param array $args Query arguments.
 	 *
-	 * @return array
+	 * @return array Associative array with price benchmarks data and the next page token.
 	 *
-	 * @throws Exception If the merchant price benchmarks report data can't be retrieved.
+	 * @throws Exception If the merchant price benchmarks data can't be retrieved.
 	 */
 	public function get_benchmark_data( array $args ): array {
 		try {
@@ -64,7 +64,7 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 	 *
 	 * @param array $args Query arguments.
 	 *
-	 * @return array Associative array with product statuses and the next page token.
+	 * @return array Associative array with price benchmarks data and the next page token.
 	 *
 	 * @throws Exception If the merchant price suggestions data can't be retrieved.
 	 */

--- a/src/API/Google/MerchantPriceBenchmarks.php
+++ b/src/API/Google/MerchantPriceBenchmarks.php
@@ -38,13 +38,15 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 	/**
 	 * Get MerchantPriceBenchmarksQuery Query response.
 	 *
-	 * @return array Associative array with product statuses and the next page token.
+	 * @param array $args Query arguments.
+	 *
+	 * @return array
 	 *
 	 * @throws Exception If the merchant price benchmarks report data can't be retrieved.
 	 */
-	public function get_benchmark_data(): array {
+	public function get_benchmark_data( array $args ): array {
 		try {
-			$response = ( new MerchantPriceBenchmarksQuery( [] ) )
+			$response = ( new MerchantPriceBenchmarksQuery( $args ) )
 			->set_client( $this->service, $this->options->get_merchant_id() )
 			->get_results();
 
@@ -60,13 +62,15 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 	/**
 	 * Get MerchantPriceSuggestions Query response.
 	 *
+	 * @param array $args Query arguments.
+	 *
 	 * @return array Associative array with product statuses and the next page token.
 	 *
 	 * @throws Exception If the merchant price suggestions data can't be retrieved.
 	 */
-	public function get_price_insights_product_view(): array {
+	public function get_price_insights_product_view( array $args ): array {
 		try {
-			$response = ( new MerchantPriceSuggestionsQuery( [] ) )
+			$response = ( new MerchantPriceSuggestionsQuery( $args ) )
 			->set_client( $this->service, $this->options->get_merchant_id() )
 			->get_results();
 

--- a/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
+++ b/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
@@ -35,7 +35,7 @@ class MerchantPriceBenchmarksQuery extends MerchantQuery {
 	 */
 	public function filter( array $ids ): QueryInterface {
 		if ( ! empty( $ids ) ) {
-			$this->where( 'product_view.id', 'IN', $ids );
+			$this->where( 'product_view.id', $ids, 'IN' );
 		}
 		return $this;
 	}

--- a/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
+++ b/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
@@ -12,12 +12,18 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantQuery;
  */
 class MerchantPriceBenchmarksQuery extends MerchantQuery {
 
+	use ReportQueryTrait;
+
 	/**
 	 * MerchantPriceBenchmarksQuery constructor.
+	 *
+	 * @param array $args Query arguments.
 	 */
-	public function __construct() {
+	public function __construct( array $args ) {
 		parent::__construct( 'PriceCompetitivenessProductView' );
+
 		$this->set_initial_columns();
+		$this->handle_query_args( $args );
 	}
 
 	/**

--- a/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
+++ b/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
@@ -5,6 +5,11 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantQuery;
 
+/**
+ * Class MerchantPriceBenchmarksQuery
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query
+ */
 class MerchantPriceBenchmarksQuery extends MerchantQuery {
 
 	use ReportQueryTrait;

--- a/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
+++ b/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
@@ -46,13 +46,13 @@ class MerchantPriceBenchmarksQuery extends MerchantQuery {
 	protected function set_initial_columns() {
 		$this->columns(
 			[
-				'id'                                 => 'product_view.id',
-				'offer_id'                           => 'product_view.offer_id',
-				'title'                              => 'product_view.title',
-				'price_micros'                       => 'product_view.price_micros',
-				'benchmark_price_micros'             => 'price_competitiveness.benchmark_price_micros',
-				'currency_code'                      => 'product_view.currency_code',
-				'price_competitiveness_country_code' => 'price_competitiveness.country_code',
+				'id'                            => 'product_view.id',
+				'offer_id'                      => 'product_view.offer_id',
+				'title'                         => 'product_view.title',
+				'price_micros'                  => 'product_view.price_micros',
+				'currency_code'                 => 'product_view.currency_code',
+				'benchmark_price_micros'        => 'price_competitiveness.benchmark_price_micros',
+				'benchmark_price_currency_code' => 'price_competitiveness.benchmark_price_country_code',
 			]
 		);
 	}

--- a/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
+++ b/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
@@ -1,0 +1,53 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantQuery;
+
+class MerchantPriceBenchmarksQuery extends MerchantQuery {
+
+	use ReportQueryTrait;
+
+	/**
+	 * MerchantPriceBenchmarksQuery constructor.
+	 *
+	 * @param array $args Query arguments.
+	 */
+	public function __construct( array $args ) {
+		parent::__construct( 'PriceCompetitivenessProductView' );
+		$this->set_initial_columns();
+		$this->handle_query_args( $args );
+	}
+
+	/**
+	 * Filter the query by a list of product IDs.
+	 *
+	 * @param array $ids List of product IDs to filter by.
+	 *
+	 * @return $this
+	 */
+	public function filter( array $ids ): QueryInterface {
+		if ( ! empty( $ids ) ) {
+			$this->where( 'product_view.id', 'IN', $ids );
+		}
+		return $this;
+	}
+
+	/**
+	 * Set the initial columns for this query.
+	 */
+	protected function set_initial_columns() {
+		$this->columns(
+			[
+				'id'                     => 'product_view.id',
+				'title'                  => 'product_view.title',
+				'price_micros'           => 'product_view.price_micros',
+				'benchmark_price_micros' => 'price_competitiveness.benchmark_price_micros',
+				'currency_code'          => 'product_view.currency_code',
+				'country_code'           => 'product_view.country_code',
+				'date'                   => 'product_view.date',
+			]
+		);
+	}
+}

--- a/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
+++ b/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
@@ -12,17 +12,12 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantQuery;
  */
 class MerchantPriceBenchmarksQuery extends MerchantQuery {
 
-	use ReportQueryTrait;
-
 	/**
 	 * MerchantPriceBenchmarksQuery constructor.
-	 *
-	 * @param array $args Query arguments.
 	 */
-	public function __construct( array $args ) {
+	public function __construct() {
 		parent::__construct( 'PriceCompetitivenessProductView' );
 		$this->set_initial_columns();
-		$this->handle_query_args( $args );
 	}
 
 	/**
@@ -45,13 +40,12 @@ class MerchantPriceBenchmarksQuery extends MerchantQuery {
 	protected function set_initial_columns() {
 		$this->columns(
 			[
-				'id'                     => 'product_view.id',
-				'title'                  => 'product_view.title',
-				'price_micros'           => 'product_view.price_micros',
-				'benchmark_price_micros' => 'price_competitiveness.benchmark_price_micros',
-				'currency_code'          => 'product_view.currency_code',
-				'country_code'           => 'product_view.country_code',
-				'date'                   => 'product_view.date',
+				'id'                                 => 'product_view.id',
+				'title'                              => 'product_view.title',
+				'price_micros'                       => 'product_view.price_micros',
+				'benchmark_price_micros'             => 'price_competitiveness.benchmark_price_micros',
+				'currency_code'                      => 'product_view.currency_code',
+				'price_competitiveness_country_code' => 'price_competitiveness.country_code',
 			]
 		);
 	}

--- a/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
+++ b/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
@@ -47,6 +47,7 @@ class MerchantPriceBenchmarksQuery extends MerchantQuery {
 		$this->columns(
 			[
 				'id'                                 => 'product_view.id',
+				'offer_id'                           => 'product_view.offer_id',
 				'title'                              => 'product_view.title',
 				'price_micros'                       => 'product_view.price_micros',
 				'benchmark_price_micros'             => 'price_competitiveness.benchmark_price_micros',

--- a/src/API/Google/Query/MerchantPriceSuggestionsQuery.php
+++ b/src/API/Google/Query/MerchantPriceSuggestionsQuery.php
@@ -12,12 +12,18 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantQuery;
  */
 class MerchantPriceSuggestionsQuery extends MerchantQuery {
 
+	use ReportQueryTrait;
+
 	/**
 	 * MerchantPriceSuggestionsQuery constructor.
+	 *
+	 * @param array $args Query arguments.
 	 */
-	public function __construct() {
+	public function __construct( array $args ) {
 		parent::__construct( 'PriceInsightsProductView' );
+
 		$this->set_initial_columns();
+		$this->handle_query_args( $args );
 	}
 
 	/**

--- a/src/API/Google/Query/MerchantPriceSuggestionsQuery.php
+++ b/src/API/Google/Query/MerchantPriceSuggestionsQuery.php
@@ -29,7 +29,7 @@ class MerchantPriceSuggestionsQuery extends MerchantQuery {
 	 */
 	public function filter( array $ids ): QueryInterface {
 		if ( ! empty( $ids ) ) {
-			$this->where( 'product_view.id', 'IN', $ids );
+			$this->where( 'product_view.id', $ids, 'IN' );
 		}
 		return $this;
 	}

--- a/src/API/Google/Query/MerchantPriceSuggestionsQuery.php
+++ b/src/API/Google/Query/MerchantPriceSuggestionsQuery.php
@@ -47,6 +47,7 @@ class MerchantPriceSuggestionsQuery extends MerchantQuery {
 		$this->columns(
 			[
 				'id'                                    => 'product_view.id',
+				'offer_id'                              => 'product_view.offer_id',
 				'title'                                 => 'product_view.title',
 				'brand'                                 => 'product_view.brand',
 				'price_micros'                          => 'product_view.price_micros',

--- a/src/API/Google/Query/MerchantPriceSuggestionsQuery.php
+++ b/src/API/Google/Query/MerchantPriceSuggestionsQuery.php
@@ -1,0 +1,56 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantQuery;
+
+/**
+ * Class MerchantPriceSuggestionsQuery
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query
+ */
+class MerchantPriceSuggestionsQuery extends MerchantQuery {
+
+	/**
+	 * MerchantPriceSuggestionsQuery constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'PriceInsightsProductView' );
+		$this->set_initial_columns();
+	}
+
+	/**
+	 * Filter the query by a list of product IDs.
+	 *
+	 * @param array $ids List of product IDs to filter by.
+	 *
+	 * @return $this
+	 */
+	public function filter( array $ids ): QueryInterface {
+		if ( ! empty( $ids ) ) {
+			$this->where( 'product_view.id', 'IN', $ids );
+		}
+		return $this;
+	}
+
+	/**
+	 * Set the initial columns for this query.
+	 */
+	protected function set_initial_columns() {
+		$this->columns(
+			[
+				'id'                                    => 'product_view.id',
+				'title'                                 => 'product_view.title',
+				'brand'                                 => 'product_view.brand',
+				'price_micros'                          => 'product_view.price_micros',
+				'currency_code'                         => 'product_view.currency_code',
+				'suggested_price_micros'                => 'price_insights.suggested_price_micros',
+				'suggested_price_currency_code'         => 'price_insights.suggested_price_currency_code',
+				'predicted_impressions_change_fraction' => 'price_insights.predicted_impressions_change_fraction',
+				'predicted_clicks_change_fraction'      => 'price_insights.predicted_clicks_change_fraction',
+				'predicted_conversions_change_fraction' => 'price_insights.predicted_conversions_change_fraction',
+			]
+		);
+	}
+}

--- a/src/API/Google/Query/MerchantPriceSuggestionsQuery.php
+++ b/src/API/Google/Query/MerchantPriceSuggestionsQuery.php
@@ -49,7 +49,6 @@ class MerchantPriceSuggestionsQuery extends MerchantQuery {
 				'id'                                    => 'product_view.id',
 				'offer_id'                              => 'product_view.offer_id',
 				'title'                                 => 'product_view.title',
-				'brand'                                 => 'product_view.brand',
 				'price_micros'                          => 'product_view.price_micros',
 				'currency_code'                         => 'product_view.currency_code',
 				'suggested_price_micros'                => 'price_insights.suggested_price_micros',

--- a/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
@@ -7,10 +7,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseControl
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantPriceSuggestionsQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantPriceBenchmarks;
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
@@ -25,24 +23,6 @@ defined( 'ABSPATH' ) || exit;
 class PriceBenchmarksController extends BaseController implements ContainerAwareInterface {
 
 	use ContainerAwareTrait;
-
-	/**
-	 * Product helper class.
-	 *
-	 * @var ProductHelper
-	 */
-	protected $product_helper;
-
-	/**
-	 * Merchant Report constructor.
-	 *
-	 * @param RESTServer    $server
-	 * @param ProductHelper $product_helper
-	 */
-	public function __construct( RESTServer $server, ProductHelper $product_helper ) {
-		parent::__construct( $server );
-		$this->product_helper = $product_helper;
-	}
 
 	/**
 	 * Register rest routes with WordPress.
@@ -115,18 +95,35 @@ class PriceBenchmarksController extends BaseController implements ContainerAware
 		if ( empty( $benchmark_data['results'] ) || empty( $price_insights_data['results'] ) ) {
 			return $mapped_data;
 		}
-		// Loop through the benchmark data results.
+
+		// Process benchmark data and add it to $mapped_data keyed by product ID.
 		foreach ( $benchmark_data['results'] as $benchmark_result ) {
-			$product_view          = $benchmark_result['productView'];
-			$price_competitiveness = $benchmark_result['priceCompetitiveness'];
+			$product_view = $benchmark_result['productView'];
+			$product_id   = $this->get_product_id( $product_view['id'] );
 
-			// Find the matching price insights data by offer_id.
-			foreach ( $price_insights_data['results'] as $price_insights_result ) {
-				if ( $product_view['id'] !== $price_insights_result['productView']['id'] ) {
-					continue;
-				}
+			$mapped_data[ $product_id ] = [
+				'product_view'          => $product_view,
+				'price_competitiveness' => $benchmark_result['priceCompetitiveness'] ?? [],
+				'price_insights'        => [], // Placeholder for price insights data.
+			];
+		}
 
-				$price_insights = $price_insights_result['priceCompetitiveness'] ?? [];
+		// Process price insights data and merge it into $mapped_data.
+		foreach ( $price_insights_data['results'] as $price_insights_result ) {
+			$product_view = $price_insights_result['productView'];
+			$product_id   = $this->get_product_id( $product_view['id'] );
+
+			if ( isset( $mapped_data[ $product_id ] ) ) {
+				$mapped_data[ $product_id ]['price_insights'] = $price_insights_result['priceCompetitiveness'] ?? [];
+			}
+		}
+
+		// Transform $mapped_data into the desired response format using array_map.
+		$response_data = array_map(
+			function ( $data ) {
+				$product_view          = $data['product_view'];
+				$price_competitiveness = $data['price_competitiveness'];
+				$price_insights        = $data['price_insights'];
 
 				// Calculate the price gap.
 				$regular_price   = (int) $product_view['priceMicros'];
@@ -134,13 +131,13 @@ class PriceBenchmarksController extends BaseController implements ContainerAware
 				$price_gap       = $regular_price - $price_on_google;
 
 				// Get the WooCommerce product ID and thumbnail.
-				$product_id = $this->product_helper->get_wc_product_id( $product_view['id'] );
-				$thumbnail  = $this->get_product_thumbnail( $product_id );
+				$wc_product_id = $this->get_product_id( $product_view['id'] );
+				$thumbnail     = $this->get_product_thumbnail( $wc_product_id );
 
 				// Map the data to the required format.
-				$mapped_data[] = [
+				return [
 					'product'         => [
-						'id'        => $product_id,
+						'id'        => $wc_product_id,
 						'thumbnail' => $thumbnail,
 						'title'     => $product_view['title'],
 					],
@@ -152,10 +149,11 @@ class PriceBenchmarksController extends BaseController implements ContainerAware
 						? round( $price_insights['suggestedPriceMicros'] / 1000000, 2 )
 						: '',
 				];
-			}
-		}
+			},
+			$mapped_data
+		);
 
-		return $mapped_data;
+		return $response_data;
 	}
 
 	/**
@@ -174,6 +172,34 @@ class PriceBenchmarksController extends BaseController implements ContainerAware
 		$thumbnail_url = wp_get_attachment_url( $thumbnail_id );
 
 		return $thumbnail_url ?? '';
+	}
+
+	/**
+	 * Gets the product ID from the Google product ID.
+	 *
+	 * @param string $mc_product_id Simple product ID (`merchant_center_id`) or
+	 *                              namespaced product ID (`online:en:GB:merchant_center_id`)
+	 *
+	 * @return int the ID for the WC product linked to the provided Google product ID (0 if not found)
+	 */
+	public function get_product_id( string $mc_product_id ): int {
+		// Maybe remove everything before the last colon ':'
+		$mc_product_id_tokens = explode( ':', $mc_product_id );
+		$mc_product_id        = end( $mc_product_id_tokens );
+
+		// Support a fully numeric ID both with and without the `gla_` prefix.
+		$wc_product_id = 0;
+		$pattern       = '/^(' . preg_quote( $this->get_slug(), '/' ) . '_)?(\d+)$/';
+		if ( preg_match( $pattern, $mc_product_id, $matches ) ) {
+			$wc_product_id = (int) $matches[2];
+		}
+
+		/**
+		 * This filter is documented in ProductHelper::get_wc_product_id.
+		 *
+		 * @see ProductHelper::get_wc_product_id
+		 */
+		return (int) apply_filters( 'woocommerce_gla_get_wc_product_id', $wc_product_id, $mc_product_id );
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
@@ -69,11 +69,10 @@ class PriceBenchmarksController extends BaseController implements ContainerAware
 				/** @var MerchantPriceBenchmarks $merchant */
 				$merchant = $this->container->get( MerchantPriceBenchmarks::class );
 
-				$benchmark_data = $merchant->get_benchmark_data( $this->prepare_query_arguments( $request ) );
-				$benchmark_data = $this->prepare_item_for_response( $benchmark_data, $request );
-
+				$benchmark_data      = $merchant->get_benchmark_data( $this->prepare_query_arguments( $request ) );
 				$price_insights_data = $merchant->get_price_insights( $this->prepare_query_arguments( $request ) );
-				$price_insights_data = $this->prepare_item_for_response( $price_insights_data, $request );
+
+				// Here we need to map the data to the expected format and then send the results in the response.
 
 				return new Response(
 					[

--- a/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
@@ -28,9 +28,8 @@ class PriceBenchmarksController extends BaseController {
 			'mc/price-benchmarks',
 			[
 				[
-					'methods'             => TransportMethods::READABLE,
-					'callback'            => $this->get_price_benchmarks_callback(),
-					//'permission_callback' => $this->get_permission_callback(),
+					'methods'  => TransportMethods::READABLE,
+					'callback' => $this->get_price_benchmarks_callback(),
 				],
 				'schema' => $this->get_api_response_schema_callback(),
 			]
@@ -51,6 +50,7 @@ class PriceBenchmarksController extends BaseController {
 						'per_page'  => 10,
 					]
 				);
+
 				$response = $benchmarks_query
 					->set_client( $this->service, $merchant_id )
 					->get_results();
@@ -76,20 +76,23 @@ class PriceBenchmarksController extends BaseController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'product' => [
+			'product'         => [
 				'description' => __( 'Product details.', 'google-listings-and-ads' ),
 				'type'        => 'object',
 				'properties'  => [
 					'id'        => [ 'type' => 'integer' ],
-					'thumbnail' => [ 'type' => 'string', 'format' => 'uri' ],
+					'thumbnail' => [
+						'type'   => 'string',
+						'format' => 'uri',
+					],
 					'title'     => [ 'type' => 'string' ],
 				],
 			],
-			'effectiveness' => [
+			'effectiveness'   => [
 				'description' => __( 'Effectiveness score.', 'google-listings-and-ads' ),
 				'type'        => 'number',
 			],
-			'regular_price' => [
+			'regular_price'   => [
 				'description' => __( 'Regular price of the product.', 'google-listings-and-ads' ),
 				'type'        => 'number',
 			],
@@ -97,7 +100,7 @@ class PriceBenchmarksController extends BaseController {
 				'description' => __( 'Price of the product on Google.', 'google-listings-and-ads' ),
 				'type'        => 'number',
 			],
-			'price_gap' => [
+			'price_gap'       => [
 				'description' => __( 'Price gap between the regular price and the price on Google.', 'google-listings-and-ads' ),
 				'type'        => 'number',
 			],

--- a/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
@@ -32,8 +32,9 @@ class PriceBenchmarksController extends BaseController implements ContainerAware
 			'mc/price-benchmarks',
 			[
 				[
-					'methods'  => TransportMethods::READABLE,
-					'callback' => $this->get_price_benchmarks_callback(),
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_price_benchmarks_callback(),
+					'permission_callback' => $this->get_permission_callback(),
 				],
 				'schema' => $this->get_api_response_schema_callback(),
 			]

--- a/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
@@ -69,10 +69,10 @@ class PriceBenchmarksController extends BaseController implements ContainerAware
 				/** @var MerchantPriceBenchmarks $merchant */
 				$merchant = $this->container->get( MerchantPriceBenchmarks::class );
 
-				$benchmark_data = $merchant->get_benchmark_data( 'products', $this->prepare_query_arguments( $request ) );
+				$benchmark_data = $merchant->get_benchmark_data( $this->prepare_query_arguments( $request ) );
 				$benchmark_data = $this->prepare_item_for_response( $benchmark_data, $request );
 
-				$get_price_insights_product_view = $merchant->get_price_insights_product_view( 'products', $this->prepare_query_arguments( $request ) );
+				$get_price_insights_product_view = $merchant->get_price_insights_product_view( $this->prepare_query_arguments( $request ) );
 				$get_price_insights_product_view = $this->prepare_item_for_response( $get_price_insights_product_view, $request );
 
 				return new Response(

--- a/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
@@ -72,13 +72,13 @@ class PriceBenchmarksController extends BaseController implements ContainerAware
 				$benchmark_data = $merchant->get_benchmark_data( $this->prepare_query_arguments( $request ) );
 				$benchmark_data = $this->prepare_item_for_response( $benchmark_data, $request );
 
-				$get_price_insights_product_view = $merchant->get_price_insights_product_view( $this->prepare_query_arguments( $request ) );
-				$get_price_insights_product_view = $this->prepare_item_for_response( $get_price_insights_product_view, $request );
+				$get_price_insights = $merchant->get_price_insights( $this->prepare_query_arguments( $request ) );
+				$get_price_insights = $this->prepare_item_for_response( $get_price_insights, $request );
 
 				return new Response(
 					[
 						'price_benchmarks' => $benchmark_data,
-						'price_insights'   => $get_price_insights_product_view,
+						'price_insights'   => $get_price_insights,
 					]
 				);
 			} catch ( Exception $e ) {

--- a/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
@@ -99,40 +99,36 @@ class PriceBenchmarksController extends BaseController implements ContainerAware
 
 		// Process benchmark data and add it to $mapped_data keyed by product ID.
 		foreach ( $benchmark_data['results'] as $benchmark_result ) {
-			$product_view = $benchmark_result['productView'];
-			$product_id   = $this->get_product_id( $product_view['id'] );
+			$product_id = $benchmark_result['offer_id'];
 
 			$mapped_data[ $product_id ] = [
-				'product_view'          => $product_view,
-				'price_competitiveness' => $benchmark_result['priceCompetitiveness'] ?? [],
+				'price_competitiveness' => $benchmark_result ?? [],
 				'price_insights'        => [], // Placeholder for price insights data.
 			];
 		}
 
 		// Process price insights data and merge it into $mapped_data.
 		foreach ( $price_insights_data['results'] as $price_insights_result ) {
-			$product_view = $price_insights_result['productView'];
-			$product_id   = $this->get_product_id( $product_view['id'] );
+			$product_id = $price_insights_result['offer_id'];
 
 			if ( isset( $mapped_data[ $product_id ] ) ) {
-				$mapped_data[ $product_id ]['price_insights'] = $price_insights_result['priceCompetitiveness'] ?? [];
+				$mapped_data[ $product_id ]['price_insights'] = $price_insights_result ?? [];
 			}
 		}
 
 		// Transform $mapped_data into the desired response format using array_map.
 		$response_data = array_map(
 			function ( $data ) {
-				$product_view          = $data['product_view'];
 				$price_competitiveness = $data['price_competitiveness'];
 				$price_insights        = $data['price_insights'];
 
 				// Calculate the price gap.
-				$regular_price   = (int) $product_view['priceMicros'];
-				$price_on_google = (int) $price_competitiveness['benchmarkPriceMicros'];
+				$regular_price   = (int) $price_competitiveness['price_micros'];
+				$price_on_google = (int) $price_competitiveness['benchmark_price_micros'];
 				$price_gap       = $regular_price - $price_on_google;
 
 				// Get the WooCommerce product ID and thumbnail.
-				$wc_product_id = $this->get_product_id( $product_view['id'] );
+				$wc_product_id = (int) $price_competitiveness['offer_id'];
 				$thumbnail     = $this->get_product_thumbnail( $wc_product_id );
 
 				// Map the data to the required format.
@@ -140,14 +136,14 @@ class PriceBenchmarksController extends BaseController implements ContainerAware
 					'product'         => [
 						'id'        => $wc_product_id,
 						'thumbnail' => $thumbnail,
-						'title'     => $product_view['title'],
+						'title'     => $price_competitiveness['title'],
 					],
 					'effectiveness'   => $price_insights['effectiveness'] ?? '',
 					'regular_price'   => round( $regular_price / 1000000, 2 ),
 					'price_on_google' => round( $price_on_google / 1000000, 2 ),
 					'price_gap'       => round( $price_gap / 1000000, 2 ),
-					'suggested_price' => isset( $price_insights['suggestedPriceMicros'] )
-						? round( $price_insights['suggestedPriceMicros'] / 1000000, 2 )
+					'suggested_price' => isset( $price_insights['suggested_price_micros'] )
+						? round( $price_insights['suggested_price_micros'] / 1000000, 2 )
 						: '',
 				];
 			},
@@ -173,34 +169,6 @@ class PriceBenchmarksController extends BaseController implements ContainerAware
 		$thumbnail_url = wp_get_attachment_url( $thumbnail_id );
 
 		return $thumbnail_url ?? '';
-	}
-
-	/**
-	 * Gets the product ID from the Google product ID.
-	 *
-	 * @param string $mc_product_id Simple product ID (`merchant_center_id`) or
-	 *                              namespaced product ID (`online:en:GB:merchant_center_id`)
-	 *
-	 * @return int the ID for the WC product linked to the provided Google product ID (0 if not found)
-	 */
-	public function get_product_id( string $mc_product_id ): int {
-		// Maybe remove everything before the last colon ':'
-		$mc_product_id_tokens = explode( ':', $mc_product_id );
-		$mc_product_id        = end( $mc_product_id_tokens );
-
-		// Support a fully numeric ID both with and without the `gla_` prefix.
-		$wc_product_id = 0;
-		$pattern       = '/^(' . preg_quote( $this->get_slug(), '/' ) . '_)?(\d+)$/';
-		if ( preg_match( $pattern, $mc_product_id, $matches ) ) {
-			$wc_product_id = (int) $matches[2];
-		}
-
-		/**
-		 * This filter is documented in ProductHelper::get_wc_product_id.
-		 *
-		 * @see ProductHelper::get_wc_product_id
-		 */
-		return (int) apply_filters( 'woocommerce_gla_get_wc_product_id', $wc_product_id, $mc_product_id );
 	}
 
 	/**

--- a/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
@@ -72,13 +72,13 @@ class PriceBenchmarksController extends BaseController implements ContainerAware
 				$benchmark_data = $merchant->get_benchmark_data( $this->prepare_query_arguments( $request ) );
 				$benchmark_data = $this->prepare_item_for_response( $benchmark_data, $request );
 
-				$get_price_insights = $merchant->get_price_insights( $this->prepare_query_arguments( $request ) );
-				$get_price_insights = $this->prepare_item_for_response( $get_price_insights, $request );
+				$price_insights_data = $merchant->get_price_insights( $this->prepare_query_arguments( $request ) );
+				$price_insights_data = $this->prepare_item_for_response( $price_insights_data, $request );
 
 				return new Response(
 					[
 						'price_benchmarks' => $benchmark_data,
-						'price_insights'   => $get_price_insights,
+						'price_insights'   => $price_insights_data,
 					]
 				);
 			} catch ( Exception $e ) {

--- a/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
@@ -1,0 +1,121 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantPriceBenchmarksQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantPriceSuggestionsQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class PriceBenchmarksController
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
+ */
+class PriceBenchmarksController extends BaseController {
+
+	use OptionsAwareTrait;
+
+	/**
+	 * Register rest routes with WordPress.
+	 */
+	public function register_routes(): void {
+		$this->register_route(
+			'mc/price-benchmarks',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_price_benchmarks_callback(),
+					//'permission_callback' => $this->get_permission_callback(),
+				],
+				'schema' => $this->get_api_response_schema_callback(),
+			]
+		);
+	}
+
+	/**
+	 * Get the callback function for the price benchmarks request.
+	 *
+	 * @return callable
+	 */
+	protected function get_price_benchmarks_callback(): callable {
+		return function () {
+			try {
+				$benchmarks_query = new MerchantPriceBenchmarksQuery(
+					[
+						'next_page' => 2,
+						'per_page'  => 10,
+					]
+				);
+				$response = $benchmarks_query
+					->set_client( $this->service, $merchant_id )
+					->get_results();
+
+				return rest_ensure_response( $response );
+			} catch ( \Exception $e ) {
+				return new \WP_Error(
+					'price_benchmarks_error',
+					__( 'Failed to fetch price benchmarks.', 'google-listings-and-ads' ),
+					[
+						'status'  => 500,
+						'message' => $e->getMessage(),
+					]
+				);
+			}
+		};
+	}
+
+	/**
+	 * Get the schema for settings endpoints.
+	 *
+	 * @return array
+	 */
+	protected function get_schema_properties(): array {
+		return [
+			'product' => [
+				'description' => __( 'Product details.', 'google-listings-and-ads' ),
+				'type'        => 'object',
+				'properties'  => [
+					'id'        => [ 'type' => 'integer' ],
+					'thumbnail' => [ 'type' => 'string', 'format' => 'uri' ],
+					'title'     => [ 'type' => 'string' ],
+				],
+			],
+			'effectiveness' => [
+				'description' => __( 'Effectiveness score.', 'google-listings-and-ads' ),
+				'type'        => 'number',
+			],
+			'regular_price' => [
+				'description' => __( 'Regular price of the product.', 'google-listings-and-ads' ),
+				'type'        => 'number',
+			],
+			'price_on_google' => [
+				'description' => __( 'Price of the product on Google.', 'google-listings-and-ads' ),
+				'type'        => 'number',
+			],
+			'price_gap' => [
+				'description' => __( 'Price gap between the regular price and the price on Google.', 'google-listings-and-ads' ),
+				'type'        => 'number',
+			],
+			'suggested_price' => [
+				'description' => __( 'Suggested price for the product.', 'google-listings-and-ads' ),
+				'type'        => 'number',
+			],
+		];
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * Used for building the API response schema.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'price_benchmarks';
+	}
+}

--- a/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
@@ -5,9 +5,13 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantPriceBenchmarksQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantPriceSuggestionsQuery;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantPriceBenchmarks;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Exception;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -16,9 +20,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
  */
-class PriceBenchmarksController extends BaseController {
+class PriceBenchmarksController extends BaseController implements ContainerAwareInterface {
 
-	use OptionsAwareTrait;
+	use ContainerAwareTrait;
 
 	/**
 	 * Register rest routes with WordPress.
@@ -37,34 +41,48 @@ class PriceBenchmarksController extends BaseController {
 	}
 
 	/**
+	 * Maps query arguments from the REST request.
+	 *
+	 * @param Request $request REST Request.
+	 * @return array
+	 */
+	protected function prepare_query_arguments( Request $request ): array {
+		$args = wp_parse_args(
+			array_intersect_key(
+				$request->get_query_params(),
+				$this->get_collection_params()
+			),
+			$request->get_default_params()
+		);
+
+		return $args;
+	}
+
+	/**
 	 * Get the callback function for the price benchmarks request.
 	 *
 	 * @return callable
 	 */
 	protected function get_price_benchmarks_callback(): callable {
-		return function () {
+		return function ( Request $request ) {
 			try {
-				$benchmarks_query = new MerchantPriceBenchmarksQuery(
+				/** @var MerchantPriceBenchmarks $merchant */
+				$merchant = $this->container->get( MerchantPriceBenchmarks::class );
+
+				$benchmark_data = $merchant->get_benchmark_data( 'products', $this->prepare_query_arguments( $request ) );
+				$benchmark_data = $this->prepare_item_for_response( $benchmark_data, $request );
+
+				$get_price_insights_product_view = $merchant->get_price_insights_product_view( 'products', $this->prepare_query_arguments( $request ) );
+				$get_price_insights_product_view = $this->prepare_item_for_response( $get_price_insights_product_view, $request );
+
+				return new Response(
 					[
-						'next_page' => 2,
-						'per_page'  => 10,
+						'price_benchmarks' => $benchmark_data,
+						'price_insights'   => $get_price_insights_product_view,
 					]
 				);
-
-				$response = $benchmarks_query
-					->set_client( $this->service, $merchant_id )
-					->get_results();
-
-				return rest_ensure_response( $response );
-			} catch ( \Exception $e ) {
-				return new \WP_Error(
-					'price_benchmarks_error',
-					__( 'Failed to fetch price benchmarks.', 'google-listings-and-ads' ),
-					[
-						'status'  => 500,
-						'message' => $e->getMessage(),
-					]
-				);
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
 			}
 		};
 	}

--- a/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
+++ b/src/API/Site/Controllers/MerchantCenter/PriceBenchmarksController.php
@@ -7,8 +7,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseControl
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantPriceSuggestionsQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantPriceBenchmarks;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
@@ -23,6 +25,24 @@ defined( 'ABSPATH' ) || exit;
 class PriceBenchmarksController extends BaseController implements ContainerAwareInterface {
 
 	use ContainerAwareTrait;
+
+	/**
+	 * Product helper class.
+	 *
+	 * @var ProductHelper
+	 */
+	protected $product_helper;
+
+	/**
+	 * Merchant Report constructor.
+	 *
+	 * @param RESTServer    $server
+	 * @param ProductHelper $product_helper
+	 */
+	public function __construct( RESTServer $server, ProductHelper $product_helper ) {
+		parent::__construct( $server );
+		$this->product_helper = $product_helper;
+	}
 
 	/**
 	 * Register rest routes with WordPress.
@@ -72,18 +92,88 @@ class PriceBenchmarksController extends BaseController implements ContainerAware
 				$benchmark_data      = $merchant->get_benchmark_data( $this->prepare_query_arguments( $request ) );
 				$price_insights_data = $merchant->get_price_insights( $this->prepare_query_arguments( $request ) );
 
-				// Here we need to map the data to the expected format and then send the results in the response.
+				// Map the data to the required format.
+				$response_data = $this->map_price_benchmarks_response( $benchmark_data, $price_insights_data );
 
-				return new Response(
-					[
-						'price_benchmarks' => $benchmark_data,
-						'price_insights'   => $price_insights_data,
-					]
-				);
+				return new Response( $response_data );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}
 		};
+	}
+
+	/**
+	 * Maps the benchmark and price insights data to the required API response format.
+	 *
+	 * @param array $benchmark_data Raw benchmark data.
+	 * @param array $price_insights_data Raw price insights data.
+	 * @return array Mapped response data.
+	 */
+	protected function map_price_benchmarks_response( array $benchmark_data, array $price_insights_data ): array {
+		$mapped_data = [];
+
+		if ( empty( $benchmark_data['results'] ) || empty( $price_insights_data['results'] ) ) {
+			return $mapped_data;
+		}
+		// Loop through the benchmark data results.
+		foreach ( $benchmark_data['results'] as $benchmark_result ) {
+			$product_view          = $benchmark_result['productView'];
+			$price_competitiveness = $benchmark_result['priceCompetitiveness'];
+
+			// Find the matching price insights data by offer_id.
+			foreach ( $price_insights_data['results'] as $price_insights_result ) {
+				if ( $product_view['id'] !== $price_insights_result['productView']['id'] ) {
+					continue;
+				}
+
+				$price_insights = $price_insights_result['priceCompetitiveness'] ?? [];
+
+				// Calculate the price gap.
+				$regular_price   = (int) $product_view['priceMicros'];
+				$price_on_google = (int) $price_competitiveness['benchmarkPriceMicros'];
+				$price_gap       = $regular_price - $price_on_google;
+
+				// Get the WooCommerce product ID and thumbnail.
+				$product_id = $this->product_helper->get_wc_product_id( $product_view['id'] );
+				$thumbnail  = $this->get_product_thumbnail( $product_id );
+
+				// Map the data to the required format.
+				$mapped_data[] = [
+					'product'         => [
+						'id'        => $product_id,
+						'thumbnail' => $thumbnail,
+						'title'     => $product_view['title'],
+					],
+					'effectiveness'   => $price_insights['effectiveness'] ?? '',
+					'regular_price'   => round( $regular_price / 1000000, 2 ),
+					'price_on_google' => round( $price_on_google / 1000000, 2 ),
+					'price_gap'       => round( $price_gap / 1000000, 2 ),
+					'suggested_price' => isset( $price_insights['suggestedPriceMicros'] )
+						? round( $price_insights['suggestedPriceMicros'] / 1000000, 2 )
+						: '',
+				];
+			}
+		}
+
+		return $mapped_data;
+	}
+
+	/**
+	 * Retrieves the product thumbnail URL.
+	 *
+	 * @param int $product_id WooCommerce product ID.
+	 * @return string|null Product thumbnail URL or null if not found.
+	 */
+	protected function get_product_thumbnail( int $product_id ): ?string {
+		$thumbnail_id = get_post_thumbnail_id( $product_id );
+
+		if ( ! $thumbnail_id ) {
+			return '';
+		}
+
+		$thumbnail_url = wp_get_attachment_url( $thumbnail_id );
+
+		return $thumbnail_url ?? '';
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -18,6 +18,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantReport;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantPriceBenchmarks;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
@@ -121,6 +122,8 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( Merchant::class, ShoppingContent::class );
 		$this->share( MerchantMetrics::class, ShoppingContent::class, GoogleAdsClient::class, WP::class, TransientsInterface::class );
 		$this->share( MerchantReport::class, ShoppingContent::class, ProductHelper::class );
+
+		$this->share( MerchantPriceBenchmarks::class, ShoppingContent::class, ProductHelper::class );
 
 		$this->share( SiteVerification::class );
 

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -123,7 +123,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( MerchantMetrics::class, ShoppingContent::class, GoogleAdsClient::class, WP::class, TransientsInterface::class );
 		$this->share( MerchantReport::class, ShoppingContent::class, ProductHelper::class );
 
-		$this->share( MerchantPriceBenchmarks::class, ShoppingContent::class, ProductHelper::class );
+		$this->share( MerchantPriceBenchmarks::class, ShoppingContent::class );
 
 		$this->share( SiteVerification::class );
 

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -144,7 +144,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( TourController::class );
 		$this->share( RestAPIAuthController::class, OAuthService::class, MerchantAccountService::class );
 		$this->share( GTINMigrationController::class, JobRepository::class );
-		$this->share( PriceBenchmarksController::class );
+		$this->share( PriceBenchmarksController::class, ProductHelper::class );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -51,6 +51,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCen
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SupportedCountriesController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SyncableProductsCountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\TargetAudienceController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\PriceBenchmarksController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestAPI\AuthController as RestAPIAuthController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\OAuthService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
@@ -143,6 +144,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( TourController::class );
 		$this->share( RestAPIAuthController::class, OAuthService::class, MerchantAccountService::class );
 		$this->share( GTINMigrationController::class, JobRepository::class );
+		$this->share( PriceBenchmarksController::class );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -144,7 +144,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( TourController::class );
 		$this->share( RestAPIAuthController::class, OAuthService::class, MerchantAccountService::class );
 		$this->share( GTINMigrationController::class, JobRepository::class );
-		$this->share( PriceBenchmarksController::class, ProductHelper::class );
+		$this->share( PriceBenchmarksController::class );
 	}
 
 	/**

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
@@ -41,49 +41,43 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_get_price_benchmarks() {
-		$product_id    = 123456;
+		$product_id    = '123456';
 		$product_title = "UGG Women's s Classic Mini";
 
 		// Mock the benchmark data.
 		$mock_benchmark_data = [
-			'results'       => [
+			'results'         => [
 				[
-					'productView'          => [
-						'id'           => 'online:en:US:gla_' . $product_id,
-						'title'        => $product_title,
-						'priceMicros'  => '124990000',
-						'currencyCode' => 'USD',
-					],
-					'priceCompetitiveness' => [
-						'countryCode'                => 'US',
-						'benchmarkPriceMicros'       => '119922291',
-						'benchmarkPriceCurrencyCode' => 'USD',
-					],
+					'id'                            => 'online:en:US:gla_' . $product_id,
+					'offer_id'                      => $product_id,
+					'title'                         => $product_title,
+					'price_micros'                  => '124990000',
+					'currency_code'                 => 'USD',
+					'benchmark_price_micros'        => '119922291',
+					'benchmark_price_currency_code' => 'USD',
 				],
 			],
-			'nextPageToken' => 'next_page_token',
+			'next_page_token' => 'next_page_token',
 		];
 
 		// Mock the price insights data.
 		$mock_price_insights_data = [
-			'results'       => [
+			'results'         => [
 				[
-					'productView'          => [
-						'id'           => 'online:en:US:gla_' . $product_id,
-						'priceMicros'  => '124990000',
-						'currencyCode' => 'USD',
-					],
-					'priceCompetitiveness' => [
-						'suggestedPriceMicros'          => '118990000',
-						'suggestedPriceCurrencyCode'    => 'US',
-						'predictedImpressionsChangeFraction' => '0.12609300017356873',
-						'predictedClicksChangeFraction' => '0.508745014667511',
-						'predictedConversionsChangeFraction' => '2.3431060314178467',
-						'effectiveness'                 => 3,
-					],
+
+					'id'                               => 'online:en:US:gla_' . $product_id,
+					'offer_id'                         => $product_id,
+					'price_micros'                     => '124990000',
+					'currency_code'                    => 'USD',
+					'suggested_price_micros'           => '118990000',
+					'suggested_price_currency_code'    => 'US',
+					'predicted_impressions_change_fraction' => '0.12609300017356873',
+					'predicted_clicks_change_fraction' => '0.508745014667511',
+					'predicted_conversions_change_fraction' => '2.3431060314178467',
+					'effectiveness'                    => 3,
 				],
 			],
-			'nextPageToken' => 'next_page_token',
+			'next_page_token' => 'next_page_token',
 		];
 
 		// Configure the mocked methods.
@@ -102,7 +96,7 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 		$expected = [
 			[
 				'product'         => [
-					'id'        => $product_id,
+					'id'        => (int) $product_id,
 					'thumbnail' => '', // The thumbnail URL of the ID.
 					'title'     => $product_title,
 				],

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
@@ -17,9 +17,6 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 	/** @var PriceBenchmarksController */
 	protected $controller;
 
-	/** @var Stub|ProductHelper $product_helper */
-	protected $product_helper;
-
 	/** @var MockObject|MerchantPriceBenchmarks */
 	protected $merchant_price_benchmarks;
 
@@ -31,22 +28,20 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->product_helper            = $this->createMock( ProductHelper::class );
 		$this->merchant_price_benchmarks = $this->createMock( MerchantPriceBenchmarks::class );
 
 		// Mock the container to return the mocked MerchantPriceBenchmarks.
 		$this->container = new Container();
 		$this->container->addShared( MerchantPriceBenchmarks::class, $this->merchant_price_benchmarks );
-		$this->container->addShared( PriceBenchmarksController::class, $this->product_helper );
 
 		// Initialize the controller.
-		$this->controller = new PriceBenchmarksController( $this->server, $this->product_helper );
+		$this->controller = new PriceBenchmarksController( $this->server );
 		$this->controller->set_container( $this->container );
 		$this->controller->register();
 	}
 
 	public function test_get_price_benchmarks() {
-		$product_id    = '123456';
+		$product_id    = 123456;
 		$product_title = "UGG Women's s Classic Mini";
 
 		// Mock the benchmark data.

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\PriceBenchmarksController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantPriceBenchmarks;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use WP_REST_Request as Request;
@@ -16,6 +17,9 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 	/** @var PriceBenchmarksController */
 	protected $controller;
 
+	/** @var Stub|ProductHelper $product_helper */
+	protected $product_helper;
+
 	/** @var MockObject|MerchantPriceBenchmarks */
 	protected $merchant_price_benchmarks;
 
@@ -27,14 +31,16 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
+		$this->product_helper            = $this->createMock( ProductHelper::class );
 		$this->merchant_price_benchmarks = $this->createMock( MerchantPriceBenchmarks::class );
 
 		// Mock the container to return the mocked MerchantPriceBenchmarks.
 		$this->container = new Container();
 		$this->container->addShared( MerchantPriceBenchmarks::class, $this->merchant_price_benchmarks );
+		$this->container->addShared( PriceBenchmarksController::class, $this->product_helper );
 
 		// Initialize the controller.
-		$this->controller = new PriceBenchmarksController( $this->server );
+		$this->controller = new PriceBenchmarksController( $this->server, $this->product_helper );
 		$this->controller->set_container( $this->container );
 		$this->controller->register();
 	}
@@ -48,7 +54,7 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 			'results'       => [
 				[
 					'productView'          => [
-						'id'           => 'online:en:US:' . $product_id,
+						'id'           => 'online:en:US:gla_' . $product_id,
 						'offer_id'     => $product_id,
 						'title'        => $product_title,
 						'priceMicros'  => '124990000',
@@ -69,7 +75,7 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 			'results'       => [
 				[
 					'productView'          => [
-						'id'           => 'online:en:US:' . $product_id,
+						'id'           => 'online:en:US:gla_' . $product_id,
 						'offer_id'     => $product_id,
 						'priceMicros'  => '124990000',
 						'currencyCode' => 'USD',
@@ -80,7 +86,7 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 						'predictedImpressionsChangeFraction' => '0.12609300017356873',
 						'predictedClicksChangeFraction' => '0.508745014667511',
 						'predictedConversionsChangeFraction' => '2.3431060314178467',
-						'effectiveness'                 => '3',
+						'effectiveness'                 => 3,
 					],
 				],
 			],
@@ -113,20 +119,20 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 					'thumbnail' => '', // The thumbnail URL of the ID.
 					'title'     => $product_title,
 				],
-				'regular_price'   => '$124.99', // Not sure the formatting here.
-				'price_on_google' => '$119.92', // Converted from micros.
-				'price_gap'       => '$5.07', // Reg price - Price on Google, Converted from micros.
-				'suggested_price' => '$118.99', // Converted from micros.
 				'effectiveness'   => 3,
+				'regular_price'   => 124.99,
+				'price_on_google' => 119.92, // Converted from micros.
+				'price_gap'       => 5.07, // Reg price - Price on Google, Converted from micros.
+				'suggested_price' => 118.99, // Converted from micros.
 			],
 		];
 
 		// Assert the response status.
 		$this->assertEquals( 200, $response->get_status() );
 
-		$this->assertSameSets( $current, $response->get_data(), 'The current implementation is returning this shape.' );
+		//$this->assertSameSets( $current, $response->get_data(), 'The current implementation is returning this shape.' );
 
 		// The expected shape should pass once the implementation is updated.
-		// $this->assertSameSets( $expected, $response->get_data(), 'The response data should match the expected structure.' );
+		$this->assertSameSets( $expected, $response->get_data(), 'The response data should match the expected structure.' );
 	}
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
@@ -105,12 +105,6 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 		// Simulate a GET request.
 		$response = $this->do_request( self::ROUTE_PRICE_BENCHMARKS, 'GET' );
 
-		// Current shape.
-		$current = [
-			'price_benchmarks' => $mock_benchmark_data,
-			'price_insights'   => $mock_price_insights_data,
-		];
-
 		// Expected shape once data from the two queries are stitched together.
 		$expected = [
 			[
@@ -129,8 +123,6 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 
 		// Assert the response status.
 		$this->assertEquals( 200, $response->get_status() );
-
-		//$this->assertSameSets( $current, $response->get_data(), 'The current implementation is returning this shape.' );
 
 		// The expected shape should pass once the implementation is updated.
 		$this->assertSameSets( $expected, $response->get_data(), 'The response data should match the expected structure.' );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
@@ -50,7 +50,6 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 				[
 					'productView'          => [
 						'id'           => 'online:en:US:gla_' . $product_id,
-						'offer_id'     => $product_id,
 						'title'        => $product_title,
 						'priceMicros'  => '124990000',
 						'currencyCode' => 'USD',
@@ -71,7 +70,6 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 				[
 					'productView'          => [
 						'id'           => 'online:en:US:gla_' . $product_id,
-						'offer_id'     => $product_id,
 						'priceMicros'  => '124990000',
 						'currencyCode' => 'USD',
 					],

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
@@ -1,0 +1,79 @@
+<?php
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\PriceBenchmarksController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantPriceBenchmarks;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+
+class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
+
+	/** @var PriceBenchmarksController */
+	protected $controller;
+
+	/** @var MockObject|MerchantPriceBenchmarks */
+	protected $merchant;
+
+	/** @var ContainerInterface */
+	protected $container;
+
+	protected const ROUTE_PRICE_BENCHMARKS = '/wc/gla/mc/price-benchmarks';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// Mock the MerchantPriceBenchmarks dependency.
+		$this->merchant = $this->createMock( MerchantPriceBenchmarks::class );
+
+		// Mock the container to return the mocked MerchantPriceBenchmarks.
+		$this->container = $this->createMock( ContainerInterface::class );
+		$this->container->method( 'get' )
+			->with( MerchantPriceBenchmarks::class )
+			->willReturn( $this->merchant );
+
+		// Initialize the controller.
+		$this->controller = new PriceBenchmarksController( $this->server );
+		$this->controller->set_container( $this->container );
+		$this->controller->register_routes();
+	}
+
+	public function test_get_price_benchmarks() {
+		// Mock the benchmark data.
+		$mock_benchmark_data = [
+			'id'                     => 'product_1',
+			'title'                  => 'Product 1',
+			'price_micros'           => 1000000,
+			'benchmark_price_micros' => 1200000,
+			'currency_code'          => 'USD',
+		];
+
+		// Mock the price insights data.
+		$mock_price_insights_data = [
+			'id'              => 'product_1',
+			'suggested_price' => 950000,
+			'price_gap'       => -50000,
+		];
+
+		// Configure the mocked methods.
+		$this->merchant->method( 'get_benchmark_data' )
+			->willReturn( $mock_benchmark_data );
+
+		$this->merchant->method( 'get_price_insights' )
+			->willReturn( $mock_price_insights_data );
+
+		// Simulate a GET request.
+		$response = $this->do_request( self::ROUTE_PRICE_BENCHMARKS, 'GET' );
+
+		// Assert the response status.
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Assert the response data.
+		// $this->assertEquals(
+		//     [
+		//         'price_benchmarks' => $mock_benchmark_data,
+		//         'price_insights'   => $mock_price_insights_data,
+		//     ],
+		//     $response->get_data()
+		// );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
@@ -2,19 +2,24 @@
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\PriceBenchmarksController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantPriceBenchmarks;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 
+/**
+ * Test class for PriceBenchmarksController.
+ *
+ * @group price-benchmarks
+ */
 class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 
 	/** @var PriceBenchmarksController */
 	protected $controller;
 
 	/** @var MockObject|MerchantPriceBenchmarks */
-	protected $merchant;
+	protected $merchant_price_benchmarks;
 
-	/** @var ContainerInterface */
+	/** @var Container */
 	protected $container;
 
 	protected const ROUTE_PRICE_BENCHMARKS = '/wc/gla/mc/price-benchmarks';
@@ -22,49 +27,106 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		// Mock the MerchantPriceBenchmarks dependency.
-		$this->merchant = $this->createMock( MerchantPriceBenchmarks::class );
+		$this->merchant_price_benchmarks = $this->createMock( MerchantPriceBenchmarks::class );
 
 		// Mock the container to return the mocked MerchantPriceBenchmarks.
-		$this->container = $this->createMock( ContainerInterface::class );
-		$this->container->method( 'get' )
-			->with( MerchantPriceBenchmarks::class )
-			->willReturn( $this->merchant );
+		$this->container = new Container();
+		$this->container->addShared( MerchantPriceBenchmarks::class, $this->merchant_price_benchmarks );
 
 		// Initialize the controller.
 		$this->controller = new PriceBenchmarksController( $this->server );
 		$this->controller->set_container( $this->container );
-		$this->controller->register_routes();
+		$this->controller->register();
 	}
 
 	public function test_get_price_benchmarks() {
+		$product_id    = '123456';
+		$product_title = "UGG Women's s Classic Mini";
+
 		// Mock the benchmark data.
 		$mock_benchmark_data = [
-			'id'                     => 'product_1',
-			'title'                  => 'Product 1',
-			'price_micros'           => 1000000,
-			'benchmark_price_micros' => 1200000,
-			'currency_code'          => 'USD',
+			'results'       => [
+				[
+					'productView'          => [
+						'id'           => 'online:en:US:' . $product_id,
+						'offer_id'     => $product_id,
+						'title'        => $product_title,
+						'priceMicros'  => '124990000',
+						'currencyCode' => 'USD',
+					],
+					'priceCompetitiveness' => [
+						'countryCode'                => 'US',
+						'benchmarkPriceMicros'       => '119922291',
+						'benchmarkPriceCurrencyCode' => 'USD',
+					],
+				],
+			],
+			'nextPageToken' => 'next_page_token',
 		];
 
 		// Mock the price insights data.
 		$mock_price_insights_data = [
-			'id'              => 'product_1',
-			'suggested_price' => 950000,
-			'price_gap'       => -50000,
+			'results'       => [
+				[
+					'productView'          => [
+						'id'           => 'online:en:US:' . $product_id,
+						'offer_id'     => $product_id,
+						'priceMicros'  => '124990000',
+						'currencyCode' => 'USD',
+					],
+					'priceCompetitiveness' => [
+						'suggestedPriceMicros'          => '118990000',
+						'suggestedPriceCurrencyCode'    => 'US',
+						'predictedImpressionsChangeFraction' => '0.12609300017356873',
+						'predictedClicksChangeFraction' => '0.508745014667511',
+						'predictedConversionsChangeFraction' => '2.3431060314178467',
+						'effectiveness'                 => '3',
+					],
+				],
+			],
+			'nextPageToken' => 'next_page_token',
 		];
 
 		// Configure the mocked methods.
-		$this->merchant->method( 'get_benchmark_data' )
+		$this->merchant_price_benchmarks->expects( $this->once() )
+			->method( 'get_benchmark_data' )
 			->willReturn( $mock_benchmark_data );
 
-		$this->merchant->method( 'get_price_insights' )
+		$this->merchant_price_benchmarks->expects( $this->once() )
+			->method( 'get_price_insights' )
 			->willReturn( $mock_price_insights_data );
 
 		// Simulate a GET request.
 		$response = $this->do_request( self::ROUTE_PRICE_BENCHMARKS, 'GET' );
 
+		// Current shape.
+		$current = [
+			'price_benchmarks' => $mock_benchmark_data,
+			'price_insights'   => $mock_price_insights_data,
+		];
+
+		// Expected shape once data from the two queries are stitched together.
+		$expected = [
+			[
+				'product'         => [
+					'id'        => $product_id,
+					'thumbnail' => '', // The thumbnail URL of the ID.
+					'title'     => $product_title,
+				],
+				'regular_price'   => '$124.99', // Not sure the formatting here.
+				'price_on_google' => '$119.92', // Converted from micros.
+				'price_gap'       => '$5.07', // Reg price - Price on Google, Converted from micros.
+				'suggested_price' => '$118.99', // Converted from micros.
+				'effectiveness'   => 3,
+			],
+		];
+
 		// Assert the response status.
 		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertSameSets( $current, $response->get_data(), 'The current implementation is returning this shape.' );
+
+		// The expected shape should pass once the implementation is updated.
+		// $this->assertSameSets( $expected, $response->get_data(), 'The response data should match the expected structure.' );
 	}
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
@@ -66,14 +66,5 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 
 		// Assert the response status.
 		$this->assertEquals( 200, $response->get_status() );
-
-		// Assert the response data.
-		// $this->assertEquals(
-		//     [
-		//         'price_benchmarks' => $mock_benchmark_data,
-		//         'price_insights'   => $mock_price_insights_data,
-		//     ],
-		//     $response->get_data()
-		// );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2825.

This PR add the support for getting price benchmarks & suggestions from the Content API.

### Detailed test instructions:
- Comment the permission callback. Revert https://github.com/woocommerce/google-listings-and-ads/pull/2838/commits/e9f8b78f9a2e9c678088848ee50fd077ba976a25 changes in your local setup.
- Check the Rest API response. Call `siteurl/index.php?rest_route=/wc/gla/mc/price-benchmarks/` (It return empty array as MC account didn't have any approved products.)



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
