### PR TITLE
Change the `woocommerce-grow-jsdoc` dependency to install directly from the woocommerce-grow on GitHub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
 				"react": "^18",
 				"react-dom": "^18",
 				"typescript": "^5.5.4",
-				"woocommerce-grow-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?eabdb5c3e6f089499a9bc62ec2e5e2251d7b23ca"
+				"woocommerce-grow-jsdoc": "git+https://github.com/woocommerce/grow#jsdoc-v1"
 			},
 			"engines": {
 				"node": "^20",
@@ -33611,9 +33611,8 @@
 			"license": "MIT"
 		},
 		"node_modules/woocommerce-grow-jsdoc": {
-			"version": "0.0.2",
-			"resolved": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?eabdb5c3e6f089499a9bc62ec2e5e2251d7b23ca",
-			"integrity": "sha512-r8yvGjSD7DSEfg6OsuEFnjIcsR8kZ8NRWclNAbTssgnSoZzwRU0hzGnGTHHa3wfrK5M8KjPtZvmZfofQbCQPqw==",
+			"version": "1.0.0",
+			"resolved": "git+ssh://git@github.com/woocommerce/grow.git#d1822ab1ad130d28d096845798200782e3a8f59d",
 			"dev": true,
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
@@ -33622,18 +33621,23 @@
 				"jsdoc-plugin-intersection": "^1.0.4",
 				"jsdoc-plugin-typescript": "^2.2.1",
 				"shelljs": "^0.8.5",
-				"woocommerce-grow-tracking-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?a22d3df5e1b121ab186c57fa4fb9bbc989c86fba"
+				"woocommerce-grow-tracking-jsdoc": "git+https://github.com/woocommerce/grow#tracking-jsdoc-v1"
 			},
 			"bin": {
 				"woocommerce-grow-jsdoc": "bin/jsdoc.mjs"
+			},
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/woocommerce-grow-tracking-jsdoc": {
-			"version": "0.0.2",
-			"resolved": "https://gitpkg.now.sh/woocommerce/grow/packages/js/tracking-jsdoc?a22d3df5e1b121ab186c57fa4fb9bbc989c86fba",
-			"integrity": "sha512-RMZecq3RbgutjnmAbrO0dLBQ/MX3i/kQXyHGeYITocOIDZIabUX6mvEEK2uHu2frtvAVn154u3upEMk7X8JZnw==",
+			"version": "1.0.0",
+			"resolved": "git+ssh://git@github.com/woocommerce/grow.git#ac115c64c5427ae6b2a9d9ccd0498e82a1864a8e",
 			"dev": true,
 			"license": "GPL-3.0-or-later",
+			"engines": {
+				"node": ">=16"
+			},
 			"peerDependencies": {
 				"jsdoc": "^4.0.2"
 			}

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"react": "^18",
 		"react-dom": "^18",
 		"typescript": "^5.5.4",
-		"woocommerce-grow-jsdoc": "https://gitpkg.now.sh/woocommerce/grow/packages/js/jsdoc?eabdb5c3e6f089499a9bc62ec2e5e2251d7b23ca"
+		"woocommerce-grow-jsdoc": "git+https://github.com/woocommerce/grow#jsdoc-v1"
 	},
 	"overrides": {
 		"@woocommerce/eslint-plugin": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The installation of `woocommerce-grow-jsdoc` failed due to gitpkg.now.sh being unavailable. Therefore, this PR changes the installation source to the release from woocommerce-grow on GitHub.

### Detailed test instructions:

1. Run `npm install` to see if the installation can succeed.
2. Run `npm run doc:tracking` to see if it can generate tracking documents to the src/Tracking/README.md file.

### Changelog entry
