### PR TITLE
Fix: GTG tag not loading post onboarding

### DIFF
--- a/src/Options/AdsSetupCompleted.php
+++ b/src/Options/AdsSetupCompleted.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Google\GoogleTagGatewayLibrary\Wordpress\Adapter;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -50,6 +51,16 @@ class AdsSetupCompleted implements OptionsAwareInterface, Registerable, Service 
 
 		if ( null === $is_gtg_configured ) {
 			$this->options->update( OptionsInterface::ADS_GTG_ENABLED, true );
+			$conversion_action = $this->options->get( OptionsInterface::ADS_CONVERSION_ACTION );
+
+			if ( $conversion_action && isset( $conversion_action['conversion_id'] ) ) {
+				$gtag_adapter = Adapter::create();
+				$gtag_adapter->update(
+					[
+						'tagId' => $conversion_action['conversion_id'],
+					]
+				);
+			}
 		}
 
 		$tours = $this->options->get( OptionsInterface::TOURS, [] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes: https://linear.app/a8c/issue/GOOWOO-358/bug-bash-gtg-checkbox-enabled-by-default-but-tags-not-loaded-in

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:

Repeat the steps given in linear issue, the tag should load post onborading without the need to toggle checkbox.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
