### PR TITLE
Schedule job to sync all products when the Push mode of product sync is switched to enable

### DIFF
--- a/src/API/Site/Controllers/RestAPI/SyncController.php
+++ b/src/API/Site/Controllers/RestAPI/SyncController.php
@@ -138,6 +138,9 @@ class SyncController extends BaseOptionsController {
 				$new_sync_mode = array_replace_recursive( $sync_mode, $new_params );
 
 				$this->options->update( OptionsInterface::API_PULL_SYNC_MODE, $new_sync_mode );
+
+				do_action( 'woocommerce_gla_sync_mode_updated', $sync_mode, $new_sync_mode );
+
 				return $this->prepare_item_for_response( $this->options->get( OptionsInterface::API_PULL_SYNC_MODE ), $request );
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );

--- a/src/Event/StartProductSync.php
+++ b/src/Event/StartProductSync.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class StartProductSync
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Product
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Event
  */
 class StartProductSync implements Registerable, Service {
 	/**

--- a/src/Event/StartProductSync.php
+++ b/src/Event/StartProductSync.php
@@ -48,6 +48,15 @@ class StartProductSync implements Registerable, Service {
 				$this->on_rules_change();
 			}
 		);
+
+		add_action(
+			'woocommerce_gla_sync_mode_updated',
+			function ( $prev_sync_mode, $sync_mode ) {
+				$this->on_sync_mode_updated( $prev_sync_mode, $sync_mode );
+			},
+			10,
+			2
+		);
 	}
 
 	/**
@@ -67,5 +76,18 @@ class StartProductSync implements Registerable, Service {
 	protected function on_rules_change() {
 		$update = $this->job_repository->get( UpdateAllProducts::class );
 		$update->schedule_delayed( 1800 ); // 30 minutes
+	}
+
+	/**
+	 * If the Push mode of product sync is switched to enable, schedule a job to sync all products.
+	 *
+	 * @param array $prev_sync_mode The previous sync mode.
+	 * @param array $sync_mode The current sync mode.
+	 */
+	protected function on_sync_mode_updated( $prev_sync_mode, $sync_mode ) {
+		if ( $prev_sync_mode['products']['push'] === false && $sync_mode['products']['push'] === true ) {
+			$update = $this->job_repository->get( UpdateAllProducts::class );
+			$update->schedule();
+		}
 	}
 }

--- a/src/Event/StartProductSync.php
+++ b/src/Event/StartProductSync.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
+use Throwable;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -85,7 +86,21 @@ class StartProductSync implements Registerable, Service {
 	 * @param array $sync_mode The current sync mode.
 	 */
 	protected function on_sync_mode_updated( $prev_sync_mode, $sync_mode ) {
-		if ( $prev_sync_mode['products']['push'] === false && $sync_mode['products']['push'] === true ) {
+		// It's possible that the incoming modes don't have the expected structure
+		// for example, due to the `woocommerce_gla_sync_mode` filter.
+		try {
+			$prev_push    = $prev_sync_mode['products']['push'] ?? null;
+			$current_push = $sync_mode['products']['push'] ?? null;
+		} catch ( Throwable $e ) {
+			do_action(
+				'woocommerce_gla_debug_message',
+				'One or more of the incoming sync mode structures are invalid.',
+				__METHOD__
+			);
+			return;
+		}
+
+		if ( $prev_push === false && $current_push === true ) {
 			$update = $this->job_repository->get( UpdateAllProducts::class );
 			$update->schedule();
 		}

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -93,6 +93,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\GoogleGtagJs;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\Tracks as TracksProxy;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WPAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\LocationRatesProcessor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingSuggestionService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ZoneMethodsParser;
@@ -242,6 +243,10 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->getContainer()
 			->inflector( MerchantCenterAwareInterface::class )
 			->invokeMethod( 'set_merchant_center_object', [ MerchantCenterService::class ] );
+
+		$this->getContainer()
+			->inflector( WPAwareInterface::class )
+			->invokeMethod( 'set_wp_proxy_object', [ WP::class ] );
 
 		// Set up Ads service, and inflect classes that need it.
 		$this->share_with_tags( AdsAccountState::class );

--- a/src/Options/Options.php
+++ b/src/Options/Options.php
@@ -7,6 +7,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidOption;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WPAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WPAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\CastableValueInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ValueInterface;
 
@@ -17,8 +20,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure
  */
-final class Options implements OptionsInterface, Service {
+final class Options implements WPAwareInterface, OptionsInterface, Service {
 
+	use WPAwareTrait;
 	use PluginHelper;
 
 	/**
@@ -40,7 +44,7 @@ final class Options implements OptionsInterface, Service {
 		$this->validate_option_key( $name );
 
 		if ( ! array_key_exists( $name, $this->options ) ) {
-			$value                  = get_option( $this->prefix_name( $name ), $default_value );
+			$value                  = $this->wp->get_option( $this->prefix_name( $name ), $default_value );
 			$this->options[ $name ] = $this->maybe_cast_value( $name, $value );
 		}
 
@@ -60,7 +64,7 @@ final class Options implements OptionsInterface, Service {
 		$value                  = $this->maybe_convert_value( $name, $value );
 		$this->options[ $name ] = $value;
 
-		$result = add_option( $this->prefix_name( $name ), $this->raw_value( $value ) );
+		$result = $this->wp->add_option( $this->prefix_name( $name ), $this->raw_value( $value ) );
 
 		do_action( "woocommerce_gla_options_updated_{$name}", $value );
 
@@ -80,7 +84,7 @@ final class Options implements OptionsInterface, Service {
 		$value                  = $this->maybe_convert_value( $name, $value );
 		$this->options[ $name ] = $value;
 
-		$result = update_option( $this->prefix_name( $name ), $this->raw_value( $value ) );
+		$result = $this->wp->update_option( $this->prefix_name( $name ), $this->raw_value( $value ) );
 
 		do_action( "woocommerce_gla_options_updated_{$name}", $value );
 
@@ -98,7 +102,7 @@ final class Options implements OptionsInterface, Service {
 		$this->validate_option_key( $name );
 		unset( $this->options[ $name ] );
 
-		$result = delete_option( $this->prefix_name( $name ) );
+		$result = $this->wp->delete_option( $this->prefix_name( $name ) );
 
 		do_action( "woocommerce_gla_options_deleted_{$name}" );
 

--- a/src/Proxies/WP.php
+++ b/src/Proxies/WP.php
@@ -349,4 +349,40 @@ class WP {
 	public function wp_is_serving_rest_request(): bool {
 		return wp_is_serving_rest_request();
 	}
+
+	/**
+	 * Wrapper of get_option.
+	 *
+	 * @param mixed ...$arguments
+	 */
+	public function get_option( ...$arguments ) {
+		return get_option( ...$arguments );
+	}
+
+	/**
+	 * Wrapper of add_option.
+	 *
+	 * @param mixed ...$arguments
+	 */
+	public function add_option( ...$arguments ) {
+		return add_option( ...$arguments );
+	}
+
+	/**
+	 * Wrapper of update_option.
+	 *
+	 * @param mixed ...$arguments
+	 */
+	public function update_option( ...$arguments ) {
+		return update_option( ...$arguments );
+	}
+
+	/**
+	 * Wrapper of delete_option.
+	 *
+	 * @param mixed ...$arguments
+	 */
+	public function delete_option( ...$arguments ) {
+		return delete_option( ...$arguments );
+	}
 }

--- a/src/Proxies/WPAwareInterface.php
+++ b/src/Proxies/WPAwareInterface.php
@@ -1,0 +1,21 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Proxies;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Interface WPAwareInterface
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Proxies
+ */
+interface WPAwareInterface {
+
+	/**
+	 * Set the WP proxy object.
+	 *
+	 * @param WP $wp
+	 */
+	public function set_wp_proxy_object( WP $wp ): void;
+}

--- a/src/Proxies/WPAwareTrait.php
+++ b/src/Proxies/WPAwareTrait.php
@@ -1,0 +1,30 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Proxies;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Trait WPAwareTrait
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Proxies
+ */
+trait WPAwareTrait {
+
+	/**
+	 * The WP proxy object.
+	 *
+	 * @var WP
+	 */
+	protected $wp;
+
+	/**
+	 * Set the WP proxy object.
+	 *
+	 * @param WP $wp
+	 */
+	public function set_wp_proxy_object( WP $wp ): void {
+		$this->wp = $wp;
+	}
+}

--- a/tests/Tools/HelperTrait/OptionsTrait.php
+++ b/tests/Tools/HelperTrait/OptionsTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\Options;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+
+trait OptionsTrait {
+	public function create_options_mock() {
+		$wp = $this->createStub( WP::class );
+
+		$wp->method( 'get_option' )->willReturnArgument( 1 );
+		$wp->method( 'add_option' )->willReturn( true );
+		$wp->method( 'update_option' )->willReturn( true );
+		$wp->method( 'delete_option' )->willReturn( true );
+
+		$options = $this->getMockBuilder( Options::class )
+			->onlyMethods( [ 'get_merchant_id', 'get_ads_id' ] )
+			->getMock();
+
+		$options->set_wp_proxy_object( $wp );
+
+		return $options;
+	}
+}

--- a/tests/Unit/API/Site/Controllers/RestAPI/SyncControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/RestAPI/SyncControllerTest.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\RestAPI;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestAPI\SyncController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\OptionsTrait;
+
+/**
+ * Class SyncControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\RestAPI
+ */
+class SyncControllerTest extends RESTControllerUnitTest {
+
+	use OptionsTrait;
+
+	protected const ROUTE = '/wc/gla/sync';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$notifications_service = $this->getMockBuilder( NotificationsService::class )
+			->disableOriginalConstructor()
+			->setMethodsExcept( [ 'set_options_object', 'get_current_sync_mode', 'get_default_sync_mode' ] )
+			->getMock();
+
+		$this->controller = new SyncController( $this->server, $notifications_service );
+		$options          = $this->create_options_mock();
+
+		$notifications_service->set_options_object( $options );
+		$this->controller->set_options_object( $options );
+		$this->controller->register();
+	}
+
+	public function test_get_sync_mode() {
+		$response = $this->do_request( self::ROUTE );
+
+		$this->assertEquals(
+			[
+				'products' => [
+					'push' => true,
+					'pull' => true,
+				],
+				'coupons'  => [
+					'push' => true,
+					'pull' => true,
+				],
+				'shipping' => [
+					'push' => true,
+					'pull' => true,
+				],
+				'settings' => [
+					'push' => true,
+					'pull' => true,
+				],
+			],
+			$response->get_data()
+		);
+	}
+
+	public function test_post_sync_mode_with_partial_configs() {
+		$response = $this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'products' => [
+					'push' => false,
+					'pull' => false,
+				],
+				'coupons'  => [
+					'push' => false,
+					'pull' => false,
+				],
+			]
+		);
+
+		$this->assertEquals(
+			[
+				'products' => [
+					'push' => false,
+					'pull' => false,
+				],
+				'coupons'  => [
+					'push' => false,
+					'pull' => false,
+				],
+				'shipping' => [
+					'push' => true,
+					'pull' => true,
+				],
+				'settings' => [
+					'push' => true,
+					'pull' => true,
+				],
+			],
+			$response->get_data()
+		);
+	}
+	public function test_post_sync_mode_with_partial_modes() {
+		$response = $this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'shipping' => [ 'push' => false ],
+				'settings' => [ 'pull' => false ],
+			]
+		);
+
+		$this->assertEquals(
+			[
+				'products' => [
+					'push' => true,
+					'pull' => true,
+				],
+				'coupons'  => [
+					'push' => true,
+					'pull' => true,
+				],
+				'shipping' => [
+					'push' => false,
+					'pull' => true,
+				],
+				'settings' => [
+					'push' => true,
+					'pull' => false,
+				],
+			],
+			$response->get_data()
+		);
+	}
+
+	public function test_post_sync_mode_with_full_configs() {
+		$response = $this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'products' => [
+					'push' => true,
+					'pull' => false,
+				],
+				'coupons'  => [
+					'push' => true,
+					'pull' => false,
+				],
+				'shipping' => [
+					'push' => true,
+					'pull' => false,
+				],
+				'settings' => [
+					'push' => true,
+					'pull' => false,
+				],
+			]
+		);
+
+		$this->assertEquals(
+			[
+				'products' => [
+					'push' => true,
+					'pull' => false,
+				],
+				'coupons'  => [
+					'push' => true,
+					'pull' => false,
+				],
+				'shipping' => [
+					'push' => true,
+					'pull' => false,
+				],
+				'settings' => [
+					'push' => true,
+					'pull' => false,
+				],
+			],
+			$response->get_data()
+		);
+
+		$response = $this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'products' => [
+					'push' => false,
+					'pull' => true,
+				],
+				'coupons'  => [
+					'push' => false,
+					'pull' => true,
+				],
+				'shipping' => [
+					'push' => false,
+					'pull' => true,
+				],
+				'settings' => [
+					'push' => false,
+					'pull' => true,
+				],
+			]
+		);
+
+		$this->assertEquals(
+			[
+				'products' => [
+					'push' => false,
+					'pull' => true,
+				],
+				'coupons'  => [
+					'push' => false,
+					'pull' => true,
+				],
+				'shipping' => [
+					'push' => false,
+					'pull' => true,
+				],
+				'settings' => [
+					'push' => false,
+					'pull' => true,
+				],
+			],
+			$response->get_data()
+		);
+	}
+
+	public function test_post_sync_mode_ignore_invalid_params() {
+		$response = $this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'test_invalid_config' => [
+					'push' => false,
+					'pull' => false,
+				],
+				'coupons'             => [
+					'test_invalid_mode' => false,
+					'pull'              => false,
+				],
+			]
+		);
+
+		$this->assertEquals(
+			[
+				'products' => [
+					'push' => true,
+					'pull' => true,
+				],
+				'coupons'  => [
+					'push' => true,
+					'pull' => false,
+				],
+				'shipping' => [
+					'push' => true,
+					'pull' => true,
+				],
+				'settings' => [
+					'push' => true,
+					'pull' => true,
+				],
+			],
+			$response->get_data()
+		);
+	}
+
+	public function test_post_sync_mode_do_action() {
+		$spy = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'callback' ] )
+			->getMock();
+
+		$spy->expects( $this->once() )
+			->method( 'callback' )
+			->with(
+				$this->equalTo(
+					[
+						'products' => [
+							'push' => true,
+							'pull' => true,
+						],
+						'coupons'  => [
+							'push' => true,
+							'pull' => true,
+						],
+						'shipping' => [
+							'push' => true,
+							'pull' => true,
+						],
+						'settings' => [
+							'push' => true,
+							'pull' => true,
+						],
+					],
+					[
+						'products' => [
+							'push' => false,
+							'pull' => false,
+						],
+						'coupons'  => [
+							'push' => true,
+							'pull' => true,
+						],
+						'shipping' => [
+							'push' => false,
+							'pull' => false,
+						],
+						'settings' => [
+							'push' => true,
+							'pull' => true,
+						],
+					]
+				)
+			);
+
+		add_action( 'woocommerce_gla_sync_mode_updated', [ $spy, 'callback' ] );
+
+		$this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'products' => [
+					'push' => false,
+					'pull' => false,
+				],
+				'shipping' => [
+					'push' => false,
+					'pull' => false,
+				],
+			]
+		);
+	}
+}

--- a/tests/Unit/Event/StartProductSyncTest.php
+++ b/tests/Unit/Event/StartProductSyncTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Event;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Event\StartProductSync;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+
+/**
+ * Class StartProductSyncTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Event
+ */
+class StartProductSyncTest extends UnitTest {
+
+	/** @var StartProductSync start_product_sync */
+	protected $start_product_sync;
+
+	/** @var Stub|JobRepository $job_repository */
+	protected $job_repository;
+
+	/** @var MockObject|UpdateAllProducts $update_all_products */
+	protected $update_all_products;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->update_all_products = $this->createMock( UpdateAllProducts::class );
+
+		$this->job_repository = $this->createStub( JobRepository::class );
+		$this->job_repository->method( 'get' )->willReturnCallback(
+			function ( $classname ) {
+				if ( $classname === UpdateAllProducts::class ) {
+					return $this->update_all_products;
+				}
+				return $this->createMock( $classname );
+			}
+		);
+
+		$this->start_product_sync = new StartProductSync( $this->job_repository );
+		$this->start_product_sync->register();
+	}
+
+	/**
+	 * Should only schedule when Push mode of product sync is switched to enable.
+	 */
+	public function test_on_sync_mode_updated_schedule_resync_all_product() {
+		$this->update_all_products->expects( $this->once() )->method( 'schedule' );
+
+		do_action(
+			'woocommerce_gla_sync_mode_updated',
+			[ 'products' => [ 'push' => false ] ],
+			[ 'products' => [ 'push' => true ] ]
+		);
+	}
+
+	/**
+	 * Should not schedule when Push mode of product sync is not switched to enable.
+	 */
+	public function test_on_sync_mode_updated_not_schedule_resync_all_product() {
+		$this->update_all_products->expects( $this->never() )->method( 'schedule' );
+
+		do_action(
+			'woocommerce_gla_sync_mode_updated',
+			[ 'products' => [ 'push' => false ] ],
+			[ 'products' => [ 'push' => false ] ]
+		);
+
+		do_action(
+			'woocommerce_gla_sync_mode_updated',
+			[ 'products' => [ 'push' => true ] ],
+			[ 'products' => [ 'push' => true ] ]
+		);
+
+		do_action(
+			'woocommerce_gla_sync_mode_updated',
+			[ 'products' => [ 'push' => true ] ],
+			[ 'products' => [ 'push' => false ] ]
+		);
+	}
+}

--- a/tests/Unit/Event/StartProductSyncTest.php
+++ b/tests/Unit/Event/StartProductSyncTest.php
@@ -79,4 +79,27 @@ class StartProductSyncTest extends UnitTest {
 			[ 'products' => [ 'push' => false ] ]
 		);
 	}
+
+	public function test_on_sync_mode_updated_receiving_unexpected_structure() {
+		$this->update_all_products->expects( $this->never() )->method( 'schedule' );
+
+		$prev_sync_mode = [ 'products' => [ 'push' => false ] ];
+		$sync_mode      = [ 'products' => [ 'push' => true ] ];
+
+		do_action( 'woocommerce_gla_sync_mode_updated', $prev_sync_mode, 'abc' );
+		do_action( 'woocommerce_gla_sync_mode_updated', $prev_sync_mode, 123 );
+		do_action( 'woocommerce_gla_sync_mode_updated', $prev_sync_mode, false );
+		do_action( 'woocommerce_gla_sync_mode_updated', $prev_sync_mode, [] );
+		do_action( 'woocommerce_gla_sync_mode_updated', $prev_sync_mode, new \stdClass() );
+		do_action( 'woocommerce_gla_sync_mode_updated', $prev_sync_mode, [ 'products' => [] ] );
+		do_action( 'woocommerce_gla_sync_mode_updated', $prev_sync_mode, [ 'products' => new \stdClass() ] );
+
+		do_action( 'woocommerce_gla_sync_mode_updated', 'abc', $sync_mode );
+		do_action( 'woocommerce_gla_sync_mode_updated', 123, $sync_mode );
+		do_action( 'woocommerce_gla_sync_mode_updated', false, $sync_mode );
+		do_action( 'woocommerce_gla_sync_mode_updated', [], $sync_mode );
+		do_action( 'woocommerce_gla_sync_mode_updated', new \stdClass(), $sync_mode );
+		do_action( 'woocommerce_gla_sync_mode_updated', [ 'products' => [] ], $sync_mode );
+		do_action( 'woocommerce_gla_sync_mode_updated', [ 'products' => new \stdClass() ], $sync_mode );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In the case of an issue during the sync mode migration, and a rollback strategy is needed to revert a merchant back to push mode, this PR schedules a job to sync all products when the Push mode of product sync is switched to enable. This will provide the ability to trigger a full re-sync of all products for the merchant.

In addition, it also wraps the calls to WP global functions in the `Options` class within the `WP` proxy class. This is to enable the use or coverage of the `Options` class when writing PHPUnit tests while avoiding the side effects of data modification.

Ref:
- p1754564027278729-slack-C02BB3F30TG
- p1753871675559559-slack-C02BB3F30TG

### Detailed test instructions:

💡 If using a local env for testing, it may need to make a temporary adjustment to prevent scheduling from being blocked by the following check. For example, make it always return true.

https://github.com/woocommerce/google-listings-and-ads/blob/ca66d673db1255695e16adf388d738e5cdff5cd2/src/MerchantCenter/MerchantCenterService.php#L109-L126

1. Complete the onboarding
2. Toggle the Push mode config of product sync via the `POST /wp-json/wc/gla/sync` API. One available method is to run the following scripts via the DevTools Console:
   ```js
   // Disable push mode
   wp.apiFetch({
     path: '/wc/gla/sync',
     method: 'POST',
     data: { products: { push: false } }
   }).then(console.log)

   // Enable push mode
   wp.apiFetch({
     path: '/wc/gla/sync',
     method: 'POST',
     data: { products: { push: true } }
   }).then(console.log)
   ```
3. Check if the `gla/jobs/update_all_products/create_batch` job is scheduled when the Push mode of product sync is switched to enable
   <img width="594" height="387" alt="image" src="https://github.com/user-attachments/assets/7fc4e737-e3a1-42f4-81e3-4a34af0c09d7" />

### Changelog entry

> Update - Schedule resynchronization for all products via the Push mode when the Push mode of product synchronization is switched to enable.
