### PR TITLE
Add default empty array return for `undefined` parameter

### DIFF
--- a/js/src/pages/reports/programs/filterConfig.js
+++ b/js/src/pages/reports/programs/filterConfig.js
@@ -70,6 +70,10 @@ export const createProgramsFilterConfig = () => {
 	};
 
 	async function getLabels( param ) {
+		if ( param === undefined ) {
+			return [];
+		}
+
 		// Get program id(s) from query parameter.
 		const ids = new Set( getIdsFromQuery( param ) );
 		let programs;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-70/the-free-listings-item-automatically-appears-in-the-selected-list-of

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the Programs tab of the Reports page.
2. Click on the programs filter and select the "Comparison" filter.
3. Select at least two campaigns via the search input below.
4. Click the "Compare" button.
5. Click the [x] button on the previously added campaign items to unselect them.
6. After unselecting all items, the "Free Listings" item should no longer appear.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Prevent “Free Listings” from being automatically added after unselecting all campaigns in the comparison filter.
