### PR TITLE
[GOOWOO-373] Update Google API Queries to allow campaigns to be created/edited without an Merchant Center account 2

### DIFF
--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -137,11 +137,18 @@ class AdsAssetGroup implements OptionsAwareInterface {
 	 * @return array
 	 */
 	public function create_operations( string $campaign_resource_name, string $asset_group_name ): array {
-		// Asset must be created before listing group.
-		return [
+		$merchant_id = $this->options->get_merchant_id();
+		$operations  = [
 			$this->asset_group_create_operation( $campaign_resource_name, $asset_group_name ),
-			$this->listing_group_create_operation(),
 		];
+
+		// Only create listing group filter when Merchant Center account is connected.
+		// Listing group filter with SHOPPING source requires a product feed.
+		if ( $merchant_id > 0 ) {
+			$operations[] = $this->listing_group_create_operation();
+		}
+
+		return $operations;
 	}
 
 	/**

--- a/tests/Unit/API/Google/AdsAssetGroupTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupTest.php
@@ -57,7 +57,10 @@ class AdsAssetGroupTest extends UnitTest {
 		$this->asset_group->set_options_object( $this->options );
 	}
 
-	public function test_create_operations() {
+	public function test_create_operations_with_merchant_center() {
+		// Mock merchant_id > 0 to simulate Merchant Center connected
+		$this->options->method( 'get_merchant_id' )->willReturn( 12345 );
+
 		$campaign_resource_name    = $this->generate_campaign_resource_name( self::TEST_CAMPAIGN_ID );
 		$asset_group_resource_name = $this->generate_asset_group_resource_name( -3 );
 
@@ -65,6 +68,9 @@ class AdsAssetGroupTest extends UnitTest {
 			$campaign_resource_name,
 			'New Campaign'
 		);
+
+		// Should return 2 operations: asset group + listing group filter
+		$this->assertCount( 2, $operations );
 
 		$operation_asset_group = $operations[0]->getAssetGroupOperation();
 		$this->assertTrue( $operation_asset_group->hasCreate() );
@@ -79,10 +85,34 @@ class AdsAssetGroupTest extends UnitTest {
 		$this->assertTrue( $operation_listing_group->hasCreate() );
 
 		$listing_group = $operation_listing_group->getCreate();
-		$this->assertEquals( 'New Campaign Asset Group', $asset_group->getName() );
 		$this->assertEquals( $asset_group_resource_name, $listing_group->getAssetGroup() );
 		$this->assertEquals( ListingGroupFilterType::UNIT_INCLUDED, $listing_group->getType() );
 		$this->assertEquals( ListingGroupFilterListingSource::SHOPPING, $listing_group->getListingSource() );
+	}
+
+	public function test_create_operations_without_merchant_center() {
+		// Mock merchant_id = 0 to simulate no Merchant Center
+		$this->options->method( 'get_merchant_id' )->willReturn( 0 );
+
+		$campaign_resource_name    = $this->generate_campaign_resource_name( self::TEST_CAMPAIGN_ID );
+		$asset_group_resource_name = $this->generate_asset_group_resource_name( -3 );
+
+		$operations = $this->asset_group->create_operations(
+			$campaign_resource_name,
+			'New Campaign'
+		);
+
+		// Should return only 1 operation: asset group (no listing group filter)
+		$this->assertCount( 1, $operations );
+
+		$operation_asset_group = $operations[0]->getAssetGroupOperation();
+		$this->assertTrue( $operation_asset_group->hasCreate() );
+
+		$asset_group = $operation_asset_group->getCreate();
+		$this->assertEquals( 'New Campaign Asset Group', $asset_group->getName() );
+		$this->assertEquals( $campaign_resource_name, $asset_group->getCampaign() );
+		$this->assertEquals( $asset_group_resource_name, $asset_group->getResourceName() );
+		$this->assertEquals( AssetGroupStatus::ENABLED, $asset_group->getStatus() );
 	}
 
 	public function test_get_asset_groups_by_campaign_id_with_assets() {
@@ -251,8 +281,44 @@ class AdsAssetGroupTest extends UnitTest {
 		}
 	}
 
-	public function test_create_asset_group() {
+	public function test_create_asset_group_with_merchant_center() {
+		// Mock merchant_id > 0 to simulate Merchant Center connected
+		$this->options->method( 'get_merchant_id' )->willReturn( 12345 );
+
 		$this->generate_asset_group_mutate_mock( 'create', self::TEST_CAMPAIGN_ID );
+
+		$this->assertEquals(
+			self::TEST_CAMPAIGN_ID,
+			$this->asset_group->create_asset_group( self::TEST_CAMPAIGN_ID )
+		);
+	}
+
+	public function test_create_asset_group_without_merchant_center() {
+		// Mock merchant_id = 0 to simulate no Merchant Center
+		$this->options->method( 'get_merchant_id' )->willReturn( 0 );
+
+		// For create without MC, we need to update the mock to expect only 1 operation
+		$asset_group_resource_name = $this->generate_asset_group_resource_name( self::TEST_CAMPAIGN_ID );
+		$asset_group_result        = $this->createMock( \Google\Ads\GoogleAds\V20\Services\MutateAssetGroupResult::class );
+		$asset_group_result->method( 'getResourceName' )->willReturn( $asset_group_resource_name );
+
+		$response = ( new \Google\Ads\GoogleAds\V20\Services\MutateGoogleAdsResponse() )->setMutateOperationResponses(
+			[
+				( new \Google\Ads\GoogleAds\V20\Services\MutateOperationResponse() )->setAssetGroupResult( $asset_group_result ),
+			]
+		);
+
+		$this->service_client->expects( $this->once() )
+			->method( 'mutate' )
+			->willReturnCallback(
+				function ( $request ) use ( $response ) {
+					$operations = $request->getMutateOperations();
+					// Should only have 1 operation (asset group, no listing group filter)
+					$this->assertCount( 1, $operations );
+					$this->assertEquals( 'asset_group_operation', $operations[0]->getOperation() );
+					return $response;
+				}
+			);
 
 		$this->assertEquals(
 			self::TEST_CAMPAIGN_ID,

--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -442,13 +442,40 @@ test.describe( 'Set up Ads account', () => {
 			} );
 		} );
 
+		test( 'Campaign creation succeeds with Merchant Center account', async () => {
+			await setupBudgetPage.fillBudget( '6' );
+
+			const campaignCreation =
+				setupBudgetPage.mockCampaignCreationAndAdsSetupCompletion(
+					'6',
+					[ 'US' ]
+				);
+
+			await setupBudgetPage.getCreateCampaignButton().click();
+
+			await campaignCreation;
+
+			await page.waitForURL(
+				'/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&guide=campaign-creation-success',
+				{
+					waitUntil: LOAD_STATE.DOM_CONTENT_LOADED,
+				}
+			);
+
+			await expect(
+				page.getByRole( 'heading', {
+					name: "You've set up a Performance Max Campaign!",
+				} )
+			).toBeVisible();
+		} );
+
 		test( 'It should show the campaign creation success message', async () => {
 			await setupBudgetPage.fillBudget( '6' );
 			await setupBudgetPage.getCreateCampaignButton().click();
 
 			const cancelButton = page.getByRole( 'button', { name: 'Cancel' } );
 			await expect(
-				page.getByText( 'This offer won’t last long!' )
+				page.getByText( "This offer won't last long!" )
 			).toBeVisible();
 			await expect( cancelButton ).toBeEnabled();
 

--- a/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
+++ b/tests/e2e/specs/add-paid-campaigns/add-paid-campaigns.test.js
@@ -475,7 +475,7 @@ test.describe( 'Set up Ads account', () => {
 
 			const cancelButton = page.getByRole( 'button', { name: 'Cancel' } );
 			await expect(
-				page.getByText( "This offer won't last long!" )
+				page.getByText( 'This offer won’t last long!' )
 			).toBeVisible();
 			await expect( cancelButton ).toBeEnabled();
 

--- a/tests/e2e/specs/onboarding/step-2-create-campaign-ads-account-only.test.js
+++ b/tests/e2e/specs/onboarding/step-2-create-campaign-ads-account-only.test.js
@@ -409,7 +409,7 @@ test.describe( 'Create campaign for Ads only merchants', () => {
 					} );
 
 					await expect(
-						page.getByText( "This offer won't last long!" )
+						page.getByText( 'This offer won’t last long!' )
 					).toBeVisible();
 					await expect( confirmButton ).toBeEnabled();
 

--- a/tests/e2e/specs/onboarding/step-2-create-campaign-ads-account-only.test.js
+++ b/tests/e2e/specs/onboarding/step-2-create-campaign-ads-account-only.test.js
@@ -388,6 +388,18 @@ test.describe( 'Create campaign for Ads only merchants', () => {
 					await campaignCreation;
 				} );
 
+				test( 'Campaign creation succeeds without Merchant Center account', async () => {
+					await setupBudgetPage.fillBudget( '120' );
+					const campaignCreation =
+						setupBudgetPage.mockCampaignCreationAndAdsSetupCompletion(
+							'120',
+							[ 'US', 'TW', 'GB' ]
+						);
+					await createCampaignPage.clickContinueButton();
+					await campaignCreation;
+					await expect( page.getByRole( 'heading' ) ).toBeVisible();
+				} );
+
 				test( 'Suggest a higher budget for getting back free credits', async () => {
 					await setupBudgetPage.fillBudget( '8' );
 					await createCampaignPage.clickContinueButton();
@@ -397,7 +409,7 @@ test.describe( 'Create campaign for Ads only merchants', () => {
 					} );
 
 					await expect(
-						page.getByText( 'This offer won’t last long!' )
+						page.getByText( "This offer won't last long!" )
 					).toBeVisible();
 					await expect( confirmButton ).toBeEnabled();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-373/update-google-api-queries-to-allow-campaigns-to-be-creatededited

Follow up to QA feedback on PR 3178: https://github.com/woocommerce/google-listings-and-ads/pull/3178#issuecomment-3689090697

### Screenshots:

N/A

### Detailed test instructions:

## Test 1: Create Campaign without Merchant Account

1. Go to: `Marketing → Google for WooCommerce → Dashboard`
2. Click "Add campaign"
3. Fill form (name, budget, countries)
4. Click "Create campaign"
5. **Verify**: Success message appears
6. **Verify**: Campaign appears in dashboard list

## Test 2: Edit Campaign without Merchant Account

1. Go to: `Marketing → Google for WooCommerce → Dashboard`
2. Find campaign created in Test 1
3. Click "Edit"
4. Change name/budget/status
5. Click "Save"
6. **Verify**: Success message appears
7. **Verify**: Changes are reflected in dashboard

## Test 3: Budget Recommendations without Merchant Account

1. Go to: `Marketing → Google for WooCommerce → Dashboard`
2. Click "Add campaign"
3. Enter budget amount in the form
4. **Verify**: Budget recommendations appear (Low/Recommended/High options with metrics)
5. **Verify**: No error messages displayed
6. **Verify**: No errors in browser console (F12)

## Test 4: Edge Case - Edit Campaign Created with Merchant Account after Merchant Account disconnected

1. Go to: `Marketing → Google for WooCommerce → Dashboard`
2. Find campaign created in Setup (before Merchant Account disconnect)
3. Click "Edit"
4. Make any change (name, budget, or status)
5. Click "Save"
6. **Verify**: Error message appears: "Cannot edit campaign: This campaign was created with a Merchant Center account, but the account is now disconnected..."
7. **Verify**: Campaign is NOT updated (changes not saved)

### Additional details:
> Update - Update Google API Queries to allow campaigns to be created/edited without an Merchant Center account