### PR TITLE
Remove default price benchmark summary data

### DIFF
--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -74,13 +74,7 @@ const DEFAULT_STATE = {
 	gtinMigrationStatus: null,
 	price_benchmark: {
 		suggestions: [],
-		summary: {
-			total_products: 0,
-			price_similar: 2,
-			price_higher: 60,
-			price_lower: 30,
-			price_unknown: 8,
-		},
+		summary: {},
 	},
 };
 

--- a/js/src/data/test/reducer.test.js
+++ b/js/src/data/test/reducer.test.js
@@ -77,13 +77,7 @@ describe( 'reducer', () => {
 			gtinMigrationStatus: null,
 			price_benchmark: {
 				suggestions: [],
-				summary: {
-					total_products: 0,
-					price_similar: 2,
-					price_higher: 60,
-					price_lower: 30,
-					price_unknown: 8,
-				},
+				summary: {},
 			},
 		} );
 

--- a/js/src/pages/price-benchmark/product-comparison-chart.js
+++ b/js/src/pages/price-benchmark/product-comparison-chart.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { isEmpty } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,7 +24,11 @@ import HorizontalStackedBar from '~/components/horizontal-stacked-bar';
 const ProductComparisonChart = () => {
 	const { summary, hasFinishedResolution } = usePriceBenchmarkSummary();
 
-	if ( ! hasFinishedResolution || ! summary ) {
+	if (
+		! hasFinishedResolution ||
+		( summary && isEmpty( summary ) ) ||
+		summary.total_products === 0
+	) {
 		return null;
 	}
 

--- a/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
+++ b/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
@@ -37,6 +37,77 @@ test.describe( 'Price Benchmark Page', () => {
 		await page.close();
 	} );
 
+	test.describe( 'Price Comparison Chart Functionality', () => {
+		test.beforeEach( async () => {
+			await priceBenchmarkPage.goto();
+		} );
+
+		test( 'Does not render the chart if there are no products', async () => {
+			await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions( [] );
+			await priceBenchmarkPage.fulfillPriceBenchmarkSummary( {
+				price_higher: 0,
+				price_lower: 0,
+				price_similar: 0,
+				price_unknown: 0,
+				total_products: 0,
+			} );
+
+			const emptyStateNotice = page.locator(
+				'.gla-price-benchmark__empty-metrics'
+			);
+
+			await expect( emptyStateNotice ).toBeVisible();
+
+			const comparisonChartElement = page.locator(
+				'.gla-price-benchmark__comparison-chart'
+			);
+			await expect( comparisonChartElement ).not.toBeVisible();
+		} );
+
+		test( "Does not render the chart if there's an API error", async () => {
+			await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions(
+				priceBenchmarkSuggestionsData
+			);
+			await priceBenchmarkPage.fulfillPriceBenchmarkSummary(
+				{
+					message: 'Forbidden.',
+				},
+				403
+			);
+
+			const errorMessage = page.locator(
+				'.components-snackbar__content'
+			);
+			await expect( errorMessage ).toBeVisible();
+			await expect( errorMessage ).toContainText(
+				'There was an error getting the price benchmark summary. Forbidden.'
+			);
+
+			const comparisonChartElement = page.locator(
+				'.gla-price-benchmark__comparison-chart'
+			);
+			await expect( comparisonChartElement ).not.toBeVisible();
+		} );
+
+		test( 'Render the chart if there are products', async () => {
+			await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions(
+				priceBenchmarkSuggestionsData
+			);
+			await priceBenchmarkPage.fulfillPriceBenchmarkSummary( {
+				price_higher: 10,
+				price_lower: 20,
+				price_similar: 30,
+				price_unknown: 40,
+				total_products: 100,
+			} );
+
+			const comparisonChartElement = page.locator(
+				'.gla-price-benchmark__comparison-chart'
+			);
+			await expect( comparisonChartElement ).toBeVisible();
+		} );
+	} );
+
 	test.describe( 'Price Benchmark Suggestions Functionality', () => {
 		test.beforeEach( async () => {
 			await priceBenchmarkPage.goto();

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -889,4 +889,20 @@ export default class MockRequests {
 			methods
 		);
 	}
+
+	/**
+	 * Fulfills a mock request for the price benchmark summary endpoint.
+	 *
+	 * @param {Object} payload - The mock response payload to be returned.
+	 * @param {number} [status=200] - The HTTP status code to be returned. Defaults to 200.
+	 * @return {Promise<void>} A promise that resolves when the request is fulfilled.
+	 */
+	async fulfillPriceBenchmarkSummary( payload, status = 200 ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/mc\/price-benchmarks\/summary\b/,
+			payload,
+			status,
+			[ 'GET' ]
+		);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2894  .

_Replace this with a good description of your changes & reasoning._

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the price benchmark page.
2. The price comparison chart (above the table) should not be rendered if there's an API error or if there are no products.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
