### PR TITLE
Change the `actions/checkout` in the deploy workflow of GitHub Actions to use the major version tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       # Checkout the private action repository
       - name: Checkout woo-product-deploy action
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v4
         with:
           repository: woocommerce/woo-product-deploy
           ref: trunk


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the `actions/checkout` in the deploy workflow of GitHub Actions to use the major version tag. Using a major version number instead of a specific revision allows for continuous updates and fixes, and it's also a recommended practice.

### Detailed test instructions:

This change can only be tested after merging it to the default branch.

### Changelog entry
