### PR TITLE
REST API endpoint to show Ads recommendations

### DIFF
--- a/src/API/Site/Controllers/Ads/RecommendationsController.php
+++ b/src/API/Site/Controllers/Ads/RecommendationsController.php
@@ -3,9 +3,12 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsRecommendationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
 use WP_REST_Request as Request;
@@ -18,7 +21,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads
  */
-class RecommendationsController extends BaseController {
+class RecommendationsController extends BaseController implements ContainerAwareInterface {
+
+	use ContainerAwareTrait;
 
 	/**
 	 * Service used to access / update Ads account data.
@@ -95,56 +100,20 @@ class RecommendationsController extends BaseController {
 					);
 				}
 
-				// TODO: Replace this with real data from AdsRecommendations service.
-				$recommendations = [
-					[
-						'id'              => 1,
-						'type'            => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
-						'resource_name'   => 'customers/123/recommendations/1',
-						'campaign_id'     => 100,
-						'campaign_name'   => 'Test Campaign',
-						'campaign_status' => 'ENABLED',
-						'last_synced'     => gmdate( 'c' ),
-					],
-					[
-						'id'              => 2,
-						'type'            => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
-						'resource_name'   => 'customers/123/recommendations/2',
-						'campaign_id'     => 101,
-						'campaign_name'   => 'Another Campaign',
-						'campaign_status' => 'PAUSED',
-						'last_synced'     => gmdate( 'c' ),
-					],
-				];
+				/** @var AdsRecommendationsService $query */
+				$query = $this->container->get( AdsRecommendationsService::class );
 
-				// If type is set, filter by type (only IMPROVE_PERFORMANCE_MAX_AD_STRENGTH is supported).
-				$type = $request->get_param( 'type' );
-				if ( $type ) {
-					$recommendations = array_filter(
-						$recommendations,
-						static function ( $rec ) use ( $type ) {
-							return $rec['type'] === $type;
-						}
-					);
-				}
+				$type = $request->get_param( 'type' ) ?? 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH';
+				$id   = (int) $request->get_param( 'id' );
 
-				// Filter by id if provided.
-				$id = $request->get_param( 'id' );
-				if ( $id ) {
-					$recommendations = array_filter(
-						$recommendations,
-						static function ( $rec ) use ( $id ) {
-							return (int) $rec['id'] === (int) $id;
-						}
-					);
-				}
+				$recommendations = $query->get_recommendations( $type, $id );
 
-				$prepared = [];
+				$result = [];
 				foreach ( $recommendations as $recommendation ) {
-					$prepared[] = $this->prepare_item_for_response( $recommendation, $request );
+					$result[] = $this->prepare_item_for_response( $recommendation, $request );
 				}
 
-				return new Response( $prepared );
+				return new Response( $result );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}

--- a/src/API/Site/Controllers/Ads/RecommendationsController.php
+++ b/src/API/Site/Controllers/Ads/RecommendationsController.php
@@ -48,7 +48,7 @@ class RecommendationsController extends BaseController {
 				[
 					'methods'             => TransportMethods::READABLE,
 					'callback'            => $this->get_recommendations_callback(),
-					'permission_callback' => $this->get_permission_callback(),
+					//'permission_callback' => $this->get_permission_callback(),
 					'args'                => $this->get_collection_params(),
 				],
 				'schema' => $this->get_api_response_schema_callback(),
@@ -140,7 +140,13 @@ class RecommendationsController extends BaseController {
 					);
 				}
 
-				return new Response( array_values( $recommendations ) );
+				// Prepare each recommendation for response using the schema.
+				$response_data = [];
+				foreach ( $recommendations as $recommendation ) {
+					$response_data[] = $this->prepare_item_for_response( $recommendation, $request );
+				}
+
+				return new Response( array_values( $response_data ) );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}

--- a/src/API/Site/Controllers/Ads/RecommendationsController.php
+++ b/src/API/Site/Controllers/Ads/RecommendationsController.php
@@ -48,7 +48,7 @@ class RecommendationsController extends BaseController {
 				[
 					'methods'             => TransportMethods::READABLE,
 					'callback'            => $this->get_recommendations_callback(),
-					//'permission_callback' => $this->get_permission_callback(),
+					'permission_callback' => $this->get_permission_callback(),
 					'args'                => $this->get_collection_params(),
 				],
 				'schema' => $this->get_api_response_schema_callback(),
@@ -67,7 +67,7 @@ class RecommendationsController extends BaseController {
 				'type'        => 'string',
 				'description' => __( 'Filter recommendations by type', 'google-listings-and-ads' ),
 				// This could also use a callback to get the set of supported recommendation types from the `AdsRecommendations` service.
-				'enum'        => array( 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH' ),
+				'enum'        => [ 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH' ],
 				'required'    => false,
 			],
 			'id'   => [
@@ -95,8 +95,6 @@ class RecommendationsController extends BaseController {
 					);
 				}
 
-				$type = $request->get_param( 'type' );
-
 				// TODO: Replace this with real data from AdsRecommendations service.
 				$recommendations = [
 					[
@@ -120,6 +118,7 @@ class RecommendationsController extends BaseController {
 				];
 
 				// If type is set, filter by type (only IMPROVE_PERFORMANCE_MAX_AD_STRENGTH is supported).
+				$type = $request->get_param( 'type' );
 				if ( $type ) {
 					$recommendations = array_filter(
 						$recommendations,
@@ -140,13 +139,12 @@ class RecommendationsController extends BaseController {
 					);
 				}
 
-				// Prepare each recommendation for response using the schema.
-				$response_data = [];
+				$prepared = [];
 				foreach ( $recommendations as $recommendation ) {
-					$response_data[] = $this->prepare_item_for_response( $recommendation, $request );
+					$prepared[] = $this->prepare_item_for_response( $recommendation, $request );
 				}
 
-				return new Response( array_values( $response_data ) );
+				return new Response( $prepared );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}

--- a/src/API/Site/Controllers/Ads/RecommendationsController.php
+++ b/src/API/Site/Controllers/Ads/RecommendationsController.php
@@ -66,6 +66,8 @@ class RecommendationsController extends BaseController {
 			'type' => [
 				'type'        => 'string',
 				'description' => __( 'Filter recommendations by type', 'google-listings-and-ads' ),
+				// This could also use a callback to get the set of supported recommendation types from the `AdsRecommendations` service.
+				'enum'        => array( 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH' ),
 				'required'    => false,
 			],
 			'id'   => [
@@ -94,11 +96,6 @@ class RecommendationsController extends BaseController {
 				}
 
 				$type = $request->get_param( 'type' );
-
-				// Only support filtering by type IMPROVE_PERFORMANCE_MAX_AD_STRENGTH for now.
-				if ( $type && $type !== 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH' ) {
-					return new Response( [] );
-				}
 
 				// TODO: Replace this with real data from AdsRecommendations service.
 				$recommendations = [

--- a/src/API/Site/Controllers/Ads/RecommendationsController.php
+++ b/src/API/Site/Controllers/Ads/RecommendationsController.php
@@ -1,0 +1,203 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Exception;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class RecommendationsController
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads
+ */
+class RecommendationsController extends BaseController {
+
+	/**
+	 * Service used to access / update Ads account data.
+	 *
+	 * @var AccountService
+	 */
+	protected $account;
+
+	/**
+	 * RecommendationsController constructor.
+	 *
+	 * @param RESTServer     $server
+	 * @param AccountService $account
+	 */
+	public function __construct( RESTServer $server, AccountService $account ) {
+		parent::__construct( $server );
+		$this->account = $account;
+	}
+
+	/**
+	 * Register rest routes with WordPress.
+	 */
+	public function register_routes(): void {
+		$this->register_route(
+			'ads/recommendations',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_recommendations_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+					'args'                => $this->get_collection_params(),
+				],
+				'schema' => $this->get_api_response_schema_callback(),
+			]
+		);
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params(): array {
+		return [
+			'type'    => [
+				'type'        => 'string',
+				'description' => __( 'Filter recommendations by type', 'google-listings-and-ads' ),
+				'required'    => false,
+			],
+			'id'      => [
+				'type'        => 'integer',
+				'description' => __( 'Filter recommendations by unique id', 'google-listings-and-ads' ),
+				'required'    => false,
+			],
+		];
+	}
+
+	/**
+	 * Get the callback function for the list accounts request.
+	 *
+	 * @return callable
+	 */
+	protected function get_recommendations_callback(): callable {
+		return function ( Request $request ) {
+			try {
+				// Checks if the ads account is connected; exits early if not connected to prevent further execution.
+				$account_status = $this->account->get_connected_account();
+				if ( isset( $account_status['status'] ) && 'connected' !== $account_status['status'] ) {
+					return new Response(
+						[ 'message' => __( 'No connected Ads account found.', 'google-listings-and-ads' ) ],
+						403
+					);
+				}
+
+				$type = $request->get_param( 'type' );
+
+				// Only support filtering by type IMPROVE_PERFORMANCE_MAX_AD_STRENGTH for now.
+				if ( $type && $type !== 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH' ) {
+					return new Response( [] );
+				}
+
+				// TODO: Replace this with real data from AdsRecommendations service.
+				$recommendations = [
+					[
+						'id'              => 1,
+						'type'            => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
+						'resource_name'   => 'customers/123/recommendations/1',
+						'campaign_id'     => 100,
+						'campaign_name'   => 'Test Campaign',
+						'campaign_status' => 'ENABLED',
+						'last_synced'     => gmdate( 'c' ),
+					],
+					[
+						'id'              => 2,
+						'type'            => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
+						'resource_name'   => 'customers/123/recommendations/2',
+						'campaign_id'     => 101,
+						'campaign_name'   => 'Another Campaign',
+						'campaign_status' => 'PAUSED',
+						'last_synced'     => gmdate( 'c' ),
+					],
+				];
+
+				// If type is set, filter by type (only IMPROVE_PERFORMANCE_MAX_AD_STRENGTH is supported).
+				if ( $type ) {
+					$recommendations = array_filter(
+						$recommendations,
+						static function ( $rec ) use ( $type ) {
+							return $rec['type'] === $type;
+						}
+					);
+				}
+
+				// Filter by id if provided.
+				$id   = $request->get_param( 'id' );
+				if ( $id ) {
+					$recommendations = array_filter(
+						$recommendations,
+						static function ( $rec ) use ( $id ) {
+							return (int) $rec['id'] === (int) $id;
+						}
+					);
+				}
+
+				return new Response( array_values( $recommendations ) );
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
+		};
+	}
+
+	/**
+	 * Get the item schema for the controller.
+	 *
+	 * @return array
+	 */
+	protected function get_schema_properties(): array {
+		return [
+			'id' => [
+				'type'        => 'integer',
+				'description' => __( 'Recommendation ID.', 'google-listings-and-ads' ),
+			],
+			'type' => [
+				'type'        => 'string',
+				'description' => __( 'Recommendation type.', 'google-listings-and-ads' ),
+			],
+			'resource_name' => [
+				'type'        => 'string',
+				'description' => __( 'Resource name of the recommendation.', 'google-listings-and-ads' ),
+			],
+			'campaign_id' => [
+				'type'        => 'integer',
+				'description' => __( 'Campaign ID associated with the recommendation.', 'google-listings-and-ads' ),
+			],
+			'campaign_name' => [
+				'type'        => 'string',
+				'description' => __( 'Campaign name associated with the recommendation.', 'google-listings-and-ads' ),
+			],
+			'campaign_status' => [
+				'type'        => 'string',
+				'description' => __( 'Status of the campaign.', 'google-listings-and-ads' ),
+				'enum'        => [ 'ENABLED', 'PAUSED', 'REMOVED', 'UNKNOWN', 'UNSPECIFIED' ],
+			],
+			'last_synced' => [
+				'type'        => 'string',
+				'format'      => 'date-time',
+				'description' => __( 'Last synced date and time.', 'google-listings-and-ads' ),
+			],
+		];
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * Used for building the API response schema.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'recommendations';
+	}
+}

--- a/src/API/Site/Controllers/Ads/RecommendationsController.php
+++ b/src/API/Site/Controllers/Ads/RecommendationsController.php
@@ -63,12 +63,12 @@ class RecommendationsController extends BaseController {
 	 */
 	public function get_collection_params(): array {
 		return [
-			'type'    => [
+			'type' => [
 				'type'        => 'string',
 				'description' => __( 'Filter recommendations by type', 'google-listings-and-ads' ),
 				'required'    => false,
 			],
-			'id'      => [
+			'id'   => [
 				'type'        => 'integer',
 				'description' => __( 'Filter recommendations by unique id', 'google-listings-and-ads' ),
 				'required'    => false,
@@ -133,7 +133,7 @@ class RecommendationsController extends BaseController {
 				}
 
 				// Filter by id if provided.
-				$id   = $request->get_param( 'id' );
+				$id = $request->get_param( 'id' );
 				if ( $id ) {
 					$recommendations = array_filter(
 						$recommendations,
@@ -157,23 +157,23 @@ class RecommendationsController extends BaseController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'id' => [
+			'id'              => [
 				'type'        => 'integer',
 				'description' => __( 'Recommendation ID.', 'google-listings-and-ads' ),
 			],
-			'type' => [
+			'type'            => [
 				'type'        => 'string',
 				'description' => __( 'Recommendation type.', 'google-listings-and-ads' ),
 			],
-			'resource_name' => [
+			'resource_name'   => [
 				'type'        => 'string',
 				'description' => __( 'Resource name of the recommendation.', 'google-listings-and-ads' ),
 			],
-			'campaign_id' => [
+			'campaign_id'     => [
 				'type'        => 'integer',
 				'description' => __( 'Campaign ID associated with the recommendation.', 'google-listings-and-ads' ),
 			],
-			'campaign_name' => [
+			'campaign_name'   => [
 				'type'        => 'string',
 				'description' => __( 'Campaign name associated with the recommendation.', 'google-listings-and-ads' ),
 			],
@@ -182,7 +182,7 @@ class RecommendationsController extends BaseController {
 				'description' => __( 'Status of the campaign.', 'google-listings-and-ads' ),
 				'enum'        => [ 'ENABLED', 'PAUSED', 'REMOVED', 'UNKNOWN', 'UNSPECIFIED' ],
 			],
-			'last_synced' => [
+			'last_synced'     => [
 				'type'        => 'string',
 				'format'      => 'date-time',
 				'description' => __( 'Last synced date and time.', 'google-listings-and-ads' ),

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -21,6 +21,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\Reports
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\SetupCompleteController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AssetGroupController as AdsAssetGroupController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AssetSuggestionsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\RecommendationsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\GTINMigrationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestAPI\SyncController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\TourController;
@@ -148,6 +149,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( GTINMigrationController::class, JobRepository::class );
 		$this->share( PriceBenchmarksController::class );
 		$this->share( SyncController::class, NotificationsService::class );
+		$this->share( RecommendationsController::class, AdsAccountService::class );
 	}
 
 	/**

--- a/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\RecommendationsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class RecommendationsControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads
+ */
+class RecommendationsControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|AccountService $account */
+	protected $account;
+
+	/** @var RecommendationsController $controller */
+	protected $controller;
+
+	protected const ROUTE_RECOMMENDATIONS = '/wc/gla/ads/recommendations';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->account    = $this->createMock( AccountService::class );
+		$this->controller = new RecommendationsController( $this->server, $this->account );
+		$this->controller->register();
+	}
+
+	public function test_get_recommendations_returns_all_recommendations() {
+		$this->account->method( 'get_connected_account' )
+			->willReturn( [ 'status' => 'connected' ] );
+
+		$response = $this->do_request( self::ROUTE_RECOMMENDATIONS, 'GET' );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertCount( 2, $data );
+		$this->assertEquals( 1, $data[0]['id'] );
+		$this->assertEquals( 2, $data[1]['id'] );
+	}
+
+	public function test_get_recommendations_returns_empty_array_when_no_recommendations() {
+		$this->account->method( 'get_connected_account' )
+			->willReturn( [ 'status' => 'connected' ] );
+
+		$filter_by_type = [
+			'type' => 'NON_EXISTENT_TYPE',
+		];
+
+		// Filter by a type that does not exist in the stubbed recommendations.
+		$response = $this->do_request( self::ROUTE_RECOMMENDATIONS, 'GET', $filter_by_type );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertCount( 0, $data );
+	}
+
+	public function test_get_recommendations_returns_error_if_account_not_connected() {
+		$this->account->method( 'get_connected_account' )
+			->willReturn( [ 'status' => 'not_connected' ] );
+
+		$response = $this->do_request( self::ROUTE_RECOMMENDATIONS, 'GET' );
+
+		$this->assertEquals( 403, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'message', $data );
+		$this->assertEquals( 'No connected Ads account found.', $data['message'] );
+	}
+
+	public function test_get_recommendations_filter_by_type_returns_only_matching() {
+		$this->account->method( 'get_connected_account' )
+			->willReturn( [ 'status' => 'connected' ] );
+
+		$filter_by_type = [
+			'type' => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
+		];
+
+		// Filter by a type that does not exist in the stubbed recommendations.
+		$response = $this->do_request( self::ROUTE_RECOMMENDATIONS, 'GET', $filter_by_type );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertCount( 2, $data );
+		foreach ( $data as $rec ) {
+			$this->assertEquals( 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH', $rec['type'] );
+		}
+	}
+
+	public function test_get_recommendations_filter_by_id_returns_single_recommendation() {
+		$this->account->method( 'get_connected_account' )
+			->willReturn( [ 'status' => 'connected' ] );
+
+		$filter_by_id = [
+			'id' => 2,
+		];
+
+		// Filter by a type that does not exist in the stubbed recommendations.
+		$response = $this->do_request( self::ROUTE_RECOMMENDATIONS, 'GET', $filter_by_id );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertCount( 1, $data );
+		$this->assertEquals( 2, $data[0]['id'] );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
@@ -2,10 +2,12 @@
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\Ads;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsRecommendationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\RecommendationsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_REST_Response as Response;
@@ -23,19 +25,57 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 	/** @var RecommendationsController $controller */
 	protected $controller;
 
+	/** @var MockObject|AdsRecommendationsService */
+	protected $recommendations;
+
+	/** @var Container */
+	protected $container;
+
 	protected const ROUTE_RECOMMENDATIONS = '/wc/gla/ads/recommendations';
 
 	public function setUp(): void {
 		parent::setUp();
 
+		$this->recommendations = $this->createMock( AdsRecommendationsService::class );
+
+		// Mock the container to return the mocked AdsRecommendationsService.
+		$this->container = new Container();
+		$this->container->addShared( AdsRecommendationsService::class, $this->recommendations );
+
 		$this->account    = $this->createMock( AccountService::class );
 		$this->controller = new RecommendationsController( $this->server, $this->account );
+		$this->controller->set_container( $this->container );
 		$this->controller->register();
 	}
 
 	public function test_get_recommendations_returns_all_recommendations() {
 		$this->account->method( 'get_connected_account' )
 			->willReturn( [ 'status' => 'connected' ] );
+
+		$mock_recommendations_data = [
+			[
+				'id'              => 1,
+				'type'            => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
+				'resource_name'   => 'customers/123/recommendations/1',
+				'campaign_id'     => 100,
+				'campaign_name'   => 'Test Campaign',
+				'campaign_status' => 'ENABLED',
+				'last_synced'     => gmdate( 'c' ),
+			],
+			[
+				'id'              => 2,
+				'type'            => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
+				'resource_name'   => 'customers/123/recommendations/2',
+				'campaign_id'     => 101,
+				'campaign_name'   => 'Another Campaign',
+				'campaign_status' => 'PAUSED',
+				'last_synced'     => gmdate( 'c' ),
+			],
+		];
+
+		$this->recommendations->expects( $this->once() )
+			->method( 'get_recommendations' )
+			->willReturn( $mock_recommendations_data );
 
 		$response = $this->do_request( self::ROUTE_RECOMMENDATIONS, 'GET' );
 
@@ -86,6 +126,48 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 			'type' => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
 		];
 
+		$mock_recommendations_data = [
+			[
+				'id'              => 1,
+				'type'            => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
+				'resource_name'   => 'customers/123/recommendations/1',
+				'campaign_id'     => 100,
+				'campaign_name'   => 'Test Campaign',
+				'campaign_status' => 'ENABLED',
+				'last_synced'     => gmdate( 'c' ),
+			],
+			[
+				'id'              => 2,
+				'type'            => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
+				'resource_name'   => 'customers/123/recommendations/2',
+				'campaign_id'     => 101,
+				'campaign_name'   => 'Another Campaign',
+				'campaign_status' => 'PAUSED',
+				'last_synced'     => gmdate( 'c' ),
+			],
+			[
+				'id'              => 3,
+				'type'            => 'CAMPAIGN_BUDGET',
+				'resource_name'   => 'customers/124/recommendations/3',
+				'campaign_id'     => 103,
+				'campaign_name'   => 'Another Campaign 03',
+				'campaign_status' => 'PAUSED',
+				'last_synced'     => gmdate( 'c' ),
+			],
+		];
+
+		// Only return the recommendation matching the filter.
+		$filtered_mock_data = array_filter(
+			$mock_recommendations_data,
+			function ( $rec ) use ( $filter_by_type ) {
+				return $rec['type'] === $filter_by_type['type'];
+			}
+		);
+
+		$this->recommendations->expects( $this->once() )
+			->method( 'get_recommendations' )
+			->willReturn( $filtered_mock_data );
+
 		// Filter by a type that does not exist in the stubbed recommendations.
 		$response = $this->do_request( self::ROUTE_RECOMMENDATIONS, 'GET', $filter_by_type );
 
@@ -104,11 +186,43 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 		$this->account->method( 'get_connected_account' )
 			->willReturn( [ 'status' => 'connected' ] );
 
+		$mock_recommendations_data = [
+			[
+				'id'              => 1,
+				'type'            => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
+				'resource_name'   => 'customers/123/recommendations/1',
+				'campaign_id'     => 100,
+				'campaign_name'   => 'Test Campaign',
+				'campaign_status' => 'ENABLED',
+				'last_synced'     => gmdate( 'c' ),
+			],
+			[
+				'id'              => 2,
+				'type'            => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
+				'resource_name'   => 'customers/123/recommendations/2',
+				'campaign_id'     => 101,
+				'campaign_name'   => 'Another Campaign',
+				'campaign_status' => 'PAUSED',
+				'last_synced'     => gmdate( 'c' ),
+			],
+		];
+
 		$filter_by_id = [
 			'id' => 2,
 		];
 
-		// Filter by a type that does not exist in the stubbed recommendations.
+		// Only return the recommendation matching the filter.
+		$filtered_mock_data = array_filter(
+			$mock_recommendations_data,
+			function ( $rec ) use ( $filter_by_id ) {
+				return $rec['id'] === $filter_by_id['id'];
+			}
+		);
+
+		$this->recommendations->expects( $this->once() )
+			->method( 'get_recommendations' )
+			->willReturn( array_values( $filtered_mock_data ) );
+
 		$response = $this->do_request( self::ROUTE_RECOMMENDATIONS, 'GET', $filter_by_id );
 
 		$this->assertEquals( 200, $response->get_status() );

--- a/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
+use WP_REST_Response as Response;
 
 /**
  * Class RecommendationsControllerTest
@@ -43,8 +44,10 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 		$data = $response->get_data();
 		$this->assertIsArray( $data );
 		$this->assertCount( 2, $data );
-		$this->assertEquals( 1, $data[0]['id'] );
-		$this->assertEquals( 2, $data[1]['id'] );
+		$this->assertInstanceOf( Response::class, $data[0] );
+		$this->assertInstanceOf( Response::class, $data[1] );
+		$this->assertEquals( 1, $data[0]->get_data()['id'] );
+		$this->assertEquals( 2, $data[1]->get_data()['id'] );
 	}
 
 	public function test_get_recommendations_returns_empty_array_when_no_recommendations() {
@@ -58,11 +61,8 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 		// Filter by a type that does not exist in the stubbed recommendations.
 		$response = $this->do_request( self::ROUTE_RECOMMENDATIONS, 'GET', $filter_by_type );
 
-		$this->assertEquals( 200, $response->get_status() );
-
-		$data = $response->get_data();
-		$this->assertIsArray( $data );
-		$this->assertCount( 0, $data );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
 	}
 
 	public function test_get_recommendations_returns_error_if_account_not_connected() {
@@ -94,8 +94,9 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 		$data = $response->get_data();
 		$this->assertIsArray( $data );
 		$this->assertCount( 2, $data );
-		foreach ( $data as $rec ) {
-			$this->assertEquals( 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH', $rec['type'] );
+		foreach ( $data as $key => $rec ) {
+			$this->assertInstanceOf( Response::class, $data[ $key ] );
+			$this->assertEquals( 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH', $rec->get_data()['type'] );
 		}
 	}
 
@@ -115,6 +116,7 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 		$data = $response->get_data();
 		$this->assertIsArray( $data );
 		$this->assertCount( 1, $data );
-		$this->assertEquals( 2, $data[0]['id'] );
+		$this->assertInstanceOf( Response::class, $data[0] );
+		$this->assertEquals( 2, $data[0]->get_data()['id'] );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-179/create-rest-api-endpoint-to-show-ads-recommendations.

### Detailed test instructions:
- Add `add_filter( 'woocommerce_gla_force_run_install', '__return_true' );` filter in your mu-plugin to create DB `wp_gla_ads_recommendations` table.
- Insert the dummy data in table using below query
```sql
INSERT INTO `wp_gla_ads_recommendations` (`recommendation_id`, `recommendation_type`, `recommendation_resource_name`, `recommendation_campaign_id`, `recommendation_campaign_name`, `recommendation_campaign_status`, `recommendation_customer_id`, `recommendation_last_synced`) VALUES
(1,	'TESTING',	'customers/123/recommendations/1',	100,	'Test Campaign',	'ENABLED',	123,	'2025-06-26 15:20:22'),
(2,	'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',	'customers/123/recommendations/2',	101,	'Another Campaign',	'PAUSED',	123,	'2025-06-27 12:00:00');
```
- Comment the permission callback in your local setup.
- Check the Rest API response. Call `siteurl/index.php?rest_route=/wc/gla/ads/recommendations` (it returns the dummy recommendations for now)
- Check the Rest API response for `type` and `id` filter. e.g. `siteurl/index.php?rest_route=/wc/gla/ads/recommendations/&id=2` 0r `siteurl/index.php?rest_route=/wc/gla/ads/recommendations/&type=IMPROVE_PERFORMANCE_MAX_AD_STRENGTH`
- `siteurl/index.php?rest_route=/wc/gla/ads/recommendations&type=TESTING` will return error as endpoint only support IMPROVE_PERFORMANCE_MAX_AD_STRENGTH type
- Disabled the Ads account from your setup `Google for WooCommerce > Settings > Click on "Disconnect Google Ads account only` and verify it will show 403 error.