### PR TITLE
Revert changes to fix an issue where asset suggestions are not being automatically filled after selecting the final campaign URL

### DIFF
--- a/js/src/components/paid-ads/asset-group/asset-group-editor/asset-field.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-editor/asset-field.js
@@ -9,7 +9,6 @@ import {
 	useRef,
 	useImperativeHandle,
 	forwardRef,
-	useEffect,
 } from '@wordpress/element';
 import { chevronUp, chevronDown } from '@wordpress/icons';
 import { Pill } from '@woocommerce/components';
@@ -56,7 +55,7 @@ function AssetField(
 	ref
 ) {
 	const containerRef = useRef();
-	const [ expanded, setExpanded ] = useState( false );
+	const [ expanded, setExpanded ] = useState( initialExpanded );
 
 	const isReducedMotion = useReducedMotion();
 
@@ -69,10 +68,6 @@ function AssetField(
 			} );
 		},
 	} ) );
-
-	useEffect( () => {
-		setExpanded( initialExpanded );
-	}, [ initialExpanded ] );
 
 	const handleToggle = () => {
 		setExpanded( ! expanded );

--- a/js/src/components/paid-ads/asset-group/asset-group-editor/asset-group-editor.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-editor/asset-group-editor.js
@@ -93,7 +93,7 @@ export default function AssetGroupEditor() {
 		: baseAssetGroup;
 
 	return (
-		<div className="gla-asset-group-editor">
+		<div key={ finalUrl } className="gla-asset-group-editor">
 			<AssetGroupTextSection
 				finalUrl={ finalUrl }
 				getNumOfIssues={ getNumOfIssues }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-223/asset-suggestions-not-populating-in-campaign-edit-form

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Navigate to the dashboard.
2. Create/edit a campaign.
3. After selecting a URL in the "Optimize your campaign" step, the sections should auto expand and auto filled with the suggestions for the different text and image fields.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Asset suggestions not being automatically filled after selecting the final campaign URL.
