### PR TITLE
Fix `UpdateMerchantPriceBenchmarks` job is not properly running

### DIFF
--- a/src/API/Google/MerchantPriceBenchmarks.php
+++ b/src/API/Google/MerchantPriceBenchmarks.php
@@ -68,6 +68,7 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 					'title'                         => $benchmark_result->getProductView()->getTitle(),
 					'price_micros'                  => $benchmark_result->getProductView()->getPriceMicros(),
 					'currency_code'                 => $benchmark_result->getProductView()->getCurrencyCode(),
+					'country_code'                  => $benchmark_result->getPriceCompetitiveness()->getCountryCode(),
 					'benchmark_price_micros'        => $benchmark_result->getPriceCompetitiveness()->getBenchmarkPriceMicros(),
 					'benchmark_price_currency_code' => $benchmark_result->getPriceCompetitiveness()->getBenchmarkPriceCurrencyCode(),
 				];

--- a/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
+++ b/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
@@ -51,9 +51,9 @@ class MerchantPriceBenchmarksQuery extends MerchantQuery {
 				'title'                         => 'product_view.title',
 				'price_micros'                  => 'product_view.price_micros',
 				'currency_code'                 => 'product_view.currency_code',
+				'country_code'                  => 'price_competitiveness.country_code',
 				'benchmark_price_micros'        => 'price_competitiveness.benchmark_price_micros',
 				'benchmark_price_currency_code' => 'price_competitiveness.benchmark_price_currency_code',
-				'benchmark_price_country_code'  => 'price_competitiveness.country_code',
 			]
 		);
 	}

--- a/src/Jobs/UpdateMerchantPriceBenchmarks.php
+++ b/src/Jobs/UpdateMerchantPriceBenchmarks.php
@@ -93,7 +93,7 @@ class UpdateMerchantPriceBenchmarks extends AbstractActionSchedulerJob {
 	 */
 	public function schedule( array $args = [] ) {
 		if ( $this->can_schedule( $args ) ) {
-			$this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), $args );
+			$this->action_scheduler->schedule_recurring( time(), 12 * HOUR_IN_SECONDS, $this->get_process_item_hook(), $args );
 		}
 	}
 

--- a/src/MerchantCenter/PriceBenchmarks.php
+++ b/src/MerchantCenter/PriceBenchmarks.php
@@ -32,7 +32,7 @@ class PriceBenchmarks implements ContainerAwareInterface, Service {
 
 			$benchmarks = $merchant->get_benchmark_data( [] );
 
-			if ( empty( $benchmarks ) || empty( $benchmarks['results'] ) ) {
+			if ( empty( $benchmarks ) ) {
 				return;
 			}
 
@@ -43,8 +43,7 @@ class PriceBenchmarks implements ContainerAwareInterface, Service {
 			$query->reload_data();
 
 			// Insert new benchmark data.
-			foreach ( $benchmarks['results'] as $benchmark ) {
-
+			foreach ( $benchmarks as $benchmark ) {
 				$price_compared_with_benchmark = $this->price_compared_with_benchmark( $benchmark['price_micros'], $benchmark['benchmark_price_micros'] );
 				$query->insert(
 					[

--- a/tests/Unit/Jobs/UpdateMerchantPriceBenchmarksTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantPriceBenchmarksTest.php
@@ -80,8 +80,13 @@ class UpdateMerchantPriceBenchmarksTest extends UnitTest {
 			->willReturn( true );
 
 		$this->action_scheduler->expects( $this->once() )
-			->method( 'schedule_immediate' )
-			->with( 'gla/jobs/' . self::JOB_NAME . '/process_item', [] );
+			->method( 'schedule_recurring' )
+			->with(
+				time(), // timestamp
+				HOUR_IN_SECONDS * 12, // interval
+				'gla/jobs/' . self::JOB_NAME . '/process_item',
+				[]
+			);
 
 		$this->job->schedule();
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2920.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check local database `wp_gla_merchant_price_benchmarks` table. Remove existing data in that table.
2. Visit the price benchmarks page in the plugin admin
3. Visit 'Tools > Scheduled Actions' from the admin menu `/wp-admin/tools.php?page=action-scheduler` and verify that the `gla/jobs/update_merchant_price_benchmarks/process_item` job has been scheduled.
4. If the job hasn't already run, you can run it from the job list
5. Confirm that the data is imported to our local database
  - Option 1: Use XDebug to confirm that this method fails
  - Option 2: Connect to the [test-proxy](https://github.com/woocommerce/google-listings-and-ads/tree/feature/2824-price-benchmarks/tests/proxy) to confirm that the mocked data get imported.

### Changelog entry
