### PR TITLE
Add event tracking for budget recommendations and metrics

### DIFF
--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -13,6 +13,8 @@ import validateCampaign from '~/components/paid-ads/validateCampaign';
 import validateAssetGroup from '~/components/paid-ads/validateAssetGroup';
 import useAdsCurrency from '~/hooks/useAdsCurrency';
 import useBudgetRecommendation from '~/hooks/useBudgetRecommendation';
+import useEventPropertiesFilter from '~/hooks/useEventPropertiesFilter';
+import { FILTER_BUDGET_RECOMMENDATIONS } from '~/utils/tracks';
 
 /**
  * @typedef {import('~/components/types.js').CampaignFormValues} CampaignFormValues
@@ -120,6 +122,11 @@ export default function CampaignAssetsForm( {
 		recommendedDailyBudget,
 		hasResolved,
 	} = useBudgetRecommendation( countryCodes );
+
+	useEventPropertiesFilter(
+		FILTER_BUDGET_RECOMMENDATIONS,
+		budgetRecommendation?.eventProps
+	);
 
 	if ( ! hasResolved ) {
 		return null;

--- a/js/src/data/adapters.js
+++ b/js/src/data/adapters.js
@@ -20,20 +20,35 @@ import { convertKeysFromSnakeCaseToCamelCase } from './utils';
  */
 export function adaptAdsBudgetRecommendation( data ) {
 	const validLevelKeys = [ 'recommended', 'high', 'low' ];
-	const { currency } = data;
+	const { currency, source } = data;
+	const eventProps = { source, metrics_availability: 'all' };
+	const availabilities = [];
 
-	return data.recommendations.reduce( ( payload, item ) => {
+	const reducer = ( payload, item ) => {
 		const { level, ...adaptingData } = item;
 		const key = level.toLowerCase();
 
 		if ( validLevelKeys.includes( key ) ) {
+			availabilities.push( adaptingData.metrics );
 			adaptingData.currency = currency;
 			payload[ key ] =
 				convertKeysFromSnakeCaseToCamelCase( adaptingData );
 		}
 
 		return payload;
-	}, {} );
+	};
+
+	const result = data.recommendations.reduce( reducer, { eventProps } );
+
+	if ( availabilities.filter( Boolean ).length === 0 ) {
+		eventProps.metrics_availability = 'none';
+	} else if ( ! availabilities.every( Boolean ) ) {
+		eventProps.metrics_availability = 'partial';
+	}
+
+	eventProps.recommended_budget = result.recommended.dailyBudget;
+
+	return result;
 }
 
 /**

--- a/js/src/data/adapters.test.js
+++ b/js/src/data/adapters.test.js
@@ -14,6 +14,7 @@ describe( 'adaptAdsBudgetRecommendation', () => {
 	beforeEach( () => {
 		input = {
 			currency: 'USD',
+			source: 'google-ads-api',
 			recommendations: [
 				{
 					level: 'Recommended',
@@ -85,6 +86,11 @@ describe( 'adaptAdsBudgetRecommendation', () => {
 			recommended,
 			high,
 			low,
+			eventProps: {
+				source: 'google-ads-api',
+				metrics_availability: 'all',
+				recommended_budget: 15,
+			},
 		} );
 	} );
 
@@ -96,7 +102,43 @@ describe( 'adaptAdsBudgetRecommendation', () => {
 		expect( adaptAdsBudgetRecommendation( input ) ).toEqual( {
 			recommended,
 			high,
+			eventProps: {
+				source: 'google-ads-api',
+				metrics_availability: 'all',
+				recommended_budget: 15,
+			},
 		} );
+	} );
+
+	it( 'Adapts the metrics availability for partially available metrics', () => {
+		input.recommendations[ 2 ].metrics = null;
+		let eventProps = adaptAdsBudgetRecommendation( input ).eventProps;
+
+		expect( eventProps.metrics_availability ).toEqual( 'partial' );
+
+		input.recommendations.pop();
+		eventProps = adaptAdsBudgetRecommendation( input ).eventProps;
+
+		expect( eventProps.metrics_availability ).toEqual( 'all' );
+
+		input.recommendations[ 0 ].metrics = null;
+		eventProps = adaptAdsBudgetRecommendation( input ).eventProps;
+
+		expect( eventProps.metrics_availability ).toEqual( 'partial' );
+
+		input.recommendations.pop();
+		eventProps = adaptAdsBudgetRecommendation( input ).eventProps;
+
+		expect( eventProps.metrics_availability ).toEqual( 'none' );
+	} );
+
+	it( 'Adapts the metrics availability for no available metrics', () => {
+		input.recommendations.forEach( ( item ) => {
+			item.metrics = null;
+		} );
+		const { eventProps } = adaptAdsBudgetRecommendation( input );
+
+		expect( eventProps.metrics_availability ).toEqual( 'none' );
 	} );
 } );
 

--- a/js/src/data/controls.js
+++ b/js/src/data/controls.js
@@ -4,6 +4,12 @@
 import { controls as dataControls } from '@wordpress/data-controls';
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * Internal dependencies
+ */
+import { recordGlaEvent } from '~/utils/tracks';
+import TYPES from './action-types';
+
 export const fetchWithHeaders = ( options ) => {
 	return {
 		type: 'FETCH_WITH_HEADERS',
@@ -17,6 +23,65 @@ export const awaitPromise = ( promise ) => {
 		promise,
 	};
 };
+
+export const recordGlaDataEvent = ( actionType, dataOrResponse ) => {
+	const isResponse = dataOrResponse instanceof Response;
+	return {
+		type: 'GLA_RECORD_DATA_EVENT',
+		actionType,
+		data: isResponse ? null : dataOrResponse,
+		response: isResponse ? dataOrResponse.clone() : null,
+	};
+};
+
+/**
+ * Received the data of budget recommendations.
+ *
+ * @event gla_ads_budget_recommendations_received
+ * @property {string} source The data source of the budget recommendations, e.g. 'google-ads-api', 'fallback-database'.
+ * @property {number} recommended_budget The recommended daily budget displayed to merchants regardless of the final amount they choose.
+ * @property {string} metrics_availability The availability of the forecast metrics for the budget recommendations, e.g. 'all', 'partial', 'none'.
+ */
+
+/**
+ * Received the data of budget metrics.
+ *
+ * @event gla_ads_budget_metrics_received
+ * @property {number} budget The budget amount.
+ * @property {string} currency The currency of the budget.
+ * @property {string} country The country code of the budget.
+ * @property {boolean} available Whether the budget metrics are available or not.
+ */
+
+/**
+ * @fires gla_ads_budget_recommendations_received
+ * @fires gla_ads_budget_metrics_received
+ */
+function recordGlaDataEventControl( { actionType, data, response } ) {
+	switch ( actionType ) {
+		case TYPES.RECEIVE_ADS_BUDGET_RECOMMENDATIONS: {
+			recordGlaEvent(
+				'gla_ads_budget_recommendations_received',
+				data.eventProps
+			);
+			break;
+		}
+
+		case TYPES.RECEIVE_ADS_BUDGET_METRICS: {
+			Promise.resolve( data || response.json() ).then(
+				( { budget, currency, country, country_codes, metrics } ) => {
+					recordGlaEvent( 'gla_ads_budget_metrics_received', {
+						budget,
+						currency,
+						country: country || country_codes.at( 0 ),
+						available: Boolean( metrics ),
+					} );
+				}
+			);
+			break;
+		}
+	}
+}
 
 export const controls = {
 	...dataControls,
@@ -36,4 +101,5 @@ export const controls = {
 			} ) );
 	},
 	GLA_AWAIT_PROMISE: ( { promise } ) => promise,
+	GLA_RECORD_DATA_EVENT: recordGlaDataEventControl,
 };

--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -27,7 +27,7 @@ import {
 	adaptAdsCampaign,
 	adaptAssetGroup,
 } from './adapters';
-import { fetchWithHeaders, awaitPromise } from './controls';
+import { fetchWithHeaders, awaitPromise, recordGlaDataEvent } from './controls';
 
 import {
 	fetchShippingRates,
@@ -541,12 +541,18 @@ export function* getAdsBudgetRecommendations( countryCodes ) {
 	const path = addQueryArgs( endpoint, query );
 
 	try {
-		const { data } = yield fetchWithHeaders( { path } );
+		let { data } = yield fetchWithHeaders( { path } );
+		data = adaptAdsBudgetRecommendation( data );
+
+		yield recordGlaDataEvent(
+			TYPES.RECEIVE_ADS_BUDGET_RECOMMENDATIONS,
+			data
+		);
 
 		return {
 			type: TYPES.RECEIVE_ADS_BUDGET_RECOMMENDATIONS,
 			countryCodesKey,
-			data: adaptAdsBudgetRecommendation( data ),
+			data,
 		};
 	} catch ( response ) {
 		// Intentionally silence the specific in case the no budget recommendations are found from the API.
@@ -577,6 +583,8 @@ export function* getAdsBudgetMetrics( countryCodes, budget ) {
 			),
 		} );
 
+		yield recordGlaDataEvent( TYPES.RECEIVE_ADS_BUDGET_METRICS, data );
+
 		return {
 			type: TYPES.RECEIVE_ADS_BUDGET_METRICS,
 			key: getAdsBudgetMetricsKey( countryCodes, budget ),
@@ -585,6 +593,11 @@ export function* getAdsBudgetMetrics( countryCodes, budget ) {
 	} catch ( response ) {
 		// No related budget metrics.
 		if ( response.status === 404 ) {
+			// Records the case of data unavailability.
+			yield recordGlaDataEvent(
+				TYPES.RECEIVE_ADS_BUDGET_METRICS,
+				response
+			);
 			return;
 		}
 

--- a/js/src/data/types.js
+++ b/js/src/data/types.js
@@ -94,6 +94,7 @@
  * @property {AdsBudgetRecommendationEntity} recommended The recommended budget.
  * @property {AdsBudgetRecommendationEntity} [high] The high budget recommendation.
  * @property {AdsBudgetRecommendationEntity} [low] The low budget recommendation.
+ * @property {Object} eventProps The relevant event properties.
  */
 
 /**

--- a/js/src/pages/ads-onboarding/ads-stepper/setup-paid-ads.js
+++ b/js/src/pages/ads-onboarding/ads-stepper/setup-paid-ads.js
@@ -17,8 +17,9 @@ import useNavigateAwayPromptEffect from '~/hooks/useNavigateAwayPromptEffect';
 import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 import useAdsSetupCompleteCallback from '~/hooks/useAdsSetupCompleteCallback';
 import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import useEventPropertiesFilter from '~/hooks/useEventPropertiesFilter';
 import CampaignAssetsForm from '~/components/paid-ads/campaign-assets-form';
-import { recordGlaEvent } from '~/utils/tracks';
+import { FILTER_BUDGET_RECOMMENDATIONS, recordGlaEvent } from '~/utils/tracks';
 import AppSpinner from '~/components/app-spinner';
 import { GOOGLE_ADS_BILLING_STATUS } from '~/constants';
 
@@ -50,6 +51,9 @@ const SetupPaidAds = () => {
 	const [ handleSetupComplete, isSubmitting ] = useAdsSetupCompleteCallback();
 	const adminUrl = useAdminUrl();
 	const { data: countryCodes } = useTargetAudienceFinalCountryCodes();
+	const getEventProps = useEventPropertiesFilter(
+		FILTER_BUDGET_RECOMMENDATIONS
+	);
 
 	const renderSubmitButton = ( formContext ) => {
 		const handleClick = () => {
@@ -79,12 +83,16 @@ const SetupPaidAds = () => {
 	};
 
 	const handleSubmit = ( values ) => {
-		const { dailyBudget } = values;
+		const { level, dailyBudget } = values;
 
-		recordGlaEvent( 'gla_launch_paid_campaign_button_click', {
-			audiences: countryCodes.join( ',' ),
-			budget: dailyBudget,
-		} );
+		recordGlaEvent(
+			'gla_launch_paid_campaign_button_click',
+			getEventProps( {
+				level,
+				audiences: countryCodes.join( ',' ),
+				budget: dailyBudget,
+			} )
+		);
 
 		handleSetupComplete( dailyBudget, countryCodes, () => {
 			// Force reload WC admin page to initiate the relevant dependencies of the Dashboard page.

--- a/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
@@ -16,9 +16,10 @@ import BudgetIncentivePrompt from '~/components/paid-ads/budget-incentive-prompt
 import CampaignAssetsForm from '~/components/paid-ads/campaign-assets-form';
 import AppButton from '~/components/app-button';
 import useGoogleAdsAccountBillingStatus from '~/hooks/useGoogleAdsAccountBillingStatus';
+import useEventPropertiesFilter from '~/hooks/useEventPropertiesFilter';
 import { getProductFeedUrl } from '~/utils/urls';
 import { handleApiError } from '~/utils/handleError';
-import { recordGlaEvent } from '~/utils/tracks';
+import { FILTER_BUDGET_RECOMMENDATIONS, recordGlaEvent } from '~/utils/tracks';
 import { useAppDispatch } from '~/data';
 import { GUIDE_NAMES, GOOGLE_ADS_BILLING_STATUS } from '~/constants';
 import { ACTION_COMPLETE, ACTION_SKIP } from './constants';
@@ -30,8 +31,11 @@ import AppSpinner from '~/components/app-spinner';
  * Clicking on the "Complete setup" button to complete the onboarding flow with paid ads.
  *
  * @event gla_onboarding_complete_with_paid_ads_button_click
+ * @property {string} level The selected level of the budget recommendation, e.g. 'low', 'medium', 'high', 'custom'.
  * @property {number} budget The budget for the campaign
  * @property {string} audiences The targeted audiences for the campaign
+ * @property {string} source The data source of the budget recommendations, e.g. 'google-ads-api', 'fallback-database'.
+ * @property {number} recommended_budget The recommended daily budget displayed to merchants regardless of the final amount they choose.
  */
 
 /**
@@ -47,6 +51,9 @@ export default function SetupPaidAds() {
 	const [ handleSetupComplete ] = useAdsSetupCompleteCallback();
 	const { billingStatus } = useGoogleAdsAccountBillingStatus();
 	const { syncSettings } = useAppDispatch();
+	const getEventProps = useEventPropertiesFilter(
+		FILTER_BUDGET_RECOMMENDATIONS
+	);
 
 	const isBillingCompleted =
 		billingStatus?.status === GOOGLE_ADS_BILLING_STATUS.APPROVED;
@@ -128,7 +135,7 @@ export default function SetupPaidAds() {
 	}
 
 	const handleSubmit = async ( values ) => {
-		const { dailyBudget } = values;
+		const { level, dailyBudget } = values;
 		const onBeforeFinish = handleSetupComplete.bind(
 			null,
 			dailyBudget,
@@ -136,10 +143,15 @@ export default function SetupPaidAds() {
 		);
 
 		setCompleting( ACTION_COMPLETE );
-		recordGlaEvent( 'gla_onboarding_complete_with_paid_ads_button_click', {
-			budget: dailyBudget,
-			audiences: countryCodes.join( ',' ),
-		} );
+
+		recordGlaEvent(
+			'gla_onboarding_complete_with_paid_ads_button_click',
+			getEventProps( {
+				level,
+				budget: dailyBudget,
+				audiences: countryCodes.join( ',' ),
+			} )
+		);
 
 		await finishOnboardingSetup( onBeforeFinish );
 	};

--- a/js/src/utils/tracks.js
+++ b/js/src/utils/tracks.js
@@ -19,10 +19,15 @@ export const hooks = createHooks();
 
 export const NAMESPACE = 'tracking';
 export const FILTER_ONBOARDING = 'FILTER_ONBOARDING';
+export const FILTER_BUDGET_RECOMMENDATIONS = 'FILTER_BUDGET_RECOMMENDATIONS';
 
 export const filterPropertiesMap = new Map();
 
 filterPropertiesMap.set( FILTER_ONBOARDING, [ 'context', 'step' ] );
+filterPropertiesMap.set( FILTER_BUDGET_RECOMMENDATIONS, [
+	'source',
+	'recommended_budget',
+] );
 
 /*
  * Please be aware of when to use these context values
@@ -168,8 +173,11 @@ export const recordTablePageEvent = ( context, page, direction ) => {
  * Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign in the Google Ads setup flow.
  *
  * @event gla_launch_paid_campaign_button_click
+ * @property {string} level The selected level of the budget recommendation, e.g. 'low', 'medium', 'high', 'custom'.
  * @property {string} audiences Country codes of the paid campaign audience countries, e.g. `'US,JP,AU'`. This means the campaign is created with the multi-country targeting feature. Before this feature support, it was implemented as 'audience'.
- * @property {string} budget Daily average cost of the paid campaign
+ * @property {number} budget Daily average cost of the paid campaign
+ * @property {string} source The data source of the budget recommendations, e.g. 'google-ads-api', 'fallback-database'.
+ * @property {number} recommended_budget The recommended daily budget displayed to merchants regardless of the final amount they choose.
  */
 
 /**

--- a/src/API/Google/AdsCampaignLabel.php
+++ b/src/API/Google/AdsCampaignLabel.php
@@ -150,7 +150,7 @@ class AdsCampaignLabel implements OptionsAwareInterface {
 	 *
 	 * @param array $operations The operations to mutate.
 	 *
-	 * @throws ApiException — Thrown if the API call fails.
+	 * @throws ApiException Thrown if the API call fails.
 	 */
 	protected function mutate( array $operations ) {
 		$request = new MutateGoogleAdsRequest();

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -112,6 +112,9 @@ class BudgetRecommendationController extends BaseController implements Container
 			$budget_recommendations = $this->container->get( BudgetRecommendations::class );
 			$recommendations        = $budget_recommendations->get_recommendations( $country_codes );
 
+			// For the frontend side to track the source of the recommendations.
+			$source = 'google-ads-api';
+
 			// Fetch fallback recommendation from the database.
 			$fallback_recommendation = $this->get_fallback_recommendation( $country_codes, $currency );
 			if ( $fallback_recommendation ) {
@@ -120,6 +123,7 @@ class BudgetRecommendationController extends BaseController implements Container
 				// Swap recommended if not set or if fallback is higher.
 				if ( empty( $recommendations[0] ) || ( ! empty( $recommendations[0]['daily_budget'] ) && $recommendations[0]['daily_budget'] < $fallback_budget ) ) {
 					$recommendations[0] = $fallback_recommendation[0];
+					$source             = 'fallback-database';
 
 					// Fetch metrics from the API for the fallback budget (only when we are going to use the fallback).
 					$budget_metrics   = $this->container->get( BudgetMetrics::class );
@@ -155,6 +159,7 @@ class BudgetRecommendationController extends BaseController implements Container
 				[
 					'currency'        => $currency,
 					'recommendations' => $recommendations,
+					'source'          => $source,
 				],
 				$request
 			);
@@ -246,6 +251,12 @@ class BudgetRecommendationController extends BaseController implements Container
 						],
 					],
 				],
+			],
+			'source'          => [
+				'type'        => 'string',
+				'enum'        => [ 'google-ads-api', 'fallback-database' ],
+				'description' => __( 'Data source of the budget recommendations, either from Google Ads API or fallback database.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
 			],
 		];
 	}

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -119,6 +119,7 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 					'level'        => 'Recommended',
 				],
 			],
+			'source'          => 'fallback-database',
 		];
 
 		$this->ads->expects( $this->once() )
@@ -143,6 +144,7 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		$expected_response_data = [
 			'currency'        => 'GBP',
 			'recommendations' => self::RECOMMENDATION_DATA,
+			'source'          => 'google-ads-api',
 		];
 
 		$this->ads->expects( $this->once() )
@@ -185,6 +187,7 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 					'level'        => 'Recommended',
 				],
 			],
+			'source'          => 'fallback-database',
 		];
 
 		$this->ads->expects( $this->once() )
@@ -244,6 +247,7 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 					'level'        => 'High',
 				],
 			],
+			'source'          => 'fallback-database',
 		];
 
 		$this->ads->expects( $this->once() )
@@ -301,6 +305,7 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 					'level'        => 'High',
 				],
 			],
+			'source'          => 'fallback-database',
 		];
 
 		$this->ads->expects( $this->once() )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project thread: pcTzPl-2Hb-p2

This is the last part of the **Send a track with the received recommended budgets, and whether they are presented to the user or the fallback is chosen** task.

- Add a new field to the response of the `ads/campaigns/budget-recommendation` API.
- Add properties of event tracking to the `adaptAdsBudgetRecommendation` function.
- Send event tracking when receiving the data of budget recommendations and forecast metrics.
- Track whether a merchant accepts budget recommendations during the onboarding and ads-onboarding flow.
- Extra change: Fix a PHP linting error in the src/API/Google/AdsCampaignLabel.php file.

💡 Please note that since the approach described in P2 project thread was based on earlier requirements, it can no longer be met with later changes in requirements. Therefore this PR is implemented with reference to the PRD in P2 project thread.

### Screenshots:

https://github.com/user-attachments/assets/17c2a0e2-438d-4ca8-99f5-08381cebae99

### Detailed test instructions:

1. Go to a WP admin page, and open the Console tab in the browser DevTool
   - Run `localStorage.setItem( 'debug', 'wc-admin:*' )` to enable tracking debugging mode 
   - Configure it as below
     ![0](https://github.com/user-attachments/assets/27d7afcf-e91b-4fb2-9ba4-f3b9bd839442)
   - Refresh the web page to make it effective
1. Go to the onboarding flow and proceed to the "Create a campaign" step
1. Check if the two events are logged in the Console tab
   1. `wcadmin_gla_ads_budget_recommendations_received`
      - ![image](https://github.com/user-attachments/assets/ff7051b9-c880-4501-bf5f-53c55c2e9511)
   2. `wcadmin_gla_ads_budget_metrics_received`
      - ![image](https://github.com/user-attachments/assets/c56e366f-c291-486b-9644-bd5e7f13c8b5)
1. Locally make the budget metrics API response with 400 by returning `null` from the beginning of `get_metrics` method:
   https://github.com/woocommerce/google-listings-and-ads/blob/2dceb4cd1e6dd9ed603dc6a46ae22966f1d92167/src/API/Google/BudgetMetrics.php#L62
1. Change the custom budget and see if the `available` property in the next `wcadmin_gla_ads_budget_metrics_received` event is `false`.
   ![image](https://github.com/user-attachments/assets/8dfa82c4-5df9-446d-9999-0586a144dc28)
1. Keep the local change made in Step 4, and adjust the `daily_budget` value of the querying row that matches your `currency` and `country` in the DB table `wp_gla_budget_recommendations` to a value greater than the recommended budget got from Google API but less than the high one
1. Refresh the web page, and check the `wcadmin_gla_ads_budget_recommendations_received` event to see:
   - If the `source` property is `'fallback-database'`
   - If the `metrics_availability` property is `'partial'`
   ![image](https://github.com/user-attachments/assets/05959598-9fdc-4948-9aed-cb60d43472af)
1. Adjust the `daily_budget` to a value higher than the high budget got from Google API
1. Refresh the web page, and check the `wcadmin_gla_ads_budget_recommendations_received` event to see if the `metrics_availability` property is `'none'`
   ![image](https://github.com/user-attachments/assets/76e5dfab-bd03-4c63-a310-79d2a150c729)
1. Complete onboarding with a campaign creation
1. Check if the `wcadmin_gla_onboarding_complete_with_paid_ads_button_click` event has the new properties `level`, `source`, and `recommended_budget`
   ![image](https://github.com/user-attachments/assets/6ee93086-c9f2-4437-a78d-81996ecb7c3f)
1. Do the similar tests for the ads-onboarding flow.
   When completing, it should send a `wcadmin_gla_launch_paid_campaign_button_click` event instead
   ![image](https://github.com/user-attachments/assets/a6d2413a-099f-4931-9c82-f8765cd06986)


### Changelog entry

> Add - Event tracking for budget recommendations and metrics
