### PR TITLE
[GOOWOO-380] Delete method for: Create new REST API endpoint to mark service based merchant setup complete

### DIFF
--- a/src/API/Site/Controllers/DisconnectController.php
+++ b/src/API/Site/Controllers/DisconnectController.php
@@ -47,6 +47,7 @@ class DisconnectController extends BaseController {
 				'google/connect',
 				'jetpack/connect',
 				'rest-api/authorize',
+				'google/onboarding/complete',
 			];
 
 			$errors    = [];

--- a/src/API/Site/Controllers/OnboardingController.php
+++ b/src/API/Site/Controllers/OnboardingController.php
@@ -4,8 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
@@ -54,7 +52,7 @@ class OnboardingController extends BaseOptionsController {
 			return new Response(
 				[
 					'status'  => 'success',
-					'message' => __( 'Successfully onboarded service based merchant', 'google-listings-and-ads' ),
+					'message' => __( 'Successfully onboarded service based merchant.', 'google-listings-and-ads' ),
 				],
 				200
 			);
@@ -73,7 +71,7 @@ class OnboardingController extends BaseOptionsController {
 			return new Response(
 				[
 					'status'  => 'success',
-					'message' => __( 'Successfully deleted onboarding completion status', 'google-listings-and-ads' ),
+					'message' => __( 'Successfully deleted onboarding completion status.', 'google-listings-and-ads' ),
 				],
 				200
 			);

--- a/src/API/Site/Controllers/OnboardingController.php
+++ b/src/API/Site/Controllers/OnboardingController.php
@@ -4,6 +4,9 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 
@@ -14,9 +17,10 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers
  */
-class OnboardingController extends BaseController {
+class OnboardingController extends BaseController implements OptionsAwareInterface {
 
 	use EmptySchemaPropertiesTrait;
+	use OptionsAwareTrait;
 
 	/**
 	 * Register rest routes with WordPress.
@@ -28,6 +32,11 @@ class OnboardingController extends BaseController {
 				[
 					'methods'             => TransportMethods::CREATABLE,
 					'callback'            => $this->get_complete_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+				[
+					'methods'             => TransportMethods::DELETABLE,
+					'callback'            => $this->get_delete_callback(),
 					'permission_callback' => $this->get_permission_callback(),
 				],
 			]
@@ -47,6 +56,25 @@ class OnboardingController extends BaseController {
 				[
 					'status'  => 'success',
 					'message' => __( 'Successfully onboarded service based merchant', 'google-listings-and-ads' ),
+				],
+				200
+			);
+		};
+	}
+
+	/**
+	 * Get the callback for deleting onboarding completion.
+	 *
+	 * @return callable
+	 */
+	protected function get_delete_callback(): callable {
+		return function ( Request $request ) {
+			$this->options->delete( OptionsInterface::ONBOARDING_COMPLETED_AT );
+
+			return new Response(
+				[
+					'status'  => 'success',
+					'message' => __( 'Successfully deleted onboarding completion status', 'google-listings-and-ads' ),
 				],
 				200
 			);

--- a/src/API/Site/Controllers/OnboardingController.php
+++ b/src/API/Site/Controllers/OnboardingController.php
@@ -17,10 +17,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers
  */
-class OnboardingController extends BaseController implements OptionsAwareInterface {
+class OnboardingController extends BaseOptionsController {
 
 	use EmptySchemaPropertiesTrait;
-	use OptionsAwareTrait;
 
 	/**
 	 * Register rest routes with WordPress.

--- a/tests/Unit/API/Site/Controllers/DisconnectControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/DisconnectControllerTest.php
@@ -1,0 +1,80 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\DisconnectController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\OnboardingController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class DisconnectControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers
+ */
+class DisconnectControllerTest extends RESTControllerUnitTest {
+
+	/** @var DisconnectController $controller */
+	protected $controller;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	protected const ROUTE_CONNECTIONS = '/wc/gla/connections';
+	protected const ROUTE_ONBOARDING_COMPLETE = '/wc/gla/google/onboarding/complete';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Register OnboardingController so it can be called by DisconnectController
+		$this->options = $this->createMock( OptionsInterface::class );
+		$onboarding_controller = new OnboardingController( $this->server );
+		$onboarding_controller->set_options_object( $this->options );
+		$onboarding_controller->register();
+
+		$this->controller = new DisconnectController( $this->server );
+		$this->controller->register();
+	}
+
+	/**
+	 * Test that the route is registered correctly.
+	 */
+	public function test_route_registered(): void {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( self::ROUTE_CONNECTIONS, $routes );
+	}
+
+	/**
+	 * Test that disconnect calls the onboarding complete DELETE endpoint.
+	 *
+	 * Note: The actual DELETE endpoint behavior is tested in OnboardingControllerTest.
+	 * This test only verifies that DisconnectController includes it in the disconnect flow.
+	 */
+	public function test_disconnect_calls_onboarding_complete_endpoint(): void {
+		// Expect the delete method to be called exactly once
+		$this->options->expects( $this->once() )
+			->method( 'delete' )
+			->with( OptionsInterface::ONBOARDING_COMPLETED_AT )
+			->willReturn( true );
+
+		$response = $this->do_request( self::ROUTE_CONNECTIONS, 'DELETE' );
+
+		// Verify the response structure
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'errors', $data );
+		$this->assertArrayHasKey( 'responses', $data );
+
+		// Verify that the onboarding complete endpoint was successfully called
+		$this->assertArrayHasKey(
+			self::ROUTE_ONBOARDING_COMPLETE,
+			$data['responses'],
+			'The onboarding complete endpoint should be successfully called by disconnect'
+		);
+	}
+}
+

--- a/tests/Unit/API/Site/Controllers/DisconnectControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/DisconnectControllerTest.php
@@ -22,7 +22,7 @@ class DisconnectControllerTest extends RESTControllerUnitTest {
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
-	protected const ROUTE_CONNECTIONS = '/wc/gla/connections';
+	protected const ROUTE_CONNECTIONS         = '/wc/gla/connections';
 	protected const ROUTE_ONBOARDING_COMPLETE = '/wc/gla/google/onboarding/complete';
 
 	/**
@@ -32,7 +32,7 @@ class DisconnectControllerTest extends RESTControllerUnitTest {
 		parent::setUp();
 
 		// Register OnboardingController so it can be called by DisconnectController
-		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options         = $this->createMock( OptionsInterface::class );
 		$onboarding_controller = new OnboardingController( $this->server );
 		$onboarding_controller->set_options_object( $this->options );
 		$onboarding_controller->register();
@@ -77,4 +77,3 @@ class DisconnectControllerTest extends RESTControllerUnitTest {
 		);
 	}
 }
-

--- a/tests/Unit/API/Site/Controllers/OnboardingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/OnboardingControllerTest.php
@@ -21,7 +21,7 @@ class OnboardingControllerTest extends RESTControllerUnitTest {
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
-	protected const ROUTE_COMPLETE = '/wc/gla/google/onboarding/complete';
+	protected const ROUTE_ONBOARDING_COMPLETE = '/wc/gla/google/onboarding/complete';
 
 	/**
 	 * Runs before each test is executed.
@@ -50,11 +50,16 @@ class OnboardingControllerTest extends RESTControllerUnitTest {
 			}
 		);
 
-		$response = $this->do_request( self::ROUTE_COMPLETE, 'POST' );
+		$response = $this->do_request( self::ROUTE_ONBOARDING_COMPLETE, 'POST' );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'success', $response->get_data()['status'] );
-		$this->assertEquals( 'Successfully onboarded service based merchant', $response->get_data()['message'] );
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully onboarded service based merchant.',
+			],
+			$response->get_data()
+		);
 
 		// Verify action was fired
 		$this->assertTrue( $onboarding_completed_fired, 'woocommerce_gla_onboarding_completed action should be fired' );
@@ -65,7 +70,7 @@ class OnboardingControllerTest extends RESTControllerUnitTest {
 	 */
 	public function test_route_registered(): void {
 		$routes = $this->server->get_routes();
-		$this->assertArrayHasKey( self::ROUTE_COMPLETE, $routes );
+		$this->assertArrayHasKey( self::ROUTE_ONBOARDING_COMPLETE, $routes );
 	}
 
 	/**
@@ -77,10 +82,15 @@ class OnboardingControllerTest extends RESTControllerUnitTest {
 			->with( OptionsInterface::ONBOARDING_COMPLETED_AT )
 			->willReturn( true );
 
-		$response = $this->do_request( self::ROUTE_COMPLETE, 'DELETE' );
+		$response = $this->do_request( self::ROUTE_ONBOARDING_COMPLETE, 'DELETE' );
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'success', $response->get_data()['status'] );
-		$this->assertEquals( 'Successfully deleted onboarding completion status', $response->get_data()['message'] );
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully deleted onboarding completion status.',
+			],
+			$response->get_data()
+		);
 	}
 }

--- a/tests/Unit/API/Site/Controllers/OnboardingControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/OnboardingControllerTest.php
@@ -4,7 +4,9 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\OnboardingController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class OnboardingControllerTest
@@ -16,6 +18,9 @@ class OnboardingControllerTest extends RESTControllerUnitTest {
 	/** @var OnboardingController $controller */
 	protected $controller;
 
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
 	protected const ROUTE_COMPLETE = '/wc/gla/google/onboarding/complete';
 
 	/**
@@ -24,7 +29,9 @@ class OnboardingControllerTest extends RESTControllerUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
+		$this->options    = $this->createMock( OptionsInterface::class );
 		$this->controller = new OnboardingController( $this->server );
+		$this->controller->set_options_object( $this->options );
 		$this->controller->register();
 	}
 
@@ -59,5 +66,21 @@ class OnboardingControllerTest extends RESTControllerUnitTest {
 	public function test_route_registered(): void {
 		$routes = $this->server->get_routes();
 		$this->assertArrayHasKey( self::ROUTE_COMPLETE, $routes );
+	}
+
+	/**
+	 * Test deleting onboarding completion successfully.
+	 */
+	public function test_delete_onboarding_completion(): void {
+		$this->options->expects( $this->once() )
+			->method( 'delete' )
+			->with( OptionsInterface::ONBOARDING_COMPLETED_AT )
+			->willReturn( true );
+
+		$response = $this->do_request( self::ROUTE_COMPLETE, 'DELETE' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'success', $response->get_data()['status'] );
+		$this->assertEquals( 'Successfully deleted onboarding completion status', $response->get_data()['message'] );
 	}
 }

--- a/tests/e2e/test-data/test-data.php
+++ b/tests/e2e/test-data/test-data.php
@@ -127,6 +127,10 @@ function set_onboarded_merchant() {
 		OptionsInterface::GOOGLE_CONNECTED,
 		true
 	);
+	$options->update(
+		OptionsInterface::ONBOARDING_COMPLETED_AT,
+		1693215209
+	);
 }
 
 /**
@@ -138,6 +142,7 @@ function clear_onboarded_merchant() {
 	$options->delete( OptionsInterface::REDIRECT_TO_ONBOARDING );
 	$options->delete( OptionsInterface::MC_SETUP_COMPLETED_AT );
 	$options->delete( OptionsInterface::GOOGLE_CONNECTED );
+	$options->delete( OptionsInterface::ONBOARDING_COMPLETED_AT );
 }
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-380/create-new-rest-api-endpoint-to-mark-service-based-merchant-setup

Follow up to https://github.com/woocommerce/google-listings-and-ads/pull/3182 (was merged prior to delete method being added).

### Screenshots:

Postman requests and responses:
<img width="1581" height="795" alt="Screenshot 2026-01-07 at 13 57 56" src="https://github.com/user-attachments/assets/0817e289-053d-417a-9493-2eccdea705df" />
<img width="1579" height="786" alt="Screenshot 2026-01-07 at 13 58 01" src="https://github.com/user-attachments/assets/9c05399e-45b1-4b24-b8e3-a6e2d4f6c26e" />

CURL requests and responses:
<img width="745" height="382" alt="Screenshot 2026-01-07 at 13 57 41" src="https://github.com/user-attachments/assets/5861f8c9-ff67-4ae6-932e-1d102f89e699" />



### Detailed test instructions:
Postman
1. Import this collection: [380-postman-testing.json](https://github.com/user-attachments/files/24473029/380-postman-testing.json) to Postman (updated from #3182 to include delete method)
2. Update the variables to add your install URL, username and application password (create one if need be)
3. Send the POST request; confirm the response says: "Successfully onboarded service based merchant"
4. Send the DELETE request; confirm the response says: "Successfully deleted onboarding completion status" 


CURL:
1.Update this to your URL, username and application; then run in a terminal:
 `curl -X POST "https://woo.test/wp-json/wc/gla/google/onboarding/complete" -u "username:generate-an-application-password" | jq`
2. Update this to your URL, username and application; then run in a terminal:
 `curl -X DELETE "https://woo.test/wp-json/wc/gla/google/onboarding/complete" -u "username:generate-an-application-password" | jq`

### Additional details:
> Adds new REST API endpoint to mark service based merchant setup is complete



