### PR TITLE
Fix E2E test compatibility issues w Woo 10.1

### DIFF
--- a/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
+++ b/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
@@ -409,7 +409,6 @@ test.describe( 'Complete your campaign', () => {
 
 			test.describe( 'Budget recommendations', () => {
 				test.beforeEach( async () => {
-					await page.evaluate( () => window.sessionStorage.clear() );
 					await setupAdsAccountPage.mockAdsAccountIncomplete();
 					await setupBudgetPage.fulfillBillingStatusRequest( {
 						status: 'approved',
@@ -417,6 +416,7 @@ test.describe( 'Complete your campaign', () => {
 					await completeCampaign.mockCompleteAdsSetup();
 					await completeCampaign.fulfillBudgetRecommendations();
 					await completeCampaign.goto();
+					await page.evaluate( () => window.sessionStorage.clear() );
 				} );
 
 				test( 'Create a campaign with a selected option from the budget recommendations', async () => {
@@ -487,10 +487,10 @@ test.describe( 'Complete your campaign', () => {
 			test.describe( 'With WooCommerce tracking disabled', () => {
 				test.beforeAll( async () => {
 					// Reset the showing status for the "Set up paid ads" section.
-					await page.evaluate( () => window.sessionStorage.clear() );
 					await setupAdsAccountPage.mockAdsAccountIncomplete();
 					await completeCampaign.goto();
 					await completeCampaign.clickSkipPaidAdsCreationButton();
+					await page.evaluate( () => window.sessionStorage.clear() );
 				} );
 
 				test( 'should see the modal', async () => {
@@ -692,7 +692,7 @@ test.describe( 'Complete your campaign', () => {
 				await completeCampaign.goto();
 				await completeCampaign.clickSkipPaidAdsCreationButton();
 				await completeCampaign.clickCompleteSetupModalButton();
-				await page.waitForNavigation( {
+				await page.waitForURL( /path=%2Fgoogle%2Fproduct-feed/, {
 					waitUntil: 'domcontentloaded',
 				} );
 				await page.evaluate( () => {

--- a/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
+++ b/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
@@ -486,11 +486,9 @@ test.describe( 'Complete your campaign', () => {
 		test.describe( 'User skips paid ads creation', () => {
 			test.describe( 'With WooCommerce tracking disabled', () => {
 				test.beforeAll( async () => {
-					// Reset the showing status for the "Set up paid ads" section.
 					await setupAdsAccountPage.mockAdsAccountIncomplete();
 					await completeCampaign.goto();
 					await completeCampaign.clickSkipPaidAdsCreationButton();
-					await page.evaluate( () => window.sessionStorage.clear() );
 				} );
 
 				test( 'should see the modal', async () => {

--- a/tests/e2e/specs/product-editor/block-integration.test.js
+++ b/tests/e2e/specs/product-editor/block-integration.test.js
@@ -13,6 +13,7 @@ test.use( { storageState: process.env.ADMINSTATE } );
 test.describe.configure( { mode: 'serial' } );
 
 test.describe( 'Product Block Editor integration', () => {
+	test.skip( 'Experimental block editor is deprecated in v10.1.0' );
 	/**
 	 * @type {Page}
 	 */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

See GOOWOO-225.

Fixes some E2E test failures when testing compatibility with Woo 10.1.0-rcX

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. [Review E2E tests for this branch](https://github.com/woocommerce/google-listings-and-ads/actions/runs/16758648108)

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

Dev – Update E2E tests ahead of Woo 10.1 release.
