### PR TITLE
WordPress 6.8 and WooCommerce 9.8 compatibility: Fix an issue that could cause all pages not to display properly

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { lazy } from '@wordpress/element';
-import { addFilter } from '@wordpress/hooks';
+import { addFilter, didFilter, hasAction } from '@wordpress/hooks';
 import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
 // See https://github.com/woocommerce/woocommerce-admin/issues/7781
@@ -60,10 +60,15 @@ const woocommerceTranslation =
 	getSetting( 'admin' )?.woocommerceTranslation ||
 	__( 'WooCommerce', 'google-listings-and-ads' );
 
-addFilter(
-	'woocommerce_admin_pages_list',
-	'woocommerce/google-listings-and-ads/add-page-routes',
-	( pages ) => {
+// Refer to https://github.com/woocommerce/woocommerce/blob/9.7.1/plugins/woocommerce/client/admin/client/layout/controller.js#L82
+const PAGES_FILTER = 'woocommerce_admin_pages_list';
+
+let hasAddedPluginAdminPages = false;
+
+const registerPluginAdminPages = () => {
+	const namespace = 'woocommerce/google-listings-and-ads/add-page-routes';
+
+	addFilter( PAGES_FILTER, namespace, ( pages ) => {
 		const initialBreadcrumbs = [
 			[ '', woocommerceTranslation ],
 			[ '/marketing', __( 'Marketing', 'google-listings-and-ads' ) ],
@@ -157,9 +162,50 @@ addFilter(
 			pagePaths.add( path );
 		} );
 
+		hasAddedPluginAdminPages = true;
+
 		return pages.concat( pluginAdminPages );
-	}
-);
+	} );
+};
+
+const hasRunFilter = () => didFilter( PAGES_FILTER ) > 0;
+const hasAddedFallback = () =>
+	hasAction( 'hookAdded', `woocommerce/woocommerce/watch_${ PAGES_FILTER }` );
+
+/* compatibility-code "WP >= 6.8 && WC >= 9.8" -- Ensure the registration of the plugin admin pages is applied to the filter
+ *
+ * Starting with WooCommerce >= 9.8, this script will run after the 'wc-admin-app'
+ * script instead of before it. Originally, this was not a problem, because
+ * WooCommerce Core has a fallback to handle this run order.
+ * Ref: https://github.com/woocommerce/woocommerce/blob/9.7.1/plugins/woocommerce/client/admin/client/layout/controller.js#L358-L382
+ *
+ * The mechanism works when these hooks run in the following order:
+ * 1. WC runs `applyFilters` to get pages
+ * 2. WC runs `addAction` to set up a fallback to handle filters being added
+ *    after the applied filter above
+ * 3. This plugin runs `addFilter` to add its pages and the above fallback will
+ *    take care of this lately added filter
+ *
+ * However, since WordPress >= 6.8, somehow there is a chance that these hooks
+ * will run in the following order:
+ * 1. WC runs `applyFilters`
+ * 2. This plugin runs `addFilter`
+ * 3. WC runs `addAction` to set up a fallback
+ *
+ * In this case, pages registration will be missed and won't be displayed.
+ * So here's a compatibility process to ensure this plugin runs `addFilter`
+ * after the fallback is set.
+ */
+if ( hasRunFilter() && ! hasAddedFallback() && ! hasAddedPluginAdminPages ) {
+	const timerId = setInterval( () => {
+		if ( hasAddedFallback() ) {
+			clearInterval( timerId );
+			registerPluginAdminPages();
+		}
+	}, 10 );
+} else {
+	registerPluginAdminPages();
+}
 
 // Ref: https://github.com/woocommerce/woocommerce/blob/6.9.0/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php#L92
 addFilter(

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -197,10 +197,17 @@ const hasAddedFallback = () =>
  * after the fallback is set.
  */
 if ( hasRunFilter() && ! hasAddedFallback() && ! hasAddedPluginAdminPages ) {
+	const startTime = Date.now();
 	const timerId = setInterval( () => {
 		if ( hasAddedFallback() ) {
 			clearInterval( timerId );
 			registerPluginAdminPages();
+			return;
+		}
+
+		// Stop trying after 3 seconds to avoid performance issues.
+		if ( Date.now() - startTime > 3000 ) {
+			clearInterval( timerId );
 		}
 	}, 10 );
 } else {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a compatibility issue with WordPress 6.8 and WooCommerce 9.8 that could cause all pages not to display properly.

The issue happens randomly and is usually more likely to happen on computers with good performance.

https://github.com/user-attachments/assets/f2f9ffe9-cd81-48bf-b7da-0072cd7370e5

### Detailed test instructions:

1. Check if the E2E test can pass with WordPress 6.8-RC3 and WooCommerce 9.8.0-rc.1
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/14355740923/job/40244654944
2. Check if the E2E test can pass with WordPress 6.8-RC3 and WooCommerce 9.7.1
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/14356113048/job/40245809666
3. Check if the E2E test can pass with WordPress 6.7.2 and WooCommerce 9.8.0-rc.1
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/14356510917/job/40247091263
4. Check if the E2E test can pass with WordPress 6.7.2 and WooCommerce 9.7.1
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/14357195063/job/40249299537

### Additional details:

Starting with WooCommerce >= 9.8, this script will run after the `'wc-admin-app'` script instead of before it. The change in order is due to the addition of a dependency on the `'wc-admin-app'` script in https://github.com/woocommerce/woocommerce/pull/55707 for the `'wc-admin-wcsettings-deprecation'` script.

📌 It's still uncertain which change in WordPress 6.8 is related to this compatibility issue.

### Changelog entry

> Fix - Compatibility issue with WordPress 6.8 and WooCommerce 9.8, which may cause all pages not to display properly.
