### PR TITLE
Update Need Help URL for App Ratings banner

### DIFF
--- a/js/src/components/experience-rating-banner/index.js
+++ b/js/src/components/experience-rating-banner/index.js
@@ -176,7 +176,7 @@ const ExperienceRatingBanner = () => {
 
 					<AppButton
 						isSecondary
-						href="https://woocommerce.com"
+						href="https://woocommerce.com/my-account/contact-support/"
 						target="_blank"
 						onClick={ handleNeedHelpOnClick }
 					>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-195/improve-redirection-flow-for-need-help-button

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Clicking the "Need Help" button within the App ratings banner should redirect the user to https://woocommerce.com/my-account/contact-support/ in a new tab.
2. If the user is not logged in to woocommerce.com, they will be prompted to log in and will be redirected to the support page (out of scope for the plugin).
3. If the user is already logged in, they will access the support page (out of scope for the plugin).


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
