### PR TITLE
Adjust the value of Merchant Center in the `/settings/google-for-woocommerce` WPCOMProxy endpoint to return null before completing onboarding

### DIFF
--- a/src/Integration/WPCOMProxy.md
+++ b/src/Integration/WPCOMProxy.md
@@ -7,6 +7,11 @@ Following is the desired and expected structure of `/settings/google-for-woocomm
 ```js
 [
     {
+        "id": "gla_plugin_version",
+        "label": "Google for WooCommerce: Current plugin version",
+        "value": WC_GLA_VERSION,
+    },
+    {
         "id": "gla_google_connected",
         "label": "Google for WooCommerce: Is Google account connected?",
         "value": ( true | false )

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -182,6 +182,10 @@ class WPCOMProxy implements Service, Registerable, ContainerAwareInterface, Opti
 					/** @var ShippingTimeQuery $shipping_time_query */
 					$shipping_time_query = $this->container->get( ShippingTimeQuery::class );
 
+					$merchant_center = $merchant_center_service->is_connected()
+						? $this->options->get( OptionsInterface::MERCHANT_CENTER, null )
+						: null;
+
 					$data = $response->get_data();
 
 					$data[] = [
@@ -202,7 +206,7 @@ class WPCOMProxy implements Service, Registerable, ContainerAwareInterface, Opti
 					$data[] = [
 						'id'    => 'gla_merchant_center',
 						'label' => 'Google for WooCommerce: Merchant Center settings',
-						'value' => $this->options->get( OptionsInterface::MERCHANT_CENTER, null ),
+						'value' => $merchant_center,
 					];
 					$data[] = [
 						'id'    => 'gla_shipping_rates',

--- a/src/Integration/WPCOMProxy.php
+++ b/src/Integration/WPCOMProxy.php
@@ -7,7 +7,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
@@ -32,40 +35,22 @@ defined( 'ABSPATH' ) || exit;
  * Its primary purpose is to prevent global endpoints from being cluttered with additional data
  * and to conceal undocumented implementation details of the integration between the G4W plugin and WPCOM proxy.
  *
+ * ContainerAware used to access:
+ * - AttributeManager
+ * - MerchantCenterService
+ * - ProductRepository
+ * - ShippingRateQuery
+ * - ShippingTimeQuery
+ *
  * @since 2.8.0
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Integration
  */
-class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
+class WPCOMProxy implements Service, Registerable, ContainerAwareInterface, OptionsAwareInterface {
 
+	use ContainerAwareTrait;
 	use OptionsAwareTrait;
 	use PluginHelper;
-
-	/**
-	 * The ShippingRateQuery object.
-	 *
-	 * @var ShippingRateQuery
-	 */
-	protected $shipping_rate_query;
-
-	/**
-	 * The ShippingTimeQuery object.
-	 *
-	 * @var ShippingTimeQuery
-	 */
-	protected $shipping_time_query;
-
-	/**
-	 * The AttributeManager object.
-	 *
-	 * @var AttributeManager
-	 */
-	protected $attribute_manager;
-
-	/**
-	 * @var ProductRepository
-	 */
-	protected $product_repository;
 
 	/**
 	 * The protected resources. Only items with visibility set to sync-and-show will be returned.
@@ -83,21 +68,6 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	protected const SETTINGS_GROUP = 'google-for-woocommerce';
 
 	/**
-	 * WPCOMProxy constructor.
-	 *
-	 * @param ShippingRateQuery $shipping_rate_query The ShippingRateQuery object.
-	 * @param ShippingTimeQuery $shipping_time_query The ShippingTimeQuery object.
-	 * @param AttributeManager  $attribute_manager   The AttributeManager object.
-	 * @param ProductRepository $product_repository  The ProductRepository object.
-	 */
-	public function __construct( ShippingRateQuery $shipping_rate_query, ShippingTimeQuery $shipping_time_query, AttributeManager $attribute_manager, ProductRepository $product_repository ) {
-		$this->shipping_rate_query = $shipping_rate_query;
-		$this->shipping_time_query = $shipping_time_query;
-		$this->attribute_manager   = $attribute_manager;
-		$this->product_repository  = $product_repository;
-	}
-
-	/**
 	 * The meta key used to filter the items.
 	 *
 	 * @var string
@@ -110,9 +80,12 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 	 * @return array
 	 */
 	private function get_post_types_to_filter() {
+		/** @var ProductRepository $product_repository */
+		$product_repository = $this->container->get( ProductRepository::class );
+
 		return [
 			'product'           => [
-				'meta_query' => $this->product_repository->get_sync_ready_products_meta_query( true ),
+				'meta_query' => $product_repository->get_sync_ready_products_meta_query( true ),
 			],
 			'shop_coupon'       => [
 				'meta_query' => [
@@ -202,6 +175,13 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 
 				if ( $request->get_route() === '/wc/v3/settings/' . self::SETTINGS_GROUP ) {
 
+					/** @var MerchantCenterService $merchant_center */
+					$merchant_center_service = $this->container->get( MerchantCenterService::class );
+					/** @var ShippingRateQuery $shipping_rate_query */
+					$shipping_rate_query = $this->container->get( ShippingRateQuery::class );
+					/** @var ShippingTimeQuery $shipping_time_query */
+					$shipping_time_query = $this->container->get( ShippingTimeQuery::class );
+
 					$data = $response->get_data();
 
 					$data[] = [
@@ -212,7 +192,7 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 					$data[] = [
 						'id'    => 'gla_google_connected',
 						'label' => 'Google for WooCommerce: Is Google account connected?',
-						'value' => rest_sanitize_boolean( $this->options->get( OptionsInterface::GOOGLE_CONNECTED, false ) ),
+						'value' => $merchant_center_service->is_google_connected(),
 					];
 					$data[] = [
 						'id'    => 'gla_language',
@@ -227,12 +207,12 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 					$data[] = [
 						'id'    => 'gla_shipping_rates',
 						'label' => 'Google for WooCommerce: Shipping Rates',
-						'value' => (object) $this->shipping_rate_query->get_all_shipping_rates(),
+						'value' => (object) $shipping_rate_query->get_all_shipping_rates(),
 					];
 					$data[] = [
 						'id'    => 'gla_shipping_times',
 						'label' => 'Google for WooCommerce: Shipping Times',
-						'value' => (object) $this->shipping_time_query->get_all_shipping_times(),
+						'value' => (object) $shipping_time_query->get_all_shipping_times(),
 					];
 					$data[] = [
 						'id'    => 'gla_target_audience',
@@ -442,7 +422,10 @@ class WPCOMProxy implements Service, Registerable, OptionsAwareInterface {
 		$resource = $this->get_route_pieces( $request )['resource'] ?? null;
 
 		if ( $item instanceof WC_Product && ( $resource === 'products' || $resource === 'variations' ) ) {
-			$attr = $this->attribute_manager->get_all_aggregated_values( $item );
+			/** @var AttributeManager $attribute_manager */
+			$attribute_manager = $this->container->get( AttributeManager::class );
+
+			$attr = $attribute_manager->get_all_aggregated_values( $item );
 			// In case of empty array, convert to object to keep the response consistent.
 			$data['gla_attributes'] = (object) $attr;
 

--- a/src/Internal/DependencyManagement/IntegrationServiceProvider.php
+++ b/src/Internal/DependencyManagement/IntegrationServiceProvider.php
@@ -3,8 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
-use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\IntegrationInitializer;
@@ -17,7 +15,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Integration\YoastWooCommerceSeo;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\JetpackWPCOM;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 
 defined( 'ABSPATH' ) || exit;
@@ -51,7 +48,7 @@ class IntegrationServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( WooCommerceProductBundles::class, AttributeManager::class );
 		$this->share_with_tags( WooCommercePreOrders::class, ProductHelper::class );
 		$this->conditionally_share_with_tags( JetpackWPCOM::class );
-		$this->share_with_tags( WPCOMProxy::class, ShippingRateQuery::class, ShippingTimeQuery::class, AttributeManager::class, ProductRepository::class );
+		$this->share_with_tags( WPCOMProxy::class );
 
 		$this->share_with_tags(
 			IntegrationInitializer::class,

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -573,6 +573,50 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 		$this->assertEquals( true, $response_mapped['gla_google_connected']['value'] );
 	}
 
+	public function test_get_settings_with_connected_google_merchant_center_account() {
+		$options = [
+			'shipping_rate' => 'flat',
+			'shipping_time' => 'flat',
+			'tax_rate'      => 'destination',
+		];
+
+		$this->options
+			->method( 'get' )
+			->willReturnCallback(
+				function ( $name, $default_value = null ) use ( $options ) {
+					if ( $name === OptionsInterface::MERCHANT_CENTER ) {
+						return $options;
+					}
+					return $default_value;
+				}
+			);
+
+		$this->merchant_center
+			->method( 'is_connected' )
+			->willReturn( true );
+
+		$response        = $this->do_request( '/wc/v3/settings/google-for-woocommerce', 'GET', [ 'gla_syncable' => '1' ] );
+		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $options, $response_mapped['gla_merchant_center']['value'] );
+	}
+
+	/**
+	 * Fall back to null in case the WP option value doesn't exist
+	 */
+	public function test_get_settings_with_connected_google_merchant_center_account_but_getting_fallback() {
+		$this->merchant_center
+			->method( 'is_connected' )
+			->willReturn( true );
+
+		$response        = $this->do_request( '/wc/v3/settings/google-for-woocommerce', 'GET', [ 'gla_syncable' => '1' ] );
+		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( null, $response_mapped['gla_merchant_center']['value'] );
+	}
+
 	public function test_get_empty_settings_for_shipping_zone_methods_as_object() {
 		$request = new WP_REST_Request( 'GET', '/wc/v3/shipping/zones/4/methods' );
 

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -4,6 +4,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Integration;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
@@ -15,7 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPCOMProxy;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\AttributeMappingRulesTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use WC_Meta_Data;
 use WP_REST_Response;
 use WP_REST_Request;
@@ -30,18 +32,41 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 	use PluginHelper;
 
 	/**
-	 * @var ContainerInterface
+	 * @var Container
 	 */
 	protected $container;
 
+	/** @var Stub|OptionsInterface $options */
+	protected $options;
+
+	/** @var Stub|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
 	public function setUp(): void {
 		parent::setUp();
-		$this->container = woogle_get_container();
+
+		$plugin_container = woogle_get_container();
 		// Since the tables for shipping rate, time, and attribute mapping rules
 		// aren't set up in the test environment, install them to prevent warnings.
-		$this->container->get( AttributeMappingRulesTable::class )->install();
-		$this->container->get( ShippingRateTable::class )->install();
-		$this->container->get( ShippingTimeTable::class )->install();
+		$plugin_container->get( AttributeMappingRulesTable::class )->install();
+		$plugin_container->get( ShippingRateTable::class )->install();
+		$plugin_container->get( ShippingTimeTable::class )->install();
+
+		$this->options         = $this->createStub( OptionsInterface::class );
+		$this->merchant_center = $this->createStub( MerchantCenterService::class );
+
+		$this->container = new Container();
+		$this->container->addShared( ShippingRateQuery::class, $plugin_container->get( ShippingRateQuery::class ) );
+		$this->container->addShared( ShippingTimeQuery::class, $plugin_container->get( ShippingTimeQuery::class ) );
+		$this->container->addShared( AttributeManager::class, $plugin_container->get( AttributeManager::class ) );
+		$this->container->addShared( ProductRepository::class, $plugin_container->get( ProductRepository::class ) );
+		$this->container->addShared( MerchantCenterService::class, $this->merchant_center );
+
+		$this->controller = new WPCOMProxy();
+		$this->controller->set_container( $this->container );
+		$this->controller->set_options_object( $this->options );
+		$this->controller->register();
+
 		do_action( 'rest_api_init' );
 	}
 
@@ -532,6 +557,20 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 		$this->assertArrayHasKey( 'gla_target_audience', $response_mapped );
 
 		$this->assertEquals( $this->get_version(), $response_mapped['gla_plugin_version']['value'] );
+		$this->assertEquals( false, $response_mapped['gla_google_connected']['value'] );
+		$this->assertEquals( null, $response_mapped['gla_merchant_center']['value'] );
+	}
+
+	public function test_get_settings_with_connected_google_account() {
+		$this->merchant_center
+			->method( 'is_google_connected' )
+			->willReturn( true );
+
+		$response        = $this->do_request( '/wc/v3/settings/google-for-woocommerce', 'GET', [ 'gla_syncable' => '1' ] );
+		$response_mapped = $this->maps_the_response_with_the_item_id( $response );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( true, $response_mapped['gla_google_connected']['value'] );
 	}
 
 	public function test_get_empty_settings_for_shipping_zone_methods_as_object() {
@@ -545,13 +584,6 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 			],
 		];
 
-		$proxy = new WPCOMProxy(
-			$this->container->get( ShippingRateQuery::class ),
-			$this->container->get( ShippingTimeQuery::class ),
-			$this->container->get( AttributeManager::class ),
-			$this->container->get( ProductRepository::class )
-		);
-
 		$this->assertEquals(
 			[
 				[
@@ -559,7 +591,7 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 					'settings' => (object) [],
 				],
 			],
-			$proxy->prepare_data( $data, $request )
+			$this->controller->prepare_data( $data, $request )
 		);
 
 		// If the request is not for shipping zone methods, the data should not be modified.
@@ -572,7 +604,7 @@ class WPCOMProxyTest extends RESTControllerUnitTest {
 					'settings' => [],
 				],
 			],
-			$proxy->prepare_data( $data, $request )
+			$this->controller->prepare_data( $data, $request )
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adjusts the value of Merchant Center in the `/settings/google-for-woocommerce` WPCOMProxy endpoint to return null before completing onboarding. This is to enable Google to determine whether the Merchant Center account has been disconnected.

Additionally, due to the increasing number of dependencies, it also changes the `WPCOMProxy` class to use the container-aware method for retrieving dependencies.

Ref: p1753871675559559-slack-C02BB3F30TG

### Detailed test instructions:

1. Disconnect all accounts
2. Run script via the DevTools Console
   ```js
   wp.apiFetch({path:'/wc/v3/settings/google-for-woocommerce?gla_syncable=1'}).then(console.log)
   ```
3. Check if the value of `gla_google_connected` setting is `false`, and if the value of `gla_merchant_center` setting is `null`
   <img width="1333" height="939" alt="image" src="https://github.com/user-attachments/assets/4f0098d1-de73-4130-802b-f2a6756a6a48" />
4. Connect to a Google account
5. Rerun the script mentioned in step 2
6. Check if the value of `gla_google_connected` setting is `true`, and if the value of `gla_merchant_center` setting is still `null`
   <img width="1376" height="975" alt="image" src="https://github.com/user-attachments/assets/be43f732-55d3-46b8-9528-bbe56ec89558" />
7. Complete onboarding
8. Rerun the script mentioned in step 2
9. Check if the value of `gla_merchant_center` is the related settings
   <img width="1424" height="938" alt="image" src="https://github.com/user-attachments/assets/69c3ed2f-37b1-44c2-aef9-d76337ee7853" />

### Changelog entry

> Tweak -  Adjust the value of the Merchant Center setting in the WPCOM proxy endpoint to null before completing onboarding so that Google service can recognize whether the Merchant Center account has been disconnected.
