### PR TITLE
Fixes an issue where without onboarding, an error occurs after deactivating this plugin.

### DIFF
--- a/src/API/WP/OAuthService.php
+++ b/src/API/WP/OAuthService.php
@@ -238,7 +238,10 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 	public function deactivate(): void {
 		// Try to revoke the token on deactivation. If no token is available, it will throw an exception which we can ignore.
 		try {
-			$this->revoke_wpcom_api_auth();
+			// Attempt to revoke the WPCOM token if setup is complete.
+			if ( $this->is_jetpack_connected() ) {
+				$this->revoke_wpcom_api_auth();
+			}
 		} catch ( Exception $e ) {
 			do_action(
 				'woocommerce_gla_error',

--- a/tests/Unit/API/WP/OAuthServiceTest.php
+++ b/tests/Unit/API/WP/OAuthServiceTest.php
@@ -107,8 +107,25 @@ class OAuthServiceTest extends UnitTest {
 		$this->service->set_container( $this->container );
 	}
 
+	public function test_deactivate_does_not_call_wpcom_api_when_jetpack_not_connected() {
+		$this->assertInstanceOf( Deactivateable::class, $this->service );
+
+		$this->jp->expects( $this->never() )
+			->method( 'remote_request' );
+
+		$this->account_service->expects( $this->never() )
+			->method( 'reset_wpcom_api_authorization_data' );
+
+		$this->service->deactivate();
+
+		$this->assertEquals( 0, did_action( 'woocommerce_gla_error' ) );
+	}
+
 	public function test_deactivation_ok() {
 		$this->assertInstanceOf( Deactivateable::class, $this->service );
+
+		// Mock the options to return true for Jetpack connected.
+		$this->options->expects( $this->once() )->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( true );
 
 		$this->jp->expects( $this->once() )
 			->method( 'remote_request' )->willReturn(
@@ -126,6 +143,9 @@ class OAuthServiceTest extends UnitTest {
 
 	public function test_deactivation_with_wp_error() {
 		$this->assertInstanceOf( Deactivateable::class, $this->service );
+
+		// Mock the options to return true for Jetpack connected.
+		$this->options->expects( $this->once() )->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( true );
 
 		$this->jp->expects( $this->once() )
 			->method( 'remote_request' )->willReturn( new WP_Error( 'error', 'error message' ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-105/without-onboarding-an-error-occurs-after-deactivating-this-plugin

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Navigate to `WooCommerce > Status > Logs` and clear all existing logs.
2. Install and activate the G4W plugin **without completing the onboarding**.
3. Deactivate the plugin.
4. Return to `WooCommerce > Status > Logs` and check for the plugin’s log entry — **no log is displayed.**


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

Fix - Avoid errors when unnecessarily revoking WPCOM connection during deactivation.
