### PR TITLE
Modify `mc/price-benchmarks` data processing

### DIFF
--- a/src/API/Google/MerchantPriceBenchmarks.php
+++ b/src/API/Google/MerchantPriceBenchmarks.php
@@ -53,8 +53,25 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 			->set_client( $this->service, $this->options->get_merchant_id() )
 			->get_results();
 
-			$results = $response->getResults() ?? [];
+			$benchmark_data = $response->getResults() ?? [];
 
+			if ( empty( $benchmark_data ) ) {
+				return $benchmark_data;
+			}
+
+			// Map the benchmark data to a require format.
+			$results = [];
+			foreach ( $benchmark_data as $benchmark_result ) {
+				$results[] = [
+					'id'                            => $benchmark_result->getProductView()->getId(),
+					'offer_id'                      => $benchmark_result->getProductView()->getOfferId(),
+					'title'                         => $benchmark_result->getProductView()->getTitle(),
+					'price_micros'                  => $benchmark_result->getProductView()->getPriceMicros(),
+					'currency_code'                 => $benchmark_result->getProductView()->getCurrencyCode(),
+					'benchmark_price_micros'        => $benchmark_result->getPriceCompetitiveness()->getBenchmarkPriceMicros(),
+					'benchmark_price_currency_code' => $benchmark_result->getPriceCompetitiveness()->getBenchmarkPriceCurrencyCode(),
+				];
+			}
 			return $results;
 		} catch ( GoogleException $e ) {
 			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
@@ -77,8 +94,28 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 			->set_client( $this->service, $this->options->get_merchant_id() )
 			->get_results();
 
-			$results = $response->getResults() ?? [];
+			$price_insights_data = $response->getResults() ?? [];
 
+			if ( empty( $price_insights_data ) ) {
+				return $price_insights_data;
+			}
+
+			// Map the benchmark data to a require format.
+			$results = [];
+			foreach ( $price_insights_data as $price_insights_result ) {
+				$results[] = [
+					'id'                               => $price_insights_result->getProductView()->getId(),
+					'offer_id'                         => $price_insights_result->getProductView()->getOfferId(),
+					'title'                            => $price_insights_result->getProductView()->getTitle(),
+					'price_micros'                     => $price_insights_result->getProductView()->getPriceMicros(),
+					'currency_code'                    => $price_insights_result->getProductView()->getCurrencyCode(),
+					'suggested_price_micros'           => $price_insights_result->getPriceInsights()->getSuggestedPriceMicros(),
+					'predicted_impressions_change_fraction' => $price_insights_result->getPriceInsights()->getPredictedImpressionsChangeFraction(),
+					'predicted_clicks_change_fraction' => $price_insights_result->getPriceInsights()->getPredictedClicksChangeFraction(),
+					'predicted_conversions_change_fraction' => $price_insights_result->getPriceInsights()->getPredictedConversionsChangeFraction(),
+					'effectiveness'                    => '', // $price_insights_result->getPriceInsights()->getEffectiveness() is not returning error, returning null.
+				];
+			}
 			return $results;
 		} catch ( GoogleException $e ) {
 			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
@@ -107,8 +144,21 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 			->set_client( $this->service, $this->options->get_merchant_id() )
 			->get_results();
 
-			$results = $response->getResults() ?? [];
+			$performance_data = $response->getResults() ?? [];
 
+			if ( empty( $performance_data ) ) {
+				return $performance_data;
+			}
+
+			// Map the performance data to a require format.
+			$results = [];
+			foreach ( $performance_data as $performance_result ) {
+				$results[] = [
+					'offer_id'    => $performance_result->getSegments()->getOfferId(),
+					'clicks'      => $performance_result->getMetrics()->getClicks(),
+					'conversions' => $performance_result->getMetrics()->getConversions(),
+				];
+			}
 			return $results;
 		} catch ( GoogleException $e ) {
 			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2907.

_Replace this with a good description of your changes & reasoning._


### Screenshots:

After the proxy tests:
**Response of `mc/price-benchmarks`:**
<img width="707" alt="Screenshot 2025-05-14 at 9 03 00 PM" src="https://github.com/user-attachments/assets/cec5d2ec-ff5a-4642-8df8-89a0be8e582a" />

**Response of `mc/price-benchmarks/103572`:**
<img width="742" alt="Screenshot 2025-05-14 at 9 03 26 PM" src="https://github.com/user-attachments/assets/0b83b4b7-97e6-499c-9c48-cb5eaed69f71" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Use instruction from #2890 to set up the test-proxy to mock API responses
2. Send a GET request to the `/wc/gla/mc/price-benchmarks/` endpoint
3. Review the response returned from the price-benchmarks endpoint



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>