### PR TITLE
Fix the API error of querying campaign assets by an invalid ID after saving a campaign with assets

### DIFF
--- a/js/src/hooks/useQuery.js
+++ b/js/src/hooks/useQuery.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { getQuery, addHistoryListener } from '@woocommerce/navigation';
+
+/**
+ * Hook to get the current URL query and ignore query changes after unmounting.
+ *
+ * This implementation differs from the one in `@woocommerce/navigation` in
+ * that it uses the current query as the initial state rather than an empty
+ * object.
+ *
+ * @return {Record<string, string>} Current query object.
+ */
+export default function useQuery() {
+	const [ query, setQuery ] = useState( getQuery );
+
+	useEffect( () => {
+		return addHistoryListener( () => {
+			// Adding a delay is because `addHistoryListener` might incorrectly
+			// dispatch events before applying changes to `history`. Calling
+			// `getQuery` immediately will get the query before the change.
+			// Ref:
+			// - https://github.com/woocommerce/woocommerce/blob/9.1.0/packages/js/navigation/src/index.js#L173-L186
+			// - https://github.com/woocommerce/woocommerce/blob/9.1.0/packages/js/navigation/src/index.js#L184-L185
+			setTimeout( () => setQuery( getQuery() ) );
+		} );
+	}, [] );
+
+	return query;
+}

--- a/js/src/pages/edit-paid-ads-campaign/index.js
+++ b/js/src/pages/edit-paid-ads-campaign/index.js
@@ -3,13 +3,14 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Stepper } from '@woocommerce/components';
-import { getQuery, getHistory, getNewPath } from '@woocommerce/navigation';
+import { getHistory, getNewPath } from '@woocommerce/navigation';
 import { useEffect, useState } from '@wordpress/element';
 import { isEqual } from 'lodash';
 /**
  * Internal dependencies
  */
 import useLayout from '~/hooks/useLayout';
+import useQuery from '~/hooks/useQuery';
 import useAdsCampaigns from '~/hooks/useAdsCampaigns';
 import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
 import { useAppDispatch } from '~/data';
@@ -43,8 +44,7 @@ const eventContext = 'edit-ads';
 const dashboardURL = getDashboardUrl();
 const helpButton = <HelpIconButton eventContext={ eventContext } />;
 
-function getCurrentStep() {
-	const { step } = getQuery();
+function getCurrentStep( step ) {
 	if ( Object.values( STEP ).includes( step ) ) {
 		return step;
 	}
@@ -77,7 +77,9 @@ const EditPaidAdsCampaign = () => {
 		updateCampaignAssetGroup,
 	} = useAppDispatch();
 
-	const id = Number( getQuery().programId );
+	const query = useQuery();
+	const id = Number( query.programId );
+
 	const { loaded, data: campaigns } = useAdsCampaigns();
 	const {
 		hasFinishedResolution: hasResolvedAssetEntityGroups,
@@ -94,7 +96,7 @@ const EditPaidAdsCampaign = () => {
 		}
 	}, [ campaign ] );
 
-	const step = getCurrentStep();
+	const step = getCurrentStep( query.step );
 
 	useNavigateAwayPromptEffect(
 		__(
@@ -106,7 +108,7 @@ const EditPaidAdsCampaign = () => {
 	);
 
 	const setStep = ( nextStep ) => {
-		const url = getNewPath( { ...getQuery(), step: nextStep } );
+		const url = getNewPath( { ...query, step: nextStep } );
 		getHistory().push( url );
 	};
 
@@ -238,7 +240,7 @@ const EditPaidAdsCampaign = () => {
 				onChange={ handleOnChange }
 			>
 				<Stepper
-					currentStep={ getCurrentStep() }
+					currentStep={ step }
 					steps={ [
 						{
 							key: STEP.CAMPAIGN,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While testing #2944, I found an error that occurs after saving campaign assets, and it's a pre-existing issue.

![image](https://github.com/user-attachments/assets/80073c12-9a99-491b-89f7-32ad7c13da3c)

This PR:

- Addes a new hook `useQuery` to get the current URL query and ignore query changes after unmounting.
   - The `useQuery` in `@woocommerce/navigation` returns an empty object first, which is not very convenient to use.
- Fixes the error caused by loading campaign assets with an invalid ID after saving them.
   - Calling `invalidateResolvedAssetEntityGroups` after saving assets immediately triggers several wp-data store updates. This causes the `EditPaidAdsCampaign` component to re-render even after unmounting. However, at this point, the ID in the URL query has been cleared by `getHistory().push( getDashboardUrl() );`, leading to API queries for assets with a `NaN` ID.

### Screenshots:

#### 📹 🐛 Before

https://github.com/user-attachments/assets/f5202082-53cf-45f1-8974-040c5cbd07bf

#### 📹 🛠️ After

https://github.com/user-attachments/assets/c2504f4b-787a-418b-bd22-b5ed782e022c

### Detailed test instructions:

1. You may need to set your local test site to be publicly accessible, or use the workaround for testing **Campaign Assets** in [Smoke-tests](https://github.com/woocommerce/google-listings-and-ads/wiki/Smoke-tests)
2. Go to edit a campaign and save it with assets
   - Can be tested by saving it directly without changes
3. After being redirected to the Dashboard page, check if the error no longer occurs

### Changelog entry

> Fix - The API error of querying campaign assets by an invalid ID after saving a campaign with assets.
