### PR TITLE
Update icon size.

### DIFF
--- a/js/src/components/experience-rating-banner/feedback-modal.js
+++ b/js/src/components/experience-rating-banner/feedback-modal.js
@@ -71,9 +71,11 @@ const FeedbackModal = ( { onRequestClose } ) => {
 					isPrimary
 					target="_blank"
 					href="https://wordpress.org/support/plugin/google-listings-and-ads/reviews/#new-post"
+					icon={ <Icon icon={ externalIcon } /> }
+					iconPosition="right"
+					iconSize={ 16 }
 				>
 					{ __( 'Rate us', 'google-listings-and-ads' ) }
-					<Icon icon={ externalIcon } size={ 18 } />
 				</AppButton>,
 			] }
 			onRequestClose={ onRequestClose }

--- a/js/src/components/experience-rating-banner/index.js
+++ b/js/src/components/experience-rating-banner/index.js
@@ -119,9 +119,9 @@ const ExperienceRatingBanner = () => {
 		}
 	}, [ isDismissed ] );
 
-	if ( ! shouldDisplayBanner() ) {
-		return null;
-	}
+	// if ( ! shouldDisplayBanner() ) {
+	// 	return null;
+	// }
 
 	const handleGoodOnClick = () => {
 		recordGlaEvent( 'gla_app_ratings_good_clicked', {
@@ -179,9 +179,11 @@ const ExperienceRatingBanner = () => {
 						href="https://woocommerce.com"
 						target="_blank"
 						onClick={ handleNeedHelpOnClick }
+						icon={ <Icon icon={ externalIcon } /> }
+						iconPosition="right"
+						iconSize={ 16 }
 					>
 						{ __( 'Need help', 'google-listings-and-ads' ) }
-						<Icon icon={ externalIcon } size={ 12 } />
 					</AppButton>
 				</div>
 			</Notice>

--- a/js/src/components/experience-rating-banner/index.js
+++ b/js/src/components/experience-rating-banner/index.js
@@ -119,9 +119,9 @@ const ExperienceRatingBanner = () => {
 		}
 	}, [ isDismissed ] );
 
-	// if ( ! shouldDisplayBanner() ) {
-	// 	return null;
-	// }
+	if ( ! shouldDisplayBanner() ) {
+		return null;
+	}
 
 	const handleGoodOnClick = () => {
 		recordGlaEvent( 'gla_app_ratings_good_clicked', {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-196/external-link-icon-on-need-help-is-the-wrong-size

_Replace this with a good description of your changes & reasoning._


### Screenshots:
![image](https://github.com/user-attachments/assets/53c39c60-3a01-4010-837e-665d398008d8)

**Modal**:
![image](https://github.com/user-attachments/assets/81f809c1-9282-4dcf-a666-abf19502715e)



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the plugin dashboard.
2. In the App Ratings banner, verify that the external link icon on the “Need Help” button matches the design specifications.
3. Click the “Good” button.
4. Ensure the external link icon on the “Rate Us” button also matches the designs.
5. Confirm that the icon size for both buttons is 16×16 pixels.


### Additional details:
* The button padding will differ from the design specifications because WordPress applies default padding to buttons that contain both text and icons.
[Reference](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/button/style.scss#L342-L343).

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
