### PR TITLE
Update effectiveness values in proxy data

### DIFF
--- a/tests/proxy/mocks/mc/price-benchmarks/price-insights-item.json
+++ b/tests/proxy/mocks/mc/price-benchmarks/price-insights-item.json
@@ -14,7 +14,7 @@
 				"predictedImpressionsChangeFraction": "0.12609300017356873",
 				"predictedClicksChangeFraction": "0.508745014667511",
 				"predictedConversionsChangeFraction": "2.3431060314178467",
-				"effectiveness": 3
+				"effectiveness": "HIGH"
 			}
 		}
 	]

--- a/tests/proxy/mocks/mc/price-benchmarks/price-insights.json
+++ b/tests/proxy/mocks/mc/price-benchmarks/price-insights.json
@@ -14,7 +14,7 @@
 				"predictedImpressionsChangeFraction": "0.12609300017356873",
 				"predictedClicksChangeFraction": "0.508745014667511",
 				"predictedConversionsChangeFraction": "2.3431060314178467",
-				"effectiveness": 3
+				"effectiveness": "HIGH"
 			}
 		},
 		{
@@ -31,7 +31,7 @@
 				"predictedImpressionsChangeFraction": "0.15723400012458974",
 				"predictedClicksChangeFraction": "0.467823012356781",
 				"predictedConversionsChangeFraction": "1.9876543210987654",
-				"effectiveness": 2
+				"effectiveness": "MEDIUM"
 			}
 		},
 		{
@@ -48,7 +48,7 @@
 				"predictedImpressionsChangeFraction": "0.18976500023145628",
 				"predictedClicksChangeFraction": "0.612345678912345",
 				"predictedConversionsChangeFraction": "2.1234567890123456",
-				"effectiveness": 1
+				"effectiveness": "LOW"
 			}
 		},
 		{
@@ -65,7 +65,7 @@
 				"predictedImpressionsChangeFraction": "0.17654300098765432",
 				"predictedClicksChangeFraction": "0.534567890123456",
 				"predictedConversionsChangeFraction": "1.9876543210123456",
-				"effectiveness": 0
+				"effectiveness": "EFFECTIVENESS_UNSPECIFIED"
 			}
 		},
 		{
@@ -82,7 +82,7 @@
 				"predictedImpressionsChangeFraction": "0.14532100078965432",
 				"predictedClicksChangeFraction": "0.487654321098765",
 				"predictedConversionsChangeFraction": "2.0123456789012345",
-				"effectiveness": 3
+				"effectiveness": "HIGH"
 			}
 		},
 		{
@@ -99,7 +99,7 @@
 				"predictedImpressionsChangeFraction": "0.12345678901234567",
 				"predictedClicksChangeFraction": "0.456789012345678",
 				"predictedConversionsChangeFraction": "1.7890123456789012",
-				"effectiveness": 2
+				"effectiveness": "MEDIUM"
 			}
 		},
 		{
@@ -116,7 +116,7 @@
 				"predictedImpressionsChangeFraction": "0.15678901234567890",
 				"predictedClicksChangeFraction": "0.543210987654321",
 				"predictedConversionsChangeFraction": "1.8901234567890123",
-				"effectiveness": 1
+				"effectiveness": "LOW"
 			}
 		},
 		{
@@ -133,7 +133,7 @@
 				"predictedImpressionsChangeFraction": "0.16789012345678901",
 				"predictedClicksChangeFraction": "0.567890123456789",
 				"predictedConversionsChangeFraction": "1.9012345678901234",
-				"effectiveness": 0
+				"effectiveness": "EFFECTIVENESS_UNSPECIFIED"
 			}
 		},
 		{
@@ -150,7 +150,7 @@
 				"predictedImpressionsChangeFraction": "0.13456789012345678",
 				"predictedClicksChangeFraction": "0.523456789012345",
 				"predictedConversionsChangeFraction": "1.8765432109876543",
-				"effectiveness": 2
+				"effectiveness": "MEDIUM"
 			}
 		},
 		{
@@ -167,7 +167,7 @@
 				"predictedImpressionsChangeFraction": "0.14321098765432109",
 				"predictedClicksChangeFraction": "0.531234567890123",
 				"predictedConversionsChangeFraction": "1.8543210987654321",
-				"effectiveness": 3
+				"effectiveness": "HIGH"
 			}
 		},
 		{
@@ -184,7 +184,7 @@
 				"predictedImpressionsChangeFraction": "0.19876543210987654",
 				"predictedClicksChangeFraction": "0.645678901234567",
 				"predictedConversionsChangeFraction": "2.4567890123456789",
-				"effectiveness": 1
+				"effectiveness": "LOW"
 			}
 		},
 		{
@@ -201,7 +201,7 @@
 				"predictedImpressionsChangeFraction": "0.17654321098765432",
 				"predictedClicksChangeFraction": "0.587654321098765",
 				"predictedConversionsChangeFraction": "2.3210987654321098",
-				"effectiveness": 0
+				"effectiveness": "EFFECTIVENESS_UNSPECIFIED"
 			}
 		},
 		{
@@ -218,7 +218,7 @@
 				"predictedImpressionsChangeFraction": "0.18765432109876543",
 				"predictedClicksChangeFraction": "0.598765432109876",
 				"predictedConversionsChangeFraction": "2.3321098765432109",
-				"effectiveness": 2
+				"effectiveness": "MEDIUM"
 			}
 		},
 		{
@@ -235,7 +235,7 @@
 				"predictedImpressionsChangeFraction": "0.16543210987654321",
 				"predictedClicksChangeFraction": "0.554321098765432",
 				"predictedConversionsChangeFraction": "2.1098765432109876",
-				"effectiveness": 1
+				"effectiveness": "LOW"
 			}
 		},
 		{
@@ -252,7 +252,7 @@
 				"predictedImpressionsChangeFraction": "0.17890123456789012",
 				"predictedClicksChangeFraction": "0.575678901234567",
 				"predictedConversionsChangeFraction": "2.2345678901234567",
-				"effectiveness": 3
+				"effectiveness": "HIGH"
 			}
 		},
 		{
@@ -269,7 +269,7 @@
 				"predictedImpressionsChangeFraction": "0.16789012345678901",
 				"predictedClicksChangeFraction": "0.569876543210987",
 				"predictedConversionsChangeFraction": "2.1987654321098765",
-				"effectiveness": 0
+				"effectiveness": "EFFECTIVENESS_UNSPECIFIED"
 			}
 		},
 		{
@@ -286,7 +286,7 @@
 				"predictedImpressionsChangeFraction": "0.15678901234567890",
 				"predictedClicksChangeFraction": "0.543210987654321",
 				"predictedConversionsChangeFraction": "2.0987654321098765",
-				"effectiveness": 2
+				"effectiveness": "MEDIUM"
 			}
 		},
 		{
@@ -303,7 +303,7 @@
 				"predictedImpressionsChangeFraction": "0.18765432109876543",
 				"predictedClicksChangeFraction": "0.598765432109876",
 				"predictedConversionsChangeFraction": "2.2567890123456789",
-				"effectiveness": 1
+				"effectiveness": "LOW"
 			}
 		},
 		{
@@ -320,7 +320,7 @@
 				"predictedImpressionsChangeFraction": "0.19012345678901234",
 				"predictedClicksChangeFraction": "0.601234567890123",
 				"predictedConversionsChangeFraction": "2.2765432109876543",
-				"effectiveness": 3
+				"effectiveness": "HIGH"
 			}
 		},
 		{
@@ -337,7 +337,7 @@
 				"predictedImpressionsChangeFraction": "0.19876543210987654",
 				"predictedClicksChangeFraction": "0.612345678901234",
 				"predictedConversionsChangeFraction": "2.2987654321098765",
-				"effectiveness": 2
+				"effectiveness": "MEDIUM"
 			}
 		}
 	]


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Related to #2911. We were able to confirm that the API queries to the `PriceInsightsProductView` can support ordering by effectiveness by including `ORDER BY price_insights.effectiveness DESC`.

At the same time, the API responses that we tested returned a slightly different value format than we were expecting. Rather than returning the array value of the enum, it returns the string value as documented in https://developers.google.com/shopping-content/reference/rest/v2.1/reports/search#Effectiveness.

This PR updates the test-proxy response data for the `PriceInsightsProductView` queries to return the expected shape.

This can be used to test the changes for #2911.