### PR TITLE
Fix: trying to access non-existent metric property.

### DIFF
--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -93,7 +93,7 @@ function injectUpliftData( budgetRecommendation, baseBudgetRecommendation ) {
 		if (
 			budgetRecommendation?.[ level ] &&
 			baseBudgetRecommendation?.[ level ] &&
-			budgetRecommendation[ level ].metrics?.conversionsValue
+			budgetRecommendation[ level ]?.metrics?.conversionsValue
 		) {
 			const baseConversionsValue =
 				baseBudgetRecommendation[ level ].metrics.conversionsValue;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes: https://linear.app/a8c/issue/GOOWOO-290/budget-recommendation-lowhigh-are-not-appearing-on-edit-campaign

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Access the budget setup screen of the campaign, it should load without any error.
2. Mock the `/gla/ads/campaigns/budget-metrics` endpoint to not return the `recommendations.metrics` property. There should not be any error on the page.
    * E.g
        ```json
        {
            "currency": "USD",
            "recommendations": [
                {
                    "daily_budget": 13,
                    "country": "MU",
                    "level": "Recommended"
                }
            ],
            "daily_budget_baseline": 13,
            "source": "fallback-database"
        }
        ```


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
