### PR TITLE
[GOOWOO-380] Create new REST API endpoint to mark service based merchant setup complete

### DIFF
--- a/src/API/Site/Controllers/OnboardingController.php
+++ b/src/API/Site/Controllers/OnboardingController.php
@@ -42,7 +42,6 @@ class OnboardingController extends BaseController {
 	protected function get_complete_callback(): callable {
 		return function ( Request $request ) {
 			do_action( 'woocommerce_gla_onboarding_completed' );
-			do_action( 'woocommerce_gla_track_event', 'onboarding_complete', [] );
 
 			return new Response(
 				[

--- a/src/API/Site/Controllers/OnboardingController.php
+++ b/src/API/Site/Controllers/OnboardingController.php
@@ -1,0 +1,67 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class OnboardingController
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers
+ */
+class OnboardingController extends BaseController {
+
+	use EmptySchemaPropertiesTrait;
+
+	/**
+	 * Register rest routes with WordPress.
+	 */
+	public function register_routes(): void {
+		$this->register_route(
+			'google/onboarding/complete',
+			[
+				[
+					'methods'             => TransportMethods::CREATABLE, 
+					'callback'            => $this->get_complete_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get the callback for completing onboarding.
+	 *
+	 * @return callable
+	 */
+	protected function get_complete_callback(): callable {
+		return function ( Request $request ) {
+			do_action( 'woocommerce_gla_onboarding_completed' );
+			do_action( 'woocommerce_gla_track_event', 'onboarding_complete', [] );
+
+			return new Response(
+				[
+					'status'  => 'success',
+					'message' => __( 'Successfully onboarded service based merchant', 'google-listings-and-ads' ),
+				],
+				200
+			);
+		};
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * Used for building the API response schema.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'onboarding';
+	}
+}

--- a/src/API/Site/Controllers/OnboardingController.php
+++ b/src/API/Site/Controllers/OnboardingController.php
@@ -26,7 +26,7 @@ class OnboardingController extends BaseController {
 			'google/onboarding/complete',
 			[
 				[
-					'methods'             => TransportMethods::CREATABLE, 
+					'methods'             => TransportMethods::CREATABLE,
 					'callback'            => $this->get_complete_callback(),
 					'permission_callback' => $this->get_permission_callback(),
 				],

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -17,6 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\BuiltScriptDependencyArray;
 use Automattic\WooCommerce\GoogleListingsAndAds\View\ViewException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -54,18 +55,25 @@ class Admin implements OptionsAwareInterface, Registerable, Service {
 	protected $ads;
 
 	/**
+	 * @var OnboardingCompleted
+	 */
+	protected $onboarding_completed;
+
+	/**
 	 * Admin constructor.
 	 *
 	 * @param AssetsHandlerInterface $assets_handler
 	 * @param ViewFactory            $view_factory
 	 * @param MerchantCenterService  $merchant_center
 	 * @param AdsService             $ads
+	 * @param OnboardingCompleted    $onboarding_completed
 	 */
-	public function __construct( AssetsHandlerInterface $assets_handler, ViewFactory $view_factory, MerchantCenterService $merchant_center, AdsService $ads ) {
-		$this->assets_handler  = $assets_handler;
-		$this->view_factory    = $view_factory;
-		$this->merchant_center = $merchant_center;
-		$this->ads             = $ads;
+	public function __construct( AssetsHandlerInterface $assets_handler, ViewFactory $view_factory, MerchantCenterService $merchant_center, AdsService $ads, OnboardingCompleted $onboarding_completed ) {
+		$this->assets_handler       = $assets_handler;
+		$this->view_factory         = $view_factory;
+		$this->merchant_center      = $merchant_center;
+		$this->ads                  = $ads;
+		$this->onboarding_completed = $onboarding_completed;
 	}
 
 	/**
@@ -135,6 +143,7 @@ class Admin implements OptionsAwareInterface, Registerable, Service {
 				'mcSupportedLanguage'      => $this->merchant_center->is_language_supported(),
 				'adsCampaignConvertStatus' => $this->options->get( OptionsInterface::CAMPAIGN_CONVERT_STATUS ),
 				'adsSetupComplete'         => $this->ads->is_setup_complete(),
+				'onboardingComplete'       => $this->onboarding_completed->is_onboarding_complete(),
 				'enableReports'            => $this->enableReports(),
 				'dateFormat'               => get_option( 'date_format' ),
 				'timeFormat'               => get_option( 'time_format' ),

--- a/src/Admin/Redirect.php
+++ b/src/Admin/Redirect.php
@@ -83,6 +83,28 @@ class Redirect implements Activateable, Service, Registerable, OptionsAwareInter
 	}
 
 	/**
+	 * Check if onboarding is complete.
+	 * For backwards compatibility, checks MC setup if ONBOARDING_COMPLETED_AT is not set.
+	 *
+	 * @return bool
+	 */
+	protected function is_onboarding_complete(): bool {
+		$onboarding_completed_at = $this->options->get( OptionsInterface::ONBOARDING_COMPLETED_AT );
+
+		if ( null !== $onboarding_completed_at ) {
+			return boolval( $onboarding_completed_at );
+		}
+
+		if ( $this->merchant_center->is_setup_complete() ) {
+			$mc_setup_completed_at = $this->options->get( OptionsInterface::MC_SETUP_COMPLETED_AT );
+			$this->options->update( OptionsInterface::ONBOARDING_COMPLETED_AT, $mc_setup_completed_at );
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Checks if merchant should be redirected to the onboarding page if it is not.
 	 *
 	 * @return void
@@ -98,12 +120,12 @@ class Redirect implements Activateable, Service, Registerable, OptionsAwareInter
 		}
 
 		// If setup ISNT complete then redirect from dashboard to onboarding
-		if ( ! boolval( $this->options->get( OptionsInterface::ONBOARDING_COMPLETED_AT ) ) && $this->is_current_wc_admin_page( self::PATHS['dashboard'] ) ) {
+		if ( ! $this->is_onboarding_complete() && $this->is_current_wc_admin_page( self::PATHS['dashboard'] ) ) {
 			return $this->redirect_to( self::PATHS['get_started'] );
 		}
 
 		// If setup IS complete then redirect from onboarding to dashboard
-		if ( boolval( $this->options->get( OptionsInterface::ONBOARDING_COMPLETED_AT ) ) && $this->is_current_wc_admin_page( self::PATHS['get_started'] ) ) {
+		if ( $this->is_onboarding_complete() && $this->is_current_wc_admin_page( self::PATHS['get_started'] ) ) {
 			return $this->redirect_to( self::PATHS['dashboard'] );
 		}
 
@@ -117,7 +139,7 @@ class Redirect implements Activateable, Service, Registerable, OptionsAwareInter
 	 */
 	protected function maybe_redirect_after_activation(): bool {
 		// Do not redirect if setup is already complete
-		if ( boolval( $this->options->get( OptionsInterface::ONBOARDING_COMPLETED_AT ) ) ) {
+		if ( $this->is_onboarding_complete() ) {
 			$this->options->update( self::OPTION, 'no' );
 			return false;
 		}

--- a/src/Admin/Redirect.php
+++ b/src/Admin/Redirect.php
@@ -98,12 +98,12 @@ class Redirect implements Activateable, Service, Registerable, OptionsAwareInter
 		}
 
 		// If setup ISNT complete then redirect from dashboard to onboarding
-		if ( ! $this->merchant_center->is_setup_complete() && $this->is_current_wc_admin_page( self::PATHS['dashboard'] ) ) {
+		if ( ! boolval( $this->options->get( OptionsInterface::ONBOARDING_COMPLETED_AT ) ) && $this->is_current_wc_admin_page( self::PATHS['dashboard'] ) ) {
 			return $this->redirect_to( self::PATHS['get_started'] );
 		}
 
 		// If setup IS complete then redirect from onboarding to dashboard
-		if ( $this->merchant_center->is_setup_complete() && $this->is_current_wc_admin_page( self::PATHS['get_started'] ) ) {
+		if ( boolval( $this->options->get( OptionsInterface::ONBOARDING_COMPLETED_AT ) ) && $this->is_current_wc_admin_page( self::PATHS['get_started'] ) ) {
 			return $this->redirect_to( self::PATHS['dashboard'] );
 		}
 
@@ -117,7 +117,7 @@ class Redirect implements Activateable, Service, Registerable, OptionsAwareInter
 	 */
 	protected function maybe_redirect_after_activation(): bool {
 		// Do not redirect if setup is already complete
-		if ( $this->merchant_center->is_setup_complete() ) {
+		if ( boolval( $this->options->get( OptionsInterface::ONBOARDING_COMPLETED_AT ) ) ) {
 			$this->options->update( self::OPTION, 'no' );
 			return false;
 		}

--- a/src/Admin/Redirect.php
+++ b/src/Admin/Redirect.php
@@ -6,8 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Activateable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -21,9 +20,8 @@ use Automattic\WooCommerce\Admin\PageController;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin
  */
-class Redirect implements Activateable, Service, Registerable, OptionsAwareInterface, MerchantCenterAwareInterface {
+class Redirect implements Activateable, Service, Registerable, OptionsAwareInterface {
 
-	use MerchantCenterAwareTrait;
 	use OptionsAwareTrait;
 
 	protected const OPTION = OptionsInterface::REDIRECT_TO_ONBOARDING;
@@ -39,12 +37,19 @@ class Redirect implements Activateable, Service, Registerable, OptionsAwareInter
 	protected $wp;
 
 	/**
+	 * @var OnboardingCompleted
+	 */
+	protected $onboarding_completed;
+
+	/**
 	 * Redirect constructor.
 	 *
-	 * @param WP $wp
+	 * @param WP                  $wp
+	 * @param OnboardingCompleted $onboarding_completed
 	 */
-	public function __construct( WP $wp ) {
-		$this->wp = $wp;
+	public function __construct( WP $wp, OnboardingCompleted $onboarding_completed ) {
+		$this->wp                   = $wp;
+		$this->onboarding_completed = $onboarding_completed;
 	}
 
 	/**
@@ -83,28 +88,6 @@ class Redirect implements Activateable, Service, Registerable, OptionsAwareInter
 	}
 
 	/**
-	 * Check if onboarding is complete.
-	 * For backwards compatibility, checks MC setup if ONBOARDING_COMPLETED_AT is not set.
-	 *
-	 * @return bool
-	 */
-	protected function is_onboarding_complete(): bool {
-		$onboarding_completed_at = $this->options->get( OptionsInterface::ONBOARDING_COMPLETED_AT );
-
-		if ( null !== $onboarding_completed_at ) {
-			return boolval( $onboarding_completed_at );
-		}
-
-		if ( $this->merchant_center->is_setup_complete() ) {
-			$mc_setup_completed_at = $this->options->get( OptionsInterface::MC_SETUP_COMPLETED_AT );
-			$this->options->update( OptionsInterface::ONBOARDING_COMPLETED_AT, $mc_setup_completed_at );
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
 	 * Checks if merchant should be redirected to the onboarding page if it is not.
 	 *
 	 * @return void
@@ -120,12 +103,12 @@ class Redirect implements Activateable, Service, Registerable, OptionsAwareInter
 		}
 
 		// If setup ISNT complete then redirect from dashboard to onboarding
-		if ( ! $this->is_onboarding_complete() && $this->is_current_wc_admin_page( self::PATHS['dashboard'] ) ) {
+		if ( ! $this->onboarding_completed->is_onboarding_complete() && $this->is_current_wc_admin_page( self::PATHS['dashboard'] ) ) {
 			return $this->redirect_to( self::PATHS['get_started'] );
 		}
 
 		// If setup IS complete then redirect from onboarding to dashboard
-		if ( $this->is_onboarding_complete() && $this->is_current_wc_admin_page( self::PATHS['get_started'] ) ) {
+		if ( $this->onboarding_completed->is_onboarding_complete() && $this->is_current_wc_admin_page( self::PATHS['get_started'] ) ) {
 			return $this->redirect_to( self::PATHS['dashboard'] );
 		}
 
@@ -139,7 +122,7 @@ class Redirect implements Activateable, Service, Registerable, OptionsAwareInter
 	 */
 	protected function maybe_redirect_after_activation(): bool {
 		// Do not redirect if setup is already complete
-		if ( $this->is_onboarding_complete() ) {
+		if ( $this->onboarding_completed->is_onboarding_complete() ) {
 			$this->options->update( self::OPTION, 'no' );
 			return false;
 		}

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -33,6 +33,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Menu\SetupMerchantCenter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Shipping;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
@@ -88,10 +89,11 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 			AssetsHandlerInterface::class,
 			PHPViewFactory::class,
 			MerchantCenterService::class,
-			AdsService::class
+			AdsService::class,
+			OnboardingCompleted::class
 		);
 		$this->share_with_tags( PHPViewFactory::class );
-		$this->share_with_tags( Redirect::class, WP::class );
+		$this->share_with_tags( Redirect::class, WP::class, OnboardingCompleted::class );
 
 		// Share bulk edit views
 		$this->share_with_tags( CouponBulkEdit::class, CouponMetaHandler::class, MerchantCenterService::class, TargetAudience::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -74,6 +74,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsSetupCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantSetupCompleted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\Options;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -191,6 +192,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		MarketingChannelRegistrar::class => true,
 		OAuthService::class              => true,
 		WPCLIMigrationGTIN::class        => true,
+		OnboardingCompleted::class       => true,
 	];
 
 	/**
@@ -378,6 +380,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			$this->share_with_tags( GLAChannel::class, MerchantCenterService::class, AdsCampaign::class, Ads::class, MerchantStatuses::class, ProductSyncStats::class );
 			$this->share_with_tags( MarketingChannelRegistrar::class, GLAChannel::class, WC::class );
 		}
+
+		$this->share_with_tags( OnboardingCompleted::class );
 
 		// ClI Classes
 		$this->conditionally_share_with_tags( WPCLIMigrationGTIN::class, ProductRepository::class, AttributeManager::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -26,6 +26,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AssetGr
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AssetSuggestionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\RecommendationsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\GTINMigrationController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\OnboardingController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestAPI\SyncController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\TourController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\DisconnectController;
@@ -158,6 +159,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( RecommendationsController::class, AdsAccountService::class );
 		$this->share( AdsSettingsController::class );
 		$this->share( ConnectController::class, Middleware::class, OptionsInterface::class );
+		$this->share( OnboardingController::class );
 	}
 
 	/**

--- a/src/Options/OnboardingCompleted.php
+++ b/src/Options/OnboardingCompleted.php
@@ -1,0 +1,40 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class OnboardingCompleted
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Options
+ */
+class OnboardingCompleted implements OptionsAwareInterface, Registerable, Service {
+
+	use OptionsAwareTrait;
+
+	protected const OPTION = OptionsInterface::ONBOARDING_COMPLETED_AT;
+
+	/**
+	 * Register a service.
+	 */
+	public function register(): void {
+		add_action(
+			'woocommerce_gla_onboarding_completed',
+			function () {
+				$this->set_completed_timestamp();
+			}
+		);
+	}
+
+	/**
+	 * Set the timestamp when setup was completed.
+	 */
+	protected function set_completed_timestamp() {
+		$this->options->update( self::OPTION, time() );
+	}
+}

--- a/src/Options/OnboardingCompleted.php
+++ b/src/Options/OnboardingCompleted.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Options;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -13,8 +15,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Options
  */
-class OnboardingCompleted implements OptionsAwareInterface, Registerable, Service {
+class OnboardingCompleted implements OptionsAwareInterface, MerchantCenterAwareInterface, Registerable, Service {
 
+	use MerchantCenterAwareTrait;
 	use OptionsAwareTrait;
 
 	protected const OPTION = OptionsInterface::ONBOARDING_COMPLETED_AT;
@@ -36,5 +39,27 @@ class OnboardingCompleted implements OptionsAwareInterface, Registerable, Servic
 	 */
 	protected function set_completed_timestamp() {
 		$this->options->update( self::OPTION, time() );
+	}
+
+	/**
+	 * Check if onboarding is complete.
+	 * For backwards compatibility, checks MC setup if ONBOARDING_COMPLETED_AT is not set.
+	 *
+	 * @return bool
+	 */
+	public function is_onboarding_complete(): bool {
+		$onboarding_completed_at = $this->options->get( OptionsInterface::ONBOARDING_COMPLETED_AT );
+
+		if ( null !== $onboarding_completed_at ) {
+			return boolval( $onboarding_completed_at );
+		}
+
+		if ( $this->merchant_center->is_setup_complete() ) {
+			$mc_setup_completed_at = $this->options->get( OptionsInterface::MC_SETUP_COMPLETED_AT );
+			$this->options->update( OptionsInterface::ONBOARDING_COMPLETED_AT, $mc_setup_completed_at );
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -49,6 +49,7 @@ interface OptionsInterface {
 	public const WPCOM_REST_API_STATUS                     = 'wpcom_rest_api_status';
 	public const GTIN_MIGRATION_STATUS                     = 'gtin_migration_status';
 	public const API_PULL_SYNC_MODE                        = 'api_pull_sync_mode';
+	public const ONBOARDING_COMPLETED_AT                   = 'onboarding_completed_at';
 
 	public const VALID_OPTIONS = [
 		self::ADS_ACCOUNT_CURRENCY                      => true,
@@ -88,6 +89,7 @@ interface OptionsInterface {
 		self::GOOGLE_WPCOM_AUTH_NONCE                   => true,
 		self::GTIN_MIGRATION_STATUS                     => true,
 		self::API_PULL_SYNC_MODE                        => true,
+		self::ONBOARDING_COMPLETED_AT                   => true,
 	];
 
 	public const OPTION_TYPES = [

--- a/tests/Unit/API/Site/Controllers/OnboardingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/OnboardingControllerTest.php
@@ -34,27 +34,13 @@ class OnboardingControllerTest extends RESTControllerUnitTest {
 	public function test_complete_onboarding(): void {
 		// Track actions that were fired
 		$onboarding_completed_fired = false;
-		$track_event_fired          = false;
-		$track_event_name           = '';
-		$track_event_details        = null;
 
-		// Add hooks to check if actions are fired
+		// Add hook to check if action is fired
 		add_action(
 			'woocommerce_gla_onboarding_completed',
 			function () use ( &$onboarding_completed_fired ) {
 				$onboarding_completed_fired = true;
 			}
-		);
-
-		add_action(
-			'woocommerce_gla_track_event',
-			function ( $event_name, $event_details ) use ( &$track_event_fired, &$track_event_name, &$track_event_details ) {
-				$track_event_fired   = true;
-				$track_event_name    = $event_name;
-				$track_event_details = $event_details;
-			},
-			10,
-			2
 		);
 
 		$response = $this->do_request( self::ROUTE_COMPLETE, 'POST' );
@@ -63,11 +49,8 @@ class OnboardingControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'success', $response->get_data()['status'] );
 		$this->assertEquals( 'Successfully onboarded service based merchant', $response->get_data()['message'] );
 
-		// Verify actions were fired
+		// Verify action was fired
 		$this->assertTrue( $onboarding_completed_fired, 'woocommerce_gla_onboarding_completed action should be fired' );
-		$this->assertTrue( $track_event_fired, 'woocommerce_gla_track_event action should be fired' );
-		$this->assertEquals( 'onboarding_complete', $track_event_name, 'Event name should be onboarding_complete' );
-		$this->assertEquals( [], $track_event_details, 'Event details should be an empty array' );
 	}
 
 	/**

--- a/tests/Unit/API/Site/Controllers/OnboardingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/OnboardingControllerTest.php
@@ -1,0 +1,80 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\OnboardingController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+
+/**
+ * Class OnboardingControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers
+ */
+class OnboardingControllerTest extends RESTControllerUnitTest {
+
+	/** @var OnboardingController $controller */
+	protected $controller;
+
+	protected const ROUTE_COMPLETE = '/wc/gla/google/onboarding/complete';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->controller = new OnboardingController( $this->server );
+		$this->controller->register();
+	}
+
+	/**
+	 * Test completing onboarding successfully.
+	 */
+	public function test_complete_onboarding(): void {
+		// Track actions that were fired
+		$onboarding_completed_fired = false;
+		$track_event_fired          = false;
+		$track_event_name           = '';
+		$track_event_details        = null;
+
+		// Add hooks to check if actions are fired
+		add_action(
+			'woocommerce_gla_onboarding_completed',
+			function () use ( &$onboarding_completed_fired ) {
+				$onboarding_completed_fired = true;
+			}
+		);
+
+		add_action(
+			'woocommerce_gla_track_event',
+			function ( $event_name, $event_details ) use ( &$track_event_fired, &$track_event_name, &$track_event_details ) {
+				$track_event_fired   = true;
+				$track_event_name    = $event_name;
+				$track_event_details = $event_details;
+			},
+			10,
+			2
+		);
+
+		$response = $this->do_request( self::ROUTE_COMPLETE, 'POST' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'success', $response->get_data()['status'] );
+		$this->assertEquals( 'Successfully onboarded service based merchant', $response->get_data()['message'] );
+
+		// Verify actions were fired
+		$this->assertTrue( $onboarding_completed_fired, 'woocommerce_gla_onboarding_completed action should be fired' );
+		$this->assertTrue( $track_event_fired, 'woocommerce_gla_track_event action should be fired' );
+		$this->assertEquals( 'onboarding_complete', $track_event_name, 'Event name should be onboarding_complete' );
+		$this->assertEquals( [], $track_event_details, 'Event details should be an empty array' );
+	}
+
+	/**
+	 * Test that the route is registered correctly.
+	 */
+	public function test_route_registered(): void {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( self::ROUTE_COMPLETE, $routes );
+	}
+}

--- a/tests/Unit/Admin/RedirectsTest.php
+++ b/tests/Unit/Admin/RedirectsTest.php
@@ -238,6 +238,49 @@ class RedirectsTest extends TestCase {
 	}
 
 	/**
+	 * Test `is_onboarding_complete` backfills ONBOARDING_COMPLETED_AT from MC_SETUP_COMPLETED_AT
+	 * for existing users who completed setup before the ONBOARDING_COMPLETED_AT option existed.
+	 *
+	 * @return void
+	 */
+	public function test_is_onboarding_complete_backfills_from_mc_setup(): void {
+		$redirect_instance = $this->get_redirect_instance();
+		$mc_timestamp      = 1234567890;
+
+		// Set up options mock: ONBOARDING_COMPLETED_AT is null, MC_SETUP_COMPLETED_AT is set
+		$this->options->method( 'get' )
+			->willReturnCallback(
+				function ( $name ) use ( $mc_timestamp ) {
+					if ( $name === OptionsInterface::ONBOARDING_COMPLETED_AT ) {
+						return null; // Not set yet
+					}
+					if ( $name === OptionsInterface::MC_SETUP_COMPLETED_AT ) {
+						return $mc_timestamp; // Existing user has MC setup complete
+					}
+					return null;
+				}
+			);
+
+		// Set up merchant center mock: setup is complete
+		$this->merchant_center->method( 'is_setup_complete' )
+			->willReturn( true );
+
+		// Should update ONBOARDING_COMPLETED_AT with MC_SETUP_COMPLETED_AT timestamp
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::ONBOARDING_COMPLETED_AT, $mc_timestamp );
+
+		// Call the protected method using reflection
+		$reflection = new \ReflectionClass( $redirect_instance );
+		$method     = $reflection->getMethod( 'is_onboarding_complete' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $redirect_instance );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
 	 * Test is_current_wc_admin_page:
 	 */
 	public function test_is_current_wc_admin_page(): void {

--- a/tests/Unit/Admin/RedirectsTest.php
+++ b/tests/Unit/Admin/RedirectsTest.php
@@ -6,7 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Redirect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\Dashboard;
 use Automattic\WooCommerce\GoogleListingsAndAds\Menu\GetStarted;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\Admin\PageController;
@@ -22,8 +22,8 @@ class RedirectsTest extends TestCase {
 	/** @var MockObject|Redirect $redirects */
 	protected $redirects;
 
-	/** @var MockObject|MerchantCenterService $merchant_center */
-	protected $merchant_center;
+	/** @var MockObject|OnboardingCompleted $onboarding_completed */
+	protected $onboarding_completed;
 
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
@@ -36,10 +36,10 @@ class RedirectsTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->wp              = $this->createMock( WP::class );
-		$this->redirects       = $this->createMock( Redirect::class );
-		$this->merchant_center = $this->createMock( MerchantCenterService::class );
-		$this->options         = $this->createMock( OptionsInterface::class );
+		$this->wp                   = $this->createMock( WP::class );
+		$this->redirects            = $this->createMock( Redirect::class );
+		$this->onboarding_completed = $this->createMock( OnboardingCompleted::class );
+		$this->options              = $this->createMock( OptionsInterface::class );
 	}
 
 	/**
@@ -52,19 +52,20 @@ class RedirectsTest extends TestCase {
 	public function test_maybe_redirect_to_onboarding(): void {
 		$redirect_instance = $this->get_redirect_instance( [ 'is_current_wc_admin_page', 'redirect_to' ] );
 
-		// Set up options mock: onboarding not complete, no redirect flag set
+		// Set up options mock: no redirect flag set
 		$this->options->method( 'get' )
 			->willReturnCallback(
 				function ( $name ) {
-					if ( $name === OptionsInterface::ONBOARDING_COMPLETED_AT ) {
-						return false; // Onboarding not complete
-					}
 					if ( $name === OptionsInterface::REDIRECT_TO_ONBOARDING ) {
 						return 'no'; // No redirect flag
 					}
 					return null;
 				}
 			);
+
+		// Set up onboarding completed mock: onboarding not complete
+		$this->onboarding_completed->method( 'is_onboarding_complete' )
+			->willReturn( false );
 
 		// Set up page check: on dashboard page
 		$redirect_instance->method( 'is_current_wc_admin_page' )
@@ -91,19 +92,20 @@ class RedirectsTest extends TestCase {
 	public function test_maybe_redirect_to_dashboard(): void {
 		$redirect_instance = $this->get_redirect_instance( [ 'is_current_wc_admin_page', 'redirect_to' ] );
 
-		// Set up options mock: onboarding complete, no redirect flag set
+		// Set up options mock: no redirect flag set
 		$this->options->method( 'get' )
 			->willReturnCallback(
 				function ( $name ) {
-					if ( $name === OptionsInterface::ONBOARDING_COMPLETED_AT ) {
-						return time(); // Onboarding complete (truthy timestamp)
-					}
 					if ( $name === OptionsInterface::REDIRECT_TO_ONBOARDING ) {
 						return 'no'; // No redirect flag
 					}
 					return null;
 				}
 			);
+
+		// Set up onboarding completed mock: onboarding complete
+		$this->onboarding_completed->method( 'is_onboarding_complete' )
+			->willReturn( true );
 
 		// Set up page check: not on dashboard, but on get_started page
 		$redirect_instance->method( 'is_current_wc_admin_page' )
@@ -135,19 +137,20 @@ class RedirectsTest extends TestCase {
 	public function test_maybe_redirect_after_activation_onboarding_complete(): void {
 		$redirect_instance = $this->get_redirect_instance( [ 'is_current_wc_admin_page', 'redirect_to' ] );
 
-		// Set up options mock: onboarding complete, redirect flag set
+		// Set up options mock: redirect flag set
 		$this->options->method( 'get' )
 			->willReturnCallback(
 				function ( $name ) {
-					if ( $name === OptionsInterface::ONBOARDING_COMPLETED_AT ) {
-						return time(); // Onboarding complete
-					}
 					if ( $name === OptionsInterface::REDIRECT_TO_ONBOARDING ) {
 						return 'yes'; // Redirect flag set
 					}
 					return null;
 				}
 			);
+
+		// Set up onboarding completed mock: onboarding complete
+		$this->onboarding_completed->method( 'is_onboarding_complete' )
+			->willReturn( true );
 
 		// Should update the redirect flag to 'no'
 		$this->options->expects( $this->once() )
@@ -170,19 +173,20 @@ class RedirectsTest extends TestCase {
 	public function test_maybe_redirect_after_activation_on_get_started_page(): void {
 		$redirect_instance = $this->get_redirect_instance( [ 'is_current_wc_admin_page', 'redirect_to' ] );
 
-		// Set up options mock: onboarding not complete, redirect flag set
+		// Set up options mock: redirect flag set
 		$this->options->method( 'get' )
 			->willReturnCallback(
 				function ( $name ) {
-					if ( $name === OptionsInterface::ONBOARDING_COMPLETED_AT ) {
-						return false; // Onboarding not complete
-					}
 					if ( $name === OptionsInterface::REDIRECT_TO_ONBOARDING ) {
 						return 'yes'; // Redirect flag set
 					}
 					return null;
 				}
 			);
+
+		// Set up onboarding completed mock: onboarding not complete
+		$this->onboarding_completed->method( 'is_onboarding_complete' )
+			->willReturn( false );
 
 		// Set up page check: on get_started page
 		$redirect_instance->method( 'is_current_wc_admin_page' )
@@ -210,19 +214,20 @@ class RedirectsTest extends TestCase {
 	public function test_maybe_redirect_after_activation_redirects_to_onboarding(): void {
 		$redirect_instance = $this->get_redirect_instance( [ 'is_current_wc_admin_page', 'redirect_to' ] );
 
-		// Set up options mock: onboarding not complete, redirect flag set
+		// Set up options mock: redirect flag set
 		$this->options->method( 'get' )
 			->willReturnCallback(
 				function ( $name ) {
-					if ( $name === OptionsInterface::ONBOARDING_COMPLETED_AT ) {
-						return false; // Onboarding not complete
-					}
 					if ( $name === OptionsInterface::REDIRECT_TO_ONBOARDING ) {
 						return 'yes'; // Redirect flag set
 					}
 					return null;
 				}
 			);
+
+		// Set up onboarding completed mock: onboarding not complete
+		$this->onboarding_completed->method( 'is_onboarding_complete' )
+			->willReturn( false );
 
 		// Set up page check: not on get_started page
 		$redirect_instance->method( 'is_current_wc_admin_page' )
@@ -235,49 +240,6 @@ class RedirectsTest extends TestCase {
 			->with( GetStarted::PATH );
 
 		$this->assertTrue( $redirect_instance->maybe_redirect() );
-	}
-
-	/**
-	 * Test `is_onboarding_complete` backfills ONBOARDING_COMPLETED_AT from MC_SETUP_COMPLETED_AT
-	 * for existing users who completed setup before the ONBOARDING_COMPLETED_AT option existed.
-	 *
-	 * @return void
-	 */
-	public function test_is_onboarding_complete_backfills_from_mc_setup(): void {
-		$redirect_instance = $this->get_redirect_instance();
-		$mc_timestamp      = 1234567890;
-
-		// Set up options mock: ONBOARDING_COMPLETED_AT is null, MC_SETUP_COMPLETED_AT is set
-		$this->options->method( 'get' )
-			->willReturnCallback(
-				function ( $name ) use ( $mc_timestamp ) {
-					if ( $name === OptionsInterface::ONBOARDING_COMPLETED_AT ) {
-						return null; // Not set yet
-					}
-					if ( $name === OptionsInterface::MC_SETUP_COMPLETED_AT ) {
-						return $mc_timestamp; // Existing user has MC setup complete
-					}
-					return null;
-				}
-			);
-
-		// Set up merchant center mock: setup is complete
-		$this->merchant_center->method( 'is_setup_complete' )
-			->willReturn( true );
-
-		// Should update ONBOARDING_COMPLETED_AT with MC_SETUP_COMPLETED_AT timestamp
-		$this->options->expects( $this->once() )
-			->method( 'update' )
-			->with( OptionsInterface::ONBOARDING_COMPLETED_AT, $mc_timestamp );
-
-		// Call the protected method using reflection
-		$reflection = new \ReflectionClass( $redirect_instance );
-		$method     = $reflection->getMethod( 'is_onboarding_complete' );
-		$method->setAccessible( true );
-
-		$result = $method->invoke( $redirect_instance );
-
-		$this->assertTrue( $result );
 	}
 
 	/**
@@ -303,12 +265,11 @@ class RedirectsTest extends TestCase {
 	 */
 	private function get_redirect_instance( $only_methods = [] ): object {
 		$instance = $this->getMockBuilder( Redirect::class )
-			->setConstructorArgs( [ $this->wp ] )
+			->setConstructorArgs( [ $this->wp, $this->onboarding_completed ] )
 			->onlyMethods( $only_methods )
 			->getMock();
 
 		$instance->set_options_object( $this->options );
-		$instance->set_merchant_center_object( $this->merchant_center );
 
 		return $instance;
 	}

--- a/tests/Unit/Admin/RedirectsTest.php
+++ b/tests/Unit/Admin/RedirectsTest.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\Admin\PageController;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class RedirectsTest extends TestCase {
@@ -43,7 +44,7 @@ class RedirectsTest extends TestCase {
 
 	/**
 	 * Test `maybe_redirect` to confirm that merchant is only redirected to onboarding if:
-	 * 1. Merchant center setup is not complete
+	 * 1. Onboarding is not complete
 	 * 2. They are attempting to access the dashboard
 	 *
 	 * @return void
@@ -51,25 +52,38 @@ class RedirectsTest extends TestCase {
 	public function test_maybe_redirect_to_onboarding(): void {
 		$redirect_instance = $this->get_redirect_instance( [ 'is_current_wc_admin_page', 'redirect_to' ] );
 
-		$this->merchant_center->method( 'is_setup_complete' )
-			->willReturn( false );
+		// Set up options mock: onboarding not complete, no redirect flag set
+		$this->options->method( 'get' )
+			->willReturnCallback(
+				function ( $name ) {
+					if ( $name === OptionsInterface::ONBOARDING_COMPLETED_AT ) {
+						return false; // Onboarding not complete
+					}
+					if ( $name === OptionsInterface::REDIRECT_TO_ONBOARDING ) {
+						return 'no'; // No redirect flag
+					}
+					return null;
+				}
+			);
 
-		$this->assertFalse( $redirect_instance->maybe_redirect() );
-
+		// Set up page check: on dashboard page
 		$redirect_instance->method( 'is_current_wc_admin_page' )
-			->with( Dashboard::PATH )
-			->willReturn( true );
+			->willReturnCallback(
+				function ( $path ) {
+					return $path === Dashboard::PATH;
+				}
+			);
 
 		$redirect_instance->expects( $this->once() )
 			->method( 'redirect_to' )
 			->with( GetStarted::PATH );
 
-		$this->assertNull( $redirect_instance->maybe_redirect() );
+		$redirect_instance->maybe_redirect();
 	}
 
 	/**
 	 * Test `maybe_redirect` to confirm that merchant is only redirected to the dashboard if:
-	 * 1. Merchant center setup is complete
+	 * 1. Onboarding is complete
 	 * 2. They are attempting to access the onboarding screen
 	 *
 	 * @return void
@@ -77,20 +91,150 @@ class RedirectsTest extends TestCase {
 	public function test_maybe_redirect_to_dashboard(): void {
 		$redirect_instance = $this->get_redirect_instance( [ 'is_current_wc_admin_page', 'redirect_to' ] );
 
-		$this->merchant_center->method( 'is_setup_complete' )
-			->willReturn( true );
+		// Set up options mock: onboarding complete, no redirect flag set
+		$this->options->method( 'get' )
+			->willReturnCallback(
+				function ( $name ) {
+					if ( $name === OptionsInterface::ONBOARDING_COMPLETED_AT ) {
+						return time(); // Onboarding complete (truthy timestamp)
+					}
+					if ( $name === OptionsInterface::REDIRECT_TO_ONBOARDING ) {
+						return 'no'; // No redirect flag
+					}
+					return null;
+				}
+			);
 
-		$this->assertFalse( $redirect_instance->maybe_redirect() );
-
+		// Set up page check: not on dashboard, but on get_started page
 		$redirect_instance->method( 'is_current_wc_admin_page' )
-			->with( GetStarted::PATH )
-			->willReturn( true );
+			->willReturnCallback(
+				function ( $path ) {
+					if ( $path === Dashboard::PATH ) {
+						return false; // Not on dashboard
+					}
+					if ( $path === GetStarted::PATH ) {
+						return true; // On get_started page
+					}
+					return false;
+				}
+			);
 
 		$redirect_instance->expects( $this->once() )
 			->method( 'redirect_to' )
 			->with( Dashboard::PATH );
 
 		$this->assertNull( $redirect_instance->maybe_redirect() );
+	}
+
+	/**
+	 * Test `maybe_redirect_after_activation` when onboarding is already complete.
+	 * Should not redirect and should clear the redirect flag.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_redirect_after_activation_onboarding_complete(): void {
+		$redirect_instance = $this->get_redirect_instance( [ 'is_current_wc_admin_page', 'redirect_to' ] );
+
+		// Set up options mock: onboarding complete, redirect flag set
+		$this->options->method( 'get' )
+			->willReturnCallback(
+				function ( $name ) {
+					if ( $name === OptionsInterface::ONBOARDING_COMPLETED_AT ) {
+						return time(); // Onboarding complete
+					}
+					if ( $name === OptionsInterface::REDIRECT_TO_ONBOARDING ) {
+						return 'yes'; // Redirect flag set
+					}
+					return null;
+				}
+			);
+
+		// Should update the redirect flag to 'no'
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::REDIRECT_TO_ONBOARDING, 'no' );
+
+		// Should not redirect
+		$redirect_instance->expects( $this->never() )
+			->method( 'redirect_to' );
+
+		$this->assertFalse( $redirect_instance->maybe_redirect() );
+	}
+
+	/**
+	 * Test `maybe_redirect_after_activation` when already on get_started page.
+	 * Should not redirect and should clear the redirect flag.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_redirect_after_activation_on_get_started_page(): void {
+		$redirect_instance = $this->get_redirect_instance( [ 'is_current_wc_admin_page', 'redirect_to' ] );
+
+		// Set up options mock: onboarding not complete, redirect flag set
+		$this->options->method( 'get' )
+			->willReturnCallback(
+				function ( $name ) {
+					if ( $name === OptionsInterface::ONBOARDING_COMPLETED_AT ) {
+						return false; // Onboarding not complete
+					}
+					if ( $name === OptionsInterface::REDIRECT_TO_ONBOARDING ) {
+						return 'yes'; // Redirect flag set
+					}
+					return null;
+				}
+			);
+
+		// Set up page check: on get_started page
+		$redirect_instance->method( 'is_current_wc_admin_page' )
+			->with( GetStarted::PATH )
+			->willReturn( true );
+
+		// Should update the redirect flag to 'no'
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::REDIRECT_TO_ONBOARDING, 'no' );
+
+		// Should not redirect
+		$redirect_instance->expects( $this->never() )
+			->method( 'redirect_to' );
+
+		$this->assertFalse( $redirect_instance->maybe_redirect() );
+	}
+
+	/**
+	 * Test `maybe_redirect_after_activation` when onboarding is not complete and not on get_started page.
+	 * Should redirect to get_started page.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_redirect_after_activation_redirects_to_onboarding(): void {
+		$redirect_instance = $this->get_redirect_instance( [ 'is_current_wc_admin_page', 'redirect_to' ] );
+
+		// Set up options mock: onboarding not complete, redirect flag set
+		$this->options->method( 'get' )
+			->willReturnCallback(
+				function ( $name ) {
+					if ( $name === OptionsInterface::ONBOARDING_COMPLETED_AT ) {
+						return false; // Onboarding not complete
+					}
+					if ( $name === OptionsInterface::REDIRECT_TO_ONBOARDING ) {
+						return 'yes'; // Redirect flag set
+					}
+					return null;
+				}
+			);
+
+		// Set up page check: not on get_started page
+		$redirect_instance->method( 'is_current_wc_admin_page' )
+			->with( GetStarted::PATH )
+			->willReturn( false );
+
+		// Should redirect to get_started
+		$redirect_instance->expects( $this->once() )
+			->method( 'redirect_to' )
+			->with( GetStarted::PATH );
+
+		$this->assertTrue( $redirect_instance->maybe_redirect() );
 	}
 
 	/**

--- a/tests/Unit/Options/OnboardingCompletedTest.php
+++ b/tests/Unit/Options/OnboardingCompletedTest.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Options;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
@@ -18,6 +19,9 @@ class OnboardingCompletedTest extends UnitTest {
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
 	/** @var OnboardingCompleted $onboarding_completed */
 	protected $onboarding_completed;
 
@@ -28,8 +32,10 @@ class OnboardingCompletedTest extends UnitTest {
 		parent::setUp();
 
 		$this->options              = $this->createMock( OptionsInterface::class );
+		$this->merchant_center      = $this->createMock( MerchantCenterService::class );
 		$this->onboarding_completed = new OnboardingCompleted();
 		$this->onboarding_completed->set_options_object( $this->options );
+		$this->onboarding_completed->set_merchant_center_object( $this->merchant_center );
 	}
 
 	/**
@@ -97,5 +103,77 @@ class OnboardingCompletedTest extends UnitTest {
 		// Verify the timestamp is between before and after (allowing 1 second difference)
 		$this->assertGreaterThanOrEqual( $before_time, $captured_timestamp );
 		$this->assertLessThanOrEqual( $after_time + 1, $captured_timestamp );
+	}
+
+	/**
+	 * Test is_onboarding_complete returns true when ONBOARDING_COMPLETED_AT is set to a timestamp.
+	 */
+	public function test_is_onboarding_complete_returns_true_when_timestamp_set(): void {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::ONBOARDING_COMPLETED_AT )
+			->willReturn( time() );
+
+		$this->assertTrue( $this->onboarding_completed->is_onboarding_complete() );
+	}
+
+	/**
+	 * Test is_onboarding_complete returns false when ONBOARDING_COMPLETED_AT is set to 0 or false.
+	 */
+	public function test_is_onboarding_complete_returns_false_when_falsy_value_set(): void {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::ONBOARDING_COMPLETED_AT )
+			->willReturn( 0 );
+
+		$this->assertFalse( $this->onboarding_completed->is_onboarding_complete() );
+	}
+
+	/**
+	 * Test is_onboarding_complete backfills ONBOARDING_COMPLETED_AT from MC_SETUP_COMPLETED_AT
+	 * for existing users who completed setup before the ONBOARDING_COMPLETED_AT option existed.
+	 */
+	public function test_is_onboarding_complete_backfills_from_mc_setup(): void {
+		$mc_timestamp = 1234567890;
+
+		// Set up options mock: ONBOARDING_COMPLETED_AT is null, MC_SETUP_COMPLETED_AT is set
+		$this->options->method( 'get' )
+			->willReturnCallback(
+				function ( $name ) use ( $mc_timestamp ) {
+					if ( $name === OptionsInterface::ONBOARDING_COMPLETED_AT ) {
+						return null; // Not set yet
+					}
+					if ( $name === OptionsInterface::MC_SETUP_COMPLETED_AT ) {
+						return $mc_timestamp; // Existing user has MC setup complete
+					}
+					return null;
+				}
+			);
+
+		// Set up merchant center mock: setup is complete
+		$this->merchant_center->method( 'is_setup_complete' )
+			->willReturn( true );
+
+		// Should update ONBOARDING_COMPLETED_AT with MC_SETUP_COMPLETED_AT timestamp
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::ONBOARDING_COMPLETED_AT, $mc_timestamp );
+
+		$result = $this->onboarding_completed->is_onboarding_complete();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test is_onboarding_complete returns false when both options are not set.
+	 */
+	public function test_is_onboarding_complete_returns_false_when_not_set(): void {
+		// Set up options mock: both options return null
+		$this->options->method( 'get' )
+			->willReturn( null );
+
+		// Set up merchant center mock: setup is not complete
+		$this->merchant_center->method( 'is_setup_complete' )
+			->willReturn( false );
+
+		$this->assertFalse( $this->onboarding_completed->is_onboarding_complete() );
 	}
 }

--- a/tests/Unit/Options/OnboardingCompletedTest.php
+++ b/tests/Unit/Options/OnboardingCompletedTest.php
@@ -1,0 +1,101 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Options;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class OnboardingCompletedTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Options
+ */
+class OnboardingCompletedTest extends UnitTest {
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var OnboardingCompleted $onboarding_completed */
+	protected $onboarding_completed;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->options              = $this->createMock( OptionsInterface::class );
+		$this->onboarding_completed = new OnboardingCompleted();
+		$this->onboarding_completed->set_options_object( $this->options );
+	}
+
+	/**
+	 * Test that register method adds the action hook.
+	 */
+	public function test_register_adds_action_hook(): void {
+		$this->onboarding_completed->register();
+
+		$this->assertTrue(
+			has_action( 'woocommerce_gla_onboarding_completed' ),
+			'woocommerce_gla_onboarding_completed action should be registered'
+		);
+	}
+
+	/**
+	 * Test that the action hook fires and updates the timestamp.
+	 */
+	public function test_onboarding_completed_action_updates_timestamp(): void {
+		$this->onboarding_completed->register();
+
+		// Mock the options update to expect a timestamp
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				OptionsInterface::ONBOARDING_COMPLETED_AT,
+				$this->callback(
+					function ( $timestamp ) {
+						// Verify it's a valid timestamp (integer)
+						return is_int( $timestamp ) && $timestamp > 0;
+					}
+				)
+			);
+
+		// Fire the action
+		do_action( 'woocommerce_gla_onboarding_completed' );
+	}
+
+	/**
+	 * Test that the timestamp is approximately the current time.
+	 */
+	public function test_onboarding_completed_sets_current_timestamp(): void {
+		$this->onboarding_completed->register();
+
+		$before_time = time();
+
+		// Capture the timestamp that was set
+		$captured_timestamp = null;
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				OptionsInterface::ONBOARDING_COMPLETED_AT,
+				$this->callback(
+					function ( $timestamp ) use ( &$captured_timestamp ) {
+						$captured_timestamp = $timestamp;
+						return true;
+					}
+				)
+			);
+
+		// Fire the action
+		do_action( 'woocommerce_gla_onboarding_completed' );
+
+		$after_time = time();
+
+		// Verify the timestamp is between before and after (allowing 1 second difference)
+		$this->assertGreaterThanOrEqual( $before_time, $captured_timestamp );
+		$this->assertLessThanOrEqual( $after_time + 1, $captured_timestamp );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-380/create-new-rest-api-endpoint-to-mark-service-based-merchant-setup#comment-f0506946

### Screenshots:

Postman request and response:
<img width="1176" height="416" alt="Screenshot 2025-12-17 at 11 27 26" src="https://github.com/user-attachments/assets/bbdce285-b819-40c1-807b-9d1eccee9fcc" />

CURL request and response:
<img width="1175" height="171" alt="Screenshot 2025-12-17 at 11 32 37" src="https://github.com/user-attachments/assets/febd7db0-c0e1-47de-9a0b-344f3e888861" />


### Detailed test instructions:
Postman
1. Import this collection: [380-postman-testing.json](https://github.com/user-attachments/files/24211849/380-postman-testing.json) to Postman
2. Update the variables to add your install URL, username and application password (create one if need be)
3. Click Send to make the request

CURL:
1.Update this to your URL, username and application; then run in a terminal:
 `curl -X POST "https://woo.test/wp-json/wc/gla/google/onboarding/complete" -u "username:generate-an-application-password" | jq`

### Additional details:
> Adds new REST API endpoint to mark service based merchant setup is complete


