### PR TITLE
Fix order of budget header tooltips

### DIFF
--- a/js/src/components/paid-ads/budget-setup/budget-setup-header.js
+++ b/js/src/components/paid-ads/budget-setup/budget-setup-header.js
@@ -31,10 +31,22 @@ export default function BudgetSetupHeader() {
 				{ __( 'Weekly conversions', 'google-listings-and-ads' ) }
 				<Tooltip
 					className={ styles.tooltip }
+					text={ __(
+						'The estimated number of conversions (unit sales) for a typical week. This number may vary based on change in your weekly spend.',
+						'google-listings-and-ads'
+					) }
+				>
+					<InfoIcon />
+				</Tooltip>
+			</span>
+			<span className={ styles.metricsItem }>
+				{ __( 'Weekly conv. value', 'google-listings-and-ads' ) }
+				<Tooltip
+					className={ styles.tooltip }
 					text={
 						<>
 							{ __(
-								'The estimated number of conversions (unit sales) for a typical week. This number may vary based on change in your weekly spend.',
+								'The estimated total value of all the conversions (sales volume) your campaign will generate in a week.',
 								'google-listings-and-ads'
 							) }
 							<Link
@@ -49,18 +61,6 @@ export default function BudgetSetupHeader() {
 							</Link>
 						</>
 					}
-				>
-					<InfoIcon />
-				</Tooltip>
-			</span>
-			<span className={ styles.metricsItem }>
-				{ __( 'Weekly conv. value', 'google-listings-and-ads' ) }
-				<Tooltip
-					className={ styles.tooltip }
-					text={ __(
-						'The estimated total value of all the conversions (sales volume) your campaign will generate in a week.',
-						'google-listings-and-ads'
-					) }
 				>
 					<InfoIcon />
 				</Tooltip>

--- a/js/src/components/paid-ads/budget-setup/budget-setup-header.js
+++ b/js/src/components/paid-ads/budget-setup/budget-setup-header.js
@@ -34,7 +34,7 @@ export default function BudgetSetupHeader() {
 					text={
 						<>
 							{ __(
-								'The estimated total value of all the conversions (sales volume) your campaign will generate in a week.',
+								'The estimated number of conversions (unit sales) for a typical week. This number may vary based on change in your weekly spend.',
 								'google-listings-and-ads'
 							) }
 							<Link
@@ -58,7 +58,7 @@ export default function BudgetSetupHeader() {
 				<Tooltip
 					className={ styles.tooltip }
 					text={ __(
-						'The estimated number of conversions (unit sales) for a typical week. This number may vary based on change in your weekly spend.',
+						'The estimated total value of all the conversions (sales volume) your campaign will generate in a week.',
 						'google-listings-and-ads'
 					) }
 				>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Fixes GOOWOO-296.

This fixes an issue where budget recommendation headers were not matching the related tooltips.

### Screenshots:

<img width="706" height="254" alt="image" src="https://github.com/user-attachments/assets/6cd90f37-6aa4-40ba-bdb7-6b674e37d479" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Edit a campaign to see budget recommendations for the campaign
2. Hover over the ℹ icon next to the headers
3. See that the text of the tooltip matches the header being described

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
