### PR TITLE
Provide the recommendations and metrics when setting a campaign budget

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -12,6 +12,12 @@
 		"max-line-length": null,
 		"no-descending-specificity": null,
 		"rule-empty-line-before": null,
-		"selector-class-pattern": null
+		"selector-class-pattern": null,
+		"selector-pseudo-class-no-unknown": [
+			true,
+			{
+				"ignorePseudoClasses": ["global"]
+			}
+		]
 	}
 }

--- a/js/src/components/paid-ads/asset-group/asset-group.js
+++ b/js/src/components/paid-ads/asset-group/asset-group.js
@@ -74,7 +74,7 @@ export default function AssetGroup( { campaign } ) {
 			context: isCreation ? 'campaign-creation' : 'campaign-editing',
 			action: event.target.dataset.action,
 			audiences: audiences.join( ',' ),
-			budget: values.amount.toString(),
+			budget: values.dailyBudget.toString(),
 			assets_validation: isValidAssetGroup ? 'valid' : 'invalid',
 		};
 

--- a/js/src/components/paid-ads/budget-section/index.js
+++ b/js/src/components/paid-ads/budget-section/index.js
@@ -3,48 +3,22 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Tip } from '@wordpress/components';
-import { useState, useEffect } from '@wordpress/element';
-import { useDebounce } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import Section from '~/components/section';
-import { useAdaptiveFormContext } from '~/components/adaptive-form';
-import useBudgetMetrics from '~/hooks/useBudgetMetrics';
-import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
-import AppInputPriceControl from '~/components/app-input-price-control';
-import AppInputControl from '~/components/app-input-control';
+import Subsection from '~/components/subsection';
+import BudgetSetup from '../budget-setup';
 import './index.scss';
 
 /**
  * Renders a UI for setting up the campaign budget.
  *
- * Please note that this component relies on a CampaignAssetsForm's context and custom adapter,
- * so it expects a `CampaignAssetsForm` to exist in its parents.
- *
  * @param {Object} props React props.
  * @param {JSX.Element} [props.children] Extra content to be rendered under the card of budget inputs.
  */
 const BudgetSection = ( { children } ) => {
-	const formContext = useAdaptiveFormContext();
-	const { adapter, getInputProps, values } = formContext;
-	const { countryCodes } = adapter;
-	const { amount } = values;
-	const { googleAdsAccount } = useGoogleAdsAccount();
-
-	const [ budget, setBudget ] = useState( amount );
-	const debouncedSetBudget = useDebounce( setBudget, 1000 );
-	const { data } = useBudgetMetrics( countryCodes, budget );
-
-	useEffect( () => {
-		debouncedSetBudget( amount );
-	}, [ debouncedSetBudget, amount ] );
-
-	// Display the currency code that will be used by Google Ads, but still use the store's currency formatting settings.
-	const currency = googleAdsAccount?.currency;
-	const weeklyCost = data ? data.metrics.cost : null;
-
 	return (
 		<div className="gla-budget-section">
 			<Section
@@ -61,24 +35,21 @@ const BudgetSection = ( { children } ) => {
 			>
 				<Section.Card>
 					<Section.Card.Body className="gla-budget-section__card-body">
-						<div className="gla-budget-section__card-body__cost">
-							<AppInputPriceControl
-								label={ __(
-									'Daily average cost',
+						<div>
+							<Subsection.Title>
+								{ __(
+									'Average daily budget',
 									'google-listings-and-ads'
 								) }
-								suffix={ currency }
-								{ ...getInputProps( 'amount' ) }
-							/>
-							<AppInputControl
-								disabled
-								label={ __(
-									'Weekly cost',
+							</Subsection.Title>
+							<Subsection.Subtitle>
+								{ __(
+									'These values are based on your settings and the budgets of similar advertisers.',
 									'google-listings-and-ads'
 								) }
-								value={ weeklyCost }
-							/>
+							</Subsection.Subtitle>
 						</div>
+						<BudgetSetup />
 						<Tip>
 							{ __(
 								'We recommend running campaigns at least 1 month so it can learn to optimize for your business.',

--- a/js/src/components/paid-ads/budget-section/index.scss
+++ b/js/src/components/paid-ads/budget-section/index.scss
@@ -3,19 +3,11 @@
 		display: flex;
 		flex-direction: column;
 		gap: var(--main-gap);
-
-		&__cost {
-			display: flex;
-			gap: var(--main-gap);
-
-			& > * {
-				flex: 1;
-			}
-		}
 	}
 
-	.components-input-control__suffix {
-		margin-right: $grid-unit-20;
+	.gla-subsection-title {
+		margin-bottom: $grid-unit-05;
+		font-weight: 400;
 	}
 
 	.components-tip {

--- a/js/src/components/paid-ads/budget-setup/budget-radio-control.js
+++ b/js/src/components/paid-ads/budget-setup/budget-radio-control.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { RadioControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import styles from './budget-setup.module.scss';
+
+/**
+ * Renders a radio control dedicated to the `BudgetSetup` component.
+ *
+ * @param {Object} props React props.
+ * @param {JSX.Element} props.label The label for the radio control.
+ * @param {string} props.value The value of the radio control.
+ * @param {string} props.selected The current selected value.
+ * @param {Object} props.rest Additional props to pass to the RadioControl.
+ */
+export default function BudgetRadioControl( {
+	label,
+	value,
+	selected,
+	...rest
+} ) {
+	return (
+		// eslint-disable-next-line jsx-a11y/label-has-associated-control
+		<label className={ styles.radioGroup }>
+			<RadioControl
+				{ ...rest }
+				checked={ selected === value }
+				options={ [ { value } ] }
+				hideLabelFromVision
+				help=""
+				aria-label={ value }
+			/>
+			<span
+				className={ classnames(
+					styles.option,
+					value === 'custom' && styles.customOption
+				) }
+			>
+				{ label }
+			</span>
+		</label>
+	);
+}

--- a/js/src/components/paid-ads/budget-setup/budget-setup-header.js
+++ b/js/src/components/paid-ads/budget-setup/budget-setup-header.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { __ } from '@wordpress/i18n';
+import { Tooltip } from '@wordpress/components';
+import { Link } from '@woocommerce/components';
+import GridiconInfoOutline from 'gridicons/dist/info-outline';
+
+/**
+ * Internal dependencies
+ */
+import styles from './budget-setup.module.scss';
+
+/**
+ * Renders the header for the budget setup component.
+ */
+export default function BudgetSetupHeader() {
+	return (
+		<div className={ classnames( styles.header, styles.metricsGroup ) }>
+			<span className={ styles.metricsItem }>
+				{ __( 'Weekly conversions', 'google-listings-and-ads' ) }
+				<Tooltip
+					className={ styles.tooltip }
+					text={
+						<>
+							{ __(
+								'The estimated total value of all the conversions (sales volume) your campaign will generate in a week.',
+								'google-listings-and-ads'
+							) }
+							<Link
+								type="external"
+								target="_blank"
+								href="https://support.google.com/google-ads/answer/7197048"
+							>
+								{ __(
+									'Learn more.',
+									'google-listings-and-ads'
+								) }
+							</Link>
+						</>
+					}
+				>
+					<GridiconInfoOutline size={ 16 } />
+				</Tooltip>
+			</span>
+			<span className={ styles.metricsItem }>
+				{ __( 'Weekly conv. value', 'google-listings-and-ads' ) }
+				<Tooltip
+					className={ styles.tooltip }
+					text={ __(
+						'The estimated number of conversions (unit sales) for a typical week. This number may vary based on change in your weekly spend.',
+						'google-listings-and-ads'
+					) }
+				>
+					<GridiconInfoOutline size={ 16 } />
+				</Tooltip>
+			</span>
+			<span className={ styles.metricsItem }>
+				{ __( 'Weekly cost', 'google-listings-and-ads' ) }
+				<Tooltip
+					className={ styles.tooltip }
+					text={ __(
+						`This is the estimated average amount you'll spend weekly during the month. Some weeks you may spend less than this amount or up to 2 times this amount.`,
+						'google-listings-and-ads'
+					) }
+				>
+					<GridiconInfoOutline size={ 16 } />
+				</Tooltip>
+			</span>
+		</div>
+	);
+}

--- a/js/src/components/paid-ads/budget-setup/budget-setup.js
+++ b/js/src/components/paid-ads/budget-setup/budget-setup.js
@@ -1,0 +1,172 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import { useDebounce } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import useBudgetMetrics from '~/hooks/useBudgetMetrics';
+import useAdsCurrency from '~/hooks/useAdsCurrency';
+import AppInputPriceControl from '~/components/app-input-price-control';
+import BudgetSetupHeader from './budget-setup-header';
+import BudgetRadioControl from './budget-radio-control';
+import LowBudgetNotice from './low-budget-notice';
+import styles from './budget-setup.module.scss';
+
+const i18nLevel = {
+	low: __( 'Low', 'google-listings-and-ads' ),
+	high: __( 'High', 'google-listings-and-ads' ),
+	recommended: __( 'Recommended', 'google-listings-and-ads' ),
+};
+
+function BudgetMetrics( { formatAmount, metrics } ) {
+	return (
+		<div className={ styles.metricsGroup }>
+			<span className={ styles.metricsItem }>
+				{ metrics ? metrics.conversions : null }
+			</span>
+			<span className={ styles.metricsItem }>
+				{ metrics ? formatAmount( metrics.conversionsValue ) : null }
+			</span>
+			<span className={ styles.metricsItem }>
+				{ metrics ? formatAmount( metrics.cost ) : null }
+			</span>
+		</div>
+	);
+}
+
+/**
+ * Renders a UI for selecting a campaign budget from recommendations or
+ * entering a custom campaign budget.
+ *
+ * Please note that this component relies on a CampaignAssetsForm's context and custom adapter,
+ * so it expects a `CampaignAssetsForm` to exist in its parents.
+ */
+export default function BudgetSetup() {
+	const formContext = useAdaptiveFormContext();
+	const { adapter, getInputProps, values } = formContext;
+	const { countryCodes, budgetRecommendation } = adapter;
+	const { amount } = values;
+	const { formatAmount } = useAdsCurrency();
+
+	const [ budget, setBudget ] = useState( amount );
+	const debouncedSetBudget = useDebounce( setBudget, 1000 );
+	const { data } = useBudgetMetrics( countryCodes, budget );
+
+	useEffect( () => {
+		debouncedSetBudget( amount );
+	}, [ debouncedSetBudget, amount ] );
+
+	const options = [ 'high', 'recommended', 'low' ].reduce( ( acc, level ) => {
+		const item = budgetRecommendation?.[ level ];
+		if ( item ) {
+			const dailyBudget = formatAmount( item.dailyBudget );
+
+			acc.push( {
+				level,
+				metrics: item.metrics,
+				radioProps: {
+					...getInputProps( 'level' ),
+					value: level,
+					label: (
+						<>
+							{ dailyBudget }
+							<span className={ styles.dayUnit }>
+								/{ __( 'day', 'google-listings-and-ads' ) }
+							</span>
+						</>
+					),
+				},
+			} );
+		}
+		return acc;
+	}, [] );
+
+	const { help, ...amountInputProps } = getInputProps( 'amount' );
+	const shouldNoticeRecommendedBudget =
+		! help &&
+		budgetRecommendation?.recommended &&
+		values.amount < budgetRecommendation?.low?.dailyBudget;
+
+	const getRowClassName = ( level ) => {
+		const selected = level === values.level;
+		return classnames(
+			styles.row,
+			level === 'custom' && styles.customRow,
+			selected && styles.rowSelected
+		);
+	};
+
+	return (
+		<div className={ styles.container }>
+			<BudgetSetupHeader />
+
+			{ options.map( ( { level, radioProps, metrics } ) => {
+				const helperContentClassName =
+					level === 'recommended'
+						? styles.highlightRecommended
+						: null;
+
+				return (
+					<div key={ level } className={ getRowClassName( level ) }>
+						<BudgetRadioControl { ...radioProps } />
+						<BudgetMetrics
+							formatAmount={ formatAmount }
+							metrics={ metrics }
+						/>
+						<div className={ styles.helper }>
+							<span className={ helperContentClassName }>
+								{ i18nLevel[ level ] }
+							</span>
+						</div>
+					</div>
+				);
+			} ) }
+
+			<div className={ getRowClassName( 'custom' ) }>
+				<BudgetRadioControl
+					{ ...getInputProps( 'level' ) }
+					value="custom"
+					label={ __(
+						'Set custom budget',
+						'google-listings-and-ads'
+					) }
+				/>
+				{ values.level === 'custom' && (
+					<>
+						<AppInputPriceControl
+							suffix={ data?.currency }
+							{ ...amountInputProps }
+							className={ classnames(
+								amountInputProps.className,
+								styles.customInput
+							) }
+						/>
+						<BudgetMetrics
+							formatAmount={ formatAmount }
+							metrics={ data?.metrics }
+						/>
+						{ help && (
+							<div className={ styles.customHelp } role="alert">
+								{ help }
+							</div>
+						) }
+						{ shouldNoticeRecommendedBudget && (
+							<LowBudgetNotice
+								className={ styles.customNotice }
+								recommendedAmount={ formatAmount(
+									budgetRecommendation.recommended.dailyBudget
+								) }
+							/>
+						) }
+					</>
+				) }
+			</div>
+		</div>
+	);
+}

--- a/js/src/components/paid-ads/budget-setup/budget-setup.module.scss
+++ b/js/src/components/paid-ads/budget-setup/budget-setup.module.scss
@@ -1,0 +1,131 @@
+.container {
+	display: grid;
+	grid-template-columns: [radio] 24fr [option] 156fr [metrics-start] 140fr 140fr 140fr;
+	align-items: center;
+	padding-bottom: $grid-unit-20;
+	border-bottom: 1px solid $gray-200;
+	line-height: 16px;
+	color: $gray-700;
+
+	:global(.gridicon) {
+		fill: currentcolor;
+	}
+}
+
+.header {
+	.metricsItem {
+		max-width: 100px;
+	}
+
+	:global(.gridicon) {
+		margin-left: $grid-unit-05;
+		vertical-align: middle;
+		cursor: help;
+	}
+}
+
+.row,
+.metricsGroup,
+.radioGroup {
+	display: contents;
+}
+
+.row {
+	font-size: $gla-font-smaller;
+
+	label {
+		font-size: 15px;
+		font-weight: 500;
+		color: $black;
+	}
+
+	&:not(.customRow) .metricsItem {
+		grid-row-end: span 2;
+	}
+
+	&::before {
+		content: "";
+		grid-column: 1 / -1;
+		height: 1px;
+		margin: $grid-unit-20 0;
+		background-color: $gray-200;
+	}
+}
+
+.rowSelected .metricsItem {
+	font-weight: 600;
+	color: $black;
+}
+
+.customRow {
+	.customInput,
+	.metricsItem {
+		padding-top: $grid-unit-20;
+	}
+}
+
+.option {
+	align-content: center;
+	min-height: 20px;
+}
+
+.metricsGroup {
+	.metricsItem:first-child {
+		grid-column-start: metrics-start;
+	}
+}
+
+.customOption {
+	grid-column: option / -1;
+}
+
+.customInput {
+	grid-column-start: option;
+	padding-right: $grid-unit-40;
+}
+
+.customHelp,
+.customNotice {
+	grid-column: option / -1;
+}
+
+.customHelp {
+	padding-top: $grid-unit-10;
+	color: $alert-red;
+}
+
+.customNotice {
+	padding-top: $grid-unit-30;
+	color: #755100;
+}
+
+.tooltip {
+	max-width: 250px;
+	padding: $grid-unit-10;
+	text-align: left;
+
+	a {
+		margin-left: $grid-unit-05;
+		color: currentcolor;
+	}
+}
+
+.dayUnit {
+	font-size: $gla-font-smaller;
+}
+
+.helper {
+	grid-column-start: option;
+	display: inline-flex;
+	padding-top: $grid-unit-05 * 1.5;
+	font-size: $gla-font-base;
+}
+
+.highlightRecommended {
+	margin-top: $grid-unit-05;
+	padding: $grid-unit-05 $grid-unit-10;
+	border-radius: 2px;
+	background-color: #eceefb;
+	font-size: $gla-font-smaller;
+	color: #1f2c70;
+}

--- a/js/src/components/paid-ads/budget-setup/index.js
+++ b/js/src/components/paid-ads/budget-setup/index.js
@@ -1,0 +1,1 @@
+export { default } from './budget-setup';

--- a/js/src/components/paid-ads/budget-setup/low-budget-notice.js
+++ b/js/src/components/paid-ads/budget-setup/low-budget-notice.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { Flex, FlexBlock } from '@wordpress/components';
+import GridiconNoticeOutline from 'gridicons/dist/notice-outline';
+
+/**
+ * Renders a notice that the budget is lower than the recommended amount.
+ *
+ * @param {Object} props React props.
+ * @param {string} [props.className] Additional class name.
+ * @param {string} props.recommendedAmount The recommended amount in currency format.
+ */
+export default function LowBudgetNotice( { className, recommendedAmount } ) {
+	return (
+		<Flex className={ className } gap={ 3 }>
+			<GridiconNoticeOutline size={ 24 } />
+			<FlexBlock>
+				{ createInterpolateElement(
+					__(
+						`Your budget is lower than other advertisers' budgets, which may affect performance. For best results, we recommend at least <amount /> per day.`,
+						'google-listings-and-ads'
+					),
+					{
+						amount: <strong>{ recommendedAmount }</strong>,
+					}
+				) }
+			</FlexBlock>
+		</Flex>
+	);
+}

--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -62,6 +62,37 @@ function convertAssetEntityGroupToFormValues( assetEntityGroup = {} ) {
 	return formValues;
 }
 
+function injectDailyBudget( values, budgetRecommendation ) {
+	return Object.defineProperty( values, 'dailyBudget', {
+		enumerable: true,
+		get() {
+			if ( this.level === 'custom' ) {
+				return this.amount;
+			}
+			return budgetRecommendation[ this.level ].dailyBudget;
+		},
+	} );
+}
+
+function resolveInitialCampaign(
+	initialCampaign,
+	defaultCampaign,
+	budgetRecommendation
+) {
+	const values = {
+		...defaultCampaign,
+		...initialCampaign,
+	};
+
+	if ( values.level !== 'custom' && ! budgetRecommendation[ values.level ] ) {
+		values.level = budgetRecommendation.recommended
+			? 'recommended'
+			: 'custom';
+	}
+
+	return injectDailyBudget( values, budgetRecommendation );
+}
+
 /**
  * Renders a form based on AdaptiveForm for managing campaign and assets.
  *
@@ -84,8 +115,11 @@ export default function CampaignAssetsForm( {
 	const [ baseAssetGroup, setBaseAssetGroup ] = useState( initialAssetGroup );
 	const [ hasImportedAssets, setHasImportedAssets ] = useState( false );
 	const { formatAmount } = useAdsCurrency();
-	const { recommendedDailyBudget, hasResolved } =
-		useBudgetRecommendation( countryCodes );
+	const {
+		data: budgetRecommendation,
+		recommendedDailyBudget,
+		hasResolved,
+	} = useBudgetRecommendation( countryCodes );
 
 	if ( ! hasResolved ) {
 		return null;
@@ -97,6 +131,7 @@ export default function CampaignAssetsForm( {
 
 		return {
 			countryCodes,
+			budgetRecommendation,
 			// Currently, the PMax Assets feature in this extension has functional limits, therefore,
 			// it needs to distinguish whether the `assetEntityGroup` is "empty" or not in order to
 			// provide different special business logic.
@@ -137,16 +172,31 @@ export default function CampaignAssetsForm( {
 		} );
 	};
 
+	const handleChange = function ( ...args ) {
+		injectDailyBudget( args[ 1 ], budgetRecommendation );
+
+		if ( adaptiveFormProps.onChange ) {
+			return adaptiveFormProps.onChange.apply( this, args );
+		}
+	};
+
 	return (
 		<AdaptiveForm
 			initialValues={ {
-				amount: recommendedDailyBudget,
-				...initialCampaign,
+				...resolveInitialCampaign(
+					initialCampaign,
+					{
+						level: 'recommended',
+						amount: recommendedDailyBudget,
+					},
+					budgetRecommendation
+				),
 				...initialAssetGroup,
 			} }
 			validate={ validateCampaignWithMinimumAmount }
 			extendAdapter={ extendAdapter }
 			{ ...adaptiveFormProps }
+			onChange={ handleChange }
 		/>
 	);
 }

--- a/js/src/components/paid-ads/campaign-assets-form.test.js
+++ b/js/src/components/paid-ads/campaign-assets-form.test.js
@@ -31,6 +31,11 @@ describe( 'CampaignAssetsForm', () => {
 		useBudgetRecommendation.mockReturnValue( {
 			hasResolved: true,
 			recommendedDailyBudget: 15,
+			data: {
+				recommended: { dailyBudget: 15 },
+				high: { dailyBudget: 30 },
+				low: { dailyBudget: 5 },
+			},
 		} );
 	} );
 
@@ -50,6 +55,11 @@ describe( 'CampaignAssetsForm', () => {
 		const formContextSchema = expect.objectContaining( {
 			adapter: expect.objectContaining( {
 				countryCodes,
+				budgetRecommendation: {
+					recommended: { dailyBudget: 15 },
+					high: { dailyBudget: 30 },
+					low: { dailyBudget: 5 },
+				},
 			} ),
 		} );
 
@@ -121,5 +131,283 @@ describe( 'CampaignAssetsForm', () => {
 		await user.click( resetButton );
 
 		expect( inspect ).toHaveBeenLastCalledWith( 0 );
+	} );
+
+	it( 'Should resolve the default dailyBudget for the initial form values', () => {
+		const children = jest.fn();
+
+		render(
+			<CampaignAssetsForm
+				validate={ alwaysValid }
+				initialCampaign={ { amount: 10 } }
+			>
+				{ children }
+			</CampaignAssetsForm>
+		);
+
+		const formContextSchema = expect.objectContaining( {
+			values: expect.objectContaining( {
+				amount: 10,
+				dailyBudget: 15,
+				level: 'recommended',
+			} ),
+		} );
+
+		expect( children ).toHaveBeenLastCalledWith( formContextSchema );
+	} );
+
+	it( 'Should resolve the available level for the initial form values', () => {
+		useBudgetRecommendation.mockReturnValue( {
+			hasResolved: true,
+			recommendedDailyBudget: 15,
+			data: {
+				recommended: { dailyBudget: 15 },
+			},
+		} );
+
+		const children = jest.fn();
+
+		render(
+			<CampaignAssetsForm
+				validate={ alwaysValid }
+				initialCampaign={ { amount: 10, level: 'high' } }
+			>
+				{ children }
+			</CampaignAssetsForm>
+		);
+
+		const formContextSchema = expect.objectContaining( {
+			values: expect.objectContaining( {
+				amount: 10,
+				dailyBudget: 15,
+				level: 'recommended',
+			} ),
+		} );
+
+		expect( children ).toHaveBeenLastCalledWith( formContextSchema );
+	} );
+
+	it( 'Should fall back to the custom level for the initial form values when there is no level available', () => {
+		useBudgetRecommendation.mockReturnValue( {
+			hasResolved: true,
+			recommendedDailyBudget: 15,
+			data: {},
+		} );
+
+		const children = jest.fn();
+
+		render(
+			<CampaignAssetsForm
+				validate={ alwaysValid }
+				initialCampaign={ { amount: 10, level: 'high' } }
+			>
+				{ children }
+			</CampaignAssetsForm>
+		);
+
+		const formContextSchema = expect.objectContaining( {
+			values: expect.objectContaining( {
+				amount: 10,
+				dailyBudget: 10,
+				level: 'custom',
+			} ),
+		} );
+
+		expect( children ).toHaveBeenLastCalledWith( formContextSchema );
+	} );
+
+	it( 'Should resolve the dailyBudget from the custom level for the initial form values', () => {
+		const children = jest.fn();
+
+		render(
+			<CampaignAssetsForm
+				validate={ alwaysValid }
+				initialCampaign={ { amount: 10, level: 'custom' } }
+			>
+				{ children }
+			</CampaignAssetsForm>
+		);
+
+		const formContextSchema = expect.objectContaining( {
+			values: expect.objectContaining( {
+				amount: 10,
+				dailyBudget: 10,
+				level: 'custom',
+			} ),
+		} );
+
+		expect( children ).toHaveBeenLastCalledWith( formContextSchema );
+	} );
+
+	it( 'Should resolve dailyBudget when calling back onChange with form values', async () => {
+		const user = userEvent.setup();
+		const inspect = jest.fn();
+
+		render(
+			<CampaignAssetsForm
+				validate={ alwaysValid }
+				initialCampaign={ { amount: 10 } }
+				onChange={ inspect }
+			>
+				{ ( { setValue } ) => {
+					const handleClick = ( e ) => {
+						setValue( 'level', e.target.textContent );
+					};
+					return (
+						<>
+							<button onClick={ handleClick }>custom</button>
+							<button onClick={ handleClick }>high</button>
+							<button onClick={ handleClick }>low</button>
+							<button onClick={ handleClick }>recommended</button>
+						</>
+					);
+				} }
+			</CampaignAssetsForm>
+		);
+
+		expect( inspect ).toHaveBeenCalledTimes( 0 );
+
+		await user.click( screen.getByRole( 'button', { name: 'custom' } ) );
+		expect( inspect ).toHaveBeenCalledTimes( 1 );
+		expect( inspect ).toHaveBeenLastCalledWith(
+			{
+				name: 'level',
+				value: 'custom',
+			},
+			expect.objectContaining( {
+				amount: 10,
+				dailyBudget: 10,
+				level: 'custom',
+			} ),
+			true
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'high' } ) );
+		expect( inspect ).toHaveBeenCalledTimes( 2 );
+		expect( inspect ).toHaveBeenLastCalledWith(
+			{
+				name: 'level',
+				value: 'high',
+			},
+			expect.objectContaining( {
+				amount: 10,
+				dailyBudget: 30,
+				level: 'high',
+			} ),
+			true
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'low' } ) );
+		expect( inspect ).toHaveBeenCalledTimes( 3 );
+		expect( inspect ).toHaveBeenLastCalledWith(
+			{
+				name: 'level',
+				value: 'low',
+			},
+			expect.objectContaining( {
+				amount: 10,
+				dailyBudget: 5,
+				level: 'low',
+			} ),
+			true
+		);
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'recommended' } )
+		);
+		expect( inspect ).toHaveBeenCalledTimes( 4 );
+		expect( inspect ).toHaveBeenLastCalledWith(
+			{
+				name: 'level',
+				value: 'recommended',
+			},
+			expect.objectContaining( {
+				amount: 10,
+				dailyBudget: 15,
+				level: 'recommended',
+			} ),
+			true
+		);
+	} );
+
+	it( 'Should resolve dailyBudget when calling back onSubmit with form values', async () => {
+		const user = userEvent.setup();
+		const inspect = jest.fn();
+
+		render(
+			<CampaignAssetsForm
+				validate={ alwaysValid }
+				initialCampaign={ { amount: 10 } }
+				onSubmit={ inspect }
+			>
+				{ ( { setValue, handleSubmit } ) => {
+					const handleClick = ( e ) => {
+						setValue( 'level', e.target.textContent );
+					};
+					return (
+						<>
+							<button onClick={ handleClick }>custom</button>
+							<button onClick={ handleClick }>high</button>
+							<button onClick={ handleClick }>low</button>
+							<button onClick={ handleClick }>recommended</button>
+							<button onClick={ handleSubmit }>submit</button>
+						</>
+					);
+				} }
+			</CampaignAssetsForm>
+		);
+
+		const submitButton = screen.getByRole( 'button', { name: 'submit' } );
+		expect( inspect ).toHaveBeenCalledTimes( 0 );
+
+		await user.click( screen.getByRole( 'button', { name: 'custom' } ) );
+		await user.click( submitButton );
+		expect( inspect ).toHaveBeenCalledTimes( 1 );
+		expect( inspect ).toHaveBeenLastCalledWith(
+			expect.objectContaining( {
+				amount: 10,
+				dailyBudget: 10,
+				level: 'custom',
+			} ),
+			expect.any( Object )
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'high' } ) );
+		await user.click( submitButton );
+		expect( inspect ).toHaveBeenCalledTimes( 2 );
+		expect( inspect ).toHaveBeenLastCalledWith(
+			expect.objectContaining( {
+				amount: 10,
+				dailyBudget: 30,
+				level: 'high',
+			} ),
+			expect.any( Object )
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'low' } ) );
+		await user.click( submitButton );
+		expect( inspect ).toHaveBeenCalledTimes( 3 );
+		expect( inspect ).toHaveBeenLastCalledWith(
+			expect.objectContaining( {
+				amount: 10,
+				dailyBudget: 5,
+				level: 'low',
+			} ),
+			expect.any( Object )
+		);
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'recommended' } )
+		);
+		await user.click( submitButton );
+		expect( inspect ).toHaveBeenCalledTimes( 4 );
+		expect( inspect ).toHaveBeenLastCalledWith(
+			expect.objectContaining( {
+				amount: 10,
+				dailyBudget: 15,
+				level: 'recommended',
+			} ),
+			expect.any( Object )
+		);
 	} );
 } );

--- a/js/src/components/paid-ads/validateCampaign.js
+++ b/js/src/components/paid-ads/validateCampaign.js
@@ -26,6 +26,11 @@ const BUDGET_MIN_PERCENT = 0.3;
 const validateCampaign = ( values, opts ) => {
 	const errors = {};
 
+	// Only the amount entered by the user needs to be verified.
+	if ( values.level !== 'custom' ) {
+		return errors;
+	}
+
 	if (
 		Number.isFinite( values.amount ) &&
 		Number.isFinite( opts.dailyBudget ) &&

--- a/js/src/components/paid-ads/validateCampaign.test.js
+++ b/js/src/components/paid-ads/validateCampaign.test.js
@@ -20,7 +20,10 @@ describe( 'validateCampaign', () => {
 
 	beforeEach( () => {
 		// Initial values
-		values = { amount: 0 };
+		values = {
+			amount: 0,
+			level: 'custom',
+		};
 	} );
 
 	it( 'When all checks are passed, should return an empty object', () => {
@@ -34,10 +37,36 @@ describe( 'validateCampaign', () => {
 		expect( errors ).toStrictEqual( {} );
 	} );
 
-	it( 'should indicate multiple unpassed checks by setting properties in the returned object', () => {
-		const errors = validateCampaign( values, validateCampaignOptions );
+	it( 'When the level is not custom, should skip the amount validation', () => {
+		const opts = {
+			dailyBudget: 100,
+			formatAmount: mockFormatAmount,
+		};
 
-		expect( errors ).toHaveProperty( 'amount' );
+		expect( validateCampaign( values, opts ) ).toHaveProperty( 'amount' );
+
+		values.level = 'recommended';
+		expect( validateCampaign( values, opts ) ).toStrictEqual( {} );
+
+		values.amount = 1;
+		expect( validateCampaign( values, opts ) ).toStrictEqual( {} );
+
+		values.level = 'high';
+		values.amount = 0;
+		expect( validateCampaign( values, opts ) ).toStrictEqual( {} );
+
+		values.amount = 1;
+		expect( validateCampaign( values, opts ) ).toStrictEqual( {} );
+
+		values.level = 'low';
+		values.amount = 0;
+		expect( validateCampaign( values, opts ) ).toStrictEqual( {} );
+
+		values.amount = 1;
+		expect( validateCampaign( values, opts ) ).toStrictEqual( {} );
+
+		values.amount = null;
+		expect( validateCampaign( values, opts ) ).toStrictEqual( {} );
 	} );
 
 	it( 'When the amount is not a number, should not pass', () => {

--- a/js/src/components/section/index.scss
+++ b/js/src/components/section/index.scss
@@ -16,6 +16,7 @@
 	&__header {
 		@include break-small {
 			width: 33%;
+			max-width: 328px;
 			padding-top: var(--main-gap);
 		}
 

--- a/js/src/pages/ads-onboarding/ads-stepper/setup-paid-ads.js
+++ b/js/src/pages/ads-onboarding/ads-stepper/setup-paid-ads.js
@@ -49,14 +49,14 @@ const SetupPaidAds = () => {
 	const { data: countryCodes } = useTargetAudienceFinalCountryCodes();
 
 	const handleSubmit = ( values ) => {
-		const { amount } = values;
+		const { dailyBudget } = values;
 
 		recordGlaEvent( 'gla_launch_paid_campaign_button_click', {
 			audiences: countryCodes.join( ',' ),
-			budget: amount,
+			budget: dailyBudget,
 		} );
 
-		handleSetupComplete( amount, countryCodes, () => {
+		handleSetupComplete( dailyBudget, countryCodes, () => {
 			// Force reload WC admin page to initiate the relevant dependencies of the Dashboard page.
 			const nextPath = getNewPath(
 				{ guide: 'campaign-creation-success' },

--- a/js/src/pages/create-paid-ads-campaign/index.js
+++ b/js/src/pages/create-paid-ads-campaign/index.js
@@ -76,11 +76,14 @@ const CreatePaidAdsCampaign = () => {
 		const { action } = enhancer.submitter.dataset;
 
 		try {
-			const { amount } = values;
+			const { dailyBudget } = values;
 
 			// Avoid re-creating a new campaign if the subsequent asset group update is failed.
 			if ( createdCampaignIdRef.current === null ) {
-				const payload = await createAdsCampaign( amount, countryCodes );
+				const payload = await createAdsCampaign(
+					dailyBudget,
+					countryCodes
+				);
 				createdCampaignIdRef.current = payload.createdCampaign.id;
 			}
 

--- a/js/src/pages/edit-paid-ads-campaign/index.js
+++ b/js/src/pages/edit-paid-ads-campaign/index.js
@@ -159,7 +159,7 @@ const EditPaidAdsCampaign = () => {
 	};
 
 	const handleOnChange = ( value, allValues ) => {
-		const isAmountChanged = allValues.amount !== campaign.amount;
+		const isAmountChanged = allValues.dailyBudget !== campaign.amount;
 
 		const isDisplayUrlPathChanged =
 			!! assetEntityGroup &&
@@ -180,7 +180,7 @@ const EditPaidAdsCampaign = () => {
 
 	const handleSubmit = async ( values, enhancer ) => {
 		const { action } = enhancer.submitter.dataset;
-		const { amount } = values;
+		const { dailyBudget: amount } = values;
 		setIsSubmit( true );
 		try {
 			await updateAdsCampaign( campaign.id, { amount } );
@@ -224,6 +224,7 @@ const EditPaidAdsCampaign = () => {
 			/>
 			<CampaignAssetsForm
 				initialCampaign={ {
+					level: 'custom',
 					amount: campaign.amount,
 				} }
 				countryCodes={ campaign.displayCountries }

--- a/js/src/pages/onboarding/setup-stepper/clientSession.js
+++ b/js/src/pages/onboarding/setup-stepper/clientSession.js
@@ -12,8 +12,8 @@ const clientSession = {
 	 * @param {CampaignData} data Campaign data to be stored.
 	 * @param {number|undefined} data.amount Daily average cost of the campaign.
 	 */
-	setCampaign( { amount } ) {
-		const json = JSON.stringify( { amount } );
+	setCampaign( { level, amount } ) {
+		const json = JSON.stringify( { level, amount } );
 		sessionStorage.setItem( KEY_PAID_ADS, json );
 	},
 

--- a/js/src/pages/onboarding/setup-stepper/clientSession.js
+++ b/js/src/pages/onboarding/setup-stepper/clientSession.js
@@ -1,5 +1,6 @@
 /**
  * @typedef {Object} CampaignData
+ * @param {string|undefined} level Selected level option of the campaign.
  * @property {number|undefined} amount Daily average cost of the paid ads campaign.
  */
 
@@ -10,7 +11,6 @@ const { sessionStorage } = window;
 const clientSession = {
 	/**
 	 * @param {CampaignData} data Campaign data to be stored.
-	 * @param {number|undefined} data.amount Daily average cost of the campaign.
 	 */
 	setCampaign( { level, amount } ) {
 		const json = JSON.stringify( { level, amount } );

--- a/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
@@ -90,7 +90,7 @@ export default function SetupPaidAds() {
 
 	const createContinueButton = ( formContext ) => {
 		const { isValidForm, values } = formContext;
-		const { amount } = values;
+		const { dailyBudget } = values;
 
 		const disabled =
 			completing === ACTION_SKIP || ! isValidForm || ! isBillingCompleted;
@@ -99,7 +99,7 @@ export default function SetupPaidAds() {
 			setCompleting( ACTION_COMPLETE );
 			const onBeforeFinish = handleSetupComplete.bind(
 				null,
-				amount,
+				dailyBudget,
 				countryCodes
 			);
 
@@ -115,7 +115,7 @@ export default function SetupPaidAds() {
 				text={ __( 'Complete setup', 'google-listings-and-ads' ) }
 				eventName="gla_onboarding_complete_with_paid_ads_button_click"
 				eventProps={ {
-					budget: amount,
+					budget: dailyBudget,
 					audiences: countryCodes?.join( ',' ),
 				} }
 			/>

--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -53,9 +53,6 @@ let setupBudgetPage = null;
 let page = null;
 
 test.describe( 'Set up Ads account', () => {
-	// The campaign budget
-	let budget = null;
-
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage();
 		dashboardPage = new DashboardPage( page );
@@ -366,17 +363,47 @@ test.describe( 'Set up Ads account', () => {
 	test.describe( 'Create Ads with billing data already setup', () => {
 		test.describe( 'Set the budget', async () => {
 			test( 'Continue button should be disabled if budget is 0', async () => {
-				budget = '0';
-				await setupBudgetPage.fillBudget( budget );
+				await setupBudgetPage.fillBudget( '0' );
 
 				await expect(
 					setupBudgetPage.getCreateCampaignButton()
 				).toBeDisabled();
 			} );
 
-			test( 'Continue button should be disabled if budget is less than recommended value', async () => {
-				budget = '2';
-				await setupBudgetPage.fillBudget( budget );
+			test( 'Continue button should be enabled when selecting an option from the recommendations, even if the entered value is invalid', async () => {
+				await setupBudgetPage.fillBudget( '0' );
+				await expect(
+					setupBudgetPage.getCreateCampaignButton()
+				).toBeDisabled();
+
+				await page.getByLabel( 'low' ).click();
+				await expect(
+					setupBudgetPage.getCreateCampaignButton()
+				).toBeEnabled();
+
+				await page.getByLabel( 'custom' ).click();
+				await expect(
+					setupBudgetPage.getCreateCampaignButton()
+				).toBeDisabled();
+
+				await page.getByLabel( 'high' ).click();
+				await expect(
+					setupBudgetPage.getCreateCampaignButton()
+				).toBeEnabled();
+
+				await page.getByLabel( 'custom' ).click();
+				await expect(
+					setupBudgetPage.getCreateCampaignButton()
+				).toBeDisabled();
+
+				await page.getByLabel( 'recommended' ).click();
+				await expect(
+					setupBudgetPage.getCreateCampaignButton()
+				).toBeEnabled();
+			} );
+
+			test( 'Continue button should be disabled if budget is less than 30% of the recommended value', async () => {
+				await setupBudgetPage.fillBudget( '2' );
 
 				await expect(
 					setupBudgetPage.getCreateCampaignButton()
@@ -384,8 +411,7 @@ test.describe( 'Set up Ads account', () => {
 			} );
 
 			test( 'User is notified of the minimum value', async () => {
-				budget = '4';
-				await setupBudgetPage.fillBudget( budget );
+				await setupBudgetPage.fillBudget( '4' );
 				await setupBudgetPage.getBudgetInput().blur();
 
 				await expect(
@@ -396,12 +422,21 @@ test.describe( 'Set up Ads account', () => {
 			} );
 
 			test( 'Continue button should be enabled if budget is above the recommended value', async () => {
-				budget = '6';
-				await setupBudgetPage.fillBudget( budget );
+				await setupBudgetPage.fillBudget( '5' );
 
 				await expect(
 					setupBudgetPage.getCreateCampaignButton()
 				).toBeEnabled();
+			} );
+
+			test( 'Display the recommended budget if the budget is valid but lower than the lowest recommended value', async () => {
+				await setupBudgetPage.fillBudget( '6' );
+
+				await expect(
+					page.getByText(
+						`Your budget is lower than other advertisers' budgets, which may affect performance. For best results, we recommend at least €15.00 per day.`
+					)
+				).toBeVisible();
 			} );
 		} );
 

--- a/tests/e2e/specs/onboarding/step-2-product-listings.test.js
+++ b/tests/e2e/specs/onboarding/step-2-product-listings.test.js
@@ -367,6 +367,22 @@ test.describe( 'Configure product listings', () => {
 		test.beforeAll( async () => {
 			await productListingsPage.checkRecommendedShippingRateRadioButton();
 			await productListingsPage.fillEstimatedShippingTimes( '14', '20' );
+			await productListingsPage.fulfillBudgetRecommendations( {
+				currency: 'USD',
+				recommendations: [
+					{
+						level: 'Recommended',
+						country: 'US',
+						daily_budget: 15,
+						metrics: {
+							cost: 105,
+							conversions: 2.2,
+							conversions_value: 89.98,
+						},
+					},
+				],
+			} );
+			await productListingsPage.mockBudgetMetrics();
 			await productListingsPage.fulfillBillingStatusRequest( {
 				status: 'pending',
 			} );

--- a/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
+++ b/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
@@ -286,25 +286,21 @@ test.describe( 'Complete your campaign', () => {
 				await completeCampaign.goto();
 			} );
 
-			test.describe( 'Set up budget', () => {
-				test( '"Daily average cost" input should have recommended value set', async () => {
-					const dailyAverageCostInput =
-						setupBudgetPage.getBudgetInput();
-					await expect( dailyAverageCostInput ).toHaveValue(
-						'100.00'
-					);
+			test.describe( 'Set up custom budget', () => {
+				test( 'The input in the "Set custom budget" option should have been set to the recommended value by default', async () => {
+					await page.getByLabel( 'custom' ).click();
+					await expect(
+						setupBudgetPage.getBudgetInput()
+					).toHaveValue( '100.00' );
 				} );
 			} );
 
-			test.describe( 'Validate budget percent', () => {
+			test.describe( 'Validate budget percent for the custom budget', () => {
 				test( 'should see validation error if lower than the 30%', async () => {
 					await setupBudgetPage.fillBudget( '10' );
 					await setupBudgetPage.getBudgetInput().blur();
-					const error = page.locator(
-						'.components-base-control__help'
-					);
 
-					await expect( error ).toHaveText(
+					await expect( page.getByRole( 'alert' ) ).toHaveText(
 						'Please make sure daily average cost is at least NT$30.00'
 					);
 				} );
@@ -312,11 +308,8 @@ test.describe( 'Complete your campaign', () => {
 				test( 'should see validation error if slightly less than the 30%', async () => {
 					await setupBudgetPage.fillBudget( '29.99' );
 					await setupBudgetPage.getBudgetInput().blur();
-					const error = page.locator(
-						'.components-base-control__help'
-					);
 
-					await expect( error ).toHaveText(
+					await expect( page.getByRole( 'alert' ) ).toHaveText(
 						'Please make sure daily average cost is at least NT$30.00'
 					);
 				} );
@@ -325,30 +318,25 @@ test.describe( 'Complete your campaign', () => {
 					await setupBudgetPage.fillBudget( '30' );
 					await setupBudgetPage.getBudgetInput().blur();
 
-					const error = page.locator(
-						'.components-base-control__help'
-					);
-					await expect( error ).not.toBeVisible();
+					await expect( page.getByRole( 'alert' ) ).not.toBeVisible();
 				} );
 
 				test( 'should not see validation error if slightly greater than 30%', async () => {
 					await setupBudgetPage.fillBudget( '30.5' );
 					await setupBudgetPage.getBudgetInput().blur();
 
-					const error = page.locator(
-						'.components-base-control__help'
-					);
-					await expect( error ).not.toBeVisible();
+					await expect( page.getByRole( 'alert' ) ).not.toBeVisible();
 				} );
 
-				test( 'should not see validation error if greater than 30%', async () => {
+				test( 'should display the recommended budget if the budget is valid but lower than the lowest recommended value', async () => {
 					await setupBudgetPage.fillBudget( '40' );
 					await setupBudgetPage.getBudgetInput().blur();
 
-					const error = page.locator(
-						'.components-base-control__help'
-					);
-					await expect( error ).not.toBeVisible();
+					await expect(
+						page.getByText(
+							`Your budget is lower than other advertisers' budgets, which may affect performance. For best results, we recommend at least NT$100.00 per day.`
+						)
+					).toBeVisible();
 				} );
 			} );
 
@@ -449,6 +437,40 @@ test.describe( 'Complete your campaign', () => {
 					const setupSuccessModal =
 						completeCampaign.getSetupSuccessModal();
 					await expect( setupSuccessModal ).toBeVisible();
+				} );
+			} );
+
+			test.describe( 'Budget recommendations', () => {
+				test.beforeAll( async () => {
+					await page.evaluate( () => window.sessionStorage.clear() );
+					await setupAdsAccountPage.mockAdsAccountIncomplete();
+					await setupBudgetPage.fulfillBillingStatusRequest( {
+						status: 'approved',
+					} );
+					await completeCampaign.mockCompleteAdsSetup();
+					await completeCampaign.goto();
+				} );
+
+				test( 'The recommended option is selected by default', async () => {
+					await expect(
+						page.getByLabel( 'recommended' )
+					).toBeChecked();
+				} );
+
+				test( 'Create a campaign with a selected option from the budget recommendations', async () => {
+					const highOption = page.getByLabel( 'high' );
+
+					await highOption.click();
+					await expect( highOption ).toBeChecked();
+
+					const campaignCreation =
+						setupBudgetPage.mockCampaignCreationAndAdsSetupCompletion(
+							'200',
+							[ 'US', 'TW', 'GB' ]
+						);
+
+					await completeCampaign.clickCompleteSetupButton();
+					await campaignCreation;
 				} );
 			} );
 		} );

--- a/tests/e2e/utils/pages/ads-onboarding/setup-budget.js
+++ b/tests/e2e/utils/pages/ads-onboarding/setup-budget.js
@@ -18,9 +18,7 @@ export default class SetupBudget extends MockRequests {
 	 * @return {import('@playwright/test').Locator} The budget input box.
 	 */
 	getBudgetInput() {
-		return this.page
-			.locator( '.gla-budget-section__card-body__cost' )
-			.getByLabel( 'Daily average cost' );
+		return this.page.getByRole( 'textbox' );
 	}
 
 	/**
@@ -86,8 +84,8 @@ export default class SetupBudget extends MockRequests {
 	 * @return {Promise<void>}
 	 */
 	async fillBudget( budget = '0' ) {
-		const input = this.getBudgetInput();
-		await input.fill( budget );
+		await this.page.getByLabel( 'custom' ).click();
+		await this.getBudgetInput().fill( budget );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project thread: pcTzPl-2Hb-p2

This is the last part of the **UI: Modify budget card to new design and support metrics** task.

This PR adjust the UI to provide the recommendations and metrics when setting a campaign budget.

- Implement the component that provides recommendations and metrics to set a campaign budget.
- Adjust the `CampaignAssetsForm` component to pass budget recommendations via context and resolve the `dailyBudget` value from the `amount` and `level` values.
- Replace the budget UI in the `BudgetSection` component with the  `BudgetSetup` component.
- Adjust all relevant components to use the `dailyBudget` value of the `CampaignAssetsForm` component instead.

### Screenshots:

#### 📹 Overall of the setup UI

https://github.com/user-attachments/assets/b5068936-cf51-4658-ae09-eb7f8cd43c63

#### 📷 When the low level of the budget recommendations is not available

![image](https://github.com/user-attachments/assets/a0bac63d-5fc9-47e3-b537-2caf22ace258)

#### 📷 When only the recommended level of the budget recommendations is available

![image](https://github.com/user-attachments/assets/6eebfb59-a86e-4d1d-b007-b63e7f2503e5)

### Detailed test instructions:

1. Go to step 3 of the Onboarding flow.
2. Interact with the selection of the budget recommendations to see if it works
3. Select the "Set custom budget" option
   1. Enter a value lower the lowest recommendation to see if the notice of the recommended budget is shown
   2. Enter a value lower the 30% of the recommended budget to see if the error message is shown
   3. Check if the complete buttons are disabled
   4. Select an option other than the custom one. Check if the complete buttons are enabled
5. Complete the onboarding flow with a campaign creation. Check if the budget of the newly created campaign is the same as the selected option or the entered custom value
6. Check if the budget setup works well on the Ads-onboarding, Campaign creating, and Campaign editing pages
7. View the E2E test result on GitHub Actions
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/14834243144

### Changelog entry

> Add - Provide the recommendations and metrics when setting a campaign budget.
