### PR TITLE
Add sales notice to ChangePriceModal

### DIFF
--- a/js/src/pages/price-benchmark/change-price-modal/index.js
+++ b/js/src/pages/price-benchmark/change-price-modal/index.js
@@ -203,7 +203,7 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 
 						<hr className="gla-change-price-modal__separator" />
 
-						{ salesPrice && (
+						{ ! isNaN( salesPrice ) && (
 							<Badge intent="warning">
 								{ __(
 									'Product is currently on sale',

--- a/js/src/pages/price-benchmark/change-price-modal/index.js
+++ b/js/src/pages/price-benchmark/change-price-modal/index.js
@@ -96,7 +96,8 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 		);
 	}
 
-	const salesPrice = Number.parseFloat( productDetails?.sale_price );
+	const salesPrice = Number.parseFloat( productDetails.sale_price );
+	const isOnSale = productDetails.on_sale;
 
 	return (
 		<AppModal
@@ -107,6 +108,7 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 					productId={ id }
 					key="price-input-footer"
 					suggestedPrice={ suggestedPrice }
+					onSale={ isOnSale }
 					salesPrice={ salesPrice }
 				/>,
 			] }
@@ -164,12 +166,14 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 							type={ METRIC_TYPE_PRICE }
 						/>
 
-						<MetricValue
-							labelKey={ LABEL_SALES_PRICE }
-							value={ salesPrice }
-							type={ METRIC_TYPE_PRICE }
-							className="gla-change-price-modal__sales-price"
-						/>
+						{ isOnSale && (
+							<MetricValue
+								labelKey={ LABEL_SALES_PRICE }
+								value={ salesPrice }
+								type={ METRIC_TYPE_PRICE }
+								className="gla-change-price-modal__sales-price"
+							/>
+						) }
 
 						<MetricValue
 							labelKey={ LABEL_SUGGESTED_PRICE }
@@ -203,7 +207,7 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 
 						<hr className="gla-change-price-modal__separator" />
 
-						{ ! isNaN( salesPrice ) && (
+						{ isOnSale && (
 							<Badge intent="warning">
 								{ __(
 									'Product is currently on sale',

--- a/js/src/pages/price-benchmark/change-price-modal/index.js
+++ b/js/src/pages/price-benchmark/change-price-modal/index.js
@@ -27,6 +27,7 @@ import AppButton from '~/components/app-button';
 import AppModal from '~/components/app-modal';
 import PriceInputFooter from './price-input-footer';
 import AppSpinner from '~/components/app-spinner';
+import Badge from '~/components/badge';
 import usePriceBenchmarkSuggestionsProduct from '~/hooks/usePriceBenchmarkSuggestionsProduct';
 import useProduct from '~/hooks/useProduct';
 import './index.scss';
@@ -167,6 +168,7 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 							labelKey={ LABEL_SALES_PRICE }
 							value={ salesPrice }
 							type={ METRIC_TYPE_PRICE }
+							className="gla-change-price-modal__sales-price"
 						/>
 
 						<MetricValue
@@ -198,6 +200,17 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 							value={ predictedConversionsChange }
 							type={ METRIC_TYPE_DELTA }
 						/>
+
+						<hr className="gla-change-price-modal__separator" />
+
+						{ salesPrice && (
+							<Badge intent="warning">
+								{ __(
+									'Product is currently on sale',
+									'google-listings-and-ads'
+								) }
+							</Badge>
+						) }
 					</div>
 				</div>
 			</div>

--- a/js/src/pages/price-benchmark/change-price-modal/index.scss
+++ b/js/src/pages/price-benchmark/change-price-modal/index.scss
@@ -70,11 +70,19 @@
 		width: 100%;
 	}
 
+	.gla-badge.is-warning {
+		grid-column: -1 / 1;
+	}
+
 	.gla-change-price-modal-price-input-footer {
 		align-items: flex-start;
-		display: flex;
-		flex-wrap: nowrap;
-		gap: calc($grid-unit-15 * 2);
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: $grid-unit-20;
+
+		@include break-large {
+			width: calc(100% - 156px - $grid-unit-50);
+		}
 
 		label.components-input-control__label {
 			color: $gray-900 !important;
@@ -94,20 +102,31 @@
 		.app-button {
 			// To align with the input
 			margin-top: 28px;
+			width: 100%;
 		}
-	}
-
-	.gla-change-price-modal-price-input-footer__price {
-		max-width: 180px;
 	}
 
 	.gla-change-price-modal-price-input-footer__price--error {
 		div.components-input-control__backdrop {
-			border-color: $gla-color-red;
+			color: $alert-red;
 		}
 
 		.components-base-control__help {
-			color: $gla-color-red;
+			color: $alert-red;
+		}
+	}
+
+	.gla-change-price-modal__sales-price {
+
+		.gla-price-benchmark__label {
+			color: $alert-red;
+		}
+	}
+
+	.app-modal__footer {
+
+		@include break-small {
+			margin-top: $grid-unit;
 		}
 	}
 }

--- a/js/src/pages/price-benchmark/change-price-modal/metric-value.js
+++ b/js/src/pages/price-benchmark/change-price-modal/metric-value.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * Internal dependencies
  */
 import {
@@ -25,10 +30,11 @@ import './metric-value.scss';
  *                              - METRIC_TYPE_DELTA: Formats the value as a percentage delta using the <DeltaValue> component.
  *                              - METRIC_TYPE_EFFECTIVENESS: Displays an effectiveness indicator using the <EffectivenessIndicator> component.
  *                              - METRIC_TYPE_PERCENTAGE: Formats the value as a percentage string.
+ * @param {string} [props.className] - Optional additional class name for the component.
  *
  * @return {JSX.Element|null} A JSX element displaying the metric value with its label, or null if the value is invalid.
  */
-const MetricValue = ( { labelKey, value, type } ) => {
+const MetricValue = ( { labelKey, value, type, className } ) => {
 	if ( value === undefined || value === null || value === '' ) {
 		return null;
 	}
@@ -51,7 +57,12 @@ const MetricValue = ( { labelKey, value, type } ) => {
 	}
 
 	return (
-		<div className="gla-change-price-modal__metric-value">
+		<div
+			className={ classnames(
+				'gla-change-price-modal__metric-value',
+				className
+			) }
+		>
 			<div className="gla-change-price-modal__metric-value-title">
 				<Label labelKey={ labelKey } />
 			</div>

--- a/js/src/pages/price-benchmark/change-price-modal/metric-value.js
+++ b/js/src/pages/price-benchmark/change-price-modal/metric-value.js
@@ -39,6 +39,10 @@ const MetricValue = ( { labelKey, value, type, className } ) => {
 		return null;
 	}
 
+	if ( type === METRIC_TYPE_PRICE && isNaN( value ) ) {
+		return null;
+	}
+
 	let formattedValue = value;
 
 	switch ( type ) {

--- a/js/src/pages/price-benchmark/change-price-modal/price-input-footer.js
+++ b/js/src/pages/price-benchmark/change-price-modal/price-input-footer.js
@@ -26,6 +26,7 @@ import useDispatchProduct from '~/hooks/useDispatchProduct';
  * @param {number} props.suggestedPrice - The suggested price for the product.
  * @param {number} [props.salesPrice] - The current sales price of the product (if any).
  * @param {Function} props.onPriceChange - Callback function triggered after the price is successfully updated.
+ * @param {boolean} props.onSale - Indicates if the product is currently on sale.
  *
  * @return {JSX.Element} The rendered PriceInputFooter component.
  */
@@ -33,6 +34,7 @@ const PriceInputFooter = ( {
 	productId,
 	suggestedPrice,
 	salesPrice,
+	onSale,
 	onPriceChange,
 } ) => {
 	const { formatAmount } = useAdsCurrency();
@@ -53,7 +55,8 @@ const PriceInputFooter = ( {
 		if (
 			! isNaN( formattedSalesPrice ) &&
 			formattedSalesPrice &&
-			updatedPrice <= formattedSalesPrice
+			updatedPrice <= formattedSalesPrice &&
+			onSale
 		) {
 			return sprintf(
 				// Translators: %s is replaced with the sales price.
@@ -73,7 +76,7 @@ const PriceInputFooter = ( {
 		}
 
 		return null;
-	}, [ newPrice, salesPrice, formatAmount ] );
+	}, [ newPrice, salesPrice, formatAmount, onSale ] );
 
 	const validatePrice = useCallback( () => {
 		const error = getInputError();

--- a/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
+++ b/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
@@ -213,7 +213,6 @@ test.describe( 'Price Benchmark Page', () => {
 			await priceBenchmarkPage.fulfillWCProduct(
 				{
 					regular_price: '100.00',
-					sale_price: '90.00',
 				},
 				[ 'GET' ]
 			);
@@ -256,21 +255,6 @@ test.describe( 'Price Benchmark Page', () => {
 			await expect( changePriceButton ).toBeDisabled();
 		} );
 
-		test( 'Displays error message when user inputs a price lower than the sale price', async () => {
-			const priceInput = await priceBenchmarkPage.getPriceInputModal();
-			await priceInput.fill( '80' );
-			await priceInput.blur();
-
-			const error = priceBenchmarkPage.getPriceInputError();
-			await expect( error ).toHaveText(
-				'New price must be greater than the sales price (NT$90.00).'
-			);
-
-			const changePriceButton =
-				await priceBenchmarkPage.getChangePriceModalButton();
-			await expect( changePriceButton ).toBeDisabled();
-		} );
-
 		test( 'Clicking "Change Price" button with a valid price closes the modal and updates the table', async () => {
 			await priceBenchmarkPage.goto();
 
@@ -281,7 +265,6 @@ test.describe( 'Price Benchmark Page', () => {
 			await priceBenchmarkPage.fulfillWCProduct(
 				{
 					regular_price: '100.00',
-					sale_price: '90.00',
 				},
 				[ 'GET' ]
 			);
@@ -320,10 +303,107 @@ test.describe( 'Price Benchmark Page', () => {
 				'NT$120.00'
 			);
 		} );
+
+		test.describe( 'Sales Price Functionality', () => {
+			test( 'Displays "Product is currently on sale" text when there is a sale price', async () => {
+				await priceBenchmarkPage.goto();
+
+				await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions( [
+					...priceBenchmarkSuggestionsData,
+				] );
+
+				await priceBenchmarkPage.fulfillWCProduct(
+					{
+						regular_price: '100.00',
+						sale_price: '90.00',
+					},
+					[ 'GET' ]
+				);
+
+				const changePriceLink =
+					await priceBenchmarkPage.getFirstProductChangePriceLink();
+				await changePriceLink.click();
+
+				const changePriceModal =
+					await priceBenchmarkPage.getChangePriceModal();
+
+				const saleText = changePriceModal.locator(
+					'span.gla-badge__content:has-text("Product is currently on sale")'
+				);
+				await expect( saleText ).toBeVisible();
+			} );
+
+			test( 'Displays error message when user inputs a price lower than the sale price', async () => {
+				const priceInput =
+					await priceBenchmarkPage.getPriceInputModal();
+				await priceInput.fill( '80' );
+				await priceInput.blur();
+
+				const error = priceBenchmarkPage.getPriceInputError();
+				await expect( error ).toHaveText(
+					'New price must be greater than the sales price (NT$90.00).'
+				);
+
+				const changePriceButton =
+					await priceBenchmarkPage.getChangePriceModalButton();
+				await expect( changePriceButton ).toBeDisabled();
+			} );
+
+			test( 'Allows changing the price to a value higher than the sales price', async () => {
+				const priceInput =
+					await priceBenchmarkPage.getPriceInputModal();
+				await priceInput.fill( '91' );
+				await priceInput.blur();
+
+				const changePriceButton =
+					await priceBenchmarkPage.getChangePriceModalButton();
+				await expect( changePriceButton ).toBeEnabled();
+				await changePriceButton.click();
+
+				const changePriceModal =
+					await priceBenchmarkPage.getChangePriceModal();
+				await expect( changePriceModal ).not.toBeVisible();
+
+				const firstProductCells = await priceBenchmarkPage
+					.getFirstProductRow()
+					.locator( 'td' );
+				await expect( firstProductCells.nth( 2 ) ).toHaveText(
+					'NT$91.00'
+				);
+			} );
+
+			test( 'Does not display "Product is currently on sale" text when there is no sale price', async () => {
+				await priceBenchmarkPage.goto();
+
+				await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions( [
+					...priceBenchmarkSuggestionsData,
+				] );
+
+				await priceBenchmarkPage.fulfillWCProduct(
+					{
+						regular_price: '100.00',
+					},
+					[ 'GET' ]
+				);
+
+				const changePriceLink =
+					await priceBenchmarkPage.getFirstProductChangePriceLink();
+				await changePriceLink.click();
+
+				const changePriceModal =
+					await priceBenchmarkPage.getChangePriceModal();
+
+				const saleText = changePriceModal.locator(
+					'span.gla-badge__content:has-text("Product is currently on sale")'
+				);
+				await expect( saleText ).not.toBeVisible();
+			} );
+		} );
 	} );
 
 	test.describe( 'Price Benchmark Suggestions Banner', () => {
 		test( 'Shows the banner when the user is not onboarded', async () => {
+			await priceBenchmarkPage.goto();
 			await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions( [
 				...priceBenchmarkSuggestionsData,
 			] );

--- a/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
+++ b/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
@@ -316,6 +316,7 @@ test.describe( 'Price Benchmark Page', () => {
 					{
 						regular_price: '100.00',
 						sale_price: '90.00',
+						on_sale: true,
 					},
 					[ 'GET' ]
 				);
@@ -382,6 +383,35 @@ test.describe( 'Price Benchmark Page', () => {
 				await priceBenchmarkPage.fulfillWCProduct(
 					{
 						regular_price: '100.00',
+					},
+					[ 'GET' ]
+				);
+
+				const changePriceLink =
+					await priceBenchmarkPage.getFirstProductChangePriceLink();
+				await changePriceLink.click();
+
+				const changePriceModal =
+					await priceBenchmarkPage.getChangePriceModal();
+
+				const saleText = changePriceModal.locator(
+					'span.gla-badge__content:has-text("Product is currently on sale")'
+				);
+				await expect( saleText ).not.toBeVisible();
+			} );
+
+			test( 'Does not display "Product is currently on sale" text when the product is not on sale but has a sale price', async () => {
+				await priceBenchmarkPage.goto();
+
+				await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions( [
+					...priceBenchmarkSuggestionsData,
+				] );
+
+				await priceBenchmarkPage.fulfillWCProduct(
+					{
+						regular_price: '100.00',
+						sale_price: '90.00',
+						on_sale: false,
 					},
 					[ 'GET' ]
 				);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2898  .

_Replace this with a good description of your changes & reasoning._


### Screenshots:

![image](https://github.com/user-attachments/assets/c03d008d-0315-4a25-a53e-372a95964162)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the price benchmarks page.
2. Click on the "Change Price" link for a product which has a sales price.
3. The modal should be as per the [designs](https://www.figma.com/design/fqR0EHi63lWahRcVTKCcba/Google-Listings---Ads-v2.x?node-id=12004-118350&t=MntmT0eX03okPxUI-4).
4. Open the modal for another product which does not have a sales price set.
5. The notice for the sales price should not be present.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
