### PR TITLE
Replace "free listings" with "product feed"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![JavaScript and CSS Linting](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-css-linting.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/js-css-linting.yml)
 [![Build](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/build.yml/badge.svg)](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/build.yml)
 
-A native integration with Google offering free listings and Performance Max ads to WooCommerce merchants.
+A native integration with Google offering product feed and Performance Max ads to WooCommerce merchants.
 
 -   [WooCommerce.com product page](https://woocommerce.com/products/google-listings-and-ads/)
 -   [WordPress.org plugin page](https://wordpress.org/plugins/google-listings-and-ads/)

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -58,7 +58,7 @@ const alwaysTrue = () => true;
 const { Fill, Slot } = createSlotFill( 'gla/SetupFreeListings/SubmitButton' );
 
 /**
- * Setup step to configure free listings.
+ * Setup step to configure product feed.
  *
  * Note that this component requires to specify the location where it wants to
  * render its submit button via `<SetupFreeListings.SubmitButton />`.

--- a/js/src/components/paid-ads/ads-campaign/faqs.js
+++ b/js/src/components/paid-ads/ads-campaign/faqs.js
@@ -46,7 +46,7 @@ const faqItems = [
 			<>
 				<div>
 					{ __(
-						'If you’re selling in the US, then eligible free listings can appear in search results across Google Search, Google Images, and the Google Shopping tab. If you’re selling outside the US, free listings will appear on the Shopping tab.',
+						'If you’re selling in the US, then eligible product feed can appear in search results across Google Search, Google Images, and the Google Shopping tab. If you’re selling outside the US, product feed will appear on the Shopping tab.',
 						'google-listings-and-ads'
 					) }
 				</div>

--- a/js/src/data/utils.js
+++ b/js/src/data/utils.js
@@ -16,7 +16,7 @@ import round from '~/utils/round';
 export const freeFields = [ 'clicks', 'impressions' ];
 export const paidFields = [ 'sales', 'conversions', 'spend', ...freeFields ];
 /**
- * Reasons why the free listings data may be missing.
+ * Reasons why the product feed data may be missing.
  *
  * @enum {number}
  */
@@ -152,7 +152,7 @@ export function calculateDelta( value, base ) {
  *
  * @param {number} [value] The primary report field fetched from report API.
  * @param {number} [base] The secondary report field fetched from report API.
- * @param {MISSING_FREE_LISTINGS_DATA} [missingFreeListingsData] Flag indicating whether the data miss entries from Free Listings.
+ * @param {MISSING_FREE_LISTINGS_DATA} [missingFreeListingsData] Flag indicating whether the data miss entries from Product Feed.
  * @return {PerformanceData} The calculated performance data of each metric.
  */
 export const fieldsToPerformance = (
@@ -270,5 +270,5 @@ export function convertKeysFromSnakeCaseToCamelCase( data ) {
  * @property {number} value Value of the current period.
  * @property {number} prevValue Value of the previous period.
  * @property {number} delta The delta of the current value compared to the previous value.
- * @property {MISSING_FREE_LISTINGS_DATA} [missingFreeListingsData] Flag indicating whether the data miss entries from Free Listings.
+ * @property {MISSING_FREE_LISTINGS_DATA} [missingFreeListingsData] Flag indicating whether the data miss entries from Product Feed.
  */

--- a/js/src/pages/dashboard/all-programs-table-card/free-listings-disabled-toggle.js
+++ b/js/src/pages/dashboard/all-programs-table-card/free-listings-disabled-toggle.js
@@ -14,7 +14,7 @@ const FreeListingsDisabledToggle = () => {
 	return (
 		<AppTooltip
 			text={ __(
-				'Free listings cannot be paused through WooCommerce. Go to Google Merchant Center for advanced settings.',
+				'Product feed cannot be paused through WooCommerce. Go to Google Merchant Center for advanced settings.',
 				'google-listings-and-ads'
 			) }
 		>

--- a/js/src/pages/dashboard/all-programs-table-card/index.js
+++ b/js/src/pages/dashboard/all-programs-table-card/index.js
@@ -100,7 +100,7 @@ const AllProgramsTableCard = ( props ) => {
 	const data = [
 		{
 			id: FREE_LISTINGS_PROGRAM_ID,
-			title: __( 'Free listings', 'google-listings-and-ads' ),
+			title: __( 'Product feed', 'google-listings-and-ads' ),
 			dailyBudget: __( 'Free', 'google-listings-and-ads' ),
 			country: (
 				<CountryColumn

--- a/js/src/pages/dashboard/all-programs-table-card/index.test.js
+++ b/js/src/pages/dashboard/all-programs-table-card/index.test.js
@@ -91,10 +91,10 @@ describe( 'AllProgramsTableCard', () => {
 		};
 	} );
 
-	it( 'Should render the free listings row with a checked toggle in the disabled state', () => {
+	it( 'Should render the product feed row with a checked toggle in the disabled state', () => {
 		render( <AllProgramsTableCard /> );
 
-		const row = screen.getByRole( 'row', { name: /free listings/i } );
+		const row = screen.getByRole( 'row', { name: /product feed/i } );
 		const checkbox = within( row ).getByRole( 'checkbox' );
 
 		expect( row ).toBeInTheDocument();
@@ -102,10 +102,10 @@ describe( 'AllProgramsTableCard', () => {
 		expect( checkbox ).toBeDisabled();
 	} );
 
-	it( 'Should render the free listings row without the edit and remove buttons', () => {
+	it( 'Should render the product feed row without the edit and remove buttons', () => {
 		render( <AllProgramsTableCard /> );
 
-		const row = screen.getByRole( 'row', { name: /free listings/i } );
+		const row = screen.getByRole( 'row', { name: /product feed/i } );
 		const editButton = getEditButton( row );
 		const removeButton = getRemoveButton( row );
 
@@ -113,10 +113,10 @@ describe( 'AllProgramsTableCard', () => {
 		expect( removeButton ).not.toBeInTheDocument();
 	} );
 
-	it( 'Should render the free listings row with a free daily budget text', () => {
+	it( 'Should render the product feed row with a free daily budget text', () => {
 		render( <AllProgramsTableCard /> );
 
-		const row = screen.getByRole( 'row', { name: /free listings/i } );
+		const row = screen.getByRole( 'row', { name: /product feed/i } );
 		const budget = within( row ).getByRole( 'cell', { name: /free/i } );
 
 		expect( budget ).toBeInTheDocument();

--- a/js/src/pages/dashboard/summary-section/index.js
+++ b/js/src/pages/dashboard/summary-section/index.js
@@ -126,7 +126,7 @@ export default function SummarySection() {
 			</SummaryCard>
 			<SummaryCard
 				title={ __(
-					'Free Listings (Limited Visibility)',
+					'Product Feed (Limited Visibility)',
 					'google-listings-and-ads'
 				) }
 			>

--- a/js/src/pages/get-started/features-card/index.js
+++ b/js/src/pages/get-started/features-card/index.js
@@ -90,7 +90,7 @@ const FeaturesCard = () => {
 						variant="body"
 					>
 						{ __(
-							'When your products are added and approved, they’ll be eligible for free listings, reaching shoppers across Google’s network.',
+							'When your products are added and approved, they’ll be eligible for product feed, reaching shoppers across Google’s network.',
 							'google-listings-and-ads'
 						) }
 					</Text>

--- a/js/src/pages/onboarding/setup-stepper/setup-accounts/faqs.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-accounts/faqs.js
@@ -32,7 +32,7 @@ const faqItems = [
 			<>
 				<p>
 					{ __(
-						'Google Merchant Center helps you sync your store and product data with Google and makes the information available for both free listings on the Shopping tab and Google Shopping Ads. That means everything about your stores and products is available to shoppers when they search on a Google property.',
+						'Google Merchant Center helps you sync your store and product data with Google and makes the information available for both product feed on the Shopping tab and Google Shopping Ads. That means everything about your stores and products is available to shoppers when they search on a Google property.',
 						'google-listings-and-ads'
 					) }
 				</p>

--- a/js/src/pages/product-feed/product-statistics/product-status-help-popover.js
+++ b/js/src/pages/product-feed/product-statistics/product-status-help-popover.js
@@ -50,7 +50,7 @@ const ProductStatusHelpPopover = () => {
 			<p>
 				{ createInterpolateElement(
 					__(
-						'<strong>‘Active’ products</strong> are fully approved and eligible to appear in free listings on Google.',
+						'<strong>‘Active’ products</strong> are fully approved and eligible to appear in product feed on Google.',
 						'google-listings-and-ads'
 					),
 					map

--- a/js/src/pages/product-feed/product-statistics/status-box/feed-status.js
+++ b/js/src/pages/product-feed/product-statistics/status-box/feed-status.js
@@ -53,7 +53,7 @@ function FeedStatus() {
 			label={
 				<span className="gla-success">
 					{ __(
-						'Free listings setup completed',
+						'Product feed setup completed',
 						'google-listings-and-ads'
 					) }
 				</span>

--- a/js/src/pages/reports/index.js
+++ b/js/src/pages/reports/index.js
@@ -53,7 +53,7 @@ export default Reports;
 
 /**
  * @typedef {Object} ProgramsReportData
- * @property {Array<ProgramsData>} freeListings Free listings data
+ * @property {Array<ProgramsData>} freeListings Product feed data
  * @property {Array<ProgramsData>} campaigns Ad campaigns data.
  * @property {Array<IntervalsData> | null} intervals Intervals data.
  * @property {PerformanceData} totals Performance data.

--- a/js/src/pages/reports/metric-number.js
+++ b/js/src/pages/reports/metric-number.js
@@ -57,8 +57,8 @@ const MetricNumber = ( {
 	const infos = [];
 	const ariaInfos = [];
 
-	// Until ~Q4 2021, metrics for all programs, may lack data for free listings.
-	// And Free Listings API may not respond with data.
+	// Until ~Q4 2021, metrics for all programs, may lack data for product feed.
+	// And Product Feed API may not respond with data.
 	if ( missingFreeListingsData !== MISSING_FREE_LISTINGS_DATA.NONE ) {
 		const text = __(
 			'This data is currently available for Google Ads campaigns only.',
@@ -69,7 +69,7 @@ const MetricNumber = ( {
 	}
 	if ( missingFreeListingsData === MISSING_FREE_LISTINGS_DATA.FOR_REQUEST ) {
 		const text = __(
-			'Please try again later, or go to <googleMerchantCenterLink /> to track your performance for Google Free Listings.',
+			'Please try again later, or go to <googleMerchantCenterLink /> to track your performance for Google Product Feed.',
 			'google-listings-and-ads'
 		);
 

--- a/js/src/pages/reports/products/filterConfig.js
+++ b/js/src/pages/reports/products/filterConfig.js
@@ -195,7 +195,7 @@ const reportSourceConfig = {
 		},
 		{
 			value: REPORT_SOURCE_FREE,
-			label: __( 'Free listings', 'google-listings-and-ads' ),
+			label: __( 'Product feed', 'google-listings-and-ads' ),
 		},
 	],
 	showFilters: ( { hasPaidSource } ) => hasPaidSource,

--- a/js/src/pages/reports/products/index.js
+++ b/js/src/pages/reports/products/index.js
@@ -74,7 +74,7 @@ const ProductsReport = ( { hasPaidSource } ) => {
 		: REPORT_SOURCE_FREE;
 
 	// Show only available data.
-	// Until ~Q4 2021, free listings, may not have all metrics.
+	// Until ~Q4 2021, product feed, may not have all metrics.
 	const metrics = useMetricsWithFormatter(
 		type === REPORT_SOURCE_PAID ? paidMetrics : freeMetrics
 	);

--- a/js/src/pages/reports/programs/compare-programs-table-card.js
+++ b/js/src/pages/reports/programs/compare-programs-table-card.js
@@ -39,7 +39,7 @@ const CompareProgramsTableCard = ( {
 	...restProps
 } ) => {
 	/**
-	 * Glue freeListings and campaigns together, hardcode Free Listings name and id.
+	 * Glue freeListings and campaigns together, hardcode Product Feed name and id.
 	 *
 	 * @type {Array<ProgramsData>}
 	 */
@@ -50,11 +50,11 @@ const CompareProgramsTableCard = ( {
 		if ( ! freeListings || freeListings.length === 0 ) {
 			return campaigns;
 		}
-		// For V1 we assume, there is only one "Free listings" object.
+		// For V1 we assume, there is only one "Product Feed" object.
 		const mergedPrograms = [
 			{
 				...freeListings[ 0 ],
-				name: __( 'Free Listings', 'google-listings-and-ads' ),
+				name: __( 'Product Feed', 'google-listings-and-ads' ),
 				id: FREE_LISTINGS_PROGRAM_ID,
 			},
 			...campaigns,

--- a/js/src/pages/reports/programs/filterConfig.js
+++ b/js/src/pages/reports/programs/filterConfig.js
@@ -12,7 +12,7 @@ import { FREE_LISTINGS_PROGRAM_ID, REPORT_PROGRAM_PARAM } from '~/constants';
 const freeListingsPrograms = [
 	{
 		id: FREE_LISTINGS_PROGRAM_ID,
-		name: __( 'Free Listings', 'google-listings-and-ads' ),
+		name: __( 'Product Feed', 'google-listings-and-ads' ),
 	},
 ];
 const freeListingsProgramsIds = new Set(

--- a/js/src/pages/reports/programs/index.js
+++ b/js/src/pages/reports/programs/index.js
@@ -72,7 +72,7 @@ const ProgramsReport = () => {
 
 	const metricsGroup = useMemo( () => {
 		const hasFieldInResults = loaded && Object.keys( totals ).length > 0;
-		// Until ~Q4 2021, free listings, may not have all metrics.
+		// Until ~Q4 2021, product feed, may not have all metrics.
 		// Anticipate all requested fields to come, show available once loaded.
 		const available = hasFieldInResults
 			? performanceMetrics.filter( ( { key } ) =>

--- a/js/src/pages/reports/utils.js
+++ b/js/src/pages/reports/utils.js
@@ -118,7 +118,7 @@ export function sumToPerformance(
 				missingFreeListingsData =
 					MISSING_FREE_LISTINGS_DATA.FOR_REQUEST;
 			} else {
-				// There is free listings data, sum with paid one.
+				// There is product feed data, sum with paid one.
 				// `freeTotals` doesn't have fallback because it will only be number or undefined type,
 				// and the undefined has been checked above.
 				value = ( paidTotals[ key ] || 0 ) + freeTotals[ key ];

--- a/js/src/pages/shipping/index.js
+++ b/js/src/pages/shipping/index.js
@@ -37,7 +37,7 @@ import { recordGlaEvent } from '~/utils/tracks';
  * Page component to edit audience and shipping settings.
  *
  * Note that:
- * - This page used to be called "Edit product feed" page.
+ * - This page used to be called "Edit free listings" page.
  * - Although it's presented on UI as "Shipping" page,
  *   it actually contains other Merchant Center settings.
  *

--- a/js/src/pages/shipping/index.js
+++ b/js/src/pages/shipping/index.js
@@ -28,7 +28,7 @@ import { handleApiError } from '~/utils/handleError';
 import { recordGlaEvent } from '~/utils/tracks';
 
 /**
- * Saving changes of audience and/or shipping settings to the free listings.
+ * Saving changes of audience and/or shipping settings to the product feed.
  *
  * @event gla_free_campaign_edited
  */
@@ -37,7 +37,7 @@ import { recordGlaEvent } from '~/utils/tracks';
  * Page component to edit audience and shipping settings.
  *
  * Note that:
- * - This page used to be called "Edit free listings" page.
+ * - This page used to be called "Edit product feed" page.
  * - Although it's presented on UI as "Shipping" page,
  *   it actually contains other Merchant Center settings.
  *

--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -141,7 +141,7 @@ class MerchantReport implements OptionsAwareInterface {
 
 
 	/**
-	 * Get report data for free listings.
+	 * Get report data for product feed.
 	 *
 	 * @param string $type Report type (free_listings or products).
 	 * @param array  $args Query arguments.

--- a/src/API/Google/Query/MerchantFreeListingReportQuery.php
+++ b/src/API/Google/Query/MerchantFreeListingReportQuery.php
@@ -25,7 +25,7 @@ class MerchantFreeListingReportQuery extends MerchantReportQuery {
 	 * @return $this
 	 */
 	public function filter( array $ids ): QueryInterface {
-		// No filtering available for free listings.
+		// No filtering available for product feed.
 		return $this;
 	}
 }

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -1022,15 +1022,15 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		 * Code 'merchant_quality_low' for matching the original issue.
 		 * Ref: https://developers.google.com/shopping-content/guides/account-issues#merchant_quality_low
 		 *
-		 * Issue string "Account isn't eligible for free listings" for matching
+		 * Issue string "Account isn't eligible for free listings" or "Account isn't eligible for product feed" for matching
 		 * the updated copy after Free and Enhanced Listings merge.
 		 *
 		 * TODO: Remove the condition of matching the $issue['issue']
 		 *       if its issue code is the same as 'merchant_quality_low'
 		 *       after Google replaces the issue title on their side.
 		 */
-		if ( 'merchant_quality_low' === $issue['code'] || "Account isn't eligible for free listings" === $issue['issue'] ) {
-			$issue['issue']      = 'Show products on additional surfaces across Google through free listings';
+		if ( 'merchant_quality_low' === $issue['code'] || "Account isn't eligible for free listings" === $issue['issue'] || "Account isn't eligible for product feed" === $issue['issue'] ) {
+			$issue['issue']      = 'Show products on additional surfaces across Google through product feed';
 			$issue['severity']   = self::SEVERITY_WARNING;
 			$issue['action_url'] = 'https://support.google.com/merchants/answer/9199328?hl=en';
 		}

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -1022,14 +1022,14 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		 * Code 'merchant_quality_low' for matching the original issue.
 		 * Ref: https://developers.google.com/shopping-content/guides/account-issues#merchant_quality_low
 		 *
-		 * Issue string "Account isn't eligible for free listings" or "Account isn't eligible for product feed" for matching
+		 * Issue string "Account isn't eligible for free listings" for matching
 		 * the updated copy after Free and Enhanced Listings merge.
 		 *
 		 * TODO: Remove the condition of matching the $issue['issue']
 		 *       if its issue code is the same as 'merchant_quality_low'
 		 *       after Google replaces the issue title on their side.
 		 */
-		if ( 'merchant_quality_low' === $issue['code'] || "Account isn't eligible for free listings" === $issue['issue'] || "Account isn't eligible for product feed" === $issue['issue'] ) {
+		if ( 'merchant_quality_low' === $issue['code'] || "Account isn't eligible for free listings" === $issue['issue'] ) {
 			$issue['issue']      = 'Show products on additional surfaces across Google through product feed';
 			$issue['severity']   = self::SEVERITY_WARNING;
 			$issue['action_url'] = 'https://support.google.com/merchants/answer/9199328?hl=en';

--- a/src/Notes/CompleteSetup.php
+++ b/src/Notes/CompleteSetup.php
@@ -37,7 +37,7 @@ class CompleteSetup extends AbstractNote implements MerchantCenterAwareInterface
 	 */
 	public function get_entry(): NoteEntry {
 		$note = new NoteEntry();
-		$note->set_title( __( 'Reach more shoppers with free listings on Google', 'google-listings-and-ads' ) );
+		$note->set_title( __( 'Reach more shoppers with product feed on Google', 'google-listings-and-ads' ) );
 		$note->set_content( __( 'Finish setting up Google for WooCommerce to list your products on Google for free and promote them with ads.', 'google-listings-and-ads' ) );
 		$note->set_content_data( new stdClass() );
 		$note->set_type( NoteEntry::E_WC_ADMIN_NOTE_INFORMATIONAL );

--- a/src/Notes/ReviewAfterClicks.php
+++ b/src/Notes/ReviewAfterClicks.php
@@ -73,7 +73,7 @@ class ReviewAfterClicks extends AbstractNote implements MerchantCenterAwareInter
 		$note->set_title(
 			sprintf(
 				/* translators: %s number of clicks */
-				__( 'You’ve gotten %s+ clicks on your free listings! 🎉', 'google-listings-and-ads' ),
+				__( 'You’ve gotten %s+ clicks on your product feed! 🎉', 'google-listings-and-ads' ),
 				$this->wp->number_format_i18n( $clicks_count_rounded )
 			)
 		);

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -548,7 +548,7 @@ Triggered when changing products & variations filter,
 - [`ProgramsReportFilters`](../../js/src/pages/reports/programs/programs-report-filters.js#L43)
 
 ### [`gla_free_campaign_edited`](../../js/src/pages/shipping/index.js#L30)
-Saving changes of audience and/or shipping settings to the free listings.
+Saving changes of audience and/or shipping settings to the product feed.
 #### Emitters
 - [`exports`](../../js/src/pages/shipping/index.js#L46)
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-226.

Replaced remaining `free listings` mentions with `product feed`. Variables, constants, function and method names were kept the same. 


### Screenshots:

Non-exhaustive list of changes:

| Before | After |
| ---- | ---- |
| <img width="592" height="298" alt="Screenshot 2025-07-30 at 13 48 55" src="https://github.com/user-attachments/assets/59b9928f-27f5-4889-a996-6040270e89db" /> | <img width="595" height="315" alt="Screenshot 2025-07-30 at 13 47 45" src="https://github.com/user-attachments/assets/589ade1d-ce12-41bb-b998-e6a1421302fa" /> |
| <img width="1396" height="759" alt="Screenshot 2025-07-30 at 13 48 30" src="https://github.com/user-attachments/assets/8f8d991b-7e99-49d4-98a3-913d92ea7c8e" /> | <img width="1394" height="752" alt="Screenshot 2025-07-30 at 13 47 57" src="https://github.com/user-attachments/assets/83c49d57-1b0c-4f90-bbce-a293a399033b" /> |
<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Click through the plugin pages to check that there is no longer `free listings` present anywhere and instead, there is `product feed`.

### Changelog entry

Tweak – Replace "free listings" with "product feed"
