### PR TITLE
Prevent user from continuing if minimum shipping time is not set

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
+++ b/js/src/components/free-listings/configure-product-listings/__snapshots__/checkErrors.test.js.snap
@@ -26,6 +26,8 @@ exports[`checkErrors Shipping times For flat type When there are any selected co
 
 exports[`checkErrors Shipping times For flat type When there are any shipping times are < 0, should not pass 1`] = `"Please specify estimated shipping times for all the countries, and the time cannot be less than 0."`;
 
+exports[`checkErrors Shipping times For flat type shouldnt pass if min or max time is null 1`] = `"The minimum shipping time must not be more than the maximum shipping time."`;
+
 exports[`checkErrors Shipping times For flat type shouldnt pass if min time is bigger than max time 1`] = `"The minimum shipping time must not be more than the maximum shipping time."`;
 
 exports[`checkErrors Shipping times When the type of shipping time is an invalid value or missing, should not pass 1`] = `"Please select a shipping time option."`;

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.js
@@ -77,7 +77,13 @@ const checkErrors = ( values, shippingTimes, finalCountryCodes ) => {
 	if (
 		values.shipping_time === 'flat' &&
 		( shippingTimes.length < finalCountryCodes.length ||
-			shippingTimes.some( ( el ) => el.time < 0 || el.maxTime < 0 ) )
+			shippingTimes.some(
+				( el ) =>
+					el.time < 0 ||
+					el.time === null ||
+					el.maxTime < 0 ||
+					el.maxTime === null
+			) )
 	) {
 		errors.shipping_country_times = __(
 			'Please specify estimated shipping times for all the countries, and the time cannot be less than 0.',

--- a/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
+++ b/js/src/components/free-listings/configure-product-listings/checkErrors.test.js
@@ -385,7 +385,7 @@ describe( 'checkErrors', () => {
 				expect( errors ).not.toHaveProperty( 'shipping_time' );
 			} );
 
-			it( `When there are any shipping times are < 0, should not pass`, () => {
+			it( 'When there are any shipping times are < 0, should not pass', () => {
 				const times = toTimes( [ 'US', 10, 10 ], [ 'JP', -1, -1 ] );
 				const codes = [ 'US', 'JP' ];
 
@@ -395,7 +395,7 @@ describe( 'checkErrors', () => {
 				expect( errors.shipping_country_times ).toMatchSnapshot();
 			} );
 
-			it( `When minimum times is < 0, should not pass`, () => {
+			it( 'When minimum times is < 0, should not pass', () => {
 				const times = toTimes( [ 'US', 10, 10 ], [ 'JP', -1, 10 ] );
 				const codes = [ 'US', 'JP' ];
 
@@ -405,7 +405,7 @@ describe( 'checkErrors', () => {
 				expect( errors.shipping_country_times ).toMatchSnapshot();
 			} );
 
-			it( `When minimum max_time is < 0, should not pass`, () => {
+			it( 'When minimum max_time is < 0, should not pass', () => {
 				const times = toTimes( [ 'US', 10, 10 ], [ 'JP', 1, -10 ] );
 				const codes = [ 'US', 'JP' ];
 
@@ -415,7 +415,7 @@ describe( 'checkErrors', () => {
 				expect( errors.shipping_country_times ).toMatchSnapshot();
 			} );
 
-			it( `When all shipping times are ≥ 0, should pass`, () => {
+			it( 'When all shipping times are ≥ 0, should pass', () => {
 				const times = toTimes( [ 'US', 1, 1 ], [ 'JP', 0, 0 ] );
 				const codes = [ 'US', 'JP' ];
 
@@ -424,8 +424,18 @@ describe( 'checkErrors', () => {
 				expect( errors ).not.toHaveProperty( 'shipping_time' );
 			} );
 
-			it( `shouldnt pass if min time is bigger than max time`, () => {
+			it( 'shouldnt pass if min time is bigger than max time', () => {
 				const times = toTimes( [ 'US', 1, 0 ], [ 'JP', 1, 1 ] );
+				const codes = [ 'US', 'JP' ];
+
+				const errors = checkErrors( flatShipping, times, codes );
+
+				expect( errors ).toHaveProperty( 'shipping_country_times' );
+				expect( errors.shipping_country_times ).toMatchSnapshot();
+			} );
+
+			it( 'shouldnt pass if min or max time is null', () => {
+				const times = toTimes( [ 'US', null, 1 ], [ 'JP', 1, null ] );
 				const codes = [ 'US', 'JP' ];
 
 				const errors = checkErrors( flatShipping, times, codes );

--- a/js/src/components/free-listings/configure-product-listings/shipping-time-setup/shipping-countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time-setup/shipping-countries-form.js
@@ -47,7 +47,7 @@ export default function ShippingCountriesForm( {
 	}
 
 	// Given the limitations of `<Form>` component we can communicate up only onChange.
-	// Therefore we loose the infromation whether it was add, change, delete.
+	// Therefore we loose the information whether it was add, change, delete.
 	// In autosave/setup MC case, we would have to either re-calculate to deduct that information,
 	// or fix that in `<Form>` component.
 	function handleDelete( deletedCountries ) {

--- a/tests/e2e/specs/onboarding/step-2-product-listings.test.js
+++ b/tests/e2e/specs/onboarding/step-2-product-listings.test.js
@@ -161,6 +161,7 @@ test.describe( 'Configure product listings', () => {
 
 	test.describe( 'Shipping rate is simple', () => {
 		test.beforeAll( async () => {
+			await productListingsPage.fulfillShippingTimes( [] );
 			await page.reload();
 
 			// Check another shipping rate first in case the simple shipping rate radio button is already checked.
@@ -217,6 +218,13 @@ test.describe( 'Configure product listings', () => {
 			const minimumOrderForFreeShippingText =
 				productListingsPage.getMinimumOrderForFreeShippingText();
 			await expect( minimumOrderForFreeShippingText ).toBeVisible();
+		} );
+
+		test( 'should show error message if min or max shipping time is not set', async () => {
+			await productListingsPage.clickContinueButton();
+			const estimatedTimesError =
+				productListingsPage.getEstimatedShippingTimesNullError();
+			await expect( estimatedTimesError ).toBeVisible();
 		} );
 
 		test( 'should show error message if min shipping time is bigger than max time', async () => {

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -920,4 +920,19 @@ export default class MockRequests {
 			[ 'GET' ]
 		);
 	}
+
+	/**
+	 * Fulfills a mock request for the shipping times endpoint.
+	 *
+	 * @param {Object} payload - The mock response payload to be returned.
+	 * @return {Promise<void>} A promise that resolves when the request is fulfilled.
+	 */
+	async fulfillShippingTimes( payload, status = 200 ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/mc\/shipping\/times\b/,
+			payload,
+			status,
+			[ 'GET' ]
+		);
+	}
 }

--- a/tests/e2e/utils/pages/onboarding/step-2-product-listings.js
+++ b/tests/e2e/utils/pages/onboarding/step-2-product-listings.js
@@ -199,6 +199,17 @@ export default class ProductListingsPage extends MockRequests {
 	}
 
 	/**
+	 * Get estimated shipping rates null error.
+	 *
+	 * @return {import('@playwright/test').Locator} Get estimated shipping rates null error.
+	 */
+	getEstimatedShippingTimesNullError() {
+		return this.getEstimatedShippingTimesCard().getByText(
+			'Please specify estimated shipping times for all the countries, and the time cannot be less than 0.'
+		);
+	}
+
+	/**
 	 * Get "Free shipping for all orders" tag.
 	 *
 	 * @return {import('@playwright/test').Locator} Get "Free shipping for all orders" tag.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-203/step-2-onboarding-allows-progression-without-required-shipping-speed

_Replace this with a good description of your changes & reasoning._


### Screenshots:
![image](https://github.com/user-attachments/assets/1136ce0e-987d-4d11-bc1e-625186b60424)

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Navigate to the user onboarding flow.
2. Proceed past the "Set up your accounts" step.
3. On the "Configure product listings" step, verify that the "Estimated shipping times" input fields (min and max) are empty by default.
4. Click the "Continue" button.
5. Confirm that the user cannot proceed because the shipping times are not set.
6. Enter a value in the "max" input field only.
7. Click "Continue" again without entering a value in the "min" input field or interacting with the "min" input field (no focus).
8. Confirm that the user is still blocked from proceeding.
9. Enter values in both the "min" and "max" fields.
10. Verify that the user can now proceed to the next step.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Prevent the user from continuing if the minimum shipping time is not set.
