### PR TITLE
Fix the issue where the interlink between Google Merchant Center and Google Ads accounts may not be completed

### DIFF
--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -129,7 +129,7 @@ class Ads implements OptionsAwareInterface {
 	 * @throws Exception When a link is unavailable.
 	 */
 	public function accept_merchant_link( int $merchant_id ) {
-		$link        = $this->get_merchant_link( $merchant_id, 5 );
+		$link        = $this->get_merchant_link( $merchant_id, 10 );
 		$link_status = $link->getStatus();
 		if ( $link_status === ProductLinkInvitationStatus::ACCEPTED ) {
 			return;

--- a/src/API/Google/Ads.php
+++ b/src/API/Google/Ads.php
@@ -123,17 +123,13 @@ class Ads implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Accept a link from a merchant account.
+	 * Accept the pending approval link sent from a merchant account.
 	 *
 	 * @param int $merchant_id Merchant Center account id.
-	 * @throws Exception When a link is unavailable.
+	 * @throws Exception When the pending approval link can not be found.
 	 */
 	public function accept_merchant_link( int $merchant_id ) {
-		$link        = $this->get_merchant_link( $merchant_id, 10 );
-		$link_status = $link->getStatus();
-		if ( $link_status === ProductLinkInvitationStatus::ACCEPTED ) {
-			return;
-		}
+		$link    = $this->get_merchant_link( $merchant_id, 10 );
 		$request = new UpdateProductLinkInvitationRequest();
 		$request->setCustomerId( $this->options->get_ads_id() );
 		$request->setResourceName( $link->getResourceName() );
@@ -323,7 +319,7 @@ class Ads implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Get the link from a merchant account.
+	 * Get the pending approval link sent from a Google Merchant account.
 	 *
 	 * The invitation link may not be available in Google Ads immediately after
 	 * the invitation is sent from Google Merchant Center, so this method offers
@@ -333,12 +329,12 @@ class Ads implements OptionsAwareInterface {
 	 * @param int $attempts_left The number of attempts left to get the link.
 	 *
 	 * @return ProductLinkInvitation
-	 * @throws Exception When the merchant link hasn't been created.
+	 * @throws Exception When the pending approval link can not be found.
 	 */
 	private function get_merchant_link( int $merchant_id, int $attempts_left = 0 ): ProductLinkInvitation {
 		$res = ( new AdsProductLinkInvitationQuery() )
 			->set_client( $this->client, $this->options->get_ads_id() )
-			->where( 'product_link_invitation.status', [ ProductLinkInvitationStatus::name( ProductLinkInvitationStatus::ACCEPTED ), ProductLinkInvitationStatus::name( ProductLinkInvitationStatus::PENDING_APPROVAL ) ], 'IN' )
+			->where( 'product_link_invitation.status', ProductLinkInvitationStatus::name( ProductLinkInvitationStatus::PENDING_APPROVAL ) )
 			->get_results();
 
 		foreach ( $res->iterateAllElements() as $row ) {
@@ -355,6 +351,6 @@ class Ads implements OptionsAwareInterface {
 			return $this->get_merchant_link( $merchant_id, $attempts_left - 1 );
 		}
 
-		throw new Exception( __( 'Merchant link is not available to accept', 'google-listings-and-ads' ) );
+		throw new Exception( __( 'Unable to find the pending approval link sent from the Merchant Center account', 'google-listings-and-ads' ) );
 	}
 }

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -312,7 +312,7 @@ class Merchant implements OptionsAwareInterface {
 	 *
 	 * @param int $ads_id Google Ads ID to link.
 	 *
-	 * @return bool
+	 * @return bool True if the link invitation is waiting for acceptance. False if the link is already active.
 	 * @throws ExceptionWithResponseData When unable to retrieve or update account data.
 	 */
 	public function link_ads_id( int $ads_id ): bool {
@@ -322,7 +322,7 @@ class Merchant implements OptionsAwareInterface {
 		// Stop early if we already have a link setup.
 		foreach ( $ads_links as $link ) {
 			if ( $ads_id === absint( $link->getAdsId() ) ) {
-				return false;
+				return $link->getStatus() !== 'active';
 			}
 		}
 

--- a/src/Ads/AccountService.php
+++ b/src/Ads/AccountService.php
@@ -348,8 +348,11 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		$mc_state = $this->container->get( MerchantAccountState::class );
 
 		// Create link for Merchant and accept it in Ads.
-		$this->container->get( Merchant::class )->link_ads_id( $this->options->get_ads_id() );
-		$this->container->get( Ads::class )->accept_merchant_link( $this->options->get_merchant_id() );
+		$waiting_acceptance = $this->container->get( Merchant::class )->link_ads_id( $this->options->get_ads_id() );
+
+		if ( $waiting_acceptance ) {
+			$this->container->get( Ads::class )->accept_merchant_link( $this->options->get_merchant_id() );
+		}
 
 		$mc_state->complete_step( 'link_ads' );
 	}

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -510,8 +510,11 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		$ads_state = $this->container->get( AdsAccountState::class );
 
 		// Create link for Merchant and accept it in Ads.
-		$this->container->get( Merchant::class )->link_ads_id( $this->options->get_ads_id() );
-		$this->container->get( Ads::class )->accept_merchant_link( $this->options->get_merchant_id() );
+		$waiting_acceptance = $this->container->get( Merchant::class )->link_ads_id( $this->options->get_ads_id() );
+
+		if ( $waiting_acceptance ) {
+			$this->container->get( Ads::class )->accept_merchant_link( $this->options->get_merchant_id() );
+		}
 
 		$ads_state->complete_step( 'link_merchant' );
 	}

--- a/tests/Unit/API/Google/AdsTest.php
+++ b/tests/Unit/API/Google/AdsTest.php
@@ -174,20 +174,7 @@ class AdsTest extends UnitTest {
 		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
 		$this->generate_mc_link_mock( [] );
 		$this->expectException( Exception::class );
-		$this->expectExceptionMessage( 'Merchant link is not available to accept' );
-
-		$this->ads->accept_merchant_link( self::TEST_MERCHANT_ID );
-	}
-
-	public function test_accept_merchant_link_already_accepted() {
-		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
-		$link = new ProductLinkInvitation();
-		$mc   = new MerchantCenterLinkInvitationIdentifier();
-		$link->setStatus( ProductLinkInvitationStatus::ACCEPTED );
-		$mc->setMerchantCenterId( self::TEST_MERCHANT_ID );
-		$link->setMerchantCenter( $mc );
-		$service = $this->generate_mc_link_mock( [ $link ] );
-		$service->expects( $this->never() )->method( 'updateProductLinkInvitation' );
+		$this->expectExceptionMessage( 'Unable to find the pending approval link sent from the Merchant Center account' );
 
 		$this->ads->accept_merchant_link( self::TEST_MERCHANT_ID );
 	}

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -430,6 +430,34 @@ class MerchantTest extends UnitTest {
 		);
 	}
 
+	public function test_link_ads_id_exist_link_awaiting_approval() {
+		$account  = $this->createMock( Account::class );
+		$ads_link = $this->createMock( AccountAdsLink::class );
+		$ads_id   = 12345;
+
+		$ads_link->expects( $this->any() )
+			->method( 'getAdsId' )
+			->willReturn( $ads_id );
+
+		$ads_link->expects( $this->any() )
+			->method( 'getStatus' )
+			->willReturn( 'pending' );
+
+		$account->expects( $this->once() )
+			->method( 'getAdsLinks' )
+			->willReturn( [ $ads_link ] );
+
+		$account->expects( $this->never() )->method( 'setAdsLinks' );
+
+		$this->mock_get_account( $account );
+
+		$this->service->accounts->expects( $this->never() )->method( 'update' );
+
+		$this->assertTrue(
+			$this->merchant->link_ads_id( $ads_id )
+		);
+	}
+
 	public function test_ads_id_already_linked() {
 		$account  = $this->createMock( Account::class );
 		$ads_link = $this->createMock( AccountAdsLink::class );
@@ -438,6 +466,10 @@ class MerchantTest extends UnitTest {
 		$ads_link->expects( $this->any() )
 			->method( 'getAdsId' )
 			->willReturn( $ads_id );
+
+		$ads_link->expects( $this->any() )
+			->method( 'getStatus' )
+			->willReturn( 'active' );
 
 		$account->expects( $this->once() )
 			->method( 'getAdsLinks' )

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -427,11 +427,39 @@ class AccountServiceTest extends UnitTest {
 
 		$this->merchant->expects( $this->once() )
 			->method( 'link_ads_id' )
-			->with( self::TEST_ACCOUNT_ID );
+			->with( self::TEST_ACCOUNT_ID )
+			->willReturn( true );
 
 		$this->ads->expects( $this->once() )
 			->method( 'accept_merchant_link' )
 			->with( self::TEST_MERCHANT_ID );
+
+		$this->assertEquals( [ 'id' => self::TEST_ACCOUNT_ID ], $this->account->setup_account() );
+	}
+
+	public function test_setup_account_step_link_merchant_already_linked() {
+		$this->options->expects( $this->any() )
+			->method( 'get_ads_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_MERCHANT_ID );
+
+		$this->state->expects( $this->once() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'link_merchant' => [ 'status' => AdsAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->merchant->expects( $this->once() )
+			->method( 'link_ads_id' )
+			->with( self::TEST_ACCOUNT_ID )
+			->willReturn( false );
+
+		$this->ads->expects( $this->never() )->method( 'accept_merchant_link' );
 
 		$this->assertEquals( [ 'id' => self::TEST_ACCOUNT_ID ], $this->account->setup_account() );
 	}

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -641,11 +641,39 @@ class AccountServiceTest extends UnitTest {
 
 		$this->merchant->expects( $this->once() )
 			->method( 'link_ads_id' )
-			->with( self::TEST_ADS_ID );
+			->with( self::TEST_ADS_ID )
+			->willReturn( true );
 
 		$this->ads->expects( $this->once() )
 			->method( 'accept_merchant_link' )
 			->with( self::TEST_ACCOUNT_ID );
+
+		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->setup_account( self::TEST_ACCOUNT_ID ) );
+	}
+
+	public function test_setup_account_step_link_ads_already_linked() {
+		$this->options->expects( $this->any() )
+			->method( 'get_ads_id' )
+			->willReturn( self::TEST_ADS_ID );
+
+		$this->options->expects( $this->any() )
+			->method( 'get_merchant_id' )
+			->willReturn( self::TEST_ACCOUNT_ID );
+
+		$this->state->expects( $this->once() )
+			->method( 'get' )
+			->willReturn(
+				[
+					'link_ads' => [ 'status' => MerchantAccountState::STEP_PENDING ],
+				]
+			);
+
+		$this->merchant->expects( $this->once() )
+			->method( 'link_ads_id' )
+			->with( self::TEST_ADS_ID )
+			->willReturn( false );
+
+		$this->ads->expects( $this->never() )->method( 'accept_merchant_link' );
 
 		$this->assertEquals( self::TEST_ACCOUNT_DATA, $this->account->setup_account( self::TEST_ACCOUNT_ID ) );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since April 18, 2025, the following queries to Google Ads API seemed to have a breaking change or unexpected behavior.

```sql
SELECT
  product_link_invitation.merchant_center.merchant_center_id,
  product_link_invitation.status
FROM product_link_invitation
WHERE
  product_link_invitation.status IN ('ACCEPTED', 'PENDING_APPROVAL');
```

Previously, the API wouldn't return revoked links. However, now its results include both active and previously active but revoked links, which makes it impossible for the plugin to distinguish whether a link is truly active. In addition, there is a significant delay on the Ads side after a link invite is sent from Merchant Center before the pending approval link can be retrieved. Both of these issues further cause the following to fail when linking to the same set of accounts again.

https://github.com/woocommerce/google-listings-and-ads/blob/fe702bee992793e0347fe7ffa52130c7290233ce/src/API/Google/Ads.php#L131-L142

https://github.com/woocommerce/google-listings-and-ads/blob/fe702bee992793e0347fe7ffa52130c7290233ce/src/API/Google/Ads.php#L338-L351

https://github.com/user-attachments/assets/89d2934d-617c-46cf-94a5-e519e99f605a

This PR uses a workaround to fix the issue.

- Change the check for whether there is an active link between Merchant Center and Ads accounts to be confirmed from Merchant Center side.
- Change retry attempts to 10 as the delay in getting the merchant link invite has been longer than it was a few weeks ago.

### Screenshots:

https://github.com/user-attachments/assets/68a38d7f-256c-4162-a0d9-a28d5d69bf57

### Detailed test instructions:

1. Go to step 1 of the onboarding flow
2. Connect to Ads and Merchant Center accounts to make sure they have ever linked to each other
3. Disconnect Merchant Center account
4. Remove the access via Google Merchant Center
   1. Go to https://merchants.google.com/mc/overview and select the Merchant Center account used in step 2
   2. Navigate to the **Apps and services** page
      ![1](https://github.com/user-attachments/assets/cf2832ad-ee71-47f1-b890-b43550b3d7bd)
   3. Remove the access to Google Ads account
      ![2](https://github.com/user-attachments/assets/a3d1d499-5c39-4cb8-a4b3-862fc9f8de1b)
6. Switch to the plugin onboarding
7. Connect to the same Merchant Center account again
8. Switch to Google Merchant Center, refresh the webpage, and check if the access to Google Ads account is created and accepted rather than waiting for approval
   ![3](https://github.com/user-attachments/assets/0e20c91a-9288-4650-84a1-17415255add2)
9. Disconnect Ads account
10. Redo step 4 to remove the access via Google Merchant Center
11. Switch to the plugin onboarding
12. Connect to the same Ads account again
13. Switch to Google Merchant Center, refresh the webpage, and check if the access to Google Ads account is created and accepted rather than waiting for approval

### Changelog entry

> Fix - The interlink between Google Merchant Center and Google Ads accounts may not be completed.
