### PR TITLE
Encode the site URL when calling the Google SDI proxy to support a URL with paths

### DIFF
--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -516,9 +516,17 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 	 * @return string
 	 */
 	protected function get_sdi_endpoint(): string {
+		/**
+		 * Reason for using `urlencode` to encode the site URL:
+		 *
+		 * This plugin doesn't natively support linking a Google Merchant
+		 * Center account and the Google Shopping Data Integration API using a
+		 * merchant URL with paths. However, some merchants still use the
+		 * plugin's WP filter `woocommerce_gla_site_url` to achieve this.
+		*/
 		return $this->container->get( 'connect_server_root' )
 			. 'google/google-sdi/v1/credentials/partners/WOO_COMMERCE/merchants/'
-			. $this->strip_url_protocol( $this->get_site_url() )
+			. urlencode( $this->strip_url_protocol( $this->get_site_url() ) )
 			. '/';
 	}
 

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -523,6 +523,13 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 		 * Center account and the Google Shopping Data Integration API using a
 		 * merchant URL with paths. However, some merchants still use the
 		 * plugin's WP filter `woocommerce_gla_site_url` to achieve this.
+		 *
+		 * However, a site URL containing paths will cause API routing errors
+		 * if it's not encoded, due to the unexpected appearance of `/`.
+		 * For example, when the URL is 'wp.test/ja/shop',
+		 * `[...]/merchants/wp.test/ja/shop/account:connect` will cause an API error.
+		 * The encoded `[...]/merchants/wp.test%2Fja%2Fshop/account:connect` will
+		 * point to the correct route.
 		*/
 		return $this->container->get( 'connect_server_root' )
 			. 'google/google-sdi/v1/credentials/partners/WOO_COMMERCE/merchants/'

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -517,7 +517,7 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 	 */
 	protected function get_sdi_endpoint(): string {
 		/**
-		 * Reason for using `urlencode` to encode the site URL:
+		 * Reason for using `rawurlencode` to encode the site URL:
 		 *
 		 * This plugin doesn't natively support linking a Google Merchant
 		 * Center account and the Google Shopping Data Integration API using a
@@ -526,7 +526,7 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 		*/
 		return $this->container->get( 'connect_server_root' )
 			. 'google/google-sdi/v1/credentials/partners/WOO_COMMERCE/merchants/'
-			. urlencode( $this->strip_url_protocol( $this->get_site_url() ) )
+			. rawurlencode( $this->strip_url_protocol( $this->get_site_url() ) )
 			. '/';
 	}
 

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -425,9 +425,12 @@ class MiddlewareTest extends UnitTest {
 	}
 
 	public function test_get_sdi_merchant_update_endpoint_with_site_url_having_path() {
-		add_filter( 'woocommerce_gla_site_url', function ( $home_url ) {
-			return 'http://example.org/shop';
-		} );
+		add_filter(
+			'woocommerce_gla_site_url',
+			function ( $home_url ) {
+				return 'http://example.org/shop';
+			}
+		);
 
 		$this->assertEquals(
 			$this->middleware->get_sdi_merchant_update_endpoint(),

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -417,6 +417,24 @@ class MiddlewareTest extends UnitTest {
 		$this->assertEquals( 'Please reconnect your Jetpack account.', $tos->message() );
 	}
 
+	public function test_get_sdi_merchant_update_endpoint() {
+		$this->assertEquals(
+			$this->middleware->get_sdi_merchant_update_endpoint(),
+			'https://connect-server.test/google/google-sdi/v1/credentials/partners/WOO_COMMERCE/merchants/example.org/account:connect'
+		);
+	}
+
+	public function test_get_sdi_merchant_update_endpoint_with_site_url_having_path() {
+		add_filter( 'woocommerce_gla_site_url', function ( $home_url ) {
+			return 'http://example.org/shop';
+		} );
+
+		$this->assertEquals(
+			$this->middleware->get_sdi_merchant_update_endpoint(),
+			'https://connect-server.test/google/google-sdi/v1/credentials/partners/WOO_COMMERCE/merchants/example.org%2Fshop/account:connect'
+		);
+	}
+
 	public function test_get_sdi_auth_endpoint() {
 		$this->assertEquals(
 			$this->middleware->get_sdi_auth_endpoint(),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes GOOWOO-295

📌 Please review this PR along with https://github.com/Automattic/woocommerce-connect-server/pull/3029

Some merchants want to use a URL with path(s) as their store homepage by using a custom code snippet. However, when calling the Google SDI proxy during the onboarding flow, the URL was not encoded, resulting in a 404 error that prevented completing the onboarding.

This PR encodes the site URL when calling the Google SDI proxy to support a URL with paths.

### Detailed test instructions:

1. Checkout [Automattic/woocommerce-connect-server#3029](https://github.com/Automattic/woocommerce-connect-server/pull/3029) and set up the environment according to that PR
2. Add a code snippet to the plugin side to use a site URL with path(s):
   ```php
   add_filter( 'woocommerce_gla_site_url', function ( $home_url ) {
   	return wc_get_page_permalink( 'shop' );
   
   	// Or return the string directly and explicitly if the above
   	// cannot return the expected store URL.
   	//
   	// return 'https://your.publicly.accessible.site/shop/';
   } );
   ```
3. Make the test site publicly accessible
4. Go to Step 1 of the onboarding flow
5. Test if the following Not Found error won't happen when connecting to a Google Merchant Center account
   <img width="1201" height="391" alt="image" src="https://github.com/user-attachments/assets/c96f8a0a-cb27-4f12-98a7-6d219f2a627b" />

### Additional details:

- Calling that Google SDI API endpoint is an initialization part of the API Pull mode.
- Another similar Google SDI endpoint generation method was not applied `urlencode`  because it is no longer used, but has not yet been removed from the codebase.
   https://github.com/woocommerce/google-listings-and-ads/blob/2be77072afbbbef47d6de658f8791733016c88ac/src/API/Google/Middleware.php#L496-L502

### Changelog entry

> Tweak - Make it possible to complete the onboarding flow using a site URL with paths.
