### PR TITLE
Confirm query methods are being called with expected params

### DIFF
--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
@@ -143,17 +143,24 @@ class PriceBenchmarksControllerTest extends RESTControllerUnitTest {
 		// Mock the performance data.
 		$report_data = $this->get_mock_report_results( $report_product_id );
 
+		$method_args = [
+			'ids' => [ self::TEST_PRODUCT_ID ],
+		];
+
 		// Configure the mocked methods.
 		$this->merchant_price_benchmarks->expects( $this->once() )
 			->method( 'get_benchmark_data' )
+			->with( $method_args )
 			->willReturn( $mock_benchmark_data );
 
 		$this->merchant_price_benchmarks->expects( $this->once() )
 			->method( 'get_price_insights' )
+			->with( $method_args )
 			->willReturn( $mock_price_insights_data );
 
 		$this->merchant_price_benchmarks->expects( $this->once() )
 			->method( 'get_merchant_performance_data' )
+			->with( $method_args )
 			->willReturn( $report_data );
 
 		// Simulate a GET request.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Related #2861 . Follow-up for #2891

This adds with() assertions to each of the mocks for methods in the test_get_price_benchmarks_item() test to ensure that the methods are being called with the expected arguments passed.

Add the `changelog: none` label if no changelog entry is needed.