### PR TITLE
GOOWOO-332 Add YouTube Connect Controller: Fix infinite loading when YouTube connection fails without channel permissions.

### DIFF
--- a/js/src/components/youtube-account-card/youtube-account-card.js
+++ b/js/src/components/youtube-account-card/youtube-account-card.js
@@ -2,6 +2,9 @@
  * Internal dependencies
  */
 import { YOUTUBE_ACCOUNT_STATUS } from '~/constants';
+import useYouTubeAccount from '~/hooks/useYouTubeAccount';
+import AccountCard from '~/components/account-card';
+import AppSpinner from '~/components/app-spinner';
 import ConnectedYouTubeAccountCard from './connected-youtube-account-card';
 import ConnectYouTubeAccountCard from './connect-youtube-account-card';
 
@@ -19,12 +22,16 @@ import ConnectYouTubeAccountCard from './connect-youtube-account-card';
 
 /**
  * Renders the YouTube account card, either connected or connect state.
- *
- * @param {Object} props React props.
- * @param {YouTubeAccount} props.youTubeAccount YouTube account info.
+ * Shows a loading spinner while the account data is being fetched.
  */
-const YouTubeAccountCard = ( { youTubeAccount } ) => {
-	if ( youTubeAccount.status === YOUTUBE_ACCOUNT_STATUS.CONNECTED ) {
+const YouTubeAccountCard = () => {
+	const { youTubeAccount, hasFinishedResolution } = useYouTubeAccount();
+
+	if ( ! hasFinishedResolution ) {
+		return <AccountCard description={ <AppSpinner /> } />;
+	}
+
+	if ( youTubeAccount?.status === YOUTUBE_ACCOUNT_STATUS.CONNECTED ) {
 		return (
 			<ConnectedYouTubeAccountCard youTubeAccount={ youTubeAccount } />
 		);

--- a/js/src/components/youtube-account-card/youtube-account-card.js
+++ b/js/src/components/youtube-account-card/youtube-account-card.js
@@ -3,8 +3,7 @@
  */
 import { YOUTUBE_ACCOUNT_STATUS } from '~/constants';
 import useYouTubeAccount from '~/hooks/useYouTubeAccount';
-import AccountCard from '~/components/account-card';
-import AppSpinner from '~/components/app-spinner';
+import SpinnerCard from '~/components/spinner-card';
 import ConnectedYouTubeAccountCard from './connected-youtube-account-card';
 import ConnectYouTubeAccountCard from './connect-youtube-account-card';
 
@@ -28,7 +27,7 @@ const YouTubeAccountCard = () => {
 	const { youTubeAccount, hasFinishedResolution } = useYouTubeAccount();
 
 	if ( ! hasFinishedResolution ) {
-		return <AccountCard description={ <AppSpinner /> } />;
+		return <SpinnerCard />;
 	}
 
 	if ( youTubeAccount?.status === YOUTUBE_ACCOUNT_STATUS.CONNECTED ) {

--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -1302,6 +1302,15 @@ export function* fetchYouTubeAccount() {
 				'google-listings-and-ads'
 			)
 		);
+
+		// Set a default disconnected state to ensure loading state resolves
+		return {
+			type: TYPES.RECEIVE_ACCOUNTS_YOUTUBE,
+			account: {
+				status: 'disconnected',
+				channel: [],
+			},
+		};
 	}
 }
 

--- a/js/src/pages/settings/linked-accounts.js
+++ b/js/src/pages/settings/linked-accounts.js
@@ -42,18 +42,22 @@ const { CONNECTED, INCOMPLETE } = GOOGLE_ADS_ACCOUNT_STATUS;
  */
 export default function LinkedAccounts() {
 	const adminUrl = useAdminUrl();
-	const { jetpack } = useJetpackAccount();
-	const { google } = useGoogleAccount();
-	const { googleMCAccount } = useGoogleMCAccount();
-	const { googleAdsAccount } = useGoogleAdsAccount();
-	const { youTubeAccount } = useYouTubeAccount();
+	const { jetpack, hasFinishedResolution: jetpackResolved } =
+		useJetpackAccount();
+	const { google, hasFinishedResolution: googleResolved } =
+		useGoogleAccount();
+	const { googleMCAccount, hasFinishedResolution: mcResolved } =
+		useGoogleMCAccount();
+	const { googleAdsAccount, hasFinishedResolution: adsResolved } =
+		useGoogleAdsAccount();
+	const { hasFinishedResolution: youtubeResolved } = useYouTubeAccount();
 
 	const isLoading = ! (
-		jetpack &&
-		google &&
-		googleMCAccount &&
-		googleAdsAccount &&
-		youTubeAccount
+		jetpackResolved &&
+		googleResolved &&
+		mcResolved &&
+		adsResolved &&
+		youtubeResolved
 	);
 
 	const hasAdsAccount = [ CONNECTED, INCOMPLETE ].includes(
@@ -120,7 +124,7 @@ export default function LinkedAccounts() {
 						</ConnectedGoogleAdsAccountCard>
 					) }
 
-					<YouTubeAccountCard youTubeAccount={ youTubeAccount } />
+					<YouTubeAccountCard />
 
 					<Flex justify="flex-end">
 						<AppButton

--- a/js/src/pages/settings/linked-accounts.js
+++ b/js/src/pages/settings/linked-accounts.js
@@ -42,22 +42,22 @@ const { CONNECTED, INCOMPLETE } = GOOGLE_ADS_ACCOUNT_STATUS;
  */
 export default function LinkedAccounts() {
 	const adminUrl = useAdminUrl();
-	const { jetpack, hasFinishedResolution: jetpackResolved } =
+	const { jetpack, hasFinishedResolution: hasResolvedJetpackAccount } =
 		useJetpackAccount();
-	const { google, hasFinishedResolution: googleResolved } =
+	const { google, hasFinishedResolution: hasResolvedGoogleAccount } =
 		useGoogleAccount();
-	const { googleMCAccount, hasFinishedResolution: mcResolved } =
+	const { googleMCAccount, hasFinishedResolution: hasResolvedMCAccount } =
 		useGoogleMCAccount();
-	const { googleAdsAccount, hasFinishedResolution: adsResolved } =
+	const { googleAdsAccount, hasFinishedResolution: hasResolvedAdsAccount } =
 		useGoogleAdsAccount();
-	const { hasFinishedResolution: youtubeResolved } = useYouTubeAccount();
-
+	const { hasFinishedResolution: hasResolvedYouTubeAccount } =
+		useYouTubeAccount();
 	const isLoading = ! (
-		jetpackResolved &&
-		googleResolved &&
-		mcResolved &&
-		adsResolved &&
-		youtubeResolved
+		hasResolvedJetpackAccount &&
+		hasResolvedGoogleAccount &&
+		hasResolvedMCAccount &&
+		hasResolvedAdsAccount &&
+		hasResolvedYouTubeAccount
 	);
 
 	const hasAdsAccount = [ CONNECTED, INCOMPLETE ].includes(

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
 			},
 			{
 				"path": "./js/build/index.js",
-				"maxSize": "18.83 kB"
+				"maxSize": "18.88 kB"
 			},
 			{
 				"path": "./js/build/commons.js",

--- a/package.json
+++ b/package.json
@@ -148,11 +148,7 @@
 			},
 			{
 				"path": "./js/build/index.js",
-<<<<<<< HEAD
 				"maxSize": "18.88 kB"
-=======
-				"maxSize": "18.85 kB"
->>>>>>> feature/GOOWOO-313-youtube-shopping
 			},
 			{
 				"path": "./js/build/commons.js",

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -1135,6 +1135,7 @@ export default class MockRequests {
 	async mockYouTubeAccountNotConnected() {
 		await this.fulfillYouTubeAccountConnection( {
 			status: 'disconnected',
+			channel: [],
 		} );
 	}
 
@@ -1173,7 +1174,7 @@ export default class MockRequests {
 	async mockYouTubeAccountNoChannels() {
 		await this.fulfillYouTubeAccountConnection( {
 			status: 'connected',
-			channel: null,
+			channel: [],
 		} );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-332/create-api-endpoint-to-allow-admins-to-connect-their-youtube-account

Follow up to #3142 (QA issue identified after merge)


### Screenshots:

N/A


### Detailed test instructions:
## Test 1: Normal Connection Flow (Happy Path)

1. Navigate to **WooCommerce → Settings → Google Listings & Ads → Linked Accounts**
2. Locate the YouTube Shopping card
3. **Expected:** Shows "Connect" button
4. Click **Connect** button
5. **Expected:** Redirected to Google OAuth screen
6. Grant **all requested permissions** (including channel access)
7. Complete OAuth flow and return to WooCommerce
8. **Expected:** 
   - Loading spinner appears briefly
   - Card shows "Connected" with your channel name
   - "Disconnect YouTube account" button visible

## Test 2: Connection Without Channel Permissions (Bug Scenario)

1. If already connected, click **Disconnect YouTube account**
2. Click **Connect** button again
3. On Google OAuth screen, **deny or skip channel permissions** (grant partial permissions only)
4. Complete OAuth and return to WooCommerce
5. **Expected:**
   - Loading spinner appears briefly
   - Error notification: "There was an error loading YouTube account info. Error retrieving channels"
   - Card shows "Connect" button (not infinite spinner)
   - Other account cards (Google, Merchant Center, Ads) are visible
   - Can click Connect to retry

6. **NOT Expected (OLD BUG):**
   - ❌ Infinite loading spinner
   - ❌ Cannot see other account cards
   - ❌ Cannot disconnect or retry

## Test 3: Disconnect Flow

1. With a connected YouTube account, click **Disconnect YouTube account**
2. **Expected:**
   - Account disconnects successfully
   - Card returns to "Connect" state
   - No errors displayed

## Test 4: Disconnect All Accounts

1. Click **Disconnect from all accounts** button at bottom of page
2. Confirm the action
3. **Expected:**
   - YouTube account is also disconnected
   - Redirected to Get Started page

## Test 5: Component Loading States

1. Navigate to Linked Accounts page
2. Open browser DevTools → Network tab
3. Throttle network to "Slow 3G"
4. Reload page
5. **Expected:**
   - Each account card shows loading spinner while data fetches
   - YouTube card shows spinner independently
   - Cards populate as data arrives
   - No infinite spinners

### Additional details:

When a merchant connects YouTube without granting all required permissions, 
the API returns an error and the account state remains null, causing an 
infinite loading spinner.

Changes:
- Update linked-accounts.js loading check to use hasFinishedResolution 
  instead of truthy checks on account objects
- Add loading state handling to YouTubeAccountCard component
- Ensure fetchYouTubeAccount dispatches default disconnected state on error
- Update e2e mocks to consistently use channel: [] structure

This ensures the loading state resolves properly even when the API fails,
allowing merchants to see the error and retry the connection.
