### PR TITLE
Add notification badge for Raise Budget Recommendations

### DIFF
--- a/src/Menu/NotificationManager.php
+++ b/src/Menu/NotificationManager.php
@@ -49,6 +49,8 @@ class NotificationManager implements ContainerAwareInterface, Service, Registera
 		// Hook into admin_menu with a high priority (e.g., 20) to ensure
 		// all other menu items have been registered by WooCommerce and other plugins.
 		add_action( 'admin_menu', [ $this, 'display_aggregated_notification_pill' ], 20 );
+
+		add_filter( 'google_for_woocommerce_admin_menu_notification_count', [ $this, 'raise_budget_recommendations_count' ] );
 	}
 
 	/**
@@ -229,6 +231,47 @@ class NotificationManager implements ContainerAwareInterface, Service, Registera
 		}
 
 		$action_time = $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['actionTime'];
+
+		if ( time() > $action_time + ( 30 * DAY_IN_SECONDS ) ) {
+			return ++$count;
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Returns the count for Raise Budget Recommendations.
+	 *
+	 * @param int $count The initial count.
+	 * @return int The updated notification count for Raise Budget Recommendations.
+	 */
+	public function raise_budget_recommendations_count( int $count ): int {
+		global $wpdb;
+
+		$query           = $this->container->get( AdsRecommendationsService::class );
+		$recommendations = $query->get_recommendations(
+			[
+				'types'       => [
+					'CAMPAIGN_BUDGET',
+					'MARGINAL_ROI_CAMPAIGN_BUDGET',
+				],
+				'campaign_id' => 0,
+			]
+		);
+
+		if ( empty( $recommendations ) ) {
+			return $count;
+		}
+
+		// Check recommendation dates and user preference.
+		$preferences = get_user_meta( get_current_user_id(), "{$wpdb->prefix}persisted_preferences", true );
+
+		// If the user has not interacted with a recommendation yet.
+		if ( ! is_array( $preferences ) || ! isset( $preferences['woocommerce/google-listings-and-ads']['raise-budget-recommendation-banner']['actionType'] ) || ! isset( $preferences['woocommerce/google-listings-and-ads']['raise-budget-recommendation-banner']['actionTime'] ) ) {
+			return ++$count;
+		}
+
+		$action_time = $preferences['woocommerce/google-listings-and-ads']['raise-budget-recommendation-banner']['actionTime'];
 
 		if ( time() > $action_time + ( 30 * DAY_IN_SECONDS ) ) {
 			return ++$count;

--- a/src/Menu/NotificationManager.php
+++ b/src/Menu/NotificationManager.php
@@ -50,6 +50,7 @@ class NotificationManager implements ContainerAwareInterface, Service, Registera
 		// all other menu items have been registered by WooCommerce and other plugins.
 		add_action( 'admin_menu', [ $this, 'display_aggregated_notification_pill' ], 20 );
 
+		add_filter( 'google_for_woocommerce_admin_menu_notification_count', [ $this, 'performance_max_ad_strength_count' ] );
 		add_filter( 'google_for_woocommerce_admin_menu_notification_count', [ $this, 'raise_budget_recommendations_count' ] );
 	}
 
@@ -151,7 +152,7 @@ class NotificationManager implements ContainerAwareInterface, Service, Registera
 		// Initialize the count and apply the filter to get the total aggregated count.
 		// All parts of the plugin (and other plugins) that need to add to the notification
 		// should hook into this filter.
-		$total_notification_count = apply_filters( 'google_for_woocommerce_admin_menu_notification_count', $this->initial_notification_count() );
+		$total_notification_count = apply_filters( 'google_for_woocommerce_admin_menu_notification_count', 0 );
 
 		// Only proceed if there's at least one notification.
 		if ( $total_notification_count > 0 ) {
@@ -194,11 +195,11 @@ class NotificationManager implements ContainerAwareInterface, Service, Registera
 	/**
 	 * Returns the initial notification count for the admin menu.
 	 *
+	 * @param int $count The initial count.
 	 * @return int The updated notification count, which is either 1 (if there are recommendations) or 0 (if there are no recommendations).
 	 */
-	public function initial_notification_count(): int {
+	public function performance_max_ad_strength_count( int $count ): int {
 		global $wpdb;
-		$count = 0;
 
 		$query        = $this->container->get( AdsRecommendationsService::class );
 		$ads_campaign = $this->container->get( AdsCampaign::class );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-309/integrate-active-raise-budget-recommendations-into-the


### Detailed test instructions:

1. Use the Raise Budget Recommendation test data plugin to generate mock recommendations.
2. When on the WordPress admin dashboard you should see the "Marketing" menu displays a red notification badge
3. When on the Marketing admin page, the  "Google for WooCommerce" menu item displays a red notification badge
4. After interacting with the Raise Budget Recommendation notification banner (dismiss or edit) the notification badge no longer displays (may require page refresh)