### PR TITLE
Display a more detailed error message when failing to link Google Ads account

### DIFF
--- a/js/src/components/google-ads-account-card/connect-ads/index.js
+++ b/js/src/components/google-ads-account-card/connect-ads/index.js
@@ -17,10 +17,10 @@ import LoadingLabel from '~/components/loading-label';
 import Section from '~/components/section';
 import Subsection from '~/components/subsection';
 import useApiFetchCallback from '~/hooks/useApiFetchCallback';
-import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
 import AdsAccountSelectControl from '~/components/ads-account-select-control';
 import { useAppDispatch } from '~/data';
+import { handleApiError } from '~/utils/handleError';
 import './index.scss';
 
 /**
@@ -39,7 +39,6 @@ const ConnectAds = ( props ) => {
 		data: { id: value },
 	} );
 	const { refetchGoogleAdsAccount } = useGoogleAdsAccount();
-	const { createNotice } = useDispatchCoreNotices();
 	const { fetchGoogleAdsAccountStatus } = useAppDispatch();
 
 	/**
@@ -62,8 +61,9 @@ const ConnectAds = ( props ) => {
 			await refetchGoogleAdsAccount();
 		} catch ( error ) {
 			setLoading( false );
-			createNotice(
-				'error',
+			handleApiError(
+				error,
+				null,
 				__(
 					'Unable to connect your Google Ads account. Please try again later.',
 					'google-listings-and-ads'

--- a/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
+++ b/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
@@ -11,13 +11,13 @@ import AccountCard from '~/components/account-card';
 import ConnectExistingAccountActions from './connect-existing-account-actions';
 import LoadingLabel from '~/components/loading-label';
 import useApiFetchCallback from '~/hooks/useApiFetchCallback';
-import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
 import { useAppDispatch } from '~/data';
 import useGoogleAdsAccountReady from '~/hooks/useGoogleAdsAccountReady';
 import AdsAccountSelectControl from '~/components/ads-account-select-control';
 import ConnectedIconLabel from '~/components/connected-icon-label';
 import { ConnectAccountButton } from '~/components/google-ads-account-card';
+import { handleApiError } from '~/utils/handleError';
 
 /**
  * Renders an account card to connect to an existing Google Ads account.
@@ -28,7 +28,6 @@ import { ConnectAccountButton } from '~/components/google-ads-account-card';
 const ConnectExistingAccount = ( { onCreateClick } ) => {
 	const [ value, setValue ] = useState();
 	const [ isLoading, setLoading ] = useState( false );
-	const { createNotice } = useDispatchCoreNotices();
 	const { fetchGoogleAdsAccountStatus } = useAppDispatch();
 	const { isGoogleAdsReady } = useGoogleAdsAccountReady();
 	const {
@@ -60,8 +59,9 @@ const ConnectExistingAccount = ( { onCreateClick } ) => {
 			await fetchGoogleAdsAccountStatus();
 			await refetchGoogleAdsAccount();
 		} catch ( error ) {
-			createNotice(
-				'error',
+			handleApiError(
+				error,
+				null,
 				__(
 					'Unable to connect your Google Ads account. Please try again later.',
 					'google-listings-and-ads'

--- a/js/src/tests/jest-unit.setup.js
+++ b/js/src/tests/jest-unit.setup.js
@@ -33,6 +33,12 @@ jest.mock( '~/hooks/useDispatchCoreNotices', () =>
 		.mockReturnValue( { createNotice: () => {} } )
 );
 
+// Avoid tests that depend on `handleError` utils needing to mock global.console individually.
+// To test real console calls, please refer to ~/utils/handleError.test.js
+jest.mock( '~/utils/console', () => ( {
+	logError: jest.fn().mockName( 'console.error' ),
+} ) );
+
 // Mock the glaData here because the `globals` object in the jest config must
 // be JSON-serializable, which cannot preserve `undefined` values.
 global.glaData = {

--- a/js/src/utils/console.js
+++ b/js/src/utils/console.js
@@ -1,5 +1,5 @@
 /*
- * This module is intended to make it easier to mock `console` it in Jest tests.
+ * This module is intended to make it easier to mock `console` in Jest tests.
  */
 
 export function logError( ...args ) {

--- a/js/src/utils/console.js
+++ b/js/src/utils/console.js
@@ -1,0 +1,8 @@
+/*
+ * This module is intended to make it easier to mock `console` it in Jest tests.
+ */
+
+export function logError( ...args ) {
+	// eslint-disable-next-line no-console
+	console.error( ...args );
+}

--- a/js/src/utils/handleError.js
+++ b/js/src/utils/handleError.js
@@ -8,6 +8,7 @@ import { __, _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { NOTICES_STORE_KEY } from '~/data/constants';
+import { logError } from './console';
 
 /**
  * @typedef {Object} ApiError
@@ -78,6 +79,5 @@ export function handleApiError( error, leadingMessage, fallbackMessage ) {
 		dispatch( NOTICES_STORE_KEY ).createNotice( 'error', message );
 	}
 
-	// eslint-disable-next-line no-console
-	console.error( error );
+	logError( error );
 }

--- a/js/src/utils/handleError.test.js
+++ b/js/src/utils/handleError.test.js
@@ -14,6 +14,11 @@ jest.mock( '@wordpress/data', () => {
 	};
 } );
 
+// Set back to the actual module to assert that it indeed calls console's methods
+jest.mock( '~/utils/console', () => ( {
+	...jest.requireActual( '~/utils/console' ),
+} ) );
+
 describe( 'resolveErrorMessage', () => {
 	it( 'When the arguments do not have any available messages, it should return "Unknown error occurred."', () => {
 		const message = resolveErrorMessage( {}, null, null );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes a bit adjustment to display a more detailed error message when failing to link Google Ads account. This allows users to know what went wrong and even troubleshoot the problem themselves.

Related to https://linear.app/a8c/issue/GOOWOO-213

### Screenshots:

#### 📷 Before

<img width="1228" height="957" alt="image" src="https://github.com/user-attachments/assets/ffac1c70-8b62-4964-afc5-cf0304a9b6b9" />

#### 📷 After

<img width="1188" height="956" alt="image" src="https://github.com/user-attachments/assets/642ba3ed-7738-48e7-95cc-ec1e843eab84" />

### Detailed test instructions:

💡 It's recommended to test this PR together with https://github.com/Automattic/woocommerce-connect-server/pull/2939

1. Disconnect Google Ads account if there is a connected one
2. Go to **[Google Ads dashboard](https://ads.google.com/) > Admin > Access & Security > Users**
   1. Invite your other Google account to join as admin role
   2. Use the newly joined Google account to set the currently connected one to a role other than admin
   <img width="805" height="529" alt="image" src="https://github.com/user-attachments/assets/4dee3d3c-0f2b-4f59-a22d-711189f9924d" />
3. Continuing from the previous step, switch to the **Managers** tab, and remove access for the currently linked manager
   <img width="1124" height="344" alt="a" src="https://github.com/user-attachments/assets/9210fcb0-11da-4682-9c2a-34c6d9ad6233" />
4. Connect to the same Google Ads account as step 1 to trigger the linking account error
5. Check if the error message shown on the bottom right of the page is clearer than before
   - Before: "Unable to connect your Google Ads account. Please try again later."
   - After: "Error linking account: The Google account you are using must have Admin access to Ads account 1234567890 to proceed."

### Changelog entry

> Tweak - Display a more detailed error message when failing to link Google Ads account.