### PR TITLE
Reduce the cache time for product statuses and issues from 12 hours to 30 minutes

### DIFF
--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -57,7 +57,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	/**
 	 * The lifetime of the status-related data.
 	 */
-	public const STATUS_LIFETIME = 12 * HOUR_IN_SECONDS;
+	public const STATUS_LIFETIME = 30 * MINUTE_IN_SECONDS;
 
 	/**
 	 * The types of issues.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR reduces the cache time for product statuses and issues from 12 hours to 30 minutes
The product statuses displayed on the plugin are synchronized from Google Merchant Center.

After product data is synchronized via the Push mode, the status cache is cleared. Because it takes some time for product statuses to be updated on Google Merchant Center, there doesn't seem to be an optimal time to synchronize the status data, and newly fetched statuses are not necessarily the most current.

Previously, the cache time was one hour, so even if the status data was outdated, it wouldn't remain so for very long. However, this was later changed to a 12-hour cache in #2329, and the cache is not cleared when data is synchronized via the API Pull mode. This results in product statuses being outdated for an extended period.

While shortening the cache time to half an hour won't make the product statuses real-time, it will at least prevent the display of outdated data for a long time.

Ref: p1753871675559559-slack-C02BB3F30TG

### Detailed test instructions:

1. Update a product and wait for it to finish synchronizing in Push mode
2. Query the newly set transient `gla_mc_statuses` via `wp transient list --search=gla_mc_statuses`
3. Check if the expiration timestamp is 30 minutes later

<img width="1112" height="146" alt="image" src="https://github.com/user-attachments/assets/e9c35910-2b2d-43d8-af59-8fe0f456dc4c" />

### Changelog entry

> Tweak - Reduce the cache time for product statuses and issues from 12 hours to 30 minutes.
