### PR TITLE
Fix edit campaign step.

### DIFF
--- a/js/src/components/raise-budget-recommendation-banner/banner.js
+++ b/js/src/components/raise-budget-recommendation-banner/banner.js
@@ -103,10 +103,7 @@ const Banner = ( { onBannerDismissed } ) => {
 			}
 		);
 
-		const editCampaignUrl = getEditCampaignUrl(
-			campaign_id,
-			'asset-group'
-		);
+		const editCampaignUrl = getEditCampaignUrl( campaign_id );
 		getHistory().push( editCampaignUrl );
 	};
 

--- a/js/src/components/raise-budget-recommendation-banner/index.test.js
+++ b/js/src/components/raise-budget-recommendation-banner/index.test.js
@@ -72,9 +72,7 @@ jest.mock( '~/hooks/useBudgetMetrics', () =>
 );
 
 jest.mock( '~/utils/urls', () => ( {
-	getEditCampaignUrl: jest.fn(
-		( programId ) => `/edit/${ programId }/asset-group`
-	),
+	getEditCampaignUrl: jest.fn( ( programId ) => `/edit/${ programId }` ),
 } ) );
 
 jest.mock( '~/utils/tracks', () => ( {
@@ -341,7 +339,7 @@ describe( 'RaiseBudgetRecommendationBanner', () => {
 		);
 
 		expect( setMock ).toHaveBeenCalled();
-		expect( getEditCampaignUrl ).toHaveBeenCalledWith( 1, 'asset-group' );
-		expect( historyPush ).toHaveBeenCalledWith( '/edit/1/asset-group' );
+		expect( getEditCampaignUrl ).toHaveBeenCalledWith( 1 );
+		expect( historyPush ).toHaveBeenCalledWith( '/edit/1' );
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-282/clicking-the-view-recommendation-button-redirects-the-user-to-the

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Ensure the Raise Budget Recommendation banner is displayed using mocked data.
2. Clicking the view recommendation button should redirect the user to the first step of the edit campaign screen.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
