### PR TITLE
Dismiss Notice when Rate us button is clicked

### DIFF
--- a/js/src/components/experience-rating-banner/feedback-modal.js
+++ b/js/src/components/experience-rating-banner/feedback-modal.js
@@ -14,7 +14,7 @@ import { APP_RATINGS_BANNER_CONTEXT } from '~/constants';
 import { recordGlaEvent } from '~/utils/tracks';
 
 /**
- * @event gla_app_ratings_cancel_clicked
+ * @event gla_app_ratings_maybe_later_clicked
  * @property {string} context The context in which the event is triggered.
  */
 
@@ -30,24 +30,26 @@ import { recordGlaEvent } from '~/utils/tracks';
  *
  * @param {Object} props - Component props.
  * @param {Function} props.onRequestClose - Function to call when the modal is closed.
+ * @param {Function} props.onRateUsClick - Function to call when the "Rate us" button is clicked.
  * @return {JSX.Element} The FeedbackModal component.
  *
- * @fires gla_app_ratings_cancel_clicked - Fired when the user clicks the "Cancel" button.
+ * @fires gla_app_ratings_maybe_later_clicked - Fired when the user clicks the "Maybe later" button.
  * @fires gla_app_ratings_rate_clicked - Fired when the user clicks the "Rate us" button.
  */
-const FeedbackModal = ( { onRequestClose } ) => {
+const FeedbackModal = ( { onRequestClose, onRateUsClick } ) => {
 	const trackEvent = ( eventName ) => {
 		recordGlaEvent( eventName, { context: APP_RATINGS_BANNER_CONTEXT } );
 	};
 
-	const handleCancelOnClick = () => {
-		trackEvent( 'gla_app_ratings_cancel_clicked' );
+	const handleMaybeLaterOnClick = () => {
+		trackEvent( 'gla_app_ratings_maybe_later_clicked' );
 		onRequestClose();
 	};
 
 	const handleRateUsOnClick = () => {
 		trackEvent( 'gla_app_ratings_rate_clicked' );
 		onRequestClose();
+		onRateUsClick();
 	};
 
 	return (
@@ -59,11 +61,11 @@ const FeedbackModal = ( { onRequestClose } ) => {
 			className="gla-experience-rating-banner__feedback-modal"
 			buttons={ [
 				<AppButton
-					key="cancel"
-					onClick={ handleCancelOnClick }
-					isTertiary
+					key="maybe-later"
+					onClick={ handleMaybeLaterOnClick }
+					isSecondary
 				>
-					{ __( 'Cancel', 'google-listings-and-ads' ) }
+					{ __( 'Maybe later', 'google-listings-and-ads' ) }
 				</AppButton>,
 				<AppButton
 					key="rate-us"

--- a/js/src/components/experience-rating-banner/index.js
+++ b/js/src/components/experience-rating-banner/index.js
@@ -119,7 +119,7 @@ const ExperienceRatingBanner = () => {
 		}
 	}, [ isDismissed ] );
 
-	if ( ! shouldDisplayBanner() ) {
+	if ( ! shouldDisplayBanner() || isDismissed ) {
 		return null;
 	}
 
@@ -143,24 +143,23 @@ const ExperienceRatingBanner = () => {
 		} );
 	};
 
-	const onDismiss = () => {
+	const dismissBanner = () => {
 		set( PREFERENCES_STORE_NAMESPACE, BANNER_DISMISSED_KEY, true );
 	};
-
-	if ( isDismissed ) {
-		return null;
-	}
 
 	return (
 		<div className="gla-experience-rating-banner__container">
 			{ showModal && (
-				<FeedbackModal onRequestClose={ handleRequestClose } />
+				<FeedbackModal
+					onRequestClose={ handleRequestClose }
+					onRateUsClick={ dismissBanner }
+				/>
 			) }
 			<Notice
 				className="gla-experience-rating-banner"
 				status="info"
 				isDismissible={ true }
-				onRemove={ onDismiss }
+				onRemove={ dismissBanner }
 			>
 				<p className="gla-experience-rating-banner__text">
 					{ __(

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -188,41 +188,41 @@ Clicking on the button to disconnect the Google Ads account.
 #### Emitters
 - [`BillingSetupCard`](../../js/src/components/paid-ads/billing-card/billing-setup-card.js#L39) When the user clicks on the button to set up billing in Google Ads.
 
-### [`gla_app_ratings_cancel_clicked`](../../js/src/components/experience-rating-banner/feedback-modal.js#L16)
-
-#### Properties
-| name | type | description |
-| ---- | ---- | ----------- |
-`context` | `string` | The context in which the event is triggered.
-#### Emitters
-- [`FeedbackModal`](../../js/src/components/experience-rating-banner/feedback-modal.js#L38) Fired when the user clicks the "Cancel" button.
-
-### [`gla_app_ratings_close`](../../js/src/components/experience-rating-banner/index.js#L40)
+### [`gla_app_ratings_close`](../../js/src/components/experience-rating-banner/index.js#L44)
 When the feedback modal is closed by the user.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
 #### Emitters
-- [`ExperienceRatingBanner`](../../js/src/components/experience-rating-banner/index.js#L68) When the feedback modal is closed.
+- [`ExperienceRatingBanner`](../../js/src/components/experience-rating-banner/index.js#L72) When the feedback modal is closed.
 
-### [`gla_app_ratings_good_clicked`](../../js/src/components/experience-rating-banner/index.js#L33)
+### [`gla_app_ratings_good_clicked`](../../js/src/components/experience-rating-banner/index.js#L37)
 When the user clicks the "Good" button on the banner.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
 #### Emitters
-- [`ExperienceRatingBanner`](../../js/src/components/experience-rating-banner/index.js#L68) When the "Good" button is clicked.
+- [`ExperienceRatingBanner`](../../js/src/components/experience-rating-banner/index.js#L72) When the "Good" button is clicked.
 
-### [`gla_app_ratings_need_help_clicked`](../../js/src/components/experience-rating-banner/index.js#L47)
+### [`gla_app_ratings_maybe_later_clicked`](../../js/src/components/experience-rating-banner/feedback-modal.js#L16)
+
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | The context in which the event is triggered.
+#### Emitters
+- [`FeedbackModal`](../../js/src/components/experience-rating-banner/feedback-modal.js#L39) Fired when the user clicks the "Maybe later" button.
+
+### [`gla_app_ratings_need_help_clicked`](../../js/src/components/experience-rating-banner/index.js#L51)
 When the user clicks the "Need help" button on the banner.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
 #### Emitters
-- [`ExperienceRatingBanner`](../../js/src/components/experience-rating-banner/index.js#L68) When the "Need help" button is clicked.
+- [`ExperienceRatingBanner`](../../js/src/components/experience-rating-banner/index.js#L72) When the "Need help" button is clicked.
 
 ### [`gla_app_ratings_rate_clicked`](../../js/src/components/experience-rating-banner/feedback-modal.js#L21)
 
@@ -231,16 +231,16 @@ When the user clicks the "Need help" button on the banner.
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
 #### Emitters
-- [`FeedbackModal`](../../js/src/components/experience-rating-banner/feedback-modal.js#L38) Fired when the user clicks the "Rate us" button.
+- [`FeedbackModal`](../../js/src/components/experience-rating-banner/feedback-modal.js#L39) Fired when the user clicks the "Rate us" button.
 
-### [`gla_app_ratings_shown`](../../js/src/components/experience-rating-banner/index.js#L26)
+### [`gla_app_ratings_shown`](../../js/src/components/experience-rating-banner/index.js#L30)
 When the experience rating banner is displayed to the user.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
 #### Emitters
-- [`ExperienceRatingBanner`](../../js/src/components/experience-rating-banner/index.js#L68) When the banner is shown.
+- [`ExperienceRatingBanner`](../../js/src/components/experience-rating-banner/index.js#L72) When the banner is shown.
 
 ### [`gla_attribute_mapping_create_rule`](../../js/src/pages/attribute-mapping/attribute-mapping-rule-modal.js#L32)
 Creates the rule successfully
@@ -644,7 +644,7 @@ Clicking on the "Yes, I want a new account" button in the warning modal for crea
 #### Emitters
 - [`WarningModal`](../../js/src/components/google-mc-account-card/warning-modal/index.js#L29)
 
-### [`gla_modal_closed`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L44)
+### [`gla_modal_closed`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L51)
 
 #### Properties
 | name | type | description |
@@ -655,8 +655,8 @@ Clicking on the "Yes, I want a new account" button in the warning modal for crea
 #### Emitters
 - [`AttributeMappingTable`](../../js/src/pages/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is closed
 - [`ChangePrice`](../../js/src/pages/price-benchmark/change-price.js#L36) with `{ context: 'price-benchmark-change-price-modal', action: 'change-price' }`
-- [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L67) with `{ context: 'price-benchmark-change-price-modal', action: 'close' }` and the product ID.
-- [`Dashboard`](../../js/src/pages/dashboard/index.js#L33) when CES modal is closed.
+- [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L74) with `{ context: 'price-benchmark-change-price-modal', action: 'close' }` and the product ID.
+- [`Dashboard`](../../js/src/pages/dashboard/index.js#L34) when CES modal is closed.
 - [`ReviewRequest`](../../js/src/pages/product-feed/review-request/index.js#L31) with `action: 'request-review-success' | 'maybe-later' | 'dismiss', context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L155) with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss'`
 
@@ -670,8 +670,8 @@ A modal is closed.
 #### Emitters
 - [`AttributeMappingTable`](../../js/src/pages/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is closed
 - [`ChangePrice`](../../js/src/pages/price-benchmark/change-price.js#L36) with `{ context: 'price-benchmark-change-price-modal', action: 'change-price' }`
-- [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L67) with `{ context: 'price-benchmark-change-price-modal', action: 'close' }` and the product ID.
-- [`Dashboard`](../../js/src/pages/dashboard/index.js#L33) when CES modal is closed.
+- [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L74) with `{ context: 'price-benchmark-change-price-modal', action: 'close' }` and the product ID.
+- [`Dashboard`](../../js/src/pages/dashboard/index.js#L34) when CES modal is closed.
 - [`ReviewRequest`](../../js/src/pages/product-feed/review-request/index.js#L31) with `action: 'request-review-success' | 'maybe-later' | 'dismiss', context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L155) with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss'`
 
@@ -685,7 +685,7 @@ Clicking on a text link within the modal content
 #### Emitters
 - [`ContentLink`](../../js/src/components/guide-page-content/index.js#L46) with given `context, href`
 
-### [`gla_modal_open`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L38)
+### [`gla_modal_open`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L45)
 
 #### Properties
 | name | type | description |
@@ -694,7 +694,7 @@ Clicking on a text link within the modal content
 `product_id` | `number` | The ID of the product whose price is being changed.
 #### Emitters
 - [`AttributeMappingTable`](../../js/src/pages/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is open with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal' }`
-- [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L67) with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
+- [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L74) with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
 - [`ReviewRequest`](../../js/src/pages/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 
@@ -706,7 +706,7 @@ A modal is open
 `context` | `string` | Indicates which modal is open
 #### Emitters
 - [`AttributeMappingTable`](../../js/src/pages/attribute-mapping/attribute-mapping-table.js#L59) When any of the modals is open with `{ context: 'attribute-mapping-manage-rule-modal' | 'attribute-mapping-create-rule-modal' }`
-- [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L67) with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
+- [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L74) with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
 - [`ReviewRequest`](../../js/src/pages/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L155) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 
@@ -768,7 +768,7 @@ Triggered when moving to another step during creating/editing a campaign.
 #### Emitters
 - [`ChangePrice`](../../js/src/pages/price-benchmark/change-price.js#L36) with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
 
-### [`gla_price_benchmarks_change_price_edited`](../../js/src/pages/price-benchmark/change-price-modal/price-input-footer.js#L19)
+### [`gla_price_benchmarks_change_price_edited`](../../js/src/pages/price-benchmark/change-price-modal/price-input-footer.js#L23)
 
 #### Properties
 | name | type | description |
@@ -779,10 +779,11 @@ Triggered when moving to another step during creating/editing a campaign.
 `recommended_price` | `number` | The recommended price for the product.
 `changed_price` | `number` | The new price set for the product.
 `currency` | `string` | The currency of the product price.
+`gtin` | `string` | The global unique identifier (e.g., GTIN) for the product.
 #### Emitters
-- [`PriceInputFooter`](../../js/src/pages/price-benchmark/change-price-modal/price-input-footer.js#L48)
+- [`PriceInputFooter`](../../js/src/pages/price-benchmark/change-price-modal/price-input-footer.js#L52)
 
-### [`gla_price_benchmarks_shown`](../../js/src/pages/price-benchmark/price-benchmark-suggestions/index.js#L167)
+### [`gla_price_benchmarks_shown`](../../js/src/pages/price-benchmark/price-benchmark-suggestions/index.js#L179)
 
 #### Properties
 | name | type | description |
@@ -790,7 +791,7 @@ Triggered when moving to another step during creating/editing a campaign.
 `context` | `string` | The context of the event.
 `suggestions` | `number` | The number of suggestions shown.
 #### Emitters
-- [`PriceBenchmarkSuggestions`](../../js/src/pages/price-benchmark/price-benchmark-suggestions/index.js#L187) with `{ context: 'price-benchmark-suggestions' }` and the suggestions count.
+- [`PriceBenchmarkSuggestions`](../../js/src/pages/price-benchmark/price-benchmark-suggestions/index.js#L199) with `{ context: 'price-benchmark-suggestions' }` and the suggestions count.
 
 ### [`gla_request_review`](../../js/src/pages/product-feed/review-request/review-request-modal.js#L19)
 Triggered when request review button is clicked

--- a/tests/e2e/specs/app-ratings-overview/experience-rating-banner.test.js
+++ b/tests/e2e/specs/app-ratings-overview/experience-rating-banner.test.js
@@ -93,7 +93,7 @@ test.describe( 'App Ratings Banner', () => {
 
 			await expect( needHelpButton ).toHaveAttribute(
 				'href',
-				'https://woocommerce.com'
+				'https://woocommerce.com/my-account/contact-support/'
 			);
 			await expect( needHelpButton ).toHaveAttribute(
 				'target',
@@ -137,14 +137,14 @@ test.describe( 'App Ratings Banner', () => {
 
 		test( 'Feedback modal has action buttons', async () => {
 			const feedbackModal = page.locator( feedbackModalClass );
-			const cancelButton = feedbackModal.getByRole( 'button', {
-				name: 'Cancel',
+			const maybeLaterButton = feedbackModal.getByRole( 'button', {
+				name: 'Maybe later',
 			} );
 			const rateUsButton = feedbackModal.getByRole( 'link', {
 				name: 'Rate us',
 			} );
 
-			await expect( cancelButton ).toBeVisible();
+			await expect( maybeLaterButton ).toBeVisible();
 			await expect( rateUsButton ).toBeVisible();
 		} );
 
@@ -163,12 +163,12 @@ test.describe( 'App Ratings Banner', () => {
 
 		test( 'Cancel button closes the modal', async () => {
 			const feedbackModal = page.locator( feedbackModalClass );
-			const cancelButton = feedbackModal.getByRole( 'button', {
-				name: 'Cancel',
+			const maybeLaterButton = feedbackModal.getByRole( 'button', {
+				name: 'Maybe later',
 			} );
 
-			await expect( cancelButton ).toBeEnabled();
-			await cancelButton.click();
+			await expect( maybeLaterButton ).toBeEnabled();
+			await maybeLaterButton.click();
 
 			const dialog = page
 				.locator( '.gla-experience-rating-feedback-modal' )
@@ -207,6 +207,25 @@ test.describe( 'App Ratings Banner', () => {
 			await expect( closeButton ).toBeVisible();
 			await closeButton.click();
 			await expect( feedbackModal ).not.toBeVisible();
+		} );
+
+		test( 'Clicking the "Rate us" button closes the modal and dismisses the notice', async () => {
+			appRatingsOverview.clickGoodButton();
+
+			await page.waitForSelector( feedbackModalClass, {
+				state: 'visible',
+			} );
+
+			const feedbackModal = page.locator( feedbackModalClass );
+			const rateUsButton = feedbackModal.getByRole( 'link', {
+				name: 'Rate us',
+			} );
+
+			await rateUsButton.click();
+			await expect( feedbackModal ).not.toBeVisible();
+
+			const banner = page.locator( BANNER_CLASS );
+			await expect( banner ).not.toBeVisible();
 		} );
 	} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-198/notification-is-not-dismissed-when-user-clicks-rate-us-button-from-the

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Navigate to the plugin's dashboard.
2. Ensure the app ratings banner is displayed.
3. Click the "Good" button.
4. From the modal, click the "Rate us" button.
5. The modal and the banner should no longer be visible on the page.
6. Reload the page.
7. The banner should not be displayed.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
