### PR TITLE
Avoid the fallback in `CSSTransition` that would cause it to use the deprecated `findDOMNode`

### DIFF
--- a/js/src/components/paid-ads/campaign-preview/campaign-preview.js
+++ b/js/src/components/paid-ads/campaign-preview/campaign-preview.js
@@ -7,6 +7,7 @@ import {
 	useCallback,
 	useEffect,
 	useImperativeHandle,
+	createRef,
 	forwardRef,
 } from '@wordpress/element';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
@@ -68,14 +69,17 @@ const bestsellingQuery = {
 	order: 'desc',
 };
 
-const mockups = [
+const mockupPairs = [
 	MockupShopping,
 	MockupYouTube,
 	MockupSearch,
 	MockupMap,
 	MockupDisplay,
 	MockupGmail,
-];
+].map( ( Mockup ) => {
+	const nodeRef = createRef( null );
+	return [ nodeRef, Mockup ];
+} );
 
 function resolvePreviewProduct( products = [] ) {
 	const currencyFactory = CurrencyFactory( getSetting( 'currency' ) );
@@ -119,7 +123,8 @@ function CampaignPreview( { autoplay = true }, ref ) {
 
 	const moveBy = useCallback( ( step ) => {
 		setIndex( ( currentIndex ) => {
-			return ( currentIndex + step + mockups.length ) % mockups.length;
+			const numPairs = mockupPairs.length;
+			return ( currentIndex + step + numPairs ) % numPairs;
 		} );
 	}, [] );
 
@@ -144,17 +149,18 @@ function CampaignPreview( { autoplay = true }, ref ) {
 		);
 	}
 
-	const Mockup = mockups[ index ];
+	const [ nodeRef, Mockup ] = mockupPairs[ index ];
 	const product = resolvePreviewProduct( data?.products );
 
 	return (
 		<TransitionGroup className="gla-campaign-preview">
 			<CSSTransition
+				nodeRef={ nodeRef }
 				key={ index }
 				classNames="gla-campaign-preview__transition-blur"
 				timeout={ 500 }
 			>
-				<Mockup product={ product } />
+				<Mockup ref={ nodeRef } product={ product } />
 			</CSSTransition>
 		</TransitionGroup>
 	);

--- a/js/src/components/paid-ads/campaign-preview/campaign-preview.js
+++ b/js/src/components/paid-ads/campaign-preview/campaign-preview.js
@@ -77,7 +77,7 @@ const mockupPairs = [
 	MockupDisplay,
 	MockupGmail,
 ].map( ( Mockup ) => {
-	const nodeRef = createRef( null );
+	const nodeRef = createRef();
 	return [ nodeRef, Mockup ];
 } );
 

--- a/js/src/components/paid-ads/campaign-preview/mockup-display.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-display.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { forwardRef } from '@wordpress/element';
 import GridiconChevronRight from 'gridicons/dist/chevron-right';
 
 /**
@@ -21,9 +22,9 @@ import adCornerButtonsImageURL from '~/images/campaign-preview/ad-corner-buttons
  * @param {Object} props React props.
  * @param {AdPreviewData} props.product Data for compositing ad preview mockups.
  */
-export default function MockupDisplay( { product } ) {
+function MockupDisplay( { product }, ref ) {
 	return (
-		<div className="gla-ads-mockup gla-ads-mockup-display">
+		<div ref={ ref } className="gla-ads-mockup gla-ads-mockup-display">
 			<div className="gla-ads-mockup__display-placeholders">
 				<Placeholder stroke="thinner" color="gray-300" />
 				<Placeholder stroke="thinner" color="gray-300" width="146" />
@@ -58,3 +59,5 @@ export default function MockupDisplay( { product } ) {
 		</div>
 	);
 }
+
+export default forwardRef( MockupDisplay );

--- a/js/src/components/paid-ads/campaign-preview/mockup-display.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-display.js
@@ -60,4 +60,6 @@ function MockupDisplay( { product }, ref ) {
 	);
 }
 
+MockupDisplay.displayName = 'MockupDisplay';
+
 export default forwardRef( MockupDisplay );

--- a/js/src/components/paid-ads/campaign-preview/mockup-gmail.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-gmail.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -31,9 +32,9 @@ function MailItem() {
  * @param {Object} props React props.
  * @param {AdPreviewData} props.product Data for compositing ad preview mockups.
  */
-export default function MockupGmail( { product } ) {
+function MockupGmail( { product }, ref ) {
 	return (
-		<div className="gla-ads-mockup gla-ads-mockup-gmail">
+		<div ref={ ref } className="gla-ads-mockup gla-ads-mockup-gmail">
 			<div className="gla-ads-mockup__gmail-header">
 				<img
 					height="15"
@@ -51,3 +52,5 @@ export default function MockupGmail( { product } ) {
 		</div>
 	);
 }
+
+export default forwardRef( MockupGmail );

--- a/js/src/components/paid-ads/campaign-preview/mockup-gmail.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-gmail.js
@@ -53,4 +53,6 @@ function MockupGmail( { product }, ref ) {
 	);
 }
 
+MockupGmail.displayName = 'MockupGmail';
+
 export default forwardRef( MockupGmail );

--- a/js/src/components/paid-ads/campaign-preview/mockup-map.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-map.js
@@ -35,4 +35,6 @@ function MockupMap( { product }, ref ) {
 	);
 }
 
+MockupMap.displayName = 'MockupMap';
+
 export default forwardRef( MockupMap );

--- a/js/src/components/paid-ads/campaign-preview/mockup-map.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-map.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { forwardRef } from '@wordpress/element';
 import GridiconLocation from 'gridicons/dist/location';
 
 /**
@@ -20,9 +21,10 @@ import mapBackgroundURL from '~/images/campaign-preview/map-background.png';
  * @param {Object} props React props.
  * @param {AdPreviewData} props.product Data for compositing ad preview mockups.
  */
-export default function MockupMap( { product } ) {
+function MockupMap( { product }, ref ) {
 	return (
 		<div
+			ref={ ref }
 			className="gla-ads-mockup gla-ads-mockup-map"
 			style={ { backgroundImage: `url(${ mapBackgroundURL })` } }
 		>
@@ -32,3 +34,5 @@ export default function MockupMap( { product } ) {
 		</div>
 	);
 }
+
+export default forwardRef( MockupMap );

--- a/js/src/components/paid-ads/campaign-preview/mockup-search.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-search.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { forwardRef } from '@wordpress/element';
 import { Flex } from '@wordpress/components';
 
 /**
@@ -23,9 +24,9 @@ import googleLogoURL from '~/images/logo/google-logo.svg';
  * @param {Object} props React props.
  * @param {AdPreviewData} props.product Data for compositing ad preview mockups.
  */
-export default function MockupSearch( { product } ) {
+function MockupSearch( { product }, ref ) {
 	return (
-		<div className="gla-ads-mockup gla-ads-mockup-search">
+		<div ref={ ref } className="gla-ads-mockup gla-ads-mockup-search">
 			<div className="gla-ads-mockup__search-header">
 				<img
 					height="22"
@@ -78,3 +79,5 @@ export default function MockupSearch( { product } ) {
 		</div>
 	);
 }
+
+export default forwardRef( MockupSearch );

--- a/js/src/components/paid-ads/campaign-preview/mockup-search.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-search.js
@@ -80,4 +80,6 @@ function MockupSearch( { product }, ref ) {
 	);
 }
 
+MockupSearch.displayName = 'MockupSearch';
+
 export default forwardRef( MockupSearch );

--- a/js/src/components/paid-ads/campaign-preview/mockup-shopping.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-shopping.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,9 +22,9 @@ import googleShoppingLogoURL from '~/images/campaign-preview/google-shopping-log
  * @param {Object} props React props.
  * @param {AdPreviewData} props.product Data for compositing ad preview mockups.
  */
-export default function MockupShopping( { product } ) {
+function MockupShopping( { product }, ref ) {
 	return (
-		<div className="gla-ads-mockup">
+		<div ref={ ref } className="gla-ads-mockup">
 			<div className="gla-ads-mockup__tab-list">
 				<Placeholder stroke="thicker" />
 				<Placeholder stroke="thicker" />
@@ -53,3 +54,5 @@ export default function MockupShopping( { product } ) {
 		</div>
 	);
 }
+
+export default forwardRef( MockupShopping );

--- a/js/src/components/paid-ads/campaign-preview/mockup-shopping.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-shopping.js
@@ -55,4 +55,6 @@ function MockupShopping( { product }, ref ) {
 	);
 }
 
+MockupShopping.displayName = 'MockupShopping';
+
 export default forwardRef( MockupShopping );

--- a/js/src/components/paid-ads/campaign-preview/mockup-youtube.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-youtube.js
@@ -58,4 +58,6 @@ function MockupYouTube( { product }, ref ) {
 	);
 }
 
+MockupYouTube.displayName = 'MockupYouTube';
+
 export default forwardRef( MockupYouTube );

--- a/js/src/components/paid-ads/campaign-preview/mockup-youtube.js
+++ b/js/src/components/paid-ads/campaign-preview/mockup-youtube.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { forwardRef } from '@wordpress/element';
 import GridiconExternal from 'gridicons/dist/external';
 
 /**
@@ -22,9 +23,9 @@ import youTubeLogoURL from '~/images/campaign-preview/youtube-logo.svg';
  * @param {Object} props React props.
  * @param {AdPreviewData} props.product Data for compositing ad preview mockups.
  */
-export default function MockupYouTube( { product } ) {
+function MockupYouTube( { product }, ref ) {
 	return (
-		<div className="gla-ads-mockup">
+		<div ref={ ref } className="gla-ads-mockup">
 			<div className="gla-ads-mockup__youtube-header">
 				<img
 					height="16"
@@ -56,3 +57,5 @@ export default function MockupYouTube( { product } ) {
 		</div>
 	);
 }
+
+export default forwardRef( MockupYouTube );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The "Warning: findDOMNode is deprecated" error was raised in https://github.com/woocommerce/google-listings-and-ads/pull/2944#pullrequestreview-2928253050.

This PR avoids the fallback in `CSSTransition` that would cause it to use the deprecated `findDOMNode`. Without specifying the `nodeRef`, it would still use the `findDOMNode` API to locate the element to be transitioned with an animation.

### Screenshots:

https://github.com/user-attachments/assets/c29b53e3-1b0a-4efa-a17a-0c9917e3bacc

### Detailed test instructions:

1. Open the Console panel of the browser's DevTool
2. Go to the campaign creating page
3. Check if the "Warning: findDOMNode is deprecated" error no longer occurs in the Console panel
4. Test if the transition of the campaign preview works as before

### Changelog entry
