### PR TITLE
Price Benchmarks: Add test-proxy support for 403 responses

### DIFF
--- a/tests/proxy/README.md
+++ b/tests/proxy/README.md
@@ -35,11 +35,13 @@ PROXY_PORT=50505 npm run test-proxy
 The mode will determine what kind of responses will be returned, this is used to mock specific responses which can't be reproduced through regular requests.
 
 Modes:
+
+- `access_error` will return a 403 error when getting market insights data (i.e. price benchmarks)
 - `delete_error` will return an internal error when deleting products
 - `update_error` will return an internal error when updating products
 
 ```
-PROXY_MODE=<delete_error|update_error> npm run test-proxy
+PROXY_MODE=<access_error|delete_error|update_error> npm run test-proxy
 ```
 
 ### Log responses when running the proxy

--- a/tests/proxy/handler.js
+++ b/tests/proxy/handler.js
@@ -2,7 +2,7 @@
 
 const config = require( './config' );
 
-module.exports.checkRequest = ( request ) => {
+module.exports.checkRequest = ( request, h ) => {
 	if ( config.logResponses ) {
 		// eslint-disable-next-line no-console
 		console.log( 'Request path: ', '\n', request.params.path );
@@ -27,6 +27,15 @@ module.exports.checkRequest = ( request ) => {
 		if ( config.logResponses ) {
 			// eslint-disable-next-line no-console
 			console.log( 'Request query: ', '\n', body.query );
+		}
+
+		// Handle access errors early.
+		if ( config.proxyMode === 'access_error' ) {
+			return h
+				.response(
+					require( './mocks/mc/price-benchmarks/403_error.json' )
+				)
+				.code( 403 );
 		}
 
 		let mockPath = false;

--- a/tests/proxy/index.js
+++ b/tests/proxy/index.js
@@ -17,7 +17,7 @@ const init = async () => {
 		path: '/{path*}',
 		config: {
 			handler: ( request, h ) => {
-				const response = handler.checkRequest( request );
+				const response = handler.checkRequest( request, h );
 				if ( response ) {
 					if ( config.logResponses ) {
 						// eslint-disable-next-line no-console

--- a/tests/proxy/mocks/mc/price-benchmarks/403_error.json
+++ b/tests/proxy/mocks/mc/price-benchmarks/403_error.json
@@ -1,0 +1,21 @@
+{
+	"error": {
+		"code": 403,
+		"message": "Market Insights not enabled for account *REDACTED*. For more information check https://support.google.com/merchants/answer/9625913",
+		"errors": [
+			{
+				"message": "Market Insights not enabled for account *REDACTED*. For more information check https://support.google.com/merchants/answer/9625913",
+				"domain": "global",
+				"reason": "forbidden"
+			}
+		],
+		"status": "PERMISSION_DENIED",
+		"details": [
+			{
+				"@type": "type.googleapis.com/google.rpc.ErrorInfo",
+				"reason": "forbidden",
+				"domain": "global"
+			}
+		]
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Follow-up to #2917.

This adds handling to the test-proxy for 403 Forbidden responses from the price benchmarks API. 
This allows us to test scenarios when a new MC account is created that does not yet have access to Market Insights data.

To use, start the test-proxy with the `PROXY_MODE` environment variable set to `access_error`:

```bash
PROXY_MODE=access_error npm run test-proxy
```

An example of an error request being returned can be seen [here](https://developers.google.com/shopping-content/guides/free-listings-return-settings#delete)

### Changelog entry
