### PR TITLE
Rename the log file to match the new product name

### DIFF
--- a/src/Logging/DebugLogger.php
+++ b/src/Logging/DebugLogger.php
@@ -103,9 +103,9 @@ class DebugLogger implements Service, Registerable, Conditional {
 		$this->logger->log(
 			$level,
 			sprintf( '%s %s', $method, $message ),
-				[
-					'source' => 'google-for-woocommerce',
-				]
+			[
+				'source' => 'google-for-woocommerce',
+			]
 		);
 	}
 }

--- a/src/Logging/DebugLogger.php
+++ b/src/Logging/DebugLogger.php
@@ -103,9 +103,9 @@ class DebugLogger implements Service, Registerable, Conditional {
 		$this->logger->log(
 			$level,
 			sprintf( '%s %s', $method, $message ),
-			[
-				'source' => 'google-listings-and-ads',
-			]
+				[
+					'source' => 'google-for-woocommerce',
+				]
 		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This pull request includes a minor update to the logging source identifier in the `DebugLogger`. The change updates the value used to identify log entries for consistency with the current plugin branding. 

* Changed the logging `source` field value from `'google-listings-and-ads'` to `'google-for-woocommerce'` in the `log` method of `src/Logging/DebugLogger.php`.

Closes Linear issue [GOOWOO-257: Rename the log file to match the new product name](https://linear.app/a8c/issue/GOOWOO-257/rename-the-log-file-to-match-the-new-product-name)

### Screenshots:

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Build this branch
2. Activate the plugin
3. Take an action that would generate a log
4. See new log name


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:

> Tweak - Updated the log file name to match the plugin name


If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Renamed the log file name from `google-listings-and-ads` to `google-for-woocommerce`.
