### PR TITLE
Add Enhanced Conversions prompt to successful onboarding modal

### DIFF
--- a/js/src/components/external/wordpress/guide/index.js
+++ b/js/src/components/external/wordpress/guide/index.js
@@ -37,7 +37,6 @@ import './index.scss';
  *                                    It is required for accessibility reasons.
  * @param {string} [props.backButtonText] Use this to customize the label of the *Previous* button shown at the end of the guide.
  * @param {string} [props.finishButtonText] Use this to customize the label of the *Finish* button shown at the end of the guide.
- * @param {renderFinishCallback} [props.renderFinish] A function for rendering custom finish block shown at the end of the guide.
  * @param {Function} props.onFinish A function which is called when the guide is finished.
  *                                  The guide is finished when the modal is closed
  *                                  or when the user clicks *Finish* on the last page of the guide.
@@ -49,7 +48,6 @@ export default function Guide( {
 	contentLabel,
 	backButtonText,
 	finishButtonText,
-	renderFinish = ( finishButton ) => finishButton,
 	onFinish,
 	pages,
 } ) {
@@ -57,6 +55,7 @@ export default function Guide( {
 
 	const canGoBack = currentPage > 0;
 	const canGoForward = currentPage < pages.length - 1;
+	const hasActions = pages[ currentPage ]?.actions;
 
 	const goBack = () => {
 		if ( canGoBack ) {
@@ -76,8 +75,8 @@ export default function Guide( {
 
 	let finishBlock = null;
 
-	if ( ! canGoForward ) {
-		const finishButton = (
+	if ( ! canGoForward && ! hasActions ) {
+		finishBlock = (
 			<FinishButton
 				className="components-guide__finish-button"
 				onClick={ onFinish }
@@ -85,8 +84,6 @@ export default function Guide( {
 				{ finishButtonText || __( 'Finish' ) }
 			</FinishButton>
 		);
-
-		finishBlock = renderFinish( finishButton );
 	}
 
 	const guideClassName = classnames(
@@ -144,6 +141,14 @@ export default function Guide( {
 						</Button>
 					) }
 					{ finishBlock }
+					{ hasActions && (
+						<>
+							<div className="gla-submission-success-guide__space_holder" />
+							<div className="components-guide__actions">
+								{ pages[ currentPage ].actions }
+							</div>
+						</>
+					) }
 				</div>
 			</div>
 		</Modal>

--- a/js/src/components/external/wordpress/guide/index.js
+++ b/js/src/components/external/wordpress/guide/index.js
@@ -132,6 +132,14 @@ export default function Guide( {
 							{ backButtonText || __( 'Previous' ) }
 						</Button>
 					) }
+					{ hasActions && (
+						<>
+							<div className="gla-submission-success-guide__space_holder" />
+							<div className="components-guide__actions">
+								{ pages[ currentPage ].actions }
+							</div>
+						</>
+					) }
 					{ canGoForward && (
 						<Button
 							className="components-guide__forward-button"
@@ -141,14 +149,6 @@ export default function Guide( {
 						</Button>
 					) }
 					{ finishBlock }
-					{ hasActions && (
-						<>
-							<div className="gla-submission-success-guide__space_holder" />
-							<div className="components-guide__actions">
-								{ pages[ currentPage ].actions }
-							</div>
-						</>
-					) }
 				</div>
 			</div>
 		</Modal>

--- a/js/src/pages/product-feed/submission-success-guide/index.js
+++ b/js/src/pages/product-feed/submission-success-guide/index.js
@@ -132,7 +132,7 @@ const pages = [
 						{
 							link: (
 								<ContentLink
-									href="https://woocommerce.com/document/google-listings-and-ads/enhanced-conversions/"
+									href="https://support.google.com/google-ads/answer/9888656"
 									context="enhanced-conversions"
 								/>
 							),

--- a/js/src/pages/product-feed/submission-success-guide/index.js
+++ b/js/src/pages/product-feed/submission-success-guide/index.js
@@ -26,7 +26,7 @@ const handleGuideFinish = ( e ) => {
 	getHistory().replace( getProductFeedUrl() );
 
 	// Since there is no built-in way to distinguish the modal/guide is closed by what action,
-	// here is a workaround by identifying the close button's data-aciton attribute.
+	// here is a workaround by identifying the close button's data-action attribute.
 	let action = 'dismiss';
 
 	if ( e ) {
@@ -37,6 +37,11 @@ const handleGuideFinish = ( e ) => {
 		context: GUIDE_NAMES.SUBMISSION_SUCCESS,
 		action,
 	} );
+};
+
+const setupEnhancedConversionsOnClick = () => {
+	handleGuideFinish();
+	window.location.href = getSettingsUrl();
 };
 
 const image = (
@@ -150,18 +155,7 @@ const pages = [
 					context: GUIDE_NAMES.SUBMISSION_SUCCESS,
 					action: 'view-enhanced-conversions-settings',
 				} }
-				onClick={ () => {
-					handleGuideFinish();
-					window.location.href = getSettingsUrl();
-				} }
-				aria-label={ __(
-					'Set up Enhanced Conversions',
-					'google-listings-and-ads'
-				) }
-				title={ __(
-					'Set up Enhanced Conversions',
-					'google-listings-and-ads'
-				) }
+				onClick={ setupEnhancedConversionsOnClick }
 			>
 				{ __(
 					'Set up Enhanced Conversions',
@@ -205,7 +199,6 @@ const pages = [
 		),
 		actions: (
 			<>
-				<div className="gla-submission-success-guide__space_holder" />
 				<AppButton
 					isSecondary
 					data-action="maybe-later"
@@ -240,7 +233,7 @@ if ( glaData.adsSetupComplete ) {
  * Show this guide modal by visiting the path with a specific query `guide=submission-success`.
  * For example: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed&guide=submission-success`.
  *
- * @fires gla_modal_closed with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss'`
+ * @fires gla_modal_closed with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss' | 'view-enhanced-conversions-settings'`
  * @fires gla_modal_open with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
  */
 const SubmissionSuccessGuide = () => {

--- a/js/src/pages/product-feed/submission-success-guide/index.js
+++ b/js/src/pages/product-feed/submission-success-guide/index.js
@@ -98,7 +98,6 @@ const pages = [
 				</p>
 			</GuidePageContent>
 		),
-		// Actions should be undefined if glaData.adsSetupComplete is false, else render the button.
 		action: glaData.adsSetupComplete ? (
 			<AppButton
 				isPrimary

--- a/js/src/pages/product-feed/submission-success-guide/index.js
+++ b/js/src/pages/product-feed/submission-success-guide/index.js
@@ -39,9 +39,9 @@ const handleGuideFinish = ( e ) => {
 	} );
 };
 
-const setupEnhancedConversionsOnClick = () => {
+const handleSetupEnhancedConversionsOnClick = () => {
 	handleGuideFinish();
-	window.location.href = getSettingsUrl();
+	getHistory().push( getSettingsUrl() );
 };
 
 const image = (
@@ -155,7 +155,7 @@ const pages = [
 					context: GUIDE_NAMES.SUBMISSION_SUCCESS,
 					action: 'view-enhanced-conversions-settings',
 				} }
-				onClick={ setupEnhancedConversionsOnClick }
+				onClick={ handleSetupEnhancedConversionsOnClick }
 			>
 				{ __(
 					'Set up Enhanced Conversions',

--- a/js/src/pages/product-feed/submission-success-guide/index.js
+++ b/js/src/pages/product-feed/submission-success-guide/index.js
@@ -2,11 +2,7 @@
  * External dependencies
  */
 import { getHistory } from '@woocommerce/navigation';
-import {
-	createInterpolateElement,
-	useEffect,
-	useCallback,
-} from '@wordpress/element';
+import { createInterpolateElement, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -18,13 +14,30 @@ import AppButton from '~/components/app-button';
 import AddPaidCampaignButton from '~/components/paid-ads/add-paid-campaign-button';
 import { glaData, GUIDE_NAMES, LOCAL_STORAGE_KEYS } from '~/constants';
 import localStorage from '~/utils/localStorage';
-import { getProductFeedUrl } from '~/utils/urls';
+import { getProductFeedUrl, getSettingsUrl } from '~/utils/urls';
 import wooLogoURL from '~/images/logo/woocommerce-logo.svg';
 import googleLogoURL from '~/images/logo/google-logo.svg';
 import { recordGlaEvent } from '~/utils/tracks';
 import './index.scss';
 
 const EVENT_NAME = 'gla_modal_closed';
+
+const handleGuideFinish = ( e ) => {
+	getHistory().replace( getProductFeedUrl() );
+
+	// Since there is no built-in way to distinguish the modal/guide is closed by what action,
+	// here is a workaround by identifying the close button's data-aciton attribute.
+	let action = 'dismiss';
+
+	if ( e ) {
+		const target = e.currentTarget || e.target;
+		action = target.dataset.action || action;
+	}
+	recordGlaEvent( EVENT_NAME, {
+		context: GUIDE_NAMES.SUBMISSION_SUCCESS,
+		action,
+	} );
+};
 
 const image = (
 	<div className="gla-submission-success-guide__logo-block">
@@ -85,6 +98,78 @@ const pages = [
 				</p>
 			</GuidePageContent>
 		),
+		// Actions should be undefined if glaData.adsSetupComplete is false, else render the button.
+		action: glaData.adsSetupComplete ? (
+			<AppButton
+				isPrimary
+				data-action="view-product-feed"
+				onClick={ handleGuideFinish }
+			>
+				{ __( 'View product feed', 'google-listings-and-ads' ) }
+			</AppButton>
+		) : undefined,
+	},
+	{
+		image,
+		content: (
+			<GuidePageContent
+				title={ __(
+					'Improve conversion tracking accuracy to improve campaign performance',
+					'google-listings-and-ads'
+				) }
+			>
+				<p>
+					{ __(
+						'Set up Enhanced Conversions, a feature designed to improve your measurement accuracy by collecting privacy-conscious data without the need for third-party cookies.',
+						'google-listings-and-ads'
+					) }
+				</p>
+				<p>
+					{ createInterpolateElement(
+						__(
+							'<link>Learn more</link> about Enhanced Conversions.',
+							'google-listings-and-ads'
+						),
+						{
+							link: (
+								<ContentLink
+									href="https://woocommerce.com/document/google-listings-and-ads/enhanced-conversions/"
+									context="enhanced-conversions"
+								/>
+							),
+						}
+					) }
+				</p>
+			</GuidePageContent>
+		),
+		actions: (
+			<AppButton
+				isPrimary
+				data-action="view-enhanced-conversions-settings"
+				eventName={ EVENT_NAME }
+				eventProps={ {
+					context: GUIDE_NAMES.SUBMISSION_SUCCESS,
+					action: 'view-enhanced-conversions-settings',
+				} }
+				onClick={ () => {
+					handleGuideFinish();
+					window.location.href = getSettingsUrl();
+				} }
+				aria-label={ __(
+					'Set up Enhanced Conversions',
+					'google-listings-and-ads'
+				) }
+				title={ __(
+					'Set up Enhanced Conversions',
+					'google-listings-and-ads'
+				) }
+			>
+				{ __(
+					'Set up Enhanced Conversions',
+					'google-listings-and-ads'
+				) }
+			</AppButton>
+		),
 	},
 	{
 		image,
@@ -119,29 +204,36 @@ const pages = [
 				</cite>
 			</GuidePageContent>
 		),
+		actions: (
+			<>
+				<div className="gla-submission-success-guide__space_holder" />
+				<AppButton
+					isSecondary
+					data-action="maybe-later"
+					onClick={ handleGuideFinish }
+				>
+					{ __( 'Maybe later', 'google-listings-and-ads' ) }
+				</AppButton>
+				<AddPaidCampaignButton
+					isPrimary
+					isSecondary={ false }
+					isSmall={ false }
+					eventName={ EVENT_NAME }
+					eventProps={ {
+						context: GUIDE_NAMES.SUBMISSION_SUCCESS,
+						action: 'create-paid-campaign',
+					} }
+				>
+					{ __( 'Create campaign', 'google-listings-and-ads' ) }
+				</AddPaidCampaignButton>
+			</>
+		),
 	},
 ];
 
 if ( glaData.adsSetupComplete ) {
 	pages.pop();
 }
-
-const handleGuideFinish = ( e ) => {
-	getHistory().replace( getProductFeedUrl() );
-
-	// Since there is no built-in way to distinguish the modal/guide is closed by what action,
-	// here is a workaround by identifying the close button's data-aciton attribute.
-	let action = 'dismiss';
-
-	if ( e ) {
-		const target = e.currentTarget || e.target;
-		action = target.dataset.action || action;
-	}
-	recordGlaEvent( EVENT_NAME, {
-		context: GUIDE_NAMES.SUBMISSION_SUCCESS,
-		action,
-	} );
-};
 
 /**
  * Modal window to greet the user at Product Feed, after successful completion of onboarding.
@@ -166,51 +258,11 @@ const SubmissionSuccessGuide = () => {
 		);
 	}, [] );
 
-	const renderFinish = useCallback( () => {
-		if ( glaData.adsSetupComplete ) {
-			return (
-				<AppButton
-					isPrimary
-					data-action="view-product-feed"
-					onClick={ handleGuideFinish }
-				>
-					{ __( 'View product feed', 'google-listings-and-ads' ) }
-				</AppButton>
-			);
-		}
-
-		return (
-			<>
-				<div className="gla-submission-success-guide__space_holder" />
-				<AppButton
-					isSecondary
-					data-action="maybe-later"
-					onClick={ handleGuideFinish }
-				>
-					{ __( 'Maybe later', 'google-listings-and-ads' ) }
-				</AppButton>
-				<AddPaidCampaignButton
-					isPrimary
-					isSecondary={ false }
-					isSmall={ false }
-					eventName={ EVENT_NAME }
-					eventProps={ {
-						context: GUIDE_NAMES.SUBMISSION_SUCCESS,
-						action: 'create-paid-campaign',
-					} }
-				>
-					{ __( 'Create campaign', 'google-listings-and-ads' ) }
-				</AddPaidCampaignButton>
-			</>
-		);
-	}, [] );
-
 	return (
 		<Guide
 			className="gla-submission-success-guide"
 			backButtonText={ __( 'Back', 'google-listings-and-ads' ) }
 			pages={ pages }
-			renderFinish={ renderFinish }
 			onFinish={ handleGuideFinish }
 		/>
 	);

--- a/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
+++ b/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
@@ -456,44 +456,6 @@ test.describe( 'Complete your campaign', () => {
 				await expect( setupSuccessModal ).toBeVisible();
 			} );
 
-			test( 'should have three prompts in the setup success modal', async () => {
-				const guideControls = page.getByRole( 'list', {
-					name: 'Guide controls',
-				} );
-				const guideControlsItems =
-					guideControls.getByRole( 'listitem' );
-				await expect( guideControlsItems ).toHaveCount( 3 );
-			} );
-
-			test( 'should see the "Enhance Conversion" prompt in the setup success modal', async () => {
-				const guideControls = page.getByRole( 'list', {
-					name: 'Guide controls',
-				} );
-				const guideControlsItems =
-					guideControls.getByRole( 'listitem' );
-
-				// click on second item in the guide controls list.
-				await guideControlsItems.nth( 1 ).click();
-				await expect(
-					page.getByText(
-						'Improve conversion tracking accuracy to improve campaign performance'
-					)
-				).toBeVisible();
-			} );
-
-			test( 'should see the "Set up Enhance Conversions" button in the setup success modal', async () => {
-				const enhanceConversionButton = page.getByRole( 'button', {
-					name: 'Set up Enhanced Conversions',
-				} );
-				await expect( enhanceConversionButton ).toBeVisible();
-
-				const dataAction =
-					await enhanceConversionButton.getAttribute( 'data-action' );
-				expect( dataAction ).toBe(
-					'view-enhanced-conversions-settings'
-				);
-			} );
-
 			test( 'should see buttons on Dashboard for Google Ads onboarding', async () => {
 				await page.keyboard.press( 'Escape' );
 				await page.getByRole( 'tab', { name: 'Dashboard' } ).click();
@@ -530,6 +492,64 @@ test.describe( 'Complete your campaign', () => {
 					/path=%2Fgoogle%2Fsetup-mc&google-mc=connected/
 				);
 			} );
+		} );
+	} );
+
+	test.describe( 'Enhanced conversion prompt should appear as last step in setup success modal', () => {
+		test.beforeAll( async () => {
+			await page.evaluate( () => window.sessionStorage.clear() );
+			await setupAdsAccountPage.mockAdsAccountConnected();
+			await completeCampaign.mockCompleteAdsSetup();
+			await completeCampaign.goto();
+			await completeCampaign.clickSkipPaidAdsCreationButton();
+			await completeCampaign.clickCompleteSetupModalButton();
+		} );
+
+		test( 'should see the setup success modal', async () => {
+			const setupSuccessModal = completeCampaign.getSetupSuccessModal();
+			await expect( setupSuccessModal ).toBeVisible();
+		} );
+
+		test( 'should have three prompts in the setup success modal', async () => {
+			const guideControls = page.getByRole( 'list', {
+				name: 'Guide controls',
+			} );
+			const guideControlsItems = guideControls.getByRole( 'listitem' );
+			await expect( guideControlsItems ).toHaveCount( 3 );
+		} );
+
+		test( 'should see the "Enhance Conversion" prompt in the setup success modal', async () => {
+			const guideControls = page.getByRole( 'list', {
+				name: 'Guide controls',
+			} );
+			const guideControlsItems = guideControls.getByRole( 'listitem' );
+			await guideControlsItems.nth( 1 ).click();
+			await expect(
+				page.getByText(
+					'Improve conversion tracking accuracy to improve campaign performance'
+				)
+			).toBeVisible();
+		} );
+
+		test( 'should see the "Set up Enhance Conversions" button in the setup success modal', async () => {
+			const enhanceConversionButton = page.getByRole( 'button', {
+				name: 'Set up Enhanced Conversions',
+			} );
+			await expect( enhanceConversionButton ).toBeVisible();
+
+			const dataAction =
+				await enhanceConversionButton.getAttribute( 'data-action' );
+			expect( dataAction ).toBe( 'view-enhanced-conversions-settings' );
+		} );
+
+		test( 'should navigate to settings page when clicking "Set up Enhanced Conversions" button', async () => {
+			const enhanceConversionButton = page.getByRole( 'button', {
+				name: 'Set up Enhanced Conversions',
+			} );
+			await enhanceConversionButton.click();
+
+			await page.waitForURL( /path=%2Fgoogle%2Fsettings/ );
+			expect( page.url() ).toMatch( /path=%2Fgoogle%2Fsettings/ );
 		} );
 	} );
 

--- a/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
+++ b/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
@@ -495,9 +495,11 @@ test.describe( 'Complete your campaign', () => {
 		} );
 	} );
 
-	test.describe( 'Enhanced conversion prompt should appear as last step in setup success modal', () => {
+	test.describe( 'Enhanced conversion prompt', () => {
 		test.beforeAll( async () => {
-			await page.evaluate( () => window.sessionStorage.clear() );
+			await page.evaluate( () => {
+				window.sessionStorage.clear();
+			} );
 			await setupAdsAccountPage.mockAdsAccountConnected();
 			await completeCampaign.mockCompleteAdsSetup();
 			await completeCampaign.goto();
@@ -510,43 +512,75 @@ test.describe( 'Complete your campaign', () => {
 			await expect( setupSuccessModal ).toBeVisible();
 		} );
 
-		test( 'should have three prompts in the setup success modal', async () => {
-			const guideControls = page.getByRole( 'list', {
-				name: 'Guide controls',
+		test.describe( 'Should be second step when ads setup is incomplete', () => {
+			test( 'should have three prompts in the setup success modal', async () => {
+				const guideControls = page.getByRole( 'list', {
+					name: 'Guide controls',
+				} );
+				const guideControlsItems =
+					guideControls.getByRole( 'listitem' );
+				await expect( guideControlsItems ).toHaveCount( 3 );
 			} );
-			const guideControlsItems = guideControls.getByRole( 'listitem' );
-			await expect( guideControlsItems ).toHaveCount( 3 );
+
+			test( 'should see the "Enhanced Conversions" prompt in the setup success modal', async () => {
+				const guideControls = page.getByRole( 'list', {
+					name: 'Guide controls',
+				} );
+				const guideControlsItems =
+					guideControls.getByRole( 'listitem' );
+				await guideControlsItems.nth( 1 ).click();
+				await expect(
+					page.getByText(
+						'Improve conversion tracking accuracy to improve campaign performance'
+					)
+				).toBeVisible();
+			} );
+
+			test( 'should see the "Set up Enhanced Conversions" button in the setup success modal', async () => {
+				const enhancedConversionsButton = page.getByRole( 'button', {
+					name: 'Set up Enhanced Conversions',
+				} );
+				await expect( enhancedConversionsButton ).toBeVisible();
+
+				const dataAction =
+					await enhancedConversionsButton.getAttribute(
+						'data-action'
+					);
+				expect( dataAction ).toBe(
+					'view-enhanced-conversions-settings'
+				);
+			} );
 		} );
 
-		test( 'should see the "Enhance Conversion" prompt in the setup success modal', async () => {
-			const guideControls = page.getByRole( 'list', {
-				name: 'Guide controls',
+		test.describe( 'should be the last step when ads setup is complete', async () => {
+			test.beforeAll( async () => {
+				await completeCampaign.goto();
+				await completeCampaign.clickSkipPaidAdsCreationButton();
+				await completeCampaign.clickCompleteSetupModalButton();
+				await page.waitForNavigation( {
+					waitUntil: 'domcontentloaded',
+				} );
+				await page.evaluate( () => {
+					window.glaData.adsSetupComplete = true;
+				} );
 			} );
-			const guideControlsItems = guideControls.getByRole( 'listitem' );
-			await guideControlsItems.nth( 1 ).click();
-			await expect(
-				page.getByText(
-					'Improve conversion tracking accuracy to improve campaign performance'
-				)
-			).toBeVisible();
-		} );
 
-		test( 'should see the "Set up Enhance Conversions" button in the setup success modal', async () => {
-			const enhanceConversionButton = page.getByRole( 'button', {
-				name: 'Set up Enhanced Conversions',
+			test( 'should have two prompts in the setup success modal', async () => {
+				const guideControls = page.getByRole( 'list', {
+					name: 'Guide controls',
+				} );
+				const guideControlsItems =
+					guideControls.getByRole( 'listitem' );
+				await guideControlsItems.nth( 1 ).click();
+				await expect( guideControlsItems ).toHaveCount( 2 );
 			} );
-			await expect( enhanceConversionButton ).toBeVisible();
-
-			const dataAction =
-				await enhanceConversionButton.getAttribute( 'data-action' );
-			expect( dataAction ).toBe( 'view-enhanced-conversions-settings' );
 		} );
 
 		test( 'should navigate to settings page when clicking "Set up Enhanced Conversions" button', async () => {
-			const enhanceConversionButton = page.getByRole( 'button', {
+			const enhancedConversionsButton = page.getByRole( 'button', {
 				name: 'Set up Enhanced Conversions',
 			} );
-			await enhanceConversionButton.click();
+			await enhancedConversionsButton.click();
 
 			await page.waitForURL( /path=%2Fgoogle%2Fsettings/ );
 			expect( page.url() ).toMatch( /path=%2Fgoogle%2Fsettings/ );

--- a/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
+++ b/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
@@ -551,7 +551,7 @@ test.describe( 'Complete your campaign', () => {
 			} );
 		} );
 
-		test.describe( 'Ads setup is completed', async () => {
+		test.describe( 'Ads setup is complete', async () => {
 			test.beforeAll( async () => {
 				await completeCampaign.goto();
 				await completeCampaign.clickSkipPaidAdsCreationButton();

--- a/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
+++ b/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
@@ -501,7 +501,6 @@ test.describe( 'Complete your campaign', () => {
 				window.sessionStorage.clear();
 			} );
 			await setupAdsAccountPage.mockAdsAccountConnected();
-			await completeCampaign.mockCompleteAdsSetup();
 			await completeCampaign.goto();
 			await completeCampaign.clickSkipPaidAdsCreationButton();
 			await completeCampaign.clickCompleteSetupModalButton();
@@ -512,7 +511,7 @@ test.describe( 'Complete your campaign', () => {
 			await expect( setupSuccessModal ).toBeVisible();
 		} );
 
-		test.describe( 'Should be second step when ads setup is incomplete', () => {
+		test.describe( 'Ads setup is incomplete', () => {
 			test( 'should have three prompts in the setup success modal', async () => {
 				const guideControls = page.getByRole( 'list', {
 					name: 'Guide controls',
@@ -552,7 +551,7 @@ test.describe( 'Complete your campaign', () => {
 			} );
 		} );
 
-		test.describe( 'should be the last step when ads setup is complete', async () => {
+		test.describe( 'Ads setup is completed', async () => {
 			test.beforeAll( async () => {
 				await completeCampaign.goto();
 				await completeCampaign.clickSkipPaidAdsCreationButton();
@@ -584,6 +583,9 @@ test.describe( 'Complete your campaign', () => {
 
 			await page.waitForURL( /path=%2Fgoogle%2Fsettings/ );
 			expect( page.url() ).toMatch( /path=%2Fgoogle%2Fsettings/ );
+
+			const setupSuccessModal = completeCampaign.getSetupSuccessModal();
+			await expect( setupSuccessModal ).not.toBeVisible();
 		} );
 	} );
 

--- a/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
+++ b/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
@@ -456,6 +456,44 @@ test.describe( 'Complete your campaign', () => {
 				await expect( setupSuccessModal ).toBeVisible();
 			} );
 
+			test( 'should have three prompts in the setup success modal', async () => {
+				const guideControls = page.getByRole( 'list', {
+					name: 'Guide controls',
+				} );
+				const guideControlsItems =
+					guideControls.getByRole( 'listitem' );
+				await expect( guideControlsItems ).toHaveCount( 3 );
+			} );
+
+			test( 'should see the "Enhance Conversion" prompt in the setup success modal', async () => {
+				const guideControls = page.getByRole( 'list', {
+					name: 'Guide controls',
+				} );
+				const guideControlsItems =
+					guideControls.getByRole( 'listitem' );
+
+				// click on second item in the guide controls list.
+				await guideControlsItems.nth( 1 ).click();
+				await expect(
+					page.getByText(
+						'Improve conversion tracking accuracy to improve campaign performance'
+					)
+				).toBeVisible();
+			} );
+
+			test( 'should see the "Set up Enhance Conversions" button in the setup success modal', async () => {
+				const enhanceConversionButton = page.getByRole( 'button', {
+					name: 'Set up Enhanced Conversions',
+				} );
+				await expect( enhanceConversionButton ).toBeVisible();
+
+				const dataAction =
+					await enhanceConversionButton.getAttribute( 'data-action' );
+				expect( dataAction ).toBe(
+					'view-enhanced-conversions-settings'
+				);
+			} );
+
 			test( 'should see buttons on Dashboard for Google Ads onboarding', async () => {
 				await page.keyboard.press( 'Escape' );
 				await page.getByRole( 'tab', { name: 'Dashboard' } ).click();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2901 .

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->
<img width="600" alt="Screenshot 2025-05-30 at 12 17 38 PM" src="https://github.com/user-attachments/assets/9d17b8a7-0c65-43eb-906c-bd5810bf7764" />


### Detailed test instructions

1. Complete the onboarding setup and you should see the setup success modal. If the ads setup is skipped, there should be 3 prompts, of which second one should be Enhanced Conversion prompt.

2. If the ads setup was completed during onboarding, the last prompt would be for EC.

3. Ensure that design matches the one provided in figma. Note that the guide controls position is not the one provided in figma, but that is out of scope of this issue. Also, `Back` and `Next` button would appear in the prompt which should be fine.

4. You can also view the prompt using by visiting the path `wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fproduct-feed&guide=submission-success`.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
