### PR TITLE
Filter Raise Budget Recommendations

### DIFF
--- a/src/Ads/AdsRecommendationsService.php
+++ b/src/Ads/AdsRecommendationsService.php
@@ -226,6 +226,11 @@ class AdsRecommendationsService implements ContainerAwareInterface, OptionsAware
 					$current_budget     = $budget_recommendation->getCurrentBudgetAmountMicros();
 					$recommended_budget = $budget_recommendation->getRecommendedBudgetAmountMicros();
 
+					// Skip recommendation if the recommended budget is lower than the current budget.
+					if ( $recommended_budget <= $current_budget ) {
+						continue;
+					}
+
 					foreach ( $budget_recommendation->getBudgetOptions() as $option ) {
 						$impact        = $option->getImpact();
 						$potential     = $impact->getPotentialMetrics();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-292/raise-budget-recommendation-should-only-show-if-the-recommendation-is



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Update one of the recommendations inside `/tests/proxy/mocks/ads/recommendations/campaign-budget.json` so that the `current_budget_amount_micros` value is larger than the `recommended_budget_amount_micros`.
2. Ensure the test proxy is running
3. Comment the permission `'permission_callback' => $this->get_permission_callback(),` callback in the `src/API/Site/Controllers/Ads/RecommendationsController` file.
4. Make a request to the REST API endpoint with the following types - `/wp-json/wc/gla/ads/recommendations?types=CAMPAIGN_BUDGET,MARGINAL_ROI_CAMPAIGN_BUDGET`
5. You should see only 1 recommendation returned in the API response. The missing recommendation should be the one where the recommended budget amount is lower than the current budget amount.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
