### PR TITLE
API Pull: Change to use opt-out when filtering syncable products data according to channel visibility

### DIFF
--- a/src/Internal/DependencyManagement/IntegrationServiceProvider.php
+++ b/src/Internal/DependencyManagement/IntegrationServiceProvider.php
@@ -17,6 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Integration\YoastWooCommerceSeo;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\JetpackWPCOM;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 
 defined( 'ABSPATH' ) || exit;
@@ -50,7 +51,7 @@ class IntegrationServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( WooCommerceProductBundles::class, AttributeManager::class );
 		$this->share_with_tags( WooCommercePreOrders::class, ProductHelper::class );
 		$this->conditionally_share_with_tags( JetpackWPCOM::class );
-		$this->share_with_tags( WPCOMProxy::class, ShippingRateQuery::class, ShippingTimeQuery::class, AttributeManager::class );
+		$this->share_with_tags( WPCOMProxy::class, ShippingRateQuery::class, ShippingTimeQuery::class, AttributeManager::class, ProductRepository::class );
 
 		$this->share_with_tags(
 			IntegrationInitializer::class,

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -194,10 +194,12 @@ class ProductRepository implements Service {
 	}
 
 	/**
+	 * @param bool $prefixed Whether to prefix the meta query keys. Default is false.
+	 *
 	 * @return array
 	 */
-	protected function get_sync_ready_products_meta_query(): array {
-		return [
+	public function get_sync_ready_products_meta_query( bool $prefixed = false ): array {
+		$meta_query = [
 			'relation' => 'OR',
 			[
 				'key'     => ProductMetaHandler::KEY_VISIBILITY,
@@ -209,6 +211,12 @@ class ProductRepository implements Service {
 				'value'   => ChannelVisibility::DONT_SYNC_AND_SHOW,
 			],
 		];
+
+		if ( $prefixed ) {
+			$meta_query = $this->meta_handler->prefix_meta_query_keys( $meta_query );
+		}
+
+		return $meta_query;
 	}
 
 	/**

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Integration;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
@@ -113,83 +114,140 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 	public function test_get_products() {
 		$product_1 = ProductHelper::create_simple_product();
 		$product_2 = ProductHelper::create_simple_product();
+		$product_3 = ProductHelper::create_simple_product();
 
+		// Only products with opt-out channel visibility will be excluded.
 		$this->add_metadata( $product_1->get_id(), $this->get_test_metadata() );
 		$this->add_metadata( $product_2->get_id(), $this->get_test_metadata( ChannelVisibility::DONT_SYNC_AND_SHOW ) );
+		$this->add_metadata( $product_3->get_id(), $this->get_test_metadata( null ) );
 
 		$response = $this->do_request( '/wc/v3/products', 'GET', [ 'gla_syncable' => '1' ] );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 1, $response->get_data() );
+		$this->assertCount( 2, $response->get_data() );
 
 		$expected_metadata = [
 			'public_meta'              => 'public',
 			WPCOMProxy::KEY_VISIBILITY => ChannelVisibility::SYNC_AND_SHOW,
 		];
 
+		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
+
+		foreach ( [ $product_1, $product_3 ] as $source_product ) {
+			$this->assertArrayHasKey( $source_product->get_id(), $response_mapped );
+
+			$product = $response_mapped[ $source_product->get_id() ];
+
+			$this->assertEmpty( array_diff_assoc( $this->format_metadata( $product['meta_data'] ), $expected_metadata ) );
+			$this->assertArrayHasKey( 'gla_attributes', $product );
+			$this->assertEquals( 'object', gettype( $product['gla_attributes'] ) );
+		}
+	}
+
+	/**
+	 * The existing meta query and its relation should be followed.
+	 */
+	public function test_get_products_combination_with_existing_meta_query() {
+		$filter_product_meta_query = function ( array $args ) {
+			$args['meta_query'] = [
+				'relation' => 'AND',
+				[
+					'key'     => 'test_level',
+					'value'   => 0,
+					'compare' => '>',
+				],
+				[
+					'key'     => 'test_level',
+					'value'   => 2,
+					'compare' => '<=',
+				],
+			];
+			return $args;
+		};
+
+		add_filter( 'woocommerce_rest_product_object_query', $filter_product_meta_query, 9 );
+
+		$product_1 = ProductHelper::create_simple_product();
+		$product_2 = ProductHelper::create_simple_product();
+		$product_3 = ProductHelper::create_simple_product();
+
+		$this->add_metadata(
+			$product_1->get_id(),
+			array_merge(
+				$this->get_test_metadata( null ),
+				[ 'test_level' => 1 ]
+			)
+		);
+		$this->add_metadata(
+			$product_2->get_id(),
+			array_merge(
+				$this->get_test_metadata( ChannelVisibility::DONT_SYNC_AND_SHOW ),
+				[ 'test_level' => 2 ]
+			)
+		);
+		$this->add_metadata(
+			$product_3->get_id(),
+			array_merge(
+				$this->get_test_metadata(),
+				[ 'test_level' => 3 ]
+			)
+		);
+
+		$response = $this->do_request( '/wc/v3/products', 'GET', [ 'gla_syncable' => '1' ] );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $response->get_data() );
 		$this->assertEquals( $product_1->get_id(), $response->get_data()[0]['id'] );
-		$this->assertEquals( $expected_metadata, $this->format_metadata( $response->get_data()[0]['meta_data'] ) );
-		$this->assertArrayHasKey( 'gla_attributes', $response->get_data()[0] );
-		$this->assertEquals( 'object', gettype( $response->get_data()[0]['gla_attributes'] ) );
+
+		remove_filter( 'woocommerce_rest_product_object_query', $filter_product_meta_query );
 	}
 
 	public function test_get_products_with_gla_syncable_false() {
 		$product_1 = ProductHelper::create_simple_product();
 		$product_2 = ProductHelper::create_simple_product();
+		$product_3 = ProductHelper::create_simple_product();
 
 		$this->add_metadata( $product_1->get_id(), $this->get_test_metadata() );
 		$this->add_metadata( $product_2->get_id(), $this->get_test_metadata( ChannelVisibility::DONT_SYNC_AND_SHOW ) );
+		$this->add_metadata( $product_3->get_id(), $this->get_test_metadata( null ) );
 
 		$response = $this->do_request( '/wc/v3/products', 'GET', [ 'gla_syncable' => '0' ] );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 2, $response->get_data() );
+		$this->assertCount( 3, $response->get_data() );
 
 		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
 
-		$this->assertArrayHasKey( $product_1->get_id(), $response_mapped );
-		$this->assertArrayHasKey( $product_2->get_id(), $response_mapped );
+		foreach ( [ $product_1, $product_2, $product_3 ] as $source_product ) {
+			$this->assertArrayHasKey( $source_product->get_id(), $response_mapped );
 
-		$this->assertEquals( $this->get_test_metadata(), $this->format_metadata( $response_mapped[ $product_1->get_id() ]['meta_data'] ) );
-		$this->assertEquals( $this->get_test_metadata( ChannelVisibility::DONT_SYNC_AND_SHOW ), $this->format_metadata( $response_mapped[ $product_2->get_id() ]['meta_data'] ) );
-		$this->assertArrayNotHasKey( 'gla_attributes', $response->get_data()[0] );
+			$product = $response_mapped[ $source_product->get_id() ];
+
+			$this->assertEquals( $source_product->get_meta_data(), $product['meta_data'] );
+			$this->assertArrayNotHasKey( 'gla_attributes', $product );
+		}
 	}
 
-	public function test_get_products_without_gla_visibility_metadata() {
-		$product_1 = ProductHelper::create_simple_product();
-		$product_2 = ProductHelper::create_simple_product();
-
-		$this->add_metadata( $product_1->get_id(), $this->get_test_metadata( null ) );
-		$this->add_metadata( $product_2->get_id(), $this->get_test_metadata() );
-
-		$response = $this->do_request( '/wc/v3/products', 'GET', [ 'gla_syncable' => '1' ] );
-
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 1, $response->get_data() );
-
-		$expected_metadata = [
-			'public_meta'              => 'public',
-			WPCOMProxy::KEY_VISIBILITY => ChannelVisibility::SYNC_AND_SHOW,
-		];
-
-		$this->assertEquals( $product_2->get_id(), $response->get_data()[0]['id'] );
-		$this->assertEquals( $expected_metadata, $this->format_metadata( $response->get_data()[0]['meta_data'] ) );
-		$this->assertArrayHasKey( 'gla_attributes', $response->get_data()[0] );
-		$this->assertEquals( 'object', gettype( $response->get_data()[0]['gla_attributes'] ) );
-	}
-
-	public function test_get_product_without_gla_visibility_metadata() {
-		// If _wc_gla_visibility is not set it should not be returned.
+	public function test_get_product_with_opt_out_gla_visibility() {
+		// Requesting an opt-out product should get 403 error.
 		$product = ProductHelper::create_simple_product();
-		$this->add_metadata( $product->get_id(), $this->get_test_metadata( null ) );
-
-		delete_post_meta( $product->get_id(), 'customer_email' );
+		$this->add_metadata( $product->get_id(), $this->get_test_metadata( ChannelVisibility::DONT_SYNC_AND_SHOW ) );
 
 		$response = $this->do_request( '/wc/v3/products/' . $product->get_id(), 'GET', [ 'gla_syncable' => '1' ] );
 
 		$this->assertEquals( 403, $response->get_status() );
 		$this->assertEquals( 'gla_rest_item_no_syncable', $response->get_data()['code'] );
 		$this->assertEquals( 'Item not syncable', $response->get_data()['message'] );
+	}
+
+	public function test_get_product() {
+		$product = ProductHelper::create_simple_product();
+		$this->add_metadata( $product->get_id(), $this->get_test_metadata( null ) );
+
+		$response = $this->do_request( '/wc/v3/products/' . $product->get_id(), 'GET', [ 'gla_syncable' => '1' ] );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $product->get_id(), $response->get_data()['id'] );
 	}
 
 	public function test_get_product_with_gla_visibility_metadata() {
@@ -201,7 +259,6 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( $product->get_id(), $response->get_data()['id'] );
 	}
-
 
 	public function test_get_product_without_gla_syncable_param() {
 		$product = ProductHelper::create_simple_product();
@@ -485,7 +542,8 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 		$proxy = new WPCOMProxy(
 			$this->container->get( ShippingRateQuery::class ),
 			$this->container->get( ShippingTimeQuery::class ),
-			$this->container->get( AttributeManager::class )
+			$this->container->get( AttributeManager::class ),
+			$this->container->get( ProductRepository::class )
 		);
 
 		$this->assertEquals(

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -47,11 +47,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	protected $wc;
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_mark_as_synced( WC_Product $product ) {
+	public function test_mark_as_synced( string $callback ) {
+		$product        = call_user_func( $callback );
 		$google_product = $this->generate_google_product_mock();
 
 		$this->target_audience->expects( $this->any() )
@@ -75,11 +76,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_mark_as_synced_keeps_existing_google_ids( WC_Product $product ) {
+	public function test_mark_as_synced_keeps_existing_google_ids( string $callback ) {
+		$product        = call_user_func( $callback );
 		$google_product = $this->generate_google_product_mock();
 
 		$this->product_meta->update_google_ids( $product, [ 'AU' => 'online:en:AU:gla_1' ] );
@@ -96,11 +98,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_mark_as_synced_deletes_errors_when_main_target_countries_synced( WC_Product $product ) {
+	public function test_mark_as_synced_deletes_errors_when_main_target_countries_synced( string $callback ) {
+		$product        = call_user_func( $callback );
 		$google_product = $this->generate_google_product_mock();
 
 		$this->target_audience->expects( $this->any() )
@@ -120,11 +123,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_mark_as_synced_doesnt_delete_errors_unless_main_target_countries_synced( WC_Product $product ) {
+	public function test_mark_as_synced_doesnt_delete_errors_unless_main_target_countries_synced( string $callback ) {
+		$product        = call_user_func( $callback );
 		$google_product = $this->generate_google_product_mock();
 
 		$this->target_audience->expects( $this->any() )
@@ -206,11 +210,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_mark_as_unsynced( WC_Product $product ) {
+	public function test_mark_as_unsynced( string $callback ) {
+		$product = call_user_func( $callback );
 		// First mark the product as synced to update its meta data
 		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
 
@@ -291,11 +296,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_remove_google_id( WC_Product $product ) {
+	public function test_remove_google_id( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_meta->update_google_ids(
 			$product,
 			[
@@ -310,11 +316,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_remove_google_id_marks_as_unsynced_if_empty_ids( WC_Product $product ) {
+	public function test_remove_google_id_marks_as_unsynced_if_empty_ids( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_meta->update_google_ids( $product, [ 'US' => 'online:en:US:gla_1' ] );
 
 		$this->product_helper->remove_google_id( $product, 'online:en:US:gla_1' );
@@ -324,12 +331,13 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_mark_as_invalid( WC_Product $product ) {
-		$errors = [
+	public function test_mark_as_invalid( string $callback ) {
+		$product = call_user_func( $callback );
+		$errors  = [
 			'Error 1',
 			'Error 2',
 		];
@@ -348,12 +356,13 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_mark_as_invalid_updates_failed_sync_attempts_if_internal_error_exists( WC_Product $product ) {
-		$errors = [
+	public function test_mark_as_invalid_updates_failed_sync_attempts_if_internal_error_exists( string $callback ) {
+		$product = call_user_func( $callback );
+		$errors  = [
 			'Error 1',
 			'Error 2',
 			GoogleProductService::INTERNAL_ERROR_REASON => 'Internal error',
@@ -429,11 +438,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_mark_as_pending( WC_Product $product ) {
+	public function test_mark_as_pending( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_helper->mark_as_pending( $product );
 
 		$this->assertEquals( SyncStatus::PENDING, $this->product_meta->get_sync_status( $product ) );
@@ -470,11 +480,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_get_synced_google_product_ids( WC_Product $product ) {
+	public function test_get_synced_google_product_ids( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_meta->update_google_ids( $product, [ 'US' => 'online:en:US:gla_1' ] );
 
 		$this->assertEquals( [ 'US' => 'online:en:US:gla_1' ], $this->product_helper->get_synced_google_product_ids( $product ) );
@@ -585,22 +596,24 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_is_product_synced( WC_Product $product ) {
+	public function test_is_product_synced( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
 		$is_product_synced = $this->product_helper->is_product_synced( $product );
 		$this->assertTrue( $is_product_synced );
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_is_product_synced_return_false_if_no_google_id( WC_Product $product ) {
+	public function test_is_product_synced_return_false_if_no_google_id( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
 		$this->product_meta->delete_google_ids( $product );
 		$is_product_synced = $this->product_helper->is_product_synced( $product );
@@ -608,11 +621,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_is_product_synced_return_false_if_no_synced_at( WC_Product $product ) {
+	public function test_is_product_synced_return_false_if_no_synced_at( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
 		$this->product_meta->delete_synced_at( $product );
 		$is_product_synced = $this->product_helper->is_product_synced( $product );
@@ -620,11 +634,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_is_sync_ready_visible_published( WC_Product $product ) {
+	public function test_is_sync_ready_visible_published( string $callback ) {
+		$product = call_user_func( $callback );
 		$product->set_status( 'publish' );
 		$product->save();
 		$this->product_meta->update_visibility( $product, ChannelVisibility::SYNC_AND_SHOW );
@@ -633,11 +648,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_is_sync_ready_not_visible_published( WC_Product $product ) {
+	public function test_is_sync_ready_not_visible_published( string $callback ) {
+		$product = call_user_func( $callback );
 		$product->set_status( 'publish' );
 		$product->save();
 		$this->product_meta->update_visibility( $product, ChannelVisibility::DONT_SYNC_AND_SHOW );
@@ -646,11 +662,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_is_sync_ready_visible_not_published( WC_Product $product ) {
+	public function test_is_sync_ready_visible_not_published( string $callback ) {
+		$product = call_user_func( $callback );
 		$product->set_status( 'draft' );
 		$product->save();
 		$this->product_meta->update_visibility( $product, ChannelVisibility::SYNC_AND_SHOW );
@@ -818,44 +835,48 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_is_sync_failed_recently( WC_Product $product ) {
+	public function test_is_sync_failed_recently( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_meta->update_failed_sync_attempts( $product, ProductSyncer::FAILURE_THRESHOLD + 5 );
 		$this->product_meta->update_sync_failed_at( $product, strtotime( '+1 year' ) );
 		$this->assertTrue( $this->product_helper->is_sync_failed_recently( $product ) );
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_is_sync_failed_recently_less_than_threshold( WC_Product $product ) {
+	public function test_is_sync_failed_recently_less_than_threshold( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_meta->update_failed_sync_attempts( $product, ProductSyncer::FAILURE_THRESHOLD - 1 );
 		$this->product_meta->update_sync_failed_at( $product, strtotime( '+1 year' ) );
 		$this->assertFalse( $this->product_helper->is_sync_failed_recently( $product ) );
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_is_sync_failed_recently_old_failure_but_more_than_threshold( WC_Product $product ) {
+	public function test_is_sync_failed_recently_old_failure_but_more_than_threshold( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_meta->update_failed_sync_attempts( $product, ProductSyncer::FAILURE_THRESHOLD + 5 );
 		$this->product_meta->update_sync_failed_at( $product, strtotime( '-1 year' ) );
 		$this->assertFalse( $this->product_helper->is_sync_failed_recently( $product ) );
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_get_channel_visibility( WC_Product $product ) {
+	public function test_get_channel_visibility( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_meta->update_visibility( $product, ChannelVisibility::DONT_SYNC_AND_SHOW );
 		$result = $this->product_helper->get_channel_visibility( $product );
 		$this->assertEquals( ChannelVisibility::DONT_SYNC_AND_SHOW, $result );
@@ -885,11 +906,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_update_channel_visibility( WC_Product $product ) {
+	public function test_update_channel_visibility( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->assertNull( $this->product_meta->get_visibility( $product ) );
 
 		$this->product_helper->update_channel_visibility( $product, ChannelVisibility::SYNC_AND_SHOW );
@@ -915,11 +937,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_update_channel_visibility_wont_update_if_invalid_value( WC_Product $product ) {
+	public function test_update_channel_visibility_wont_update_if_invalid_value( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->assertNull( $this->product_meta->get_visibility( $product ) );
 		$this->product_helper->update_channel_visibility( $product, 'phpunit-test-disallowed-value' );
 		$this->assertNull( $this->product_meta->get_visibility( $product ) );
@@ -945,21 +968,23 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_get_sync_status( WC_Product $product ) {
+	public function test_get_sync_status( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_meta->update_sync_status( $product, SyncStatus::SYNCED );
 		$this->assertEquals( SyncStatus::SYNCED, $this->product_helper->get_sync_status( $product ) );
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_get_mc_status( WC_Product $product ) {
+	public function test_get_mc_status( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_meta->update_mc_status( $product, MCStatus::APPROVED );
 		$this->assertEquals( MCStatus::APPROVED, $this->product_helper->get_mc_status( $product ) );
 	}
@@ -1068,12 +1093,13 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_get_validation_errors( WC_Product $product ) {
-		$errors = [
+	public function test_get_validation_errors( string $callback ) {
+		$product = call_user_func( $callback );
+		$errors  = [
 			1111 => [
 				'Variation Error 1',
 				'Variation Error 2',
@@ -1102,12 +1128,13 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_get_validation_errors_returns_as_is_if_keys_arent_product_ids( WC_Product $product ) {
-		$errors = [
+	public function test_get_validation_errors_returns_as_is_if_keys_arent_product_ids( string $callback ) {
+		$product = call_user_func( $callback );
+		$errors  = [
 			[
 				'Variation Error 1',
 				'Variation Error 2',
@@ -1131,11 +1158,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_increment_failed_delete_attempt( WC_Product $product ) {
+	public function test_increment_failed_delete_attempt( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_meta->update_failed_delete_attempts( $product, 1 );
 		$this->product_helper->increment_failed_delete_attempt( $product );
 
@@ -1143,11 +1171,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_is_delete_failed_threshold_reached( WC_Product $product ) {
+	public function test_is_delete_failed_threshold_reached( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_meta->update_failed_delete_attempts( $product, 4 );
 		$this->assertFalse( $this->product_helper->is_delete_failed_threshold_reached( $product ) );
 
@@ -1157,11 +1186,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_increment_failed_update_attempt( WC_Product $product ) {
+	public function test_increment_failed_update_attempt( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_meta->update_failed_sync_attempts( $product, 99 );
 
 		$this->product_helper->increment_failed_update_attempt( $product );
@@ -1170,11 +1200,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
-	 * @param WC_Product $product
+	 * @param string $callback
 	 *
-	 * @dataProvider return_test_products
+	 * @dataProvider return_test_product_callbacks
 	 */
-	public function test_is_update_failed_threshold_reached( WC_Product $product ) {
+	public function test_is_update_failed_threshold_reached( string $callback ) {
+		$product = call_user_func( $callback );
 		$this->product_meta->update_failed_sync_attempts( $product, 4 );
 		$this->assertFalse( $this->product_helper->is_update_failed_threshold_reached( $product ) );
 
@@ -1374,13 +1405,18 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 	}
 
 	/**
+	 * - Variation products are provided separately to related tests.
+	 * - Return callables to make the data provider itself efficient and without
+	 *   side effects. Especially when using `--filter` to run test suites, all
+	 *   data provider methods will still be called regardless of whether the
+	 *   decorated test cases are included or not.
+	 *
 	 * @return array
 	 */
-	public function return_test_products(): array {
-		// variation products are provided separately to related tests
+	public function return_test_product_callbacks(): array {
 		return [
-			[ WC_Helper_Product::create_simple_product() ],
-			[ WC_Helper_Product::create_variation_product() ], // WC_Product_Variable
+			[ 'WC_Helper_Product::create_simple_product' ],
+			[ 'WC_Helper_Product::create_variation_product' ], // WC_Product_Variable
 		];
 	}
 

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -90,6 +90,40 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		$this->assertContainsOnly( 'integer', $results );
 	}
 
+	public function test_get_sync_ready_products_meta_query() {
+		$this->assertEquals(
+			[
+				'relation' => 'OR',
+				[
+					'key'     => 'visibility',
+					'compare' => 'NOT EXISTS',
+				],
+				[
+					'key'     => 'visibility',
+					'compare' => '!=',
+					'value'   => 'dont-sync-and-show',
+				],
+			],
+			$this->product_repository->get_sync_ready_products_meta_query()
+		);
+
+		$this->assertEquals(
+			[
+				'relation' => 'OR',
+				[
+					'key'     => '_wc_gla_visibility',
+					'compare' => 'NOT EXISTS',
+				],
+				[
+					'key'     => '_wc_gla_visibility',
+					'compare' => '!=',
+					'value'   => 'dont-sync-and-show',
+				],
+			],
+			$this->product_repository->get_sync_ready_products_meta_query( true )
+		);
+	}
+
 	public function test_find_passes_query_args() {
 		$product_1 = WC_Helper_Product::create_simple_product();
 		$product_1->set_status( 'draft' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

For API Pull mode, this PR changes to use opt-out when filtering syncable products data according to channel visibility. In addition to using logic consistent with push mode, pull mode no longer relies on default channel visibility metadata populated in push mode. This further decouples the two modes. Ref:
- https://github.com/woocommerce/google-listings-and-ads/blob/3.3.0/src/Product/ProductRepository.php#L236-L249
- https://github.com/woocommerce/google-listings-and-ads/blob/3.3.0/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L166-L167
- https://github.com/woocommerce/google-listings-and-ads/blob/3.3.0/src/Product/ProductHelper.php#L262-L264

In addition, this PR also makes the data provider in `ProductHelperTest` efficient and have no side effects. This will make development more efficient because when using `--filter` to run test suites, all data provider methods will still be called regardless of whether the decorated test cases are included or not

### Detailed test instructions:

1. Reset products' channel visibility metadata that may have been set by push mode
   ```sql
   DELETE FROM wp_postmeta WHERE meta_key = '_wc_gla_visibility';
   ```
2. Open the Console panel of the browser's DevTool
3. Run the following scripts to simulate the requests sent to `WPCOMProxy`, and check if only opted-out products do not appear in the results. (Note that the results are paginated)
   - `wp.apiFetch({ path:'/wc/v3/products?orderby=id&gla_syncable=1' }).then(console.log)`
   - `wp.apiFetch({ path:'/wc/v3/products/<product_id>?orderby=id&gla_syncable=1' }).then(console.log)`
   - `wp.apiFetch({ path:'/wc/v3/products/<variable_product_id>/variations?orderby=id&gla_syncable=1' }).then(console.log)`
   - `wp.apiFetch({ path:'/wc/v3/products/<variable_product_id>/variations/<variation_product_id>?orderby=id&gla_syncable=1' }).then(console.log)`
4. Go to edit the **Channel visibility** for some products that appeared or didn't appear in the previous results, and test if their appearances in the new results are changed accordingly
   <img width="1281" height="628" alt="image" src="https://github.com/user-attachments/assets/c842bdfb-a975-4fd7-9d70-106e7a0cb7af" />

### Changelog entry

> Update - The filtering for synchronizable products data by channel visibility in API Pull mode is now opt-out, changed from its previous opt-in setting.
