### PR TITLE
Fix Intermittent Failure to Disable EC via Checkbox

### DIFF
--- a/src/API/Site/Controllers/Ads/AdsSettingsController.php
+++ b/src/API/Site/Controllers/Ads/AdsSettingsController.php
@@ -94,7 +94,11 @@ class AdsSettingsController extends BaseOptionsController {
 
 				$stored = $this->options->get( $key );
 
-				if ( ! is_null( $stored ) && (bool) $stored === $value ) {
+				if ( is_null( $stored ) ) {
+					$this->options->add( $key, $value );
+					$settings[ $key ] = $value;
+					continue;
+				} elseif ( (bool) $stored === $value ) {
 					$settings[ $key ] = $value;
 					continue;
 				}

--- a/src/API/Site/Controllers/Ads/AdsSettingsController.php
+++ b/src/API/Site/Controllers/Ads/AdsSettingsController.php
@@ -92,7 +92,14 @@ class AdsSettingsController extends BaseOptionsController {
 					continue;
 				}
 
-				$result = $this->options->update( $key, (bool) $value );
+				$stored = (bool) $this->options->get( $key );
+
+				if ( ! is_null( $stored ) && $stored === $value ) {
+					$settings[ $key ] = $value;
+					continue;
+				}
+
+				$result = $this->options->update( $key, $value );
 
 				if ( false === $result ) {
 					return new WP_REST_Response(

--- a/src/API/Site/Controllers/Ads/AdsSettingsController.php
+++ b/src/API/Site/Controllers/Ads/AdsSettingsController.php
@@ -92,9 +92,9 @@ class AdsSettingsController extends BaseOptionsController {
 					continue;
 				}
 
-				$stored = (bool) $this->options->get( $key );
+				$stored = $this->options->get( $key );
 
-				if ( ! is_null( $stored ) && $stored === $value ) {
+				if ( ! is_null( $stored ) && (bool) $stored === $value ) {
 					$settings[ $key ] = $value;
 					continue;
 				}

--- a/tests/Unit/API/Site/Controllers/Ads/AdsSettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AdsSettingsControllerTest.php
@@ -54,7 +54,21 @@ class AdsSettingsControllerTest extends RESTControllerUnitTest {
 			'enhanced_conversions_enabled' => false,
 		];
 
+		$this->options->expects( $this->once() )->method( 'get' )->willReturn( true );
 		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED, false )->willReturn( true );
+
+		$response = $this->do_request( self::ROUTE_SETTINGS, 'POST', $expected );
+
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_edit_settings_with_same_value() {
+		$expected = [
+			'enhanced_conversions_enabled' => false,
+		];
+
+		$this->options->expects( $this->once() )->method( 'get' )->willReturn( false );
 
 		$response = $this->do_request( self::ROUTE_SETTINGS, 'POST', $expected );
 
@@ -67,6 +81,7 @@ class AdsSettingsControllerTest extends RESTControllerUnitTest {
 			'enhanced_conversions_enabled' => false,
 		];
 
+		$this->options->expects( $this->once() )->method( 'get' )->willReturn( true );
 		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED, false )->willReturn( false );
 
 		$response = $this->do_request( self::ROUTE_SETTINGS, 'POST', $query );

--- a/tests/Unit/API/Site/Controllers/Ads/AdsSettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AdsSettingsControllerTest.php
@@ -76,6 +76,19 @@ class AdsSettingsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
+	public function test_edit_settings_with_null_option_value() {
+		$expected = [
+			'enhanced_conversions_enabled' => false,
+		];
+
+		$this->options->expects( $this->once() )->method( 'get' )->willReturn( null );
+
+		$response = $this->do_request( self::ROUTE_SETTINGS, 'POST', $expected );
+
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
 	public function test_edit_settings_fail() {
 		$query = [
 			'enhanced_conversions_enabled' => false,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-212/intermittent-failure-to-disable-ec-via-checkbox

Fixes issue where REST API endpoint would return a 400 error response when attempting to set the enhanced conversion status to the same value as what is stored in the database.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go the Settings page and see the Enhanced Conversion settings.
2. Use Postman to make a POST request to the `/wp-json/wc/gla/ads/settings` to set the current value to the opposite of what is seen on the settings page (If checked, set `enhanced_conversions_enabled` to `false`, if unchecked `true`)
3. Enable (or disable) the Enhanced Conversions checkbox in the settings page. The checkbox status should update to match what is already stored in the database and a success notification is displayed. The error notification no longer shows.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
