### PR TITLE
Include the current plugin version in the `/settings/google-for-woocommerce` WPCOMProxy endpoint

### DIFF
--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use WC_Product;
@@ -38,6 +39,7 @@ defined( 'ABSPATH' ) || exit;
 class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 
 	use OptionsAwareTrait;
+	use PluginHelper;
 
 	/**
 	 * The ShippingRateQuery object.
@@ -202,6 +204,11 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 
 					$data = $response->get_data();
 
+					$data[] = [
+						'id'    => 'gla_plugin_version',
+						'label' => 'Google for WooCommerce: Current plugin version',
+						'value' => $this->get_version(),
+					];
 					$data[] = [
 						'id'    => 'gla_google_connected',
 						'label' => 'Google for WooCommerce: Is Google account connected?',

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Integration;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper;
@@ -26,6 +27,7 @@ use WP_REST_Request;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Integration
  */
 class WPCOMProxyTest extends RESTControllerUnitTest {
+	use PluginHelper;
 
 	/**
 	 * @var ContainerInterface
@@ -505,6 +507,7 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 
 		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
 
+		$this->assertArrayNotHasKey( 'gla_plugin_version', $response_mapped );
 		$this->assertArrayNotHasKey( 'gla_google_connected', $response_mapped );
 		$this->assertArrayNotHasKey( 'gla_language', $response_mapped );
 		$this->assertArrayNotHasKey( 'gla_merchant_center', $response_mapped );
@@ -520,12 +523,15 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 
 		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
 
+		$this->assertArrayHasKey( 'gla_plugin_version', $response_mapped );
 		$this->assertArrayHasKey( 'gla_google_connected', $response_mapped );
 		$this->assertArrayHasKey( 'gla_language', $response_mapped );
 		$this->assertArrayHasKey( 'gla_merchant_center', $response_mapped );
 		$this->assertArrayHasKey( 'gla_shipping_rates', $response_mapped );
 		$this->assertArrayHasKey( 'gla_shipping_times', $response_mapped );
 		$this->assertArrayHasKey( 'gla_target_audience', $response_mapped );
+
+		$this->assertEquals( $this->get_version(), $response_mapped['gla_plugin_version']['value'] );
 	}
 
 	public function test_get_empty_settings_for_shipping_zone_methods_as_object() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR includes the current plugin version in the `/settings/google-for-woocommerce` WPCOMProxy endpoint. This is to enable Google to recognize which plugin version a merchant is using.

Ref:
- p1754907880856619-slack-C02BB3F30TG
- p1753871675559559-slack-C02BB3F30TG

### Detailed test instructions:

1. Run script via the DevTools Console
   ```js
   wp.apiFetch({path:'/wc/v3/settings/google-for-woocommerce?gla_syncable=1'}).then(console.log)
   ```
2. Check if the plugin info is included in the response body
   <img width="669" height="942" alt="image" src="https://github.com/user-attachments/assets/407fc969-8e38-4b2e-a1dd-6352770cc246" />

### Changelog entry

> Update - Include the current plugin version in the WPCOM proxy endpoint for Google service to recognize which plugin version is being used.
