### PR TITLE
[GOOWOO-373] Update Google API Queries to allow campaigns to be created/edited without an Merchant Center account

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -644,7 +644,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 		$request->setCustomerId( $this->options->get_ads_id() );
 		$request->setMutateOperations( $operations );
 		$responses = $this->client->getGoogleAdsServiceClient()->mutate( $request );
-		foreach ( $responses->getMutateOperationResponses() as $response ) {
+		foreach ( $responses->getMutateOperationResponses() ?? [] as $response ) {
 			if ( 'campaign_result' === $response->getResponse() ) {
 				$campaign_result = $response->getCampaignResult();
 				return $this->parse_campaign_id( $campaign_result->getResourceName() );

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -296,25 +296,6 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	 */
 	public function edit_campaign( int $campaign_id, array $params ): int {
 		try {
-			// Check edge case: campaign created with MC but MC is now disconnected.
-			$existing_campaign = $this->get_campaign( $campaign_id );
-			$merchant_id       = $this->options->get_merchant_id();
-
-			// If campaign exists, has a country from shopping_setting, but MC is disconnected, throw error.
-			if ( ! empty( $existing_campaign ) && ! empty( $existing_campaign['country'] ) && $merchant_id === 0 ) {
-				throw new ExceptionWithResponseData(
-					__( 'Cannot edit campaign: This campaign was created with a Merchant Center account, but the account is now disconnected. Please reconnect your Merchant Center account to edit this campaign.', 'google-listings-and-ads' ),
-					400,
-					null,
-					[
-						'errors' => [
-							'MERCHANT_CENTER_DISCONNECTED' => __( 'Merchant Center account is disconnected', 'google-listings-and-ads' ),
-						],
-						'id'     => $campaign_id,
-					]
-				);
-			}
-
 			$operations      = [];
 			$campaign_fields = [];
 

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -183,10 +183,13 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			$converted_campaigns = [];
 
 			// Get only the first element from campaign results
-			foreach ( $campaign_results->iterateAllElements() as $row ) {
-				$campaign                               = $this->convert_campaign( $row );
-				$converted_campaigns[ $campaign['id'] ] = $campaign;
-				break;
+			$elements = $campaign_results->iterateAllElements();
+			if ( $elements !== null ) {
+				foreach ( $elements as $row ) {
+					$campaign                               = $this->convert_campaign( $row );
+					$converted_campaigns[ $campaign['id'] ] = $campaign;
+					break;
+				}
 			}
 
 			if ( ! empty( $converted_campaigns ) ) {
@@ -506,7 +509,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	 * @return MutateOperation
 	 */
 	protected function create_operation( string $campaign_name, ?string $country, bool $is_eu_political ): MutateOperation {
-		$merchant_id = $this->options->get_merchant_id();
+		$merchant_id   = $this->options->get_merchant_id();
 		$campaign_data = [
 			'resource_name'                     => $this->temporary_resource_name(),
 			'name'                              => $campaign_name,

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -293,6 +293,25 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	 */
 	public function edit_campaign( int $campaign_id, array $params ): int {
 		try {
+			// Check edge case: campaign created with MC but MC is now disconnected.
+			$existing_campaign = $this->get_campaign( $campaign_id );
+			$merchant_id       = $this->options->get_merchant_id();
+
+			// If campaign exists, has a country from shopping_setting, but MC is disconnected, throw error.
+			if ( ! empty( $existing_campaign ) && ! empty( $existing_campaign['country'] ) && $merchant_id === 0 ) {
+				throw new ExceptionWithResponseData(
+					__( 'Cannot edit campaign: This campaign was created with a Merchant Center account, but the account is now disconnected. Please reconnect your Merchant Center account to edit this campaign.', 'google-listings-and-ads' ),
+					400,
+					null,
+					[
+						'errors' => [
+							'MERCHANT_CENTER_DISCONNECTED' => __( 'Merchant Center account is disconnected', 'google-listings-and-ads' ),
+						],
+						'id'     => $campaign_id,
+					]
+				);
+			}
+
 			$operations      = [];
 			$campaign_fields = [];
 
@@ -480,31 +499,36 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	/**
 	 * Returns a campaign create operation.
 	 *
-	 * @param string $campaign_name
-	 * @param string $country
-	 * @param bool   $is_eu_political
+	 * @param string      $campaign_name
+	 * @param string|null $country
+	 * @param bool        $is_eu_political
 	 *
 	 * @return MutateOperation
 	 */
-	protected function create_operation( string $campaign_name, string $country, bool $is_eu_political ): MutateOperation {
-		$campaign = new Campaign(
-			[
-				'resource_name'                     => $this->temporary_resource_name(),
-				'name'                              => $campaign_name,
-				'advertising_channel_type'          => AdvertisingChannelType::PERFORMANCE_MAX,
-				'status'                            => CampaignStatus::number( 'enabled' ),
-				'campaign_budget'                   => $this->budget->temporary_resource_name(),
-				'maximize_conversion_value'         => new MaximizeConversionValue(),
-				'url_expansion_opt_out'             => false,
-				'shopping_setting'                  => new ShoppingSetting(
-					[
-						'merchant_id' => $this->options->get_merchant_id(),
-						'feed_label'  => $country,
-					]
-				),
-				'contains_eu_political_advertising' => $is_eu_political ? EuPoliticalAdvertisingStatus::CONTAINS_EU_POLITICAL_ADVERTISING : EuPoliticalAdvertisingStatus::DOES_NOT_CONTAIN_EU_POLITICAL_ADVERTISING,
-			]
-		);
+	protected function create_operation( string $campaign_name, ?string $country, bool $is_eu_political ): MutateOperation {
+		$merchant_id = $this->options->get_merchant_id();
+		$campaign_data = [
+			'resource_name'                     => $this->temporary_resource_name(),
+			'name'                              => $campaign_name,
+			'advertising_channel_type'          => AdvertisingChannelType::PERFORMANCE_MAX,
+			'status'                            => CampaignStatus::number( 'enabled' ),
+			'campaign_budget'                   => $this->budget->temporary_resource_name(),
+			'maximize_conversion_value'         => new MaximizeConversionValue(),
+			'url_expansion_opt_out'             => false,
+			'contains_eu_political_advertising' => $is_eu_political ? EuPoliticalAdvertisingStatus::CONTAINS_EU_POLITICAL_ADVERTISING : EuPoliticalAdvertisingStatus::DOES_NOT_CONTAIN_EU_POLITICAL_ADVERTISING,
+		];
+
+		// Only include shopping_setting if Merchant Center account is connected.
+		if ( $merchant_id > 0 && $country !== null ) {
+			$campaign_data['shopping_setting'] = new ShoppingSetting(
+				[
+					'merchant_id' => $merchant_id,
+					'feed_label'  => $country,
+				]
+			);
+		}
+
+		$campaign = new Campaign( $campaign_data );
 
 		$operation = ( new CampaignOperation() )->setCreate( $campaign );
 		return ( new MutateOperation() )->setCampaignOperation( $operation );

--- a/src/API/Google/BudgetMetrics.php
+++ b/src/API/Google/BudgetMetrics.php
@@ -69,34 +69,39 @@ class BudgetMetrics implements OptionsAwareInterface, TransientsAwareInterface {
 		}
 
 		$location_ids = $this->get_location_ids( $country_codes );
+		$merchant_id  = $this->options->get_merchant_id();
 
-		$request = new GenerateRecommendationsRequest(
-			[
-				'customer_id'                => $this->options->get_ads_id(),
-				'merchant_center_account_id' => $this->options->get_merchant_id(),
-				'recommendation_types'       => [ RecommendationType::CAMPAIGN_BUDGET ],
-				'advertising_channel_type'   => AdvertisingChannelType::PERFORMANCE_MAX,
-				'positive_locations_ids'     => array_keys( $location_ids ),
-				'country_codes'              => $country_codes,
-				'bidding_info'               => new BiddingInfo(
+		$request_data = [
+			'customer_id'              => $this->options->get_ads_id(),
+			'recommendation_types'     => [ RecommendationType::CAMPAIGN_BUDGET ],
+			'advertising_channel_type' => AdvertisingChannelType::PERFORMANCE_MAX,
+			'positive_locations_ids'   => array_keys( $location_ids ),
+			'country_codes'            => $country_codes,
+			'bidding_info'             => new BiddingInfo(
+				[
+					'bidding_strategy_type' => BiddingStrategyType::MAXIMIZE_CONVERSION_VALUE,
+				]
+			),
+			'budget_info'              => new BudgetInfo(
+				[
+					'current_budget' => $this->to_micro( $budget ),
+				],
+			),
+			'asset_group_info'         => [
+				new AssetGroupInfo(
 					[
-						'bidding_strategy_type' => BiddingStrategyType::MAXIMIZE_CONVERSION_VALUE,
-					]
-				),
-				'budget_info'                => new BudgetInfo(
-					[
-						'current_budget' => $this->to_micro( $budget ),
+						'final_url' => $this->get_site_url(),
 					],
 				),
-				'asset_group_info'           => [
-					new AssetGroupInfo(
-						[
-							'final_url' => $this->get_site_url(),
-						],
-					),
-				],
-			]
-		);
+			],
+		];
+
+		// Only include merchant_center_account_id if Merchant Center account is connected.
+		if ( $merchant_id > 0 ) {
+			$request_data['merchant_center_account_id'] = $merchant_id;
+		}
+
+		$request = new GenerateRecommendationsRequest( $request_data );
 
 		try {
 			$response = $this->client->getRecommendationServiceClient()->generateRecommendations( $request );

--- a/src/API/Google/BudgetRecommendations.php
+++ b/src/API/Google/BudgetRecommendations.php
@@ -69,29 +69,34 @@ class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInt
 		}
 
 		$location_ids = $this->get_location_ids( $country_codes );
+		$merchant_id  = $this->options->get_merchant_id();
 
-		$request = new GenerateRecommendationsRequest(
-			[
-				'customer_id'                => $this->options->get_ads_id(),
-				'merchant_center_account_id' => $this->options->get_merchant_id(),
-				'recommendation_types'       => [ RecommendationType::CAMPAIGN_BUDGET ],
-				'advertising_channel_type'   => AdvertisingChannelType::PERFORMANCE_MAX,
-				'positive_locations_ids'     => array_keys( $location_ids ),
-				'country_codes'              => $country_codes,
-				'bidding_info'               => new BiddingInfo(
+		$request_data = [
+			'customer_id'              => $this->options->get_ads_id(),
+			'recommendation_types'     => [ RecommendationType::CAMPAIGN_BUDGET ],
+			'advertising_channel_type' => AdvertisingChannelType::PERFORMANCE_MAX,
+			'positive_locations_ids'   => array_keys( $location_ids ),
+			'country_codes'            => $country_codes,
+			'bidding_info'             => new BiddingInfo(
+				[
+					'bidding_strategy_type' => BiddingStrategyType::MAXIMIZE_CONVERSION_VALUE,
+				]
+			),
+			'asset_group_info'         => [
+				new AssetGroupInfo(
 					[
-						'bidding_strategy_type' => BiddingStrategyType::MAXIMIZE_CONVERSION_VALUE,
-					]
+						'final_url' => $this->get_site_url(),
+					],
 				),
-				'asset_group_info'           => [
-					new AssetGroupInfo(
-						[
-							'final_url' => $this->get_site_url(),
-						],
-					),
-				],
-			]
-		);
+			],
+		];
+
+		// Only include merchant_center_account_id if Merchant Center account is connected.
+		if ( $merchant_id > 0 ) {
+			$request_data['merchant_center_account_id'] = $merchant_id;
+		}
+
+		$request = new GenerateRecommendationsRequest( $request_data );
 
 		try {
 			$response = $this->client->getRecommendationServiceClient()->generateRecommendations( $request );

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -501,45 +501,6 @@ class AdsCampaignTest extends UnitTest {
 		}
 	}
 
-	public function test_edit_campaign_merchant_center_disconnected() {
-		$campaign_data = [
-			'amount' => 40,
-			'status' => 'paused',
-		];
-
-		// Mock get_campaign to return a campaign with country (created with MC account).
-		$campaign_with_mc = [
-			'id'                                    => self::TEST_CAMPAIGN_ID,
-			'name'                                  => 'Campaign with MC',
-			'status'                                => 'enabled',
-			'type'                                  => 'performance_max',
-			'amount'                                => 10,
-			'country'                               => 'US', // Indicates campaign was created with MC.
-			'targeted_locations'                    => [],
-			'eu_political_advertising_confirmation' => false,
-		];
-
-		$this->generate_ads_campaign_query_mock( [ $campaign_with_mc ], [] );
-
-		// Mock merchant_id to return 0 (MC disconnected).
-		$this->options->method( 'get_merchant_id' )->willReturn( 0 );
-
-		try {
-			$this->campaign->edit_campaign( self::TEST_CAMPAIGN_ID, $campaign_data );
-			$this->fail( 'Expected ExceptionWithResponseData was not thrown.' );
-		} catch ( ExceptionWithResponseData $e ) {
-			$this->assertStringContainsString(
-				'Cannot edit campaign: This campaign was created with a Merchant Center account',
-				$e->getMessage()
-			);
-			$this->assertEquals( 400, $e->getCode() );
-			$response_data = $e->get_response_data( true );
-			$this->assertArrayHasKey( 'errors', $response_data );
-			$this->assertArrayHasKey( 'MERCHANT_CENTER_DISCONNECTED', $response_data['errors'] );
-			$this->assertEquals( self::TEST_CAMPAIGN_ID, $response_data['id'] );
-		}
-	}
-
 	public function test_delete_campaign() {
 		$this->generate_campaign_mutate_mock( 'remove', self::TEST_CAMPAIGN_ID );
 

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -465,6 +465,9 @@ class AdsCampaignTest extends UnitTest {
 			'status' => 'paused',
 		];
 
+		// Mock get_campaign to return a campaign without country (no MC account).
+		$this->generate_ads_campaign_query_mock( [], [] );
+
 		$this->generate_campaign_mutate_mock( 'update', self::TEST_CAMPAIGN_ID );
 
 		$this->assertEquals(
@@ -477,6 +480,9 @@ class AdsCampaignTest extends UnitTest {
 		$campaign_data = [
 			'amount' => 0.001,
 		];
+
+		// Mock get_campaign to return a campaign without country (no MC account).
+		$this->generate_ads_campaign_query_mock( [], [] );
 
 		$this->generate_campaign_mutate_mock_exception( new ApiException( 'invalid', 3, 'INVALID_ARGUMENT' ) );
 
@@ -492,6 +498,45 @@ class AdsCampaignTest extends UnitTest {
 				$e->get_response_data( true )
 			);
 			$this->assertEquals( 400, $e->getCode() );
+		}
+	}
+
+	public function test_edit_campaign_merchant_center_disconnected() {
+		$campaign_data = [
+			'amount' => 40,
+			'status' => 'paused',
+		];
+
+		// Mock get_campaign to return a campaign with country (created with MC account).
+		$campaign_with_mc = [
+			'id'                                    => self::TEST_CAMPAIGN_ID,
+			'name'                                  => 'Campaign with MC',
+			'status'                                => 'enabled',
+			'type'                                  => 'performance_max',
+			'amount'                                => 10,
+			'country'                               => 'US', // Indicates campaign was created with MC.
+			'targeted_locations'                    => [],
+			'eu_political_advertising_confirmation' => false,
+		];
+
+		$this->generate_ads_campaign_query_mock( [ $campaign_with_mc ], [] );
+
+		// Mock merchant_id to return 0 (MC disconnected).
+		$this->options->method( 'get_merchant_id' )->willReturn( 0 );
+
+		try {
+			$this->campaign->edit_campaign( self::TEST_CAMPAIGN_ID, $campaign_data );
+			$this->fail( 'Expected ExceptionWithResponseData was not thrown.' );
+		} catch ( ExceptionWithResponseData $e ) {
+			$this->assertStringContainsString(
+				'Cannot edit campaign: This campaign was created with a Merchant Center account',
+				$e->getMessage()
+			);
+			$this->assertEquals( 400, $e->getCode() );
+			$response_data = $e->get_response_data( true );
+			$this->assertArrayHasKey( 'errors', $response_data );
+			$this->assertArrayHasKey( 'MERCHANT_CENTER_DISCONNECTED', $response_data['errors'] );
+			$this->assertEquals( self::TEST_CAMPAIGN_ID, $response_data['id'] );
 		}
 	}
 

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -465,9 +465,6 @@ class AdsCampaignTest extends UnitTest {
 			'status' => 'paused',
 		];
 
-		// Mock get_campaign to return a campaign without country (no MC account).
-		$this->generate_ads_campaign_query_mock( [], [] );
-
 		$this->generate_campaign_mutate_mock( 'update', self::TEST_CAMPAIGN_ID );
 
 		$this->assertEquals(
@@ -480,9 +477,6 @@ class AdsCampaignTest extends UnitTest {
 		$campaign_data = [
 			'amount' => 0.001,
 		];
-
-		// Mock get_campaign to return a campaign without country (no MC account).
-		$this->generate_ads_campaign_query_mock( [], [] );
 
 		$this->generate_campaign_mutate_mock_exception( new ApiException( 'invalid', 3, 'INVALID_ARGUMENT' ) );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-373/update-google-api-queries-to-allow-campaigns-to-be-creatededited

### Screenshots:

N/A

### Detailed test instructions:

## Test 1: Create Campaign without Merchant Account

1. Go to: `Marketing → Google for WooCommerce → Dashboard`
2. Click "Add campaign"
3. Fill form (name, budget, countries)
4. Click "Create campaign"
5. **Verify**: Success message appears
6. **Verify**: Campaign appears in dashboard list

## Test 2: Edit Campaign without Merchant Account

1. Go to: `Marketing → Google for WooCommerce → Dashboard`
2. Find campaign created in Test 1
3. Click "Edit"
4. Change name/budget/status
5. Click "Save"
6. **Verify**: Success message appears
7. **Verify**: Changes are reflected in dashboard

## Test 3: Budget Recommendations without Merchant Account

1. Go to: `Marketing → Google for WooCommerce → Dashboard`
2. Click "Add campaign"
3. Enter budget amount in the form
4. **Verify**: Budget recommendations appear (Low/Recommended/High options with metrics)
5. **Verify**: No error messages displayed
6. **Verify**: No errors in browser console (F12)

## Test 4: Edge Case - Edit Campaign Created with Merchant Account after Merchant Account disconnected

1. Go to: `Marketing → Google for WooCommerce → Dashboard`
2. Find campaign created in Setup (before Merchant Account disconnect)
3. Click "Edit"
4. Make any change (name, budget, or status)
5. Click "Save"
6. **Verify**: Error message appears: "Cannot edit campaign: This campaign was created with a Merchant Center account, but the account is now disconnected..."
7. **Verify**: Campaign is NOT updated (changes not saved)

### Additional details:
> Update - Update Google API Queries to allow campaigns to be created/edited without an Merchant Center account