### PR TITLE
Avoid duplicates when the conversion-related metrics across all budget recommendations are identical

### DIFF
--- a/js/src/data/adapters.js
+++ b/js/src/data/adapters.js
@@ -9,8 +9,55 @@ import { convertKeysFromSnakeCaseToCamelCase } from './utils';
  * @typedef {import('~/data/actions').Campaign} Campaign
  * @typedef {import('~/data/types.js').AssetEntityGroup} AssetEntityGroup
  * @typedef {import('~/data/types.js').AdsBudgetRecommendation} AdsBudgetRecommendation
+ * @typedef {import('~/data/types.js').AdsBudgetRecommendationEntity} AdsBudgetRecommendationEntity
  * @typedef {import('~/data/types.js').AdsBudgetMetrics} AdsBudgetMetrics
  */
+
+/**
+ * A workaround to eliminate recommendations when conversion-related metrics
+ * are identical. It only keeps the lowest-budget one, taking its place as
+ * "recommended" level. Otherwise, it returns the original recommendations.
+ *
+ * Currently, Google Ads API might return the exact same forecast metrics, so
+ * this workaround is intended to avoid user confusion. It only keeps the
+ * lowest budget since that would have the best ROAS.
+ *
+ * @param {Array<AdsBudgetRecommendationEntity>} rawRecommendations The raw budget recommendations.
+ * @return {Array<AdsBudgetRecommendationEntity>} The eliminated or original recommendations.
+ */
+function eliminateIdenticalMetrics( rawRecommendations ) {
+	const recommendations = rawRecommendations.filter(
+		( item ) => item.metrics
+	);
+
+	if ( recommendations.length <= 1 ) {
+		return rawRecommendations;
+	}
+
+	let lowest = recommendations[ 0 ];
+
+	for ( let i = 1; i < recommendations.length; i += 1 ) {
+		const item = recommendations[ i ];
+
+		if (
+			item.metrics.conversions === lowest.metrics.conversions &&
+			item.metrics.conversionsValue === lowest.metrics.conversionsValue
+		) {
+			if ( item.dailyBudget < lowest.dailyBudget ) {
+				lowest = item;
+			}
+		} else {
+			return rawRecommendations;
+		}
+	}
+
+	return [
+		{
+			...lowest,
+			level: 'recommended',
+		},
+	];
+}
 
 /**
  * Adapts the ads budget recommendation data received from API.
@@ -24,7 +71,7 @@ export function adaptAdsBudgetRecommendation( rawData ) {
 	const { currency, source, recommendations, ...data } =
 		convertKeysFromSnakeCaseToCamelCase( rawData );
 
-	recommendations.forEach( ( item ) => {
+	eliminateIdenticalMetrics( recommendations ).forEach( ( item ) => {
 		const { level, ...adaptingItem } = item;
 		const key = level.toLowerCase();
 

--- a/js/src/data/adapters.test.js
+++ b/js/src/data/adapters.test.js
@@ -145,6 +145,123 @@ describe( 'adaptAdsBudgetRecommendation', () => {
 
 		expect( eventProps.metrics_availability ).toEqual( 'none' );
 	} );
+
+	describe( 'eliminateIdenticalMetrics', () => {
+		const eliminatedRecommended = structuredClone( recommended );
+		const eliminatedHigh = structuredClone( high );
+		const eliminatedLow = structuredClone( low );
+
+		beforeEach( () => {
+			const conversions = 3.56;
+			const conversionsValue = 71.55541399333742;
+
+			input.recommendations.forEach( ( item ) => {
+				item.metrics.conversions = conversions;
+				item.metrics.conversions_value = conversionsValue;
+			} );
+
+			[ eliminatedRecommended, eliminatedHigh, eliminatedLow ].forEach(
+				( item ) => {
+					item.metrics.conversions = conversions;
+					item.metrics.conversionsValue = conversionsValue;
+				}
+			);
+		} );
+
+		it( 'Should eliminate the budget recommendations to keep the lowest-budget one when conversion-related metrics are identical', () => {
+			expect( adaptAdsBudgetRecommendation( input ) ).toEqual( {
+				recommended: eliminatedLow,
+				dailyBudgetBaseline: 13,
+				recommendedDailyBudget: 7,
+				eventProps: {
+					source: 'google-ads-api',
+					metrics_availability: 'all',
+					recommended_budget: 7,
+				},
+			} );
+
+			input.recommendations.pop();
+
+			expect( adaptAdsBudgetRecommendation( input ) ).toEqual( {
+				recommended: eliminatedRecommended,
+				dailyBudgetBaseline: 13,
+				recommendedDailyBudget: 15,
+				eventProps: {
+					source: 'google-ads-api',
+					metrics_availability: 'all',
+					recommended_budget: 15,
+				},
+			} );
+		} );
+
+		it( 'Should not eliminate when only some of the recommendations have the same metrics', () => {
+			input.recommendations[ 2 ].metrics.conversions = 2.5;
+
+			expect( adaptAdsBudgetRecommendation( input ) ).toEqual( {
+				recommended: eliminatedRecommended,
+				high: eliminatedHigh,
+				low: {
+					...eliminatedLow,
+					metrics: {
+						...eliminatedLow.metrics,
+						conversions: 2.5,
+					},
+				},
+				dailyBudgetBaseline: 13,
+				recommendedDailyBudget: 15,
+				eventProps: {
+					source: 'google-ads-api',
+					metrics_availability: 'all',
+					recommended_budget: 15,
+				},
+			} );
+		} );
+
+		it( 'Should not eliminate if the number of recommendations having metrics is less than 2', () => {
+			input.recommendations[ 1 ].metrics = null;
+			input.recommendations[ 2 ].metrics = null;
+
+			const expected = {
+				recommended: eliminatedRecommended,
+				high: {
+					...eliminatedHigh,
+					metrics: null,
+				},
+				low: {
+					...eliminatedLow,
+					metrics: null,
+				},
+				dailyBudgetBaseline: 13,
+				recommendedDailyBudget: 15,
+				eventProps: {
+					source: 'google-ads-api',
+					metrics_availability: 'partial',
+					recommended_budget: 15,
+				},
+			};
+
+			expect( adaptAdsBudgetRecommendation( input ) ).toEqual( expected );
+
+			input.recommendations.pop();
+
+			expect( adaptAdsBudgetRecommendation( input ) ).toEqual( {
+				...expected,
+				low: undefined,
+			} );
+
+			input.recommendations.pop();
+
+			expect( adaptAdsBudgetRecommendation( input ) ).toEqual( {
+				...expected,
+				high: undefined,
+				low: undefined,
+				eventProps: {
+					...expected.eventProps,
+					metrics_availability: 'all',
+				},
+			} );
+		} );
+	} );
 } );
 
 describe( 'adaptAdsBudgetMetrics', () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR avoids duplicates when the conversion-related metrics across all budget recommendations are identical.

Context reference: p1750785910227279/1749657379.120619-slack-C02BB3F30TG

### Screenshots:

#### 📷 Before

![before](https://github.com/user-attachments/assets/475a4978-5df0-44c3-99b6-529cc083253b)

#### 📷 After

![after](https://github.com/user-attachments/assets/6f594c03-a121-473a-a78c-29bc16a7dc48)

### Detailed test instructions:

1. Add a code snippet to simulate the budget recommendations having the same metrics.
   ```php
   add_filter(
     'woocommerce_gla_prepared_response_ads-campaigns-budget-recommendation',
     function( $response ) {
       $data = <<<EOT
       {
         "currency": "USD",
         "recommendations": [
           {
             "daily_budget": 21.71,
             "metrics": {
               "cost": 151.97,
               "conversions": 2.3,
               "conversions_value": 78.06413352154777
             },
             "country": "US",
             "level": "Recommended"
           },
           {
             "daily_budget": 24.05,
             "metrics": {
               "cost": 168.35,
               "conversions": 2.3,
               "conversions_value": 78.06413352154777
             },
             "country": "US",
             "level": "High"
           },
           {
             "daily_budget": 19.37,
             "metrics": {
               "cost": 135.59,
               "conversions": 2.3,
               "conversions_value": 78.06413352154777
             },
             "country": "US",
             "level": "Low"
           }
         ],
         "daily_budget_baseline": 15,
         "source": "google-ads-api"
       }
       EOT;
       return json_decode( $data );
     }
   );
   ```
2. Go to step 3 of the onboarding flow or campaign creation page.
3. Check if the UI only shows the "Recommended" level option, and its daily budget comes from the lowest one.
4. Make some changes to the mocked data to get different metrics.
5. Refresh the webpage to see if the UI shows all level options.

### Changelog entry
