### PR TITLE
Avoid scheduling the job to synchronize all products when initializing for the first time

### DIFF
--- a/src/Jobs/AbstractProductSyncerBatchedJob.php
+++ b/src/Jobs/AbstractProductSyncerBatchedJob.php
@@ -81,6 +81,6 @@ abstract class AbstractProductSyncerBatchedJob extends AbstractBatchedActionSche
 	 * @return bool Returns true if the job can be scheduled.
 	 */
 	public function can_schedule( $args = [] ): bool {
-		return ! $this->is_running( $args ) && $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_PRODUCT );
+		return ! $this->is_running( $args ) && $this->merchant_center->is_ready_for_syncing() && $this->merchant_center->is_enabled_for_datatype( NotificationsService::DATATYPE_PRODUCT );
 	}
 }

--- a/src/Jobs/ActionSchedulerJobMonitor.php
+++ b/src/Jobs/ActionSchedulerJobMonitor.php
@@ -42,7 +42,7 @@ class ActionSchedulerJobMonitor implements Service {
 	 * Check whether the failure rate is above the specified threshold within the timeframe.
 	 *
 	 * To protect against failing jobs running forever the job's failure rate is checked before creating a new batch.
-	 * By default, a job is stopped if it has 5 failures in the last hour.
+	 * By default, a job is stopped if it has 3 failures in the last 2 hours.
 	 *
 	 * @param ActionSchedulerJobInterface $job
 	 * @param string                      $hook The job action hook.

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -126,7 +126,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	}
 
 	/**
-	 * Whether we should push data into MC. Only is MC is ready for syncing.
+	 * Whether we should push data into MC. Only if MC is ready for syncing.
 	 *
 	 * @see is_ready_for_syncing
 	 * @return bool

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUn
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPCOMProxy;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\AttributeMappingRulesTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
 use WC_Meta_Data;
@@ -33,8 +34,10 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 		$this->container = woogle_get_container();
-		// Since the shipping time tables and attributeMappingRules aren't set up in the test environment, we install them to prevent warnings.
+		// Since the tables for shipping rate, time, and attribute mapping rules
+		// aren't set up in the test environment, install them to prevent warnings.
 		$this->container->get( AttributeMappingRulesTable::class )->install();
+		$this->container->get( ShippingRateTable::class )->install();
 		$this->container->get( ShippingTimeTable::class )->install();
 		do_action( 'rest_api_init' );
 	}

--- a/tests/Unit/Jobs/UpdateAllProductsTest.php
+++ b/tests/Unit/Jobs/UpdateAllProductsTest.php
@@ -51,6 +51,12 @@ class UpdateAllProductsTest extends UnitTest {
 	/** @var MockObject|MerchantCenterService $merchant_center */
 	protected $merchant_center;
 
+	/** @var bool $is_ready_for_syncing */
+	protected $is_ready_for_syncing;
+
+	/** @var bool $is_enabled_for_datatype */
+	protected $is_enabled_for_datatype;
+
 	/** @var UpdateAllProducts $job */
 	protected $job;
 
@@ -87,9 +93,23 @@ class UpdateAllProductsTest extends UnitTest {
 			$this->merchant_statuses
 		);
 
+		$this->is_ready_for_syncing = true;
 		$this->merchant_center
 			->method( 'is_ready_for_syncing' )
-			->willReturn( true );
+			->willReturnCallback(
+				function () {
+					return $this->is_ready_for_syncing;
+				}
+			);
+
+		$this->is_enabled_for_datatype = true;
+		$this->merchant_center
+			->method( 'is_enabled_for_datatype' )
+			->willReturnCallback(
+				function () {
+					return $this->is_enabled_for_datatype;
+				}
+			);
 
 		$this->merchant_center
 			->method( 'should_push' )
@@ -130,10 +150,6 @@ class UpdateAllProductsTest extends UnitTest {
 			->method( 'has_scheduled_action' )
 			->willReturn( false );
 
-		$this->merchant_center
-			->method( 'is_enabled_for_datatype' )
-			->willReturn( true );
-
 		/*
 		 * We expect only single call to `has_scheduled_action` when scheduling
 		 * the batch and no calls further since batch is empty.
@@ -169,10 +185,6 @@ class UpdateAllProductsTest extends UnitTest {
 				[ self::PROCESS_ITEM_HOOK, [ $filtered_product_list->get_product_ids() ] ]
 			);
 
-		$this->merchant_center
-			->method( 'is_enabled_for_datatype' )
-			->willReturn( true );
-
 		$this->job->schedule();
 
 		do_action( self::CREATE_BATCH_HOOK, 1 );
@@ -204,10 +216,6 @@ class UpdateAllProductsTest extends UnitTest {
 		$this->action_scheduler
 			->method( 'has_scheduled_action' )
 			->willReturn( false );
-
-		$this->merchant_center
-			->method( 'is_enabled_for_datatype' )
-			->willReturn( true );
 
 		$this->job->schedule();
 
@@ -243,10 +251,6 @@ class UpdateAllProductsTest extends UnitTest {
 			->method( 'has_scheduled_action' )
 			->willReturn( false );
 
-		$this->merchant_center
-			->method( 'is_enabled_for_datatype' )
-			->willReturn( true );
-
 		$this->job->schedule();
 
 		do_action( self::CREATE_BATCH_HOOK, 1 );
@@ -280,10 +284,6 @@ class UpdateAllProductsTest extends UnitTest {
 			->method( 'find_sync_ready_products' )
 			->withConsecutive( [ [], 2, 0 ], [ [], 2, 2 ], [ [], 2, 4 ] )
 			->willReturnOnConsecutiveCalls( $batch_a, $batch_b, $batch_c );
-
-		$this->merchant_center
-			->method( 'is_enabled_for_datatype' )
-			->willReturn( true );
 
 		$this->job->schedule();
 
@@ -355,17 +355,21 @@ class UpdateAllProductsTest extends UnitTest {
 			->method( 'schedule_single' )
 			->with( gmdate( 'U' ) + 100, self::CREATE_BATCH_HOOK, [ 1 ] );
 
-		$this->merchant_center
-			->method( 'is_enabled_for_datatype' )
-			->willReturn( true );
-
 		$this->job->schedule_delayed( 100 );
 	}
 
+	public function test_can_schedule() {
+		$this->assertTrue( $this->job->can_schedule() );
+	}
+
+	public function test_cannot_schedule_when_mc_is_not_ready_for_syncing() {
+		$this->is_ready_for_syncing = false;
+
+		$this->assertFalse( $this->job->can_schedule() );
+	}
+
 	public function test_cannot_schedule_when_mc_push_is_blocked() {
-		$this->merchant_center
-			->method( 'is_enabled_for_datatype' )
-			->willReturn( false );
+		$this->is_enabled_for_datatype = false;
 
 		$this->assertFalse( $this->job->can_schedule() );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR avoids scheduling the job to synchronize all products when initializing for the first time.

When the plugin is updated, `UpdateAllProducts` job is scheduled via [`Installer`](https://github.com/woocommerce/google-listings-and-ads/blob/3.2.0/src/Installer.php#L83-L93) and [`PluginUpdate`](https://github.com/woocommerce/google-listings-and-ads/blob/3.2.0/src/Jobs/Update/PluginUpdate.php#L36-L63) classes. This was originally intended for data migration during plugin upgrades. However, in version 3.2.0, it was unexpectedly scheduled for new installations as well, further causing subsequent product synchronization to be continuously blocked by [the error rate threshold mechanism](https://github.com/woocommerce/google-listings-and-ads/blob/3.2.0/src/Jobs/ActionSchedulerJobMonitor.php#L41-L57) in `ActionSchedulerJobMonitor` class.

<img width="1790" height="1926" alt="image" src="https://github.com/user-attachments/assets/433726c0-8755-4920-9ae0-4e79677607de" />

#### 💡 Extra changes

- Correct the doc of `ActionSchedulerJobMonitor::validate_failure_rate`.
   - The corresponding update for the threshold was missed in #1023
- Avoid warnings about shipping rate tables not existing during PHP unit testing.
   - The corresponding update was missed in #2821

### Detailed test instructions:

#### 📌 Reproduce the issue

1. Checkout the current `develop` revision 478c93fa255a7d7383820fb6c58350957b126cd3
2. Disconnect all accounts if there are any
3. Go to the Scheduled Actions page, and delete all failed jobs related to this plugin
4. Delete `gla_db_version` from WP Options to simulate the first time initialization
   ```sql
   DELETE FROM wp_options WHERE option_name = 'gla_db_version';
   ```
5. Refresh the Scheduled Actions page
6. Find the newly scheduled jobs starting with `gla/jobs/update_all_products`, wait for them to be run, and refresh the Scheduled Actions page again
7. Check if there are failed jobs starting with `gla/jobs/update_all_products`

https://github.com/user-attachments/assets/da8a920b-df33-4136-96d7-01f1346468c4

#### 📌 Verify the fixes

1. Checkout this PR
2. Repeat steps 3-5 in the above test instructions
3. Check if there are no more jobs starting with `gla/jobs/update_all_products` scheduled
4. Inspect the PHP Unit testing runs on GitHub Actions to see if the following warnings are gone
   https://github.com/woocommerce/google-listings-and-ads/actions/runs/16719154640?pr=3034
   <img width="1056" height="796" alt="image" src="https://github.com/user-attachments/assets/b4e6f792-5e57-46b1-b76c-7678bd71ad31" />

### Additional details:

There still seem to be some unresolved concerns regarding the ambiguity and technical design of push and pull synchronization modes. However, since this issue has prevented users who have newly installed this plugin from successfully synchronizing products in push mode and has also indirectly blocked pull mode, the first priority is to resolve the issue.

Ref:

- https://github.com/woocommerce/google-listings-and-ads/pull/2810#discussion_r2018653620
- https://github.com/woocommerce/google-listings-and-ads/pull/2810#discussion_r2018697778

### Changelog entry

> Fix - Avoid scheduling the job to synchronize all products with Google Merchant Center when the plugin is initialized for the first time.
