### PR TITLE
Add ConnectedGoogleAdsOnlyAccountCard component

### DIFF
--- a/js/src/components/google-combo-account-card/connected-google-ads-only-account-card.js
+++ b/js/src/components/google-combo-account-card/connected-google-ads-only-account-card.js
@@ -1,0 +1,167 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useAppDispatch } from '~/data';
+import { SwitchAccountButton } from '~/components/google-account-card';
+import AccountCard, { APPEARANCE } from '~/components/account-card';
+import ConnectAds from './connect-ads';
+import AccountDetails from './account-details';
+import ConnectedAdsAccountDetail from './connected-ads-account-detail';
+import Indicator from './indicator';
+import getAccountCreationTexts from './getAccountCreationTexts';
+import SpinnerCard from '~/components/spinner-card';
+import useAutoCreateAdsAccount from '~/hooks/useAutoCreateAdsAccount';
+import useExistingGoogleAdsAccounts from '~/hooks/useExistingGoogleAdsAccounts';
+import AppButton from '~/components/app-button';
+import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useUpsertAdsAccount from '~/hooks/useUpsertAdsAccount';
+import showAdsConversionNotice from '~/utils/showAdsConversionNotice';
+import './connected-google-combo-account-card.scss';
+
+/**
+ * Renders a Google account card UI with connected account information.
+ * It will also kickoff Ads account creation if the user does not have an Ads account.
+ */
+const ConnectedGoogleAdsOnlyAccountCard = () => {
+	const [ editMode, setEditMode ] = useState( false );
+	const { hasDetermined, creatingWhich } = useAutoCreateAdsAccount();
+	const { text, subText } = getAccountCreationTexts( creatingWhich );
+	const { existingAccounts: existingGoogleAdsAccounts } =
+		useExistingGoogleAdsAccounts();
+	const { invalidateResolution } = useAppDispatch();
+	const { googleAdsAccount, hasGoogleAdsConnection } = useGoogleAdsAccount();
+	const { hasAccess, step } = useGoogleAdsAccountStatus();
+	const [ upsertAdsAccount, { action, loading } ] = useUpsertAdsAccount();
+
+	const hasExistingGoogleAdsAccounts = existingGoogleAdsAccounts?.length > 0;
+	const shouldClaimGoogleAdsAccount = Boolean(
+		! loading && googleAdsAccount?.id && hasAccess === false
+	);
+	const finalizeAdsAccountCreation =
+		hasAccess === true && step === 'conversion_action';
+
+	useEffect( () => {
+		const upsertAccount = async () => {
+			if ( finalizeAdsAccountCreation ) {
+				await upsertAdsAccount();
+				invalidateResolution( 'getExistingGoogleAdsAccounts', [] );
+			}
+		};
+
+		upsertAccount();
+	}, [ finalizeAdsAccountCreation, upsertAdsAccount, invalidateResolution ] );
+
+	const handleCancelClick = () => {
+		setEditMode( false );
+	};
+
+	const handleEditClick = () => {
+		setEditMode( true );
+	};
+
+	// After creating a new account, it may not show up in the existing accounts list
+	// immediately. In this case, we show the ConnectAds component in edit mode unless
+	// we're showing the claim notice in the upper card.
+	const canShowConnectAds =
+		hasGoogleAdsConnection || hasExistingGoogleAdsAccounts;
+	const showConnectAds =
+		canShowConnectAds && ( editMode || ! hasGoogleAdsConnection );
+
+	// When Ads account is disconnected in edit mode, exit edit mode.
+	useEffect( () => {
+		if ( editMode && ! hasGoogleAdsConnection ) {
+			setEditMode( false );
+		}
+	}, [ editMode, hasGoogleAdsConnection ] );
+
+	if ( ! hasDetermined ) {
+		return <SpinnerCard />;
+	}
+
+	const switchAccountButton = (
+		<SwitchAccountButton
+			isTertiary
+			text={ __(
+				'Or, connect to a different Google account',
+				'google-listings-and-ads'
+			) }
+		/>
+	);
+
+	const getCardActions = () => {
+		if ( editMode ) {
+			return (
+				<div className="gla-google-combo-account-card__description-actions">
+					{ switchAccountButton }
+					<AppButton isTertiary onClick={ handleCancelClick }>
+						{ __( 'Cancel', 'google-listings-and-ads' ) }
+					</AppButton>
+				</div>
+			);
+		}
+
+		// When not in edit mode, only show the edit button if clicking the
+		// button would change the visibility of the ConnectAds card.
+		return (
+			<div className="gla-google-combo-account-card__description-actions">
+				{ showConnectAds || ! canShowConnectAds ? (
+					switchAccountButton
+				) : (
+					<AppButton
+						isTertiary
+						text={ __( 'Edit', 'google-listings-and-ads' ) }
+						onClick={ handleEditClick }
+					/>
+				) }
+			</div>
+		);
+	};
+
+	// Show the spinner if there's an account creation in progress and account should not be claimed.
+	// If account is being claimed, then show the spinner in the Google combo card.
+	const showSpinner =
+		( Boolean( creatingWhich ) && ! shouldClaimGoogleAdsAccount ) ||
+		( ! showConnectAds && finalizeAdsAccountCreation );
+
+	const showConversionMeasurementNotice =
+		showAdsConversionNotice( googleAdsAccount );
+
+	return (
+		<div className="gla-google-combo-account-card-wrapper">
+			<AccountCard
+				appearance={ APPEARANCE.GOOGLE }
+				alignIcon="top"
+				className="gla-google-combo-account-card gla-google-combo-account-card--connected gla-google-combo-service-account-card--google"
+				description={ text || <AccountDetails /> }
+				actions={ getCardActions() }
+				helper={ subText }
+				indicator={ <Indicator showSpinner={ showSpinner } /> }
+				detail={
+					<ConnectedAdsAccountDetail
+						showConversionMeasurementNotice={
+							showConversionMeasurementNotice
+						}
+						claimGoogleAdsAccount={ shouldClaimGoogleAdsAccount }
+					/>
+				}
+				expandedDetail
+			/>
+
+			{ showConnectAds && (
+				<ConnectAds
+					onRequestCreate={ upsertAdsAccount }
+					upsertingAction={ action }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default ConnectedGoogleAdsOnlyAccountCard;

--- a/js/src/components/google-combo-account-card/connected-google-ads-only-account-card/index.js
+++ b/js/src/components/google-combo-account-card/connected-google-ads-only-account-card/index.js
@@ -10,11 +10,11 @@ import { useState, useEffect } from '@wordpress/element';
 import { useAppDispatch } from '~/data';
 import { SwitchAccountButton } from '~/components/google-account-card';
 import AccountCard, { APPEARANCE } from '~/components/account-card';
-import ConnectAds from './connect-ads';
-import AccountDetails from './account-details';
-import ConnectedAdsAccountDetail from './connected-ads-account-detail';
+import ConnectAds from '../connect-ads';
+import AccountDetails from '../account-details';
+import ConnectedAdsAccountDetail from '../connected-ads-account-detail';
 import Indicator from './indicator';
-import getAccountCreationTexts from './getAccountCreationTexts';
+import getAccountCreationTexts from '../getAccountCreationTexts';
 import SpinnerCard from '~/components/spinner-card';
 import useAutoCreateAdsAccount from '~/hooks/useAutoCreateAdsAccount';
 import useExistingGoogleAdsAccounts from '~/hooks/useExistingGoogleAdsAccounts';
@@ -23,7 +23,7 @@ import useGoogleAdsAccountStatus from '~/hooks/useGoogleAdsAccountStatus';
 import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
 import useUpsertAdsAccount from '~/hooks/useUpsertAdsAccount';
 import showAdsConversionNotice from '~/utils/showAdsConversionNotice';
-import './connected-google-combo-account-card.scss';
+import './index.scss';
 
 /**
  * Renders a Google account card UI with connected account information.
@@ -98,7 +98,7 @@ const ConnectedGoogleAdsOnlyAccountCard = () => {
 	const getCardActions = () => {
 		if ( editMode ) {
 			return (
-				<div className="gla-google-combo-account-card__description-actions">
+				<div className="gla-connected-google-ads-only-account-card__description-actions">
 					{ switchAccountButton }
 					<AppButton isTertiary onClick={ handleCancelClick }>
 						{ __( 'Cancel', 'google-listings-and-ads' ) }
@@ -110,7 +110,7 @@ const ConnectedGoogleAdsOnlyAccountCard = () => {
 		// When not in edit mode, only show the edit button if clicking the
 		// button would change the visibility of the ConnectAds card.
 		return (
-			<div className="gla-google-combo-account-card__description-actions">
+			<div className="gla-connected-google-ads-only-account-card__description-actions">
 				{ showConnectAds || ! canShowConnectAds ? (
 					switchAccountButton
 				) : (
@@ -134,11 +134,11 @@ const ConnectedGoogleAdsOnlyAccountCard = () => {
 		showAdsConversionNotice( googleAdsAccount );
 
 	return (
-		<div className="gla-google-combo-account-card-wrapper">
+		<div className="gla-connected-google-ads-only-account-card-wrapper">
 			<AccountCard
 				appearance={ APPEARANCE.GOOGLE }
 				alignIcon="top"
-				className="gla-google-combo-account-card gla-google-combo-account-card--connected gla-google-combo-service-account-card--google"
+				className="gla-connected-google-ads-only-account-card gla-connected-google-ads-only-account-card--connected gla-connected-google-ads-only-account-card--google"
 				description={ text || <AccountDetails /> }
 				actions={ getCardActions() }
 				helper={ subText }

--- a/js/src/components/google-combo-account-card/connected-google-ads-only-account-card/index.scss
+++ b/js/src/components/google-combo-account-card/connected-google-ads-only-account-card/index.scss
@@ -1,0 +1,26 @@
+.gla-connected-google-ads-only-account-card-wrapper {
+
+	.components-card {
+		&:not(:last-child) {
+			border-bottom-left-radius: 0;
+			border-bottom-right-radius: 0;
+		}
+
+		&:not(:first-child) {
+			border-top-left-radius: 0;
+			border-top-right-radius: 0;
+		}
+	}
+}
+
+.gla-connected-google-ads-only-account-card--connected {
+
+	.gla-account-card__description {
+		gap: 0;
+	}
+
+	.gla-connected-google-ads-only-account-card__description-actions {
+		display: flex;
+		gap: var(--large-gap);
+	}
+}

--- a/js/src/components/google-combo-account-card/connected-google-ads-only-account-card/indicator.js
+++ b/js/src/components/google-combo-account-card/connected-google-ads-only-account-card/indicator.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import ConnectedIconLabel from '~/components/connected-icon-label';
+import LoadingLabel from '~/components/loading-label';
+import useGoogleAdsAccountReady from '~/hooks/useGoogleAdsAccountReady';
+
+/**
+ * Account creation indicator.
+ * Displays a loading indicator when an account is being created or a connected icon when an Ads account is connected.
+ * @param {Object} props Component props.
+ * @param {boolean} props.showSpinner Whether to display a spinner.
+ * @return {JSX.Element|null} Indicator component.
+ */
+const Indicator = ( { showSpinner } ) => {
+	const { isGoogleAdsReady } = useGoogleAdsAccountReady();
+
+	if ( showSpinner ) {
+		return (
+			<LoadingLabel
+				text={ __( 'Creating…', 'google-listings-and-ads' ) }
+			/>
+		);
+	}
+
+	if ( isGoogleAdsReady ) {
+		return <ConnectedIconLabel />;
+	}
+
+	return null;
+};
+
+export default Indicator;

--- a/js/src/components/google-combo-account-card/index.js
+++ b/js/src/components/google-combo-account-card/index.js
@@ -7,6 +7,8 @@ import AccountCard from '~/components/account-card';
 import { RequestFullAccessGoogleAccountCard } from '~/components/google-account-card';
 import ConnectGoogleComboAccountCard from './connect-google-combo-account-card';
 import ConnectedGoogleComboAccountCard from './connected-google-combo-account-card';
+import ConnectedGoogleAdsOnlyAccountCard from './connected-google-ads-only-account-card';
+import useServiceBasedMerchant from '~/hooks/useServiceBasedMerchant';
 import './index.scss';
 
 /**
@@ -19,6 +21,7 @@ import './index.scss';
  */
 export default function GoogleComboAccountCard( { disabled = false } ) {
 	const { google, scope, hasFinishedResolution } = useGoogleAccount();
+	const serviceBasedMerchant = useServiceBasedMerchant();
 
 	if ( ! hasFinishedResolution ) {
 		return <AccountCard description={ <AppSpinner /> } />;
@@ -27,6 +30,10 @@ export default function GoogleComboAccountCard( { disabled = false } ) {
 	const isConnected = google?.active === 'yes';
 
 	if ( isConnected && scope.onboardingRequired ) {
+		if ( serviceBasedMerchant ) {
+			return <ConnectedGoogleAdsOnlyAccountCard />;
+		}
+
 		return <ConnectedGoogleComboAccountCard />;
 	}
 

--- a/js/src/hooks/useAutoCreateAdsAccount.js
+++ b/js/src/hooks/useAutoCreateAdsAccount.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useUpsertAdsAccount from '~/hooks/useUpsertAdsAccount';
+import useShouldCreateAdsAccount from './useShouldCreateAdsAccount';
+import { CREATING_ADS_ACCOUNT } from '~/components/google-combo-account-card/constants';
+
+/**
+ * @typedef {Object} AutoCreateAdsAccountsData
+ * @property {boolean} hasDetermined - Whether the checks to determine if accounts should be created are finished.
+ * @property {('ads'|null)} creatingWhich - Which accounts are being created 'ads' or `null` if none.
+ */
+
+/**
+ * useAutoCreateAdsAccount hook.
+ * Creates Google Ads account if the user doesn't have any existing and connected account.
+ * @return {AutoCreateAdsAccountsData} Object containing account creation data.
+ */
+const useAutoCreateAdsAccount = () => {
+	const lockedRef = useRef( false );
+	const shouldCreateAds = useShouldCreateAdsAccount();
+	const [ creatingWhich, setCreatingWhich ] = useState( null );
+	const [ hasDetermined, setDetermined ] = useState( false );
+	const [ upsertAdsAccount ] = useUpsertAdsAccount();
+
+	useEffect( () => {
+		if (
+			// Wait for all determinations to be ready
+			shouldCreateAds === null ||
+			// Avoid repeated calls
+			lockedRef.current
+		) {
+			return;
+		}
+
+		let which = null;
+
+		lockedRef.current = true;
+
+		if ( shouldCreateAds ) {
+			which = CREATING_ADS_ACCOUNT;
+		}
+
+		setCreatingWhich( which );
+		setDetermined( true );
+
+		if ( which ) {
+			const handleCreateAccountCallback = async () => {
+				await upsertAdsAccount();
+				setCreatingWhich( null );
+			};
+
+			handleCreateAccountCallback();
+		}
+	}, [ shouldCreateAds, upsertAdsAccount ] );
+
+	return {
+		hasDetermined,
+		creatingWhich,
+	};
+};
+
+export default useAutoCreateAdsAccount;

--- a/js/src/hooks/useAutoCreateAdsAccount.test.js
+++ b/js/src/hooks/useAutoCreateAdsAccount.test.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useAutoCreateAdsAccount from './useAutoCreateAdsAccount';
+import useGoogleAdsAccount from './useGoogleAdsAccount';
+import useExistingGoogleAdsAccounts from './useExistingGoogleAdsAccounts';
+import useUpsertAdsAccount from './useUpsertAdsAccount';
+
+jest.mock( './useUpsertAdsAccount' );
+jest.mock( './useGoogleAdsAccount' );
+jest.mock( './useExistingGoogleAdsAccounts' );
+
+describe( 'useAutoCreateAdsAccount hook', () => {
+	let upsertAdsAccount;
+
+	beforeEach( () => {
+		upsertAdsAccount = jest.fn( () => Promise.resolve() );
+
+		useGoogleAdsAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			hasGoogleAdsConnection: false,
+		} );
+
+		useExistingGoogleAdsAccounts.mockReturnValue( {
+			hasFinishedResolution: true,
+			existingAccounts: [],
+		} );
+	} );
+
+	describe( 'Automatic account creation', () => {
+		it( 'should create a Google Ads account if there is none', async () => {
+			useUpsertAdsAccount.mockReturnValue( [
+				upsertAdsAccount,
+				{ loading: true },
+			] );
+
+			const { result } = renderHook( () => useAutoCreateAdsAccount() );
+			await act( async () => {
+				expect( result.current.creatingWhich ).toBe( 'ads' );
+			} );
+
+			expect( upsertAdsAccount ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'Existing accounts', () => {
+		it( 'should not create any Ads accounts if they already exist', () => {
+			useExistingGoogleAdsAccounts.mockReturnValue( {
+				hasFinishedResolution: true,
+				existingAccounts: [
+					{
+						id: '1234',
+						name: 'Test Account',
+					},
+				],
+			} );
+
+			const { result } = renderHook( () => useAutoCreateAdsAccount() );
+
+			expect( result.current.creatingWhich ).toBe( null );
+			expect( upsertAdsAccount ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/js/src/hooks/useAutoCreateAdsMCAccounts.js
+++ b/js/src/hooks/useAutoCreateAdsMCAccounts.js
@@ -6,35 +6,15 @@ import { useEffect, useState, useRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import useGoogleAdsAccount from './useGoogleAdsAccount';
-import useExistingGoogleAdsAccounts from './useExistingGoogleAdsAccounts';
 import useGoogleMCAccount from './useGoogleMCAccount';
 import useExistingGoogleMCAccounts from './useExistingGoogleMCAccounts';
 import useUpsertAdsAccount from '~/hooks/useUpsertAdsAccount';
+import useShouldCreateAdsAccount from './useShouldCreateAdsAccount';
 import {
 	CREATING_ADS_ACCOUNT,
 	CREATING_BOTH_ACCOUNTS,
 	CREATING_MC_ACCOUNT,
 } from '~/components/google-combo-account-card/constants';
-
-const useShouldCreateAdsAccount = () => {
-	const {
-		hasFinishedResolution: hasResolvedAccount,
-		hasGoogleAdsConnection: hasConnection,
-	} = useGoogleAdsAccount();
-
-	const {
-		hasFinishedResolution: hasResolvedExistingAccounts,
-		existingAccounts: accounts,
-	} = useExistingGoogleAdsAccounts();
-
-	// Return null if the account hasn't been resolved or the existing accounts haven't been resolved
-	if ( ! hasResolvedAccount || ! hasResolvedExistingAccounts ) {
-		return null;
-	}
-
-	return ! hasConnection && accounts?.length === 0;
-};
 
 const useShouldCreateMCAccount = () => {
 	const {

--- a/js/src/hooks/useShouldCreateAdsAccount.js
+++ b/js/src/hooks/useShouldCreateAdsAccount.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import useGoogleAdsAccount from './useGoogleAdsAccount';
+import useExistingGoogleAdsAccounts from './useExistingGoogleAdsAccounts';
+
+/**
+ * Determines whether a Google Ads account should be created.
+ *
+ * @return {boolean|null} True if an Ads account should be created, false if not, or null if still determining.
+ */
+const useShouldCreateAdsAccount = () => {
+	const {
+		hasFinishedResolution: hasResolvedAccount,
+		hasGoogleAdsConnection: hasConnection,
+	} = useGoogleAdsAccount();
+
+	const {
+		hasFinishedResolution: hasResolvedExistingAccounts,
+		existingAccounts: accounts,
+	} = useExistingGoogleAdsAccounts();
+
+	// Return null if the account hasn't been resolved or the existing accounts haven't been resolved
+	if ( ! hasResolvedAccount || ! hasResolvedExistingAccounts ) {
+		return null;
+	}
+
+	return ! hasConnection && accounts?.length === 0;
+};
+
+export default useShouldCreateAdsAccount;

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -139,7 +139,7 @@ class Admin implements OptionsAwareInterface, Registerable, Service {
 				'dateFormat'               => get_option( 'date_format' ),
 				'timeFormat'               => get_option( 'time_format' ),
 				'siteLogoUrl'              => wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ), 'full' ),
-				'serviceBasedMerchant'     => true, // @TODO: Update with BEE logic.
+				'serviceBasedMerchant'     => false, // @TODO: Update with BEE logic.
 				'initialWpData'            => [
 					'version' => $this->get_version(),
 					'mcId'    => $this->options->get_merchant_id() ?: null,

--- a/tests/e2e/specs/onboarding/step-1-accounts-service-based-merchants.test.js
+++ b/tests/e2e/specs/onboarding/step-1-accounts-service-based-merchants.test.js
@@ -1,0 +1,666 @@
+/**
+ * Internal dependencies
+ */
+import SetUpAccountsPage from '../../utils/pages/onboarding/step-1-set-up-accounts';
+import { LOAD_STATE } from '../../utils/constants';
+import {
+	getFAQPanelTitle,
+	getFAQPanelRow,
+	checkFAQExpandable,
+} from '../../utils/page';
+
+/**
+ * External dependencies
+ */
+const { test, expect } = require( '@playwright/test' );
+
+test.use( { storageState: process.env.ADMINSTATE } );
+
+test.describe.configure( { mode: 'serial' } );
+
+/**
+ * @type {import('../../utils/pages/onboarding/step-1-set-up-accounts.js').default} setUpAccountsPage
+ */
+let setUpAccountsPage = null;
+
+/**
+ * @type {import('@playwright/test').Page} page
+ */
+let page = null;
+
+const ADS_ACCOUNTS = [
+	{
+		id: 111111,
+		name: 'gla',
+	},
+	{
+		id: 222222,
+		name: 'gla',
+	},
+	{
+		id: 333333,
+		name: 'gla',
+	},
+];
+
+test.describe( 'Set up accounts for service based merchants', () => {
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		await page.addInitScript( () => {
+			window.glaData = Object.assign( {}, window.glaData || {}, {
+				serviceBasedMerchant: true,
+			} );
+		} );
+		setUpAccountsPage = new SetUpAccountsPage( page );
+	} );
+
+	test.afterAll( async () => {
+		await setUpAccountsPage.closePage();
+	} );
+
+	test( 'JetpackDisconnected: should see accounts step header, "Connect your WordPress.com account" & connect button', async () => {
+		await setUpAccountsPage.goto();
+
+		await expect(
+			page.getByRole( 'heading', { name: 'Set up your accounts' } )
+		).toBeVisible();
+
+		await expect(
+			page.getByText(
+				'Connect the accounts required to use Google for WooCommerce.'
+			)
+		).toBeVisible();
+
+		const wpAccountCard = setUpAccountsPage.getWPAccountCard();
+		await expect( wpAccountCard ).toBeEnabled();
+		await expect( wpAccountCard ).toContainText( 'WordPress.com' );
+		await expect( wpAccountCard.getByRole( 'button' ) ).toBeEnabled();
+
+		const googleAccountCard = setUpAccountsPage.getGoogleAccountCard();
+		await expect( googleAccountCard.getByRole( 'button' ) ).toBeDisabled();
+
+		const continueButton = setUpAccountsPage.getContinueButton();
+		await expect( continueButton ).toBeDisabled();
+	} );
+
+	test.describe( 'FAQ panels', () => {
+		test( 'should see two questions in FAQ', async () => {
+			const faqTitles = getFAQPanelTitle( page );
+			await expect( faqTitles ).toHaveCount( 2 );
+		} );
+
+		test( 'should not see FAQ rows when FAQ titles are not clicked', async () => {
+			const faqRows = getFAQPanelRow( page );
+			await expect( faqRows ).toHaveCount( 0 );
+		} );
+
+		// eslint-disable-next-line jest/expect-expect
+		test( 'should see FAQ rows when all FAQ titles are clicked', async () => {
+			await checkFAQExpandable( page );
+		} );
+	} );
+
+	test.describe( 'Connect WordPress.com account', () => {
+		test( 'should send an API request to connect Jetpack, and redirect to the returned URL', async ( {
+			baseURL,
+		} ) => {
+			// Mock Jetpack connect
+			await setUpAccountsPage.mockJetpackConnect( baseURL + 'auth_url' );
+
+			// Click the enabled connect button.
+			page.locator(
+				"//button[text()='Connect'][not(@disabled)]"
+			).click();
+			await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+
+			// Expect the user to be redirected
+			await page.waitForURL( baseURL + 'auth_url' );
+
+			expect( page.url() ).toMatch( baseURL + 'auth_url' );
+		} );
+	} );
+
+	test.describe( 'Connected WordPress.com account', async () => {
+		test.beforeAll( async () => {
+			// Mock Jetpack as connected
+			await setUpAccountsPage.mockJetpackConnected(
+				'Test user',
+				'jetpack@example.com'
+			);
+
+			// Mock google as not connected.
+			// When pending even WPORG will not render yet.
+			// If not mocked will fail and render nothing,
+			// as Jetpack is mocked only on the client-side.
+			await setUpAccountsPage.mockGoogleNotConnected();
+
+			await setUpAccountsPage.goto();
+		} );
+
+		test( 'should not show the WP.org connection card when already connected', async () => {
+			await expect(
+				page.getByRole( 'heading', { name: 'Set up your accounts' } )
+			).toBeVisible();
+
+			await expect(
+				page.getByText(
+					'Connect the accounts required to use Google for WooCommerce.'
+				)
+			).toBeVisible();
+
+			const wpAccountCard = setUpAccountsPage.getWPAccountCard();
+			await expect( wpAccountCard ).not.toBeVisible();
+		} );
+	} );
+
+	test.describe( 'Connect Google account', () => {
+		test.beforeAll( async () => {
+			// Mock Jetpack as not connected
+			await setUpAccountsPage.mockJetpackNotConnected();
+
+			// Mock google as not connected.
+			// When pending even WPORG will not render yet.
+			// If not mocked will fail and render nothing,
+			// as Jetpack is mocked only on the client-side.
+			await setUpAccountsPage.mockGoogleNotConnected();
+
+			await setUpAccountsPage.goto();
+		} );
+
+		test( 'should see the connect button and terms and conditions checkbox disabled when jetpack is not connected', async () => {
+			const connectButton = setUpAccountsPage
+				.getGoogleAccountCard()
+				.getByRole( 'button', { name: 'Connect' } );
+
+			await expect( connectButton ).toBeDisabled();
+
+			const termsCheckbox = setUpAccountsPage.getTermsCheckbox();
+			await expect( termsCheckbox ).toBeDisabled();
+		} );
+
+		test( 'should see their WPORG email, "Google" title & connect button', async () => {
+			// Mock Jetpack as connected
+			await setUpAccountsPage.mockJetpackConnected();
+
+			await setUpAccountsPage.goto();
+
+			const googleAccountCard = setUpAccountsPage.getGoogleAccountCard();
+
+			await expect(
+				googleAccountCard.getByText( 'Google', { exact: true } )
+			).toBeVisible();
+
+			await expect(
+				googleAccountCard.getByRole( 'button', { name: 'Connect' } )
+			).toBeDisabled();
+
+			const continueButton = setUpAccountsPage.getContinueButton();
+			await expect( continueButton ).toBeDisabled();
+		} );
+
+		test( 'should see the terms and conditions checkbox unchecked by default', async () => {
+			const termsCheckbox = setUpAccountsPage.getTermsCheckbox();
+			await expect( termsCheckbox ).not.toBeChecked();
+
+			// Also ensure that connect button is disabled.
+			const connectButton = setUpAccountsPage.getConnectButton();
+			await expect( connectButton ).toBeDisabled();
+		} );
+
+		test( 'after clicking the "Connect your Google account" button should send an API request to connect Google account, and redirect to the returned URL', async ( {
+			baseURL,
+		} ) => {
+			// Mock google connect.
+			await setUpAccountsPage.mockGoogleConnect(
+				baseURL + 'google_auth'
+			);
+
+			await setUpAccountsPage.getTermsCheckbox().check();
+
+			// Click the enabled connect button
+			page.locator(
+				"//button[text()='Connect'][not(@disabled)]"
+			).click();
+			await page.waitForLoadState( LOAD_STATE.DOM_CONTENT_LOADED );
+
+			// Expect the user to be redirected
+			await page.waitForURL( baseURL + 'google_auth' );
+
+			expect( page.url() ).toMatch( baseURL + 'google_auth' );
+		} );
+
+		test( 'should create an Ads account if does not exist for the user', async () => {
+			const once = setUpAccountsPage.withFulfillTimes( 1 );
+			const deferred = once.withFulfillDeferred();
+
+			await setUpAccountsPage.mockJetpackConnected();
+			await setUpAccountsPage.mockGoogleConnected();
+
+			await deferred.mockAdsCreateAccount();
+
+			await once.mockAdsHasNoAccounts();
+			await once.mockAdsAccountDisconnected();
+			await once.mockAdsStatusDisconnected();
+
+			await setUpAccountsPage.goto();
+
+			const googleAccountCard =
+				setUpAccountsPage.getServiceBasedMerchantGoogleAccountCard();
+
+			await expect(
+				googleAccountCard.getByText(
+					'You don’t have Google Ads account, so we’re creating one for you.',
+					{
+						exact: true,
+					}
+				)
+			).toBeVisible();
+
+			deferred.continueFulfill();
+
+			await expect(
+				googleAccountCard.getByText( 'mail@example.com' )
+			).toBeVisible();
+		} );
+
+		test( 'should show Ads claim after auto-creation, when appropriate', async () => {
+			await setUpAccountsPage.mockJetpackConnected();
+			await setUpAccountsPage.mockGoogleConnected();
+			await setUpAccountsPage.mockAdsCreateAccount();
+			await setUpAccountsPage.mockAdsAccountIncomplete( 'claim_account' );
+			await setUpAccountsPage.mockAdsStatusNotClaimed();
+
+			const once = setUpAccountsPage.withFulfillTimes( 1 );
+
+			await once.mockAdsHasNoAccounts();
+			await once.mockAdsAccountDisconnected();
+			await once.mockAdsStatusDisconnected();
+
+			await setUpAccountsPage.goto();
+
+			const googleAccountCard =
+				setUpAccountsPage.getServiceBasedMerchantGoogleAccountCard();
+
+			await expect(
+				googleAccountCard.getByRole( 'button', {
+					name: 'Claim account in Google Ads',
+				} )
+			).toBeVisible();
+		} );
+
+		test.describe( 'After connecting Google account', () => {
+			test.beforeEach( async () => {
+				await setUpAccountsPage.mockJetpackConnected();
+				await setUpAccountsPage.mockGoogleConnected();
+				await setUpAccountsPage.mockAdsAccountConnected();
+				await setUpAccountsPage.mockAdsAccountsResponse( ADS_ACCOUNTS );
+				await setUpAccountsPage.goto();
+			} );
+
+			test( 'should see the ads account id if connected', async () => {
+				await setUpAccountsPage.mockAdsStatusClaimed();
+
+				const googleAccountCard =
+					setUpAccountsPage.getServiceBasedMerchantGoogleAccountCard();
+
+				await expect(
+					googleAccountCard.getByText( 'Google Ads ID: 12345', {
+						exact: true,
+					} )
+				).toBeVisible();
+
+				await expect(
+					googleAccountCard.getByText( 'Connected', { exact: true } )
+				).toBeVisible();
+			} );
+		} );
+	} );
+
+	test.describe( 'Google Ads card', () => {
+		test.beforeAll( async () => {
+			await setUpAccountsPage.mockJetpackConnected();
+			await setUpAccountsPage.mockGoogleConnected();
+			await setUpAccountsPage.mockAdsAccountDisconnected();
+			await setUpAccountsPage.fulfillAdsAccounts( ADS_ACCOUNTS );
+
+			await setUpAccountsPage.goto();
+		} );
+
+		test.describe( 'When existing Google Ads accounts are available, but not connected', () => {
+			test( 'should see the Google Ads card with the correct title and body', async () => {
+				const googleAdsAccountCard =
+					setUpAccountsPage.getGoogleAdsAccountCard();
+
+				await expect(
+					googleAdsAccountCard.getByText(
+						'Connect to existing Google Ads account',
+						{ exact: true }
+					)
+				).toBeVisible();
+
+				await expect(
+					googleAdsAccountCard.getByText(
+						'Required to set up conversion measurement for your store.',
+						{ exact: true }
+					)
+				).toBeVisible();
+			} );
+
+			test( 'should see the button as enabled when selects the account from dropdown', async () => {
+				const googleAdsAccountCard =
+					setUpAccountsPage.getGoogleAdsAccountCard();
+
+				const adsAccountDropdown =
+					googleAdsAccountCard.locator( 'select' );
+				await adsAccountDropdown.selectOption( '222222' );
+
+				await expect(
+					googleAdsAccountCard.getByRole( 'button', {
+						name: 'Connect',
+					} )
+				).toBeEnabled();
+			} );
+
+			test( 'should send an API request to connect existing Google Ads account', async () => {
+				const adsAccountsResponse =
+					setUpAccountsPage.registerAdsAccountsResponse();
+
+				const googleAdsAccountCard =
+					setUpAccountsPage.getGoogleAdsAccountCard();
+				await setUpAccountsPage.mockAdsStatusClaimed();
+
+				const adsAccountDropdown =
+					googleAdsAccountCard.locator( 'select' );
+				await adsAccountDropdown.selectOption( '222222' );
+				await googleAdsAccountCard
+					.getByRole( 'button', { name: 'Connect' } )
+					.click();
+
+				await setUpAccountsPage.mockAdsAccountConnected( 222222 );
+				await adsAccountsResponse;
+
+				const googleAccountCard =
+					setUpAccountsPage.getServiceBasedMerchantGoogleAccountCard();
+				await expect(
+					googleAccountCard.getByText( 'Google Ads ID: 222222' )
+				).toBeVisible();
+			} );
+		} );
+
+		test.describe( 'When new Google Ads account is created', () => {
+			test.beforeAll( async () => {
+				await setUpAccountsPage.mockAdsAccountDisconnected();
+
+				await setUpAccountsPage.goto();
+			} );
+
+			test( 'should see the Create new Google Ads account link', async () => {
+				const googleAdsAccountCard =
+					setUpAccountsPage.getGoogleAdsAccountCard();
+
+				await expect(
+					googleAdsAccountCard.getByText(
+						'Or, create a new Google Ads account',
+						{ exact: true }
+					)
+				).toBeVisible();
+			} );
+
+			test( 'clicking the "Create new Google Ads account" link should open the modal', async () => {
+				const googleAdsAccountCard =
+					setUpAccountsPage.getGoogleAdsAccountCard();
+
+				await googleAdsAccountCard
+					.getByText( 'Or, create a new Google Ads account' )
+					.click();
+
+				await expect( setUpAccountsPage.getModal() ).toBeVisible();
+				await expect( setUpAccountsPage.getModalHeader() ).toHaveText(
+					'Create Google Ads Account'
+				);
+
+				// "Yes, I want a new account" button should be disabled and secondary.
+				const yesButton = setUpAccountsPage.getModalSecondaryButton();
+				const cancelButton = setUpAccountsPage.getModalPrimaryButton();
+				await expect( yesButton ).toHaveText(
+					'Yes, I want a new account'
+				);
+
+				await expect( cancelButton ).toHaveText( 'Cancel' );
+
+				// Click the cancel button to close the modal.
+				await cancelButton.click();
+				await expect( setUpAccountsPage.getModal() ).not.toBeVisible();
+			} );
+
+			test( 'clicking the "Yes, I want a new account" button should create a new Google Ads account', async () => {
+				const googleAccountCard =
+					setUpAccountsPage.getServiceBasedMerchantGoogleAccountCard();
+				const googleAdsAccountCard =
+					setUpAccountsPage.getGoogleAdsAccountCard();
+
+				await setUpAccountsPage.fulfillAdsAccounts( [
+					{
+						id: 111111,
+					},
+				] );
+
+				await setUpAccountsPage.mockAdsStatusNotClaimed();
+				await setUpAccountsPage.mockAdsAccountIncomplete();
+
+				await googleAdsAccountCard
+					.getByText( 'Or, create a new Google Ads account' )
+					.click();
+
+				await expect( setUpAccountsPage.getModal() ).toBeVisible();
+
+				const yesButton = setUpAccountsPage.getModalSecondaryButton();
+				await yesButton.click();
+
+				await expect( setUpAccountsPage.getModal() ).not.toBeVisible();
+
+				// Google Ads ID should be displayed.
+				await expect(
+					googleAccountCard.getByText( 'Google Ads ID: 12345' )
+				).toBeVisible();
+			} );
+		} );
+	} );
+
+	test.describe( 'Claim Google Ads Account', () => {
+		test.beforeAll( async () => {
+			await setUpAccountsPage.mockJetpackConnected();
+			await setUpAccountsPage.mockGoogleConnected();
+			await setUpAccountsPage.fulfillAdsAccounts( [ { id: 12345 } ] );
+			await setUpAccountsPage.mockAdsAccountConnected();
+			await setUpAccountsPage.mockAdsStatusNotClaimed();
+
+			await setUpAccountsPage.goto();
+		} );
+
+		test( 'should see the claim button', async () => {
+			const googleAccountCard =
+				setUpAccountsPage.getServiceBasedMerchantGoogleAccountCard();
+			await expect(
+				googleAccountCard.getByRole( 'button', {
+					name: 'Claim account in Google Ads',
+				} )
+			).toBeVisible();
+		} );
+
+		test( 'should open the popup when the claim button is clicked', async () => {
+			const googleAccountCard =
+				setUpAccountsPage.getServiceBasedMerchantGoogleAccountCard();
+
+			const [ popupPage ] = await Promise.all( [
+				page.waitForEvent( 'popup' ),
+				googleAccountCard
+					.getByRole( 'button', {
+						name: 'Claim account in Google Ads',
+					} )
+					.click(),
+			] );
+
+			await popupPage.waitForLoadState();
+			const url = popupPage.url();
+			expect( url ).toMatch( /^https:\/\/example\.com\/?$/ );
+			await popupPage.close();
+		} );
+
+		test( 'should see the accounts card connected', async () => {
+			await setUpAccountsPage.mockAdsStatusClaimed();
+
+			await page.reload();
+
+			const googleAccountCard =
+				setUpAccountsPage.getServiceBasedMerchantGoogleAccountCard();
+
+			await expect(
+				googleAccountCard.getByText( 'Connected', {
+					exact: true,
+				} )
+			).toBeVisible();
+		} );
+	} );
+
+	test.describe( 'Continue button', () => {
+		test.beforeAll( async () => {
+			// Mock Jetpack as connected
+			await setUpAccountsPage.mockJetpackConnected();
+
+			// Mock google as connected.
+			await setUpAccountsPage.mockGoogleConnected();
+		} );
+
+		test.describe( 'When only Ads is connected', async () => {
+			test.beforeAll( async () => {
+				await setUpAccountsPage.mockAdsAccountConnected();
+
+				await setUpAccountsPage.goto();
+			} );
+
+			test( 'should see "Continue" button is disabled when only Ads is connected', async () => {
+				const continueButton =
+					await setUpAccountsPage.getContinueButton();
+				await expect( continueButton ).toBeDisabled();
+			} );
+		} );
+	} );
+
+	test.describe( 'Edit button', () => {
+		test.beforeAll( async () => {
+			await setUpAccountsPage.mockJetpackConnected();
+			await setUpAccountsPage.mockGoogleConnected();
+			await setUpAccountsPage.mockAdsAccountConnected();
+			await setUpAccountsPage.fulfillAdsAccounts( ADS_ACCOUNTS );
+			await setUpAccountsPage.mockAdsStatusClaimed();
+			await setUpAccountsPage.goto();
+		} );
+
+		test( 'should display the Edit button and the Ads account card is not visible', async () => {
+			const editButton = setUpAccountsPage.getEditButton();
+			await expect( editButton ).toBeVisible();
+
+			const googleAdsAccountCard =
+				setUpAccountsPage.getGoogleAdsAccountCard();
+			await expect( googleAdsAccountCard ).not.toBeVisible();
+		} );
+
+		test.describe( 'clicking the Edit button', async () => {
+			test( 'the "Or, connect to a different Google account" button is visible', async () => {
+				const editButton = setUpAccountsPage.getEditButton();
+				await editButton.click();
+
+				const connectDifferentGoogleAccountButton =
+					setUpAccountsPage.getConnectDifferentGoogleAccountButton();
+				await expect(
+					connectDifferentGoogleAccountButton
+				).toBeVisible();
+			} );
+
+			test( 'the "Cancel" button is visible', async () => {
+				const cancelButton = setUpAccountsPage.getCancelButton();
+				await expect( cancelButton ).toBeVisible();
+			} );
+
+			test( 'Ads account card is visible', async () => {
+				const googleAdsAccountCard =
+					setUpAccountsPage.getGoogleAdsAccountCard();
+				await expect( googleAdsAccountCard ).toBeVisible();
+			} );
+		} );
+
+		test.describe( 'clicking the Cancel button', async () => {
+			test( 'the "Edit" button is visible', async () => {
+				const cancelButton = setUpAccountsPage.getCancelButton();
+				await cancelButton.click();
+
+				const editButton = setUpAccountsPage.getEditButton();
+				await expect( editButton ).toBeVisible();
+			} );
+
+			test( 'Ads account card is not visible', async () => {
+				const googleAdsAccountCard =
+					setUpAccountsPage.getGoogleAdsAccountCard();
+				await expect( googleAdsAccountCard ).not.toBeVisible();
+			} );
+		} );
+
+		test.describe( 'clicking "Edit" when an Ads account is being claimed', async () => {
+			test( 'should let you connect to a different account', async () => {
+				await setUpAccountsPage.mockAdsStatusNotClaimed();
+				await setUpAccountsPage.mockAdsAccountIncomplete(
+					'claim_account'
+				);
+
+				await setUpAccountsPage.goto();
+
+				const editButton = setUpAccountsPage.getEditButton();
+				await editButton.click();
+
+				const connectDifferentGoogleAdsAccountButton =
+					setUpAccountsPage.getConnectDifferentAdsAccountButton();
+
+				await expect(
+					connectDifferentGoogleAdsAccountButton
+				).toBeVisible();
+			} );
+
+			test( 'should disable the create new account button if there are no other existing accounts', async () => {
+				await setUpAccountsPage.mockAdsStatusNotClaimed();
+				await setUpAccountsPage.mockAdsHasNoAccounts();
+				await setUpAccountsPage.mockAdsAccountIncomplete(
+					'claim_account'
+				);
+
+				await setUpAccountsPage.goto();
+
+				const editButton = setUpAccountsPage.getEditButton();
+				await editButton.click();
+
+				const createNewAdsAccountButton =
+					setUpAccountsPage.getCreateNewAdsAccountButton();
+
+				await expect( createNewAdsAccountButton ).toBeDisabled();
+			} );
+		} );
+
+		test.describe( 'clicking "Edit" when there are no other existing accounts', async () => {
+			test( 'should let you create new accounts', async () => {
+				await setUpAccountsPage.mockAdsStatusClaimed();
+				await setUpAccountsPage.mockAdsAccountConnected();
+				await setUpAccountsPage.mockAdsHasNoAccounts();
+
+				await setUpAccountsPage.goto();
+
+				const editButton = setUpAccountsPage.getEditButton();
+				await editButton.click();
+
+				const createNewAdsAccountButton =
+					setUpAccountsPage.getCreateNewAdsAccountButton();
+
+				await expect( createNewAdsAccountButton ).toBeVisible();
+			} );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/onboarding/step-1-accounts-service-based-merchants.test.js
+++ b/tests/e2e/specs/onboarding/step-1-accounts-service-based-merchants.test.js
@@ -46,12 +46,9 @@ const ADS_ACCOUNTS = [
 test.describe( 'Set up accounts for service based merchants', () => {
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage();
-		await page.addInitScript( () => {
-			window.glaData = Object.assign( {}, window.glaData || {}, {
-				serviceBasedMerchant: true,
-			} );
+		setUpAccountsPage = new SetUpAccountsPage( page, {
+			serviceBasedMerchant: true,
 		} );
-		setUpAccountsPage = new SetUpAccountsPage( page );
 	} );
 
 	test.afterAll( async () => {

--- a/tests/e2e/utils/pages/onboarding/step-1-set-up-accounts.js
+++ b/tests/e2e/utils/pages/onboarding/step-1-set-up-accounts.js
@@ -241,6 +241,17 @@ export default class SetUpAccountsPage extends MockRequests {
 	}
 
 	/**
+	 * Get service-based Merchant Google account card.
+	 *
+	 * @return {import('@playwright/test').Locator} Get service-based Merchant Google account card.
+	 */
+	getServiceBasedMerchantGoogleAccountCard() {
+		return this.page.locator(
+			'.gla-connected-google-ads-only-account-card--google'
+		);
+	}
+
+	/**
 	 * Get Google Ads account card.
 	 *
 	 * @return {import('@playwright/test').Locator} Get Google Ads account card.

--- a/tests/e2e/utils/pages/onboarding/step-1-set-up-accounts.js
+++ b/tests/e2e/utils/pages/onboarding/step-1-set-up-accounts.js
@@ -11,9 +11,31 @@ export default class SetUpAccountsPage extends MockRequests {
 	/**
 	 * @param {import('@playwright/test').Page} page
 	 */
-	constructor( page ) {
+	constructor( page, { serviceBasedMerchant = false } = {} ) {
 		super( page );
 		this.page = page;
+
+		if ( serviceBasedMerchant ) {
+			this.page.addInitScript( () => {
+				// Use a setter so PHP's inline script goes through our override
+				( () => {
+					let _glaData;
+
+					Object.defineProperty( window, 'glaData', {
+						configurable: true,
+						get() {
+							return _glaData;
+						},
+						set( value ) {
+							// Merge the PHP-injected object with our property
+							_glaData = Object.assign( {}, value, {
+								serviceBasedMerchant: true,
+							} );
+						},
+					} );
+				} )();
+			} );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-363/create-ads-only-components-and-prevent-mc-related-info-to-be

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. If this is not a fresh install, first disconnect all Google accounts from the `Settings → Linked Accounts` section.
2. Set `serviceBasedMerchant` to `true` in `src/Admin/Admin.php`. Currently `false`.
3. Start the onboarding flow from the beginning.
4. Verify that the merchant can only connect a Google Ads account (no Merchant Center connection should appear).
5. If the merchant does not already have a Google Ads account, confirm that:
	* A new Ads account is automatically created, and
	* The claim Google Ads account step still behaves exactly as in the standard (non-service-based) flow.
6. Ensure that no requests are made to any /wc/gla/mc/* endpoints at any point in the onboarding process.
7. The "Continue" button remains disabled even when there's a connected Google Ads account. This is expected for now since it's WIP.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
