### PR TITLE
Fill missing intervals in chart.

### DIFF
--- a/js/src/pages/reports/chart-section.js
+++ b/js/src/pages/reports/chart-section.js
@@ -37,6 +37,14 @@ function generateDateRange( start, end ) {
 	return dates;
 }
 
+/**
+ * Renders a report chart.
+ *
+ * @param {Object} props React props.
+ * @param {Array<Metric>} props.metrics Metrics to display.
+ * @param {boolean} props.loaded Whether the data have been loaded.
+ * @param {Array<IntervalsData>} props.intervals Report's intervals data.
+ */
 export default function ChartSection( { metrics, loaded, intervals } ) {
 	const query = useUrlQuery();
 	const storeCurrencyConfig = useStoreCurrency();
@@ -53,6 +61,8 @@ export default function ChartSection( { metrics, loaded, intervals } ) {
 	const { key, label, isCurrency = false, formatFn } = visibleMetric;
 
 	// Preferably we would use the currency of the selected metric to be used on y axis.
+	// But due to https://github.com/woocommerce/woocommerce-admin/issues/7694 Chart will not react on changes.
+	// Therefore, we will use sotre's one without the symbol, to slightly reduce the merchants confusion.
 	const visibleCurrency = { ...storeCurrencyConfig, symbol: '' };
 	const chartType = getChartTypeForQuery( query );
 	const valueType = isCurrency ? 'currency' : 'number';

--- a/js/src/pages/reports/chart-section.js
+++ b/js/src/pages/reports/chart-section.js
@@ -18,13 +18,30 @@ const emptyMessage = __(
 );
 
 /**
- * Renders a report chart.
- *
- * @param {Object} props React props.
- * @param {Array<Metric>} props.metrics Metrics to display.
- * @param {boolean} props.loaded Whether the data have been loaded.
- * @param {Array<IntervalsData>} props.intervals Report's intervals data.
+ * Utility to format Date as YYYY-MM-DD
  */
+function formatDate( date ) {
+	const year = date.getFullYear();
+	const month = String( date.getMonth() + 1 ).padStart( 2, '0' );
+	const day = String( date.getDate() ).padStart( 2, '0' );
+	return `${ year }-${ month }-${ day }`;
+}
+
+/**
+ * Utility to generate all dates between start and end (inclusive)
+ */
+function generateDateRange( start, end ) {
+	const dates = [];
+	const current = new Date( start );
+	const endDate = new Date( end );
+
+	while ( current <= endDate ) {
+		dates.push( formatDate( current ) );
+		current.setDate( current.getDate() + 1 );
+	}
+	return dates;
+}
+
 export default function ChartSection( { metrics, loaded, intervals } ) {
 	const query = useUrlQuery();
 	const storeCurrencyConfig = useStoreCurrency();
@@ -40,25 +57,37 @@ export default function ChartSection( { metrics, loaded, intervals } ) {
 
 	const { key, label, isCurrency = false, formatFn } = visibleMetric;
 
-	// Preferably we would use the currency of the selected metric to be used on y axis.
-	// But due to https://github.com/woocommerce/woocommerce-admin/issues/7694 Chart will not react on changes.
-	// Therefore, we will use sotre's one without the symbol, to slightly reduce the merchants confusion.
 	const visibleCurrency = { ...storeCurrencyConfig, symbol: '' };
-
 	const chartType = getChartTypeForQuery( query );
 	const valueType = isCurrency ? 'currency' : 'number';
 	const localizedFormatFn = formatFn.bind( visibleMetric );
 
 	const chartData = useMemo( () => {
-		if ( ! loaded ) {
+		if ( ! loaded || ! intervals.length ) {
 			return [];
 		}
 
-		return intervals.map( ( { interval, subtotals } ) => {
+		// Map existing intervals for quick lookup
+		const intervalMap = intervals.reduce(
+			( acc, { interval, subtotals } ) => {
+				acc[ interval ] = subtotals;
+				return acc;
+			},
+			{}
+		);
+
+		// Generate full date range
+		const startDate = intervals[ 0 ].interval;
+		const endDate = intervals[ intervals.length - 1 ].interval;
+		const allDates = generateDateRange( startDate, endDate );
+
+		// Build chart data ensuring all dates are included
+		return allDates.map( ( date ) => {
+			const subtotals = intervalMap[ date ] || { [ key ]: 0 };
 			return {
-				date: interval,
+				date,
 				[ label ]: {
-					value: subtotals[ key ],
+					value: subtotals[ key ] ?? 0,
 					label,
 				},
 			};

--- a/js/src/pages/reports/chart-section.js
+++ b/js/src/pages/reports/chart-section.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
+import { format } from '@wordpress/date';
 import { Chart } from '@woocommerce/components';
 import { getChartTypeForQuery } from '@woocommerce/date';
 
@@ -18,17 +19,11 @@ const emptyMessage = __(
 );
 
 /**
- * Utility to format Date as YYYY-MM-DD
- */
-function formatDate( date ) {
-	const year = date.getFullYear();
-	const month = String( date.getMonth() + 1 ).padStart( 2, '0' );
-	const day = String( date.getDate() ).padStart( 2, '0' );
-	return `${ year }-${ month }-${ day }`;
-}
-
-/**
  * Utility to generate all dates between start and end (inclusive)
+ *
+ * @param {string} start - Start date in YYYY-MM-DD format.
+ * @param {string} end - End date in YYYY-MM-DD format.
+ * @return {string[]} Array of date strings in YYYY-MM-DD format.
  */
 function generateDateRange( start, end ) {
 	const dates = [];
@@ -36,7 +31,7 @@ function generateDateRange( start, end ) {
 	const endDate = new Date( end );
 
 	while ( current <= endDate ) {
-		dates.push( formatDate( current ) );
+		dates.push( format( 'Y-m-d', current ) );
 		current.setDate( current.getDate() + 1 );
 	}
 	return dates;
@@ -57,6 +52,7 @@ export default function ChartSection( { metrics, loaded, intervals } ) {
 
 	const { key, label, isCurrency = false, formatFn } = visibleMetric;
 
+	// Preferably we would use the currency of the selected metric to be used on y axis.
 	const visibleCurrency = { ...storeCurrencyConfig, symbol: '' };
 	const chartType = getChartTypeForQuery( query );
 	const valueType = isCurrency ? 'currency' : 'number';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes: https://linear.app/a8c/issue/GOOWOO-26/fill-the-interval-gaps-for-chart

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions

1. Go to `Google for WooCommerce > Reports > Products`

2. You will see two requests like following `https://domain.com/wp-json/wc/gla/ads/reports/products?after=2025-10-01&before=2025-10-09&fields%5B0%5D=sales&fields%5B1%5D=conversions&fields%5B2%5D=spend&fields%5B3%5D=clicks&fields%5B4%5D=impressions&interval=day&orderby=sales&order=desc&_locale=user`

3. Notice that in the following JSON response, you will have to add the date range for current tenure and previous tenure, so select the week so that adding internal for the week would be easy, you can also use any AI tool to generate similar response.

4. Override the response content with the following similar structure (make sure to add the proper dates in interval which have been selected in dropdown):

```json
{
    "products": null,
    "campaigns": null,
    "intervals": [
		{
			"interval": "2020-01-01",
			"subtotals": { "clicks": 9799 }
		},
		{
			"interval": "2020-01-02",
			"subtotals": { "clicks": 7603 }
		},
		{
			"interval": "2020-01-04",
			"subtotals": { "clicks": 6829 }
		},
		{
			"interval": "2020-01-07",
			"subtotals": { "clicks": 0 }
		}
	],
    "totals": {
        "sales": 0,
        "conversions": 0,
        "spend": 0,
        "clicks": 0,
        "impressions": 0
    },
    "next_page": null
}
```

5. Ensure that bar and line chart contains all date ranges.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Fill missing intervals in products chart.
