### PR TITLE
Ensure EC settings defaults to false

### DIFF
--- a/src/API/Site/Controllers/Ads/AdsSettingsController.php
+++ b/src/API/Site/Controllers/Ads/AdsSettingsController.php
@@ -48,7 +48,7 @@ class AdsSettingsController extends BaseOptionsController {
 	 */
 	protected function get_allowed_options(): array {
 		return [
-			OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED => true,
+			OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED => false,
 		];
 	}
 

--- a/tests/Unit/API/Site/Controllers/Ads/AdsSettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AdsSettingsControllerTest.php
@@ -49,6 +49,20 @@ class AdsSettingsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
+	public function test_get_settings_with_null_option_value() {
+		$expected = [
+			'enhanced_conversions_enabled' => false,
+		];
+
+		$this->options->expects( $this->once() )->method( 'get_ads_id' )->willReturn( 1 );
+		$this->options->expects( $this->once() )->method( 'get' )->willReturn( null );
+
+		$response = $this->do_request( self::ROUTE_SETTINGS, 'GET' );
+
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
 	public function test_edit_settings() {
 		$expected = [
 			'enhanced_conversions_enabled' => false,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-212. Follow-up to #3002.

This ensures that the settings API endpoint returns false until the user explicitly enables this feature.

### Screenshots:

<img width="819" height="195" alt="image" src="https://github.com/user-attachments/assets/a9c5a894-42c0-45e5-9e98-fe002e0e3cec" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Delete the `gla_enhanced_conversions_enabled` option from the local database.
2. Load the setting screen and see that the checkbox is unchecked.
3. Ensure that when unchecked, the EC tag is not being added to the front-end


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
