### PR TITLE
Use `isGoogleAdsReady` to check for connected Ads account

### DIFF
--- a/js/src/components/experience-rating-banner/index.js
+++ b/js/src/components/experience-rating-banner/index.js
@@ -3,7 +3,7 @@
  */
 import Banner from './banner';
 import usePreference from '~/hooks/usePreference';
-import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleAdsAccountReady from '~/hooks/useGoogleAdsAccountReady';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import { BANNER_DISMISSED_KEY } from './constants';
 import './index.scss';
@@ -16,11 +16,11 @@ import './index.scss';
  * @return {JSX.Element|null} The ExperienceRatingBanner component, or null if dismissed or Ads account is disconnected or the MC account is not ready.
  */
 const ExperienceRatingBanner = () => {
-	const { hasGoogleAdsConnection } = useGoogleAdsAccount();
+	const { isGoogleAdsReady } = useGoogleAdsAccountReady();
 	const { isReady: isMCAccountReady } = useGoogleMCAccount();
 	const isDismissed = usePreference( BANNER_DISMISSED_KEY );
 
-	if ( ! hasGoogleAdsConnection || ! isMCAccountReady || isDismissed ) {
+	if ( ! isGoogleAdsReady || ! isMCAccountReady || isDismissed ) {
 		return null;
 	}
 

--- a/js/src/components/pmax-improve-assets-banner/index.js
+++ b/js/src/components/pmax-improve-assets-banner/index.js
@@ -9,7 +9,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  * Internal dependencies
  */
 import { PREFERENCES_STORE_NAMESPACE, DAY_IN_SECONDS } from '~/constants';
-import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleAdsAccountReady from '~/hooks/useGoogleAdsAccountReady';
 import usePreference from '~/hooks/usePreference';
 import Banner from './banner';
 import './index.scss';
@@ -31,7 +31,7 @@ const ACTION_TYPE_DISMISS = 'dismiss';
  * @return {JSX.Element|null} The banner component, or null if not applicable.
  */
 const PMaxImproveAssetsBanner = () => {
-	const { hasGoogleAdsConnection } = useGoogleAdsAccount();
+	const { isGoogleAdsReady } = useGoogleAdsAccountReady();
 	const { set } = useDispatch( preferencesStore );
 	const { actionTime, actionType } =
 		usePreference( PREFERENCE_BANNER_KEY ) || {};
@@ -46,7 +46,7 @@ const PMaxImproveAssetsBanner = () => {
 	// Don't display the banner if the banner has been dismissed less than 30 days ago
 	// or there is no Google Ads connection.
 	if (
-		! hasGoogleAdsConnection ||
+		! isGoogleAdsReady ||
 		( actionType === ACTION_TYPE_DISMISS &&
 			Date.now() < actionTime + 30 * DAY_IN_SECONDS * 1000 )
 	) {

--- a/js/src/components/pmax-improve-assets-banner/index.test.js
+++ b/js/src/components/pmax-improve-assets-banner/index.test.js
@@ -14,7 +14,7 @@ import { PREFERENCES_STORE_NAMESPACE } from '~/constants';
 import PMaxImproveAssetsBanner from './index';
 import usePreference from '~/hooks/usePreference';
 import useRecommendedPMaxCampaign from '~/hooks/useRecommendedPMaxCampaign';
-import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleAdsAccountReady from '~/hooks/useGoogleAdsAccountReady';
 
 jest.mock( '@woocommerce/components', () => ( {
 	...jest.requireActual( '@woocommerce/components' ),
@@ -40,8 +40,8 @@ jest.mock( '@wordpress/data', () => ( {
 	useDispatch: jest.fn(),
 } ) );
 
-jest.mock( '~/hooks/useGoogleAdsAccount', () =>
-	jest.fn().mockName( 'useGoogleAdsAccount' )
+jest.mock( '~/hooks/useGoogleAdsAccountReady', () =>
+	jest.fn().mockName( 'useGoogleAdsAccountReady' )
 );
 
 jest.mock( '~/hooks/usePreference', () =>
@@ -65,7 +65,7 @@ const recommendedCampaign = { campaign_id: 2, campaign_name: 'Campaign 2' };
 describe( 'PMaxImproveAssetsBanner', () => {
 	beforeEach( () => {
 		useDispatch.mockReturnValue( { set: () => null } );
-		useGoogleAdsAccount.mockReturnValue( { hasGoogleAdsConnection: true } );
+		useGoogleAdsAccountReady.mockReturnValue( { isGoogleAdsReady: true } );
 	} );
 
 	it( 'renders nothing if expiry is not expired', () => {
@@ -82,9 +82,7 @@ describe( 'PMaxImproveAssetsBanner', () => {
 	} );
 
 	it( 'renders nothing if Google Ads account is not connected', () => {
-		useGoogleAdsAccount.mockReturnValue( {
-			hasGoogleAdsConnection: false,
-		} );
+		useGoogleAdsAccountReady.mockReturnValue( { isGoogleAdsReady: false } );
 		usePreference.mockReturnValue( { expiry: Date.now() + 100000 } );
 		useRecommendedPMaxCampaign.mockReturnValue( {
 			campaign: recommendedCampaign,

--- a/tests/e2e/utils/app-ratings-overview.js
+++ b/tests/e2e/utils/app-ratings-overview.js
@@ -73,6 +73,7 @@ export default class AppRatingsOverview extends MockRequests {
 			this.mockJetpackConnected(),
 			this.mockGoogleConnected(),
 			this.mockAdsAccountConnected(),
+			this.mockAdsStatusClaimed(),
 			this.mockMCConnected(),
 		] );
 	}


### PR DESCRIPTION

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-258/dashboard-error-when-ads-account-has-not-been-claimed

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Complete the onboarding flow.
2. Disconnect the Google Ads account from the Plugin Settings tab.
3. Navigate to the Dashboard and click Add Campaign to start creating a new campaign.
4. When prompted, create or connect a Google Ads account.
5. Choose to create a new Ads account but leave it unclaimed.
6. Return to the dashboard by clicking the back arrow in the "Set up your campaign" header.
7. Confirm that no errors appear on the dashboard, even with an unclaimed/unconnected Ads account.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Use `isGoogleAdsReady` property instead of `hasGoogleAdsConnection` to check for a connected Ads account.
