### PR TITLE
Fix incorrect URL for product variation

### DIFF
--- a/js/src/pages/price-benchmark/change-price-modal/index.js
+++ b/js/src/pages/price-benchmark/change-price-modal/index.js
@@ -77,7 +77,6 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 		product: productDetails,
 		hasFinishedResolution: hasResolvedProduct,
 	} = useProduct( productId );
-
 	const { data, hasFinishedResolution } = usePriceBenchmarkSuggestions( {
 		product_id: productId,
 	} );

--- a/js/src/pages/price-benchmark/change-price-modal/index.js
+++ b/js/src/pages/price-benchmark/change-price-modal/index.js
@@ -77,6 +77,7 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 		product: productDetails,
 		hasFinishedResolution: hasResolvedProduct,
 	} = useProduct( productId );
+
 	const { data, hasFinishedResolution } = usePriceBenchmarkSuggestions( {
 		product_id: productId,
 	} );
@@ -141,11 +142,16 @@ const ChangePriceModal = ( { productId, onRequestClose, onPriceChange } ) => {
 		predicted_conversions_change: predictedConversionsChange,
 		product: { id, title, thumbnail },
 	} = data;
+	const {
+		type,
+		parent_id: parentId,
+		sale_price: salePrice,
+		on_sale: isOnSale,
+	} = productDetails;
+	const salesPrice = Number.parseFloat( salePrice );
 
-	const salesPrice = Number.parseFloat( productDetails.sale_price );
-	const isOnSale = productDetails.on_sale;
 	const editProductUrl = addQueryArgs( `${ adminUrl }post.php`, {
-		post: productId,
+		post: type === 'variation' && parentId ? parentId : productId,
 		action: 'edit',
 	} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-261/incorrect-url-for-edit-product-link-for-product-variation

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Navigate to the Price Benchmark tab in the plugin.
2. Mock the `/wc/gla/mc/price-benchmarks` endpoint with the following sample [response](https://gist.github.com/asvinb/500f48ca9f2e4bf7f6b192e3fdd1246e), replacing any `product.id` by a product variant ID (which has been previously created in WooCommerce).
3. Locate a product variation and click the "Change Price" button.
4. In the Change Price modal, click the "Edit Product" link.
5. Verify that you are redirected to the edit page for the main product (not the variation).


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Correct the product edit URL to properly handle product variations in the Price Benchmark modal.
