### PR TITLE
Do not render experience rating banner if Ads account is disconnected.

### DIFF
--- a/js/src/components/experience-rating-banner/banner.js
+++ b/js/src/components/experience-rating-banner/banner.js
@@ -1,0 +1,193 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { Notice, Icon } from '@wordpress/components';
+import { external as externalIcon } from '@wordpress/icons';
+import { useState, useEffect, useMemo } from '@wordpress/element';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import { recordGlaEvent } from '~/utils/tracks';
+import { BANNER_DISMISSED_KEY } from './constants';
+import {
+	REPORT_SOURCE_PAID,
+	PREFERENCES_STORE_NAMESPACE,
+	APP_RATINGS_BANNER_CONTEXT,
+} from '~/constants';
+import AppButton from '~/components/app-button';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+import useMCProductStatistics from '~/hooks/useMCProductStatistics';
+import useProductsReport from '~/pages/reports/products/useProductsReport';
+import FeedbackModal from './feedback-modal';
+import './index.scss';
+
+/**
+ * When the experience rating banner is displayed to the user.
+ *
+ * @event gla_app_ratings_shown
+ * @property {string} context The context in which the event is triggered.
+ */
+
+/**
+ * When the user clicks the "Good" button on the banner.
+ *
+ * @event gla_app_ratings_good_clicked
+ * @property {string} context The context in which the event is triggered.
+ */
+
+/**
+ * When the feedback modal is closed by the user.
+ *
+ * @event gla_app_ratings_close
+ * @property {string} context The context in which the event is triggered.
+ */
+
+/**
+ * When the user clicks the "Need help" button on the banner.
+ *
+ * @event gla_app_ratings_need_help_clicked
+ * @property {string} context The context in which the event is triggered.
+ */
+
+/**
+ * Banner component.
+ *
+ * Displays a dismissible banner asking users to rate their experience with Google for WooCommerce.
+ * Handles user interactions such as clicking "Good", "Need help", and dismissing the banner,
+ * and records corresponding events. Shows a feedback modal when "Good" is clicked.
+ *
+ * @return {JSX.Element|null} The Banner component, or null if dismissed.
+ *
+ * @fires gla_app_ratings_shown When the banner is shown.
+ * @fires gla_app_ratings_good_clicked When the "Good" button is clicked.
+ * @fires gla_app_ratings_close When the feedback modal is closed.
+ * @fires gla_app_ratings_need_help_clicked When the "Need help" button is clicked.
+ */
+const Banner = () => {
+	const { data: statisticsData } = useMCProductStatistics();
+	const { isReady: isMCAccountReady } = useGoogleMCAccount();
+	const { data: productsReport } = useProductsReport( REPORT_SOURCE_PAID );
+	const [ showModal, setShowModal ] = useState( false );
+	const { set } = useDispatch( preferencesStore );
+
+	const shouldDisplayBanner = useMemo( () => {
+		const statistics = statisticsData?.statistics || {};
+
+		if ( Object.keys( statistics ).length === 0 ) {
+			return false;
+		}
+
+		const totalProducts = Object.values( statistics ).reduce(
+			( total, value ) => total + value,
+			0
+		);
+
+		if ( ! totalProducts ) {
+			return false;
+		}
+
+		const notSyncedProducts = statistics.not_synced;
+		const activeProducts = statistics.active;
+		const conversions = productsReport?.totals?.conversions?.value || 0;
+
+		const hasEnoughActiveProducts =
+			( activeProducts / totalProducts ) * 100 >= 70;
+		const hasAllProductsSynced =
+			notSyncedProducts === 0 && activeProducts > 0;
+		const hasConversions = conversions > 0;
+
+		return (
+			hasEnoughActiveProducts &&
+			hasAllProductsSynced &&
+			isMCAccountReady &&
+			hasConversions
+		);
+	}, [ isMCAccountReady, statisticsData, productsReport ] );
+
+	// Track event when banner is shown.
+	useEffect( () => {
+		if ( ! shouldDisplayBanner ) {
+			return false;
+		}
+
+		recordGlaEvent( 'gla_app_ratings_shown', {
+			context: APP_RATINGS_BANNER_CONTEXT,
+		} );
+	}, [ shouldDisplayBanner ] );
+
+	if ( ! shouldDisplayBanner ) {
+		return null;
+	}
+
+	const handleGoodOnClick = () => {
+		recordGlaEvent( 'gla_app_ratings_good_clicked', {
+			context: APP_RATINGS_BANNER_CONTEXT,
+		} );
+		setShowModal( true );
+	};
+
+	const handleRequestClose = () => {
+		recordGlaEvent( 'gla_app_ratings_close', {
+			context: APP_RATINGS_BANNER_CONTEXT,
+		} );
+		setShowModal( false );
+	};
+
+	const handleNeedHelpOnClick = () => {
+		recordGlaEvent( 'gla_app_ratings_need_help_clicked', {
+			context: APP_RATINGS_BANNER_CONTEXT,
+		} );
+	};
+
+	const dismissBanner = () => {
+		set( PREFERENCES_STORE_NAMESPACE, BANNER_DISMISSED_KEY, true );
+	};
+
+	return (
+		<div className="gla-experience-rating-banner__container">
+			{ showModal && (
+				<FeedbackModal
+					onRequestClose={ handleRequestClose }
+					onRateUsClick={ dismissBanner }
+				/>
+			) }
+			<Notice
+				className="gla-experience-rating-banner"
+				status="info"
+				isDismissible={ true }
+				onRemove={ dismissBanner }
+			>
+				<p className="gla-experience-rating-banner__text">
+					{ __(
+						'How was your experience with Google for WooCommerce?',
+						'google-listings-and-ads'
+					) }
+				</p>
+
+				<div className="gla-experience-rating-banner__actions">
+					<AppButton onClick={ handleGoodOnClick } isSecondary>
+						{ __( 'Good', 'google-listings-and-ads' ) }
+					</AppButton>
+
+					<AppButton
+						isSecondary
+						href="https://woocommerce.com/my-account/contact-support/"
+						target="_blank"
+						onClick={ handleNeedHelpOnClick }
+						icon={ <Icon icon={ externalIcon } /> }
+						iconPosition="right"
+						iconSize={ 16 }
+					>
+						{ __( 'Need help', 'google-listings-and-ads' ) }
+					</AppButton>
+				</div>
+			</Notice>
+		</div>
+	);
+};
+
+export default Banner;

--- a/js/src/components/experience-rating-banner/banner.js
+++ b/js/src/components/experience-rating-banner/banner.js
@@ -19,7 +19,6 @@ import {
 	APP_RATINGS_BANNER_CONTEXT,
 } from '~/constants';
 import AppButton from '~/components/app-button';
-import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import useMCProductStatistics from '~/hooks/useMCProductStatistics';
 import useProductsReport from '~/pages/reports/products/useProductsReport';
 import FeedbackModal from './feedback-modal';
@@ -69,10 +68,9 @@ import './index.scss';
  */
 const Banner = () => {
 	const { data: statisticsData } = useMCProductStatistics();
-	const { isReady: isMCAccountReady } = useGoogleMCAccount();
 	const { data: productsReport } = useProductsReport( REPORT_SOURCE_PAID );
 	const [ showModal, setShowModal ] = useState( false );
-	const { set } = useDispatch( preferencesStore );
+	const { set } = useDispatch( preferencesStore ) || {};
 
 	const shouldDisplayBanner = useMemo( () => {
 		const statistics = statisticsData?.statistics || {};
@@ -101,22 +99,16 @@ const Banner = () => {
 		const hasConversions = conversions > 0;
 
 		return (
-			hasEnoughActiveProducts &&
-			hasAllProductsSynced &&
-			isMCAccountReady &&
-			hasConversions
+			hasEnoughActiveProducts && hasAllProductsSynced && hasConversions
 		);
-	}, [ isMCAccountReady, statisticsData, productsReport ] );
+	}, [ statisticsData, productsReport ] );
 
-	// Track event when banner is shown.
 	useEffect( () => {
-		if ( ! shouldDisplayBanner ) {
-			return false;
+		if ( shouldDisplayBanner ) {
+			recordGlaEvent( 'gla_app_ratings_shown', {
+				context: APP_RATINGS_BANNER_CONTEXT,
+			} );
 		}
-
-		recordGlaEvent( 'gla_app_ratings_shown', {
-			context: APP_RATINGS_BANNER_CONTEXT,
-		} );
 	}, [ shouldDisplayBanner ] );
 
 	if ( ! shouldDisplayBanner ) {

--- a/js/src/components/experience-rating-banner/constants.js
+++ b/js/src/components/experience-rating-banner/constants.js
@@ -1,0 +1,1 @@
+export const BANNER_DISMISSED_KEY = 'experience-rating-banner-dismissed';

--- a/js/src/components/experience-rating-banner/index.js
+++ b/js/src/components/experience-rating-banner/index.js
@@ -1,193 +1,28 @@
 /**
- * External dependencies
- */
-import { Notice, Icon } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { external as externalIcon } from '@wordpress/icons';
-import { store as preferencesStore } from '@wordpress/preferences';
-
-/**
  * Internal dependencies
  */
-import AppButton from '../app-button';
-import {
-	REPORT_SOURCE_PAID,
-	PREFERENCES_STORE_NAMESPACE,
-	APP_RATINGS_BANNER_CONTEXT,
-} from '~/constants';
-import useMCProductStatistics from '~/hooks/useMCProductStatistics';
-import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
-import useProductsReport from '~/pages/reports/products/useProductsReport';
 import usePreference from '~/hooks/usePreference';
-import FeedbackModal from './feedback-modal';
-import { recordGlaEvent } from '~/utils/tracks';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import Banner from './banner';
+import { BANNER_DISMISSED_KEY } from './constants';
 import './index.scss';
-
-const BANNER_DISMISSED_KEY = 'experience-rating-banner-dismissed';
-
-/**
- * When the experience rating banner is displayed to the user.
- *
- * @event gla_app_ratings_shown
- * @property {string} context The context in which the event is triggered.
- */
-
-/**
- * When the user clicks the "Good" button on the banner.
- *
- * @event gla_app_ratings_good_clicked
- * @property {string} context The context in which the event is triggered.
- */
-
-/**
- * When the feedback modal is closed by the user.
- *
- * @event gla_app_ratings_close
- * @property {string} context The context in which the event is triggered.
- */
-
-/**
- * When the user clicks the "Need help" button on the banner.
- *
- * @event gla_app_ratings_need_help_clicked
- * @property {string} context The context in which the event is triggered.
- */
 
 /**
  * ExperienceRatingBanner component.
  *
- * Displays a dismissible banner asking users to rate their experience with Google for WooCommerce.
- * Handles user interactions such as clicking "Good", "Need help", and dismissing the banner,
- * and records corresponding events. Shows a feedback modal when "Good" is clicked.
+ * Displays a banner asking users to rate their experience with Google for WooCommerce.
  *
- * @return {JSX.Element|null} The ExperienceRatingBanner component, or null if dismissed.
- *
- * @fires gla_app_ratings_shown When the banner is shown.
- * @fires gla_app_ratings_good_clicked When the "Good" button is clicked.
- * @fires gla_app_ratings_close When the feedback modal is closed.
- * @fires gla_app_ratings_need_help_clicked When the "Need help" button is clicked.
+ * @return {JSX.Element|null} The ExperienceRatingBanner component, or null if dismissed or Ads account is disconnected.
  */
 const ExperienceRatingBanner = () => {
-	const { data: statisticsData } = useMCProductStatistics();
-	const { isReady: isMCAccountReady } = useGoogleMCAccount();
-	const { data: productsReport } = useProductsReport( REPORT_SOURCE_PAID );
-	const [ showModal, setShowModal ] = useState( false );
-	const { set } = useDispatch( preferencesStore );
+	const { hasGoogleAdsConnection } = useGoogleAdsAccount();
 	const isDismissed = usePreference( BANNER_DISMISSED_KEY );
-	const statistics = statisticsData?.statistics || {};
 
-	const shouldDisplayBanner = () => {
-		if ( Object.keys( statistics ).length === 0 ) {
-			return false;
-		}
-
-		const totalProducts = Object.values( statistics ).reduce(
-			( total, value ) => total + value,
-			0
-		);
-
-		if ( ! totalProducts ) {
-			return false;
-		}
-
-		const notSyncedProducts = statistics.not_synced;
-		const activeProducts = statistics.active;
-		const conversions = productsReport?.totals?.conversions?.value || 0;
-
-		const hasEnoughActiveProducts =
-			( activeProducts / totalProducts ) * 100 >= 70;
-		const hasAllProductsSynced =
-			notSyncedProducts === 0 && activeProducts > 0;
-		const hasConversions = conversions > 0;
-
-		return (
-			hasEnoughActiveProducts &&
-			hasAllProductsSynced &&
-			isMCAccountReady &&
-			hasConversions
-		);
-	};
-
-	// Fire event when banner is shown.
-	useEffect( () => {
-		if ( ! isDismissed ) {
-			recordGlaEvent( 'gla_app_ratings_shown', {
-				context: APP_RATINGS_BANNER_CONTEXT,
-			} );
-		}
-	}, [ isDismissed ] );
-
-	if ( ! shouldDisplayBanner() || isDismissed ) {
+	if ( ! hasGoogleAdsConnection || isDismissed ) {
 		return null;
 	}
 
-	const handleGoodOnClick = () => {
-		recordGlaEvent( 'gla_app_ratings_good_clicked', {
-			context: APP_RATINGS_BANNER_CONTEXT,
-		} );
-		setShowModal( true );
-	};
-
-	const handleRequestClose = () => {
-		recordGlaEvent( 'gla_app_ratings_close', {
-			context: APP_RATINGS_BANNER_CONTEXT,
-		} );
-		setShowModal( false );
-	};
-
-	const handleNeedHelpOnClick = () => {
-		recordGlaEvent( 'gla_app_ratings_need_help_clicked', {
-			context: APP_RATINGS_BANNER_CONTEXT,
-		} );
-	};
-
-	const dismissBanner = () => {
-		set( PREFERENCES_STORE_NAMESPACE, BANNER_DISMISSED_KEY, true );
-	};
-
-	return (
-		<div className="gla-experience-rating-banner__container">
-			{ showModal && (
-				<FeedbackModal
-					onRequestClose={ handleRequestClose }
-					onRateUsClick={ dismissBanner }
-				/>
-			) }
-			<Notice
-				className="gla-experience-rating-banner"
-				status="info"
-				isDismissible={ true }
-				onRemove={ dismissBanner }
-			>
-				<p className="gla-experience-rating-banner__text">
-					{ __(
-						'How was your experience with Google for WooCommerce?',
-						'google-listings-and-ads'
-					) }
-				</p>
-
-				<div className="gla-experience-rating-banner__actions">
-					<AppButton onClick={ handleGoodOnClick } isSecondary>
-						{ __( 'Good', 'google-listings-and-ads' ) }
-					</AppButton>
-
-					<AppButton
-						isSecondary
-						href="https://woocommerce.com/my-account/contact-support/"
-						target="_blank"
-						onClick={ handleNeedHelpOnClick }
-						icon={ <Icon icon={ externalIcon } /> }
-						iconPosition="right"
-						iconSize={ 16 }
-					>
-						{ __( 'Need help', 'google-listings-and-ads' ) }
-					</AppButton>
-				</div>
-			</Notice>
-		</div>
-	);
+	return <Banner />;
 };
 
 export default ExperienceRatingBanner;

--- a/js/src/components/experience-rating-banner/index.js
+++ b/js/src/components/experience-rating-banner/index.js
@@ -1,9 +1,10 @@
 /**
  * Internal dependencies
  */
+import Banner from './banner';
 import usePreference from '~/hooks/usePreference';
 import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
-import Banner from './banner';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import { BANNER_DISMISSED_KEY } from './constants';
 import './index.scss';
 
@@ -12,13 +13,14 @@ import './index.scss';
  *
  * Displays a banner asking users to rate their experience with Google for WooCommerce.
  *
- * @return {JSX.Element|null} The ExperienceRatingBanner component, or null if dismissed or Ads account is disconnected.
+ * @return {JSX.Element|null} The ExperienceRatingBanner component, or null if dismissed or Ads account is disconnected or the MC account is not ready.
  */
 const ExperienceRatingBanner = () => {
 	const { hasGoogleAdsConnection } = useGoogleAdsAccount();
+	const { isReady: isMCAccountReady } = useGoogleMCAccount();
 	const isDismissed = usePreference( BANNER_DISMISSED_KEY );
 
-	if ( ! hasGoogleAdsConnection || isDismissed ) {
+	if ( ! hasGoogleAdsConnection || ! isMCAccountReady || isDismissed ) {
 		return null;
 	}
 

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -188,23 +188,23 @@ Clicking on the button to disconnect the Google Ads account.
 #### Emitters
 - [`BillingSetupCard`](../../js/src/components/paid-ads/billing-card/billing-setup-card.js#L39) When the user clicks on the button to set up billing in Google Ads.
 
-### [`gla_app_ratings_close`](../../js/src/components/experience-rating-banner/index.js#L44)
+### [`gla_app_ratings_close`](../../js/src/components/experience-rating-banner/banner.js#L42)
 When the feedback modal is closed by the user.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
 #### Emitters
-- [`ExperienceRatingBanner`](../../js/src/components/experience-rating-banner/index.js#L72) When the feedback modal is closed.
+- [`Banner`](../../js/src/components/experience-rating-banner/banner.js#L70) When the feedback modal is closed.
 
-### [`gla_app_ratings_good_clicked`](../../js/src/components/experience-rating-banner/index.js#L37)
+### [`gla_app_ratings_good_clicked`](../../js/src/components/experience-rating-banner/banner.js#L35)
 When the user clicks the "Good" button on the banner.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
 #### Emitters
-- [`ExperienceRatingBanner`](../../js/src/components/experience-rating-banner/index.js#L72) When the "Good" button is clicked.
+- [`Banner`](../../js/src/components/experience-rating-banner/banner.js#L70) When the "Good" button is clicked.
 
 ### [`gla_app_ratings_maybe_later_clicked`](../../js/src/components/experience-rating-banner/feedback-modal.js#L16)
 
@@ -215,14 +215,14 @@ When the user clicks the "Good" button on the banner.
 #### Emitters
 - [`FeedbackModal`](../../js/src/components/experience-rating-banner/feedback-modal.js#L39) Fired when the user clicks the "Maybe later" button.
 
-### [`gla_app_ratings_need_help_clicked`](../../js/src/components/experience-rating-banner/index.js#L51)
+### [`gla_app_ratings_need_help_clicked`](../../js/src/components/experience-rating-banner/banner.js#L49)
 When the user clicks the "Need help" button on the banner.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
 #### Emitters
-- [`ExperienceRatingBanner`](../../js/src/components/experience-rating-banner/index.js#L72) When the "Need help" button is clicked.
+- [`Banner`](../../js/src/components/experience-rating-banner/banner.js#L70) When the "Need help" button is clicked.
 
 ### [`gla_app_ratings_rate_clicked`](../../js/src/components/experience-rating-banner/feedback-modal.js#L21)
 
@@ -233,14 +233,14 @@ When the user clicks the "Need help" button on the banner.
 #### Emitters
 - [`FeedbackModal`](../../js/src/components/experience-rating-banner/feedback-modal.js#L39) Fired when the user clicks the "Rate us" button.
 
-### [`gla_app_ratings_shown`](../../js/src/components/experience-rating-banner/index.js#L30)
+### [`gla_app_ratings_shown`](../../js/src/components/experience-rating-banner/banner.js#L28)
 When the experience rating banner is displayed to the user.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
 #### Emitters
-- [`ExperienceRatingBanner`](../../js/src/components/experience-rating-banner/index.js#L72) When the banner is shown.
+- [`Banner`](../../js/src/components/experience-rating-banner/banner.js#L70) When the banner is shown.
 
 ### [`gla_attribute_mapping_create_rule`](../../js/src/pages/attribute-mapping/attribute-mapping-rule-modal.js#L32)
 Creates the rule successfully

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -188,23 +188,23 @@ Clicking on the button to disconnect the Google Ads account.
 #### Emitters
 - [`BillingSetupCard`](../../js/src/components/paid-ads/billing-card/billing-setup-card.js#L39) When the user clicks on the button to set up billing in Google Ads.
 
-### [`gla_app_ratings_close`](../../js/src/components/experience-rating-banner/banner.js#L42)
+### [`gla_app_ratings_close`](../../js/src/components/experience-rating-banner/banner.js#L41)
 When the feedback modal is closed by the user.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
 #### Emitters
-- [`Banner`](../../js/src/components/experience-rating-banner/banner.js#L70) When the feedback modal is closed.
+- [`Banner`](../../js/src/components/experience-rating-banner/banner.js#L69) When the feedback modal is closed.
 
-### [`gla_app_ratings_good_clicked`](../../js/src/components/experience-rating-banner/banner.js#L35)
+### [`gla_app_ratings_good_clicked`](../../js/src/components/experience-rating-banner/banner.js#L34)
 When the user clicks the "Good" button on the banner.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
 #### Emitters
-- [`Banner`](../../js/src/components/experience-rating-banner/banner.js#L70) When the "Good" button is clicked.
+- [`Banner`](../../js/src/components/experience-rating-banner/banner.js#L69) When the "Good" button is clicked.
 
 ### [`gla_app_ratings_maybe_later_clicked`](../../js/src/components/experience-rating-banner/feedback-modal.js#L16)
 
@@ -215,14 +215,14 @@ When the user clicks the "Good" button on the banner.
 #### Emitters
 - [`FeedbackModal`](../../js/src/components/experience-rating-banner/feedback-modal.js#L39) Fired when the user clicks the "Maybe later" button.
 
-### [`gla_app_ratings_need_help_clicked`](../../js/src/components/experience-rating-banner/banner.js#L49)
+### [`gla_app_ratings_need_help_clicked`](../../js/src/components/experience-rating-banner/banner.js#L48)
 When the user clicks the "Need help" button on the banner.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
 #### Emitters
-- [`Banner`](../../js/src/components/experience-rating-banner/banner.js#L70) When the "Need help" button is clicked.
+- [`Banner`](../../js/src/components/experience-rating-banner/banner.js#L69) When the "Need help" button is clicked.
 
 ### [`gla_app_ratings_rate_clicked`](../../js/src/components/experience-rating-banner/feedback-modal.js#L21)
 
@@ -233,14 +233,14 @@ When the user clicks the "Need help" button on the banner.
 #### Emitters
 - [`FeedbackModal`](../../js/src/components/experience-rating-banner/feedback-modal.js#L39) Fired when the user clicks the "Rate us" button.
 
-### [`gla_app_ratings_shown`](../../js/src/components/experience-rating-banner/banner.js#L28)
+### [`gla_app_ratings_shown`](../../js/src/components/experience-rating-banner/banner.js#L27)
 When the experience rating banner is displayed to the user.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the event is triggered.
 #### Emitters
-- [`Banner`](../../js/src/components/experience-rating-banner/banner.js#L70) When the banner is shown.
+- [`Banner`](../../js/src/components/experience-rating-banner/banner.js#L69) When the banner is shown.
 
 ### [`gla_attribute_mapping_create_rule`](../../js/src/pages/attribute-mapping/attribute-mapping-rule-modal.js#L32)
 Creates the rule successfully


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-210/api-errors-triggered-from-app-ratings-notice-when-no-ads-account-is

_Replace this with a good description of your changes & reasoning._
* The `useProductsReport` hook is used in other parts of the app, so I avoided adding a check for a connected Ads account directly within the hook to prevent potential regressions.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Starting at URL: `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings`
2. Disconnect the Google Ads account only
3. Visit any other tab in the plugin admin screen, e.g. the Dashboard Tab (`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard`)
4. There should not be any error message (see ticket for error message)
5. No requests should be sent to the `/wc/gla/ads/reports/products` endpoint.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

Fix - Do not render experience rating banner if Ads account is disconnected.
