### PR TITLE
Remove hard coded simulate arg from the deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
           version: ${{ github.event.inputs.version }}
           node_version: '20'
           npm_version: '10'
-          simulate: true # Hard coding until after we've verified everything is working as expected.
+          simulate: ${{ github.event.inputs.simulate }}
           github_release: ${{ github.event.inputs.deploy_github }}
           wporg_release: ${{ github.event.inputs.deploy_wporg }}
           wporg_username: ${{ secrets.WPORG_USERNAME }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-368.

This is a follow up to #3165 to remove the hard coded `simulate` arg used during testing.

See passing simulated deploy action: https://github.com/woocommerce/google-listings-and-ads/actions/runs/20040420463