### PR TITLE
Add job role option to `SkipPaidAdsConfirmationModal`

### DIFF
--- a/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/constants.js
+++ b/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/constants.js
@@ -46,7 +46,7 @@ export const OPTIONS = [
 		hasTextInput: false,
 		optionType: 'checkbox',
 		notice: __(
-			'Setup takes less than 1 minute',
+			'Are you sure? Setup takes less than 1 minute.',
 			'google-listings-and-ads'
 		),
 	},

--- a/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/constants.js
+++ b/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/constants.js
@@ -5,9 +5,46 @@ import { __ } from '@wordpress/i18n';
 
 export const OPTIONS = [
 	{
+		label: __( 'Your role', 'google-listings-and-ads' ),
+		value: 'your_role',
+		hasTextInput: false,
+		optionType: 'select',
+		options: [
+			{
+				label: __( 'Select an option', 'google-listings-and-ads' ),
+				value: '',
+			},
+			{
+				label: __( 'Owner', 'google-listings-and-ads' ),
+				value: 'owner',
+			},
+			{
+				label: __( 'Developer', 'google-listings-and-ads' ),
+				value: 'developer',
+			},
+			{
+				label: __( 'Agency', 'google-listings-and-ads' ),
+				value: 'agency',
+			},
+			{
+				label: __( 'Marketing lead', 'google-listings-and-ads' ),
+				value: 'marketing_lead',
+			},
+			{
+				label: __( 'Other', 'google-listings-and-ads' ),
+				value: 'other',
+			},
+		],
+		otherInputTextPlaceholder: __(
+			'Tell us your role',
+			'google-listings-and-ads'
+		),
+	},
+	{
 		label: __( 'I already have ads on Google', 'google-listings-and-ads' ),
 		value: 'i_already_have_ads_on_google',
 		hasTextInput: false,
+		optionType: 'checkbox',
 	},
 	{
 		label: __(
@@ -16,6 +53,7 @@ export const OPTIONS = [
 		),
 		value: 'i_dont_have_the_budget_to_create_ads_now',
 		hasTextInput: false,
+		optionType: 'checkbox',
 	},
 	{
 		label: __(
@@ -24,20 +62,34 @@ export const OPTIONS = [
 		),
 		value: 'ive_tried_google_ads_before_without_success',
 		hasTextInput: false,
+		optionType: 'checkbox',
 	},
 	{
 		label: __( 'I don’t want ads on Google', 'google-listings-and-ads' ),
 		value: 'i_dont_want_ads_on_google',
 		hasTextInput: true,
+		optionType: 'checkbox',
 	},
 	{
 		label: __( 'I’ll create ads later', 'google-listings-and-ads' ),
 		value: 'ill_create_ads_later',
 		hasTextInput: true,
+		optionType: 'checkbox',
+	},
+	{
+		label: __( "I don't have time", 'google-listings-and-ads' ),
+		value: 'i_dont_have_time',
+		hasTextInput: false,
+		optionType: 'checkbox',
+		notice: __(
+			'Setup takes less than 1 minute',
+			'google-listings-and-ads'
+		),
 	},
 	{
 		label: __( 'Other', 'google-listings-and-ads' ),
 		value: 'other',
 		hasTextInput: true,
+		optionType: 'checkbox',
 	},
 ];

--- a/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/constants.js
+++ b/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/constants.js
@@ -5,42 +5,6 @@ import { __ } from '@wordpress/i18n';
 
 export const OPTIONS = [
 	{
-		label: __( 'Your role', 'google-listings-and-ads' ),
-		value: 'your_role',
-		hasTextInput: false,
-		optionType: 'select',
-		options: [
-			{
-				label: __( 'Select an option', 'google-listings-and-ads' ),
-				value: '',
-			},
-			{
-				label: __( 'Owner', 'google-listings-and-ads' ),
-				value: 'owner',
-			},
-			{
-				label: __( 'Developer', 'google-listings-and-ads' ),
-				value: 'developer',
-			},
-			{
-				label: __( 'Agency', 'google-listings-and-ads' ),
-				value: 'agency',
-			},
-			{
-				label: __( 'Marketing lead', 'google-listings-and-ads' ),
-				value: 'marketing_lead',
-			},
-			{
-				label: __( 'Other', 'google-listings-and-ads' ),
-				value: 'other',
-			},
-		],
-		otherInputTextPlaceholder: __(
-			'Tell us your role',
-			'google-listings-and-ads'
-		),
-	},
-	{
 		label: __( 'I already have ads on Google', 'google-listings-and-ads' ),
 		value: 'i_already_have_ads_on_google',
 		hasTextInput: false,
@@ -91,5 +55,41 @@ export const OPTIONS = [
 		value: 'other',
 		hasTextInput: true,
 		optionType: 'checkbox',
+	},
+	{
+		label: __( 'Your role (optional)', 'google-listings-and-ads' ),
+		value: 'your_role',
+		hasTextInput: false,
+		optionType: 'select',
+		options: [
+			{
+				label: __( 'Select an option', 'google-listings-and-ads' ),
+				value: '',
+			},
+			{
+				label: __( 'Owner', 'google-listings-and-ads' ),
+				value: 'owner',
+			},
+			{
+				label: __( 'Developer', 'google-listings-and-ads' ),
+				value: 'developer',
+			},
+			{
+				label: __( 'Agency', 'google-listings-and-ads' ),
+				value: 'agency',
+			},
+			{
+				label: __( 'Marketing lead', 'google-listings-and-ads' ),
+				value: 'marketing_lead',
+			},
+			{
+				label: __( 'Other', 'google-listings-and-ads' ),
+				value: 'other',
+			},
+		],
+		otherInputTextPlaceholder: __(
+			'Tell us your role',
+			'google-listings-and-ads'
+		),
 	},
 ];

--- a/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey-modal.js
+++ b/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey-modal.js
@@ -23,6 +23,8 @@ import './survey-modal.scss';
  *
  * @event gla_skip_campaign_creation_survey
  * @property {string} context Name of the context where the survey was triggered (e.g. 'skip-paid-ads-survey-modal').
+ * @property {string} your_role The role of the user (e.g. 'owner', 'developer', 'agency', 'marketing_lead', 'other').
+ * @property {string} your_role_text Text input for the user's role if 'other' is selected.
  * @property {boolean} i_already_have_ads_on_google Indicates if the user already has ads on Google.
  * @property {boolean} i_dont_have_the_budget_to_create_ads_now Indicates if the user doesn't have the budget to create ads now.
  * @property {boolean} ive_tried_google_ads_before_without_success Indicates if the user has tried Google ads before without success.
@@ -30,6 +32,7 @@ import './survey-modal.scss';
  * @property {string} i_dont_want_ads_on_google_text Text input for the reason why the user doesn't want ads on Google.
  * @property {boolean} ill_create_ads_later Indicates if the user will create ads later.
  * @property {string} ill_create_ads_later_text Text input for the reason why the user will create ads later.
+ * @property {boolean} i_dont_have_time Indicates if the user doesn't have time.
  * @property {boolean} other Indicates if the user has another reason.
  * @property {string} other_text Text input for the user's other reason.
  */
@@ -52,7 +55,7 @@ const SurveyModal = ( { onRequestClose, onSkipCreatePaidAds } ) => {
 			return {
 				...accumulator,
 				[ option.value ]: false,
-				[ `${ option.value }__text` ]: '', // This is to handle the text input for options that require additional explanation.
+				[ `${ option.value }_text` ]: '', // This is to handle the text input for options that require additional explanation.
 			};
 		}
 

--- a/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey-modal.js
+++ b/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey-modal.js
@@ -147,7 +147,7 @@ const SurveyModal = ( { onRequestClose, onSkipCreatePaidAds } ) => {
 													</h4>
 													<p>
 														{ __(
-															'Reach new audiences across Google Search, YouTube, and Discover using Google’s AI.',
+															"Let Google's AI find and connect you with converting customers across Search, Maps, YouTube, and more.",
 															'google-listings-and-ads'
 														) }
 													</p>

--- a/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey-modal.js
+++ b/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey-modal.js
@@ -181,7 +181,7 @@ const SurveyModal = ( { onRequestClose, onSkipCreatePaidAds } ) => {
 													</p>
 													<p>
 														<AppDocumentationLink
-															href="https://support.google.com/google-ads/answer/10724817"
+															href="https://woocommerce.com/document/google-for-woocommerce/get-started/google-performance-max-campaigns/"
 															context="skip-paid-ads-survey-modal"
 															linkId="paid-ads-with-performance-max-campaigns-learn-more"
 														>

--- a/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey.js
+++ b/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey.js
@@ -40,7 +40,7 @@ const Survey = () => {
 					return (
 						<li key={ option.value }>
 							{ option.optionType === 'select' && (
-								<>
+								<div className="gla-skip-paid-ads-survey-modal__select">
 									<SelectControl
 										options={ option.options }
 										label={ option.label }
@@ -60,11 +60,11 @@ const Survey = () => {
 											rows={ 2 }
 										/>
 									) }
-								</>
+								</div>
 							) }
 
 							{ option.optionType === 'checkbox' && (
-								<>
+								<div>
 									<CheckboxControl
 										label={ option.label }
 										value={ option.value }
@@ -100,7 +100,7 @@ const Survey = () => {
 											) }
 										</>
 									) }
-								</>
+								</div>
 							) }
 						</li>
 					);

--- a/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey.js
+++ b/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey.js
@@ -37,7 +37,6 @@ const Survey = () => {
 				{ OPTIONS.map( ( option ) => {
 					const inputProps = getInputProps( option.value );
 
-					console.log( 'option', option, inputProps );
 					return (
 						<li key={ option.value }>
 							{ option.optionType === 'select' && (

--- a/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey.js
+++ b/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey.js
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl, TextareaControl } from '@wordpress/components';
+import {
+	CheckboxControl,
+	SelectControl,
+	Notice,
+	TextareaControl,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -32,28 +37,71 @@ const Survey = () => {
 				{ OPTIONS.map( ( option ) => {
 					const inputProps = getInputProps( option.value );
 
+					console.log( 'option', option, inputProps );
 					return (
 						<li key={ option.value }>
-							<CheckboxControl
-								label={ option.label }
-								value={ option.value }
-								{ ...inputProps }
-							/>
-
-							{ option.hasTextInput && inputProps.checked && (
-								<div className="gla-skip-paid-ads-survey-modal__text-input">
-									<TextareaControl
-										placeholder={ __(
-											'Tell us why (optional)',
-											'google-listings-and-ads'
-										) }
-										name={ `${ option.value }_text` }
-										{ ...getInputProps(
-											`${ option.value }_text`
-										) }
-										rows={ 2 }
+							{ option.optionType === 'select' && (
+								<>
+									<SelectControl
+										options={ option.options }
+										label={ option.label }
+										value={ option.value }
+										{ ...inputProps }
 									/>
-								</div>
+
+									{ inputProps.value === 'other' && (
+										<TextareaControl
+											placeholder={
+												option.otherInputTextPlaceholder
+											}
+											name={ `${ option.value }_text` }
+											{ ...getInputProps(
+												`${ option.value }_text`
+											) }
+											rows={ 2 }
+										/>
+									) }
+								</>
+							) }
+
+							{ option.optionType === 'checkbox' && (
+								<>
+									<CheckboxControl
+										label={ option.label }
+										value={ option.value }
+										{ ...inputProps }
+									/>
+
+									{ inputProps.checked && (
+										<>
+											{ option.hasTextInput && (
+												<div className="gla-skip-paid-ads-survey-modal__text-input">
+													<TextareaControl
+														placeholder={ __(
+															'Tell us why (optional)',
+															'google-listings-and-ads'
+														) }
+														name={ `${ option.value }_text` }
+														{ ...getInputProps(
+															`${ option.value }_text`
+														) }
+														rows={ 2 }
+													/>
+												</div>
+											) }
+
+											{ option.notice && (
+												<Notice
+													status="info"
+													isDismissible={ false }
+													className="gla-skip-paid-ads-survey-modal__notice"
+												>
+													{ option.notice }
+												</Notice>
+											) }
+										</>
+									) }
+								</>
 							) }
 						</li>
 					);

--- a/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey.scss
+++ b/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey.scss
@@ -14,4 +14,8 @@
 		padding-top: $grid-unit-10;
 		padding-bottom: $grid-unit-10;
 	}
+
+	.gla-skip-paid-ads-survey-modal__select {
+		margin-top: $grid-unit-20;
+	}
 }

--- a/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey.scss
+++ b/js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey.scss
@@ -4,7 +4,14 @@
 		font-weight: 600;
 	}
 
+	.gla-skip-paid-ads-survey-modal__notice,
 	.gla-skip-paid-ads-survey-modal__text-input {
 		margin-left: $grid-unit-30;
+	}
+
+	.gla-skip-paid-ads-survey-modal__notice {
+		background-color: $gray-100;
+		padding-top: $grid-unit-10;
+		padding-bottom: $grid-unit-10;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-320/update-skippaidadsconfirmationmodal-to-include-additional-fields

_Replace this with a good description of your changes & reasoning._


### Screenshots:
<img width="839" height="532" alt="image" src="https://github.com/user-attachments/assets/8b573300-109c-4d06-97cb-bb4ea02bf7c0" />



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Disable WooCommerce.com tracking in WooCommerce settings: `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
2. Navigate to the plugin dashboard.
3. Disconnect all connected accounts (if any).
4. Go through the onboarding process.
5. At the third step (Create Campaign), click the "Skip Ads Creation" button.
6. The existing modal should be displayed with the current functionality.
7. Enable WooCommerce.com tracking in settings.
8. Repeat steps 2 to 5.
9. On clicking "Skip Ads Creation", the new survey modal should be displayed as per the Figma design.
12. All fields in the survey are optional.
13. Clicking "Send and complete setup" should:
	* Send the user’s selection (if any) to WooCommerce’s tracking database.
	* Close the modal.
	* Redirect the user to the dashboard.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Additional options to the skip paid ads survey.
