### PR TITLE
Use types instead of type

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -1268,11 +1268,11 @@ export function* receivePriceBenchmarkSuggestionsProductPrice(
 
 export function* receiveAdsRecommendations(
 	recommendations,
-	recommendationType
+	recommendationTypes
 ) {
 	return {
 		type: TYPES.RECEIVE_ADS_RECOMMENDATIONS,
 		recommendations,
-		recommendationType,
+		recommendationTypes,
 	};
 }

--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -618,11 +618,11 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		}
 
 		case TYPES.RECEIVE_ADS_RECOMMENDATIONS: {
-			const { recommendations, recommendationType } = action;
+			const { recommendations, recommendationTypes } = action;
 
 			return setIn(
 				state,
-				[ 'ads', 'recommendations', recommendationType ],
+				[ 'ads', 'recommendations', recommendationTypes ],
 				recommendations
 			);
 		}

--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -19,6 +19,7 @@ import {
 	getReportKey,
 	getCountryCodesKey,
 	getAdsBudgetMetricsKey,
+	arrayToUnderscoreKey,
 } from './utils';
 import { handleApiError } from '~/utils/handleError';
 import {
@@ -745,15 +746,16 @@ export function* getPriceBenchmarkSuggestions( args ) {
 /**
  * Resolver for getting the Ads recommendations.
  */
-export function* getAdsRecommendations( type ) {
+export function* getAdsRecommendations( types ) {
 	try {
 		const response = yield apiFetch( {
 			path: addQueryArgs( `${ API_NAMESPACE }/ads/recommendations`, {
-				type,
+				types,
 			} ),
 		} );
 
-		yield receiveAdsRecommendations( response, type );
+		const typesKey = arrayToUnderscoreKey( types );
+		yield receiveAdsRecommendations( response, typesKey );
 	} catch ( error ) {
 		handleApiError(
 			error,

--- a/js/src/data/selectors.js
+++ b/js/src/data/selectors.js
@@ -10,6 +10,7 @@ import createSelector from 'rememo';
 import { STORE_KEY } from './constants';
 import { generateKeyFromObject } from '~/utils/generateKeyFromObject';
 import {
+	arrayToUnderscoreKey,
 	getReportQuery,
 	getReportKey,
 	getPerformanceQuery,
@@ -489,9 +490,10 @@ export const getPriceBenchmarkSuggestion = ( state, productId ) => {
  * Retrieves ad recommendations of a specific type from the state.
  *
  * @param {Object} state - The Redux state object containing ads data.
- * @param {string} type - The type of ad recommendations to retrieve.
+ * @param {Array<string>} types - The types of ad recommendations to retrieve.
  * @return {Object|null} The recommendations for the specified type, or null if not found.
  */
-export const getAdsRecommendations = ( state, type ) => {
-	return state.ads.recommendations[ type ] || null;
+export const getAdsRecommendations = ( state, types ) => {
+	const key = arrayToUnderscoreKey( types );
+	return state.ads.recommendations[ key ] || null;
 };

--- a/js/src/data/utils.js
+++ b/js/src/data/utils.js
@@ -195,13 +195,35 @@ export function mapReportFieldsToPerformance(
 }
 
 /**
+ * Converts an array of strings into a single underscore-separated, lowercase string.
+ *
+ * @param {string[]} [arr=[]] - The array of strings to convert.
+ * @return {string} The underscore-separated, lowercase string.
+ */
+export const arrayToUnderscoreKey = ( arr = [] ) => {
+	return arr
+		.map(
+			( str ) =>
+				String( str )
+					.normalize( 'NFKD' )
+					.replace( /[\u0300-\u036f]/g, '' ) // remove accents
+					.trim()
+					.toLowerCase()
+					.replace( /[^a-z0-9_ ]/g, '' ) // allow underscores
+					.replace( /\s+/g, '_' ) // replace spaces with underscores
+					.replace( /_+/g, '_' ) // collapse multiple underscores
+		)
+		.join( '_' );
+};
+
+/**
  * Generates a unique key (slug) from an array of country codes.
  *
  * @param {Array<CountryCode>} [countryCodes] - An array of country code strings.
  * @return {string} An underscore-separated, lowercase string representing the given country codes.
  */
 export function getCountryCodesKey( countryCodes = [] ) {
-	return countryCodes.join( '_' ).toLowerCase();
+	return arrayToUnderscoreKey( countryCodes );
 }
 
 /**

--- a/js/src/hooks/useRecommendedPMaxCampaign.js
+++ b/js/src/hooks/useRecommendedPMaxCampaign.js
@@ -26,7 +26,7 @@ const useRecommendedPMaxCampaign = () => {
 			'getAdsRecommendations',
 			[ [ PMAX_IMPROVE_PERFORMANCE_MAX_AD_STRENGTH ] ]
 		);
-		console.log( hasResolvedRecommendations );
+
 		if ( ! recommendations?.length ) {
 			return {
 				campaign: null,

--- a/js/src/hooks/useRecommendedPMaxCampaign.js
+++ b/js/src/hooks/useRecommendedPMaxCampaign.js
@@ -19,14 +19,14 @@ import { PMAX_IMPROVE_PERFORMANCE_MAX_AD_STRENGTH } from '~/constants';
 const useRecommendedPMaxCampaign = () => {
 	return useSelect( ( select ) => {
 		const selector = select( STORE_KEY );
-		const recommendations = selector.getAdsRecommendations(
-			PMAX_IMPROVE_PERFORMANCE_MAX_AD_STRENGTH
-		);
+		const recommendations = selector.getAdsRecommendations( [
+			PMAX_IMPROVE_PERFORMANCE_MAX_AD_STRENGTH,
+		] );
 		const hasResolvedRecommendations = selector.hasFinishedResolution(
 			'getAdsRecommendations',
-			[ PMAX_IMPROVE_PERFORMANCE_MAX_AD_STRENGTH ]
+			[ [ PMAX_IMPROVE_PERFORMANCE_MAX_AD_STRENGTH ] ]
 		);
-
+		console.log( hasResolvedRecommendations );
 		if ( ! recommendations?.length ) {
 			return {
 				campaign: null,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-251/update-getadsrecommendations-selectorresolver-to-accept-types-as-an

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
Wait for https://linear.app/a8c/issue/GOOWOO-246/enhance-adsrecommendations-rest-api-endpoint-to-retrieve-campaign to be merged.

1. Test for the Pmax notification banner same as per https://github.com/woocommerce/google-listings-and-ads/pull/2983. Instead of mocking the `/wp-json/wc/gla/ads/recommendations?type=IMPROVE_PERFORMANCE_MAX_AD_STRENGTH` endpoint, the `/wp-json/wc/gla/ads/recommendations?types%5B0%5D=IMPROVE_PERFORMANCE_MAX_AD_STRENGTH` endpoint should be mocked. Response should be similar.
2. Test the creation of a new campaign and budget recommendations are displayed since some changes to the function to generate a slug were made.
3. Test the onboarding flow as well. There should be no changes.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
