### PR TITLE
Change back to using a fixed value based on country and currency as the reference value for the minimum budget limit

### DIFF
--- a/js/src/components/paid-ads/budget-incentive-prompt.test.js
+++ b/js/src/components/paid-ads/budget-incentive-prompt.test.js
@@ -23,8 +23,9 @@ jest.mock( '~/hooks/useGoogleAdsAccount', () =>
 jest.mock( '~/hooks/useBudgetRecommendation', () =>
 	jest.fn().mockReturnValue( {
 		hasResolved: true,
-		recommendedDailyBudget: 15,
 		data: {
+			dailyBudgetBaseline: 13,
+			recommendedDailyBudget: 15,
 			recommended: {
 				currency: 'USD',
 				country: 'US',

--- a/js/src/components/paid-ads/budget-setup/budget-setup.test.js
+++ b/js/src/components/paid-ads/budget-setup/budget-setup.test.js
@@ -44,6 +44,8 @@ jest.mock( '~/hooks/useBudgetMetrics', () =>
 
 function mockBudgetRecommendation( ...availableKeys ) {
 	const data = {
+		dailyBudgetBaseline: 12,
+		recommendedDailyBudget: 15,
 		high: {
 			currency: 'USD',
 			country: 'US',
@@ -86,7 +88,6 @@ function mockBudgetRecommendation( ...availableKeys ) {
 
 	useBudgetRecommendation.mockReturnValue( {
 		hasResolved: true,
-		recommendedDailyBudget: 15,
 		data,
 	} );
 }

--- a/js/src/components/paid-ads/budget-setup/budget-setup.test.js
+++ b/js/src/components/paid-ads/budget-setup/budget-setup.test.js
@@ -271,9 +271,9 @@ describe( 'BudgetSetup', () => {
 		jest.clearAllTimers();
 	} );
 
-	it( 'should show help message when the entered custom budget is less than 30% of the recommended one', async () => {
+	it( 'should show help message when the entered custom budget is less than 30% of the daily budget baseline', async () => {
 		const user = userEvent.setup();
-		const message = 'Please make sure daily average cost is at least $5.00';
+		const message = 'Please make sure daily average cost is at least $4.00';
 
 		render( <Wrapper /> );
 
@@ -283,19 +283,19 @@ describe( 'BudgetSetup', () => {
 
 		const input = screen.getByRole( 'textbox' );
 		await user.clear( input );
-		await user.type( input, '4.99' );
+		await user.type( input, '3.99' );
 		await user.tab();
 
 		expect( screen.getByText( message ) ).toBeInTheDocument();
 
 		await user.clear( input );
-		await user.type( input, '5' );
+		await user.type( input, '4' );
 		await user.tab();
 
 		expect( screen.queryByText( message ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should notice the recommended budget when the custom budget is lower than the lowest recommended one and not less than 30% of the recommended one', async () => {
+	it( 'should notice the recommended budget when the custom budget is lower than the lowest recommended one and not less than 30% of the daily budget baseline', async () => {
 		const user = userEvent.setup();
 		const notice = `Your budget is lower than other advertisers' budgets, which may affect performance. For best results, we recommend at least $15.00 per day.`;
 

--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -122,7 +122,6 @@ export default function CampaignAssetsForm( {
 		useBudgetRecommendation( countryCodes );
 
 	const budgetRecommendation = budgetRecommendationData || {};
-	const recommendedDailyBudget = budgetRecommendation.recommendedDailyBudget;
 
 	useEventPropertiesFilter(
 		FILTER_BUDGET_RECOMMENDATIONS,
@@ -175,7 +174,7 @@ export default function CampaignAssetsForm( {
 
 	const validateCampaignWithMinimumAmount = ( values ) => {
 		return validateCampaign( values, {
-			dailyBudget: recommendedDailyBudget,
+			dailyBudget: budgetRecommendation.dailyBudgetBaseline,
 			formatAmount,
 		} );
 	};
@@ -195,7 +194,7 @@ export default function CampaignAssetsForm( {
 					initialCampaign,
 					{
 						level: 'recommended',
-						amount: recommendedDailyBudget,
+						amount: budgetRecommendation.recommendedDailyBudget,
 					},
 					budgetRecommendation
 				),

--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -118,10 +118,12 @@ export default function CampaignAssetsForm( {
 	const [ hasImportedAssets, setHasImportedAssets ] = useState( false );
 	const { formatAmount } = useAdsCurrency();
 	const {
-		data: budgetRecommendation,
+		data: budgetRecommendationData,
 		recommendedDailyBudget,
 		hasResolved,
 	} = useBudgetRecommendation( countryCodes );
+
+	const budgetRecommendation = budgetRecommendationData || {};
 
 	useEventPropertiesFilter(
 		FILTER_BUDGET_RECOMMENDATIONS,

--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -118,13 +118,11 @@ export default function CampaignAssetsForm( {
 	const [ baseAssetGroup, setBaseAssetGroup ] = useState( initialAssetGroup );
 	const [ hasImportedAssets, setHasImportedAssets ] = useState( false );
 	const { formatAmount } = useAdsCurrency();
-	const {
-		data: budgetRecommendationData,
-		recommendedDailyBudget,
-		hasResolved,
-	} = useBudgetRecommendation( countryCodes );
+	const { data: budgetRecommendationData, hasResolved } =
+		useBudgetRecommendation( countryCodes );
 
 	const budgetRecommendation = budgetRecommendationData || {};
+	const recommendedDailyBudget = budgetRecommendation.recommendedDailyBudget;
 
 	useEventPropertiesFilter(
 		FILTER_BUDGET_RECOMMENDATIONS,

--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -9,6 +9,7 @@ import { isPlainObject } from 'lodash';
  */
 import { ASSET_GROUP_KEY, ASSET_FORM_KEY } from '~/constants';
 import AdaptiveForm from '~/components/adaptive-form';
+import AppSpinner from '~/components/app-spinner';
 import validateCampaign from '~/components/paid-ads/validateCampaign';
 import validateAssetGroup from '~/components/paid-ads/validateAssetGroup';
 import useAdsCurrency from '~/hooks/useAdsCurrency';
@@ -131,7 +132,7 @@ export default function CampaignAssetsForm( {
 	);
 
 	if ( ! hasResolved ) {
-		return null;
+		return <AppSpinner />;
 	}
 
 	const extendAdapter = ( formContext ) => {

--- a/js/src/components/paid-ads/campaign-assets-form.test.js
+++ b/js/src/components/paid-ads/campaign-assets-form.test.js
@@ -216,6 +216,34 @@ describe( 'CampaignAssetsForm', () => {
 		expect( children ).toHaveBeenLastCalledWith( formContextSchema );
 	} );
 
+	it( 'Should fall back to the custom level for the initial form values when budget recommendation responds with 404 not found', () => {
+		useBudgetRecommendation.mockReturnValue( {
+			hasResolved: true,
+			data: null,
+		} );
+
+		const children = jest.fn();
+
+		render(
+			<CampaignAssetsForm
+				validate={ alwaysValid }
+				initialCampaign={ { amount: 20, level: 'low' } }
+			>
+				{ children }
+			</CampaignAssetsForm>
+		);
+
+		const formContextSchema = expect.objectContaining( {
+			values: expect.objectContaining( {
+				amount: 20,
+				dailyBudget: 20,
+				level: 'custom',
+			} ),
+		} );
+
+		expect( children ).toHaveBeenLastCalledWith( formContextSchema );
+	} );
+
 	it( 'Should resolve the dailyBudget from the custom level for the initial form values', () => {
 		const children = jest.fn();
 

--- a/js/src/components/paid-ads/campaign-assets-form.test.js
+++ b/js/src/components/paid-ads/campaign-assets-form.test.js
@@ -30,8 +30,9 @@ describe( 'CampaignAssetsForm', () => {
 
 		useBudgetRecommendation.mockReturnValue( {
 			hasResolved: true,
-			recommendedDailyBudget: 15,
 			data: {
+				dailyBudgetBaseline: 13,
+				recommendedDailyBudget: 15,
 				recommended: { dailyBudget: 15 },
 				high: { dailyBudget: 30 },
 				low: { dailyBudget: 5 },
@@ -56,6 +57,8 @@ describe( 'CampaignAssetsForm', () => {
 			adapter: expect.objectContaining( {
 				countryCodes,
 				budgetRecommendation: {
+					dailyBudgetBaseline: 13,
+					recommendedDailyBudget: 15,
 					recommended: { dailyBudget: 15 },
 					high: { dailyBudget: 30 },
 					low: { dailyBudget: 5 },
@@ -159,8 +162,9 @@ describe( 'CampaignAssetsForm', () => {
 	it( 'Should resolve the available level for the initial form values', () => {
 		useBudgetRecommendation.mockReturnValue( {
 			hasResolved: true,
-			recommendedDailyBudget: 15,
 			data: {
+				dailyBudgetBaseline: 13,
+				recommendedDailyBudget: 15,
 				recommended: { dailyBudget: 15 },
 			},
 		} );
@@ -190,8 +194,10 @@ describe( 'CampaignAssetsForm', () => {
 	it( 'Should fall back to the custom level for the initial form values when there is no level available', () => {
 		useBudgetRecommendation.mockReturnValue( {
 			hasResolved: true,
-			recommendedDailyBudget: 15,
-			data: {},
+			data: {
+				dailyBudgetBaseline: 13,
+				recommendedDailyBudget: 15,
+			},
 		} );
 
 		const children = jest.fn();

--- a/js/src/data/adapters.js
+++ b/js/src/data/adapters.js
@@ -15,40 +15,40 @@ import { convertKeysFromSnakeCaseToCamelCase } from './utils';
 /**
  * Adapts the ads budget recommendation data received from API.
  *
- * @param {Object} data The ads budget recommendation data to be adapted.
+ * @param {Object} rawData The ads budget recommendation data to be adapted.
  * @return {AdsBudgetRecommendation} Ads budget recommendation data.
  */
-export function adaptAdsBudgetRecommendation( data ) {
+export function adaptAdsBudgetRecommendation( rawData ) {
 	const validLevelKeys = [ 'recommended', 'high', 'low' ];
-	const { currency, source } = data;
-	const eventProps = { source, metrics_availability: 'all' };
 	const availabilities = [];
+	const { currency, source, recommendations, ...data } =
+		convertKeysFromSnakeCaseToCamelCase( rawData );
 
-	const reducer = ( payload, item ) => {
-		const { level, ...adaptingData } = item;
+	recommendations.forEach( ( item ) => {
+		const { level, ...adaptingItem } = item;
 		const key = level.toLowerCase();
 
 		if ( validLevelKeys.includes( key ) ) {
-			availabilities.push( adaptingData.metrics );
-			adaptingData.currency = currency;
-			payload[ key ] =
-				convertKeysFromSnakeCaseToCamelCase( adaptingData );
+			availabilities.push( adaptingItem.metrics );
+			adaptingItem.currency = currency;
+			data[ key ] = adaptingItem;
 		}
+	} );
 
-		return payload;
+	data.recommendedDailyBudget = data.recommended.dailyBudget;
+	data.eventProps = {
+		source,
+		recommended_budget: data.recommendedDailyBudget,
+		metrics_availability: 'all',
 	};
 
-	const result = data.recommendations.reduce( reducer, { eventProps } );
-
 	if ( availabilities.filter( Boolean ).length === 0 ) {
-		eventProps.metrics_availability = 'none';
+		data.eventProps.metrics_availability = 'none';
 	} else if ( ! availabilities.every( Boolean ) ) {
-		eventProps.metrics_availability = 'partial';
+		data.eventProps.metrics_availability = 'partial';
 	}
 
-	eventProps.recommended_budget = result.recommended.dailyBudget;
-
-	return result;
+	return data;
 }
 
 /**

--- a/js/src/data/adapters.test.js
+++ b/js/src/data/adapters.test.js
@@ -15,6 +15,7 @@ describe( 'adaptAdsBudgetRecommendation', () => {
 		input = {
 			currency: 'USD',
 			source: 'google-ads-api',
+			daily_budget_baseline: 13,
 			recommendations: [
 				{
 					level: 'Recommended',
@@ -86,6 +87,8 @@ describe( 'adaptAdsBudgetRecommendation', () => {
 			recommended,
 			high,
 			low,
+			dailyBudgetBaseline: 13,
+			recommendedDailyBudget: 15,
 			eventProps: {
 				source: 'google-ads-api',
 				metrics_availability: 'all',
@@ -102,6 +105,8 @@ describe( 'adaptAdsBudgetRecommendation', () => {
 		expect( adaptAdsBudgetRecommendation( input ) ).toEqual( {
 			recommended,
 			high,
+			dailyBudgetBaseline: 13,
+			recommendedDailyBudget: 15,
 			eventProps: {
 				source: 'google-ads-api',
 				metrics_availability: 'all',

--- a/js/src/data/types.js
+++ b/js/src/data/types.js
@@ -94,6 +94,8 @@
  * @property {AdsBudgetRecommendationEntity} recommended The recommended budget.
  * @property {AdsBudgetRecommendationEntity} [high] The high budget recommendation.
  * @property {AdsBudgetRecommendationEntity} [low] The low budget recommendation.
+ * @property {number} recommendedDailyBudget The recommended daily budget.
+ * @property {number} dailyBudgetBaseline The daily budget baseline.
  * @property {Object} eventProps The relevant event properties.
  */
 

--- a/js/src/hooks/useBudgetRecommendation.js
+++ b/js/src/hooks/useBudgetRecommendation.js
@@ -17,7 +17,6 @@ import useCountryCodesForBudgetQuery from './useCountryCodesForBudgetQuery';
 /**
  * @typedef {Object} BudgetRecommendationPayload
  * @property {AdsBudgetRecommendation|null} data The budget recommendation data.
- * @property {number|null} recommendedDailyBudget The recommended daily budget. `null` if not yet fetched.
  * @property {boolean} hasResolved Whether the data fetching is finished.
  */
 
@@ -38,12 +37,6 @@ const useBudgetRecommendation = ( countryCodes ) => {
 				select( STORE_KEY );
 
 			const data = getAdsBudgetRecommendations( resolvedCountryCodes );
-			let recommendedDailyBudget = null;
-
-			if ( data ) {
-				recommendedDailyBudget = data.recommended.dailyBudget;
-			}
-
 			const hasResolved = resolvedCountryCodes.length
 				? hasFinishedResolution( 'getAdsBudgetRecommendations', [
 						resolvedCountryCodes,
@@ -52,7 +45,6 @@ const useBudgetRecommendation = ( countryCodes ) => {
 
 			return {
 				data,
-				recommendedDailyBudget,
 				hasResolved,
 			};
 		},

--- a/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
@@ -31,7 +31,7 @@ import AppSpinner from '~/components/app-spinner';
  * Clicking on the "Complete setup" button to complete the onboarding flow with paid ads.
  *
  * @event gla_onboarding_complete_with_paid_ads_button_click
- * @property {string} level The selected level of the budget recommendation, e.g. 'low', 'medium', 'high', 'custom'.
+ * @property {string} level The selected level of the budget recommendation, e.g. 'low', 'recommended', 'high', 'custom'.
  * @property {number} budget The budget for the campaign
  * @property {string} audiences The targeted audiences for the campaign
  * @property {string} source The data source of the budget recommendations, e.g. 'google-ads-api', 'fallback-database'.

--- a/js/src/utils/tracks.js
+++ b/js/src/utils/tracks.js
@@ -173,7 +173,7 @@ export const recordTablePageEvent = ( context, page, direction ) => {
  * Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign in the Google Ads setup flow.
  *
  * @event gla_launch_paid_campaign_button_click
- * @property {string} level The selected level of the budget recommendation, e.g. 'low', 'medium', 'high', 'custom'.
+ * @property {string} level The selected level of the budget recommendation, e.g. 'low', 'recommended', 'high', 'custom'.
  * @property {string} audiences Country codes of the paid campaign audience countries, e.g. `'US,JP,AU'`. This means the campaign is created with the multi-country targeting feature. Before this feature support, it was implemented as 'audience'.
  * @property {number} budget Daily average cost of the paid campaign
  * @property {string} source The data source of the budget recommendations, e.g. 'google-ads-api', 'fallback-database'.

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -116,7 +116,7 @@ class BudgetRecommendationController extends BaseController implements Container
 			$source = 'google-ads-api';
 
 			// The fallback recommendation is still needed to ensure there is a
-			// baseline budget for validatting the minimum value.
+			// baseline budget for validating the minimum value.
 			$budget_baseline = 0;
 
 			// Fetch fallback recommendation from the database.

--- a/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
+++ b/src/API/Site/Controllers/Ads/BudgetRecommendationController.php
@@ -115,10 +115,15 @@ class BudgetRecommendationController extends BaseController implements Container
 			// For the frontend side to track the source of the recommendations.
 			$source = 'google-ads-api';
 
+			// The fallback recommendation is still needed to ensure there is a
+			// baseline budget for validatting the minimum value.
+			$budget_baseline = 0;
+
 			// Fetch fallback recommendation from the database.
 			$fallback_recommendation = $this->get_fallback_recommendation( $country_codes, $currency );
 			if ( $fallback_recommendation ) {
 				$fallback_budget = $fallback_recommendation[0]['daily_budget'] ?? 0;
+				$budget_baseline = $fallback_budget;
 
 				// Swap recommended if not set or if fallback is higher.
 				if ( empty( $recommendations[0] ) || ( ! empty( $recommendations[0]['daily_budget'] ) && $recommendations[0]['daily_budget'] < $fallback_budget ) ) {
@@ -157,9 +162,10 @@ class BudgetRecommendationController extends BaseController implements Container
 
 			return $this->prepare_item_for_response(
 				[
-					'currency'        => $currency,
-					'recommendations' => $recommendations,
-					'source'          => $source,
+					'currency'              => $currency,
+					'recommendations'       => $recommendations,
+					'daily_budget_baseline' => $budget_baseline,
+					'source'                => $source,
 				],
 				$request
 			);
@@ -205,13 +211,13 @@ class BudgetRecommendationController extends BaseController implements Container
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'currency'        => [
+			'currency'              => [
 				'type'              => 'string',
 				'description'       => __( 'The currency to use for the shipping rate.', 'google-listings-and-ads' ),
 				'context'           => [ 'view' ],
 				'validate_callback' => 'rest_validate_request_arg',
 			],
-			'recommendations' => [
+			'recommendations'       => [
 				'type'  => 'array',
 				'items' => [
 					'type'       => 'object',
@@ -252,7 +258,12 @@ class BudgetRecommendationController extends BaseController implements Container
 					],
 				],
 			],
-			'source'          => [
+			'daily_budget_baseline' => [
+				'type'        => 'number',
+				'description' => __( 'The baseline daily budget for a country.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+			],
+			'source'                => [
 				'type'        => 'string',
 				'enum'        => [ 'google-ads-api', 'fallback-database' ],
 				'description' => __( 'Data source of the budget recommendations, either from Google Ads API or fallback database.', 'google-listings-and-ads' ),

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -111,15 +111,16 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		];
 
 		$expected_response_data = [
-			'currency'        => 'TWD',
-			'recommendations' => [
+			'currency'              => 'TWD',
+			'recommendations'       => [
 				[
 					'daily_budget' => 330.0,
 					'country'      => 'TW',
 					'level'        => 'Recommended',
 				],
 			],
-			'source'          => 'fallback-database',
+			'daily_budget_baseline' => 330.0,
+			'source'                => 'fallback-database',
 		];
 
 		$this->ads->expects( $this->once() )
@@ -142,9 +143,10 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		];
 
 		$expected_response_data = [
-			'currency'        => 'GBP',
-			'recommendations' => self::RECOMMENDATION_DATA,
-			'source'          => 'google-ads-api',
+			'currency'              => 'GBP',
+			'recommendations'       => self::RECOMMENDATION_DATA,
+			'daily_budget_baseline' => 0,
+			'source'                => 'google-ads-api',
 		];
 
 		$this->ads->expects( $this->once() )
@@ -179,15 +181,16 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		];
 
 		$expected_response_data = [
-			'currency'        => 'GBP',
-			'recommendations' => [
+			'currency'              => 'GBP',
+			'recommendations'       => [
 				[
 					'daily_budget' => 15.0,
 					'country'      => 'GB',
 					'level'        => 'Recommended',
 				],
 			],
-			'source'          => 'fallback-database',
+			'daily_budget_baseline' => 15.0,
+			'source'                => 'fallback-database',
 		];
 
 		$this->ads->expects( $this->once() )
@@ -228,8 +231,8 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		];
 
 		$expected_response_data = [
-			'currency'        => 'GBP',
-			'recommendations' => [
+			'currency'              => 'GBP',
+			'recommendations'       => [
 				[
 					'daily_budget' => 13.2,
 					'country'      => 'GB',
@@ -247,7 +250,8 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 					'level'        => 'High',
 				],
 			],
-			'source'          => 'fallback-database',
+			'daily_budget_baseline' => 13.2,
+			'source'                => 'fallback-database',
 		];
 
 		$this->ads->expects( $this->once() )
@@ -287,8 +291,8 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 		];
 
 		$expected_response_data = [
-			'currency'        => 'GBP',
-			'recommendations' => [
+			'currency'              => 'GBP',
+			'recommendations'       => [
 				[
 					'daily_budget' => 13.2,
 					'country'      => 'GB',
@@ -305,7 +309,8 @@ class BudgetRecommendationControllerTest extends RESTControllerUnitTest {
 					'level'        => 'High',
 				],
 			],
-			'source'          => 'fallback-database',
+			'daily_budget_baseline' => 13.2,
+			'source'                => 'fallback-database',
 		];
 
 		$this->ads->expects( $this->once() )

--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -404,7 +404,7 @@ test.describe( 'Set up Ads account', () => {
 				).toBeEnabled();
 			} );
 
-			test( 'Continue button should be disabled if budget is less than 30% of the recommended value', async () => {
+			test( 'Continue button should be disabled if budget is less than 30% of the daily budget baseline', async () => {
 				await setupBudgetPage.fillBudget( '2' );
 
 				await expect(
@@ -413,12 +413,12 @@ test.describe( 'Set up Ads account', () => {
 			} );
 
 			test( 'User is notified of the minimum value', async () => {
-				await setupBudgetPage.fillBudget( '4' );
+				await setupBudgetPage.fillBudget( '3' );
 				await setupBudgetPage.getBudgetInput().blur();
 
 				await expect(
 					page.getByText(
-						'Please make sure daily average cost is at least €5.00'
+						'Please make sure daily average cost is at least €4.00'
 					)
 				).toBeVisible();
 			} );

--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -65,6 +65,7 @@ test.describe( 'Set up Ads account', () => {
 		} );
 		await setupBudgetPage.fulfillBudgetRecommendations( {
 			currency: 'EUR',
+			daily_budget_baseline: 12,
 			recommendations: [
 				{
 					level: 'Recommended',

--- a/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
+++ b/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
@@ -215,6 +215,7 @@ test.describe( 'Complete your campaign', () => {
 				await setupAdsAccountPage.mockAdsAccountConnected();
 				await setupBudgetPage.fulfillBudgetRecommendations( {
 					currency: 'TWD',
+					daily_budget_baseline: 100,
 					recommendations: [
 						{
 							level: 'Recommended',

--- a/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
+++ b/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
@@ -220,7 +220,7 @@ test.describe( 'Complete your campaign', () => {
 						{
 							level: 'Recommended',
 							country: 'TW',
-							daily_budget: 100,
+							daily_budget: 120,
 							metrics: {
 								cost: 700,
 								conversions: 2.2,
@@ -258,7 +258,7 @@ test.describe( 'Complete your campaign', () => {
 					await page.getByLabel( 'custom' ).click();
 					await expect(
 						setupBudgetPage.getBudgetInput()
-					).toHaveValue( '100.00' );
+					).toHaveValue( '120.00' );
 				} );
 			} );
 
@@ -301,7 +301,7 @@ test.describe( 'Complete your campaign', () => {
 
 					await expect(
 						page.getByText(
-							`Your budget is lower than other advertisers' budgets, which may affect performance. For best results, we recommend at least NT$100.00 per day.`
+							`Your budget is lower than other advertisers' budgets, which may affect performance. For best results, we recommend at least NT$120.00 per day.`
 						)
 					).toBeVisible();
 				} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Project thread: pcTzPl-2Hb-p2

This PR change back to using a fixed value based on country and currency as the reference value for the minimum budget limit. Thus, there will be stable validation without asking for a higher minimum value when some users have a higher recommended value.

- Add `daily_budget_baseline` field to the response of `ads/campaigns/budget-recommendation` API.
- Adjust the adapter for budget recommendation data accordingly, and move `recommendedDailyBudget` from the related hook to it.
- Replace the minimum value validation from the recommended budget to the budget baseline.

Extra changes:

- Correct the example value of the level property in JSDoc for the campaign creation event tracking.
   Only the descriptions in the JSDoc were wrong. The 'medium' value should be 'recommended'.
   Related event tracking:
   - `gla_onboarding_complete_with_paid_ads_button_click`
   - `gla_launch_paid_campaign_button_click`
- Fall back to the custom level when the budget recommendation API responds with 404.
   - Normally this doesn't happen, but there is still a chance that an edge may occur and cause the `CampaignAssetsForm` component to render incorrectly.
- Add a loading spinner to the `CampaignAssetsForm` component.
   - The load time of recommendations is significantly longer. This prevents users from thinking that something is wrong during loading.

### Screenshots:

![1](https://github.com/user-attachments/assets/1bbc0a21-011a-4acb-b9eb-400e5f8b6468)

### Detailed test instructions:

1. Go to the campaign creating page
2. Test if the minimum budget limit is changed to [30%](https://github.com/woocommerce/google-listings-and-ads/blob/232536a557a7e070e844cfa768456c1225e3dfac/js/src/components/paid-ads/validateCampaign.js#L42) of the daily budget baseline instead of the one in the recommended level
   - Source of the daily budget baseline: https://github.com/woocommerce/google-listings-and-ads/blob/232536a557a7e070e844cfa768456c1225e3dfac/data/budget-recommendations.csv
   - It's also the original budget recommendation data before replacing it with Google API data
3. Check the result of E2E tests on GitHub Actions
   - https://github.com/woocommerce/google-listings-and-ads/actions/runs/15750017217

### Changelog entry
