### PR TITLE
Use isGoogleAdsReady property instead of hasGoogleAdsConnection during onboarding

### DIFF
--- a/js/src/components/ads-account-select-control/index.js
+++ b/js/src/components/ads-account-select-control/index.js
@@ -10,6 +10,7 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
 import AppSelectControl from '~/components/app-select-control';
 import useExistingGoogleAdsAccounts from '~/hooks/useExistingGoogleAdsAccounts';
 import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useGoogleAdsAccountReady from '~/hooks/useGoogleAdsAccountReady';
 
 /**
  * @param {Object} props The component props
@@ -17,14 +18,15 @@ import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
  */
 const AdsAccountSelectControl = ( props ) => {
 	const { existingAccounts } = useExistingGoogleAdsAccounts();
-	const { googleAdsAccount, hasGoogleAdsConnection } = useGoogleAdsAccount();
+	const { googleAdsAccount } = useGoogleAdsAccount();
+	const { isGoogleAdsReady } = useGoogleAdsAccountReady();
 
 	const accountIdExists = existingAccounts?.some(
 		( existingAccount ) => existingAccount.id === googleAdsAccount?.id
 	);
 
 	// If the account ID is not in the list of existing accounts, fake the select options by displaying the connected account ID only.
-	if ( ! accountIdExists && hasGoogleAdsConnection ) {
+	if ( ! accountIdExists && isGoogleAdsReady ) {
 		const domain = new URL( getSetting( 'homeUrl' ) ).host;
 
 		return (

--- a/js/src/components/google-combo-account-card/connect-ads/confirm-create-modal.js
+++ b/js/src/components/google-combo-account-card/connect-ads/confirm-create-modal.js
@@ -2,10 +2,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import { useAppDispatch } from '~/data';
 import AppModal from '~/components/app-modal';
 import AppButton from '~/components/app-button';
 import WarningIcon from '~/components/warning-icon';
@@ -21,6 +23,16 @@ import './confirm-create-modal.scss';
  * @return {JSX.Element} Confirmation modal.
  */
 const ConfirmCreateModal = ( { onContinue, onRequestClose } ) => {
+	const { disconnectGoogleAdsAccount } = useAppDispatch();
+	const [ isDisconnecting, setDisconnecting ] = useState( false );
+
+	const handleOnClick = () => {
+		setDisconnecting( true );
+		disconnectGoogleAdsAccount( true )
+			.then( () => onContinue() )
+			.catch( () => setDisconnecting( false ) );
+	};
+
 	return (
 		<AppModal
 			className="gla-ads-warning-modal"
@@ -29,7 +41,12 @@ const ConfirmCreateModal = ( { onContinue, onRequestClose } ) => {
 				'google-listings-and-ads'
 			) }
 			buttons={ [
-				<AppButton key="confirm" isSecondary onClick={ onContinue }>
+				<AppButton
+					key="confirm"
+					onClick={ handleOnClick }
+					loading={ isDisconnecting }
+					isSecondary
+				>
 					{ __(
 						'Yes, I want a new account',
 						'google-listings-and-ads'

--- a/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
+++ b/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
@@ -136,7 +136,7 @@ const ConnectExistingAccount = ( { onCreateClick } ) => {
 			actions={
 				<ConnectExistingAccountActions
 					disabled={ isLoading }
-					isConnected={ isGoogleAdsReady }
+					isConnected={ isGoogleAdsReady || hasGoogleAdsConnection }
 					onCreateNewClick={ onCreateClick }
 					onDisconnected={ handleDisconnected }
 				/>

--- a/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
+++ b/js/src/components/google-combo-account-card/connect-ads/connect-existing-account.js
@@ -101,7 +101,7 @@ const ConnectExistingAccount = ( { onCreateClick } ) => {
 
 		return (
 			<ConnectAccountButton
-				disabled={ hasGoogleAdsConnection }
+				disabled={ isGoogleAdsReady }
 				accountID={ value }
 				onClick={ handleConnectClick }
 			/>
@@ -130,13 +130,13 @@ const ConnectExistingAccount = ( { onCreateClick } ) => {
 					value={ value }
 					onChange={ setValue }
 					autoSelectFirstOption
-					nonInteractive={ hasGoogleAdsConnection }
+					nonInteractive={ isGoogleAdsReady }
 				/>
 			}
 			actions={
 				<ConnectExistingAccountActions
 					disabled={ isLoading }
-					isConnected={ hasGoogleAdsConnection }
+					isConnected={ isGoogleAdsReady }
 					onCreateNewClick={ onCreateClick }
 					onDisconnected={ handleDisconnected }
 				/>

--- a/js/src/hooks/useAutoCreateAdsMCAccounts.js
+++ b/js/src/hooks/useAutoCreateAdsMCAccounts.js
@@ -6,10 +6,10 @@ import { useEffect, useState, useRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useGoogleAdsAccount from './useGoogleAdsAccount';
 import useExistingGoogleAdsAccounts from './useExistingGoogleAdsAccounts';
 import useGoogleMCAccount from './useGoogleMCAccount';
 import useExistingGoogleMCAccounts from './useExistingGoogleMCAccounts';
+import useGoogleAdsAccountReady from './useGoogleAdsAccountReady';
 import useUpsertAdsAccount from '~/hooks/useUpsertAdsAccount';
 import {
 	CREATING_ADS_ACCOUNT,
@@ -18,10 +18,7 @@ import {
 } from '~/components/google-combo-account-card/constants';
 
 const useShouldCreateAdsAccount = () => {
-	const {
-		hasFinishedResolution: hasResolvedAccount,
-		hasGoogleAdsConnection: hasConnection,
-	} = useGoogleAdsAccount();
+	const { isGoogleAdsAccountReady } = useGoogleAdsAccountReady();
 
 	const {
 		hasFinishedResolution: hasResolvedExistingAccounts,
@@ -29,11 +26,11 @@ const useShouldCreateAdsAccount = () => {
 	} = useExistingGoogleAdsAccounts();
 
 	// Return null if the account hasn't been resolved or the existing accounts haven't been resolved
-	if ( ! hasResolvedAccount || ! hasResolvedExistingAccounts ) {
+	if ( ! hasResolvedExistingAccounts ) {
 		return null;
 	}
 
-	return ! hasConnection && accounts?.length === 0;
+	return ! isGoogleAdsAccountReady && accounts?.length === 0;
 };
 
 const useShouldCreateMCAccount = () => {

--- a/js/src/hooks/useAutoCreateAdsMCAccounts.test.js
+++ b/js/src/hooks/useAutoCreateAdsMCAccounts.test.js
@@ -7,7 +7,7 @@ import { act, renderHook } from '@testing-library/react';
  * Internal dependencies
  */
 import useAutoCreateAdsMCAccounts from './useAutoCreateAdsMCAccounts';
-import useGoogleAdsAccount from './useGoogleAdsAccount';
+import useGoogleAdsAccountReady from './useGoogleAdsAccountReady';
 import useExistingGoogleAdsAccounts from './useExistingGoogleAdsAccounts';
 import useGoogleMCAccount from './useGoogleMCAccount';
 import useExistingGoogleMCAccounts from './useExistingGoogleMCAccounts';
@@ -16,7 +16,7 @@ import useUpsertAdsAccount from './useUpsertAdsAccount';
 
 jest.mock( './useCreateMCAccount' );
 jest.mock( './useUpsertAdsAccount' );
-jest.mock( './useGoogleAdsAccount' );
+jest.mock( './useGoogleAdsAccountReady' );
 jest.mock( './useExistingGoogleAdsAccounts' );
 jest.mock( './useGoogleMCAccount' );
 jest.mock( './useExistingGoogleMCAccounts' );
@@ -29,9 +29,8 @@ describe( 'useAutoCreateAdsMCAccounts hook', () => {
 		createMCAccount = jest.fn( () => Promise.resolve() );
 		upsertAdsAccount = jest.fn( () => Promise.resolve() );
 
-		useGoogleAdsAccount.mockReturnValue( {
-			hasFinishedResolution: true,
-			hasGoogleAdsConnection: false,
+		useGoogleAdsAccountReady.mockReturnValue( {
+			isGoogleAdsReady: false,
 		} );
 
 		useExistingGoogleAdsAccounts.mockReturnValue( {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-204/google-ads-card-disappears-when-account-creation-limit-is-reached

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go through the onboarding process and test different scenarios such as
	* creating a new Ads account
	* connecting an existing account
	* claim an Ads account
	* auto Ads account creation if there is none

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Use isGoogleAdsReady property instead of hasGoogleAdsConnection during the onboarding process.
