### PR TITLE
Fix: Inconsistent focus after checking/unchecking a checkbox.

### DIFF
--- a/js/src/components/tree-select-control/index.js
+++ b/js/src/components/tree-select-control/index.js
@@ -433,7 +433,11 @@ const TreeSelectControl = ( {
 		}
 
 		setInputControlValue( '' );
-		if ( ! nodesExpanded.includes( option.parent ) ) {
+		if (
+			! option.hasChildren &&
+			option.parent &&
+			! nodesExpanded.includes( option.parent )
+		) {
 			controlRef.current.focus();
 		}
 	};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes: https://linear.app/a8c/issue/GOOWOO-63/tree-select-control-inconsistent-focus-after-checkingunchecking-a

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Go to `Marketing > Google for WooCommerce > Shipping > Audience > Location`
2. After checking/unchecking a checkbox, the focus should stay on the clicked checkbox when not in searching.
3. Whenever any option is selecetd, focus should not be shifted to input box.
4. When we click `Asia`, it should get expanded and focus should be on `Asia`.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Improve focus handling in `TreeSelectControl`.
