### PR TITLE
Temporary fix: hardcode WooCommerce versions

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -47,11 +47,9 @@ jobs:
         uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
           slug: wordpress
-      - name: Get Release versions from WooCommerce
+      - name: Temporarily hardcode wc-versions
         id: wc
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
-        with:
-          slug: woocommerce
+        run: echo "versions=['10.4.3', '10.3.6', '10.2.2']" >> $GITHUB_OUTPUT
 
   UnitTests:
     if: github.event_name != 'workflow_dispatch'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes N/A

### Screenshots:

Error from https://github.com/woocommerce/google-listings-and-ads/actions/runs/20433635600/job/58714664314?pr=3180:
<img width="921" height="661" alt="Screenshot 2025-12-23 at 12 57 27" src="https://github.com/user-attachments/assets/80f487ec-2875-4ba6-942e-b780fa0ae864" />


### Detailed test instructions:

1. Confirm PHPUnit tests run and pass 

### Additional details:

> Fix - Hardcoded WooCommerce versions to resolve failing tests due to 10.3.7 tag not currently being available on Github
