### PR TITLE
Remove ads account status check from `ads/recommendations` endpoint

### DIFF
--- a/src/API/Site/Controllers/Ads/RecommendationsController.php
+++ b/src/API/Site/Controllers/Ads/RecommendationsController.php
@@ -93,15 +93,6 @@ class RecommendationsController extends BaseController implements ContainerAware
 	protected function get_recommendations_callback(): callable {
 		return function ( Request $request ) {
 			try {
-				// Checks if the ads account is connected; exits early if not connected to prevent further execution.
-				$account_status = $this->account->get_connected_account();
-				if ( isset( $account_status['status'] ) && 'connected' !== $account_status['status'] ) {
-					return new Response(
-						[ 'message' => __( 'No connected Ads account found.', 'google-listings-and-ads' ) ],
-						403
-					);
-				}
-
 				/** @var AdsRecommendationsService $query */
 				$query = $this->container->get( AdsRecommendationsService::class );
 

--- a/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
@@ -49,9 +49,6 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_get_recommendations_returns_empty_result() {
-		$this->account->method( 'get_connected_account' )
-			->willReturn( [ 'status' => 'connected' ] );
-
 		$response = $this->do_request( self::ROUTE_RECOMMENDATIONS, 'GET' );
 
 		$this->assertEquals( 400, $response->get_status() );
@@ -59,9 +56,6 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_get_recommendations_returns_all_recommendations() {
-		$this->account->method( 'get_connected_account' )
-			->willReturn( [ 'status' => 'connected' ] );
-
 		$mock_recommendations_data = [
 			[
 				'id'              => 1,
@@ -105,9 +99,6 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_get_recommendations_returns_empty_array_when_filter_by_non_existent_type() {
-		$this->account->method( 'get_connected_account' )
-			->willReturn( [ 'status' => 'connected' ] );
-
 		$filter_by_type = [
 			'types' => 'NON_EXISTENT_TYPE',
 		];
@@ -120,9 +111,6 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_get_recommendations_filter_by_type_returns_only_matching() {
-		$this->account->method( 'get_connected_account' )
-			->willReturn( [ 'status' => 'connected' ] );
-
 		$filter_by_type = [
 			'types' => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
 		];
@@ -186,9 +174,6 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_get_recommendations_filter_by_multiple_type_returns_only_matching() {
-		$this->account->method( 'get_connected_account' )
-			->willReturn( [ 'status' => 'connected' ] );
-
 		$filter_by_type = [
 			'types' => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH, MARGINAL_ROI_CAMPAIGN_BUDGET',
 		];
@@ -252,9 +237,6 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_get_recommendations_filter_by_campaign_id_returns_single_recommendation() {
-		$this->account->method( 'get_connected_account' )
-			->willReturn( [ 'status' => 'connected' ] );
-
 		$mock_recommendations_data = [
 			[
 				'id'              => 1,
@@ -306,9 +288,6 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_get_recommendations_includes_correct_details_property() {
-		$this->account->method( 'get_connected_account' )
-			->willReturn( [ 'status' => 'connected' ] );
-
 		$mock_recommendations_data = [
 			[
 				'id'              => 1,

--- a/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
@@ -119,23 +119,6 @@ class RecommendationsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
 	}
 
-	public function test_get_recommendations_returns_error_if_account_not_connected() {
-		$this->account->method( 'get_connected_account' )
-			->willReturn( [ 'status' => 'not_connected' ] );
-
-		$filter_by_type = [
-			'types' => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
-		];
-
-		$response = $this->do_request( self::ROUTE_RECOMMENDATIONS, 'GET', $filter_by_type );
-
-		$this->assertEquals( 403, $response->get_status() );
-
-		$data = $response->get_data();
-		$this->assertArrayHasKey( 'message', $data );
-		$this->assertEquals( 'No connected Ads account found.', $data['message'] );
-	}
-
 	public function test_get_recommendations_filter_by_type_returns_only_matching() {
 		$this->account->method( 'get_connected_account' )
 			->willReturn( [ 'status' => 'connected' ] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create new ads account in onboarding without setup the billing.
2. Go to dashboard.
3. It will not show error related to `Ads account`.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Remove ads account status check from `ads/recommendations` endpoint.
