### PR TITLE
Fix the decimal precision issue when comparing a budget with a low recommended value, which is used to trigger a recommended budget notice

### DIFF
--- a/js/src/components/paid-ads/budget-setup/budget-setup.js
+++ b/js/src/components/paid-ads/budget-setup/budget-setup.js
@@ -16,6 +16,7 @@ import AppInputPriceControl from '~/components/app-input-price-control';
 import BudgetSetupHeader from './budget-setup-header';
 import BudgetRadioControl from './budget-radio-control';
 import LowBudgetNotice from './low-budget-notice';
+import round from '~/utils/round';
 import styles from './budget-setup.module.scss';
 
 const i18nLevel = {
@@ -23,6 +24,17 @@ const i18nLevel = {
 	high: __( 'High', 'google-listings-and-ads' ),
 	recommended: __( 'Recommended', 'google-listings-and-ads' ),
 };
+
+function isBelowLowRecommendation( amount, recommendation, precision ) {
+	if (
+		! recommendation?.low?.dailyBudget ||
+		! Number.isInteger( precision )
+	) {
+		return false;
+	}
+
+	return amount < round( recommendation.low.dailyBudget, precision );
+}
 
 function BudgetMetrics( { formatAmount, metrics } ) {
 	return (
@@ -55,7 +67,7 @@ export default function BudgetSetup( { hideRecommendations = false } ) {
 	const { adapter, getInputProps, values } = formContext;
 	const { countryCodes, budgetRecommendation } = adapter;
 	const { amount } = values;
-	const { formatAmount } = useAdsCurrency();
+	const { adsCurrencyConfig, formatAmount } = useAdsCurrency();
 
 	const [ budget, setBudget ] = useState( amount );
 	const debouncedSetBudget = useDebounce( setBudget, 1000 );
@@ -98,7 +110,11 @@ export default function BudgetSetup( { hideRecommendations = false } ) {
 		! help &&
 		! hideRecommendations &&
 		budgetRecommendation?.recommended &&
-		values.amount < budgetRecommendation?.low?.dailyBudget;
+		isBelowLowRecommendation(
+			amount,
+			budgetRecommendation,
+			adsCurrencyConfig.precision
+		);
 
 	const getRowClassName = ( level ) => {
 		const selected = level === values.level;

--- a/js/src/components/paid-ads/budget-setup/budget-setup.test.js
+++ b/js/src/components/paid-ads/budget-setup/budget-setup.test.js
@@ -306,11 +306,11 @@ describe( 'BudgetSetup', () => {
 
 		const input = screen.getByRole( 'textbox' );
 		await user.clear( input );
-		await user.type( input, '7' );
+		await user.type( input, '7.23' );
 
 		expect( container ).toHaveTextContent( notice );
 
-		await user.type( input, '.5' );
+		await user.keyboard( '{End}{Backspace}4' );
 
 		expect( container ).not.toHaveTextContent( notice );
 	} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Related to #2896

This PR fixes the decimal precision issue when comparing a budget with a low recommended value in the `BudgetSetup` component. It should show the notice when the custom budget is less than the low recommendation.

### Screenshots:

#### 📷 Before fix

![image](https://github.com/user-attachments/assets/d5ef3a26-0290-4e66-9990-9608809322cb)

#### 📷 After fix

![image](https://github.com/user-attachments/assets/db480e16-6222-4c1c-85a0-2f83fb71dca2)
