### PR TITLE
Add ExperienceRatingBanner to price benchmarks tab.

### DIFF
--- a/js/src/components/experience-rating-banner/index.js
+++ b/js/src/components/experience-rating-banner/index.js
@@ -119,9 +119,9 @@ const ExperienceRatingBanner = () => {
 		}
 	}, [ isDismissed ] );
 
-	if ( ! shouldDisplayBanner() ) {
-		return null;
-	}
+	// if ( ! shouldDisplayBanner() ) {
+	// 	return null;
+	// }
 
 	const handleGoodOnClick = () => {
 		recordGlaEvent( 'gla_app_ratings_good_clicked', {

--- a/js/src/components/experience-rating-banner/index.js
+++ b/js/src/components/experience-rating-banner/index.js
@@ -119,9 +119,9 @@ const ExperienceRatingBanner = () => {
 		}
 	}, [ isDismissed ] );
 
-	// if ( ! shouldDisplayBanner() ) {
-	// 	return null;
-	// }
+	if ( ! shouldDisplayBanner() ) {
+		return null;
+	}
 
 	const handleGoodOnClick = () => {
 		recordGlaEvent( 'gla_app_ratings_good_clicked', {

--- a/js/src/pages/price-benchmark/index.js
+++ b/js/src/pages/price-benchmark/index.js
@@ -9,6 +9,7 @@ import { Card } from '@wordpress/components';
  * Internal dependencies
  */
 import { glaData } from '~/constants';
+import ExperienceRatingBanner from '~/components/experience-rating-banner';
 import AppNotice from '~/components/app-notice';
 import AppSpinner from '~/components/app-spinner';
 import MainTabNav from '~/components/main-tab-nav';
@@ -52,8 +53,8 @@ const PriceBenchmark = () => {
 
 	return (
 		<div className="gla-price-benchmark">
+			<ExperienceRatingBanner />
 			<MainTabNav />
-
 			<Banner />
 			<ProductComparisonChart />
 

--- a/js/src/pages/price-benchmark/index.js
+++ b/js/src/pages/price-benchmark/index.js
@@ -9,13 +9,13 @@ import { Card } from '@wordpress/components';
  * Internal dependencies
  */
 import { glaData } from '~/constants';
-import ExperienceRatingBanner from '~/components/experience-rating-banner';
 import AppNotice from '~/components/app-notice';
 import AppSpinner from '~/components/app-spinner';
+import Banner from './banner';
+import ExperienceRatingBanner from '~/components/experience-rating-banner';
 import MainTabNav from '~/components/main-tab-nav';
 import PriceBenchmarkSuggestions from './price-benchmark-suggestions';
 import ProductComparisonChart from './product-comparison-chart';
-import Banner from './banner';
 import './index.scss';
 
 const PriceBenchmark = () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-197/add-notification-banner-to-price-benchmark-tab

_Replace this with a good description of your changes & reasoning._


### Screenshots:
![image](https://github.com/user-attachments/assets/03e2d1dd-b4d7-45dc-bd99-123de22a80c8)

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Navigate to the Price Benchmarks tab: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fprice-benchmark`.
2. If the App Ratings banner has not been dismissed previously, it should be visible.
3. After dismissing the banner, it should no longer appear upon reloading the page.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
