### PR TITLE
Add /wc/gla/connect endpoint for Google-triggered account linking

### DIFF
--- a/src/API/Site/Controllers/ConnectController.php
+++ b/src/API/Site/Controllers/ConnectController.php
@@ -47,7 +47,7 @@ class ConnectController extends BaseController {
 	public function __construct( RESTServer $server, Middleware $middleware, OptionsInterface $options ) {
 		parent::__construct( $server );
 		$this->middleware = $middleware;
-		$this->options = $options;
+		$this->options    = $options;
 	}
 
 	/**
@@ -77,7 +77,7 @@ class ConnectController extends BaseController {
 			try {
 				// Trigger the account connection
 				$this->middleware->update_sdi_merchant_account();
-				
+
 				$result = [
 					'status'             => 'success',
 					'message'            => __( 'Account connection triggered successfully.', 'google-listings-and-ads' ),
@@ -99,13 +99,13 @@ class ConnectController extends BaseController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'status' => [
+			'status'             => [
 				'description' => __( 'Status of the connection request.', 'google-listings-and-ads' ),
 				'type'        => 'string',
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],
-			'message' => [
+			'message'            => [
 				'description' => __( 'Message describing the connection result.', 'google-listings-and-ads' ),
 				'type'        => 'string',
 				'context'     => [ 'view' ],
@@ -117,7 +117,7 @@ class ConnectController extends BaseController {
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],
-			'blog_id' => [
+			'blog_id'            => [
 				'description' => __( 'The WordPress.com blog ID.', 'google-listings-and-ads' ),
 				'type'        => 'integer',
 				'context'     => [ 'view' ],

--- a/src/API/Site/Controllers/ConnectController.php
+++ b/src/API/Site/Controllers/ConnectController.php
@@ -1,0 +1,139 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Exception;
+use WP_REST_Request as Request;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ConnectController
+ *
+ * Handles the /wc/gla/connect endpoint for Google-requested account linking.
+ * When Google calls this endpoint, it triggers a call to the external /account:connect endpoint.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers
+ */
+class ConnectController extends BaseController {
+
+	/**
+	 * Service used to make external account connect calls.
+	 *
+	 * @var Middleware
+	 */
+	protected $middleware;
+
+	/**
+	 * Options service to access merchant ID.
+	 *
+	 * @var OptionsInterface
+	 */
+	protected $options;
+
+	/**
+	 * ConnectController constructor.
+	 *
+	 * @param RESTServer       $server
+	 * @param Middleware       $middleware
+	 * @param OptionsInterface $options
+	 */
+	public function __construct( RESTServer $server, Middleware $middleware, OptionsInterface $options ) {
+		parent::__construct( $server );
+		$this->middleware = $middleware;
+		$this->options = $options;
+	}
+
+	/**
+	 * Register rest routes with WordPress.
+	 */
+	public function register_routes(): void {
+		$this->register_route(
+			'connect',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_connect_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+				'schema' => $this->get_api_response_schema_callback(),
+			]
+		);
+	}
+
+	/**
+	 * Get the callback function for the connect request.
+	 *
+	 * @return callable
+	 */
+	protected function get_connect_callback(): callable {
+		return function ( Request $request ) {
+			try {
+				// Trigger the account connection
+				$this->middleware->update_sdi_merchant_account();
+				
+				$result = [
+					'status'             => 'success',
+					'message'            => __( 'Account connection triggered successfully.', 'google-listings-and-ads' ),
+					'merchant_center_id' => $this->options->get_merchant_id(),
+					'blog_id'            => \Jetpack_Options::get_option( 'id' ),
+				];
+
+				return $this->prepare_item_for_response( $result, $request );
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
+		};
+	}
+
+	/**
+	 * Get the schema for the connect endpoint.
+	 *
+	 * @return array
+	 */
+	protected function get_schema_properties(): array {
+		return [
+			'status' => [
+				'description' => __( 'Status of the connection request.', 'google-listings-and-ads' ),
+				'type'        => 'string',
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+			],
+			'message' => [
+				'description' => __( 'Message describing the connection result.', 'google-listings-and-ads' ),
+				'type'        => 'string',
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+			],
+			'merchant_center_id' => [
+				'description' => __( 'The Merchant Center ID that was connected.', 'google-listings-and-ads' ),
+				'type'        => 'integer',
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+			],
+			'blog_id' => [
+				'description' => __( 'The WordPress.com blog ID.', 'google-listings-and-ads' ),
+				'type'        => 'integer',
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+			],
+		];
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * Used for building the API response schema.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'connect';
+	}
+}

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -25,6 +25,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\GTINMigrati
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestAPI\SyncController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\TourController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\DisconnectController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\ConnectController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Google\AccountController as GoogleAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Jetpack\AccountController as JetpackAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\AccountController as MerchantCenterAccountController;
@@ -70,6 +71,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PhoneVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PolicyComplianceCheck;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMapping\AttributeMappingHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
@@ -148,6 +150,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( GTINMigrationController::class, JobRepository::class );
 		$this->share( PriceBenchmarksController::class );
 		$this->share( SyncController::class, NotificationsService::class );
+		$this->share( ConnectController::class, Middleware::class, OptionsInterface::class );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Implements **Option 1** from the account linking requirements - adds a new REST endpoint `/wc/gla/connect` that Google can call to manually trigger account linking for existing merchants or special cases.

This PR builds on #2976 (reintroduce-account-connect functionality) and adds the additional endpoint for Google-initiated requests.

### Changes Made:

1. **Created `ConnectController`** - New REST API controller
   - Handles `GET /wp-json/wc/gla/v1/connect` endpoint
   - Triggers `update_sdi_merchant_account()` when called
   - Returns success response with merchant data

2. **Registered controller in `RESTServiceProvider`**
   - Added proper dependency injection for `Middleware` and `OptionsInterface`
   - Controller automatically registered with WordPress REST API

3. **Endpoint Response Format**:
```json
{
  "status": "success",
  "message": "Account connection triggered successfully.",
  "merchant_center_id": 12345,
  "blog_id": 67890
}
```

### When to use this endpoint:

- **Existing merchants** who were part of dark sync but haven't completed account linking
- **Manual triggers** when Google needs to force account linking for specific merchants  
- **Retry scenarios** when automatic onboarding failed

### API Details:

- **Endpoint**: `GET /wp-json/wc/gla/v1/connect`
- **Authentication**: Uses existing WooCommerce permissions (`manage_woocommerce`)
- **Dependencies**: Requires merchant to have valid Merchant Center ID
- **Action**: Calls external account:connect endpoint with `merchant_center_id` and `blog_id`

## Test plan

- [ ] Test endpoint returns 200 with proper response format
- [ ] Verify endpoint calls `update_sdi_merchant_account()` correctly
- [ ] Test error handling when merchant ID is not set
- [ ] Verify external API call includes both merchant_center_id and blog_id
- [ ] Test endpoint with invalid permissions returns proper error

## Relationship to other PRs

This PR depends on #2976 (reintroduce-account-connect) and implements the optional Google-triggered endpoint functionality described in the original requirements.

🤖 Generated with [Claude Code](https://claude.ai/code)

### Changelog entry

> Add - A new endpoint for Google-triggered account linking.
