### PR TITLE
Support Enhanced Conversions Setting via REST API

### DIFF
--- a/src/API/Site/Controllers/Ads/AdsSettingsController.php
+++ b/src/API/Site/Controllers/Ads/AdsSettingsController.php
@@ -6,7 +6,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use WP_REST_Request as Request;
 use WP_REST_Response;
 
@@ -18,15 +17,6 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads
  */
 class AdsSettingsController extends BaseOptionsController {
-
-	/**
-	 * AdsSettingsController constructor.
-	 *
-	 * @param RESTServer $server
-	 */
-	public function __construct( RESTServer $server ) {
-		parent::__construct( $server );
-	}
 
 	/**
 	 * Register rest routes with WordPress.

--- a/src/API/Site/Controllers/Ads/AdsSettingsController.php
+++ b/src/API/Site/Controllers/Ads/AdsSettingsController.php
@@ -125,7 +125,7 @@ class AdsSettingsController extends BaseOptionsController {
 	 */
 	protected function get_endpoint_params(): array {
 		return [
-			'enhanced_conversions_enabled' => [
+			OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED => [
 				'type'        => 'boolean',
 				'description' => __(
 					'Whether enhanced conversions are enabled.',
@@ -142,7 +142,7 @@ class AdsSettingsController extends BaseOptionsController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'enhanced_conversions_enabled' => [
+			OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED => [
 				'type'        => 'boolean',
 				'description' => __(
 					'Whether enhanced conversions are enabled.',

--- a/src/API/Site/Controllers/Ads/AdsSettingsController.php
+++ b/src/API/Site/Controllers/Ads/AdsSettingsController.php
@@ -87,7 +87,7 @@ class AdsSettingsController extends BaseOptionsController {
 	}
 
 	/**
-	 * Get a callback for editing the settings endpoint.
+	 * Get a callback for editing the ads settings endpoint.
 	 *
 	 * @return callable
 	 */
@@ -102,7 +102,7 @@ class AdsSettingsController extends BaseOptionsController {
 					continue;
 				}
 
-				$result = $this->options->update( $key, $value );
+				$result = $this->options->update( $key, (bool) $value );
 
 				if ( false === $result ) {
 					return new WP_REST_Response(
@@ -119,7 +119,7 @@ class AdsSettingsController extends BaseOptionsController {
 	}
 
 	/**
-	 * Get requests parameters for the settings endpoint.
+	 * Get requests parameters for the ads settings endpoint.
 	 *
 	 * @return array
 	 */
@@ -136,7 +136,7 @@ class AdsSettingsController extends BaseOptionsController {
 	}
 
 	/**
-	 * Get the schema for settings endpoints.
+	 * Get the schema for ads settings endpoints.
 	 *
 	 * @return array
 	 */

--- a/src/API/Site/Controllers/Ads/AdsSettingsController.php
+++ b/src/API/Site/Controllers/Ads/AdsSettingsController.php
@@ -1,0 +1,166 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use WP_REST_Request as Request;
+use WP_REST_Response;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsSettingsController
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads
+ */
+class AdsSettingsController extends BaseOptionsController {
+
+	/**
+	 * AdsSettingsController constructor.
+	 *
+	 * @param RESTServer   $server
+	 */
+	public function __construct( RESTServer $server ) {
+		parent::__construct( $server );
+	}
+
+	/**
+	 * Register rest routes with WordPress.
+	 */
+	public function register_routes(): void {
+		$this->register_route(
+			'ads/settings',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_settings_endpoint_read_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+				[
+					'methods'             => TransportMethods::EDITABLE,
+					'callback'            => $this->get_settings_endpoint_edit_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+					'args'                => $this->get_endpoint_params()
+				],
+				'schema' => $this->get_api_response_schema_callback(),
+			]
+		);
+	}
+
+	/**
+	 * Get an array of allowed options.
+	 *
+	 * @return array
+	 */
+	protected function get_allowed_options(): array {
+		return [
+			OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED => true,
+		];
+	}
+
+	/**
+	 * Get a callback for the settings endpoint.
+	 *
+	 * @return callable
+	 */
+	protected function get_settings_endpoint_read_callback(): callable {
+		return function () {
+			if ( 0 === $this->options->get_ads_id() ) {
+				return new WP_REST_Response(
+					__( 'Not Allowed.', 'google-listings-and-ads' ),
+					403
+				);
+			}
+
+			$settings = [];
+
+			foreach ( $this->get_allowed_options() as $key => $default ) {
+				$settings[ $key ] = $this->options->get( $key, $default );
+			}
+
+			return $settings;
+		};
+	}
+
+	/**
+	 * Get a callback for editing the settings endpoint.
+	 *
+	 * @return callable
+	 */
+	protected function get_settings_endpoint_edit_callback(): callable {
+		return function ( Request $request ) {
+			$params          = $request->get_params();
+			$allowed_options = $this->get_allowed_options();
+			$settings        = [];
+
+			foreach ( $params as $key => $value ) {
+				if ( ! array_key_exists( $key, $allowed_options ) ) {
+					continue;
+				}
+
+				$result = $this->options->update( $key, $value );
+
+				if ( false === $result ) {
+					return new WP_REST_Response(
+						__( 'Unable to update setting.', 'google-listings-and-ads' ),
+						403
+					);
+				}
+
+				$settings[ $key ] = $value;
+			}
+
+			return $settings;
+		};
+	}
+
+	/**
+	 * Get requests parameters for the settings endpoint.
+	 *
+	 * @return array
+	 */
+	protected function get_endpoint_params(): array {
+		return [
+			'enhanced_conversions_enabled' => [
+				'type'        => 'boolean',
+				'description' => __(
+					'Whether enhanced conversions are enabled.',
+					'google-listings-and-ads'
+				),
+			],
+		];
+	}
+
+	/**
+	 * Get the schema for settings endpoints.
+	 *
+	 * @return array
+	 */
+	protected function get_schema_properties(): array {
+		return [
+			'enhanced_conversions_enabled' => [
+				'type'        => 'boolean',
+				'description' => __(
+					'Whether enhanced conversions are enabled.',
+					'google-listings-and-ads'
+				),
+				'context'     => [ 'view', 'edit' ],
+			],
+		];
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * Used for building the API response schema.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'ads_settings';
+	}
+}

--- a/src/API/Site/Controllers/Ads/AdsSettingsController.php
+++ b/src/API/Site/Controllers/Ads/AdsSettingsController.php
@@ -97,7 +97,7 @@ class AdsSettingsController extends BaseOptionsController {
 				if ( false === $result ) {
 					return new WP_REST_Response(
 						__( 'Unable to update setting.', 'google-listings-and-ads' ),
-						403
+						400
 					);
 				}
 

--- a/src/API/Site/Controllers/Ads/AdsSettingsController.php
+++ b/src/API/Site/Controllers/Ads/AdsSettingsController.php
@@ -22,7 +22,7 @@ class AdsSettingsController extends BaseOptionsController {
 	/**
 	 * AdsSettingsController constructor.
 	 *
-	 * @param RESTServer   $server
+	 * @param RESTServer $server
 	 */
 	public function __construct( RESTServer $server ) {
 		parent::__construct( $server );
@@ -44,7 +44,7 @@ class AdsSettingsController extends BaseOptionsController {
 					'methods'             => TransportMethods::EDITABLE,
 					'callback'            => $this->get_settings_endpoint_edit_callback(),
 					'permission_callback' => $this->get_permission_callback(),
-					'args'                => $this->get_endpoint_params()
+					'args'                => $this->get_endpoint_params(),
 				],
 				'schema' => $this->get_api_response_schema_callback(),
 			]

--- a/src/API/Site/Controllers/Ads/AdsSettingsController.php
+++ b/src/API/Site/Controllers/Ads/AdsSettingsController.php
@@ -82,7 +82,7 @@ class AdsSettingsController extends BaseOptionsController {
 				$settings[ $key ] = $this->options->get( $key, $default );
 			}
 
-			return $settings;
+			return new WP_REST_Response( $settings );
 		};
 	}
 
@@ -114,7 +114,7 @@ class AdsSettingsController extends BaseOptionsController {
 				$settings[ $key ] = $value;
 			}
 
-			return $settings;
+			return new WP_REST_Response( $settings );
 		};
 	}
 

--- a/src/Ads/AccountService.php
+++ b/src/Ads/AccountService.php
@@ -301,6 +301,7 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		$this->options->delete( OptionsInterface::ADS_ACCOUNT_STATE );
 		$this->options->delete( OptionsInterface::ADS_BILLING_URL );
 		$this->options->delete( OptionsInterface::ADS_CONVERSION_ACTION );
+		$this->options->delete( OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED );
 		$this->options->delete( OptionsInterface::ADS_ID );
 		$this->options->delete( OptionsInterface::ADS_SETUP_COMPLETED_AT );
 		$this->options->delete( OptionsInterface::CAMPAIGN_CONVERT_STATUS );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroup;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AccountController as AdsAccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AdsSettingsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\BudgetRecommendationController as AdsBudgetRecommendationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\CampaignController as AdsCampaignController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\ReportsController as AdsReportsController;
@@ -146,6 +147,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( RestAPIAuthController::class, OAuthService::class, MerchantAccountService::class );
 		$this->share( GTINMigrationController::class, JobRepository::class );
 		$this->share( SyncController::class, NotificationsService::class );
+		$this->share( AdsSettingsController::class );
 	}
 
 	/**

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -15,6 +15,7 @@ interface OptionsInterface {
 	public const ADS_ACCOUNT_CURRENCY                      = 'ads_account_currency';
 	public const ADS_ACCOUNT_OCID                          = 'ads_account_ocid';
 	public const ADS_ACCOUNT_STATE                         = 'ads_account_state';
+	public const ADS_ENHANCED_CONVERSIONS_ENABLED          = 'enhanced_conversions_enabled';
 	public const ADS_BILLING_URL                           = 'ads_billing_url';
 	public const ADS_ID                                    = 'ads_id';
 	public const ADS_CONVERSION_ACTION                     = 'ads_conversion_action';
@@ -53,6 +54,7 @@ interface OptionsInterface {
 		self::ADS_ACCOUNT_CURRENCY                      => true,
 		self::ADS_ACCOUNT_OCID                          => true,
 		self::ADS_ACCOUNT_STATE                         => true,
+		self::ADS_ENHANCED_CONVERSIONS_ENABLED          => true,
 		self::ADS_BILLING_URL                           => true,
 		self::ADS_ID                                    => true,
 		self::ADS_CONVERSION_ACTION                     => true,

--- a/tests/Unit/API/Site/Controllers/Ads/AdsSettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AdsSettingsControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AdsSettingsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class AdsSettingsControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ */
+class AdsSettingsControllerTest extends RESTControllerUnitTest {
+
+	/** @var AdsSettingsController $controller */
+	protected $controller;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	protected const ROUTE_SETTINGS = '/wc/gla/ads/settings';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->options    = $this->createMock( OptionsInterface::class );
+		$this->controller = new AdsSettingsController( $this->server );
+		$this->controller->set_options_object( $this->options );
+		$this->controller->register();
+	}
+
+	public function test_get_settings() {
+		$expected = [
+			'enhanced_conversions_enabled' => true,
+		];
+
+		$this->options->expects( $this->once() )->method( 'get_ads_id' )->willReturn( 1 );
+
+		$this->options->expects( $this->once() )->method( 'get' )->willReturn( true );
+
+		$response = $this->do_request( self::ROUTE_SETTINGS, 'GET' );
+
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_edit_settings() {
+		$expected = [
+			'enhanced_conversions_enabled' => false,
+		];
+
+		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED, false )->willReturn( true );
+
+		$response = $this->do_request( self::ROUTE_SETTINGS, 'POST', $expected );
+
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/Ads/AdsSettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AdsSettingsControllerTest.php
@@ -61,4 +61,17 @@ class AdsSettingsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( $expected, $response->get_data() );
 		$this->assertEquals( 200, $response->get_status() );
 	}
+
+	public function test_edit_settings_fail() {
+		$query = [
+			'enhanced_conversions_enabled' => false,
+		];
+
+		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED, false )->willReturn( false );
+
+		$response = $this->do_request( self::ROUTE_SETTINGS, 'POST', $query );
+
+		$this->assertEquals( 'Unable to update setting.', $response->get_data() );
+		$this->assertEquals( 400, $response->get_status() );
+	}
 }

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -725,7 +725,7 @@ class AccountServiceTest extends UnitTest {
 	}
 
 	public function test_disconnect() {
-		$this->options->expects( $this->exactly( 8 ) )
+		$this->options->expects( $this->exactly( 9 ) )
 			->method( 'delete' )
 			->withConsecutive(
 				[ OptionsInterface::ADS_ACCOUNT_CURRENCY ],
@@ -733,6 +733,7 @@ class AccountServiceTest extends UnitTest {
 				[ OptionsInterface::ADS_ACCOUNT_STATE ],
 				[ OptionsInterface::ADS_BILLING_URL ],
 				[ OptionsInterface::ADS_CONVERSION_ACTION ],
+				[ OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED ],
 				[ OptionsInterface::ADS_ID ],
 				[ OptionsInterface::ADS_SETUP_COMPLETED_AT ],
 				[ OptionsInterface::CAMPAIGN_CONVERT_STATUS ]


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2903

Creates a REST API endpoint for updating ad related settings, focusing on Enhanced Conversions option first.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Configure Postman to send API request to WordPress with correct authentication and capabilities (`manage_woocommerce`) to make the following requests to `/wp-json/wc/gla/ads/settings`


**Get settings**
Making a GET request to the endpoint should return the enhanced conversions option only as it's the only one supported. The value should reflect the current option state or `true` if not created.

If there is no Ads account connected, a 403 response is returned.

**Request**
```
GET /wp-json/wc/gla/ads/settings
```

**Response**
```
{
    "enhanced_conversions_enabled": true
}
```

**Update setting**
Making a `PUT`, `PATCH` or `POST` request to the endpoint with the correct body should update the option and return it's new status. This should only work with the enhanced conversions option.

**Request**
```
POST /wp-json/wc/gla/ads/settings

BODY
{
    "enhanced_conversions_enabled": false
}
```

**Response**
```
{
    "enhanced_conversions_enabled": false
}
```

**Get endpoint schema**
When an `OPTION` request is made the correct schema is returned.

**Disconnect Ads account**
When the Ads account is disconnected in the admin, the enhanced conversions enabled option is deleted from the options table.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
