### PR TITLE
Reintroduce account:connect functionality for Google account linking

### DIFF
--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -488,6 +488,75 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 	}
 
 	/**
+	 * Get the URL for the Google SDI merchant update endpoint.
+	 *
+	 * @return string
+	 */
+	public function get_sdi_merchant_update_endpoint(): string {
+		return $this->get_sdi_endpoint() . 'account:connect';
+	}
+
+	/**
+	 * Get the base endpoint to the Google Shopping Data Integration (SDI).
+	 *
+	 * @return string
+	 */
+	protected function get_sdi_endpoint(): string {
+		return $this->container->get( 'connect_server_root' )
+			. 'google/google-sdi/v1/credentials/partners/WOO_COMMERCE/merchants/'
+			. $this->strip_url_protocol( $this->get_site_url() )
+			. '/';
+	}
+
+	/**
+	 * Performs a request to Google Shopping Data Integration (SDI) to update the merchant center account.
+	 *
+	 * @throws NotFoundExceptionInterface  When the container was not found.
+	 * @throws ContainerExceptionInterface When an error happens while retrieving the container.
+	 * @throws Exception When the response status is not successful, or merchant ID is not set.
+	 * @see google-sdi in google/services inside WCS
+	 */
+	public function update_sdi_merchant_account() {
+		try {
+			if ( ! $this->options->get_merchant_id() ) {
+				throw new Exception( __( 'Merchant ID must be set before updating in SDI.', 'google-listings-and-ads' ) );
+			}
+
+			/** @var Client $client */
+			$client = $this->container->get( Client::class );
+			$result = $client->post(
+				$this->get_sdi_merchant_update_endpoint(),
+				[
+					'body' => wp_json_encode(
+						[
+							'merchant_center_id' => $this->options->get_merchant_id(),
+							'blog_id'            => \Jetpack_Options::get_option( 'id' ),
+						]
+					),
+				]
+			);
+
+			// Check the status, since an empty response is returned upon success.
+			if ( 200 !== $result->getStatusCode() ) {
+				$response = json_decode( $result->getBody()->getContents(), true );
+				do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
+
+				throw new Exception(
+					__( 'Invalid response when updating merchant account in Google Partner APP.', 'google-listings-and-ads' ),
+					$result->getStatusCode()
+				);
+			}
+		} catch ( ClientExceptionInterface $e ) {
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
+
+			throw new Exception(
+				$this->client_exception_message( $e, __( 'Error updating merchant account in Google Partner APP.', 'google-listings-and-ads' ) ),
+				$e->getCode()
+			);
+		}
+	}
+
+	/**
 	 * Generate a descriptive name for a new account.
 	 * Use site name if available.
 	 *

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -347,6 +347,9 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 							$merchant->claimwebsite();
 						}
 						break;
+					case 'sdi_update':
+						$middleware->update_sdi_merchant_account();
+						break;
 					case 'link_ads':
 						// Continue to next step if Ads account is not connected yet.
 						if ( ! $this->options->get_ads_id() ) {

--- a/src/Options/MerchantAccountState.php
+++ b/src/Options/MerchantAccountState.php
@@ -30,7 +30,7 @@ class MerchantAccountState extends AccountState {
 	 * @return string[]
 	 */
 	protected function account_creation_steps(): array {
-		return [ 'set_id', 'verify', 'link', 'claim', 'link_ads' ];
+		return [ 'set_id', 'verify', 'link', 'claim', 'sdi_update', 'link_ads' ];
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Reintroduces the account:connect functionality that was previously reverted in PR #2851, with the added requirement to include `blog_id` in the payload for Google account linking.

### Changes Made:

1. **Added `update_sdi_merchant_account()` method** to `Middleware` class
   - Calls Google's SDI `account:connect` endpoint
   - Includes both `merchant_center_id` and `blog_id` in request payload
   - Proper error handling and action hooks

2. **Added supporting endpoint methods**:
   - `get_sdi_merchant_update_endpoint()` - returns the account:connect endpoint URL
   - `get_sdi_endpoint()` - base SDI endpoint helper method

3. **Integrated into merchant account setup flow**:
   - Added `sdi_update` step to `MerchantAccountState` account creation steps
   - Added `sdi_update` case to `AccountService::setup_account_steps()`
   - Automatically triggers during onboarding after website claim

### API Payload Format:
```json
{
  "merchant_center_id": [MC_ID],
  "blog_id": [BLOG_ID]
}
```

### When account:connect is called:
- Automatically during merchant onboarding when MC account is connected
- After website claiming step, before ads linking

## Test plan
- [ ] Test merchant center onboarding flow calls account:connect endpoint
- [ ] Verify both merchant_center_id and blog_id are included in payload
- [ ] Test error handling when endpoint fails
- [ ] Verify onboarding completes successfully after account:connect call

🤖 Generated with [Claude Code](https://claude.ai/code)

### Changelog entry
