### PR TITLE
Update the GTG settings in API call for ads settings.

### DIFF
--- a/src/API/Site/Controllers/Ads/AdsSettingsController.php
+++ b/src/API/Site/Controllers/Ads/AdsSettingsController.php
@@ -49,6 +49,7 @@ class AdsSettingsController extends BaseOptionsController {
 	protected function get_allowed_options(): array {
 		return [
 			OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED => false,
+			OptionsInterface::ADS_GTG_ENABLED => false,
 		];
 	}
 

--- a/src/API/Site/Controllers/Ads/AdsSettingsController.php
+++ b/src/API/Site/Controllers/Ads/AdsSettingsController.php
@@ -49,7 +49,7 @@ class AdsSettingsController extends BaseOptionsController {
 	protected function get_allowed_options(): array {
 		return [
 			OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED => false,
-			OptionsInterface::ADS_GTG_ENABLED => false,
+			OptionsInterface::ADS_GTG_ENABLED                  => false,
 		];
 	}
 

--- a/tests/Unit/API/Site/Controllers/Ads/AdsSettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AdsSettingsControllerTest.php
@@ -37,11 +37,12 @@ class AdsSettingsControllerTest extends RESTControllerUnitTest {
 	public function test_get_settings() {
 		$expected = [
 			'enhanced_conversions_enabled' => true,
+			'google_tag_gateway_enabled'   => true,
 		];
 
 		$this->options->expects( $this->once() )->method( 'get_ads_id' )->willReturn( 1 );
 
-		$this->options->expects( $this->once() )->method( 'get' )->willReturn( true );
+		$this->options->expects( $this->exactly( 2 ) )->method( 'get' )->willReturn( true );
 
 		$response = $this->do_request( self::ROUTE_SETTINGS, 'GET' );
 
@@ -52,10 +53,11 @@ class AdsSettingsControllerTest extends RESTControllerUnitTest {
 	public function test_get_settings_with_null_option_value() {
 		$expected = [
 			'enhanced_conversions_enabled' => false,
+			'google_tag_gateway_enabled'   => false,
 		];
 
 		$this->options->expects( $this->once() )->method( 'get_ads_id' )->willReturn( 1 );
-		$this->options->expects( $this->once() )->method( 'get' )->willReturn( null );
+		$this->options->expects( $this->exactly( 2 ) )->method( 'get' )->willReturn( null );
 
 		$response = $this->do_request( self::ROUTE_SETTINGS, 'GET' );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes: https://linear.app/a8c/issue/GOOWOO-308/add-support-for-gtg-to-the-ads-settings-endpoint

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to Marketing > Google for Woocommerce > Settings > Improve data strength > Enable Google tag gateway for advertisers
2. Try enabling/disabling the GTG option.
3. Refresh the page and the state must persist for the GTG option.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
