### PR TITLE
Fix the invalid event property names sent to WC Tracks

### DIFF
--- a/js/src/pages/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal.js
+++ b/js/src/pages/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal.js
@@ -17,7 +17,7 @@ import './edit-program-prompt-modal.scss';
  * Triggered when "continue" to edit program button is clicked.
  *
  * @event gla_dashboard_edit_program_click
- * @property {string} programId program id
+ * @property {string} program_id program id
  * @property {string} url URL for editing the program (paid campaign)
  */
 
@@ -39,7 +39,7 @@ const EditProgramPromptModal = ( { programId, onRequestClose } ) => {
 		getHistory().push( url );
 
 		recordGlaEvent( 'gla_dashboard_edit_program_click', {
-			programId,
+			program_id: programId,
 			url,
 		} );
 	};

--- a/js/src/pages/reports/products/products-report-filters.js
+++ b/js/src/pages/reports/products/products-report-filters.js
@@ -75,9 +75,7 @@ const ProductsReportFilters = ( props ) => {
 		recordGlaEvent( 'gla_filter', {
 			report: trackEventId,
 			filter: data.filter || 'all',
-			// wc-admin does not send it
-			// https://github.com/woocommerce/woocommerce-admin/issues/6221
-			filterVariations: data[ 'filter-variations' ],
+			filter_variation: data[ 'filter-variations' ],
 		} );
 
 	/**

--- a/js/src/utils/tracks.js
+++ b/js/src/utils/tracks.js
@@ -152,7 +152,7 @@ export const recordTablePageEvent = ( context, page, direction ) => {
  * @event gla_filter
  * @property {string} report Name of the report (e.g. `"reports-products"`)
  * @property {string} filter Value of the filter (e.g. `"all" | "single-product" | "compare-products"`)
- * @property {string | undefined} variationFilter Value of the variation filter (e.g. `undefined | "single-variation" | "compare-variations"`)
+ * @property {string} [filter_variation] Value of the variation filter (e.g. `"single-variation" | "compare-variations"`)
  */
 
 /**

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -284,7 +284,7 @@ Triggered when "continue" to edit program button is clicked.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
-`programId` | `string` | program id
+`program_id` | `string` | program id
 `url` | `string` | URL for editing the program (paid campaign)
 #### Emitters
 - [`EditProgramPromptModal`](../../js/src/pages/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal.js#L31) when "Continue to edit" is clicked.
@@ -470,7 +470,7 @@ Triggered when changing products & variations filter,
 | ---- | ---- | ----------- |
 `report` | `string` | Name of the report (e.g. `"reports-products"`)
 `filter` | `string` | Value of the filter (e.g. `"all" \| "single-product" \| "compare-products"`)
-`variationFilter` | `string \| undefined` | Value of the variation filter (e.g. `undefined \| "single-variation" \| "compare-variations"`)
+`filter_variation` | `string` | Value of the variation filter (e.g. `"single-variation" \| "compare-variations"`)
 #### Emitters
 - [`ProductsReportFilters`](../../js/src/pages/reports/products/products-report-filters.js#L41)
 - [`ProgramsReportFilters`](../../js/src/pages/reports/programs/programs-report-filters.js#L43)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

An invalid property name `programId` was found in https://github.com/woocommerce/google-listings-and-ads/pull/2944#pullrequestreview-2928253050.

This PR fixes two invalid event property names sent to WC Tracks:

- `programId` -> `program_id`
- `filterVariations` -> `filter_variation`
   - The change from plural to singular is to match its actual value and to be consistent with [a similar use in WC Core](https://github.com/woocommerce/woocommerce/blob/9.9.4/plugins/woocommerce/client/admin/client/analytics/components/report-filters/index.js#L68)

References:

- https://github.com/woocommerce/woocommerce/blob/9.9.4/plugins/woocommerce/includes/tracks/class-wc-site-tracking.php#L103-L114
- https://github.com/woocommerce/woocommerce/blob/9.9.4/plugins/woocommerce/includes/tracks/class-wc-tracks-event.php#L26

### Detailed test instructions:

Check if the updated property names comply with the pattern of `/^[a-z_][a-z0-9_]*$/`.

### Changelog entry
