### PR TITLE
Bump bundlewatch limit for index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
 			},
 			{
 				"path": "./js/build/index.js",
-				"maxSize": "18.69 kB"
+				"maxSize": "18.7 kB"
 			},
 			{
 				"path": "./js/build/commons.js",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes N/A .

Bumps the bundlewatch limit for `./js/build/index.js`. See: #3125 ([Failed job](https://github.com/woocommerce/google-listings-and-ads/actions/runs/20007315629/job/57371969401)).


### Screenshots:

Previous run failed due to a 3B change.

<img width="837" height="51" alt="image" src="https://github.com/user-attachments/assets/72b6d655-f0ee-4557-b853-344b787b0124" />

After the PR:

<img width="839" height="53" alt="image" src="https://github.com/user-attachments/assets/30366d99-a8b2-46ee-80fc-1a4f96aaae2a" />


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
