### PR TITLE
GOOWOO-66 change overflow to auto in attribute mapping modal

### DIFF
--- a/js/src/pages/attribute-mapping/attribute-mapping-rule-modal.js
+++ b/js/src/pages/attribute-mapping/attribute-mapping-rule-modal.js
@@ -169,7 +169,7 @@ const AttributeMappingRuleModal = ( { rule, onRequestClose = noop } ) => {
 
 	return (
 		<AppModal
-			overflow="visible"
+			overflow="auto"
 			onRequestClose={ handleClose }
 			className="gla-attribute-mapping__rule-modal"
 			title={


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-66/overflow-issue-in-attribute-mapping-modal

Fixed modal overflow on small viewports

### Screenshots:

<img width="503" height="454" alt="Screenshot 2025-07-21 at 15 49 37" src="https://github.com/user-attachments/assets/d6881746-3adf-4315-80ae-4fa40d9b95d7" />


### Detailed test instructions:

1. Click on Attributes tab
2. "Create attribute rule"
3. Select an option (e.g. "Age group")
4. Resize the window horizontally and vertically so that the buttons are not visible anymore

### Additional details:

### Changelog entry

Fix - Modal overflow on small viewports.