### PR TITLE
Update .github/release.yml to exclude bot accounts from GitHub release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,7 +4,9 @@ changelog:
       - "changelog: none"
     authors:
       - dependabot
+      - dependabot[bot]
       - github-actions
+      - github-actions[bot]
 
   categories:
     # Major level


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR update .github/release.yml to exclude bot accounts from GitHub release notes.

Originally, PRs created by the github-actions bot would not have been included, but they have been recently.

<img width="640" height="115" alt="image" src="https://github.com/user-attachments/assets/bd97d84c-4ec4-4fc5-b5cd-dfd16250a78b" />

### Changelog entry
