### PR TITLE
Add FAQ link to the price benchmark suggestions header.

### DIFF
--- a/js/src/pages/price-benchmark/faq-link.js
+++ b/js/src/pages/price-benchmark/faq-link.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ExternalLink } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { recordGlaEvent } from '~/utils/tracks';
+
+const URL = 'https://woocommerce.com/document/google-for-woocommerce/faq/';
+
+const FaqLink = () => {
+	return (
+		<ExternalLink
+			onClick={ () => {
+				recordGlaEvent( 'gla_price_benchmark_faq_link_clicked', {
+					context: 'price_benchmark',
+					link_id: 'faq_link',
+					href: URL,
+				} );
+			} }
+			href={ URL }
+		>
+			{ __( 'FAQ', 'google-listings-and-ads' ) }
+		</ExternalLink>
+	);
+};
+
+export default FaqLink;

--- a/js/src/pages/price-benchmark/faq-link.js
+++ b/js/src/pages/price-benchmark/faq-link.js
@@ -11,18 +11,23 @@ import { recordGlaEvent } from '~/utils/tracks';
 
 const URL = 'https://woocommerce.com/document/google-for-woocommerce/faq/';
 
+/**
+ * Renders an external FAQ link and tracks click events for analytics.
+ *
+ * @fires gla_documentation_link_click with `{ context: 'price-benchmark-suggestions', link_id: 'price-benchmark-suggestions-faq' }` and the URL.
+ * @return {JSX.Element} The rendered external FAQ link component.
+ */
 const FaqLink = () => {
+	const handleClick = () => {
+		recordGlaEvent( 'gla_documentation_link_click', {
+			context: 'price-benchmark-suggestions',
+			link_id: 'price-benchmark-suggestions-faq',
+			href: URL,
+		} );
+	};
+
 	return (
-		<ExternalLink
-			onClick={ () => {
-				recordGlaEvent( 'gla_price_benchmark_faq_link_clicked', {
-					context: 'price_benchmark',
-					link_id: 'faq_link',
-					href: URL,
-				} );
-			} }
-			href={ URL }
-		>
+		<ExternalLink onClick={ handleClick } href={ URL }>
 			{ __( 'FAQ', 'google-listings-and-ads' ) }
 		</ExternalLink>
 	);

--- a/js/src/pages/price-benchmark/price-benchmark-suggestions/index.js
+++ b/js/src/pages/price-benchmark/price-benchmark-suggestions/index.js
@@ -15,6 +15,7 @@ import ChangePrice from '../change-price';
 import EffectivenessIndicator from '../effectiveness-indicator';
 import Label from '../label';
 import Price from '../price';
+import FaqLink from '../faq-link';
 import {
 	LABELS,
 	LABEL_CHANGE_EFFECTIVENESS,
@@ -259,6 +260,7 @@ const PriceBenchmarkSuggestions = ( { isViewportMobile } ) => {
 					paginationInfo={ paginationInfo }
 					onChangeView={ handleOnChangeView }
 					defaultLayouts={ [] }
+					header={ <FaqLink /> }
 				/>
 			) }
 		</div>

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -340,6 +340,7 @@ When a documentation link is clicked.
 	- with `{ context: "reports-products", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
 	- with `{ context: "reports-programs", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
 - [`EditStoreAddress`](../../js/src/pages/settings/edit-store-address.js#L41) with `{ context: "settings-store-address", link_id: "contact-information-read-more", href: "https://woocommerce.com/document/google-for-woocommerce/get-started/requirements/#contact-information" }`
+- [`FaqLink`](../../js/src/pages/price-benchmark/faq-link.js#L20) with `{ context: 'price-benchmark-suggestions', link_id: 'price-benchmark-suggestions-faq' }` and the URL.
 - [`Faqs`](../../js/src/components/paid-ads/asset-group/faqs.js#L72) with `{ context: 'assets-faq', linkId: 'assets-faq-about-ad-formats-available-in-different-campaign-types', href: 'https://support.google.com/google-ads/answer/1722124' }`.
 - [`Faqs`](../../js/src/pages/get-started/faqs/index.js#L428)
 	- with `{ context: 'faqs', linkId: 'general-requirements', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/requirements/#general-requirements' }`.

--- a/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
+++ b/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
@@ -223,40 +223,18 @@ test.describe( 'Price Benchmark Page', () => {
 			);
 		} );
 
-		test( 'FAQ link is present and clickable', async () => {
-			await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions( [
-				...priceBenchmarkSuggestionsData,
-			] );
+		test( 'FAQ link is present and has the correct URL', async () => {
+			await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions(
+				priceBenchmarkSuggestionsData
+			);
 			// Get the faq link by .dataviews__view-actions > .components-external-link by text.
 			const faqLink = page.locator(
 				'.dataviews__view-actions .components-external-link'
 			);
 			await expect( faqLink ).toBeVisible();
 			await expect( faqLink ).toContainText( 'FAQ' );
-		} );
-
-		test( 'Clicking the FAQ link opens the correct URL', async () => {
-			await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions( [
-				...priceBenchmarkSuggestionsData,
-			] );
-
-			const faqLink = page.locator(
-				'.dataviews__view-actions .components-external-link'
-			);
 			await expect( faqLink ).toHaveAttribute(
 				'href',
-				'https://woocommerce.com/document/google-for-woocommerce/faq/'
-			);
-
-			await faqLink.click();
-
-			const [ newPage ] = await Promise.all( [
-				page.context().waitForEvent( 'page' ),
-				faqLink.click(),
-			] );
-
-			await newPage.waitForLoadState( 'domcontentloaded' );
-			await expect( newPage ).toHaveURL(
 				'https://woocommerce.com/document/google-for-woocommerce/faq/'
 			);
 		} );

--- a/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
+++ b/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
@@ -222,6 +222,44 @@ test.describe( 'Price Benchmark Page', () => {
 				'There was an error loading the price benchmark suggestions.'
 			);
 		} );
+
+		test( 'FAQ link is present and clickable', async () => {
+			await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions( [
+				...priceBenchmarkSuggestionsData,
+			] );
+			// Get the faq link by .dataviews__view-actions > .components-external-link by text.
+			const faqLink = page.locator(
+				'.dataviews__view-actions .components-external-link'
+			);
+			await expect( faqLink ).toBeVisible();
+			await expect( faqLink ).toContainText( 'FAQ' );
+		} );
+
+		test( 'Clicking the FAQ link opens the correct URL', async () => {
+			await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions( [
+				...priceBenchmarkSuggestionsData,
+			] );
+
+			const faqLink = page.locator(
+				'.dataviews__view-actions .components-external-link'
+			);
+			await expect( faqLink ).toHaveAttribute(
+				'href',
+				'https://woocommerce.com/document/google-for-woocommerce/faq/'
+			);
+
+			await faqLink.click();
+
+			const [ newPage ] = await Promise.all( [
+				page.context().waitForEvent( 'page' ),
+				faqLink.click(),
+			] );
+
+			await newPage.waitForLoadState( 'domcontentloaded' );
+			await expect( newPage ).toHaveURL(
+				'https://woocommerce.com/document/google-for-woocommerce/faq/'
+			);
+		} );
 	} );
 
 	test.describe( 'Change Price Modal Functionality', () => {
@@ -269,7 +307,7 @@ test.describe( 'Price Benchmark Page', () => {
 
 			const error = priceBenchmarkPage.getPriceInputError();
 			await expect( error ).toHaveText(
-				'New price must be greater than the sales price (NT$90.00).'
+				'New price must be greater than or equals to zero.'
 			);
 
 			const changePriceButton =

--- a/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
+++ b/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
@@ -296,6 +296,19 @@ test.describe( 'Price Benchmark Page', () => {
 		} );
 
 		test( 'Displays error message when user inputs a negative price', async () => {
+			await priceBenchmarkPage.goto();
+			await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions(
+				priceBenchmarkSuggestionsData
+			);
+			await priceBenchmarkPage.fulfillWCProduct(
+				{
+					regular_price: '100.00',
+					sale_price: '90.00',
+					on_sale: true,
+				},
+				[ 'GET' ]
+			);
+
 			// Open the modal again
 			const changePriceLink =
 				await priceBenchmarkPage.getFirstProductChangePriceLink();
@@ -307,7 +320,7 @@ test.describe( 'Price Benchmark Page', () => {
 
 			const error = priceBenchmarkPage.getPriceInputError();
 			await expect( error ).toHaveText(
-				'New price must be greater than or equals to zero.'
+				'New price must be greater than the sales price (NT$90.00).'
 			);
 
 			const changePriceButton =


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2919 

_Replace this with a good description of your changes & reasoning._


### Screenshots:
<img width="1301" alt="Screenshot 2025-05-21 at 4 34 44 PM" src="https://github.com/user-attachments/assets/77f93916-e3b4-47d1-aa76-e4e50a3cd87e" />



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Refer to [these instructions](https://fueled.slack.com/archives/C060DC0NXNG/p1746022629480549?thread_ts=1744918427.217079&cid=C060DC0NXNG) on how to mock the price benchmark & suggestions data.
2. Go to Marketing > Google for WooCommerce > Price benchmarks
3. Once the data is loaded, FAQ link should be visible with the external icon.
4. Clicking on link will open the new window with the URL given in AC.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
