### PR TITLE
Fix floating point precision when converting to micro units

### DIFF
--- a/src/API/MicroTrait.php
+++ b/src/API/MicroTrait.php
@@ -22,7 +22,7 @@ trait MicroTrait {
 	/**
 	 * Convert to micro units.
 	 * We round to the nearest integer to avoid floating point precision issues.
-	 * For e.g 33.3, we want to get 33300000 and not 33299999 which can cause 
+	 * For e.g 33.3, we want to get 33300000 and not 33299999 which can cause
 	 * the Google Ads API to throw the NON_MULTIPLE_OF_MINIMUM_CURRENCY_UNIT error.
 	 *
 	 * @param float $num Number to convert to micro units.

--- a/src/API/MicroTrait.php
+++ b/src/API/MicroTrait.php
@@ -21,13 +21,16 @@ trait MicroTrait {
 
 	/**
 	 * Convert to micro units.
+	 * We round to the nearest integer to avoid floating point precision issues.
+	 * For e.g 33.3, we want to get 33300000 and not 33299999 which can cause 
+	 * the Google Ads API to throw the NON_MULTIPLE_OF_MINIMUM_CURRENCY_UNIT error.
 	 *
 	 * @param float $num Number to convert to micro units.
 	 *
 	 * @return int
 	 */
 	protected function to_micro( float $num ): int {
-		return (int) ( $num * self::$micro );
+		return (int) round( $num * self::$micro );
 	}
 
 	/**


### PR DESCRIPTION
- Use round() before casting to int in to_micro() to prevent precision errors (e.g., 33.3 * 1,000,000)
- Ensures correct conversion and avoids NON_MULTIPLE_OF_MINIMUM_CURRENCY_UNIT errors with Google Ads API

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-291/error-editing-campaign-a-money-amount-was-not-a-multiple-of-a-minimum

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a new campaign.
2. Set a custom amount of 33.30 or the following values: 99.99, 1234.56, 1.23 , 10.99
3. The campaign should be successfully saved.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Prevent floating point precision errors when converting to micro units by rounding before casting to integer. 
