### PR TITLE
Fix broken ads report request in E2E tests

### DIFF
--- a/tests/e2e/specs/app-ratings-overview/experience-rating-banner.test.js
+++ b/tests/e2e/specs/app-ratings-overview/experience-rating-banner.test.js
@@ -296,8 +296,18 @@ test.describe( 'App Ratings Banner', () => {
 				error: null,
 			} );
 
-			appRatingsOverview.fulfillProductsReport( {
-				totals: { conversions: { value: 0 } },
+			appRatingsOverview.fulfillAdsReportProducts( {
+				products: null,
+				campaigns: null,
+				intervals: null,
+				totals: {
+					sales: 0,
+					conversions: 0,
+					spend: 0,
+					clicks: 0,
+					impressions: 0,
+				},
+				next_page: null,
 			} );
 
 			await appRatingsOverview.goto();

--- a/tests/e2e/specs/app-ratings-overview/experience-rating-banner.test.js
+++ b/tests/e2e/specs/app-ratings-overview/experience-rating-banner.test.js
@@ -8,6 +8,7 @@ import { expect, test } from '@playwright/test';
  */
 import { clearOnboardedMerchant, setOnboardedMerchant } from '../../utils/api';
 import AppRatingsOverview from '../../utils/app-ratings-overview';
+import adsReportProductsData from '../../utils/__fixtures__/ads-report-products.json';
 
 test.use( { storageState: process.env.ADMINSTATE } );
 
@@ -296,19 +297,9 @@ test.describe( 'App Ratings Banner', () => {
 				error: null,
 			} );
 
-			appRatingsOverview.fulfillAdsReportProducts( {
-				products: null,
-				campaigns: null,
-				intervals: null,
-				totals: {
-					sales: 0,
-					conversions: 0,
-					spend: 0,
-					clicks: 0,
-					impressions: 0,
-				},
-				next_page: null,
-			} );
+			appRatingsOverview.fulfillAdsReportProducts(
+				adsReportProductsData
+			);
 
 			await appRatingsOverview.goto();
 			await page.waitForSelector( '.gla-dashboard', {

--- a/tests/e2e/utils/__fixtures__/ads-report-products.json
+++ b/tests/e2e/utils/__fixtures__/ads-report-products.json
@@ -1,0 +1,13 @@
+{
+	"products": null,
+	"campaigns": null,
+	"intervals": null,
+	"totals": {
+		"sales": 0,
+		"conversions": 0,
+		"spend": 0,
+		"clicks": 0,
+		"impressions": 0
+	},
+	"next_page": null
+}

--- a/tests/e2e/utils/__fixtures__/mc-product-statistics.json
+++ b/tests/e2e/utils/__fixtures__/mc-product-statistics.json
@@ -1,0 +1,13 @@
+{
+	"timestamp": 1751036728,
+	"statistics": {
+		"active": 0,
+		"expiring": 0,
+		"pending": 0,
+		"disapproved": 0,
+		"not_synced": 0
+	},
+	"scheduled_sync": 0,
+	"loading": false,
+	"error": null
+}

--- a/tests/e2e/utils/app-ratings-overview.js
+++ b/tests/e2e/utils/app-ratings-overview.js
@@ -3,6 +3,7 @@
  */
 import { LOAD_STATE } from './constants';
 import MockRequests from './mock-requests';
+import adsReportProductsData from './__fixtures__/ads-report-products.json';
 
 /**
  * AppRatingsOverview class.
@@ -63,17 +64,11 @@ export default class AppRatingsOverview extends MockRequests {
 				error: null,
 			} ),
 			this.fulfillAdsReportProducts( {
-				products: null,
-				campaigns: null,
-				intervals: null,
+				...adsReportProductsData,
 				totals: {
-					sales: 0,
+					...adsReportProductsData.totals,
 					conversions: 5,
-					spend: 0,
-					clicks: 0,
-					impressions: 0,
 				},
-				next_page: null,
 			} ),
 			this.mockJetpackConnected(),
 			this.mockGoogleConnected(),

--- a/tests/e2e/utils/app-ratings-overview.js
+++ b/tests/e2e/utils/app-ratings-overview.js
@@ -62,14 +62,16 @@ export default class AppRatingsOverview extends MockRequests {
 				loading: false,
 				error: null,
 			} ),
-			this.fulfillProductsReport( {
-				free_listings: null,
+			this.fulfillAdsReportProducts( {
 				products: null,
+				campaigns: null,
 				intervals: null,
 				totals: {
+					sales: 0,
+					conversions: 5,
+					spend: 0,
 					clicks: 0,
 					impressions: 0,
-					conversions: 5,
 				},
 				next_page: null,
 			} ),

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -150,6 +150,19 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Fulfill the Ads Report Products request.
+	 *
+	 * @param {Object} payload
+	 * @return {Promise<void>}
+	 */
+	async fulfillAdsReportProducts( payload ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/ads\/reports\/products\b/,
+			payload
+		);
+	}
+
+	/**
 	 * Fulfill the Target Audience request.
 	 *
 	 * @param {Object} payload
@@ -899,18 +912,6 @@ export default class MockRequests {
 			payload,
 			200,
 			methods
-		);
-	}
-
-	/**
-	 * Mock the request to fetch the product reports.
-	 *
-	 * @param {Object} payload
-	 */
-	async fulfillProductsReport( payload ) {
-		await this.fulfillRequest(
-			/\/wc\/gla\/ads\/reports\/products\b/,
-			payload
 		);
 	}
 

--- a/tests/e2e/utils/pages/dashboard.js
+++ b/tests/e2e/utils/pages/dashboard.js
@@ -83,19 +83,7 @@ export default class DashboardPage extends MockRequests {
 			status: 'disconnected',
 		} );
 
-		await this.fulfillAdsReportProducts( {
-			products: null,
-			campaigns: null,
-			intervals: null,
-			totals: {
-				sales: 0,
-				conversions: 0,
-				spend: 0,
-				clicks: 0,
-				impressions: 0,
-			},
-			next_page: null,
-		} );
+		await this.fulfillAdsReportProducts( adsReportProductsData );
 	}
 
 	/**

--- a/tests/e2e/utils/pages/dashboard.js
+++ b/tests/e2e/utils/pages/dashboard.js
@@ -93,6 +93,20 @@ export default class DashboardPage extends MockRequests {
 			symbol: '$',
 			status: 'disconnected',
 		} );
+
+		await this.fulfillAdsReportProducts( {
+			products: null,
+			campaigns: null,
+			intervals: null,
+			totals: {
+				sales: 0,
+				conversions: 0,
+				spend: 0,
+				clicks: 0,
+				impressions: 0,
+			},
+			next_page: null,
+		} );
 	}
 
 	/**

--- a/tests/e2e/utils/pages/dashboard.js
+++ b/tests/e2e/utils/pages/dashboard.js
@@ -4,6 +4,7 @@
 import { LOAD_STATE } from '../constants';
 import MockRequests from '../mock-requests';
 import adsReportProductsData from '../__fixtures__/ads-report-products.json';
+import mcProductStatistics from '../__fixtures__/mc-product-statistics.json';
 
 /**
  * Dashboard page object class.
@@ -59,6 +60,7 @@ export default class DashboardPage extends MockRequests {
 		} );
 
 		await this.fulfillAdsReportProgram( adsReportProductsData );
+		await this.fulfillProductStatisticsRequest( mcProductStatistics );
 
 		await this.fulfillTargetAudience( {
 			location: 'selected',

--- a/tests/e2e/utils/pages/dashboard.js
+++ b/tests/e2e/utils/pages/dashboard.js
@@ -3,6 +3,7 @@
  */
 import { LOAD_STATE } from '../constants';
 import MockRequests from '../mock-requests';
+import adsReportProductsData from '../__fixtures__/ads-report-products.json';
 
 /**
  * Dashboard page object class.
@@ -57,19 +58,7 @@ export default class DashboardPage extends MockRequests {
 			next_page: null,
 		} );
 
-		await this.fulfillAdsReportProgram( {
-			products: null,
-			campaigns: null,
-			intervals: null,
-			totals: {
-				sales: 0,
-				conversions: 0,
-				spend: 0,
-				clicks: 0,
-				impressions: 0,
-			},
-			next_page: null,
-		} );
+		await this.fulfillAdsReportProgram( adsReportProductsData );
 
 		await this.fulfillTargetAudience( {
 			location: 'selected',

--- a/tests/e2e/utils/pages/price-benchmark.js
+++ b/tests/e2e/utils/pages/price-benchmark.js
@@ -4,6 +4,7 @@
 import { LOAD_STATE } from '../constants';
 import MockRequests from '../mock-requests';
 import adsReportProductsData from '../__fixtures__/ads-report-products.json';
+import mcProductStatistics from '../__fixtures__/mc-product-statistics.json';
 
 /**
  * ProductFeed page object class.
@@ -55,6 +56,7 @@ export default class PriceBenchmarkPage extends MockRequests {
 			} ),
 
 			this.fulfillAdsReportProducts( adsReportProductsData ),
+			this.fulfillProductStatisticsRequest( mcProductStatistics ),
 
 			this.mockJetpackConnected(),
 			this.mockGoogleConnected(),

--- a/tests/e2e/utils/pages/price-benchmark.js
+++ b/tests/e2e/utils/pages/price-benchmark.js
@@ -53,6 +53,20 @@ export default class PriceBenchmarkPage extends MockRequests {
 				loading: false,
 			} ),
 
+			this.fulfillAdsReportProducts( {
+				products: null,
+				campaigns: null,
+				intervals: null,
+				totals: {
+					sales: 0,
+					conversions: 0,
+					spend: 0,
+					clicks: 0,
+					impressions: 0,
+				},
+				next_page: null,
+			} ),
+
 			this.mockJetpackConnected(),
 			this.mockGoogleConnected(),
 			this.mockAdsAccountConnected(),

--- a/tests/e2e/utils/pages/price-benchmark.js
+++ b/tests/e2e/utils/pages/price-benchmark.js
@@ -3,6 +3,7 @@
  */
 import { LOAD_STATE } from '../constants';
 import MockRequests from '../mock-requests';
+import adsReportProductsData from '../__fixtures__/ads-report-products.json';
 
 /**
  * ProductFeed page object class.
@@ -53,19 +54,7 @@ export default class PriceBenchmarkPage extends MockRequests {
 				loading: false,
 			} ),
 
-			this.fulfillAdsReportProducts( {
-				products: null,
-				campaigns: null,
-				intervals: null,
-				totals: {
-					sales: 0,
-					conversions: 0,
-					spend: 0,
-					clicks: 0,
-					impressions: 0,
-				},
-				next_page: null,
-			} ),
+			this.fulfillAdsReportProducts( adsReportProductsData ),
 
 			this.mockJetpackConnected(),
 			this.mockGoogleConnected(),

--- a/tests/e2e/utils/pages/product-feed.js
+++ b/tests/e2e/utils/pages/product-feed.js
@@ -4,6 +4,7 @@
 import { LOAD_STATE } from '../constants';
 import MockRequests from '../mock-requests';
 import adsReportProductsData from '../__fixtures__/ads-report-products.json';
+import mcProductStatistics from '../__fixtures__/mc-product-statistics.json';
 
 /**
  * ProductFeed page object class.
@@ -51,6 +52,7 @@ export default class ProductFeedPage extends MockRequests {
 			} ),
 
 			this.fulfillAdsReportProducts( adsReportProductsData ),
+			this.fulfillProductStatisticsRequest( mcProductStatistics ),
 
 			this.mockJetpackConnected(),
 			this.mockGoogleConnected(),

--- a/tests/e2e/utils/pages/product-feed.js
+++ b/tests/e2e/utils/pages/product-feed.js
@@ -49,6 +49,20 @@ export default class ProductFeedPage extends MockRequests {
 				loading: false,
 			} ),
 
+			this.fulfillAdsReportProducts( {
+				products: null,
+				campaigns: null,
+				intervals: null,
+				totals: {
+					sales: 0,
+					conversions: 0,
+					spend: 0,
+					clicks: 0,
+					impressions: 0,
+				},
+				next_page: null,
+			} ),
+
 			this.mockJetpackConnected(),
 			this.mockGoogleConnected(),
 			this.mockAdsAccountConnected(),

--- a/tests/e2e/utils/pages/product-feed.js
+++ b/tests/e2e/utils/pages/product-feed.js
@@ -3,6 +3,7 @@
  */
 import { LOAD_STATE } from '../constants';
 import MockRequests from '../mock-requests';
+import adsReportProductsData from '../__fixtures__/ads-report-products.json';
 
 /**
  * ProductFeed page object class.
@@ -49,19 +50,7 @@ export default class ProductFeedPage extends MockRequests {
 				loading: false,
 			} ),
 
-			this.fulfillAdsReportProducts( {
-				products: null,
-				campaigns: null,
-				intervals: null,
-				totals: {
-					sales: 0,
-					conversions: 0,
-					spend: 0,
-					clicks: 0,
-					impressions: 0,
-				},
-				next_page: null,
-			} ),
+			this.fulfillAdsReportProducts( adsReportProductsData ),
 
 			this.mockJetpackConnected(),
 			this.mockGoogleConnected(),

--- a/tests/e2e/utils/pages/settings.js
+++ b/tests/e2e/utils/pages/settings.js
@@ -4,6 +4,7 @@
 import MockRequests from '../mock-requests';
 import { LOAD_STATE } from '../constants';
 import adsReportProductsData from '../__fixtures__/ads-report-products.json';
+import mcProductStatistics from '../__fixtures__/mc-product-statistics.json';
 
 export default class SettingsPage extends MockRequests {
 	/**
@@ -49,6 +50,7 @@ export default class SettingsPage extends MockRequests {
 		await this.mockSuccessfulSettingsSyncRequest();
 
 		await this.fulfillAdsReportProducts( adsReportProductsData );
+		await this.fulfillProductStatisticsRequest( mcProductStatistics );
 	}
 
 	/**

--- a/tests/e2e/utils/pages/settings.js
+++ b/tests/e2e/utils/pages/settings.js
@@ -46,6 +46,20 @@ export default class SettingsPage extends MockRequests {
 		await this.mockAdsAccountConnected();
 		await this.mockContactInformation();
 		await this.mockSuccessfulSettingsSyncRequest();
+
+		await this.fulfillAdsReportProducts( {
+			products: null,
+			campaigns: null,
+			intervals: null,
+			totals: {
+				sales: 0,
+				conversions: 0,
+				spend: 0,
+				clicks: 0,
+				impressions: 0,
+			},
+			next_page: null,
+		} );
 	}
 
 	/**

--- a/tests/e2e/utils/pages/settings.js
+++ b/tests/e2e/utils/pages/settings.js
@@ -3,6 +3,7 @@
  */
 import MockRequests from '../mock-requests';
 import { LOAD_STATE } from '../constants';
+import adsReportProductsData from '../__fixtures__/ads-report-products.json';
 
 export default class SettingsPage extends MockRequests {
 	/**
@@ -47,19 +48,7 @@ export default class SettingsPage extends MockRequests {
 		await this.mockContactInformation();
 		await this.mockSuccessfulSettingsSyncRequest();
 
-		await this.fulfillAdsReportProducts( {
-			products: null,
-			campaigns: null,
-			intervals: null,
-			totals: {
-				sales: 0,
-				conversions: 0,
-				spend: 0,
-				clicks: 0,
-				impressions: 0,
-			},
-			next_page: null,
-		} );
+		await this.fulfillAdsReportProducts( adsReportProductsData );
 	}
 
 	/**

--- a/tests/e2e/utils/pages/shipping.js
+++ b/tests/e2e/utils/pages/shipping.js
@@ -8,6 +8,7 @@ import { Locator } from '@playwright/test';
  */
 import MockRequests from '../mock-requests';
 import { LOAD_STATE } from '../constants';
+import adsReportProductsData from '../__fixtures__/ads-report-products.json';
 
 export default class ShippingPage extends MockRequests {
 	/**
@@ -39,19 +40,7 @@ export default class ShippingPage extends MockRequests {
 			language: 'English',
 		} );
 
-		await this.fulfillAdsReportProducts( {
-			products: null,
-			campaigns: null,
-			intervals: null,
-			totals: {
-				sales: 0,
-				conversions: 0,
-				spend: 0,
-				clicks: 0,
-				impressions: 0,
-			},
-			next_page: null,
-		} );
+		await this.fulfillAdsReportProducts( adsReportProductsData );
 	}
 
 	/**

--- a/tests/e2e/utils/pages/shipping.js
+++ b/tests/e2e/utils/pages/shipping.js
@@ -9,6 +9,7 @@ import { Locator } from '@playwright/test';
 import MockRequests from '../mock-requests';
 import { LOAD_STATE } from '../constants';
 import adsReportProductsData from '../__fixtures__/ads-report-products.json';
+import mcProductStatistics from '../__fixtures__/mc-product-statistics.json';
 
 export default class ShippingPage extends MockRequests {
 	/**
@@ -41,6 +42,7 @@ export default class ShippingPage extends MockRequests {
 		} );
 
 		await this.fulfillAdsReportProducts( adsReportProductsData );
+		await this.fulfillProductStatisticsRequest( mcProductStatistics );
 	}
 
 	/**

--- a/tests/e2e/utils/pages/shipping.js
+++ b/tests/e2e/utils/pages/shipping.js
@@ -38,6 +38,20 @@ export default class ShippingPage extends MockRequests {
 			locale: 'en_US',
 			language: 'English',
 		} );
+
+		await this.fulfillAdsReportProducts( {
+			products: null,
+			campaigns: null,
+			intervals: null,
+			totals: {
+				sales: 0,
+				conversions: 0,
+				spend: 0,
+				clicks: 0,
+				impressions: 0,
+			},
+			next_page: null,
+		} );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes the broken E2E tests in the App Ratings feature (#2969). Previously, during E2E test runs for the Shipping page, the request to the `ads\reports\products` endpoint used for determining if the App Ratings banner should be shown would result in an error in the E2E tests, which can cause some E2E tests to fail because of the unexpected SnackBar.

### Screenshots:


![test-failed-1](https://github.com/user-attachments/assets/253f0206-1784-4c6b-a649-75d48a9b904a)


### Additional details:

Passing E2E tests: https://github.com/woocommerce/google-listings-and-ads/actions/runs/15910816761

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
