### PR TITLE
Add API_PULL_SYNC_MODE to WooCommerce System Status Report

### DIFF
--- a/src/Admin/SystemStatusService.php
+++ b/src/Admin/SystemStatusService.php
@@ -125,22 +125,27 @@ class SystemStatusService implements Service, Registerable {
 					$pull_enabled = isset( $modes['pull'] ) && $modes['pull'];
 					$push_enabled = isset( $modes['push'] ) && $modes['push'];
 					
-					$pull_status = $pull_enabled ? '✔ Enabled' : '❌ Disabled';
-					$push_status = $push_enabled ? '✔ Enabled' : '❌ Disabled';
-					$pull_class  = $pull_enabled ? 'yes' : 'error';
-					$push_class  = $push_enabled ? 'yes' : 'error';
+					$pull_status_text = $pull_enabled ? 'Enabled' : 'Disabled';
+					$push_status_text = $push_enabled ? 'Enabled' : 'Disabled';
 					
-					// Format for both display and text export
-					$status_text = sprintf(
-						'API Pull: %s, MC Push: %s',
-						$pull_enabled ? 'Enabled' : 'Disabled',
-						$push_enabled ? 'Enabled' : 'Disabled'
-					);
+					// Create a concise status that matches WooCommerce export patterns
+					$status_summary = sprintf( 'API Pull: %s / MC Push: %s', $pull_status_text, $push_status_text );
+					
+					if ( $pull_enabled && $push_enabled ) {
+						$class = 'yes';
+						$icon = 'dashicons-yes';
+					} elseif ( ! $pull_enabled && ! $push_enabled ) {
+						$class = 'error';
+						$icon = 'dashicons-warning';
+					} else {
+						$class = 'error'; // Mixed state
+						$icon = 'dashicons-warning';
+					}
 					?>
-					<span data-export-label="<?php echo esc_attr( $status_text ); ?>">
-						<mark class="<?php echo esc_attr( $pull_class ); ?>"><?php echo esc_html( $pull_status ); ?></mark> / 
-						<mark class="<?php echo esc_attr( $push_class ); ?>"><?php echo esc_html( $push_status ); ?></mark>
-					</span>
+					<mark class="<?php echo esc_attr( $class ); ?>">
+						<span class="dashicons <?php echo esc_attr( $icon ); ?>"></span>
+						<?php echo esc_html( $status_summary ); ?>
+					</mark>
 				</td>
 			</tr>
 			<?php

--- a/src/Admin/SystemStatusService.php
+++ b/src/Admin/SystemStatusService.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -27,12 +28,19 @@ class SystemStatusService implements Service, Registerable {
 	private $notifications_service;
 
 	/**
+	 * @var MerchantCenterService $merchant_center
+	 */
+	private $merchant_center;
+
+	/**
 	 * SystemStatusService constructor
 	 *
-	 * @param NotificationsService $notifications_service
+	 * @param NotificationsService  $notifications_service
+	 * @param MerchantCenterService $merchant_center
 	 */
-	public function __construct( NotificationsService $notifications_service ) {
+	public function __construct( NotificationsService $notifications_service, MerchantCenterService $merchant_center ) {
 		$this->notifications_service = $notifications_service;
+		$this->merchant_center       = $merchant_center;
 	}
 
 	/**
@@ -100,14 +108,17 @@ class SystemStatusService implements Service, Registerable {
 			return;
 		}
 
+		$is_pull_ready = $this->notifications_service->is_ready();
+		$is_push_ready = $this->merchant_center->is_ready_for_syncing();
+
 		foreach ( $sync_mode as $data_type => $modes ) {
 			if ( ! is_array( $modes ) ) {
 				continue;
 			}
 
 			$data_type_label = ucfirst( str_replace( '_', ' ', $data_type ) );
-			$pull_enabled    = isset( $modes['pull'] ) && $modes['pull'];
-			$push_enabled    = isset( $modes['push'] ) && $modes['push'];
+			$pull_enabled    = $is_pull_ready && isset( $modes['pull'] ) && $modes['pull'];
+			$push_enabled    = $is_push_ready && isset( $modes['push'] ) && $modes['push'];
 
 			// API Pull row
 			?>
@@ -116,7 +127,7 @@ class SystemStatusService implements Service, Registerable {
 					<?php echo esc_html( sprintf( '%s API Pull:', $data_type_label ) ); ?>
 				</td>
 				<td class="help">
-					<?php echo wp_kses_post( wc_help_tip( sprintf( 'Shows if API Pull sync is enabled for %s data.', strtolower( $data_type_label ) ) ) ); ?>
+					<?php echo wp_kses_post( wc_help_tip( sprintf( 'Shows if API Pull sync is ready and enabled for %s data.', strtolower( $data_type_label ) ) ) ); ?>
 				</td>
 				<td>
 					<?php if ( $pull_enabled ) : ?>
@@ -135,7 +146,7 @@ class SystemStatusService implements Service, Registerable {
 					<?php echo esc_html( sprintf( '%s MC Push:', $data_type_label ) ); ?>
 				</td>
 				<td class="help">
-					<?php echo wp_kses_post( wc_help_tip( sprintf( 'Shows if MC Push sync is enabled for %s data.', strtolower( $data_type_label ) ) ) ); ?>
+					<?php echo wp_kses_post( wc_help_tip( sprintf( 'Shows if MC Push sync is ready and enabled for %s data.', strtolower( $data_type_label ) ) ) ); ?>
 				</td>
 				<td>
 					<?php if ( $push_enabled ) : ?>

--- a/src/Admin/SystemStatusService.php
+++ b/src/Admin/SystemStatusService.php
@@ -1,0 +1,154 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class SystemStatusService
+ * This class adds Google for WooCommerce information to the WooCommerce System Status Report
+ *
+ * @since 3.2.0
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin
+ */
+class SystemStatusService implements Service, Registerable {
+
+	/**
+	 * The NotificationsService instance
+	 *
+	 * @var NotificationsService
+	 */
+	private $notifications_service;
+
+	/**
+	 * SystemStatusService constructor
+	 *
+	 * @param NotificationsService $notifications_service
+	 */
+	public function __construct( NotificationsService $notifications_service ) {
+		$this->notifications_service = $notifications_service;
+	}
+
+	/**
+	 * Register the service
+	 */
+	public function register(): void {
+		add_action( 'woocommerce_system_status_report', [ $this, 'add_system_status_section' ] );
+	}
+
+	/**
+	 * Add Google for WooCommerce section to System Status Report
+	 */
+	public function add_system_status_section(): void {
+		// Check if the notifications service is available to prevent fatal errors
+		if ( ! $this->notifications_service ) {
+			return;
+		}
+
+		?>
+		<table class="wc_status_table widefat" cellspacing="0">
+			<thead>
+				<tr>
+					<th colspan="3" data-export-label="Google for WooCommerce">
+						<h2><?php esc_html_e( 'Google for WooCommerce', 'google-listings-and-ads' ); ?></h2>
+					</th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php $this->render_sync_mode_rows(); ?>
+			</tbody>
+		</table>
+		<?php
+	}
+
+	/**
+	 * Render the sync mode configuration rows
+	 */
+	private function render_sync_mode_rows(): void {
+		try {
+			$sync_mode = $this->notifications_service->get_current_sync_mode();
+		} catch ( Exception $exception ) {
+			?>
+			<tr>
+				<td data-export-label="Sync Mode Status"><?php esc_html_e( 'Sync Mode Status:', 'google-listings-and-ads' ); ?></td>
+				<td class="help"><?php echo wc_help_tip( 'Current sync mode configuration status.' ); ?></td>
+				<td>
+					<mark class="error">
+						<span class="dashicons dashicons-warning"></span> 
+						<?php esc_html_e( 'Error retrieving sync mode configuration', 'google-listings-and-ads' ); ?>
+					</mark>
+				</td>
+			</tr>
+			<?php
+			return;
+		}
+
+		if ( ! is_array( $sync_mode ) || empty( $sync_mode ) ) {
+			?>
+			<tr>
+				<td data-export-label="Sync Mode Status"><?php esc_html_e( 'Sync Mode Status:', 'google-listings-and-ads' ); ?></td>
+				<td class="help"><?php echo wc_help_tip( 'Current sync mode configuration status.' ); ?></td>
+				<td>
+					<mark class="error">
+						<span class="dashicons dashicons-warning"></span> 
+						<?php esc_html_e( 'No sync mode configuration found', 'google-listings-and-ads' ); ?>
+					</mark>
+				</td>
+			</tr>
+			<?php
+			return;
+		}
+
+		foreach ( $sync_mode as $data_type => $modes ) {
+			if ( ! is_array( $modes ) ) {
+				continue;
+			}
+
+			$data_type_label = ucfirst( str_replace( '_', ' ', $data_type ) );
+			
+			?>
+			<tr>
+				<td data-export-label="<?php echo esc_attr( $data_type_label . ' Sync Mode' ); ?>">
+					<?php echo esc_html( sprintf( '%s Sync Mode:', $data_type_label ) ); ?>
+				</td>
+				<td class="help">
+					<?php echo wc_help_tip( sprintf( 'Shows the current API Pull and MC Push sync settings for %s data.', strtolower( $data_type_label ) ) ); ?>
+				</td>
+				<td>
+					<?php
+					$pull_enabled = isset( $modes['pull'] ) && $modes['pull'];
+					$push_enabled = isset( $modes['push'] ) && $modes['push'];
+					
+					$pull_status = $pull_enabled ? 'Enabled' : 'Disabled';
+					$push_status = $push_enabled ? 'Enabled' : 'Disabled';
+					$pull_class  = $pull_enabled ? 'yes' : 'error';
+					$push_class  = $push_enabled ? 'yes' : 'error';
+					$pull_icon   = $pull_enabled ? 'dashicons-yes' : 'dashicons-warning';
+					$push_icon   = $push_enabled ? 'dashicons-yes' : 'dashicons-warning';
+					?>
+					<div style="margin-bottom: 5px;">
+						<strong><?php esc_html_e( 'API Pull:', 'google-listings-and-ads' ); ?></strong> 
+						<mark class="<?php echo esc_attr( $pull_class ); ?>">
+							<span class="dashicons <?php echo esc_attr( $pull_icon ); ?>"></span> 
+							<?php echo esc_html( $pull_status ); ?>
+						</mark>
+					</div>
+					<div>
+						<strong><?php esc_html_e( 'MC Push:', 'google-listings-and-ads' ); ?></strong> 
+						<mark class="<?php echo esc_attr( $push_class ); ?>">
+							<span class="dashicons <?php echo esc_attr( $push_icon ); ?>"></span> 
+							<?php echo esc_html( $push_status ); ?>
+						</mark>
+					</div>
+				</td>
+			</tr>
+			<?php
+		}
+	}
+}

--- a/src/Admin/SystemStatusService.php
+++ b/src/Admin/SystemStatusService.php
@@ -46,11 +46,6 @@ class SystemStatusService implements Service, Registerable {
 	 * Add Google for WooCommerce section to System Status Report
 	 */
 	public function add_system_status_section(): void {
-		// Check if the notifications service is available to prevent fatal errors
-		if ( ! $this->notifications_service ) {
-			return;
-		}
-
 		?>
 		<table class="wc_status_table widefat" cellspacing="0">
 			<thead>

--- a/src/Admin/SystemStatusService.php
+++ b/src/Admin/SystemStatusService.php
@@ -77,7 +77,7 @@ class SystemStatusService implements Service, Registerable {
 			?>
 			<tr>
 				<td data-export-label="Sync Mode Status"><?php esc_html_e( 'Sync Mode Status:', 'google-listings-and-ads' ); ?></td>
-				<td class="help"><?php echo wc_help_tip( 'Current sync mode configuration status.' ); ?></td>
+				<td class="help"><?php echo wp_kses_post( wc_help_tip( 'Current sync mode configuration status.' ) ); ?></td>
 				<td>
 					<mark class="error">
 						<span class="dashicons dashicons-warning"></span> 
@@ -93,7 +93,7 @@ class SystemStatusService implements Service, Registerable {
 			?>
 			<tr>
 				<td data-export-label="Sync Mode Status"><?php esc_html_e( 'Sync Mode Status:', 'google-listings-and-ads' ); ?></td>
-				<td class="help"><?php echo wc_help_tip( 'Current sync mode configuration status.' ); ?></td>
+				<td class="help"><?php echo wp_kses_post( wc_help_tip( 'Current sync mode configuration status.' ) ); ?></td>
 				<td>
 					<mark class="error">
 						<span class="dashicons dashicons-warning"></span> 
@@ -111,9 +111,9 @@ class SystemStatusService implements Service, Registerable {
 			}
 
 			$data_type_label = ucfirst( str_replace( '_', ' ', $data_type ) );
-			$pull_enabled = isset( $modes['pull'] ) && $modes['pull'];
-			$push_enabled = isset( $modes['push'] ) && $modes['push'];
-			
+			$pull_enabled    = isset( $modes['pull'] ) && $modes['pull'];
+			$push_enabled    = isset( $modes['push'] ) && $modes['push'];
+
 			// API Pull row
 			?>
 			<tr>
@@ -121,7 +121,7 @@ class SystemStatusService implements Service, Registerable {
 					<?php echo esc_html( sprintf( '%s API Pull:', $data_type_label ) ); ?>
 				</td>
 				<td class="help">
-					<?php echo wc_help_tip( sprintf( 'Shows if API Pull sync is enabled for %s data.', strtolower( $data_type_label ) ) ); ?>
+					<?php echo wp_kses_post( wc_help_tip( sprintf( 'Shows if API Pull sync is enabled for %s data.', strtolower( $data_type_label ) ) ) ); ?>
 				</td>
 				<td>
 					<?php if ( $pull_enabled ) : ?>
@@ -132,7 +132,7 @@ class SystemStatusService implements Service, Registerable {
 				</td>
 			</tr>
 			<?php
-			
+
 			// MC Push row
 			?>
 			<tr>
@@ -140,7 +140,7 @@ class SystemStatusService implements Service, Registerable {
 					<?php echo esc_html( sprintf( '%s MC Push:', $data_type_label ) ); ?>
 				</td>
 				<td class="help">
-					<?php echo wc_help_tip( sprintf( 'Shows if MC Push sync is enabled for %s data.', strtolower( $data_type_label ) ) ); ?>
+					<?php echo wp_kses_post( wc_help_tip( sprintf( 'Shows if MC Push sync is enabled for %s data.', strtolower( $data_type_label ) ) ) ); ?>
 				</td>
 				<td>
 					<?php if ( $push_enabled ) : ?>

--- a/src/Admin/SystemStatusService.php
+++ b/src/Admin/SystemStatusService.php
@@ -125,27 +125,22 @@ class SystemStatusService implements Service, Registerable {
 					$pull_enabled = isset( $modes['pull'] ) && $modes['pull'];
 					$push_enabled = isset( $modes['push'] ) && $modes['push'];
 					
-					$pull_status = $pull_enabled ? 'Enabled' : 'Disabled';
-					$push_status = $push_enabled ? 'Enabled' : 'Disabled';
+					$pull_status = $pull_enabled ? '✔ Enabled' : '❌ Disabled';
+					$push_status = $push_enabled ? '✔ Enabled' : '❌ Disabled';
 					$pull_class  = $pull_enabled ? 'yes' : 'error';
 					$push_class  = $push_enabled ? 'yes' : 'error';
-					$pull_icon   = $pull_enabled ? 'dashicons-yes' : 'dashicons-warning';
-					$push_icon   = $push_enabled ? 'dashicons-yes' : 'dashicons-warning';
+					
+					// Format for both display and text export
+					$status_text = sprintf(
+						'API Pull: %s, MC Push: %s',
+						$pull_enabled ? 'Enabled' : 'Disabled',
+						$push_enabled ? 'Enabled' : 'Disabled'
+					);
 					?>
-					<div style="margin-bottom: 5px;">
-						<strong><?php esc_html_e( 'API Pull:', 'google-listings-and-ads' ); ?></strong> 
-						<mark class="<?php echo esc_attr( $pull_class ); ?>">
-							<span class="dashicons <?php echo esc_attr( $pull_icon ); ?>"></span> 
-							<?php echo esc_html( $pull_status ); ?>
-						</mark>
-					</div>
-					<div>
-						<strong><?php esc_html_e( 'MC Push:', 'google-listings-and-ads' ); ?></strong> 
-						<mark class="<?php echo esc_attr( $push_class ); ?>">
-							<span class="dashicons <?php echo esc_attr( $push_icon ); ?>"></span> 
-							<?php echo esc_html( $push_status ); ?>
-						</mark>
-					</div>
+					<span data-export-label="<?php echo esc_attr( $status_text ); ?>">
+						<mark class="<?php echo esc_attr( $pull_class ); ?>"><?php echo esc_html( $pull_status ); ?></mark> / 
+						<mark class="<?php echo esc_attr( $push_class ); ?>"><?php echo esc_html( $push_status ); ?></mark>
+					</span>
 				</td>
 			</tr>
 			<?php

--- a/src/Admin/SystemStatusService.php
+++ b/src/Admin/SystemStatusService.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * Class SystemStatusService
  * This class adds Google for WooCommerce information to the WooCommerce System Status Report
  *
- * @since 3.2.0
+ * @since x.x.x
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin
  */
 class SystemStatusService implements Service, Registerable {

--- a/src/Admin/SystemStatusService.php
+++ b/src/Admin/SystemStatusService.php
@@ -111,41 +111,43 @@ class SystemStatusService implements Service, Registerable {
 			}
 
 			$data_type_label = ucfirst( str_replace( '_', ' ', $data_type ) );
+			$pull_enabled = isset( $modes['pull'] ) && $modes['pull'];
+			$push_enabled = isset( $modes['push'] ) && $modes['push'];
 			
+			// API Pull row
 			?>
 			<tr>
-				<td data-export-label="<?php echo esc_attr( $data_type_label . ' Sync Mode' ); ?>">
-					<?php echo esc_html( sprintf( '%s Sync Mode:', $data_type_label ) ); ?>
+				<td data-export-label="<?php echo esc_attr( $data_type_label . ' API Pull' ); ?>">
+					<?php echo esc_html( sprintf( '%s API Pull:', $data_type_label ) ); ?>
 				</td>
 				<td class="help">
-					<?php echo wc_help_tip( sprintf( 'Shows the current API Pull and MC Push sync settings for %s data.', strtolower( $data_type_label ) ) ); ?>
+					<?php echo wc_help_tip( sprintf( 'Shows if API Pull sync is enabled for %s data.', strtolower( $data_type_label ) ) ); ?>
 				</td>
 				<td>
-					<?php
-					$pull_enabled = isset( $modes['pull'] ) && $modes['pull'];
-					$push_enabled = isset( $modes['push'] ) && $modes['push'];
-					
-					$pull_status_text = $pull_enabled ? 'Enabled' : 'Disabled';
-					$push_status_text = $push_enabled ? 'Enabled' : 'Disabled';
-					
-					// Create a concise status that matches WooCommerce export patterns
-					$status_summary = sprintf( 'API Pull: %s / MC Push: %s', $pull_status_text, $push_status_text );
-					
-					if ( $pull_enabled && $push_enabled ) {
-						$class = 'yes';
-						$icon = 'dashicons-yes';
-					} elseif ( ! $pull_enabled && ! $push_enabled ) {
-						$class = 'error';
-						$icon = 'dashicons-warning';
-					} else {
-						$class = 'error'; // Mixed state
-						$icon = 'dashicons-warning';
-					}
-					?>
-					<mark class="<?php echo esc_attr( $class ); ?>">
-						<span class="dashicons <?php echo esc_attr( $icon ); ?>"></span>
-						<?php echo esc_html( $status_summary ); ?>
-					</mark>
+					<?php if ( $pull_enabled ) : ?>
+						<mark class="yes"><span class="dashicons dashicons-yes"></span> Enabled</mark>
+					<?php else : ?>
+						<mark class="error"><span class="dashicons dashicons-warning"></span> Disabled</mark>
+					<?php endif; ?>
+				</td>
+			</tr>
+			<?php
+			
+			// MC Push row
+			?>
+			<tr>
+				<td data-export-label="<?php echo esc_attr( $data_type_label . ' MC Push' ); ?>">
+					<?php echo esc_html( sprintf( '%s MC Push:', $data_type_label ) ); ?>
+				</td>
+				<td class="help">
+					<?php echo wc_help_tip( sprintf( 'Shows if MC Push sync is enabled for %s data.', strtolower( $data_type_label ) ) ); ?>
+				</td>
+				<td>
+					<?php if ( $push_enabled ) : ?>
+						<mark class="yes"><span class="dashicons dashicons-yes"></span> Enabled</mark>
+					<?php else : ?>
+						<mark class="error"><span class="dashicons dashicons-warning"></span> Disabled</mark>
+					<?php endif; ?>
 				</td>
 			</tr>
 			<?php

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -11,7 +11,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\CouponChannelVisib
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Redirect;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\SystemStatusService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\ConnectionTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
@@ -67,6 +69,7 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 		SetupAds::class            => true,
 		SetupMerchantCenter::class => true,
 		Shipping::class            => true,
+		SystemStatusService::class => true,
 		Service::class             => true,
 	];
 
@@ -108,5 +111,6 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 		$this->share_with_tags( SetupAds::class );
 		$this->share_with_tags( SetupMerchantCenter::class );
 		$this->share_with_tags( Shipping::class );
+		$this->share_with_tags( SystemStatusService::class, NotificationsService::class );
 	}
 }

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -111,6 +111,6 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 		$this->share_with_tags( SetupAds::class );
 		$this->share_with_tags( SetupMerchantCenter::class );
 		$this->share_with_tags( Shipping::class );
-		$this->share_with_tags( SystemStatusService::class, NotificationsService::class );
+		$this->share_with_tags( SystemStatusService::class, NotificationsService::class, MerchantCenterService::class );
 	}
 }


### PR DESCRIPTION
## Summary
- Adds a new SystemStatusService that displays API Pull and MC Push sync mode configuration in the WooCommerce System Status Report
- Creates a new "Google for WooCommerce" section showing sync settings for all data types (products, settings, coupons, shipping)
- Includes proper error handling and visual status indicators

## Test plan
- [ ] Navigate to WooCommerce > Status > System Status
- [ ] Verify the "Google for WooCommerce" section appears
- [ ] Confirm sync mode settings are displayed correctly for each data type
- [ ] Check that API Pull and MC Push statuses show appropriate enabled/disabled indicators
- [ ] Test error handling when sync mode data is unavailable

🤖 Generated with [Claude Code](https://claude.ai/code)

### Changelog entry

> Add - Display the statuses of synchronization modes with Google Merchant Center in WooCommerce System Status Report.
