### PR TITLE
Use setValues instead of individual setValue calls.

### DIFF
--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -158,12 +158,18 @@ export default function CampaignAssetsForm( {
 					: initialAssetGroup;
 				let hasNonEmptyAssets = false;
 
+				const updatedContextValues = {};
 				Object.keys( emptyAssetGroup ).forEach( ( key ) => {
 					if ( assetGroup && assetGroup[ key ]?.length ) {
 						hasNonEmptyAssets = true;
 					}
-					formContext.setValue( key, nextAssetGroup[ key ] );
+
+					updatedContextValues[ key ] = nextAssetGroup[ key ];
 				} );
+
+				if ( Object.keys( updatedContextValues ).length ) {
+					formContext.setValues( updatedContextValues );
+				}
 
 				setHasImportedAssets( hasNonEmptyAssets );
 				setBaseAssetGroup( nextAssetGroup );

--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -158,14 +158,14 @@ export default function CampaignAssetsForm( {
 					: initialAssetGroup;
 				let hasNonEmptyAssets = false;
 
-				const updatedContextValues = {};
-				Object.keys( emptyAssetGroup ).forEach( ( key ) => {
-					if ( assetGroup && assetGroup[ key ]?.length ) {
-						hasNonEmptyAssets = true;
-					}
-
-					updatedContextValues[ key ] = nextAssetGroup[ key ];
-				} );
+				const updatedContextValues = Object.fromEntries(
+					Object.keys( emptyAssetGroup ).map( ( key ) => {
+						if ( assetGroup?.[ key ]?.length ) {
+							hasNonEmptyAssets = true;
+						}
+						return [ key, nextAssetGroup[ key ] ];
+					} )
+				);
 
 				if ( Object.keys( updatedContextValues ).length ) {
 					formContext.setValues( updatedContextValues );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-245/investigate-long-headline-validation-issue

_Replace this with a good description of your changes & reasoning._
I suspect there’s a race condition occurring due to successive calls to formContext.setValue. Upon investigation, the issue affects not only the long headline but also other fields, such as the business name. It does not reproduce consistently.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Navigate to the plugin dashboard.
2. Edit a campaign
3. In the second step, after choosing an URL, the form should be populated with some initial data.
4. There should be no validation errors if a field is valid (for e.g some fields are not blank)
5. Check for when there are empty/non empty assets for the campaign.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Replaced multiple `setValue` calls with a single `setValues` call to eliminate race conditions during form initialization and reduce inconsistent validation behavior. 
