### PR TITLE
Use `wp_is_serving_rest_request()` to detect if we are handling a REST API request

### DIFF
--- a/src/Admin/Redirect.php
+++ b/src/Admin/Redirect.php
@@ -68,7 +68,7 @@ class Redirect implements Activateable, Service, Registerable, OptionsAwareInter
 	 */
 	public function activate(): void {
 		// Do not take any action if activated in a REST request (via wc-admin).
-		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		if ( $this->wp->wp_is_serving_rest_request() ) {
 			return;
 		}
 

--- a/src/Proxies/WP.php
+++ b/src/Proxies/WP.php
@@ -340,4 +340,13 @@ class WP {
 	public function wp_print_inline_script_tag( string $data, array $attributes = [] ) {
 		return wp_print_inline_script_tag( $data, $attributes );
 	}
+
+	/**
+	 * Determines whether WordPress is currently serving a REST API request.
+	 *
+	 * @return bool True if it's a WordPress REST API request, false otherwise.
+	 */
+	public function wp_is_serving_rest_request(): bool {
+		return wp_is_serving_rest_request();
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2303.

https://linear.app/a8c/issue/GOOWOO-93/use-wp-is-serving-rest-request-to-detect-if-we-are-handling-a-rest-api

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install and activate WC in fresh setup
2. Install Google for WooCommerce and activate
3. Make sure it redirect to onboarding page.

### Changelog entry

Fix – Use `wp_is_serving_rest_request()` to detect if we are handling a REST API request.