### PR TITLE
Remove WPCOM API authorization check as authorization is granted by default

### DIFF
--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -130,7 +130,6 @@ class NotificationsService implements Service, OptionsAwareInterface {
 				'message'                     => 'Notification was not sent because the Notification Service is not ready or the topic is not valid.',
 				'data_type'                   => $this->get_datatype_from_topic( $topic ),
 				'topic_is_valid'              => $this->yes_or_no( $is_valid_topic ),
-				'wpcom_authorized'            => $this->yes_or_no( $this->options->is_wpcom_api_authorized() ),
 				'wpcom_healthy'               => $this->yes_or_no( $this->account_service->is_wpcom_api_status_healthy() ),
 				'mc_sync_ready'               => $this->yes_or_no( $this->merchant_center->is_ready_for_syncing() ),
 				'notification_service_status' => $this->enabled_or_disabled( $this->is_enabled() ),
@@ -206,14 +205,14 @@ class NotificationsService implements Service, OptionsAwareInterface {
 
 	/**
 	 * If the Notifications are ready
-	 * This happens when the WPCOM API is Authorized and the feature is enabled.
+	 * This happens when the feature is enabled and Merchant Center is ready for syncing.
 	 *
 	 * @param string|null $data_type The data type to check.
 	 * @param bool        $with_health_check If true. Performs a remote request to WPCOM API to get the status.
 	 *        * @return bool
 	 */
 	public function is_ready( string $data_type = null, bool $with_health_check = true ): bool {
-		$is_ready = $this->options->is_wpcom_api_authorized() && $this->is_enabled() && $this->merchant_center->is_ready_for_syncing() && ( $with_health_check === false || $this->account_service->is_wpcom_api_status_healthy() );
+		$is_ready = $this->is_enabled() && $this->merchant_center->is_ready_for_syncing() && ( $with_health_check === false || $this->account_service->is_wpcom_api_status_healthy() );
 		return $is_ready && ( is_null( $data_type ) || $this->is_pull_enabled_for_datatype( $data_type ) );
 	}
 

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -207,12 +207,4 @@ final class Options implements OptionsInterface, Service {
 		return "{$this->get_slug()}_{$name}";
 	}
 
-	/**
-	 * Checks if WPCOM API is Authorized.
-	 *
-	 * @return bool
-	 */
-	public function is_wpcom_api_authorized(): bool {
-		return $this->get( self::WPCOM_REST_API_STATUS ) === 'approved';
-	}
 }

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -206,5 +206,4 @@ final class Options implements OptionsInterface, Service {
 	protected function prefix_name( string $name ): string {
 		return "{$this->get_slug()}_{$name}";
 	}
-
 }

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -153,10 +153,4 @@ interface OptionsInterface {
 	 */
 	public function get_ads_id(): int;
 
-	/**
-	 * If the WPCOM API is authorized
-	 *
-	 * @return bool
-	 */
-	public function is_wpcom_api_authorized(): bool;
 }

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -152,5 +152,4 @@ interface OptionsInterface {
 	 * @return int
 	 */
 	public function get_ads_id(): int;
-
 }

--- a/src/Tracking/TrackerSnapshot.php
+++ b/src/Tracking/TrackerSnapshot.php
@@ -97,7 +97,6 @@ class TrackerSnapshot implements ContainerAwareInterface, OptionsAwareInterface,
 			'ads_setup_started'               => $ads_service->is_setup_started() ? 'yes' : 'no',
 			'ads_customer_id'                 => $this->options->get_ads_id(),
 			'ads_campaign_count'              => $merchant_metrics->get_campaign_count(),
-			'wpcom_api_authorized'            => $this->options->is_wpcom_api_authorized(),
 		];
 	}
 

--- a/tests/Unit/API/WP/NotificationsServiceTest.php
+++ b/tests/Unit/API/WP/NotificationsServiceTest.php
@@ -244,9 +244,8 @@ class NotificationsServiceTest extends UnitTest {
 	 * Mocks the service
 	 *
 	 * @param bool $mc_ready
-	 * @param bool $wpcom_authorized
 	 * @param bool $is_wpcom_api_status_healthy
-	 * @return TransformerService
+	 * @return NotificationsService
 	 */
 	public function get_mock( $mc_ready = true, $is_wpcom_api_status_healthy = true ) {
 		$this->merchant_center = $this->createMock( MerchantCenterService::class );

--- a/tests/Unit/API/WP/NotificationsServiceTest.php
+++ b/tests/Unit/API/WP/NotificationsServiceTest.php
@@ -191,15 +191,6 @@ class NotificationsServiceTest extends UnitTest {
 		$this->assertEquals( did_action( 'woocommerce_gla_error' ), 1 );
 	}
 
-	/**
-	 * Test notify() function logs an error when WPCOM Auth is not authorized
-	 */
-	public function test_notify_show_error_when_wpcom_not_authorized() {
-		$this->service = $this->get_mock( true, false );
-		$this->service->expects( $this->never() )->method( 'do_request' );
-		$this->assertFalse( $this->service->notify( 'product.create', 1 ) );
-		$this->assertEquals( did_action( 'woocommerce_gla_error' ), 1 );
-	}
 
 	/**
 	 * Test notify() function logs an error when disabled
@@ -231,14 +222,14 @@ class NotificationsServiceTest extends UnitTest {
 	 * Test notify() function logs an error when WPCOM Auth is not healthy
 	 */
 	public function test_notify_show_error_when_wpcom_not_healthy() {
-		$this->service = $this->get_mock( true, true, false );
+		$this->service = $this->get_mock( true, false );
 		$this->service->expects( $this->never() )->method( 'do_request' );
 		$this->assertFalse( $this->service->notify( 'product.create', 1 ) );
 		$this->assertEquals( did_action( 'woocommerce_gla_error' ), 1 );
 	}
 
 	public function test_is_ready_not_calling_status_api_if_with_health_check_is_false() {
-		$this->service = $this->get_mock( true, true, false );
+		$this->service = $this->get_mock( true, false );
 		$this->account->expects( $this->never() )->method( 'is_wpcom_api_status_healthy' );
 		$this->assertTrue( $this->service->is_ready( null, false ) );
 	}
@@ -257,13 +248,12 @@ class NotificationsServiceTest extends UnitTest {
 	 * @param bool $is_wpcom_api_status_healthy
 	 * @return TransformerService
 	 */
-	public function get_mock( $mc_ready = true, $wpcom_authorized = true, $is_wpcom_api_status_healthy = true ) {
+	public function get_mock( $mc_ready = true, $is_wpcom_api_status_healthy = true ) {
 		$this->merchant_center = $this->createMock( MerchantCenterService::class );
 		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( $mc_ready );
 		$this->account = $this->createMock( AccountService::class );
 		$this->account->method( 'is_wpcom_api_status_healthy' )->willReturn( $is_wpcom_api_status_healthy );
 		$this->options = $this->createMock( OptionsInterface::class );
-		$this->options->method( 'is_wpcom_api_authorized' )->willReturn( $wpcom_authorized );
 
 		/** @var NotificationsService $mock */
 		$mock = $this->getMockBuilder( NotificationsService::class )


### PR DESCRIPTION
## Summary

- Remove `is_wpcom_api_authorized()` method from Options and OptionsInterface classes
- Update NotificationsService to remove redundant authorization checks from business logic
- Clean up authorization-related fields from error logging and analytics tracking
- Update unit tests to remove authorization-specific test scenarios

## Background

Authorization is now granted by default, making the WPCOM API authorization check redundant. This change simplifies the codebase by removing unnecessary validation while maintaining robust functionality through other existing checks.

## Changes Made

### Core Changes
- **OptionsInterface.php**: Removed `is_wpcom_api_authorized()` method declaration
- **Options.php**: Removed `is_wpcom_api_authorized()` method implementation
- **NotificationsService.php**: 
  - Removed authorization check from `is_ready()` method (line 216)
  - Removed `wpcom_authorized` field from error logging debug output (line 133)
  - Updated method documentation to reflect authorization is no longer required
- **TrackerSnapshot.php**: Removed `wpcom_api_authorized` field from analytics tracking data

### Test Updates
- **NotificationsServiceTest.php**: 
  - Removed `test_notify_show_error_when_wpcom_not_authorized()` test method
  - Updated `get_mock()` method signature to remove `$wpcom_authorized` parameter
  - Updated test method calls to match new mock signature

## Remaining Validation

The NotificationsService `is_ready()` method still maintains robust validation through:
- ✅ Feature enablement check (`is_enabled()`)
- ✅ Merchant Center readiness validation (`is_ready_for_syncing()`) 
- ✅ WordPress.com API health verification (`is_wpcom_api_status_healthy()`)
- ✅ Data type-specific sync settings (`is_pull_enabled_for_datatype()`)

## Test Plan

- [ ] Run unit tests to ensure no regressions: `composer test`
- [ ] Verify NotificationService continues to function correctly
- [ ] Confirm error logging still provides useful debug information
- [ ] Test that analytics tracking data is still collected properly
- [ ] Ensure linting passes: `composer lint`

🤖 Generated with [Claude Code](https://claude.ai/code)

### Changelog entry
