### PR TITLE
Add Price Benchmark tracking

### DIFF
--- a/js/src/pages/price-benchmark/change-price-modal/index.js
+++ b/js/src/pages/price-benchmark/change-price-modal/index.js
@@ -134,6 +134,7 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 
 	const salesPrice = Number.parseFloat( productDetails.sale_price );
 	const isOnSale = productDetails.on_sale;
+	const globalUniqueId = productDetails.global_unique_id;
 
 	return (
 		<AppModal
@@ -147,6 +148,7 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 					onSale={ isOnSale }
 					salesPrice={ salesPrice }
 					regularPrice={ regularPrice }
+					globalUniqueId={ globalUniqueId }
 				/>,
 			] }
 		>

--- a/js/src/pages/price-benchmark/change-price-modal/index.js
+++ b/js/src/pages/price-benchmark/change-price-modal/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useEffect, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,7 +22,9 @@ import {
 	METRIC_TYPE_EFFECTIVENESS,
 	METRIC_TYPE_PERCENTAGE,
 	METRIC_TYPE_PRICE,
+	PRICE_BENCHMARK_CHANGE_PRICE_MODAL_CONTEXT,
 } from '../constants';
+import { recordGlaEvent } from '~/utils/tracks';
 import MetricValue from './metric-value';
 import AppButton from '~/components/app-button';
 import AppModal from '~/components/app-modal';
@@ -33,10 +36,26 @@ import useProduct from '~/hooks/useProduct';
 import './index.scss';
 
 /**
+ * @event gla_modal_open
+ * @property {string} context The context in which the event is triggered.
+ * @property {number} productID The ID of the product whose price is being changed.
+ */
+
+/**
+ * @event gla_modal_closed
+ * @property {string} context The context in which the event is triggered.
+ * @property {number} productID The ID of the product whose price is being changed.
+ * @property {string} action The action taken to close the modal.
+ */
+
+/**
  * ChangePriceModal component.
  *
  * This component renders a modal for changing the price of a product. It displays
  * product details, price metrics, and allows the user to input a new price.
+ *
+ * @fires gla_modal_open with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
+ * @fires gla_modal_closed with `{ context: 'price-benchmark-change-price-modal', action: 'close' }` and the product ID.
  *
  * @param {Object} props - Component properties.
  * @param {number|string} props.productId - The ID of the product to change the price for.
@@ -65,9 +84,26 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 		product: { id, title, thumbnail },
 	} = product || {};
 
+	useEffect( () => {
+		recordGlaEvent( 'gla_modal_open', {
+			context: PRICE_BENCHMARK_CHANGE_PRICE_MODAL_CONTEXT,
+			productID: productId,
+		} );
+	}, [ productId ] );
+
+	const handleOnRequestClose = useCallback( () => {
+		recordGlaEvent( 'gla_modal_closed', {
+			context: PRICE_BENCHMARK_CHANGE_PRICE_MODAL_CONTEXT,
+			productID: productId,
+			action: 'close',
+		} );
+
+		onRequestClose();
+	}, [ onRequestClose, productId ] );
+
 	const appModalProps = {
 		title: __( 'Change Price', 'google-listings-and-ads' ),
-		onRequestClose,
+		onRequestClose: handleOnRequestClose,
 		className: 'gla-change-price-modal',
 	};
 
@@ -110,6 +146,7 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 					suggestedPrice={ suggestedPrice }
 					onSale={ isOnSale }
 					salesPrice={ salesPrice }
+					regularPrice={ regularPrice }
 				/>,
 			] }
 		>

--- a/js/src/pages/price-benchmark/change-price-modal/index.js
+++ b/js/src/pages/price-benchmark/change-price-modal/index.js
@@ -38,13 +38,13 @@ import './index.scss';
 /**
  * @event gla_modal_open
  * @property {string} context The context in which the event is triggered.
- * @property {number} productID The ID of the product whose price is being changed.
+ * @property {number} product_id The ID of the product whose price is being changed.
  */
 
 /**
  * @event gla_modal_closed
  * @property {string} context The context in which the event is triggered.
- * @property {number} productID The ID of the product whose price is being changed.
+ * @property {number} product_id The ID of the product whose price is being changed.
  * @property {string} action The action taken to close the modal.
  */
 
@@ -87,14 +87,14 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 	useEffect( () => {
 		recordGlaEvent( 'gla_modal_open', {
 			context: PRICE_BENCHMARK_CHANGE_PRICE_MODAL_CONTEXT,
-			productID: productId,
+			product_id: productId,
 		} );
 	}, [ productId ] );
 
 	const handleOnRequestClose = useCallback( () => {
 		recordGlaEvent( 'gla_modal_closed', {
 			context: PRICE_BENCHMARK_CHANGE_PRICE_MODAL_CONTEXT,
-			productID: productId,
+			product_id: productId,
 			action: 'close',
 		} );
 

--- a/js/src/pages/price-benchmark/change-price-modal/price-input-footer.js
+++ b/js/src/pages/price-benchmark/change-price-modal/price-input-footer.js
@@ -24,6 +24,7 @@ import useDispatchProduct from '~/hooks/useDispatchProduct';
  * @property {number} recommended_price The recommended price for the product.
  * @property {number} changed_price The new price set for the product.
  * @property {string} currency The currency of the product price.
+ * @property {string} gtin The global unique identifier (e.g., GTIN) for the product.
  */
 
 /**
@@ -42,6 +43,7 @@ import useDispatchProduct from '~/hooks/useDispatchProduct';
  * @param {number} [props.salesPrice] - The current sales price of the product (if any).
  * @param {Function} props.onPriceChange - Callback function triggered after the price is successfully updated.
  * @param {boolean} props.onSale - Indicates if the product is currently on sale.
+ * @param {string} props.globalUniqueId - The global unique identifier (e.g., GTIN) for the product.
  *
  * @return {JSX.Element} The rendered PriceInputFooter component.
  */
@@ -52,6 +54,7 @@ const PriceInputFooter = ( {
 	salesPrice,
 	onSale,
 	onPriceChange,
+	globalUniqueId,
 } ) => {
 	const { formatAmount } = useAdsCurrency();
 	const { updateProduct } = useDispatchProduct();
@@ -119,6 +122,7 @@ const PriceInputFooter = ( {
 				recommended_price: suggestedPrice,
 				changed_price: newPrice,
 				currency: googleAdsAccount?.currency,
+				gtin: globalUniqueId,
 			} );
 		} catch ( error ) {
 			setNewPriceError( error?.message );

--- a/js/src/pages/price-benchmark/change-price-modal/price-input-footer.js
+++ b/js/src/pages/price-benchmark/change-price-modal/price-input-footer.js
@@ -115,7 +115,7 @@ const PriceInputFooter = ( {
 			recordGlaEvent( 'gla_price_benchmarks_change_price_edited', {
 				context: PRICE_BENCHMARK_CHANGE_PRICE_MODAL_CONTEXT,
 				product_id: productId,
-				previous_rice: regularPrice,
+				previous_price: regularPrice,
 				recommended_price: suggestedPrice,
 				changed_price: newPrice,
 				currency: googleAdsAccount?.currency,

--- a/js/src/pages/price-benchmark/change-price-modal/price-input-footer.js
+++ b/js/src/pages/price-benchmark/change-price-modal/price-input-footer.js
@@ -19,10 +19,10 @@ import useDispatchProduct from '~/hooks/useDispatchProduct';
 /**
  * @event gla_price_benchmarks_change_price_edited
  * @property {string} context The context in which the event is triggered.
- * @property {number} productID The ID of the product whose price is being changed.
- * @property {number} previousPrice The previous price of the product.
- * @property {number} recommendedPrice The recommended price for the product.
- * @property {number} changedPrice The new price set for the product.
+ * @property {number} product_id The ID of the product whose price is being changed.
+ * @property {number} previous_price The previous price of the product.
+ * @property {number} recommended_price The recommended price for the product.
+ * @property {number} changed_price The new price set for the product.
  * @property {string} currency The currency of the product price.
  */
 
@@ -114,10 +114,10 @@ const PriceInputFooter = ( {
 
 			recordGlaEvent( 'gla_price_benchmarks_change_price_edited', {
 				context: PRICE_BENCHMARK_CHANGE_PRICE_MODAL_CONTEXT,
-				productID: productId,
-				previousPrice: regularPrice,
-				recommendedPrice: suggestedPrice,
-				changedPrice: newPrice,
+				product_id: productId,
+				previous_rice: regularPrice,
+				recommended_price: suggestedPrice,
+				changed_price: newPrice,
 				currency: googleAdsAccount?.currency,
 			} );
 		} catch ( error ) {

--- a/js/src/pages/price-benchmark/change-price-modal/price-input-footer.js
+++ b/js/src/pages/price-benchmark/change-price-modal/price-input-footer.js
@@ -8,11 +8,23 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import { PRICE_BENCHMARK_CHANGE_PRICE_MODAL_CONTEXT } from '../constants';
+import { recordGlaEvent } from '~/utils/tracks';
 import AppButton from '~/components/app-button';
 import AppInputPriceControl from '~/components/app-input-price-control';
 import useAdsCurrency from '~/hooks/useAdsCurrency';
 import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
 import useDispatchProduct from '~/hooks/useDispatchProduct';
+
+/**
+ * @event gla_price_benchmarks_change_price_edited
+ * @property {string} context The context in which the event is triggered.
+ * @property {number} productID The ID of the product whose price is being changed.
+ * @property {number} previousPrice The previous price of the product.
+ * @property {number} recommendedPrice The recommended price for the product.
+ * @property {number} changedPrice The new price set for the product.
+ * @property {string} currency The currency of the product price.
+ */
 
 /**
  * PriceInputFooter component.
@@ -21,8 +33,11 @@ import useDispatchProduct from '~/hooks/useDispatchProduct';
  * update the price of a product. It includes validation for the new price and
  * handles the update process.
  *
+ * @fires gla_price_benchmarks_change_price_edited
+ *
  * @param {Object} props - Component properties.
  * @param {number} props.productId - The ID of the product being updated.
+ * @param {number} props.regularPrice - The regular price of the product.
  * @param {number} props.suggestedPrice - The suggested price for the product.
  * @param {number} [props.salesPrice] - The current sales price of the product (if any).
  * @param {Function} props.onPriceChange - Callback function triggered after the price is successfully updated.
@@ -32,6 +47,7 @@ import useDispatchProduct from '~/hooks/useDispatchProduct';
  */
 const PriceInputFooter = ( {
 	productId,
+	regularPrice,
 	suggestedPrice,
 	salesPrice,
 	onSale,
@@ -95,6 +111,15 @@ const PriceInputFooter = ( {
 			await updateProduct( productId, {
 				regular_price: `${ newPrice }`,
 			} );
+
+			recordGlaEvent( 'gla_price_benchmarks_change_price_edited', {
+				context: PRICE_BENCHMARK_CHANGE_PRICE_MODAL_CONTEXT,
+				productID: productId,
+				previousPrice: regularPrice,
+				recommendedPrice: suggestedPrice,
+				changedPrice: newPrice,
+				currency: googleAdsAccount?.currency,
+			} );
 		} catch ( error ) {
 			setNewPriceError( error?.message );
 			setLoading( false );
@@ -103,20 +128,28 @@ const PriceInputFooter = ( {
 
 		setLoading( false );
 		onPriceChange( productId, newPrice );
-	}, [ newPrice, productId, onPriceChange, updateProduct, validatePrice ] );
+	}, [
+		newPrice,
+		productId,
+		onPriceChange,
+		updateProduct,
+		validatePrice,
+		googleAdsAccount,
+		regularPrice,
+		suggestedPrice,
+	] );
 
 	useEffect( () => {
 		validatePrice();
 	}, [ newPrice, validatePrice ] );
 
-	const currency = googleAdsAccount?.currency;
 	const hasError = getInputError();
 
 	return (
 		<div className="gla-change-price-modal-price-input-footer">
 			<AppInputPriceControl
 				label={ __( 'New price', 'google-listings-and-ads' ) }
-				suffix={ currency }
+				suffix={ googleAdsAccount?.currency }
 				value={ newPrice }
 				onChange={ setNewPrice }
 				className={ classnames(

--- a/js/src/pages/price-benchmark/change-price.js
+++ b/js/src/pages/price-benchmark/change-price.js
@@ -8,12 +8,26 @@ import { useCallback, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { useAppDispatch } from '~/data';
+import { recordGlaEvent } from '~/utils/tracks';
+import {
+	PRICE_BENCHMARK_CHANGE_PRICE_MODAL_CONTEXT,
+	PRICE_BENCHMARK_SUGGESTIONS_CONTEXT,
+} from './constants';
 import AppButton from '~/components/app-button';
 import ChangePriceModal from './change-price-modal';
 
 /**
+ * @event gla_price_benchmarks_change-price_clicked
+ * @property {string} context The context in which the event is triggered.
+ * @property {number} productID The ID of the product whose price is being changed.
+ */
+
+/**
  * ChangePrice component allows users to update the price of a product.
  * It provides a button to open a modal where the price can be changed.
+ *
+ * @fires gla_price_benchmarks_change-price_clicked with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
+ * @fires gla_modal_closed with `{ context: 'price-benchmark-change-price-modal', action: 'change-price' }`
  *
  * @param {Object} props - Component properties.
  * @param {number} props.productId - The ID of the product whose price is to be changed.
@@ -34,6 +48,11 @@ const ChangePrice = ( { productId } ) => {
 				newPrice
 			);
 
+			recordGlaEvent( 'gla_modal_closed', {
+				context: PRICE_BENCHMARK_CHANGE_PRICE_MODAL_CONTEXT,
+				action: 'change-price',
+			} );
+
 			handleOnRequestClose();
 		},
 		[ receivePriceBenchmarkSuggestionsRegularPrice ]
@@ -43,13 +62,22 @@ const ChangePrice = ( { productId } ) => {
 		return null;
 	}
 
-	const openModal = () => {
+	const handleOnClick = () => {
 		setIsOpen( true );
 	};
 
 	return (
 		<>
-			<AppButton onClick={ openModal } variant="tertiary" size="compact">
+			<AppButton
+				onClick={ handleOnClick }
+				variant="tertiary"
+				size="compact"
+				eventName="gla_price_benchmarks_change-price_clicked"
+				eventProps={ {
+					context: PRICE_BENCHMARK_SUGGESTIONS_CONTEXT,
+					productID: productId,
+				} }
+			>
 				{ __( 'Change price', 'google-listings-and-ads' ) }
 			</AppButton>
 

--- a/js/src/pages/price-benchmark/change-price.js
+++ b/js/src/pages/price-benchmark/change-price.js
@@ -19,7 +19,7 @@ import ChangePriceModal from './change-price-modal';
 /**
  * @event gla_price_benchmarks_change_price_clicked
  * @property {string} context The context in which the event is triggered.
- * @property {number} productID The ID of the product whose price is being changed.
+ * @property {number} product_id The ID of the product whose price is being changed.
  */
 
 /**
@@ -75,7 +75,7 @@ const ChangePrice = ( { productId } ) => {
 				eventName="gla_price_benchmarks_change_price_clicked"
 				eventProps={ {
 					context: PRICE_BENCHMARK_SUGGESTIONS_CONTEXT,
-					productID: productId,
+					product_id: productId,
 				} }
 			>
 				{ __( 'Change price', 'google-listings-and-ads' ) }

--- a/js/src/pages/price-benchmark/change-price.js
+++ b/js/src/pages/price-benchmark/change-price.js
@@ -17,7 +17,7 @@ import AppButton from '~/components/app-button';
 import ChangePriceModal from './change-price-modal';
 
 /**
- * @event gla_price_benchmarks_change-price_clicked
+ * @event gla_price_benchmarks_change_price_clicked
  * @property {string} context The context in which the event is triggered.
  * @property {number} productID The ID of the product whose price is being changed.
  */
@@ -26,7 +26,7 @@ import ChangePriceModal from './change-price-modal';
  * ChangePrice component allows users to update the price of a product.
  * It provides a button to open a modal where the price can be changed.
  *
- * @fires gla_price_benchmarks_change-price_clicked with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
+ * @fires gla_price_benchmarks_change_price_clicked with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
  * @fires gla_modal_closed with `{ context: 'price-benchmark-change-price-modal', action: 'change-price' }`
  *
  * @param {Object} props - Component properties.
@@ -72,7 +72,7 @@ const ChangePrice = ( { productId } ) => {
 				onClick={ handleOnClick }
 				variant="tertiary"
 				size="compact"
-				eventName="gla_price_benchmarks_change-price_clicked"
+				eventName="gla_price_benchmarks_change_price_clicked"
 				eventProps={ {
 					context: PRICE_BENCHMARK_SUGGESTIONS_CONTEXT,
 					productID: productId,

--- a/js/src/pages/price-benchmark/constants.js
+++ b/js/src/pages/price-benchmark/constants.js
@@ -3,6 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 
+export const PRICE_BENCHMARK_SUGGESTIONS_CONTEXT =
+	'price-benchmark-suggestions';
+export const PRICE_BENCHMARK_CHANGE_PRICE_MODAL_CONTEXT =
+	'price-benchmark-change-price-modal';
 export const LABEL_CHANGE_EFFECTIVENESS = 'LABEL_CHANGE_EFFECTIVENESS';
 export const LABEL_AVG_PRICE_ON_GOOGLE = 'LABEL_AVG_PRICE_ON_GOOGLE';
 export const LABEL_PRICE_GAP_PERCENT = 'LABEL_PRICE_GAP_PERCENT';

--- a/js/src/pages/price-benchmark/price-benchmark-suggestions/index.js
+++ b/js/src/pages/price-benchmark/price-benchmark-suggestions/index.js
@@ -9,6 +9,7 @@ import { useState, useMemo, useEffect, useCallback } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { recordGlaEvent } from '~/utils/tracks';
 import EmptyMetricsNotice from '../empty-metrics-notice';
 import usePriceBenchmarkSuggestions from '~/hooks/usePriceBenchmarkSuggestions';
 import ChangePrice from '../change-price';
@@ -16,6 +17,7 @@ import EffectivenessIndicator from '../effectiveness-indicator';
 import Label from '../label';
 import Price from '../price';
 import {
+	PRICE_BENCHMARK_SUGGESTIONS_CONTEXT,
 	LABELS,
 	LABEL_CHANGE_EFFECTIVENESS,
 	LABEL_AVG_PRICE_ON_GOOGLE,
@@ -162,12 +164,20 @@ const METRICS_TABLE_FIELDS = [
 const TABLE_FIELDS_MOBILE = [ 'action' ];
 
 /**
+ * @event gla_price_benchmarks_shown
+ * @property {string} context The context of the event.
+ * @property {number} suggestions The number of suggestions shown.
+ */
+
+/**
  * PriceBenchmarkSuggestions component.
  *
  * This component fetches and displays price benchmark suggestions using the
  * `usePriceBenchmarkSuggestions` hook. It renders a table with the suggestions
  * data and handles responsiveness by providing different field configurations
  * for desktop and mobile views.
+ *
+ * @fires gla_price_benchmarks_shown with `{ context: 'price-benchmark-suggestions' }` and the suggestions count.
  *
  * @param {Object} props - The component props.
  * @param {boolean} props.isViewportMobile - Indicates if the viewport is in mobile size.
@@ -226,6 +236,17 @@ const PriceBenchmarkSuggestions = ( { isViewportMobile } ) => {
 			fields: viewportFields,
 		} ) );
 	}, [ viewportFields ] );
+
+	useEffect( () => {
+		if ( ! hasFinishedResolution ) {
+			return;
+		}
+
+		recordGlaEvent( 'gla_price_benchmarks_shown', {
+			context: PRICE_BENCHMARK_SUGGESTIONS_CONTEXT,
+			suggestions: suggestions.length,
+		} );
+	}, [ hasFinishedResolution, suggestions ] );
 
 	if ( hasFinishedResolution && suggestions.length === 0 ) {
 		return <EmptyMetricsNotice />;

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -589,6 +589,22 @@ Clicking on the "Yes, I want a new account" button in the warning modal for crea
 #### Emitters
 - [`WarningModal`](../../js/src/components/google-mc-account-card/warning-modal/index.js#L29)
 
+### [`gla_modal_closed`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L44)
+
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | The context in which the event is triggered.
+`productID` | `number` | The ID of the product whose price is being changed.
+`action` | `string` | The action taken to close the modal.
+#### Emitters
+- [`AttributeMappingTable`](../../js/src/pages/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is closed
+- [`ChangePrice`](../../js/src/pages/price-benchmark/change-price.js#L36) with `{ context: 'price-benchmark-change-price-modal', action: 'change-price' }`
+- [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L67) with `{ context: 'price-benchmark-change-price-modal', action: 'close' }` and the product ID.
+- [`Dashboard`](../../js/src/pages/dashboard/index.js#L33) when CES modal is closed.
+- [`ReviewRequest`](../../js/src/pages/product-feed/review-request/index.js#L31) with `action: 'request-review-success' | 'maybe-later' | 'dismiss', context: REQUEST_REVIEW`
+- [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L155) with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss'`
+
 ### [`gla_modal_closed`](../../js/src/utils/tracks.js#L241)
 A modal is closed.
 #### Properties
@@ -598,6 +614,8 @@ A modal is closed.
 `action` | `string` | Indicates the modal is closed by what action (e.g. `maybe-later`\|`dismiss` \| `create-another-campaign`)    - `maybe-later` is used when the "Maybe later" button on the modal is clicked    - `dismiss` is used when the modal is dismissed by clicking on "X" icon, overlay, generic "Cancel" button, or pressing ESC    - `create-another-campaign` is used when the button "Create another campaign" is clicked    - `create-paid-campaign` is used when the button "Create paid campaign" is clicked    - `confirm` is used when the button "Confirm", "Save"  or similar generic "Accept" button is clicked
 #### Emitters
 - [`AttributeMappingTable`](../../js/src/pages/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is closed
+- [`ChangePrice`](../../js/src/pages/price-benchmark/change-price.js#L36) with `{ context: 'price-benchmark-change-price-modal', action: 'change-price' }`
+- [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L67) with `{ context: 'price-benchmark-change-price-modal', action: 'close' }` and the product ID.
 - [`Dashboard`](../../js/src/pages/dashboard/index.js#L33) when CES modal is closed.
 - [`ReviewRequest`](../../js/src/pages/product-feed/review-request/index.js#L31) with `action: 'request-review-success' | 'maybe-later' | 'dismiss', context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L155) with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss'`
@@ -612,6 +630,19 @@ Clicking on a text link within the modal content
 #### Emitters
 - [`ContentLink`](../../js/src/components/guide-page-content/index.js#L46) with given `context, href`
 
+### [`gla_modal_open`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L38)
+
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | The context in which the event is triggered.
+`productID` | `number` | The ID of the product whose price is being changed.
+#### Emitters
+- [`AttributeMappingTable`](../../js/src/pages/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is open with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal' }`
+- [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L67) with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
+- [`ReviewRequest`](../../js/src/pages/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
+- [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
+
 ### [`gla_modal_open`](../../js/src/utils/tracks.js#L254)
 A modal is open
 #### Properties
@@ -620,6 +651,7 @@ A modal is open
 `context` | `string` | Indicates which modal is open
 #### Emitters
 - [`AttributeMappingTable`](../../js/src/pages/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is open with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal' }`
+- [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L67) with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
 - [`ReviewRequest`](../../js/src/pages/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 
@@ -670,6 +702,40 @@ Triggered when moving to another step during creating/editing a campaign.
 - [`EditPaidAdsCampaign`](../../js/src/pages/edit-paid-ads-campaign/index.js#L69)
 	- with `{ context: 'edit-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
 	- with `{ context: 'edit-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
+
+### [`gla_price_benchmarks_change_price_clicked`](../../js/src/pages/price-benchmark/change-price.js#L19)
+
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | The context in which the event is triggered.
+`productID` | `number` | The ID of the product whose price is being changed.
+#### Emitters
+- [`ChangePrice`](../../js/src/pages/price-benchmark/change-price.js#L36) with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
+
+### [`gla_price_benchmarks_change_price_edited`](../../js/src/pages/price-benchmark/change-price-modal/price-input-footer.js#L19)
+
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | The context in which the event is triggered.
+`productID` | `number` | The ID of the product whose price is being changed.
+`previousPrice` | `number` | The previous price of the product.
+`recommendedPrice` | `number` | The recommended price for the product.
+`changedPrice` | `number` | The new price set for the product.
+`currency` | `string` | The currency of the product price.
+#### Emitters
+- [`PriceInputFooter`](../../js/src/pages/price-benchmark/change-price-modal/price-input-footer.js#L48)
+
+### [`gla_price_benchmarks_shown`](../../js/src/pages/price-benchmark/price-benchmark-suggestions/index.js#L166)
+
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | The context of the event.
+`suggestions` | `number` | The number of suggestions shown.
+#### Emitters
+- [`PriceBenchmarkSuggestions`](../../js/src/pages/price-benchmark/price-benchmark-suggestions/index.js#L186) with `{ context: 'price-benchmark-suggestions' }` and the suggestions count.
 
 ### [`gla_request_review`](../../js/src/pages/product-feed/review-request/review-request-modal.js#L19)
 Triggered when request review button is clicked

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -596,7 +596,7 @@ Clicking on the "Yes, I want a new account" button in the warning modal for crea
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
-`productID` | `number` | The ID of the product whose price is being changed.
+`product_id` | `number` | The ID of the product whose price is being changed.
 `action` | `string` | The action taken to close the modal.
 #### Emitters
 - [`AttributeMappingTable`](../../js/src/pages/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is closed
@@ -637,7 +637,7 @@ Clicking on a text link within the modal content
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
-`productID` | `number` | The ID of the product whose price is being changed.
+`product_id` | `number` | The ID of the product whose price is being changed.
 #### Emitters
 - [`AttributeMappingTable`](../../js/src/pages/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is open with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal' }`
 - [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L67) with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
@@ -710,7 +710,7 @@ Triggered when moving to another step during creating/editing a campaign.
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
-`productID` | `number` | The ID of the product whose price is being changed.
+`product_id` | `number` | The ID of the product whose price is being changed.
 #### Emitters
 - [`ChangePrice`](../../js/src/pages/price-benchmark/change-price.js#L36) with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
 
@@ -720,15 +720,15 @@ Triggered when moving to another step during creating/editing a campaign.
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
-`productID` | `number` | The ID of the product whose price is being changed.
-`previousPrice` | `number` | The previous price of the product.
-`recommendedPrice` | `number` | The recommended price for the product.
-`changedPrice` | `number` | The new price set for the product.
+`product_id` | `number` | The ID of the product whose price is being changed.
+`previous_price` | `number` | The previous price of the product.
+`recommended_price` | `number` | The recommended price for the product.
+`changed_price` | `number` | The new price set for the product.
 `currency` | `string` | The currency of the product price.
 #### Emitters
 - [`PriceInputFooter`](../../js/src/pages/price-benchmark/change-price-modal/price-input-footer.js#L48)
 
-### [`gla_price_benchmarks_shown`](../../js/src/pages/price-benchmark/price-benchmark-suggestions/index.js#L166)
+### [`gla_price_benchmarks_shown`](../../js/src/pages/price-benchmark/price-benchmark-suggestions/index.js#L167)
 
 #### Properties
 | name | type | description |
@@ -736,7 +736,7 @@ Triggered when moving to another step during creating/editing a campaign.
 `context` | `string` | The context of the event.
 `suggestions` | `number` | The number of suggestions shown.
 #### Emitters
-- [`PriceBenchmarkSuggestions`](../../js/src/pages/price-benchmark/price-benchmark-suggestions/index.js#L186) with `{ context: 'price-benchmark-suggestions' }` and the suggestions count.
+- [`PriceBenchmarkSuggestions`](../../js/src/pages/price-benchmark/price-benchmark-suggestions/index.js#L187) with `{ context: 'price-benchmark-suggestions' }` and the suggestions count.
 
 ### [`gla_request_review`](../../js/src/pages/product-feed/review-request/review-request-modal.js#L19)
 Triggered when request review button is clicked


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2888 .

_Replace this with a good description of your changes & reasoning._

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Open the Console tab in the browser DevTool, and run `localStorage.setItem( 'debug', 'wc-admin:*' )` to enable tracking debugging mode.
2. Check if the tracking data as per the AC
3. Some values have been altered. For e.g `gla_price_benchmarks_change-price_clicked` is `gla_price_benchmarks_change_price_clicked` to be consistent with the naming structure. [Related note](https://github.com/woocommerce/google-listings-and-ads/issues/2888#issuecomment-2879627501).


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
