### PR TITLE
Change the `get-plugin-releases` action to get the WooCommerce releases from GitHub

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -44,14 +44,12 @@ jobs:
     steps:
       - name: Get Release versions from WordPress
         id: wp
-        # uses: woocommerce/grow/get-plugin-releases@actions-v2
-        uses: woocommerce/grow/get-plugin-releases@add/actions-get-plugin-releases-from-github-test-build
+        uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
           slug: wordpress
       - name: Get Release versions from WooCommerce
         id: wc
-        # uses: woocommerce/grow/get-plugin-releases@actions-v2
-        uses: woocommerce/grow/get-plugin-releases@add/actions-get-plugin-releases-from-github-test-build
+        uses: woocommerce/grow/get-plugin-releases@actions-v2
         with:
           source: github
           slug: woocommerce/woocommerce

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -44,14 +44,17 @@ jobs:
     steps:
       - name: Get Release versions from WordPress
         id: wp
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        # uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@add/actions-get-plugin-releases-from-github-test-build
         with:
           slug: wordpress
       - name: Get Release versions from WooCommerce
         id: wc
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        # uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@add/actions-get-plugin-releases-from-github-test-build
         with:
-          slug: woocommerce
+          source: github
+          slug: woocommerce/woocommerce
 
   UnitTests:
     if: github.event_name != 'workflow_dispatch'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Due to occasional inconsistencies between WooCommerce releases on WPORG and GitHub, the PHP Unit Tests workflow on GitHub Actions that gets WooCommerce versions and subsequently clones them from GitHub may be problematic under these circumstances. This PR changes the workflow to get versions from GitHub to avoid issues.

### Detailed test instructions:

Confirmed that the PHP Unit Tests workflow has been successfully run and passed.

https://github.com/woocommerce/google-listings-and-ads/actions/runs/20654566926?pr=3189

<img width="945" height="609" alt="image" src="https://github.com/user-attachments/assets/cb733ca6-a477-47ea-8953-48bdc9d264da" />

### Changelog entry
