### PR TITLE
Fix enhanced conversion data not sent when google analytics is also active

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -237,10 +237,14 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	public function activate_global_site_tag( string $ads_conversion_id ) {
 		if ( $this->gtag_js->is_adding_framework() ) {
 			if ( $this->gtag_js->ga4w_v2 ) {
+				$inline_script  = $this->get_gtag_config( $ads_conversion_id );
+				$inline_script .= "\n" . $this->get_enhanced_conversion_tag();
+
 				$this->wp->wp_add_inline_script(
 					'woocommerce-google-analytics-integration',
-					$this->get_gtag_config( $ads_conversion_id )
+					$inline_script
 				);
+
 			} else {
 				// Legacy code to support Google Analytics for WooCommerce version < 2.0.0.
 				add_filter(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes [GOOWOO-343](https://linear.app/a8c/issue/GOOWOO-343/enhanced-conversion-data-not-sent-when-google-analytics-is-also-active)

### Detailed Test Instructions
1. Install and configure the [Google Analytics for WooCommerce](https://wordpress.org/plugins/woocommerce-google-analytics-integration/) plugin
2. Enable Enhanced Conversions in the G4W plugin
- Go to: `Marketing > Google for WooCommerce > Settings`
- Enable the option: `Send Enhanced Conversions data to Google Ads`

3. Visit the frontend and trigger an event
- Navigate through the storefront (e.g., add a product to cart or initiate checkout) to ensure Enhanced Conversions data is being sent.

4. Verify the Enhanced Conversions output

- Inspect the frontend (browser DevTools → Console) and confirm that the `gtag("set", "user_data", ...)` payload is generated.

   Example EC data for reference:

   ```js
   gtag("set", "user_data", {
       "sha256_email_address":"be3221a6fac131657111728b4d912a877ec158b123d5db3afef3bd8a59784ece",
       "address":{
           "sha256_first_name":"959a45d44e6fcf58361ed004681556fe50129f2109e817dec098c00c9e5d2578",
           "sha256_last_name":"198dea392afc21d070f8abfc7c06d11060f1b278e5d62501bd57f1159a72ebac",
           "postal_code":"380061",
           "country":"IN",
           "street":"4 dev vved",
           "city":"Ahmedabad",
           "region":"GJ"
       }
   });
   ```


### Changelog entry

> Fix - Setup enhanced conversion data when gtag is added by the Google Analytics extension.
