### PR TITLE
Fix the issue where a Notifications Schedule E2E test was not rescheduling a job correctly

### DIFF
--- a/tests/e2e/specs/notifications/notifications-schedule.test.js
+++ b/tests/e2e/specs/notifications/notifications-schedule.test.js
@@ -35,7 +35,7 @@ let productEditor = null;
 let page = null;
 
 const actionSchedulerLink =
-	'wp-admin/admin.php?page=wc-status&tab=action-scheduler&orderby=schedule&order=desc';
+	'wp-admin/admin.php?page=wc-status&tab=action-scheduler&orderby=schedule&order=desc&s=gla%2Fjobs%2Fnotifications';
 
 const getASJobRowName = ( itemId, notificationType, status = 'Pending' ) => {
 	return `gla/jobs/notifications/products/process_item Run | Cancel ${ status } 0 => array ( 'item_id' => ${ itemId }, 'topic' => '${ notificationType }'`;

--- a/tests/e2e/specs/notifications/notifications-schedule.test.js
+++ b/tests/e2e/specs/notifications/notifications-schedule.test.js
@@ -184,13 +184,25 @@ test.describe( 'Notifications Schedule', () => {
 		await productEditor.publish();
 		const id = productEditor.getPostID();
 
+		// Run the scheduled product.create job so that the subsequent product.create job
+		// being rescheduled won't be skipped due to the existence of the same job.
+		await page.goto( actionSchedulerLink );
+		let row = page.getByRole( 'row', {
+			name: getASJobRowName( id, 'product.create' ),
+		} );
+		await expect( row ).toBeVisible();
+		await row.hover( { force: true } );
+		await row.getByRole( 'link' ).first().click();
+		await page.waitForURL( actionSchedulerLink );
+		await expect( row ).not.toBeVisible();
+
 		await productEditor.gotoEditProductPage( id );
 		await productEditor.mockNotificationStatus( 'created' );
 		await productEditor.unpublish();
 
 		// Check the product.update job is scheduled.
 		await page.goto( actionSchedulerLink );
-		let row = page.getByRole( 'row', {
+		row = page.getByRole( 'row', {
 			name: getASJobRowName( id, 'product.delete' ),
 		} );
 		await expect( row ).toBeVisible();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the issue where a Notifications Schedule E2E test was not rescheduling a job correctly.
- Test case: "Unpublish a notified product schedules product.delete notification."
- The test is expected to match the (second) `'product.create'` job rescheduled after the `'product.delete'` job when checking for a rescheduled job. However, it accidentally matches the first `'product.create'` job and results in a false negative result.
- In addition, filter hook name to reduce the chance that the matching target is not on the first page.

See the **Additional details** section for more details

### Detailed test instructions:

1. Check if the E2E test can pass with WooCommerce 9.8.0-rc.1
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/14329539720/job/40162181430
2. Check if the E2E test can pass with WooCommerce 9.7.1
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/14329911619/job/40163343776

### Additional details:

https://github.com/woocommerce/google-listings-and-ads/blob/d2c61835e6961a5355b8fce5a2fa7ae408fc3b6a/tests/e2e/specs/notifications/notifications-schedule.test.js#L181-L209

The above test case failed when running E2E test with WC 9.8.0-rc.1. See https://github.com/woocommerce/google-listings-and-ads/actions/runs/14214677442/job/39832818951

In the past, the test case could pass because it accidentally matches the `'product.create'` job scheduled before the `'product.delete'` job.

![1](https://github.com/user-attachments/assets/8b56d1b7-b75c-413f-9ae9-447305f6b419)

However, the test case is expected to match the (second) `'product.create'` job rescheduled after the `'product.delete'` job. The second job was not scheduled because the `AbstractActionSchedulerJob` checks if there is the same job running before scheduling.

https://github.com/woocommerce/google-listings-and-ads/blob/d2c61835e6961a5355b8fce5a2fa7ae408fc3b6a/src/Jobs/AbstractActionSchedulerJob.php#L67-L69

https://github.com/woocommerce/google-listings-and-ads/blob/d2c61835e6961a5355b8fce5a2fa7ae408fc3b6a/src/Jobs/AbstractActionSchedulerJob.php#L111-L113

With WC 9.8.0-rc.1, there are more jobs when mutating a product, so the accidentally matched `'product.create'` job is on the second page, which leads to test failure.

![2](https://github.com/user-attachments/assets/f94f1705-5741-49e7-9b60-86baf9fd51eb)

After this PR, it should match the expected job.

![3](https://github.com/user-attachments/assets/67276cf0-c9df-4b7b-8125-57931ad6e8fc)

### Changelog entry
