### PR TITLE
Fix merchant price competitiveness query

### DIFF
--- a/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
+++ b/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
@@ -52,7 +52,8 @@ class MerchantPriceBenchmarksQuery extends MerchantQuery {
 				'price_micros'                  => 'product_view.price_micros',
 				'currency_code'                 => 'product_view.currency_code',
 				'benchmark_price_micros'        => 'price_competitiveness.benchmark_price_micros',
-				'benchmark_price_currency_code' => 'price_competitiveness.benchmark_price_country_code',
+				'benchmark_price_currency_code' => 'price_competitiveness.benchmark_price_currency_code',
+				'benchmark_price_country_code'  => 'price_competitiveness.country_code',
 			]
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow up to #2838.

After initializing a new MC account where I was able to test the queries to the Content API, I noticed a couple of errors being returned due to expected fields not being included in the resulting SELECT query.

Ex:

```
Error in query: query from table 'PriceCompetitivenessProductView' is expected to have 'price_competitiveness.country_code' field in SELECT clause
```


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. From the `feature/2824-price-benchmarks` branch, go to the Google for Woo admin page and run the following in your dev tools console to fetch the endpoint:
  ```js
  wp.apiFetch( { path: 'wc/gla/mc/price-benchmarks' } ).then( ( data ) => {
      console.log( data );
  } );
  ```
2. Notice the error in the console log
3. Check out this PR and run the fetch again to see that the error has gone away

### Changelog entry
