### PR TITLE
fix: Update AdsSetupCompleted structure and related test

### DIFF
--- a/src/Options/AdsSetupCompleted.php
+++ b/src/Options/AdsSetupCompleted.php
@@ -54,7 +54,10 @@ class AdsSetupCompleted implements OptionsAwareInterface, Registerable, Service 
 
 		$tours = $this->options->get( OptionsInterface::TOURS, [] );
 		if ( is_array( $tours ) ) {
-			$tours['google-tag-gateway-tour'] = true;
+			$tours['google-tag-gateway-tour'] = [
+				'id'      => 'google-tag-gateway-tour',
+				'checked' => true,
+			];
 			$this->options->update( OptionsInterface::TOURS, $tours );
 		}
 	}

--- a/tests/Unit/API/Site/Controllers/Ads/SetupCompleteControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/SetupCompleteControllerTest.php
@@ -72,7 +72,7 @@ class SetupCompleteControllerTest extends RESTControllerUnitTest {
 			->withConsecutive(
 				[ \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::ADS_SETUP_COMPLETED_AT, $this->isType( 'int' ) ],
 				[ \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::ADS_GTG_ENABLED, true ],
-				[ \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::TOURS, [ 'google-tag-gateway-tour' => true ] ]
+				[ \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::TOURS, [ 'google-tag-gateway-tour' => [ 'id' => 'google-tag-gateway-tour', 'checked' => true ] ] ]
 			);
 
 		$this->ads_setup_controller->set_options_object( $options );

--- a/tests/Unit/API/Site/Controllers/Ads/SetupCompleteControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/SetupCompleteControllerTest.php
@@ -72,7 +72,15 @@ class SetupCompleteControllerTest extends RESTControllerUnitTest {
 			->withConsecutive(
 				[ \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::ADS_SETUP_COMPLETED_AT, $this->isType( 'int' ) ],
 				[ \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::ADS_GTG_ENABLED, true ],
-				[ \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::TOURS, [ 'google-tag-gateway-tour' => [ 'id' => 'google-tag-gateway-tour', 'checked' => true ] ] ]
+				[
+					\Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::TOURS,
+					[
+						'google-tag-gateway-tour' => [
+							'id'      => 'google-tag-gateway-tour',
+							'checked' => true,
+						],
+					],
+				]
 			);
 
 		$this->ads_setup_controller->set_options_object( $options );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-323/qa-gtg-fatal-error-when-tour-gtg-tour-appear-after-re-connecting-ads

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Disconnect all accounts and complete the onboarding process.
2. Go to the dashboard. The GTG tour should not be rendered and there should not be any errors.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
