### PR TITLE
Feature/262 adapt ads recommendation endpoint for raise budget

### DIFF
--- a/src/Ads/AdsRecommendationsService.php
+++ b/src/Ads/AdsRecommendationsService.php
@@ -224,12 +224,28 @@ class AdsRecommendationsService implements ContainerAwareInterface, OptionsAware
 						continue;
 					}
 
+					$current_budget     = $budget_recommendation->getCurrentBudgetAmountMicros();
+					$recommended_budget = $budget_recommendation->getRecommendedBudgetAmountMicros();
+
 					foreach ( $budget_recommendation->getBudgetOptions() as $option ) {
-						$impact    = $option->getImpact();
-						$potential = $impact->getPotentialMetrics();
+						$impact        = $option->getImpact();
+						$potential     = $impact->getPotentialMetrics();
+						$budget_amount = $option->getBudgetAmountMicros();
+
+						// Determine budget option level.
+						$level = __( 'Low', 'google-listings-and-ads' );
+
+						if ( $budget_amount === $current_budget ) {
+							$level = __( 'Current', 'google-listings-and-ads' );
+						} elseif ( $budget_amount === $recommended_budget ) {
+							$level = __( 'Recommended', 'google-listings-and-ads' );
+						} elseif ( $budget_amount > $recommended_budget ) {
+							$level = __( 'High', 'google-listings-and-ads' );
+						}
 
 						$budget_options[] = [
-							'budget_amount' => $this->from_micro( $option->getBudgetAmountMicros() ),
+							'budget_amount' => $this->from_micro( $budget_amount ),
+							'level'         => $level,
 							'metrics'       => [
 								'cost'              => $this->from_micro( $potential->getCostMicros() ),
 								'conversions'       => $potential->getConversions(),
@@ -240,8 +256,8 @@ class AdsRecommendationsService implements ContainerAwareInterface, OptionsAware
 
 					$recommendation_details = [
 						'campaign_budget_recommendation' => [
-							'current_budget_amount'     => $this->from_micro( $budget_recommendation->getCurrentBudgetAmountMicros() ),
-							'recommended_budget_amount' => $this->from_micro( $budget_recommendation->getRecommendedBudgetAmountMicros() ),
+							'current_budget_amount'     => $this->from_micro( $current_budget ),
+							'recommended_budget_amount' => $this->from_micro( $recommended_budget ),
 							'budget_options'            => $budget_options,
 						],
 					];

--- a/src/Ads/AdsRecommendationsService.php
+++ b/src/Ads/AdsRecommendationsService.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AdsRecommendationsQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsRecommendationsQuery as GoogleAdsRecommendationsQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\MicroTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
@@ -32,6 +33,7 @@ class AdsRecommendationsService implements ContainerAwareInterface, OptionsAware
 	use ContainerAwareTrait;
 	use OptionsAwareTrait;
 	use TransientsAwareTrait;
+	use MicroTrait;
 
 	/**
 	 * Allowed recommendation types.
@@ -224,31 +226,23 @@ class AdsRecommendationsService implements ContainerAwareInterface, OptionsAware
 
 					foreach ( $budget_recommendation->getBudgetOptions() as $option ) {
 						$impact    = $option->getImpact();
-						$base      = $impact->getBaseMetrics();
 						$potential = $impact->getPotentialMetrics();
 
 						$budget_options[] = [
-							'budget_amount_micros' => $option->getBudgetAmountMicros(),
-							'impact'               => [
-								'base_metrics'      => [
-									'cost_micros'       => $base->getCostMicros(),
-									'conversions'       => $base->getConversions(),
-									'conversions_value' => $base->getConversionsValue(),
-								],
-								'potential_metrics' => [
-									'cost_micros'       => $potential->getCostMicros(),
-									'conversions'       => $potential->getConversions(),
-									'conversions_value' => $potential->getConversionsValue(),
-								],
+							'budget_amount' => $this->from_micro( $option->getBudgetAmountMicros() ),
+							'metrics'       => [
+								'cost'              => $this->from_micro( $potential->getCostMicros() ),
+								'conversions'       => $potential->getConversions(),
+								'conversions_value' => $potential->getConversionsValue(),
 							],
 						];
 					}
 
 					$recommendation_details = [
 						'campaign_budget_recommendation' => [
-							'current_budget_amount_micros'     => $budget_recommendation->getCurrentBudgetAmountMicros(),
-							'recommended_budget_amount_micros' => $budget_recommendation->getRecommendedBudgetAmountMicros(),
-							'budget_options'                   => $budget_options,
+							'current_budget_amount'     => $this->from_micro( $budget_recommendation->getCurrentBudgetAmountMicros() ),
+							'recommended_budget_amount' => $this->from_micro( $budget_recommendation->getRecommendedBudgetAmountMicros() ),
+							'budget_options'            => $budget_options,
 						],
 					];
 				}

--- a/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
@@ -335,45 +335,45 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 				'campaign_name'   => 'Another Campaign',
 				'campaign_status' => 'ENABLED',
 				'details'         => [
-					"campaign_budget_recommendation" => [
-						"current_budget_amount" => 20,
-						"recommended_budget_amount" => 31,
-						"budget_options" => [
+					'campaign_budget_recommendation' => [
+						'current_budget_amount'     => 20,
+						'recommended_budget_amount' => 31,
+						'budget_options'            => [
 							[
-								"metrics" => [
-									"cost" => "139.964209",
-									"conversions" => 4,
-									"conversions_value" => 545.7408447265625,
+								'budget_amount' => 20,
+								'level'         => 'Current',
+								'metrics'       => [
+									'cost'              => 139.964209,
+									'conversions'       => 4,
+									'conversions_value' => 545.7408447265625,
 								],
-								"budget_amount" => "20",
-								"level" => "Current",
 							],
 							[
-								"metrics" => [
-									"cost" => "181.971258",
-									"conversions" => 4.828944206237793,
-									"conversions_value" => 622.0850219726562,
+								'budget_amount' => 26,
+								'level'         => 'Low',
+								'metrics'       => [
+									'cost'              => 181.971258,
+									'conversions'       => 4.828944206237793,
+									'conversions_value' => 622.0850219726562,
 								],
-								"budget_amount" => "26",
-								"level" => "Low",
 							],
 							[
-								"metrics" => [
-									"cost" => "216961447",
-									"conversions" => 5.398608684539795,
-									"conversions_value" => 679.2435913085938,
+								'budget_amount' => 31,
+								'level'         => 'Recommended',
+								'metrics'       => [
+									'cost'              => 216961447,
+									'conversions'       => 5.398608684539795,
+									'conversions_value' => 679.2435913085938,
 								],
-								"budget_amount" => "31",
-								"level" => "Recommended",
 							],
 							[
-								"metrics" => [
-									"cost" => "251946304",
-									"conversions" => 5.776357173919678,
-									"conversions_value" => 731.8743286132812,
+								'budget_amount' => 36,
+								'level'         => 'High',
+								'metrics'       => [
+									'cost'              => 251946304,
+									'conversions'       => 5.776357173919678,
+									'conversions_value' => 731.8743286132812,
 								],
-								"budget_amount" => "36",
-								"level" => "High",
 							],
 						],
 					],
@@ -388,45 +388,45 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 				'campaign_name'   => 'Another Campaign 02',
 				'campaign_status' => 'ENABLED',
 				'details'         => [
-					"campaign_budget_recommendation" => [
-						"current_budget_amount" => 20,
-						"recommended_budget_amount" => 31,
-						"budget_options" => [
+					'campaign_budget_recommendation' => [
+						'current_budget_amount'     => 20,
+						'recommended_budget_amount' => 31,
+						'budget_options'            => [
 							[
-								"metrics" => [
-									"cost" => "139.964209",
-									"conversions" => 4,
-									"conversions_value" => 545.7408447265625,
+								'budget_amount' => 20,
+								'level'         => 'Current',
+								'metrics'       => [
+									'cost'              => 139.964209,
+									'conversions'       => 4,
+									'conversions_value' => 545.7408447265625,
 								],
-								"budget_amount" => "20",
-								"level" => "Current",
 							],
 							[
-								"metrics" => [
-									"cost" => "181.971258",
-									"conversions" => 4.828944206237793,
-									"conversions_value" => 622.0850219726562,
+								'budget_amount' => 26,
+								'level'         => 'Low',
+								'metrics'       => [
+									'cost'              => 181.971258,
+									'conversions'       => 4.828944206237793,
+									'conversions_value' => 622.0850219726562,
 								],
-								"budget_amount" => "26",
-								"level" => "Low",
 							],
 							[
-								"metrics" => [
-									"cost" => "216961447",
-									"conversions" => 5.398608684539795,
-									"conversions_value" => 679.2435913085938,
+								'budget_amount' => 31,
+								'level'         => 'Recommended',
+								'metrics'       => [
+									'cost'              => 216961447,
+									'conversions'       => 5.398608684539795,
+									'conversions_value' => 679.2435913085938,
 								],
-								"budget_amount" => "31",
-								"level" => "Recommended",
 							],
 							[
-								"metrics" => [
-									"cost" => "251946304",
-									"conversions" => 5.776357173919678,
-									"conversions_value" => 731.8743286132812,
+								'budget_amount' => 36,
+								'level'         => 'High',
+								'metrics'       => [
+									'cost'              => 251946304,
+									'conversions'       => 5.776357173919678,
+									'conversions_value' => 731.8743286132812,
 								],
-								"budget_amount" => "36",
-								"level" => "High",
 							],
 						],
 					],

--- a/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
@@ -311,4 +311,160 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 		$this->assertCount( 1, $data );
 		$this->assertEquals( 101, $data[0]['campaign_id'] );
 	}
+
+	public function test_get_recommendations_includes_correct_details_property() {
+		$this->account->method( 'get_connected_account' )
+			->willReturn( [ 'status' => 'connected' ] );
+
+		$mock_recommendations_data = [
+			[
+				'id'              => 1,
+				'type'            => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
+				'resource_name'   => 'customers/123/recommendations/1',
+				'campaign_id'     => 100,
+				'campaign_name'   => 'Test Campaign',
+				'campaign_status' => 'ENABLED',
+				'details'         => [],
+				'last_synced'     => gmdate( 'c' ),
+			],
+			[
+				'id'              => 2,
+				'type'            => 'MARGINAL_ROI_CAMPAIGN_BUDGET',
+				'resource_name'   => 'customers/123/recommendations/2',
+				'campaign_id'     => 101,
+				'campaign_name'   => 'Another Campaign',
+				'campaign_status' => 'ENABLED',
+				'details'         => [
+					"campaign_budget_recommendation" => [
+						"current_budget_amount" => 20,
+						"recommended_budget_amount" => 31,
+						"budget_options" => [
+							[
+								"metrics" => [
+									"cost" => "139.964209",
+									"conversions" => 4,
+									"conversions_value" => 545.7408447265625,
+								],
+								"budget_amount" => "20",
+								"level" => "Current",
+							],
+							[
+								"metrics" => [
+									"cost" => "181.971258",
+									"conversions" => 4.828944206237793,
+									"conversions_value" => 622.0850219726562,
+								],
+								"budget_amount" => "26",
+								"level" => "Low",
+							],
+							[
+								"metrics" => [
+									"cost" => "216961447",
+									"conversions" => 5.398608684539795,
+									"conversions_value" => 679.2435913085938,
+								],
+								"budget_amount" => "31",
+								"level" => "Recommended",
+							],
+							[
+								"metrics" => [
+									"cost" => "251946304",
+									"conversions" => 5.776357173919678,
+									"conversions_value" => 731.8743286132812,
+								],
+								"budget_amount" => "36",
+								"level" => "High",
+							],
+						],
+					],
+				],
+				'last_synced'     => gmdate( 'c' ),
+			],
+			[
+				'id'              => 3,
+				'type'            => 'CAMPAIGN_BUDGET',
+				'resource_name'   => 'customers/124/recommendations/3',
+				'campaign_id'     => 102,
+				'campaign_name'   => 'Another Campaign 02',
+				'campaign_status' => 'ENABLED',
+				'details'         => [
+					"campaign_budget_recommendation" => [
+						"current_budget_amount" => 20,
+						"recommended_budget_amount" => 31,
+						"budget_options" => [
+							[
+								"metrics" => [
+									"cost" => "139.964209",
+									"conversions" => 4,
+									"conversions_value" => 545.7408447265625,
+								],
+								"budget_amount" => "20",
+								"level" => "Current",
+							],
+							[
+								"metrics" => [
+									"cost" => "181.971258",
+									"conversions" => 4.828944206237793,
+									"conversions_value" => 622.0850219726562,
+								],
+								"budget_amount" => "26",
+								"level" => "Low",
+							],
+							[
+								"metrics" => [
+									"cost" => "216961447",
+									"conversions" => 5.398608684539795,
+									"conversions_value" => 679.2435913085938,
+								],
+								"budget_amount" => "31",
+								"level" => "Recommended",
+							],
+							[
+								"metrics" => [
+									"cost" => "251946304",
+									"conversions" => 5.776357173919678,
+									"conversions_value" => 731.8743286132812,
+								],
+								"budget_amount" => "36",
+								"level" => "High",
+							],
+						],
+					],
+				],
+				'last_synced'     => gmdate( 'c' ),
+			],
+		];
+
+		$filter_types = [
+			'types' => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH, MARGINAL_ROI_CAMPAIGN_BUDGET, CAMPAIGN_BUDGET',
+		];
+
+		$this->recommendations->expects( $this->once() )
+			->method( 'get_recommendations' )
+			->willReturn( array_values( $mock_recommendations_data ) );
+
+		$response = $this->do_request( self::ROUTE_RECOMMENDATIONS, 'GET', $filter_types );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertCount( 3, $data );
+
+		$this->assertEquals( 100, $data[0]['campaign_id'] );
+		$this->assertEquals( 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH', $data[0]['type'] );
+		$this->assertEmpty( $data[0]['details'] );
+
+		$this->assertEquals( 101, $data[1]['campaign_id'] );
+		$this->assertEquals( 'MARGINAL_ROI_CAMPAIGN_BUDGET', $data[1]['type'] );
+		$this->assertIsArray( $data[1]['details'] );
+		$this->assertIsArray( $data[1]['details']['campaign_budget_recommendation'] );
+		$this->assertIsArray( $data[1]['details']['campaign_budget_recommendation']['budget_options'] );
+
+		$this->assertEquals( 102, $data[2]['campaign_id'] );
+		$this->assertEquals( 'CAMPAIGN_BUDGET', $data[2]['type'] );
+		$this->assertIsArray( $data[2]['details'] );
+		$this->assertIsArray( $data[2]['details']['campaign_budget_recommendation'] );
+		$this->assertIsArray( $data[2]['details']['campaign_budget_recommendation']['budget_options'] );
+	}
 }

--- a/tests/proxy/mocks/ads/recommendations/campaign-budget.json
+++ b/tests/proxy/mocks/ads/recommendations/campaign-budget.json
@@ -5,66 +5,66 @@
 				"type": "CAMPAIGN_BUDGET",
 				"resource_name": "customers/123/recommendations/1",
 				"campaign_budget_recommendation": {
-					"current_budget_amount_micros": "5000000", 
-					"recommended_budget_amount_micros": "8000000",
+					"current_budget_amount_micros": "90000000", 
+					"recommended_budget_amount_micros": "270000000",
 					"budget_options": [
 						{
-							"budget_amount_micros": 100000000,
+							"budget_amount_micros": 90000000,
 							"impact": {
 								"base_metrics": {
-									"cost_micros": 700000000,
-									"conversions": 12,
-									"conversions_value": 481.12592352792007
+									"cost_micros": "525584630",
+									"conversions": 280.89,
+									"conversions_value": 24966.4
 								},
 								"potential_metrics": {
-									"cost_micros": 700000000,
-									"conversions": 12,
-									"conversions_value": 481.12592352792007
+									"cost_micros": "525584630",
+									"conversions": 280.89,
+									"conversions_value": 24966.4
 								}
 							}
 						},
 						{
-							"budget_amount_micros": 43120000,
+							"budget_amount_micros": 170000000,
 							"impact": {
 								"base_metrics": {
-									"cost_micros": 700000000,
-									"conversions": 12,
-									"conversions_value": 481.12592352792007
+									"cost_micros": "525584630",
+									"conversions": 280.89,
+									"conversions_value": 24966.4
 								},
 								"potential_metrics": {
-									"cost_micros": 301840000,
-									"conversions": 10.8,
-									"conversions_value": 433.37067044358912
+									"cost_micros": "992770967",
+									"conversions": 386.05,
+									"conversions_value": 34313.03
 								}
 							}
 						},
 						{
-							"budget_amount_micros": 53900000,
+							"budget_amount_micros": 270000000,
 							"impact": {
 								"base_metrics": {
-									"cost_micros": 700000000,
-									"conversions": 12,
-									"conversions_value": 481.12592352792007
+									"cost_micros": "525584630",
+									"conversions": 280.89,
+									"conversions_value": 24966.4
 								},
 								"potential_metrics": {
-									"cost_micros": 377300000,
-									"conversions": 11.4,
-									"conversions_value": 456.78674456853338
+									"cost_micros": "1576753890",
+									"conversions": 486.52,
+									"conversions_value": 43243.07
 								}
 							}
 						},
 						{
-							"budget_amount_micros": 64680000,
+							"budget_amount_micros": 370000000,
 							"impact": {
 								"base_metrics": {
-									"cost_micros": 700000000,
-									"conversions": 12,
-									"conversions_value": 481.12592352792007
+									"cost_micros": "525584630",
+									"conversions": 280.89,
+									"conversions_value": 24966.4
 								},
 								"potential_metrics": {
-									"cost_micros": 452760000,
-									"conversions": 11.9,
-									"conversions_value": 475.17892021524108
+									"cost_micros": "2160736812",
+									"conversions": 569.53,
+									"conversions_value": 50621.55
 								}
 							}
 						}
@@ -85,66 +85,66 @@
 				"type": "MARGINAL_ROI_CAMPAIGN_BUDGET",
 				"resource_name": "customers/456/recommendations/2",
 				"marginal_roi_campaign_budget_recommendation": {
-					"current_budget_amount_micros": "2000000", 
-					"recommended_budget_amount_micros": "9000000",
+					"current_budget_amount_micros": "20000000", 
+					"recommended_budget_amount_micros": "31000000",
 					"budget_options": [
 						{
-							"budget_amount_micros": 100000000,
+							"budget_amount_micros": 20000000,
 							"impact": {
 								"base_metrics": {
-									"cost_micros": 700000000,
-									"conversions": 12,
-									"conversions_value": 481.12592352792007
+									"cost_micros": "139964209",
+									"conversions": 4,
+									"conversions_value": 545.7408447265625
 								},
 								"potential_metrics": {
-									"cost_micros": 700000000,
-									"conversions": 12,
-									"conversions_value": 481.12592352792007
+									"cost_micros": "139964209",
+									"conversions": 4,
+									"conversions_value": 545.7408447265625
 								}
 							}
 						},
 						{
-							"budget_amount_micros": 43120000,
+							"budget_amount_micros": 26000000,
 							"impact": {
 								"base_metrics": {
-									"cost_micros": 700000000,
-									"conversions": 12,
-									"conversions_value": 481.12592352792007
+									"cost_micros": "139964209",
+									"conversions": 4,
+									"conversions_value": 545.7408447265625
 								},
 								"potential_metrics": {
-									"cost_micros": 301840000,
-									"conversions": 10.8,
-									"conversions_value": 433.37067044358912
+									"cost_micros": "181971258",
+									"conversions": 4.828944206237793,
+									"conversions_value": 622.08502197265625
 								}
 							}
 						},
 						{
-							"budget_amount_micros": 53900000,
+							"budget_amount_micros": 31000000,
 							"impact": {
 								"base_metrics": {
-									"cost_micros": 700000000,
-									"conversions": 12,
-									"conversions_value": 481.12592352792007
+									"cost_micros": "139964209",
+									"conversions": 4,
+									"conversions_value": 545.7408447265625
 								},
 								"potential_metrics": {
-									"cost_micros": 377300000,
-									"conversions": 11.4,
-									"conversions_value": 456.78674456853338
+									"cost_micros": "216961447",
+									"conversions": 5.3986086845397949,
+									"conversions_value": 679.24359130859375
 								}
 							}
 						},
 						{
-							"budget_amount_micros": 64680000,
+							"budget_amount_micros": 36000000,
 							"impact": {
 								"base_metrics": {
-									"cost_micros": 700000000,
-									"conversions": 12,
-									"conversions_value": 481.12592352792007
+									"cost_micros": "139964209",
+									"conversions": 4,
+									"conversions_value": 545.7408447265625
 								},
 								"potential_metrics": {
-									"cost_micros": 452760000,
-									"conversions": 11.9,
-									"conversions_value": 475.17892021524108
+									"cost_micros": "251946304",
+									"conversions": 5.7763571739196777,
+									"conversions_value": 731.87432861328125
 								}
 							}
 						}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-262/adapt-adsrecommendations-endpoint-for-raise-budget-recommendations#comment-b1522e48

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Ensure the test proxy is running
2. Comment the permission `'permission_callback' => $this->get_permission_callback(),` callback in the `src/API/Site/Controllers/Ads/RecommendationsController` file.
3. Make a request to the REST API endpoint with the following types - `/wp-json/wc/gla/ads/recommendations?types=CAMPAIGN_BUDGET,MARGINAL_ROI_CAMPAIGN_BUDGET`
4. A response contains a recommendations with:
    - `details` property with the `campaign_budget_recommendation` inside.
    - `campaign_budget_recommendation` has the following values:
        - `current_budget_amount `
        - `recommended_budget_amount`
        - `budget_options`
    - Each `budget_options` has a `level` property with either `High`, `Recommended`, `Low` or `Current`.
    - All budget and cost amounts are converted from micros to the currency amount.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
