### PR TITLE
Add notification manager admin script to build process

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,6 +106,11 @@ const webpackConfig = {
 			'js/src/wp-consent-api',
 			'index.js'
 		),
+		'notification-manager': path.resolve(
+			process.cwd(),
+			'js/src/notification-manager',
+			'index.js'
+		),
 	} ),
 	output: {
 		...defaultConfig.output,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Fixes error with missing admin script.

Closes https://linear.app/a8c/issue/GOOWOO-182/display-notification-badge-in-the-admin-menu-when-there-are

See https://github.com/woocommerce/google-listings-and-ads/pull/3001 for details on how to use the feature.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Error with missing admin script.