### PR TITLE
Test Proxy: Update mock data for price benchmarks

### DIFF
--- a/tests/proxy/mocks/mc/price-benchmarks/merchant-report.json
+++ b/tests/proxy/mocks/mc/price-benchmarks/merchant-report.json
@@ -2,11 +2,211 @@
 	"results": [
 		{
 			"segments": {
-				"offerId": "gla_103572"
+				"offerId": "gla_37"
 			},
 			"metrics": {
 				"clicks": "3",
-				"conversions": 0
+				"conversions": 0,
+				"impressions": "5",
+				"ctr": 0.6
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_36"
+			},
+			"metrics": {
+				"clicks": "2",
+				"conversions": 0,
+				"impressions": "4",
+				"ctr": 0.5
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_35"
+			},
+			"metrics": {
+				"clicks": "1",
+				"conversions": 0,
+				"impressions": "3",
+				"ctr": 0.33
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_34"
+			},
+			"metrics": {
+				"clicks": "2",
+				"conversions": 0,
+				"impressions": "6",
+				"ctr": 0.33
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_33"
+			},
+			"metrics": {
+				"clicks": "1",
+				"conversions": 0,
+				"impressions": "3",
+				"ctr": 0.33
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_27"
+			},
+			"metrics": {
+				"clicks": "5",
+				"conversions": 1,
+				"impressions": "10",
+				"ctr": 0.5
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_26"
+			},
+			"metrics": {
+				"clicks": "8",
+				"conversions": 2,
+				"impressions": "20",
+				"ctr": 0.4
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_25"
+			},
+			"metrics": {
+				"clicks": "6",
+				"conversions": 1,
+				"impressions": "15",
+				"ctr": 0.4
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_24"
+			},
+			"metrics": {
+				"clicks": "10",
+				"conversions": 2,
+				"impressions": "25",
+				"ctr": 0.4
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_23"
+			},
+			"metrics": {
+				"clicks": "12",
+				"conversions": 3,
+				"impressions": "30",
+				"ctr": 0.4
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_22"
+			},
+			"metrics": {
+				"clicks": "15",
+				"conversions": 4,
+				"impressions": "35",
+				"ctr": 0.43
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_21"
+			},
+			"metrics": {
+				"clicks": "20",
+				"conversions": 5,
+				"impressions": "50",
+				"ctr": 0.4
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_20"
+			},
+			"metrics": {
+				"clicks": "18",
+				"conversions": 4,
+				"impressions": "45",
+				"ctr": 0.4
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_19"
+			},
+			"metrics": {
+				"clicks": "16",
+				"conversions": 3,
+				"impressions": "40",
+				"ctr": 0.4
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_18"
+			},
+			"metrics": {
+				"clicks": "14",
+				"conversions": 3,
+				"impressions": "35",
+				"ctr": 0.4
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_17"
+			},
+			"metrics": {
+				"clicks": "12",
+				"conversions": 2,
+				"impressions": "30",
+				"ctr": 0.4
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_16"
+			},
+			"metrics": {
+				"clicks": "10",
+				"conversions": 2,
+				"impressions": "25",
+				"ctr": 0.4
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_15"
+			},
+			"metrics": {
+				"clicks": "8",
+				"conversions": 1,
+				"impressions": "20",
+				"ctr": 0.4
+			}
+		},
+		{
+			"segments": {
+				"offerId": "gla_14"
+			},
+			"metrics": {
+				"clicks": "6",
+				"conversions": 1,
+				"impressions": "15",
+				"ctr": 0.4
 			}
 		}
 	]

--- a/tests/proxy/mocks/mc/price-benchmarks/price-competitiveness-item.json
+++ b/tests/proxy/mocks/mc/price-benchmarks/price-competitiveness-item.json
@@ -2,16 +2,16 @@
 	"results": [
 		{
 			"productView": {
-				"offerId": "gla_103572",
-				"title": "Dr. Seuss The Grinch Stole Christmas Ugly Sweater xl",
+				"offerId": "gla_37",
+				"title": "WordPress Pennant",
 				"currencyCode": "USD",
-				"priceMicros": "34950000",
-				"id": "online:en:US:gla_103572"
+				"priceMicros": "20000000",
+				"id": "online:en:US:gla_37"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "15131447"
+				"benchmarkPriceMicros": "19500000"
 			}
 		}
 	]

--- a/tests/proxy/mocks/mc/price-benchmarks/price-competitiveness.json
+++ b/tests/proxy/mocks/mc/price-benchmarks/price-competitiveness.json
@@ -2,282 +2,254 @@
 	"results": [
 		{
 			"productView": {
-				"offerId": "gla_103572",
-				"title": "Dr. Seuss The Grinch Stole Christmas Ugly Sweater xl",
+				"offerId": "gla_37",
+				"title": "WordPress Pennant",
 				"currencyCode": "USD",
-				"priceMicros": "34950000",
-				"id": "online:en:US:gla_103572"
+				"priceMicros": "20000000",
+				"id": "online:en:US:gla_37"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "15131447"
+				"benchmarkPriceMicros": "19500000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_103628",
-				"title": "Dr. Seuss The Grinch Stole Christmas Ugly Sweater xl",
+				"offerId": "gla_36",
+				"title": "Logo Collection",
 				"currencyCode": "USD",
-				"priceMicros": "27950000",
-				"id": "online:en:US:gla_103628"
+				"priceMicros": "18000000",
+				"id": "online:en:US:gla_36"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "15131447"
+				"benchmarkPriceMicros": "18500000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119547",
-				"title": "Black Panther Nano-T Unisex T-Shirt l",
+				"offerId": "gla_35",
+				"title": "Beanie with Logo",
 				"currencyCode": "USD",
-				"priceMicros": "24950000",
-				"id": "online:en:US:gla_119547"
+				"priceMicros": "17000000",
+				"id": "online:en:US:gla_35"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "16609362"
+				"benchmarkPriceMicros": "18500000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119553",
-				"title": "Black Panther Nano-T Unisex T-Shirt l",
+				"offerId": "gla_34",
+				"title": "T-Shirt with Logo",
 				"currencyCode": "USD",
-				"priceMicros": "25950000",
-				"id": "online:en:US:gla_119553"
+				"priceMicros": "18000000",
+				"id": "online:en:US:gla_34"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "16609362"
+				"benchmarkPriceMicros": "18000000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119577",
-				"title": "Black Panther Nano-T Unisex T-Shirt s",
+				"offerId": "gla_27",
+				"title": "Single",
 				"currencyCode": "USD",
-				"priceMicros": "24950000",
-				"id": "online:en:US:gla_119577"
+				"priceMicros": "2000000",
+				"id": "online:en:US:gla_27"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "21065000"
+				"benchmarkPriceMicros": "2500000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119622",
-				"title": "Black Panther Unisex T-Shirt l",
+				"offerId": "gla_26",
+				"title": "Album",
 				"currencyCode": "USD",
-				"priceMicros": "22950000",
-				"id": "online:en:US:gla_119622"
+				"priceMicros": "15000000",
+				"id": "online:en:US:gla_26"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "16609362"
+				"benchmarkPriceMicros": "14000000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119624",
-				"title": "Black Panther Unisex T-Shirt 2xl",
+				"offerId": "gla_25",
+				"title": "Polo",
 				"currencyCode": "USD",
-				"priceMicros": "24450000",
-				"id": "online:en:US:gla_119624"
+				"priceMicros": "20000000",
+				"id": "online:en:US:gla_25"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "20886623"
+				"benchmarkPriceMicros": "19000000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119627",
-				"title": "Black Panther Unisex T-Shirt 5xl",
+				"offerId": "gla_24",
+				"title": "Long Sleeve Tee",
 				"currencyCode": "USD",
-				"priceMicros": "26450000",
-				"id": "online:en:US:gla_119627"
+				"priceMicros": "25000000",
+				"id": "online:en:US:gla_24"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "23083000"
+				"benchmarkPriceMicros": "27500000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119632",
-				"title": "Black Panther Unisex T-Shirt 2xl",
+				"offerId": "gla_23",
+				"title": "Hoodie with Zipper",
 				"currencyCode": "USD",
-				"priceMicros": "24450000",
-				"id": "online:en:US:gla_119632"
+				"priceMicros": "45000000",
+				"id": "online:en:US:gla_23"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "20886623"
+				"benchmarkPriceMicros": "44000000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119668",
-				"title": "Black Panther Unisex T-Shirt 2xl",
+				"offerId": "gla_22",
+				"title": "Hoodie with Pocket",
 				"currencyCode": "USD",
-				"priceMicros": "24450000",
-				"id": "online:en:US:gla_119668"
+				"priceMicros": "35000000",
+				"id": "online:en:US:gla_22"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "12028852"
+				"benchmarkPriceMicros": "45000000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1244613",
-				"title": "Star Wars Kylo Ren Ugly Christmas Sweater 2xl",
+				"offerId": "gla_21",
+				"title": "Sunglasses",
 				"currencyCode": "USD",
-				"priceMicros": "34950000",
-				"id": "online:en:US:gla_1244613"
+				"priceMicros": "90000000",
+				"id": "online:en:US:gla_21"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "35605385"
+				"benchmarkPriceMicros": "95000000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1244626",
-				"title": "Star Wars Kylo Ren Ugly Christmas Sweater m",
+				"offerId": "gla_20",
+				"title": "Cap",
 				"currencyCode": "USD",
-				"priceMicros": "32950000",
-				"id": "online:en:US:gla_1244626"
+				"priceMicros": "16000000",
+				"id": "online:en:US:gla_20"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "18566000"
+				"benchmarkPriceMicros": "16200000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1244627",
-				"title": "Star Wars Kylo Ren Ugly Christmas Sweater l",
+				"offerId": "gla_19",
+				"title": "Belt",
 				"currencyCode": "USD",
-				"priceMicros": "32950000",
-				"id": "online:en:US:gla_1244627"
+				"priceMicros": "55000000",
+				"id": "online:en:US:gla_19"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "34256923"
+				"benchmarkPriceMicros": "58000000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1279304",
-				"title": "Mom And Daughter Shirt | Premium Mom V-Neck T-Shirt | Best ing Partner In Crime 2xl",
+				"offerId": "gla_18",
+				"title": "Beanie",
 				"currencyCode": "USD",
-				"priceMicros": "26950000",
-				"id": "online:en:US:gla_1279304"
+				"priceMicros": "18000000",
+				"id": "online:en:US:gla_18"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "17983333"
+				"benchmarkPriceMicros": "17000000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1287790",
-				"title": "Science Shirt for Mom | Chemistry Mom T-shirt | Mother Periodic Table Shirt 3xl",
+				"offerId": "gla_17",
+				"title": "T-Shirt",
 				"currencyCode": "USD",
-				"priceMicros": "26950000",
-				"id": "online:en:US:gla_1287790"
+				"priceMicros": "18000000",
+				"id": "online:en:US:gla_17"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "17812000"
+				"benchmarkPriceMicros": "18000000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1287799",
-				"title": "Science Shirt for Mom | Chemistry Mom T-shirt | Mother Periodic Table Shirt 3xl",
+				"offerId": "gla_16",
+				"title": "Hoodie with Logo",
 				"currencyCode": "USD",
-				"priceMicros": "26950000",
-				"id": "online:en:US:gla_1287799"
+				"priceMicros": "45000000",
+				"id": "online:en:US:gla_16"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "17812000"
+				"benchmarkPriceMicros": "42000000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1287830",
-				"title": "Science Shirt for Mom | Premium Chemistry Mom T-shirt | Mother Periodic Table Shirt m",
+				"offerId": "gla_15",
+				"title": "Hoodie",
 				"currencyCode": "USD",
-				"priceMicros": "25950000",
-				"id": "online:en:US:gla_1287830"
+				"priceMicros": "42000000",
+				"id": "online:en:US:gla_15"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "14484644"
+				"benchmarkPriceMicros": "40000000"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1287834",
-				"title": "Science Shirt for Mom | Premium Chemistry Mom T-shirt | Mother Periodic Table Shirt 3xl",
+				"offerId": "gla_14",
+				"title": "V-Neck T-Shirt",
 				"currencyCode": "USD",
-				"priceMicros": "28550000",
-				"id": "online:en:US:gla_1287834"
+				"priceMicros": "15000000",
+				"id": "online:en:US:gla_14"
 			},
 			"priceCompetitiveness": {
 				"countryCode": "US",
 				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "17812000"
-			}
-		},
-		{
-			"productView": {
-				"offerId": "gla_1287863",
-				"title": "Science Shirt for Mom | Premium Chemistry Mom T-shirt | Mother Periodic Table Shirt 3xl",
-				"currencyCode": "USD",
-				"priceMicros": "28550000",
-				"id": "online:en:US:gla_1287863"
-			},
-			"priceCompetitiveness": {
-				"countryCode": "US",
-				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "17812000"
-			}
-		},
-		{
-			"productView": {
-				"offerId": "gla_1287871",
-				"title": "Science Shirt for Mom | Premium Chemistry Mom T-shirt | Mother Periodic Table Shirt 3xl",
-				"currencyCode": "USD",
-				"priceMicros": "28550000",
-				"id": "online:en:US:gla_1287871"
-			},
-			"priceCompetitiveness": {
-				"countryCode": "US",
-				"benchmarkPriceCurrencyCode": "USD",
-				"benchmarkPriceMicros": "17812000"
+				"benchmarkPriceMicros": "16500000"
 			}
 		}
 	]

--- a/tests/proxy/mocks/mc/price-benchmarks/price-insights-item.json
+++ b/tests/proxy/mocks/mc/price-benchmarks/price-insights-item.json
@@ -2,18 +2,18 @@
 	"results": [
 		{
 			"productView": {
-				"offerId": "gla_103572",
-				"title": "Dr. Seuss The Grinch Stole Christmas Ugly Sweater xl",
+				"offerId": "gla_37",
+				"title": "WordPress Pennant",
 				"currencyCode": "USD",
-				"priceMicros": "34950000",
-				"id": "online:en:US:gla_103572"
+				"priceMicros": "20000000",
+				"id": "online:en:US:gla_37"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "135680000",
+				"suggestedPriceMicros": "19000000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.12609300017356873",
 				"predictedClicksChangeFraction": "0.508745014667511",
-				"predictedConversionsChangeFraction": "2.3431060314178467",
+				"predictedConversionsChangeFraction": "0.343106031417846",
 				"effectiveness": "HIGH"
 			}
 		}

--- a/tests/proxy/mocks/mc/price-benchmarks/price-insights.json
+++ b/tests/proxy/mocks/mc/price-benchmarks/price-insights.json
@@ -2,342 +2,308 @@
 	"results": [
 		{
 			"productView": {
-				"offerId": "gla_103572",
-				"title": "Dr. Seuss The Grinch Stole Christmas Ugly Sweater xl",
+				"offerId": "gla_37",
+				"title": "WordPress Pennant",
 				"currencyCode": "USD",
-				"priceMicros": "34950000",
-				"id": "online:en:US:gla_103572"
+				"priceMicros": "20000000",
+				"id": "online:en:US:gla_37"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "135680000",
+				"suggestedPriceMicros": "19000000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.12609300017356873",
 				"predictedClicksChangeFraction": "0.508745014667511",
-				"predictedConversionsChangeFraction": "2.3431060314178467",
+				"predictedConversionsChangeFraction": "0.343106031417846",
 				"effectiveness": "HIGH"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_103628",
-				"title": "Dr. Seuss The Grinch Stole Christmas Ugly Sweater xl",
+				"offerId": "gla_36",
+				"title": "Logo Collection",
 				"currencyCode": "USD",
-				"priceMicros": "27950000",
-				"id": "online:en:US:gla_103628"
+				"priceMicros": "18000000",
+				"id": "online:en:US:gla_36"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "122450000",
+				"suggestedPriceMicros": "17500000",
 				"suggestedPriceCurrencyCode": "USD",
-				"predictedImpressionsChangeFraction": "0.15723400012458974",
-				"predictedClicksChangeFraction": "0.467823012356781",
-				"predictedConversionsChangeFraction": "1.9876543210987654",
+				"predictedImpressionsChangeFraction": "0.09723400012458974",
+				"predictedClicksChangeFraction": "0.267823012356781",
+				"predictedConversionsChangeFraction": "0.287654321098765",
 				"effectiveness": "MEDIUM"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119547",
-				"title": "Black Panther Nano-T Unisex T-Shirt l",
+				"offerId": "gla_35",
+				"title": "Beanie with Logo",
 				"currencyCode": "USD",
-				"priceMicros": "24950000",
-				"id": "online:en:US:gla_119547"
+				"priceMicros": "17000000",
+				"id": "online:en:US:gla_35"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "115260000",
+				"suggestedPriceMicros": "16500000",
 				"suggestedPriceCurrencyCode": "USD",
-				"predictedImpressionsChangeFraction": "0.18976500023145628",
-				"predictedClicksChangeFraction": "0.612345678912345",
-				"predictedConversionsChangeFraction": "2.1234567890123456",
+				"predictedImpressionsChangeFraction": "0.08976500023145628",
+				"predictedClicksChangeFraction": "0.212345678912345",
+				"predictedConversionsChangeFraction": "0.223456789012345",
 				"effectiveness": "LOW"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119553",
-				"title": "Black Panther Nano-T Unisex T-Shirt l",
+				"offerId": "gla_34",
+				"title": "T-Shirt with Logo",
 				"currencyCode": "USD",
-				"priceMicros": "25950000",
-				"id": "online:en:US:gla_119553"
+				"priceMicros": "18000000",
+				"id": "online:en:US:gla_34"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "118730000",
+				"suggestedPriceMicros": "17800000",
 				"suggestedPriceCurrencyCode": "USD",
-				"predictedImpressionsChangeFraction": "0.17654300098765432",
-				"predictedClicksChangeFraction": "0.534567890123456",
-				"predictedConversionsChangeFraction": "1.9876543210123456",
+				"predictedImpressionsChangeFraction": "0.07654300098765432",
+				"predictedClicksChangeFraction": "0.234567890123456",
+				"predictedConversionsChangeFraction": "0.187654321012345",
 				"effectiveness": "EFFECTIVENESS_UNSPECIFIED"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119577",
-				"title": "Black Panther Nano-T Unisex T-Shirt s",
+				"offerId": "gla_27",
+				"title": "Single",
 				"currencyCode": "USD",
-				"priceMicros": "24950000",
-				"id": "online:en:US:gla_119577"
+				"priceMicros": "2000000",
+				"id": "online:en:US:gla_27"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "107850000",
+				"suggestedPriceMicros": "1900000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.14532100078965432",
 				"predictedClicksChangeFraction": "0.487654321098765",
-				"predictedConversionsChangeFraction": "2.0123456789012345",
+				"predictedConversionsChangeFraction": "0.401234567890123",
 				"effectiveness": "HIGH"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119622",
-				"title": "Black Panther Unisex T-Shirt l",
+				"offerId": "gla_26",
+				"title": "Album",
 				"currencyCode": "USD",
-				"priceMicros": "22950000",
-				"id": "online:en:US:gla_119622"
+				"priceMicros": "15000000",
+				"id": "online:en:US:gla_26"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "98760000",
+				"suggestedPriceMicros": "14500000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.12345678901234567",
 				"predictedClicksChangeFraction": "0.456789012345678",
-				"predictedConversionsChangeFraction": "1.7890123456789012",
+				"predictedConversionsChangeFraction": "0.278901234567890",
 				"effectiveness": "MEDIUM"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119624",
-				"title": "Black Panther Unisex T-Shirt 2xl",
+				"offerId": "gla_25",
+				"title": "Polo",
 				"currencyCode": "USD",
-				"priceMicros": "24450000",
-				"id": "online:en:US:gla_119624"
+				"priceMicros": "20000000",
+				"id": "online:en:US:gla_25"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "105430000",
+				"suggestedPriceMicros": "19500000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.15678901234567890",
-				"predictedClicksChangeFraction": "0.543210987654321",
-				"predictedConversionsChangeFraction": "1.8901234567890123",
+				"predictedClicksChangeFraction": "0.343210987654321",
+				"predictedConversionsChangeFraction": "0.289012345678901",
 				"effectiveness": "LOW"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119627",
-				"title": "Black Panther Unisex T-Shirt 5xl",
+				"offerId": "gla_24",
+				"title": "Long Sleeve Tee",
 				"currencyCode": "USD",
-				"priceMicros": "26450000",
-				"id": "online:en:US:gla_119627"
+				"priceMicros": "25000000",
+				"id": "online:en:US:gla_24"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "119870000",
+				"suggestedPriceMicros": "24500000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.16789012345678901",
-				"predictedClicksChangeFraction": "0.567890123456789",
-				"predictedConversionsChangeFraction": "1.9012345678901234",
+				"predictedClicksChangeFraction": "0.367890123456789",
+				"predictedConversionsChangeFraction": "0.290123456789012",
 				"effectiveness": "EFFECTIVENESS_UNSPECIFIED"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119632",
-				"title": "Black Panther Unisex T-Shirt 2xl",
+				"offerId": "gla_23",
+				"title": "Hoodie with Zipper",
 				"currencyCode": "USD",
-				"priceMicros": "24450000",
-				"id": "online:en:US:gla_119632"
+				"priceMicros": "45000000",
+				"id": "online:en:US:gla_23"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "103450000",
+				"suggestedPriceMicros": "43500000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.13456789012345678",
-				"predictedClicksChangeFraction": "0.523456789012345",
-				"predictedConversionsChangeFraction": "1.8765432109876543",
+				"predictedClicksChangeFraction": "0.323456789012345",
+				"predictedConversionsChangeFraction": "0.276543210987654",
 				"effectiveness": "MEDIUM"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_119668",
-				"title": "Black Panther Unisex T-Shirt 2xl",
+				"offerId": "gla_22",
+				"title": "Hoodie with Pocket",
 				"currencyCode": "USD",
-				"priceMicros": "24450000",
-				"id": "online:en:US:gla_119668"
+				"priceMicros": "35000000",
+				"id": "online:en:US:gla_22"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "102340000",
+				"suggestedPriceMicros": "34000000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.14321098765432109",
-				"predictedClicksChangeFraction": "0.531234567890123",
-				"predictedConversionsChangeFraction": "1.8543210987654321",
+				"predictedClicksChangeFraction": "0.331234567890123",
+				"predictedConversionsChangeFraction": "0.254321098765432",
 				"effectiveness": "HIGH"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1244613",
-				"title": "Star Wars Kylo Ren Ugly Christmas Sweater 2xl",
+				"offerId": "gla_21",
+				"title": "Sunglasses",
 				"currencyCode": "USD",
-				"priceMicros": "34950000",
-				"id": "online:en:US:gla_1244613"
+				"priceMicros": "90000000",
+				"id": "online:en:US:gla_21"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "145780000",
+				"suggestedPriceMicros": "88000000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.19876543210987654",
-				"predictedClicksChangeFraction": "0.645678901234567",
-				"predictedConversionsChangeFraction": "2.4567890123456789",
+				"predictedClicksChangeFraction": "0.445678901234567",
+				"predictedConversionsChangeFraction": "0.356789012345678",
 				"effectiveness": "LOW"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1244626",
-				"title": "Star Wars Kylo Ren Ugly Christmas Sweater m",
+				"offerId": "gla_20",
+				"title": "Cap",
 				"currencyCode": "USD",
-				"priceMicros": "32950000",
-				"id": "online:en:US:gla_1244626"
+				"priceMicros": "16000000",
+				"id": "online:en:US:gla_20"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "125670000",
+				"suggestedPriceMicros": "15500000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.17654321098765432",
-				"predictedClicksChangeFraction": "0.587654321098765",
-				"predictedConversionsChangeFraction": "2.3210987654321098",
+				"predictedClicksChangeFraction": "0.387654321098765",
+				"predictedConversionsChangeFraction": "0.321098765432109",
 				"effectiveness": "EFFECTIVENESS_UNSPECIFIED"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1244627",
-				"title": "Star Wars Kylo Ren Ugly Christmas Sweater l",
+				"offerId": "gla_19",
+				"title": "Belt",
 				"currencyCode": "USD",
-				"priceMicros": "32950000",
-				"id": "online:en:US:gla_1244627"
+				"priceMicros": "55000000",
+				"id": "online:en:US:gla_19"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "128750000",
+				"suggestedPriceMicros": "54000000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.18765432109876543",
-				"predictedClicksChangeFraction": "0.598765432109876",
-				"predictedConversionsChangeFraction": "2.3321098765432109",
+				"predictedClicksChangeFraction": "0.398765432109876",
+				"predictedConversionsChangeFraction": "0.332109876543210",
 				"effectiveness": "MEDIUM"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1279304",
-				"title": "Mom And Daughter Shirt | Premium Mom V-Neck T-Shirt | Best ing Partner In Crime 2xl",
+				"offerId": "gla_18",
+				"title": "Beanie",
 				"currencyCode": "USD",
-				"priceMicros": "26950000",
-				"id": "online:en:US:gla_1279304"
+				"priceMicros": "18000000",
+				"id": "online:en:US:gla_18"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "118560000",
+				"suggestedPriceMicros": "17500000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.16543210987654321",
-				"predictedClicksChangeFraction": "0.554321098765432",
-				"predictedConversionsChangeFraction": "2.1098765432109876",
+				"predictedClicksChangeFraction": "0.354321098765432",
+				"predictedConversionsChangeFraction": "0.210987654321098",
 				"effectiveness": "LOW"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1287790",
-				"title": "Science Shirt for Mom | Chemistry Mom T-shirt | Mother Periodic Table Shirt 3xl",
+				"offerId": "gla_17",
+				"title": "T-Shirt",
 				"currencyCode": "USD",
-				"priceMicros": "26950000",
-				"id": "online:en:US:gla_1287790"
+				"priceMicros": "18000000",
+				"id": "online:en:US:gla_17"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "119870000",
+				"suggestedPriceMicros": "17000000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.17890123456789012",
-				"predictedClicksChangeFraction": "0.575678901234567",
-				"predictedConversionsChangeFraction": "2.2345678901234567",
+				"predictedClicksChangeFraction": "0.375678901234567",
+				"predictedConversionsChangeFraction": "0.234567890123456",
 				"effectiveness": "HIGH"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1287799",
-				"title": "Science Shirt for Mom | Chemistry Mom T-shirt | Mother Periodic Table Shirt 3xl",
+				"offerId": "gla_16",
+				"title": "Hoodie with Logo",
 				"currencyCode": "USD",
-				"priceMicros": "26950000",
-				"id": "online:en:US:gla_1287799"
+				"priceMicros": "45000000",
+				"id": "online:en:US:gla_16"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "117890000",
+				"suggestedPriceMicros": "44000000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.16789012345678901",
-				"predictedClicksChangeFraction": "0.569876543210987",
-				"predictedConversionsChangeFraction": "2.1987654321098765",
+				"predictedClicksChangeFraction": "0.369876543210987",
+				"predictedConversionsChangeFraction": "0.298765432109876",
 				"effectiveness": "EFFECTIVENESS_UNSPECIFIED"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1287830",
-				"title": "Science Shirt for Mom | Premium Chemistry Mom T-shirt | Mother Periodic Table Shirt m",
+				"offerId": "gla_15",
+				"title": "Hoodie",
 				"currencyCode": "USD",
-				"priceMicros": "25950000",
-				"id": "online:en:US:gla_1287830"
+				"priceMicros": "42000000",
+				"id": "online:en:US:gla_15"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "112340000",
+				"suggestedPriceMicros": "41000000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.15678901234567890",
-				"predictedClicksChangeFraction": "0.543210987654321",
-				"predictedConversionsChangeFraction": "2.0987654321098765",
+				"predictedClicksChangeFraction": "0.343210987654321",
+				"predictedConversionsChangeFraction": "0.298765432109876",
 				"effectiveness": "MEDIUM"
 			}
 		},
 		{
 			"productView": {
-				"offerId": "gla_1287834",
-				"title": "Science Shirt for Mom | Premium Chemistry Mom T-shirt | Mother Periodic Table Shirt 3xl",
+				"offerId": "gla_14",
+				"title": "V-Neck T-Shirt",
 				"currencyCode": "USD",
-				"priceMicros": "28550000",
-				"id": "online:en:US:gla_1287834"
+				"priceMicros": "15000000",
+				"id": "online:en:US:gla_14"
 			},
 			"priceInsights": {
-				"suggestedPriceMicros": "123450000",
+				"suggestedPriceMicros": "14500000",
 				"suggestedPriceCurrencyCode": "USD",
 				"predictedImpressionsChangeFraction": "0.18765432109876543",
-				"predictedClicksChangeFraction": "0.598765432109876",
-				"predictedConversionsChangeFraction": "2.2567890123456789",
+				"predictedClicksChangeFraction": "0.398765432109876",
+				"predictedConversionsChangeFraction": "0.256789012345678",
 				"effectiveness": "LOW"
-			}
-		},
-		{
-			"productView": {
-				"offerId": "gla_1287863",
-				"title": "Science Shirt for Mom | Premium Chemistry Mom T-shirt | Mother Periodic Table Shirt 3xl",
-				"currencyCode": "USD",
-				"priceMicros": "28550000",
-				"id": "online:en:US:gla_1287863"
-			},
-			"priceInsights": {
-				"suggestedPriceMicros": "124870000",
-				"suggestedPriceCurrencyCode": "USD",
-				"predictedImpressionsChangeFraction": "0.19012345678901234",
-				"predictedClicksChangeFraction": "0.601234567890123",
-				"predictedConversionsChangeFraction": "2.2765432109876543",
-				"effectiveness": "HIGH"
-			}
-		},
-		{
-			"productView": {
-				"offerId": "gla_1287871",
-				"title": "Science Shirt for Mom | Premium Chemistry Mom T-shirt | Mother Periodic Table Shirt 3xl",
-				"currencyCode": "USD",
-				"priceMicros": "28550000",
-				"id": "online:en:US:gla_1287871"
-			},
-			"priceInsights": {
-				"suggestedPriceMicros": "126780000",
-				"suggestedPriceCurrencyCode": "USD",
-				"predictedImpressionsChangeFraction": "0.19876543210987654",
-				"predictedClicksChangeFraction": "0.612345678901234",
-				"predictedConversionsChangeFraction": "2.2987654321098765",
-				"effectiveness": "MEDIUM"
 			}
 		}
 	]


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

See #2824.

This updates the test data for price benchmarks to be based on the same products that are included in the sample products data included with WC core.

See: https://woocommerce.com/document/importing-woocommerce-sample-data/

### Testing instruction

- Ensure you have the test-proxy running by following [these instructions](https://github.com/woocommerce/google-listings-and-ads/blob/fix/2824-search-and-sort-updates/tests/proxy/README.md)
- Empty all values in the `wp_gla_merchant_price_benchmarks` table
- Go to Tools > Scheduled Actions and run the pending job for the `gla/jobs/update_merchant_price_benchmarks/process_item` hook
- Check that the data has been refreshed
- Make sure you have imported products from [the sample data from the WC repo](https://github.com/woocommerce/woocommerce/tree/trunk/plugins/woocommerce/sample-data)
- Visit the price benchmarks page from the plugin admin screen and see that the live data is working correctly

