### PR TITLE
Display badge count when there's a PMax recommendation

### DIFF
--- a/js/src/components/pmax-improve-assets-banner/banner.js
+++ b/js/src/components/pmax-improve-assets-banner/banner.js
@@ -52,6 +52,7 @@ const PMAX_ASSETS_IMPROVEMENTS_BANNER_CONTEXT =
  * Clicking "Improve Assets" navigates to the asset group edit page for the highest-spending PMAX campaign.
  * @param {Object} props Component properties.
  * @param {Function} props.onBannerDismissed Callback function to call when the banner is dismissed.
+ * @param {Function} props.onBannerShown Callback function to call when the banner is shown.
  *
  * @return {JSX.Element|null} The banner component, or null if not applicable.
  *
@@ -59,7 +60,7 @@ const PMAX_ASSETS_IMPROVEMENTS_BANNER_CONTEXT =
  * @fires gla_pmax_assets_improvements_improve_assets_clicked when the "Improve Assets" button is clicked.
  * @fires gla_pmax_assets_improvements_dismiss_clicked when the banner is dismissed.
  */
-const Banner = ( { onBannerDismissed } ) => {
+const Banner = ( { onBannerDismissed, onBannerShown } ) => {
 	const { campaign, hasFinishedResolution } = useRecommendedPMaxCampaign();
 
 	useEffect( () => {
@@ -69,6 +70,12 @@ const Banner = ( { onBannerDismissed } ) => {
 			} );
 		}
 	}, [ campaign, hasFinishedResolution ] );
+
+	useEffect( () => {
+		if ( campaign && hasFinishedResolution ) {
+			onBannerShown();
+		}
+	}, [ campaign, hasFinishedResolution, onBannerShown ] );
 
 	if ( ! campaign || ! hasFinishedResolution ) {
 		return null;

--- a/js/src/components/pmax-improve-assets-banner/index.js
+++ b/js/src/components/pmax-improve-assets-banner/index.js
@@ -38,7 +38,7 @@ const PMaxImproveAssetsBanner = () => {
 		if ( expiry !== undefined && Date.now() >= expiry ) {
 			set( PREFERENCES_STORE_NAMESPACE, PREFERENCE_BANNER_KEY, {
 				expiry: undefined,
-				hasRecommendation: true,
+				hasRecommendation: undefined,
 			} );
 		}
 	}, [ expiry, set ] );

--- a/js/src/components/pmax-improve-assets-banner/index.js
+++ b/js/src/components/pmax-improve-assets-banner/index.js
@@ -25,17 +25,20 @@ const PREFERENCE_BANNER_KEY = 'pmax-improve-assets-banner';
  *
  * When dismissed, the banner will not reappear until the expiry time elapses.
  * Clicking "Improve Assets" navigates to the asset group edit page for the highest-spending PMAX campaign.
+ * Another property, "hasRecommendation" is used to track if there are any recommendations available.
  *
  * @return {JSX.Element|null} The banner component, or null if not applicable.
  */
 const PMaxImproveAssetsBanner = () => {
 	const { set } = useDispatch( preferencesStore );
-	const { expiry } = usePreference( PREFERENCE_BANNER_KEY ) || {};
+	const { expiry, hasRecommendation } =
+		usePreference( PREFERENCE_BANNER_KEY ) || {};
 
 	useEffect( () => {
 		if ( expiry !== undefined && Date.now() >= expiry ) {
 			set( PREFERENCES_STORE_NAMESPACE, PREFERENCE_BANNER_KEY, {
 				expiry: undefined,
+				hasRecommendation: true,
 			} );
 		}
 	}, [ expiry, set ] );
@@ -43,15 +46,31 @@ const PMaxImproveAssetsBanner = () => {
 	const handleOnBannerDismissed = useCallback( () => {
 		set( PREFERENCES_STORE_NAMESPACE, PREFERENCE_BANNER_KEY, {
 			expiry: Date.now() + DAY_IN_SECONDS * 30 * 1000, // 30 days in ms
+			hasRecommendation: undefined,
 		} );
 	}, [ set ] );
+
+	const handleOnBannerShown = useCallback( () => {
+		if ( hasRecommendation ) {
+			return;
+		}
+		set( PREFERENCES_STORE_NAMESPACE, PREFERENCE_BANNER_KEY, {
+			expiry,
+			hasRecommendation: true,
+		} );
+	}, [ set, hasRecommendation, expiry ] );
 
 	// Do not show the banner if the expiry is set and not yet expired
 	if ( expiry !== undefined && Date.now() < expiry ) {
 		return null;
 	}
 
-	return <Banner onBannerDismissed={ handleOnBannerDismissed } />;
+	return (
+		<Banner
+			onBannerDismissed={ handleOnBannerDismissed }
+			onBannerShown={ handleOnBannerShown }
+		/>
+	);
 };
 
 export default PMaxImproveAssetsBanner;

--- a/src/Menu/NotificationManager.php
+++ b/src/Menu/NotificationManager.php
@@ -44,7 +44,6 @@ class NotificationManager implements Service, Registerable {
 		// Hook into admin_menu with a high priority (e.g., 20) to ensure
 		// all other menu items have been registered by WooCommerce and other plugins.
 		add_action( 'admin_menu', [ $this, 'display_aggregated_notification_pill' ], 20 );
-		add_filter( 'google_for_woocommerce_admin_menu_notification_count', [ $this, 'filter_notification_count' ] );
 	}
 
 	/**
@@ -186,16 +185,14 @@ class NotificationManager implements Service, Registerable {
 	}
 
 	/**
-	 * Filter the notification count for the admin menu.
-	 *
-	 * This method checks the user's persisted preferences to determine if there are any recommendations.
-	 * If there are recommendations, it increments the count by 1; otherwise, it returns 0.
+	 * Returns the initial notification count for the admin menu.
 	 *
 	 * @return int The updated notification count, which is either 1 (if there are recommendations) or 0 (if there are no recommendations).
 	 */
 	public function initial_notification_count(): int {
+		global $wpdb;
 		$count       = 0;
-		$preferences = get_user_meta( get_current_user_id(), 'wp_persisted_preferences', true );
+		$preferences = get_user_meta( get_current_user_id(), "{$wpdb->prefix}persisted_preferences", true );
 
 		if ( is_array( $preferences ) && isset( $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['hasRecommendations'] ) && $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['hasRecommendations'] ) {
 			return ++$count;

--- a/src/Menu/NotificationManager.php
+++ b/src/Menu/NotificationManager.php
@@ -198,7 +198,7 @@ class NotificationManager implements Service, Registerable {
 		$preferences = get_user_meta( get_current_user_id(), 'wp_persisted_preferences', true );
 
 		if ( is_array( $preferences ) && isset( $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['hasRecommendations'] ) && $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['hasRecommendations'] ) {
-			$count = $count + 1;
+			return ++$count;
 		}
 
 		return $count;

--- a/src/Menu/NotificationManager.php
+++ b/src/Menu/NotificationManager.php
@@ -145,7 +145,7 @@ class NotificationManager implements Service, Registerable {
 		// Initialize the count and apply the filter to get the total aggregated count.
 		// All parts of the plugin (and other plugins) that need to add to the notification
 		// should hook into this filter.
-		$total_notification_count = apply_filters( 'google_for_woocommerce_admin_menu_notification_count', 0 );
+		$total_notification_count = apply_filters( 'google_for_woocommerce_admin_menu_notification_count', $this->initial_notification_count() );
 
 		// Only proceed if there's at least one notification.
 		if ( $total_notification_count > 0 ) {
@@ -189,16 +189,16 @@ class NotificationManager implements Service, Registerable {
 	 * Filter the notification count for the admin menu.
 	 *
 	 * This method checks the user's persisted preferences to determine if there are any recommendations.
-	 * If there are recommendations, it increments the count by 1; otherwise, it returns
+	 * If there are recommendations, it increments the count by 1; otherwise, it returns 0.
 	 *
-	 * @param int $count The current notification count.
 	 * @return int The updated notification count, which is either 1 (if there are recommendations) or 0 (if there are no recommendations).
 	 */
-	public function filter_notification_count( int $count ): int {
+	public function initial_notification_count(): int {
+		$count = 0;
 		$preferences = get_user_meta( get_current_user_id(), 'wp_persisted_preferences', true );
 
 		if ( is_array( $preferences ) && isset( $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['hasRecommendations'] ) && $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['hasRecommendations'] ) {
-			return ++$count;
+			$count = $count + 1;
 		}
 
 		return $count;

--- a/src/Menu/NotificationManager.php
+++ b/src/Menu/NotificationManager.php
@@ -194,7 +194,7 @@ class NotificationManager implements Service, Registerable {
 	 * @return int The updated notification count, which is either 1 (if there are recommendations) or 0 (if there are no recommendations).
 	 */
 	public function initial_notification_count(): int {
-		$count = 0;
+		$count       = 0;
 		$preferences = get_user_meta( get_current_user_id(), 'wp_persisted_preferences', true );
 
 		if ( is_array( $preferences ) && isset( $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['hasRecommendations'] ) && $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['hasRecommendations'] ) {

--- a/src/Menu/NotificationManager.php
+++ b/src/Menu/NotificationManager.php
@@ -44,6 +44,7 @@ class NotificationManager implements Service, Registerable {
 		// Hook into admin_menu with a high priority (e.g., 20) to ensure
 		// all other menu items have been registered by WooCommerce and other plugins.
 		add_action( 'admin_menu', [ $this, 'display_aggregated_notification_pill' ], 20 );
+		add_filter( 'google_for_woocommerce_admin_menu_notification_count', [ $this, 'filter_notification_count' ] );
 	}
 
 	/**
@@ -182,6 +183,25 @@ class NotificationManager implements Service, Registerable {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Filter the notification count for the admin menu.
+	 *
+	 * This method checks the user's persisted preferences to determine if there are any recommendations.
+	 * If there are recommendations, it increments the count by 1; otherwise, it returns
+	 *
+	 * @param int $count The current notification count.
+	 * @return int The updated notification count, which is either 1 (if there are recommendations) or 0 (if there are no recommendations).
+	 */
+	public function filter_notification_count( int $count ): int {
+		$preferences = get_user_meta( get_current_user_id(), 'wp_persisted_preferences', true );
+
+		if ( is_array( $preferences ) && isset( $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['hasRecommendations'] ) && $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['hasRecommendations'] ) {
+			return ++$count;
+		}
+
+		return $count;
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,6 +106,11 @@ const webpackConfig = {
 			'js/src/wp-consent-api',
 			'index.js'
 		),
+		'notification-manager': path.resolve(
+			process.cwd(),
+			'js/src/notification-manager',
+			'index.js'
+		),
 	} ),
 	output: {
 		...defaultConfig.output,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes: https://linear.app/a8c/issue/GOOWOO-217/display-badge-count-when-theres-a-pmax-recommendation

_Replace this with a good description of your changes & reasoning._


### Screenshots:
<img width="600" height="589" alt="Screenshot 2025-07-22 at 2 12 22 PM" src="https://github.com/user-attachments/assets/7765415e-bf8e-4a2f-93bf-1fe35844b4e8" />

### Detailed test instructions:

1. Add the following code in mu plugin and visit the dashboard. Once the dashboard is loaded successfully, remove this code. It will add the recommendation in DB.

```js
add_filter( 'admin_footer', function() {
    $data = [
        'woocommerce/google-listings-and-ads' => [
            'pmax-improve-assets-banner' => [
                'hasRecommendations' => true,
                'expiry' => 1753115365905,
            ],
        ],
        '_modified' => '2025-07-17T12:17:58.427Z',
    ];

    // insert data in user meta `wp_persisted_preferences` meta key.
    update_user_meta( get_current_user_id(), 'wp_persisted_preferences', $data );
} );
```

2. Refresh the dashboard again and you should be able to see the notification badge in `Marketing` tab when collapsed. The notification pill be moved to `Google for woocommerce` submenu when `Marketing` tab is expanded, this must have been already tested in [GOOWOO-182](https://linear.app/a8c/issue/GOOWOO-182/display-notification-badge-in-the-admin-menu-when-there-are)

3. Run this command in terminal for docker container to remove the recommendations option from DB.

```js
  npm run wp-env run cli wp user meta delete 1 wp_persisted_preferences
```

4. Visit the dashboard, notification badge should no longer be available.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Update - Display badge count when there's a PMax recommendation.