### PR TITLE
Bump required WordPress to 6.6 and WooCommerce to 9.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ If you have a WooCommerce.com account, you can [start a chat or open a ticket on
 
 We aim to support the latest two minor versions of WordPress, WooCommerce, and PHP. (L-2 policy)
 
--   WordPress 6.1+
--   WooCommerce 7.9+
+-   WordPress 6.6+
+-   WooCommerce 9.7+
 -   PHP 7.4+ (64 bits)
 
 ### Browsers supported

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -7,12 +7,12 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
- * Requires at least: 6.1
+ * Requires at least: 6.6
  * Tested up to: 6.8
  * Requires PHP: 7.4
  * Requires PHP Architecture: 64 bits
  * Requires Plugins: woocommerce
- * WC requires at least: 7.9
+ * WC requires at least: 9.7
  * WC tested up to: 10.0
  * Woo:
  *
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'WC_GLA_VERSION', '3.1.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.4' );
-define( 'WC_GLA_MIN_WC_VER', '7.9' );
+define( 'WC_GLA_MIN_WC_VER', '9.7' );
 
 // Load and initialize the autoloader.
 require_once __DIR__ . '/src/Autoloader.php';

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
 	<!-- Set the minimum WP version -->
-	<config name="minimum_supported_wp_version" value="6.1"/>
+	<config name="minimum_supported_wp_version" value="6.6"/>
 
 	<rule ref="WordPress">
 		<!-- We don't require conforming to WP file naming -->

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Google for WooCommerce ===
 Contributors: automattic, google, woocommerce
 Tags: woocommerce, google, product feed, ads, listings
-Requires at least: 6.1
+Requires at least: 6.6
 Tested up to: 6.8
 Requires PHP: 7.4
 Requires PHP Architecture: 64 Bits
@@ -51,8 +51,8 @@ Once you’re running Google Ads campaigns, the Google tag feature in the extens
 
 = Minimum Requirements =
 
-* WordPress 6.1 or greater
-* WooCommerce 7.9 or greater
+* WordPress 6.6 or greater
+* WooCommerce 9.7 or greater
 * PHP version 7.4 or greater
 * PHP Architecture 64 bits
 * MySQL version 5.6 or greater

--- a/tests/phpcs.xml.dist
+++ b/tests/phpcs.xml.dist
@@ -3,7 +3,7 @@
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
 	<!-- Set the minimum WP version -->
-	<config name="minimum_supported_wp_version" value="6.1"/>
+	<config name="minimum_supported_wp_version" value="6.6"/>
 
 	<rule ref="WordPress">
 		<!-- We don't require conforming to WP file naming -->


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-189/bump-required-wordpress-to-66-and-woocommerce-to-97

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<img width="1459" alt="Screenshot 2025-07-02 at 5 25 08 PM" src="https://github.com/user-attachments/assets/a026acc0-ebfa-423c-bc6b-f50f42c65c0a" />


### Detailed test instructions:

1. Search the codebase to see if there are any WordPress and WooCommerce versions noted that have not been updated together.

2. Setup the site with older woocommerce version, which should show the notice as shown in above screenshot.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Bump required WordPress to 6.6 and WooCommerce to 9.7.
