### PR TITLE
Improve error handling for GoogleExceptions in PriceBenchmarksController

### DIFF
--- a/js/src/pages/price-benchmark/faq-link.js
+++ b/js/src/pages/price-benchmark/faq-link.js
@@ -27,7 +27,11 @@ const FaqLink = () => {
 	};
 
 	return (
-		<ExternalLink onClick={ handleClick } href={ URL }>
+		<ExternalLink
+			onClick={ handleClick }
+			href={ URL }
+			className="gla-price-benchmark-suggestions__faq"
+		>
 			{ __( 'FAQ', 'google-listings-and-ads' ) }
 		</ExternalLink>
 	);

--- a/js/src/pages/price-benchmark/index.scss
+++ b/js/src/pages/price-benchmark/index.scss
@@ -10,3 +10,12 @@
 		max-width: 224px;
 	}
 }
+
+.gla-price-benchmark-suggestions__faq {
+	color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+
+	&:hover,
+	&:focus {
+		color: var(--wp-components-color-accent-darker-20, var(--wp-admin-theme-color-darker-20, #183ad6));
+	}
+}

--- a/src/API/Google/MerchantPriceBenchmarks.php
+++ b/src/API/Google/MerchantPriceBenchmarks.php
@@ -81,7 +81,6 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 			$errors = $this->get_exception_errors( $e );
 
 			throw new ExceptionWithResponseData(
-				/* translators: %s Error message */
 				__( 'Unable to retrieve price benchmark data', 'google-listings-and-ads' ),
 				$e->getCode(),
 				null,
@@ -139,7 +138,6 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 			$errors = $this->get_exception_errors( $e );
 
 			throw new ExceptionWithResponseData(
-				/* translators: %s Error message */
 				__( 'Unable to retrieve price insights data', 'google-listings-and-ads' ),
 				$e->getCode(),
 				null,
@@ -190,7 +188,6 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 			$errors = $this->get_exception_errors( $e );
 
 			throw new ExceptionWithResponseData(
-				/* translators: %s Error message */
 				__( 'Unable to retrieve product metrics data', 'google-listings-and-ads' ),
 				$e->getCode(),
 				null,

--- a/src/API/Google/MerchantPriceBenchmarks.php
+++ b/src/API/Google/MerchantPriceBenchmarks.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantPriceBenchmarksQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantPriceSuggestionsQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\MerchantPriceBenchmarksProductReportQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Exception as GoogleException;
@@ -21,6 +22,7 @@ use Exception;
 class MerchantPriceBenchmarks implements OptionsAwareInterface {
 
 	use OptionsAwareTrait;
+	use ExceptionTrait;
 
 	/**
 	 * The shopping service.
@@ -45,7 +47,7 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 	 *
 	 * @return array Associative array with price benchmarks data and the next page token.
 	 *
-	 * @throws Exception If the merchant price benchmarks data can't be retrieved.
+	 * @throws ExceptionWithResponseData If the merchant price benchmarks data can't be retrieved.
 	 */
 	public function get_benchmark_data( array $args ): array {
 		try {
@@ -76,7 +78,15 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 			return $results;
 		} catch ( GoogleException $e ) {
 			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
-			throw new Exception( __( 'Unable to retrieve Merchant Price Benchmarks.', 'google-listings-and-ads' ) . $e->getMessage(), $e->getCode() );
+			$errors = $this->get_exception_errors( $e );
+
+			throw new ExceptionWithResponseData(
+				/* translators: %s Error message */
+				__( 'Unable to retrieve price benchmark data', 'google-listings-and-ads' ),
+				$e->getCode(),
+				null,
+				[ 'errors' => $errors ]
+			);
 		}
 	}
 
@@ -87,7 +97,7 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 	 *
 	 * @return array Associative array with price benchmarks data and the next page token.
 	 *
-	 * @throws Exception If the merchant price suggestions data can't be retrieved.
+	 * @throws ExceptionWithResponseData If the merchant price suggestions data can't be retrieved.
 	 */
 	public function get_price_insights( array $args ): array {
 		try {
@@ -126,7 +136,15 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 			return $results;
 		} catch ( GoogleException $e ) {
 			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
-			throw new Exception( __( 'Unable to retrieve Merchant Price Benchmarks.', 'google-listings-and-ads' ) . $e->getMessage(), $e->getCode() );
+			$errors = $this->get_exception_errors( $e );
+
+			throw new ExceptionWithResponseData(
+				/* translators: %s Error message */
+				__( 'Unable to retrieve price insights data', 'google-listings-and-ads' ),
+				$e->getCode(),
+				null,
+				[ 'errors' => $errors ]
+			);
 		}
 	}
 
@@ -137,7 +155,7 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 	 *
 	 * @return array The specific product report data as an associative array.
 	 *
-	 * @throws Exception If there is an error retrieving the product report.
+	 * @throws ExceptionWithResponseData If there is an error retrieving the product report.
 	 */
 	public function get_merchant_performance_data( array $args ): array {
 		try {
@@ -169,7 +187,15 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 			return $results;
 		} catch ( GoogleException $e ) {
 			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
-			throw new Exception( __( 'Unable to retrieve performance data for requested product.', 'google-listings-and-ads' ) . $e->getMessage(), $e->getCode() );
+			$errors = $this->get_exception_errors( $e );
+
+			throw new ExceptionWithResponseData(
+				/* translators: %s Error message */
+				__( 'Unable to retrieve product metrics data', 'google-listings-and-ads' ),
+				$e->getCode(),
+				null,
+				[ 'errors' => $errors ]
+			);
 		}
 	}
 

--- a/src/API/Google/MerchantPriceBenchmarks.php
+++ b/src/API/Google/MerchantPriceBenchmarks.php
@@ -68,6 +68,7 @@ class MerchantPriceBenchmarks implements OptionsAwareInterface {
 					'title'                         => $benchmark_result->getProductView()->getTitle(),
 					'price_micros'                  => $benchmark_result->getProductView()->getPriceMicros(),
 					'currency_code'                 => $benchmark_result->getProductView()->getCurrencyCode(),
+					'country_code'                  => $benchmark_result->getPriceCompetitiveness()->getCountryCode(),
 					'benchmark_price_micros'        => $benchmark_result->getPriceCompetitiveness()->getBenchmarkPriceMicros(),
 					'benchmark_price_currency_code' => $benchmark_result->getPriceCompetitiveness()->getBenchmarkPriceCurrencyCode(),
 				];

--- a/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
+++ b/src/API/Google/Query/MerchantPriceBenchmarksQuery.php
@@ -51,9 +51,9 @@ class MerchantPriceBenchmarksQuery extends MerchantQuery {
 				'title'                         => 'product_view.title',
 				'price_micros'                  => 'product_view.price_micros',
 				'currency_code'                 => 'product_view.currency_code',
+				'country_code'                  => 'price_competitiveness.country_code',
 				'benchmark_price_micros'        => 'price_competitiveness.benchmark_price_micros',
 				'benchmark_price_currency_code' => 'price_competitiveness.benchmark_price_currency_code',
-				'benchmark_price_country_code'  => 'price_competitiveness.country_code',
 			]
 		);
 	}

--- a/src/Jobs/UpdateMerchantPriceBenchmarks.php
+++ b/src/Jobs/UpdateMerchantPriceBenchmarks.php
@@ -93,7 +93,7 @@ class UpdateMerchantPriceBenchmarks extends AbstractActionSchedulerJob {
 	 */
 	public function schedule( array $args = [] ) {
 		if ( $this->can_schedule( $args ) ) {
-			$this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), $args );
+			$this->action_scheduler->schedule_recurring( time(), 12 * HOUR_IN_SECONDS, $this->get_process_item_hook(), $args );
 		}
 	}
 

--- a/src/MerchantCenter/PriceBenchmarks.php
+++ b/src/MerchantCenter/PriceBenchmarks.php
@@ -32,7 +32,7 @@ class PriceBenchmarks implements ContainerAwareInterface, Service {
 
 			$benchmarks = $merchant->get_benchmark_data( [] );
 
-			if ( empty( $benchmarks ) || empty( $benchmarks['results'] ) ) {
+			if ( empty( $benchmarks ) ) {
 				return;
 			}
 
@@ -43,8 +43,7 @@ class PriceBenchmarks implements ContainerAwareInterface, Service {
 			$query->reload_data();
 
 			// Insert new benchmark data.
-			foreach ( $benchmarks['results'] as $benchmark ) {
-
+			foreach ( $benchmarks as $benchmark ) {
 				$price_compared_with_benchmark = $this->price_compared_with_benchmark( $benchmark['price_micros'], $benchmark['benchmark_price_micros'] );
 				$query->insert(
 					[

--- a/tests/Unit/Jobs/UpdateMerchantPriceBenchmarksTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantPriceBenchmarksTest.php
@@ -80,8 +80,13 @@ class UpdateMerchantPriceBenchmarksTest extends UnitTest {
 			->willReturn( true );
 
 		$this->action_scheduler->expects( $this->once() )
-			->method( 'schedule_immediate' )
-			->with( 'gla/jobs/' . self::JOB_NAME . '/process_item', [] );
+			->method( 'schedule_recurring' )
+			->with(
+				time(), // timestamp
+				HOUR_IN_SECONDS * 12, // interval
+				'gla/jobs/' . self::JOB_NAME . '/process_item',
+				[]
+			);
 
 		$this->job->schedule();
 	}

--- a/tests/proxy/mocks/mc/price-benchmarks/price-insights-item.json
+++ b/tests/proxy/mocks/mc/price-benchmarks/price-insights-item.json
@@ -14,7 +14,7 @@
 				"predictedImpressionsChangeFraction": "0.12609300017356873",
 				"predictedClicksChangeFraction": "0.508745014667511",
 				"predictedConversionsChangeFraction": "2.3431060314178467",
-				"effectiveness": 3
+				"effectiveness": "HIGH"
 			}
 		}
 	]

--- a/tests/proxy/mocks/mc/price-benchmarks/price-insights.json
+++ b/tests/proxy/mocks/mc/price-benchmarks/price-insights.json
@@ -14,7 +14,7 @@
 				"predictedImpressionsChangeFraction": "0.12609300017356873",
 				"predictedClicksChangeFraction": "0.508745014667511",
 				"predictedConversionsChangeFraction": "2.3431060314178467",
-				"effectiveness": 3
+				"effectiveness": "HIGH"
 			}
 		},
 		{
@@ -31,7 +31,7 @@
 				"predictedImpressionsChangeFraction": "0.15723400012458974",
 				"predictedClicksChangeFraction": "0.467823012356781",
 				"predictedConversionsChangeFraction": "1.9876543210987654",
-				"effectiveness": 2
+				"effectiveness": "MEDIUM"
 			}
 		},
 		{
@@ -48,7 +48,7 @@
 				"predictedImpressionsChangeFraction": "0.18976500023145628",
 				"predictedClicksChangeFraction": "0.612345678912345",
 				"predictedConversionsChangeFraction": "2.1234567890123456",
-				"effectiveness": 1
+				"effectiveness": "LOW"
 			}
 		},
 		{
@@ -65,7 +65,7 @@
 				"predictedImpressionsChangeFraction": "0.17654300098765432",
 				"predictedClicksChangeFraction": "0.534567890123456",
 				"predictedConversionsChangeFraction": "1.9876543210123456",
-				"effectiveness": 0
+				"effectiveness": "EFFECTIVENESS_UNSPECIFIED"
 			}
 		},
 		{
@@ -82,7 +82,7 @@
 				"predictedImpressionsChangeFraction": "0.14532100078965432",
 				"predictedClicksChangeFraction": "0.487654321098765",
 				"predictedConversionsChangeFraction": "2.0123456789012345",
-				"effectiveness": 3
+				"effectiveness": "HIGH"
 			}
 		},
 		{
@@ -99,7 +99,7 @@
 				"predictedImpressionsChangeFraction": "0.12345678901234567",
 				"predictedClicksChangeFraction": "0.456789012345678",
 				"predictedConversionsChangeFraction": "1.7890123456789012",
-				"effectiveness": 2
+				"effectiveness": "MEDIUM"
 			}
 		},
 		{
@@ -116,7 +116,7 @@
 				"predictedImpressionsChangeFraction": "0.15678901234567890",
 				"predictedClicksChangeFraction": "0.543210987654321",
 				"predictedConversionsChangeFraction": "1.8901234567890123",
-				"effectiveness": 1
+				"effectiveness": "LOW"
 			}
 		},
 		{
@@ -133,7 +133,7 @@
 				"predictedImpressionsChangeFraction": "0.16789012345678901",
 				"predictedClicksChangeFraction": "0.567890123456789",
 				"predictedConversionsChangeFraction": "1.9012345678901234",
-				"effectiveness": 0
+				"effectiveness": "EFFECTIVENESS_UNSPECIFIED"
 			}
 		},
 		{
@@ -150,7 +150,7 @@
 				"predictedImpressionsChangeFraction": "0.13456789012345678",
 				"predictedClicksChangeFraction": "0.523456789012345",
 				"predictedConversionsChangeFraction": "1.8765432109876543",
-				"effectiveness": 2
+				"effectiveness": "MEDIUM"
 			}
 		},
 		{
@@ -167,7 +167,7 @@
 				"predictedImpressionsChangeFraction": "0.14321098765432109",
 				"predictedClicksChangeFraction": "0.531234567890123",
 				"predictedConversionsChangeFraction": "1.8543210987654321",
-				"effectiveness": 3
+				"effectiveness": "HIGH"
 			}
 		},
 		{
@@ -184,7 +184,7 @@
 				"predictedImpressionsChangeFraction": "0.19876543210987654",
 				"predictedClicksChangeFraction": "0.645678901234567",
 				"predictedConversionsChangeFraction": "2.4567890123456789",
-				"effectiveness": 1
+				"effectiveness": "LOW"
 			}
 		},
 		{
@@ -201,7 +201,7 @@
 				"predictedImpressionsChangeFraction": "0.17654321098765432",
 				"predictedClicksChangeFraction": "0.587654321098765",
 				"predictedConversionsChangeFraction": "2.3210987654321098",
-				"effectiveness": 0
+				"effectiveness": "EFFECTIVENESS_UNSPECIFIED"
 			}
 		},
 		{
@@ -218,7 +218,7 @@
 				"predictedImpressionsChangeFraction": "0.18765432109876543",
 				"predictedClicksChangeFraction": "0.598765432109876",
 				"predictedConversionsChangeFraction": "2.3321098765432109",
-				"effectiveness": 2
+				"effectiveness": "MEDIUM"
 			}
 		},
 		{
@@ -235,7 +235,7 @@
 				"predictedImpressionsChangeFraction": "0.16543210987654321",
 				"predictedClicksChangeFraction": "0.554321098765432",
 				"predictedConversionsChangeFraction": "2.1098765432109876",
-				"effectiveness": 1
+				"effectiveness": "LOW"
 			}
 		},
 		{
@@ -252,7 +252,7 @@
 				"predictedImpressionsChangeFraction": "0.17890123456789012",
 				"predictedClicksChangeFraction": "0.575678901234567",
 				"predictedConversionsChangeFraction": "2.2345678901234567",
-				"effectiveness": 3
+				"effectiveness": "HIGH"
 			}
 		},
 		{
@@ -269,7 +269,7 @@
 				"predictedImpressionsChangeFraction": "0.16789012345678901",
 				"predictedClicksChangeFraction": "0.569876543210987",
 				"predictedConversionsChangeFraction": "2.1987654321098765",
-				"effectiveness": 0
+				"effectiveness": "EFFECTIVENESS_UNSPECIFIED"
 			}
 		},
 		{
@@ -286,7 +286,7 @@
 				"predictedImpressionsChangeFraction": "0.15678901234567890",
 				"predictedClicksChangeFraction": "0.543210987654321",
 				"predictedConversionsChangeFraction": "2.0987654321098765",
-				"effectiveness": 2
+				"effectiveness": "MEDIUM"
 			}
 		},
 		{
@@ -303,7 +303,7 @@
 				"predictedImpressionsChangeFraction": "0.18765432109876543",
 				"predictedClicksChangeFraction": "0.598765432109876",
 				"predictedConversionsChangeFraction": "2.2567890123456789",
-				"effectiveness": 1
+				"effectiveness": "LOW"
 			}
 		},
 		{
@@ -320,7 +320,7 @@
 				"predictedImpressionsChangeFraction": "0.19012345678901234",
 				"predictedClicksChangeFraction": "0.601234567890123",
 				"predictedConversionsChangeFraction": "2.2765432109876543",
-				"effectiveness": 3
+				"effectiveness": "HIGH"
 			}
 		},
 		{
@@ -337,7 +337,7 @@
 				"predictedImpressionsChangeFraction": "0.19876543210987654",
 				"predictedClicksChangeFraction": "0.612345678901234",
 				"predictedConversionsChangeFraction": "2.2987654321098765",
-				"effectiveness": 2
+				"effectiveness": "MEDIUM"
 			}
 		}
 	]


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

See #2917.

This improves the error messages that are returned from the `mc/price-benchmarks` controller when the queries to the Google Content API return error responses. Previously, the entire error response from those Google Content API calls were encoded in the error response that was returned from the REST API. Now, the data from that response is handled more gracefully by throwing a `ExceptionWithResponseData` exception that formats the error messages in a more graceful way.

Previous response from the REST API:

```json
{
	"message": "Unable to retrieve Merchant Price Benchmarks.",
	"error": {
		"code": 403,
		"message": "Market Insights not enabled for account *REDACTED*. For more information check https://support.google.com/merchants/answer/9625913",
		"errors": [
			{
				"message": "Market Insights not enabled for account *REDACTED*. For more information check https://support.google.com/merchants/answer/9625913",
				"domain": "global",
				"reason": "forbidden"
			}
		],
		"status": "PERMISSION_DENIED",
		"details": [
			{
				"@type": "type.googleapis.com/google.rpc.ErrorInfo",
				"reason": "forbidden",
				"domain": "global"
			}
		]
	}
}

```

New message:

```json
{
	"message": "Unable to retrieve price benchmark data.",
	"errors": {
		"forbidden": "Market Insights not enabled for account *REDACTED*. For more information check https://support.google.com/merchants/answer/9625913"
	}
}
```

### Changelog entry
