### PR TITLE
Add blog_id to all notification messages (INTEGRA-49)

### DIFF
--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -77,6 +77,13 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	private $notification_url;
 
 	/**
+	 * The WordPress.com blog ID
+	 *
+	 * @var int $blog_id
+	 */
+	private $blog_id;
+
+	/**
 	 * The Merchant center service
 	 *
 	 * @var MerchantCenterService $merchant_center
@@ -97,10 +104,10 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 * @param AccountService        $account_service
 	 */
 	public function __construct( MerchantCenterService $merchant_center, AccountService $account_service ) {
-		$blog_id                = Jetpack_Options::get_option( 'id' );
+		$this->blog_id          = Jetpack_Options::get_option( 'id' );
 		$this->merchant_center  = $merchant_center;
 		$this->account_service  = $account_service;
-		$this->notification_url = "https://public-api.wordpress.com/wpcom/v2/sites/{$blog_id}/partners/google/notifications";
+		$this->notification_url = "https://public-api.wordpress.com/wpcom/v2/sites/{$this->blog_id}/partners/google/notifications";
 	}
 
 	/**
@@ -148,7 +155,13 @@ class NotificationsService implements Service, OptionsAwareInterface {
 				'x-woocommerce-topic' => $topic,
 				'Content-Type'        => 'application/json',
 			],
-			'body'    => array_merge( $data, [ 'item_id' => $item_id ] ),
+			'body'    => array_merge(
+				$data,
+				[
+					'item_id' => $item_id,
+					'blog_id' => $this->blog_id,
+				]
+			),
 			'url'     => $this->get_notification_url(),
 		];
 

--- a/tests/Unit/API/WP/NotificationsServiceTest.php
+++ b/tests/Unit/API/WP/NotificationsServiceTest.php
@@ -115,6 +115,7 @@ class NotificationsServiceTest extends UnitTest {
 			],
 			'body'    => [
 				'item_id' => $item_id,
+				'blog_id' => self::DUMMY_BLOG_ID,
 			],
 			'url'     => $this->service->get_notification_url(),
 		];


### PR DESCRIPTION
## Summary

Implements **INTEGRA-49** by adding `blog_id` to all notification messages sent to WPCOM endpoints. This enables the WPCOM notification proxy to properly work with the new client credentials authentication flow.

### Problem

The current notification system sends messages to WPCOM without including the `blog_id` in the message body. While the `blog_id` is embedded in the URL endpoint, the WPCOM proxy system requires it in the message payload to properly route notifications in the client credentials authentication model.

### Solution

1. **Added `blog_id` property** to `NotificationsService` class
2. **Modified constructor** to store the blog_id from `Jetpack_Options::get_option('id')`  
3. **Updated `notify()` method** to include `blog_id` in all notification message bodies
4. **Updated tests** to expect `blog_id` in request verification

### Changes Made

#### NotificationsService.php
- Added private `$blog_id` property to store WordPress.com blog ID
- Modified constructor to store blog_id instead of just using it in URL
- Updated `notify()` method to include `blog_id` in message body alongside `item_id`

#### NotificationsServiceTest.php  
- Updated test expectation to include `blog_id` in request body verification
- Uses existing `DUMMY_BLOG_ID` constant for test consistency

### Message Format Changes

**Before:**
```php
'body' => array_merge($data, ['item_id' => $item_id])
```

**After:** 
```php
'body' => array_merge($data, [
    'item_id' => $item_id,
    'blog_id' => $this->blog_id,
])
```

### Affected Notification Types

This change affects **all** notification types automatically:
- Product notifications (create/update/delete)
- Coupon notifications (create/update/delete)  
- Shipping notifications (update)
- Settings notifications (update)

### WPCOM Compatibility

The WPCOM counterpart already handles additional data in the request body:

```php
private function get_data() {
    $body = json_decode($this->request->get_body() ?? '', true);
    $id   = $body['item_id'];
    unset($body['item_id']);
    return array_merge($body, ['id' => $id]);
}
```

This means the `blog_id` will be preserved and passed through to the notification processing logic.

### Test Plan

- [x] ✅ PHP coding standards pass
- [x] ✅ Updated test expects blog_id in notification body
- [x] ✅ All notification types automatically include blog_id
- [ ] Verify WPCOM proxy properly receives and processes blog_id
- [ ] Test notification flow with client credentials authentication

### Impact

- **Zero breaking changes** - purely additive enhancement
- **Backward compatible** - WPCOM endpoints handle additional data gracefully  
- **Automatic coverage** - all existing notification flows get blog_id inclusion
- **Enables client credentials** - satisfies WPCOM proxy requirements

## Related Issues

- **INTEGRA-49**: Add blog_id to notification messages 
- **INTEGRA-30**: Overall client credentials migration project
- Supports the broader effort to migrate from OAuth to client credentials authentication

🤖 Generated with [Claude Code](https://claude.ai/code)

### Changelog entry
