### PR TITLE
Fix rewrite rules registration

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -131,6 +131,9 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			'update_option_' . $gtag_option_name,
 			function ( $old_value, $value ) use ( $ads_conversion_id ) {
 				if ( $value ) {
+					// Ensure save_mod_rewrite_rules is loaded.
+					require_once ABSPATH . 'wp-admin/includes/misc.php';
+
 					$this->gtag_adapter->update(
 						[
 							'tagId' => $ads_conversion_id,

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -76,6 +76,13 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	protected $products = [];
 
 	/**
+	 * GTG Adapter instance.
+	 *
+	 * @var Adapter|null
+	 */
+	protected $gtag_adapter = null;
+
+	/**
 	 * Global Site Tag constructor.
 	 *
 	 * @param AssetsHandlerInterface $assets_handler
@@ -112,22 +119,29 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		$ads_conversion_id    = $conversion_action['conversion_id'];
 		$ads_conversion_label = $conversion_action['conversion_label'];
 
-		if ( $this->is_gtg_enabled() ) {
-			add_action(
-				'init',
-				static function () use ( $ads_conversion_id ) {
-					$gtg_adapter = Adapter::create();
-					$gtg_adapter->initialize();
-					$gtg_adapter->update(
+		$this->gtag_adapter = Adapter::create();
+
+		// Initialize GTG Adapter if enabled and this is a front end request.
+		if ( $this->wp->is_front_end_request() && $this->is_gtg_enabled() ) {
+			$this->gtag_adapter->initialize();
+		}
+
+		$gtag_option_name = $this->get_slug() . '_' . OptionsInterface::ADS_GTG_ENABLED;
+		add_action(
+			'update_option_' . $gtag_option_name,
+			function ( $old_value, $value ) use ( $ads_conversion_id ) {
+				if ( $value ) {
+					$this->gtag_adapter->update(
 						[
-							'tagId'           => $ads_conversion_id,
-							'measurementPath' => '/wc/google/metrics/',
+							'tagId' => $ads_conversion_id,
 						]
 					);
-				},
-				9
-			);
-		}
+				}
+				// @todo: Remove rewrites when GTG is disabled.
+			},
+			10,
+			3
+		);
 
 		add_action(
 			'wp_head',

--- a/src/Proxies/WP.php
+++ b/src/Proxies/WP.php
@@ -385,4 +385,13 @@ class WP {
 	public function delete_option( ...$arguments ) {
 		return delete_option( ...$arguments );
 	}
+
+	/**
+	 * Determines whether the current request is a front-end request.
+	 *
+	 * @return bool True if it's a front-end request, false otherwise.
+	 */
+	public function is_front_end_request(): bool {
+		return ! is_admin() && ! $this->wp_is_serving_rest_request() && ! $this->wp_doing_ajax();
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-317.

This updates the implementation so that it only runs Adapter::update() when the GTG feature is enabled, but calling it on the update_option callback. This also fixes a bug that kept the rewrite rules from being written because the save_mod_rewrite_rules function was not loaded at the time this process ran.

