### PR TITLE
Remove opt-in/opt-out UI controls for product data sync

### DIFF
--- a/js/src/components/google-mc-account-card/merchant-center-account-info-card.js
+++ b/js/src/components/google-mc-account-card/merchant-center-account-info-card.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { sprintf, __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
 import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
 // See https://github.com/woocommerce/woocommerce-admin/issues/7781
@@ -11,30 +10,13 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
  * Internal dependencies
  */
 import AccountCard, { APPEARANCE } from '~/components/account-card';
-import AppButton from '~/components/app-button';
 import ConnectedIconLabel from '~/components/connected-icon-label';
-import Section from '~/components/section';
 import { GOOGLE_WPCOM_APP_CONNECTED_STATUS } from '~/constants';
-import { API_NAMESPACE } from '~/data/constants';
-import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
-import useApiFetchCallback from '~/hooks/useApiFetchCallback';
-import { useAppDispatch } from '~/data';
 import EnableNewProductSyncButton from '~/components/enable-new-product-sync-button';
 import AppNotice from '~/components/app-notice';
-import DisconnectModal, {
-	API_DATA_FETCH_FEATURE,
-} from '~/pages/settings/disconnect-modal';
-import { getSettingsUrl } from '~/utils/urls';
-import { recordGlaEvent } from '~/utils/tracks';
 
 /**
  * @typedef {import('~/data/types.js').GoogleMCAccount} GoogleMCAccount
- */
-
-/**
- * Clicking on the button to disable the new product sync (API Pull).
- *
- * @event gla_disable_product_sync_click
  */
 
 /**
@@ -42,62 +24,9 @@ import { recordGlaEvent } from '~/utils/tracks';
  *
  * @param {Object} props React props.
  * @param {GoogleMCAccount} props.googleMCAccount A data payload object of Google Merchant Center account.
- *
- * @fires gla_disable_product_sync_click
  */
 const MerchantCenterAccountInfoCard = ( { googleMCAccount } ) => {
-	const { createNotice, removeNotice } = useDispatchCoreNotices();
-	const { invalidateResolution } = useAppDispatch();
-
-	const [
-		fetchDisableNotifications,
-		{ loading: loadingDisableNotifications },
-	] = useApiFetchCallback( {
-		path: `${ API_NAMESPACE }/rest-api/authorize`,
-		method: 'DELETE',
-	} );
-
-	/**
-	 * Temporary code for disabling the API PULL Beta Feature from the GMC Card
-	 */
-	const [ openedModal, setOpenedModal ] = useState( null );
-	const dismissModal = () => setOpenedModal( null );
-	const openDisableDataFetchModal = () =>
-		setOpenedModal( API_DATA_FETCH_FEATURE );
-
 	const domain = new URL( getSetting( 'homeUrl' ) ).host;
-
-	const disableNotifications = async () => {
-		recordGlaEvent( 'gla_disable_product_sync_click' );
-
-		const { notice } = await createNotice(
-			'info',
-			__(
-				'Disabling the new Product Sync feature, please wait…',
-				'google-listings-and-ads'
-			)
-		);
-
-		try {
-			await fetchDisableNotifications();
-			invalidateResolution( 'getGoogleMCAccount', [] );
-		} catch ( error ) {
-			createNotice(
-				'error',
-				__(
-					'Unable to disable new product sync. Please try again later.',
-					'google-listings-and-ads'
-				)
-			);
-		}
-
-		removeNotice( notice.id );
-	};
-
-	// Show the button if the status is "approved".
-	const showDisconnectNotificationsButton =
-		googleMCAccount.wpcom_rest_api_status ===
-		GOOGLE_WPCOM_APP_CONNECTED_STATUS.APPROVED;
 
 	// Show the error if the status is set but is not "approved".
 	const showErrorNotificationsNotice =
@@ -126,14 +55,6 @@ const MerchantCenterAccountInfoCard = ( { googleMCAccount } ) => {
 				)
 			}
 		>
-			{ showDisconnectNotificationsButton && (
-				<AppNotice status="success" isDismissible={ false }>
-					{ __(
-						'Google has been granted access to fetch your product data.',
-						'google-listings-and-ads'
-					) }
-				</AppNotice>
-			) }
 
 			{ showErrorNotificationsNotice && (
 				<AppNotice status="warning" isDismissible={ false }>
@@ -142,32 +63,6 @@ const MerchantCenterAccountInfoCard = ( { googleMCAccount } ) => {
 						'google-listings-and-ads'
 					) }
 				</AppNotice>
-			) }
-
-			{ openedModal && (
-				<DisconnectModal
-					onRequestClose={ dismissModal }
-					onDisconnected={ () => {
-						window.location.href = getSettingsUrl();
-					} }
-					disconnectTarget={ openedModal }
-					disconnectAction={ disableNotifications }
-				/>
-			) }
-
-			{ showDisconnectNotificationsButton && (
-				<Section.Card.Footer>
-					<AppButton
-						isDestructive
-						isLink
-						disabled={ loadingDisableNotifications }
-						text={ __(
-							'Disable product data fetch',
-							'google-listings-and-ads'
-						) }
-						onClick={ openDisableDataFetchModal }
-					/>
-				</Section.Card.Footer>
 			) }
 		</AccountCard>
 	);

--- a/js/src/pages/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.js
@@ -12,7 +12,7 @@ import AppModal from '~/components/app-modal';
 import AppButton from '~/components/app-button';
 import WarningIcon from '~/components/warning-icon';
 import { useAppDispatch } from '~/data';
-import { ALL_ACCOUNTS, ADS_ACCOUNT, API_DATA_FETCH_FEATURE } from './constants';
+import { ALL_ACCOUNTS, ADS_ACCOUNT } from './constants';
 
 const textDict = {
 	[ ALL_ACCOUNTS ]: {
@@ -62,24 +62,6 @@ const textDict = {
 			),
 			__(
 				'Some configurations for Google Ads created through WooCommerce may be lost. This cannot be undone.',
-				'google-listings-and-ads'
-			),
-		],
-	},
-	[ API_DATA_FETCH_FEATURE ]: {
-		title: __( 'Disable data fetching', 'google-listings-and-ads' ),
-		confirmButton: __( 'Disable data fetching', 'google-listings-and-ads' ),
-		confirmation: __(
-			'Yes, I want to disable the data fetching feature.',
-			'google-listings-and-ads'
-		),
-		contents: [
-			__(
-				'I understand that I am disabling the data fetching feature from this WooCommerce extension.',
-				'google-listings-and-ads'
-			),
-			__(
-				'Any ongoing campaigns and configuration will continue to run. They will be pushed to Google as in the previous versions of this extension.',
 				'google-listings-and-ads'
 			),
 		],

--- a/js/src/pages/settings/disconnect-modal/constants.js
+++ b/js/src/pages/settings/disconnect-modal/constants.js
@@ -1,3 +1,2 @@
 export const ALL_ACCOUNTS = 'all-accounts';
 export const ADS_ACCOUNT = 'ads-account';
-export const API_DATA_FETCH_FEATURE = 'api-data-fetch-feature';

--- a/js/src/pages/settings/index.js
+++ b/js/src/pages/settings/index.js
@@ -18,7 +18,6 @@ import LinkedAccounts from './linked-accounts';
 import ReconnectWPComAccount from './reconnect-wpcom-account';
 import ReconnectGoogleAccount from './reconnect-google-account';
 import EditStoreAddress from './edit-store-address';
-import EnableNewProductSyncNotice from '~/components/enable-new-product-sync-notice';
 import MainTabNav from '~/components/main-tab-nav';
 import RebrandingTour from '~/components/tours/rebranding-tour';
 import './index.scss';
@@ -62,7 +61,6 @@ const Settings = () => {
 
 	return (
 		<div className={ pageClassName }>
-			<EnableNewProductSyncNotice />
 			<MainTabNav />
 			<RebrandingTour />
 			<ContactInformationPreview />


### PR DESCRIPTION
## Summary

Removes user-facing UI controls for enabling/disabling the new product sync feature since it's now enabled by default with client credentials.

## Changes Made

### 🗑️ Removed UI Components:
- **"Disable product data fetch" button** from Merchant Center account card
- **EnableNewProductSyncNotice banner** from settings page  
- **API_DATA_FETCH_FEATURE option** from disconnect modal

### ✅ Preserved Essential Functionality:
- **EnableNewProductSyncButton** for "Grant access" during auth errors
- **Backend API endpoints** for sync control remain functional
- **Both push and pull sync mechanisms** continue to work
- **API-based configuration control** for developers

## Impact

- ✅ Clean UI without confusing opt-in/opt-out controls
- ✅ Sync functionality remains fully operational and controllable via API
- ✅ Feature enabled by default with client credentials from INTEGRA-48
- ✅ Fallback "Grant access" button preserved for edge cases with connectivity issues

## Technical Details

The new product sync feature (API pull method) is now automatically enabled with client credentials. Users no longer need to manually opt-in or have the ability to opt-out through the UI, simplifying the user experience while maintaining full programmatic control.

## Test Plan

- [x] Verify build completes successfully
- [x] Confirm no broken UI elements
- [x] Test that sync functionality remains operational
- [x] Ensure API endpoints still work for programmatic control

## Related Issues

- Addresses: INTEGRA-47
- Built on: INTEGRA-48 (OAuth to client credentials)
- Coordinates with: INTEGRA-51 (WPCOM API fixes)

🤖 Generated with [Claude Code](https://claude.ai/code)

### Changelog entry
