### PR TITLE
Remove problematic duplicate conversion event

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -122,7 +122,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		add_action(
 			'woocommerce_before_thankyou',
 			function ( $order_id ) use ( $ads_conversion_id, $ads_conversion_label ) {
-				$this->maybe_display_purchase_event_snippets( $ads_conversion_id, $ads_conversion_label, $order_id );
+				$this->maybe_display_purchase_event_snippet( $ads_conversion_id, $ads_conversion_label, $order_id );
 			},
 		);
 
@@ -355,7 +355,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	 * @param string $ads_conversion_label Google Ads conversion label.
 	 * @param int    $order_id The order id.
 	 */
-	public function maybe_display_purchase_event_snippets( string $ads_conversion_id, string $ads_conversion_label, int $order_id ): void {
+	public function maybe_display_purchase_event_snippet( string $ads_conversion_id, string $ads_conversion_label, int $order_id ): void {
 		// Only display on the order confirmation page.
 		if ( ! is_order_received_page() ) {
 			return;

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -122,7 +122,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		add_action(
 			'woocommerce_before_thankyou',
 			function ( $order_id ) use ( $ads_conversion_id, $ads_conversion_label ) {
-				$this->maybe_display_conversion_and_purchase_event_snippets( $ads_conversion_id, $ads_conversion_label, $order_id );
+				$this->maybe_display_purchase_event_snippets( $ads_conversion_id, $ads_conversion_label, $order_id );
 			},
 		);
 
@@ -349,13 +349,13 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	}
 
 	/**
-	 * Display the JavaScript code to track conversions on the order confirmation page.
+	 * Display the JavaScript code to track purchase on the order confirmation page.
 	 *
 	 * @param string $ads_conversion_id Google Ads account conversion ID.
 	 * @param string $ads_conversion_label Google Ads conversion label.
 	 * @param int    $order_id The order id.
 	 */
-	public function maybe_display_conversion_and_purchase_event_snippets( string $ads_conversion_id, string $ads_conversion_label, int $order_id ): void {
+	public function maybe_display_purchase_event_snippets( string $ads_conversion_id, string $ads_conversion_label, int $order_id ): void {
 		// Only display on the order confirmation page.
 		if ( ! is_order_received_page() ) {
 			return;
@@ -370,20 +370,6 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		// Mark the order as tracked, to avoid double-reporting if the confirmation page is reloaded.
 		$order->update_meta_data( self::ORDER_CONVERSION_META_KEY, 1 );
 		$order->save_meta_data();
-
-		$conversion_gtag_info =
-		sprintf(
-			'gtag("event", "conversion", {
-			send_to: "%s",
-			value: %f,
-			currency: "%s",
-			transaction_id: "%s"});',
-			esc_js( "{$ads_conversion_id}/{$ads_conversion_label}" ),
-			$order->get_total(),
-			esc_js( $order->get_currency() ),
-			esc_js( $order->get_id() ),
-		);
-		$this->add_inline_event_script( $conversion_gtag_info );
 
 		// Get the item info in the order
 		$item_info = [];

--- a/tests/Unit/Google/GlobalSiteTagTest.php
+++ b/tests/Unit/Google/GlobalSiteTagTest.php
@@ -68,14 +68,14 @@ class GlobalSiteTagTest extends UnitTest {
 		add_filter( 'woocommerce_is_order_received_page', '__return_false' );
 		$this->wp->expects( $this->never() )->method( 'wp_print_inline_script_tag' );
 
-		$this->tag->maybe_display_purchase_event_snippets( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, 0 );
+		$this->tag->maybe_display_purchase_event_snippet( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, 0 );
 	}
 
 	public function test_purchase_event_no_order() {
 		add_filter( 'woocommerce_is_order_received_page', '__return_true' );
 		$this->wp->expects( $this->never() )->method( 'wp_print_inline_script_tag' );
 
-		$this->tag->maybe_display_purchase_event_snippets( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, 0 );
+		$this->tag->maybe_display_purchase_event_snippet( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, 0 );
 	}
 
 	public function test_purchase_event_already_tracked() {
@@ -87,7 +87,7 @@ class GlobalSiteTagTest extends UnitTest {
 
 		$this->wp->expects( $this->never() )->method( 'wp_print_inline_script_tag' );
 
-		$this->tag->maybe_display_purchase_event_snippets( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, $order->get_id() );
+		$this->tag->maybe_display_purchase_event_snippet( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, $order->get_id() );
 	}
 
 	public function test_purchase_event() {
@@ -106,7 +106,7 @@ class GlobalSiteTagTest extends UnitTest {
 				}
 			);
 
-		$this->tag->maybe_display_purchase_event_snippets( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, $order->get_id() );
+		$this->tag->maybe_display_purchase_event_snippet( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, $order->get_id() );
 
 		// Reload order and confirm tracked meta is set.
 		$order = wc_get_order( $order->get_id() );

--- a/tests/Unit/Google/GlobalSiteTagTest.php
+++ b/tests/Unit/Google/GlobalSiteTagTest.php
@@ -64,21 +64,21 @@ class GlobalSiteTagTest extends UnitTest {
 		$this->tag->set_options_object( $this->options );
 	}
 
-	public function test_conversion_and_purchase_event_not_order_received_page() {
+	public function test_purchase_event_not_order_received_page() {
 		add_filter( 'woocommerce_is_order_received_page', '__return_false' );
 		$this->wp->expects( $this->never() )->method( 'wp_print_inline_script_tag' );
 
-		$this->tag->maybe_display_conversion_and_purchase_event_snippets( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, 0 );
+		$this->tag->maybe_display_purchase_event_snippets( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, 0 );
 	}
 
-	public function test_conversion_and_purchase_event_no_order() {
+	public function test_purchase_event_no_order() {
 		add_filter( 'woocommerce_is_order_received_page', '__return_true' );
 		$this->wp->expects( $this->never() )->method( 'wp_print_inline_script_tag' );
 
-		$this->tag->maybe_display_conversion_and_purchase_event_snippets( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, 0 );
+		$this->tag->maybe_display_purchase_event_snippets( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, 0 );
 	}
 
-	public function test_conversion_and_purchase_event_already_tracked() {
+	public function test_purchase_event_already_tracked() {
 		add_filter( 'woocommerce_is_order_received_page', '__return_true' );
 
 		$order = WC_Helper_Order::create_order();
@@ -87,30 +87,26 @@ class GlobalSiteTagTest extends UnitTest {
 
 		$this->wp->expects( $this->never() )->method( 'wp_print_inline_script_tag' );
 
-		$this->tag->maybe_display_conversion_and_purchase_event_snippets( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, $order->get_id() );
+		$this->tag->maybe_display_purchase_event_snippets( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, $order->get_id() );
 	}
 
-	public function test_conversion_and_purchase_event() {
+	public function test_purchase_event() {
 		add_filter( 'woocommerce_is_order_received_page', '__return_true' );
 
 		$order = WC_Helper_Order::create_order();
 
-		$invoked_count = $this->exactly( 2 );
+		$invoked_count = $this->exactly( 1 );
 		$this->wp->expects( $invoked_count )
 			->method( 'wp_print_inline_script_tag' )
 			->willReturnCallback(
 				function ( string $script ) use ( $invoked_count ) {
 					if ( 1 === $invoked_count->getInvocationCount() ) {
-						$this->assertStringStartsWith( 'gtag("event", "conversion"', $script );
-					}
-
-					if ( 2 === $invoked_count->getInvocationCount() ) {
 						$this->assertStringStartsWith( 'gtag("event", "purchase"', $script );
 					}
 				}
 			);
 
-		$this->tag->maybe_display_conversion_and_purchase_event_snippets( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, $order->get_id() );
+		$this->tag->maybe_display_purchase_event_snippets( self::TEST_CONVERSION_ID, self::TEST_CONVERSION_LABEL, $order->get_id() );
 
 		// Reload order and confirm tracked meta is set.
 		$order = wc_get_order( $order->get_id() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-348/identical-purchase-and-conversion-events-may-be-problematic-according

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Add a product to the cart and place an order. On the order confirmation page, ensure that the `conversion` event does not run.

**Note for testing:** Since the events on the order confirmation page fire only once, comment out the following lines so the event loads every time: https://github.com/woocommerce/google-listings-and-ads/blob/fix/GOOWOO-348-remove-problematic-conversion-event/src/Google/GlobalSiteTag.php#L366-L368

### Before:
```JS
<script>
gtag("event", "conversion", {
			send_to: "AW-16939825035/MsMwCLCN5M0bEIvvxI0_",
			value: 30.000000,
			currency: "USD",
			transaction_id: "135"});
</script>
<script>
gtag("event", "purchase", {
			ecomm_pagetype: "purchase",
			send_to: "AW-16939825035/MsMwCLCN5M0bEIvvxI0_",
			transaction_id: "135",
			currency: "USD",
			country: "US",
			value: 30.000000,
			new_customer: true,
			tax: 0.000000,
			shipping: 0.000000,
			delivery_postal_code: "12345",
			aw_feed_country: "US",
			aw_feed_language: "English",
			items: [{
				id: "gla_100",
				price: 15.000000,
				google_business_vertical: "retail",
				name: "Album",
				quantity: 2,
				}]});
</script>
```

### After:
```JS
<script>
gtag("event", "purchase", {
			ecomm_pagetype: "purchase",
			send_to: "AW-16939825035/MsMwCLCN5M0bEIvvxI0_",
			transaction_id: "135",
			currency: "USD",
			country: "US",
			value: 30.000000,
			new_customer: true,
			tax: 0.000000,
			shipping: 0.000000,
			delivery_postal_code: "12345",
			aw_feed_country: "US",
			aw_feed_language: "English",
			items: [{
				id: "gla_100",
				price: 15.000000,
				google_business_vertical: "retail",
				name: "Album",
				quantity: 2,
				}]});
</script>
```

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Remove problematic duplicate conversion event
