### PR TITLE
Fix WPCOM API partner token validation for client credentials

### DIFF
--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -679,7 +679,7 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 				$status = [ 'is_healthy' => false ];
 			} else {
 				$status = json_decode( wp_remote_retrieve_body( $integration_remote_request_response ), true ) ?? [ 'is_healthy' => false ];
-				
+
 				/*
 				 * Since we switched from OAuth to client credentials,
 				 * WPCOM's partner token validation returns false. Inject true status until

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -226,6 +226,15 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		$id                    = $this->options->get_merchant_id();
 		$wpcom_rest_api_status = $this->options->get( OptionsInterface::WPCOM_REST_API_STATUS );
 
+		/*
+		 * Since we switched to client credentials, authorization is granted by default.
+		 * Set status to 'approved' if not set. This code is preserved for future UI functionality.
+		 */
+		if ( ! $wpcom_rest_api_status ) {
+			$wpcom_rest_api_status = OAuthService::STATUS_APPROVED;
+			$this->options->update( OptionsInterface::WPCOM_REST_API_STATUS, $wpcom_rest_api_status );
+		}
+
 		// If token is revoked outside the extension. Set the status as error to force the merchant to grant access again.
 		if ( $wpcom_rest_api_status === 'approved' && ! $this->is_wpcom_api_status_healthy() ) {
 			$wpcom_rest_api_status = OAuthService::STATUS_ERROR;
@@ -670,6 +679,15 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 				$status = [ 'is_healthy' => false ];
 			} else {
 				$status = json_decode( wp_remote_retrieve_body( $integration_remote_request_response ), true ) ?? [ 'is_healthy' => false ];
+				
+				/*
+				 * Since we switched from OAuth to client credentials,
+				 * WPCOM's partner token validation returns false. Inject true status until
+				 * the issue is resolved. Preserving for future UI functionality.
+				 */
+				if ( isset( $status['is_partner_token_healthy'] ) && ! $status['is_partner_token_healthy'] ) {
+					$status['is_partner_token_healthy'] = true;
+				}
 			}
 
 			$transients->set( TransientsInterface::WPCOM_API_STATUS, $status, MINUTE_IN_SECONDS * 30 );

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -867,7 +867,7 @@ class AccountServiceTest extends UnitTest {
 			->getMock();
 		$account_mock->set_container( $this->container );
 		$account_mock->set_options_object( $this->options );
-		
+	
 		// Mock the health check to return true (simulating client credentials success)
 		$account_mock->expects( $this->any() )
 			->method( 'is_wpcom_api_status_healthy' )

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -867,7 +867,7 @@ class AccountServiceTest extends UnitTest {
 			->getMock();
 		$account_mock->set_container( $this->container );
 		$account_mock->set_options_object( $this->options );
-	
+
 		// Mock the health check to return true (simulating client credentials success)
 		$account_mock->expects( $this->any() )
 			->method( 'is_wpcom_api_status_healthy' )

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -860,6 +860,19 @@ class AccountServiceTest extends UnitTest {
 	}
 
 	public function test_get_connected_status_incomplete() {
+		// Create partial mock to mock is_wpcom_api_status_healthy method
+		$account_mock = $this->getMockBuilder( AccountService::class )
+			->setConstructorArgs( [ $this->state ] )
+			->onlyMethods( [ 'is_wpcom_api_status_healthy' ] )
+			->getMock();
+		$account_mock->set_container( $this->container );
+		$account_mock->set_options_object( $this->options );
+		
+		// Mock the health check to return true (simulating client credentials success)
+		$account_mock->expects( $this->any() )
+			->method( 'is_wpcom_api_status_healthy' )
+			->willReturn( true );
+
 		$this->options->expects( $this->once() )
 			->method( 'get_merchant_id' )
 			->willReturn( self::TEST_ACCOUNT_ID );
@@ -878,9 +891,9 @@ class AccountServiceTest extends UnitTest {
 				'status'                       => 'incomplete',
 				'step'                         => 'verify',
 				'notification_service_enabled' => true,
-				'wpcom_rest_api_status'        => null,
+				'wpcom_rest_api_status'        => 'approved',  // Updated to reflect new client credentials logic
 			],
-			$this->account->get_connected_status()
+			$account_mock->get_connected_status()
 		);
 	}
 


### PR DESCRIPTION
## Summary

Fixes WPCOM API health checks that are failing after switching from OAuth to client credentials in INTEGRA-48. The system incorrectly reports partner token as unhealthy, causing authorization status to be set to 'error' and blocking functionality.

## Root Cause

- WPCOM's `/wc/partners/google/remote-site-status` endpoint still validates OAuth-based partner tokens
- Returns `is_partner_token_healthy: false` for client credentials authentication
- Causes `get_connected_status()` to set `WPCOM_REST_API_STATUS` to 'error' instead of 'approved'
- Results in broken UI states and blocked notifications/sync functionality

## Changes Made

### 1. Fix partner token health check in `AccountService::is_wpcom_api_status_healthy()`
- Inject `is_partner_token_healthy: true` when WPCOM returns false
- Preserve existing logic for future compatibility
- Add comment explaining temporary fix until INTEGRA-50 updates WPCOM API

### 2. Auto-set WPCOM_REST_API_STATUS to 'approved' in `AccountService::get_connected_status()`
- Set status to 'approved' by default when not set (since authorization is automatic with client credentials)
- Preserve code structure for future UI functionality that may allow user control
- Fixes "NOT SET" status in debug interfaces

## Impact

- ✅ Unblocks NotificationsService functionality
- ✅ Fixes Merchant Center account connection status
- ✅ Resolves UI showing incorrect "Grant access" buttons
- ✅ Ensures system works properly with client credentials from INTEGRA-48

## Technical Notes

- These are temporary compatibility fixes until INTEGRA-50 updates WPCOM API
- Code preserved for future UI functionality allowing user management of these settings
- Maintains all existing security and health checks except the problematic partner token validation

## Test Plan

- [x] Verify Connection Test page shows 'approved' instead of 'NOT SET'
- [x] Confirm NotificationsService.is_ready() returns true
- [x] Test that Merchant Center account shows proper connected state
- [x] Ensure no "Grant access" buttons appear inappropriately
- [x] Verify product sync and notifications work correctly

## Related Issues

- Addresses: INTEGRA-51
- Fixes issues introduced by: INTEGRA-48
- Coordinates with: INTEGRA-50 (WPCOM API updates)

🤖 Generated with [Claude Code](https://claude.ai/code)

### Changelog entry