### PR TITLE
Fix error when no ads account connected in NotificationManager

### DIFF
--- a/src/Ads/AdsRecommendationsService.php
+++ b/src/Ads/AdsRecommendationsService.php
@@ -70,6 +70,11 @@ class AdsRecommendationsService implements ContainerAwareInterface, OptionsAware
 	 * @return array Array of recommendations.
 	 */
 	public function get_recommendations( array $args = [] ): array {
+		// Return early if no connected ads account.
+		if ( empty( $this->options->get_ads_id() ) ) {
+			return [];
+		}
+
 		// Make sure a valid type is passed.
 		$types = isset( $args['types'] ) && is_array( $args['types'] ) ? self::get_valid_recommendation_types( $args['types'] ) : [];
 
@@ -84,7 +89,13 @@ class AdsRecommendationsService implements ContainerAwareInterface, OptionsAware
 			return $transient[ $cache_key ];
 		}
 
-		$result = $this->get_google_recommendations( $args );
+		try {
+			$result = $this->get_google_recommendations( $args );
+		} catch ( \Exception $e ) {
+			do_action( 'woocommerce_gla_debug_message', $e->getMessage(), __METHOD__ );
+
+			return [];
+		}
 
 		$recommendations = [];
 

--- a/src/Ads/AdsRecommendationsService.php
+++ b/src/Ads/AdsRecommendationsService.php
@@ -70,11 +70,6 @@ class AdsRecommendationsService implements ContainerAwareInterface, OptionsAware
 	 * @return array Array of recommendations.
 	 */
 	public function get_recommendations( array $args = [] ): array {
-		// Return early if no connected ads account.
-		if ( empty( $this->options->get_ads_id() ) ) {
-			return [];
-		}
-
 		// Make sure a valid type is passed.
 		$types = isset( $args['types'] ) && is_array( $args['types'] ) ? self::get_valid_recommendation_types( $args['types'] ) : [];
 
@@ -174,9 +169,16 @@ class AdsRecommendationsService implements ContainerAwareInterface, OptionsAware
 	 * @throws Exception If the recommendations data can't be retrieved.
 	 */
 	public function get_google_recommendations( $args ): array {
+		// Return early if no connected ads account.
+		$ads_id = $this->options->get_ads_id();
+
+		if ( empty( $ads_id ) ) {
+			return [];
+		}
+
 		try {
 			$query = ( new AdsRecommendationsQuery() )
-			->set_client( $this->client, $this->options->get_ads_id() );
+			->set_client( $this->client, $ads_id );
 
 			$types       = isset( $args['types'] ) && is_array( $args['types'] ) ? self::get_valid_recommendation_types( $args['types'] ) : [];
 			$campaign_id = isset( $args['campaign_id'] ) ? (int) $args['campaign_id'] : 0;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-316/catch-error-in-notificationmanager-when-no-ads-account-is-connected

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
