### PR TITLE
Set custom message

### DIFF
--- a/src/Validator/ImageUrlConstraint.php
+++ b/src/Validator/ImageUrlConstraint.php
@@ -14,7 +14,12 @@ defined( 'ABSPATH' ) || exit;
  */
 class ImageUrlConstraint extends UrlConstraint {
 	/**
-	 * @var string
+	 * Constructor.
+	 *
+	 * @param array|null $options Options.
 	 */
-	public $message = 'Product image "{{ name }}" is not a valid name.';
+	public function __construct( $options = null ) {
+		parent::__construct( $options );
+		$this->message = 'Product image "{{ name }}" is not a valid name.';
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #3188 and https://linear.app/a8c/issue/GOOWOO-407/fatal-error-in-351-with-php-83-imageurlconstraintdollarmessage-type


ImageUrlConstraint.php now uses a constructor that calls the parent and then sets the custom message, avoiding any property signature mismatches regardless of Symfony/PHP version.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix: Fatal error in 3.5.1 with PHP 8.3: ImageUrlConstraint::$message type mismatch
