### PR TITLE
GOOWOO-297: Ensure PHP 8.4 Compatibility

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - "release/**"
   pull_request:
-    branches:
-      - "release/**"
   workflow_dispatch:
     inputs:
       wp-rc-version:

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -7,10 +7,14 @@ on:
       - develop
     paths:
       - "**.php"
+      - composer.json # Required for PHP compat tests.
+      - composer.lock # Required for PHP compat tests.
       - .github/workflows/php-coding-standards.yml
   pull_request:
     paths:
       - "**.php"
+      - composer.json # Required for PHP compat tests.
+      - composer.lock # Required for PHP compat tests.
       - .github/workflows/php-coding-standards.yml
 
 concurrency:
@@ -38,3 +42,48 @@ jobs:
 
       - name: Run PHPCS on all tests
         run: vendor/bin/phpcs -q --standard=tests/phpcs.xml.dist --report=checkstyle | cs2pr
+
+  phpcompat:
+    name: PHP compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Prepare PHP
+        uses: woocommerce/grow/prepare-php@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        with:
+          tools: cs2pr
+          install-deps: no
+
+      - name: Prepare node
+        uses: woocommerce/grow/prepare-node@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        with:
+          node-version-file: ".nvmrc"
+          ignore-scripts: "no"
+
+      # The use of WP-Scripts results in PHP files being generated during the npm build step.
+      # In order to ensure PHP Compatibility, the build step must be run in order to ensure all
+      # files in the production release of the plugin are compatible with the target PHP versions.
+      - name: Build production bundle
+        run: |
+          echo "::group::Build log"
+          npm run build
+          echo "::endgroup::"
+
+      # The PHP Compatibility sniffs need to include the vendor directory to ensure all files
+      # in the production release of the plugin are compatible with the target PHP versions.
+      - name: Install composer production dependencies
+        run: composer install --no-dev --prefer-dist --optimize-autoloader
+
+      # Installed globally to ensure dev dependencies are not included in compatibility sniffs.
+      # At the time of writing no production version of PHPCompatibility/PHP-Compatibility supports
+      # PHP 8.4 so a dev version is used in order to ensure the sniffs that have been created are
+      # included in the checks.
+      - name: Install PHP Compatibility dev-develop globally
+        run: |
+          composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer global require --dev phpcompatibility/php-compatibility:dev-develop#8daeec54772a592ad369be23ae02ed593c71e7f1
+
+      - name: Run PHPCompatibility on all files
+        run: ~/.composer/vendor/bin/phpcs . --standard=.php-compat.xml.dist -q --report=checkstyle | cs2pr

--- a/.php-compat.xml.dist
+++ b/.php-compat.xml.dist
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPCompatibilityWP" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
+
+    <description>WordPress specific ruleset which checks for PHP cross version compatibility.</description>
+	<!-- Once PHPCompatibility/PHPCompatibilityWP supports the targeted versions of PHP, this config file can be updated accordingly. -->
+
+	<!-- Test PHP 7.4 thru 8.4 -->
+	<config name="testVersion" value="7.4-8.4"/>
+	<file>.</file>
+	<arg name="extensions" value="php,inc" />
+
+    <rule ref="PHPCompatibility">
+        <!--
+        Contained in /wp-includes/compat.php.
+
+        History of the polyfills in WP:
+        * hash_hmac(): since WP 3.2.0.
+        * json_encode() and json_decode(): since unknown.
+        * hash_equals(): since WP 3.9.2.
+        * JSON_PRETTY_PRINT: since WP 4.1.0.
+        * json_last_error_msg(): since WP 4.4.0.
+        * JsonSerializable: since WP 4.4.0.
+        * array_replace_recursive(): since WP 4.5.3 up to 5.2.x. The polyfill was removed in WP 5.3.
+        * is_iterable(): since WP 4.9.6
+        * is_countable(): since WP 4.9.6
+        * IMAGETYPE_WEBP and IMG_WEBP: since WP 5.8.0.
+        * array_key_first(): since WP 5.9.0
+        * array_key_last(): since WP 5.9.0
+        * str_contains(): since WP 5.9.0
+        * str_starts_with(): since WP 5.9.0
+        * str_ends_with(): since WP 5.9.0
+        * array_is_list(): since WP 6.5.0
+        -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_hmacFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_encodeFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_decodeFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.hash_equalsFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.json_pretty_printFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.json_last_error_msgFound"/>
+        <exclude name="PHPCompatibility.Interfaces.NewInterfaces.jsonserializableFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_replace_recursiveFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.is_iterableFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.is_countableFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.imagetype_webpFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.img_webpFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_key_firstFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_key_lastFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_containsFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_starts_withFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_ends_withFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.array_is_listFound"/>
+
+        <!--
+        Contained in /wp-includes/spl-autoload-compat.php.
+
+        History of the polyfills in WP:
+        * spl_autoload_register(), spl_autoload_unregister() and spl_autoload_functions() were
+          introduced in WP 4.6.0 and available up to WP 5.2.x. The polyfills were removed in WP 5.3.
+        -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_registerFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_unregisterFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_functionsFound"/>
+    </rule>
+
+</ruleset>

--- a/.php-compat.xml.dist
+++ b/.php-compat.xml.dist
@@ -8,6 +8,7 @@
 	<config name="testVersion" value="7.4-8.4"/>
 	<file>.</file>
 	<arg name="extensions" value="php,inc" />
+    <arg name="basepath" value="." />
 
     <rule ref="PHPCompatibility">
         <!--
@@ -60,6 +61,12 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_registerFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_unregisterFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_functionsFound"/>
+
+    </rule>
+
+    <!-- This is a problem in the Google vendor library -->
+    <rule ref="Internal.LineEndings.Mixed">
+        <exclude-pattern>**/vendor/**</exclude-pattern>
     </rule>
 
 </ruleset>

--- a/.php-compat.xml.dist
+++ b/.php-compat.xml.dist
@@ -100,6 +100,10 @@
         <exclude-pattern>/polyfill[_-]php74/Php74\.php$</exclude-pattern>
     </rule>
 
+    <!-- Prevent false positives being thrown when run over the code of polyfill-ctype itself. -->
+    <rule ref="PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations.mixedFound">
+        <exclude-pattern>/polyfill-ctype/bootstrap80.php</exclude-pattern>
+    </rule>
 
     <!-- This is a problem in the Google vendor library -->
     <rule ref="Internal.LineEndings.Mixed">

--- a/.php-compat.xml.dist
+++ b/.php-compat.xml.dist
@@ -62,7 +62,44 @@
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_unregisterFound"/>
         <exclude name="PHPCompatibility.FunctionUse.NewFunctions.spl_autoload_functionsFound"/>
 
+
+        <!-- Polyfills from the Symphony package -->
+
+        <!-- https://github.com/symfony/polyfill-php80/blob/main/bootstrap.php -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.fdivFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.get_resource_idFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.preg_last_error_msgFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_containsFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_ends_withFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.str_starts_withFound"/>
+        <exclude name="PHPCompatibility.Constants.NewConstants.filter_validate_boolFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.get_debug_typeFound"/>
+
+        <!-- https://github.com/symfony/polyfill-php80/tree/main/Resources/stubs -->
+        <exclude name="PHPCompatibility.Interfaces.NewInterfaces.stringableFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.attributeFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.phptokenFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.unhandledmatcherrorFound"/>
+        <exclude name="PHPCompatibility.Classes.NewClasses.valueerrorFound"/>
+
+        <!-- https://github.com/symfony/polyfill-php74/blob/main/bootstrap.php -->
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.get_mangled_object_varsFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.mb_str_splitFound"/>
+        <exclude name="PHPCompatibility.FunctionUse.NewFunctions.password_algosFound"/>
     </rule>
+
+
+    <!-- Prevent false positives being thrown when run over the code of polyfill-php74 itself. -->
+    <rule ref="PHPCompatibility.Constants.NewConstants.password_bcryptFound">
+        <exclude-pattern>/polyfill[_-]php74/Php74\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Constants.NewConstants.password_argon2iFound">
+        <exclude-pattern>/polyfill[_-]php74/Php74\.php$</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Constants.NewConstants.password_argon2idFound">
+        <exclude-pattern>/polyfill[_-]php74/Php74\.php$</exclude-pattern>
+    </rule>
+
 
     <!-- This is a problem in the Google vendor library -->
     <rule ref="Internal.LineEndings.Mixed">

--- a/.php-compat.xml.dist
+++ b/.php-compat.xml.dist
@@ -110,4 +110,90 @@
         <exclude-pattern>**/vendor/**</exclude-pattern>
     </rule>
 
+    <!-- Prevent false positives for files that run on PHP 8.0+  -->
+     <rule ref="PHPCompatibility.Classes.NewTypedProperties.mixedFound">
+        <exclude-pattern>**/vendor/google/auth/src/Cache/TypedItem.php</exclude-pattern>
+     </rule>
+
+    <rule ref="PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.mixedFound">
+        <exclude-pattern>**/vendor/google/auth/src/Cache/TypedItem.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.staticFound">
+        <exclude-pattern>**/vendor/google/auth/src/Cache/TypedItem.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.Classes.NewConstructorPropertyPromotion.Found">
+        <exclude-pattern>**/vendor/google/auth/src/Cache/TypedItem.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.FunctionDeclarations.NewParamTypeDeclarations.mixedFound">
+        <exclude-pattern>**/vendor/google/auth/src/Cache/TypedItem.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.Classes.NewClasses.weakmapFound">
+        <exclude-pattern>**/vendor/monolog/monolog/src/Monolog/Logger.php</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.Classes.NewClasses.fiberFound">
+        <exclude-pattern>**/vendor/monolog/monolog/src/Monolog/Logger.php</exclude-pattern>
+    </rule>
+
+    <!-- Prevent false positives for non-required extension -->
+    <rule ref="PHPCompatibility.Extensions.RemovedExtensions.mcryptDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_generic_initDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_genericDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_list_algorithmsDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_module_closeDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_module_openDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.mcrypt_module_closeDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.FunctionUse.RemovedFunctions.mdecrypt_genericDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.Constants.RemovedConstants.mcrypt_mode_ecbDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.Constants.RemovedConstants.mcrypt_mode_cbcDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.Constants.RemovedConstants.mcrypt_mode_nofbDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.Constants.RemovedConstants.mcrypt_mode_cfbDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.Constants.RemovedConstants.mcrypt_mode_ofbDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
+    <rule ref="PHPCompatibility.Constants.RemovedConstants.mcrypt_mode_streamDeprecatedRemoved">
+        <exclude-pattern>**/vendor/phpseclib/phpseclib/**</exclude-pattern>
+    </rule>
+
 </ruleset>

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-	"phpVersion": "8.0",
+	"phpVersion": "7.4",
 	"plugins": [
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"./tests/e2e/test-data",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-297/project-ensure-php-84-compatibility

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
