### PR TITLE
Remove unnecessary kebab menu from `Google for WooCommerce` setup task

### DIFF
--- a/src/TaskList/CompleteSetupTask.php
+++ b/src/TaskList/CompleteSetupTask.php
@@ -75,15 +75,6 @@ class CompleteSetupTask extends Task implements Service, Registerable, MerchantC
 	}
 
 	/**
-	 * Always dismissable.
-	 *
-	 * @return bool
-	 */
-	public function is_dismissable() {
-		return true;
-	}
-
-	/**
 	 * Get completion status.
 	 * Forwards from the merchant center setup status.
 	 *

--- a/tests/Unit/TaskList/CompleteSetupTaskTest.php
+++ b/tests/Unit/TaskList/CompleteSetupTaskTest.php
@@ -67,7 +67,7 @@ class CompleteSetupTaskTest extends UnitTest {
 	}
 
 	public function test_dismissable() {
-		$this->assertTrue( $this->task->is_dismissable() );
+		$this->assertFalse( $this->task->is_dismissable() );
 	}
 
 	public function test_is_complete_and_mc_setup_not_complete() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-192/bug-remove-unnecessary-kebab-menu-from-google-setup-task

_Replace this with a good description of your changes & reasoning._


### Screenshots:
#### Before:
<img width="721" alt="Screenshot 2025-07-10 at 10 11 08 AM" src="https://github.com/user-attachments/assets/e1390a12-ae77-4e68-bc09-814ba3834445" />

#### After:
<img width="709" alt="Screenshot 2025-07-10 at 10 11 25 AM" src="https://github.com/user-attachments/assets/61690817-2c0f-4a56-9824-8a49ea9bdf47" />



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Login to WP admin
2. Go to WooCommerce Home
3. Scroll down to the `Things to do next` task list.
4. Make sure `Set up Google for WooCommerce` do not have kebab menu.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

Fix - Remove unnecessary kebab menu from setup task.
