### PR TITLE
Enable GTG by default to new merchants during onboarding

### DIFF
--- a/src/Options/AdsSetupCompleted.php
+++ b/src/Options/AdsSetupCompleted.php
@@ -30,6 +30,7 @@ class AdsSetupCompleted implements OptionsAwareInterface, Registerable, Service 
 			'woocommerce_gla_ads_setup_completed',
 			function () {
 				$this->set_completed_timestamp();
+				$this->enable_gtg_and_complete_tour();
 			}
 		);
 	}
@@ -39,5 +40,22 @@ class AdsSetupCompleted implements OptionsAwareInterface, Registerable, Service 
 	 */
 	protected function set_completed_timestamp() {
 		$this->options->update( self::OPTION, time() );
+	}
+
+	/**
+	 * Enables Google Tag Gateway and mark the tour as completed.
+	 */
+	protected function enable_gtg_and_complete_tour() {
+		$is_gtg_configured = $this->options->get( OptionsInterface::ADS_GTG_ENABLED );
+
+		if ( null === $is_gtg_configured ) {
+			$this->options->update( OptionsInterface::ADS_GTG_ENABLED, true );
+		}
+
+		$tours = $this->options->get( OptionsInterface::TOURS, [] );
+		if ( is_array( $tours ) ) {
+			$tours['google-tag-gateway-tour'] = true;
+			$this->options->update( OptionsInterface::TOURS, $tours );
+		}
 	}
 }

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -19,6 +19,7 @@ interface OptionsInterface {
 	public const ADS_BILLING_URL                           = 'ads_billing_url';
 	public const ADS_ID                                    = 'ads_id';
 	public const ADS_CONVERSION_ACTION                     = 'ads_conversion_action';
+	public const ADS_GTG_ENABLED						   = 'google_tag_gateway_enabled';
 	public const ADS_SETUP_COMPLETED_AT                    = 'ads_setup_completed_at';
 	public const CAMPAIGN_CONVERT_STATUS                   = 'campaign_convert_status';
 	public const CLAIMED_URL_HASH                          = 'claimed_url_hash';
@@ -55,6 +56,7 @@ interface OptionsInterface {
 		self::ADS_ACCOUNT_OCID                          => true,
 		self::ADS_ACCOUNT_STATE                         => true,
 		self::ADS_ENHANCED_CONVERSIONS_ENABLED          => true,
+		self::ADS_GTG_ENABLED                           => true,
 		self::ADS_BILLING_URL                           => true,
 		self::ADS_ID                                    => true,
 		self::ADS_CONVERSION_ACTION                     => true,

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -19,7 +19,7 @@ interface OptionsInterface {
 	public const ADS_BILLING_URL                           = 'ads_billing_url';
 	public const ADS_ID                                    = 'ads_id';
 	public const ADS_CONVERSION_ACTION                     = 'ads_conversion_action';
-	public const ADS_GTG_ENABLED						   = 'google_tag_gateway_enabled';
+	public const ADS_GTG_ENABLED                           = 'google_tag_gateway_enabled';
 	public const ADS_SETUP_COMPLETED_AT                    = 'ads_setup_completed_at';
 	public const CAMPAIGN_CONVERT_STATUS                   = 'campaign_convert_status';
 	public const CLAIMED_URL_HASH                          = 'claimed_url_hash';

--- a/tests/Unit/API/Site/Controllers/Ads/SetupCompleteControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/SetupCompleteControllerTest.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\SetupCompleteController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsSetupCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\TrackingTrait;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -23,13 +24,16 @@ class SetupCompleteControllerTest extends RESTControllerUnitTest {
 	/** @var SetupCompleteController $controller */
 	protected $controller;
 
+	protected $ads_setup_controller;
+
 	protected const ROUTE = '/wc/gla/ads/setup/complete';
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->metrics    = $this->createMock( MerchantMetrics::class );
-		$this->controller = new SetupCompleteController( $this->server, $this->metrics );
+		$this->metrics              = $this->createMock( MerchantMetrics::class );
+		$this->ads_setup_controller = new AdsSetupCompleted();
+		$this->controller           = new SetupCompleteController( $this->server, $this->metrics );
 		$this->controller->register();
 	}
 
@@ -50,5 +54,30 @@ class SetupCompleteControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'success', $response->get_data()['status'] );
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 1, did_action( 'woocommerce_gla_ads_setup_completed' ) );
+	}
+
+	public function test_gtg_is_enabled_post_onboarding() {
+		// Mock $options object.
+		$options = $this->createMock( \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::class );
+		$options->method( 'get' )
+			->willReturnMap(
+				[
+					[ \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::ADS_GTG_ENABLED, null, null ],
+					[ \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::TOURS, [], [] ],
+				]
+			);
+
+		$options->expects( $this->exactly( 3 ) )
+			->method( 'update' )
+			->withConsecutive(
+				[ \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::ADS_SETUP_COMPLETED_AT, $this->isType( 'int' ) ],
+				[ \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::ADS_GTG_ENABLED, true ],
+				[ \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::TOURS, [ 'google-tag-gateway-tour' => true ] ]
+			);
+
+		$this->ads_setup_controller->set_options_object( $options );
+		$this->ads_setup_controller->register();
+
+		$this->do_request( self::ROUTE, 'POST' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes: https://linear.app/a8c/issue/GOOWOO-274/enable-gtg-by-default-to-new-merchants-during-onboarding

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions

1. Run the following command to check that GTG flag does not exist in the setup.

```bash
  npm run wp-env run cli wp option get gla_google_tag_gateway_enabled  
```

2. Disconnect all accounts so that we can do the onboarding, else if it is a fresh site, perform and complete the onboarding. Make sure that Ads setup is completed.

3. Once onboarding and ads setup is completed, run above command again and ensure that the flag is set and the value is `true` (`1`).

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
