### PR TITLE
Allow assets to be passed during campaign creation

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -788,7 +788,6 @@ export function* createAdsCampaign(
  *
  * @param {number} amount Daily average cost of the paid ads campaign.
  * @param {Array<CountryCode>} countryCodes Country code of the paid ads campaign audience country. Example: 'US'.
- * @param {string} finalUrl Final URL of the ads campaign.
  * @param {AssetEntityGroupUpdateBody} assets Assets of the ads campaign.
  * @param {boolean} [hasConfirmedEuPoliticalContent=false] Whether the user has confirmed that the ads campaign contains EU political content.
  *
@@ -797,7 +796,6 @@ export function* createAdsCampaign(
 export function* createAdsWithAssetsCampaign(
 	amount,
 	countryCodes,
-	finalUrl,
 	assets,
 	hasConfirmedEuPoliticalContent = false
 ) {
@@ -819,8 +817,10 @@ export function* createAdsWithAssetsCampaign(
 				eu_political_advertising_confirmation:
 					hasConfirmedEuPoliticalContent,
 				label,
-				final_url: finalUrl,
-				assets,
+				final_url: assets.finalUrl,
+				assets: assets.assets,
+				path1: assets.path1,
+				path2: assets.path2,
 			},
 		} );
 

--- a/js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/index.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/index.js
@@ -21,7 +21,7 @@ import CampaignAssetsForm from '~/components/paid-ads/campaign-assets-form';
 import AssetGroup from '~/components/paid-ads/asset-group';
 import SetupPaidAds from './setup-paid-ads';
 import convertToAssetGroupUpdateBody from '~/components/paid-ads/convertToAssetGroupUpdateBody';
-import { GUIDE_NAMES, ASSET_FORM_KEY } from '~/constants';
+import { GUIDE_NAMES } from '~/constants';
 import { ADS_ONLY_STEP_NAME_KEY_MAP } from '../constants';
 import { getDashboardUrl } from '~/utils/urls';
 import {

--- a/js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/index.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/index.js
@@ -114,7 +114,6 @@ const SavedAdsOnlySetupStepper = ( { savedStep } ) => {
 			await createAdsWithAssetsCampaign(
 				dailyBudget,
 				countryCodes,
-				values[ ASSET_FORM_KEY.FINAL_URL ],
 				assets,
 				hasConfirmedEuPoliticalContent
 			);

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -253,6 +253,41 @@ class AdsAsset implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Returns an array of operations to create multiple assets.
+	 *
+	 * @param array $assets An array of assets, each containing content and field_type keys
+	 * @return array An array of MutateOperation
+	 */
+	public function create_operations( array $assets ): array {
+		if ( empty( $assets ) ) {
+			return [];
+		}
+
+		$operations  = [];
+		$image_types = [
+			AssetFieldType::LOGO,
+			AssetFieldType::MARKETING_IMAGE,
+			AssetFieldType::SQUARE_MARKETING_IMAGE,
+			AssetFieldType::PORTRAIT_MARKETING_IMAGE,
+		];
+
+		foreach ( $assets as $asset ) {
+			// For image assets, fetch the image data.
+			if ( in_array( $asset['field_type'], $image_types, true ) ) {
+				$image_data    = $this->get_image_data( $asset['content'] );
+				$asset['body'] = $image_data['body'];
+			}
+
+			$operations[] = $this->create_operation(
+				$asset,
+				self::$temporary_id--
+			);
+		}
+
+		return $operations;
+	}
+
+	/**
 	 * Returns the asset content for the given row.
 	 *
 	 * @param GoogleAdsRow $row Data row returned from a query request.

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -25,6 +25,10 @@ use Google\Protobuf\FieldMask;
 use Exception;
 use DateTime;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Google\Ads\GoogleAds\V20\Resources\AssetGroupAsset;
+use Google\Ads\GoogleAds\V20\Services\AssetGroupAssetOperation;
 
 /**
  * Class AdsAssetGroup
@@ -36,10 +40,11 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseD
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */
-class AdsAssetGroup implements OptionsAwareInterface {
+class AdsAssetGroup implements OptionsAwareInterface, ContainerAwareInterface {
 
 	use ExceptionTrait;
 	use OptionsAwareTrait;
+	use ContainerAwareTrait;
 
 	/**
 	 * Temporary ID to use within a batch job.
@@ -137,15 +142,66 @@ class AdsAssetGroup implements OptionsAwareInterface {
 	 * @return array
 	 */
 	public function create_operations( string $campaign_resource_name, string $asset_group_name ): array {
-		$merchant_id = $this->options->get_merchant_id();
-		$operations  = [
+		// Asset must be created before listing group.
+		return [
 			$this->asset_group_create_operation( $campaign_resource_name, $asset_group_name ),
+			$this->listing_group_create_operation(),
 		];
+	}
 
-		// Only create listing group filter when Merchant Center account is connected.
-		// Listing group filter with SHOPPING source requires a product feed.
-		if ( $merchant_id > 0 ) {
-			$operations[] = $this->listing_group_create_operation();
+	/**
+	 * Returns a set of operations to create an asset group with assets.
+	 *
+	 * @param string $campaign_resource_name
+	 * @param string $campaign_name
+	 * @param string $final_url
+	 * @param array  $asset_group_assets
+	 * @return array
+	 */
+	public function create_operations_with_assets( string $campaign_resource_name, string $campaign_name, string $final_url, array $asset_group_assets ): array {
+		$operations = [];
+
+		$asset_group_resource_name = $this->temporary_resource_name();
+
+		// Create the asset group operation.
+		$asset_group = new AssetGroup(
+			[
+				'resource_name' => $asset_group_resource_name,
+				'name'          => $campaign_name . ' Asset Group',
+				'campaign'      => $campaign_resource_name,
+				'status'        => AssetGroupStatus::ENABLED,
+				'final_urls'    => [ $final_url ],
+			]
+		);
+
+		$operations[] = ( new MutateOperation() )->setAssetGroupOperation(
+			( new AssetGroupOperation() )->setCreate( $asset_group )
+		);
+
+		// Create assets operations.
+		$asset_ops  = $this->container->get( AdsAsset::class )->create_operations( $asset_group_assets );
+		$operations = array_merge( $operations, $asset_ops );
+
+		// Attach assets to group.
+		foreach ( $asset_ops as $i => $asset_op ) {
+			$asset_resource_name = $asset_op
+				->getAssetOperation()
+				->getCreate()
+				->getResourceName();
+
+			$operations[] = ( new MutateOperation() )->setAssetGroupAssetOperation(
+				( new AssetGroupAssetOperation() )->setCreate(
+					new AssetGroupAsset(
+						[
+							'asset_group' => $asset_group_resource_name,
+							'asset'       => $asset_resource_name,
+							'field_type'  => AssetFieldType::number(
+								$asset_group_assets[ $i ]['field_type']
+							),
+						]
+					)
+				)
+			);
 		}
 
 		return $operations;

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -236,18 +236,43 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 
 			$location_ids = array_filter( $location_ids );
 
-			// Operations must be in a specific order to match the temporary ID's.
-			$operations = array_merge(
-				[ $this->budget->create_operation( $params['name'], $params['amount'] ) ],
-				[ $this->create_operation( $params['name'], $base_country, $params['eu_political_advertising_confirmation'] ) ],
-				$this->container->get( AdsAssetGroup::class )->create_operations(
+			// Create budget operations.
+			$budget_operations = [ $this->budget->create_operation( $params['name'], $params['amount'] ) ];
+
+			// Create campaign operations.
+			$campaign_operations = [ $this->create_operation( $params['name'], $base_country, $params['eu_political_advertising_confirmation'] ) ];
+
+			// Create asset group operations.
+			$ad_asset_group = $this->container->get( AdsAssetGroup::class );
+
+			// If final URL and assets are passed create operations for those.
+			if ( isset( $params['final_url'] ) && isset( $params['assets'] ) ) {
+				$asset_group_operations = $ad_asset_group->create_operations_with_assets(
+					$this->temporary_resource_name(),
+					$params['name'],
+					$params['final_url'],
+					$params['assets']
+				);
+			} else {
+				// Create "empty" asset group operations.
+				$asset_group_operations = $ad_asset_group->create_operations(
 					$this->temporary_resource_name(),
 					$params['name']
-				),
-				$this->criterion->create_operations(
-					$this->temporary_resource_name(),
-					$location_ids
-				)
+				);
+			}
+
+			// Location/Targeting criteria operations.
+			$criteria_operations = $this->criterion->create_operations(
+				$this->temporary_resource_name(),
+				$location_ids
+			);
+
+			// Operations must be in a specific order to match the temporary ID's.
+			$operations = array_merge(
+				$budget_operations,
+				$campaign_operations,
+				$asset_group_operations,
+				$criteria_operations
 			);
 
 			$campaign_id = $this->mutate( $operations );

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignType;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
@@ -410,6 +411,83 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 				'validate_callback' => 'rest_validate_request_arg',
 				'required'          => false,
 				'default'           => false,
+			],
+			'final_url'                             => [
+				'type'        => 'string',
+				'description' => __( 'Final URL', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+
+			],
+			'assets'                                => [
+				'type'        => 'array',
+				'description' => __( 'Asset is a part of an ad which can be shared across multiple ads. It can be an image, headlines, descriptions, etc.', 'google-listings-and-ads' ),
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						AssetFieldType::SQUARE_MARKETING_IMAGE   => $this->get_schema_field_type_asset(),
+						AssetFieldType::MARKETING_IMAGE          => $this->get_schema_field_type_asset(),
+						AssetFieldType::PORTRAIT_MARKETING_IMAGE => $this->get_schema_field_type_asset(),
+						AssetFieldType::LOGO                     => $this->get_schema_field_type_asset(),
+						AssetFieldType::BUSINESS_NAME            => $this->get_schema_field_type_asset(),
+						AssetFieldType::HEADLINE                 => $this->get_schema_field_type_asset(),
+						AssetFieldType::DESCRIPTION              => $this->get_schema_field_type_asset(),
+						AssetFieldType::LONG_HEADLINE            => $this->get_schema_field_type_asset(),
+						AssetFieldType::CALL_TO_ACTION_SELECTION => $this->get_schema_field_type_asset(),
+						AssetFieldType::YOUTUBE_VIDEO            => $this->get_schema_field_type_asset(),
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Get the item schema for the field type asset.
+	 *
+	 * @return array the field type asset schema.
+	 */
+	protected function get_schema_field_type_asset(): array {
+		return [
+			'type'     => 'array',
+			'items'    => $this->get_schema_asset(),
+			'required' => false,
+		];
+	}
+
+	/**
+	 * Get the item schema for the asset.
+	 *
+	 * @return array
+	 */
+	protected function get_schema_asset() {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'id'         => [
+					'type'        => [ 'integer', 'null' ],
+					'description' => __( 'Asset ID', 'google-listings-and-ads' ),
+				],
+				'content'    => [
+					'type'        => [ 'string', 'null' ],
+					'description' => __( 'Asset content', 'google-listings-and-ads' ),
+				],
+				'field_type' => [
+					'type'        => 'string',
+					'description' => __( 'Asset field type', 'google-listings-and-ads' ),
+					'required'    => true,
+					'context'     => [ 'edit' ],
+					'enum'        => [
+						AssetFieldType::HEADLINE,
+						AssetFieldType::LONG_HEADLINE,
+						AssetFieldType::DESCRIPTION,
+						AssetFieldType::BUSINESS_NAME,
+						AssetFieldType::MARKETING_IMAGE,
+						AssetFieldType::SQUARE_MARKETING_IMAGE,
+						AssetFieldType::LOGO,
+						AssetFieldType::CALL_TO_ACTION_SELECTION,
+						AssetFieldType::PORTRAIT_MARKETING_IMAGE,
+						AssetFieldType::YOUTUBE_VIDEO,
+					],
+				],
 			],
 		];
 	}

--- a/src/API/Site/Controllers/Ads/CampaignController.php
+++ b/src/API/Site/Controllers/Ads/CampaignController.php
@@ -415,12 +415,14 @@ class CampaignController extends BaseController implements GoogleHelperAwareInte
 			'final_url'                             => [
 				'type'        => 'string',
 				'description' => __( 'Final URL', 'google-listings-and-ads' ),
-				'context'     => [ 'view' ],
-
+				'context'     => [ 'edit' ],
+				'required'    => false,
 			],
 			'assets'                                => [
 				'type'        => 'array',
 				'description' => __( 'Asset is a part of an ad which can be shared across multiple ads. It can be an image, headlines, descriptions, etc.', 'google-listings-and-ads' ),
+				'context'     => [ 'edit' ],
+				'required'    => false,
 				'items'       => [
 					'type'       => 'object',
 					'properties' => [

--- a/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
+++ b/tests/Tools/HelperTrait/GoogleAdsClientTrait.php
@@ -1157,4 +1157,30 @@ trait GoogleAdsClientTrait {
 
 		$this->generate_ads_query_mock( array_values( $locations ) );
 	}
+
+	/**
+	 * Generates a mocked asset create operation.
+	 *
+	 * @param integer $asset_id The asset ID.
+	 * @param string  $field_type The asset field type.
+	 * @param string  $content The asset content.
+	 * @return MutateOperation
+	 */
+	protected function generate_asset_create_operation( int $asset_id, string $field_type, string $content ): MutateOperation {
+		$asset = $this->generate_asset(
+			[
+				'field_type' => $field_type,
+				'content'    => $content,
+			]
+		);
+
+		$asset->setResourceName(
+			$this->generate_asset_resource_name( $asset_id )
+		);
+
+		return ( new MutateOperation() )->setAssetOperation(
+			( new \Google\Ads\GoogleAds\V20\Services\AssetOperation() )
+				->setCreate( $asset )
+		);
+	}
 }

--- a/tests/Unit/API/Google/AdsAssetGroupTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupTest.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroup;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroupAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -15,6 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Google\ApiCore\ApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -32,6 +34,12 @@ class AdsAssetGroupTest extends UnitTest {
 
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
+
+	/** @var Container $container */
+	protected $container;
+
+	/** @var AdsAsset $asset */
+	protected $asset;
 
 	/** @var AdsAssetGroup $asset_group */
 	protected $asset_group;
@@ -53,8 +61,14 @@ class AdsAssetGroupTest extends UnitTest {
 		$this->options           = $this->createMock( OptionsInterface::class );
 		$this->options->method( 'get_ads_id' )->willReturn( $this->ads_id );
 
+		$this->asset = $this->createMock( AdsAsset::class );
+
+		$this->container = new Container();
+		$this->container->addShared( AdsAsset::class, $this->asset );
+
 		$this->asset_group = new AdsAssetGroup( $this->client, $this->asset_group_asset );
 		$this->asset_group->set_options_object( $this->options );
+		$this->asset_group->set_container( $this->container );
 	}
 
 	public function test_create_operations_with_merchant_center() {
@@ -283,5 +297,51 @@ class AdsAssetGroupTest extends UnitTest {
 			);
 			$this->assertEquals( 400, $e->getCode() );
 		}
+	}
+
+	public function test_create_create_operations_with_assets_returns_expected_operations() {
+		$campaign_resource_name = $this->generate_campaign_resource_name( self::TEST_CAMPAIGN_ID );
+		$asset_group_assets     = [
+			[
+				'field_type' => AssetFieldType::HEADLINE,
+				'content'    => 'Test headline',
+			],
+			[
+				'field_type' => AssetFieldType::SQUARE_MARKETING_IMAGE,
+				'content'    => 'https://example.com/image.jpg',
+			],
+		];
+
+		$this->asset->expects( $this->once() )
+			->method( 'create_operations' )
+			->with( $asset_group_assets )
+			->willReturn(
+				[
+					$this->generate_asset_create_operation(
+						-1,
+						$asset_group_assets[0]['field_type'],
+						$asset_group_assets[0]['content'],
+					),
+					$this->generate_asset_create_operation(
+						-2,
+						$asset_group_assets[1]['field_type'],
+						$asset_group_assets[1]['content'],
+					),
+				]
+			);
+
+		$operations = $this->asset_group->create_operations_with_assets(
+			$campaign_resource_name,
+			'New Campaign',
+			'https://example.com',
+			$asset_group_assets
+		);
+
+		$this->assertCount( 5, $operations );
+		$this->assertTrue( $operations[0]->hasAssetGroupOperation() );
+		$this->assertTrue( $operations[1]->hasAssetOperation() );
+		$this->assertTrue( $operations[2]->hasAssetOperation() );
+		$this->assertTrue( $operations[3]->hasAssetGroupAssetOperation() );
+		$this->assertTrue( $operations[4]->hasAssetGroupAssetOperation() );
 	}
 }

--- a/tests/Unit/API/Google/AdsAssetGroupTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupTest.php
@@ -90,31 +90,6 @@ class AdsAssetGroupTest extends UnitTest {
 		$this->assertEquals( ListingGroupFilterListingSource::SHOPPING, $listing_group->getListingSource() );
 	}
 
-	public function test_create_operations_without_merchant_center() {
-		// Mock merchant_id = 0 to simulate no Merchant Center
-		$this->options->method( 'get_merchant_id' )->willReturn( 0 );
-
-		$campaign_resource_name    = $this->generate_campaign_resource_name( self::TEST_CAMPAIGN_ID );
-		$asset_group_resource_name = $this->generate_asset_group_resource_name( -3 );
-
-		$operations = $this->asset_group->create_operations(
-			$campaign_resource_name,
-			'New Campaign'
-		);
-
-		// Should return only 1 operation: asset group (no listing group filter)
-		$this->assertCount( 1, $operations );
-
-		$operation_asset_group = $operations[0]->getAssetGroupOperation();
-		$this->assertTrue( $operation_asset_group->hasCreate() );
-
-		$asset_group = $operation_asset_group->getCreate();
-		$this->assertEquals( 'New Campaign Asset Group', $asset_group->getName() );
-		$this->assertEquals( $campaign_resource_name, $asset_group->getCampaign() );
-		$this->assertEquals( $asset_group_resource_name, $asset_group->getResourceName() );
-		$this->assertEquals( AssetGroupStatus::ENABLED, $asset_group->getStatus() );
-	}
-
 	public function test_get_asset_groups_by_campaign_id_with_assets() {
 		$assets_data = [
 			self::TEST_ASSET_GROUP_ID   => [
@@ -286,39 +261,6 @@ class AdsAssetGroupTest extends UnitTest {
 		$this->options->method( 'get_merchant_id' )->willReturn( 12345 );
 
 		$this->generate_asset_group_mutate_mock( 'create', self::TEST_CAMPAIGN_ID );
-
-		$this->assertEquals(
-			self::TEST_CAMPAIGN_ID,
-			$this->asset_group->create_asset_group( self::TEST_CAMPAIGN_ID )
-		);
-	}
-
-	public function test_create_asset_group_without_merchant_center() {
-		// Mock merchant_id = 0 to simulate no Merchant Center
-		$this->options->method( 'get_merchant_id' )->willReturn( 0 );
-
-		// For create without MC, we need to update the mock to expect only 1 operation
-		$asset_group_resource_name = $this->generate_asset_group_resource_name( self::TEST_CAMPAIGN_ID );
-		$asset_group_result        = $this->createMock( \Google\Ads\GoogleAds\V20\Services\MutateAssetGroupResult::class );
-		$asset_group_result->method( 'getResourceName' )->willReturn( $asset_group_resource_name );
-
-		$response = ( new \Google\Ads\GoogleAds\V20\Services\MutateGoogleAdsResponse() )->setMutateOperationResponses(
-			[
-				( new \Google\Ads\GoogleAds\V20\Services\MutateOperationResponse() )->setAssetGroupResult( $asset_group_result ),
-			]
-		);
-
-		$this->service_client->expects( $this->once() )
-			->method( 'mutate' )
-			->willReturnCallback(
-				function ( $request ) use ( $response ) {
-					$operations = $request->getMutateOperations();
-					// Should only have 1 operation (asset group, no listing group filter)
-					$this->assertCount( 1, $operations );
-					$this->assertEquals( 'asset_group_operation', $operations[0]->getOperation() );
-					return $response;
-				}
-			);
 
 		$this->assertEquals(
 			self::TEST_CAMPAIGN_ID,

--- a/tests/Unit/API/Google/AdsAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetTest.php
@@ -15,7 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Exception;
 use WP_Error;
 use ArrayObject;
-
+use Automattic\WooCommerce\GoogleListingsAndAds\Container;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -260,6 +260,35 @@ class AdsAssetTest extends UnitTest {
 		$matcher = $this->exactly( 3 );
 		$this->generate_asset_batch_mutate_mock( $matcher, $assert_batches );
 		$this->asset->create_assets( $assets, 5 * 1024 * 1024 );
+	}
+
+	public function test_create_operations_returns_expected_operations() {
+		$assets = [
+			[
+				'field_type' => AssetFieldType::HEADLINE,
+				'content'    => 'Test headline',
+			],
+			[
+				'field_type' => AssetFieldType::SQUARE_MARKETING_IMAGE,
+				'content'    => 'https://example.com/image.jpg',
+			],
+		];
+
+		$this->wp->expects( $this->once() )
+			->method( 'wp_remote_get' )
+			->with( 'https://example.com/image.jpg' )
+			->willReturn(
+				[
+					'body'    => 'image-binary-data',
+					'headers' => new ArrayObject( [ 'content-length' => 1234 ] ),
+				]
+			);
+
+		$operations = $this->asset->create_operations( $assets );
+
+		$this->assertCount( 2, $operations );
+		$this->assertTrue( $operations[0]->hasAssetOperation() );
+		$this->assertTrue( $operations[1]->hasAssetOperation() );
 	}
 
 	/**

--- a/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/CampaignControllerTest.php
@@ -356,6 +356,63 @@ class CampaignControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 400, $response->get_status() );
 	}
 
+	public function test_create_campaign_with_final_url_and_assets() {
+		$campaign_data = [
+			'name'               => 'New Campaign',
+			'amount'             => 50,
+			'targeted_locations' => [ 'US', 'GB' ],
+			'final_url'          => 'https://example.com',
+			'assets'             => [
+				[
+					'field_type' => 'headline',
+					'content'    => 'Test headline',
+				],
+				[
+					'field_type' => 'square_marketing_image',
+					'content'    => 'https://example.com/image.jpg',
+				],
+			],
+		];
+
+		$expected = [
+			'id'                                    => self::TEST_CAMPAIGN_ID,
+			'status'                                => 'enabled',
+			'type'                                  => 'performance_max',
+			'country'                               => self::BASE_COUNTRY,
+			'name'                                  => 'New Campaign',
+			'amount'                                => 50,
+			'targeted_locations'                    => [ 'US', 'GB' ],
+			'eu_political_advertising_confirmation' => false,
+		];
+
+		$this->ads_campaign->expects( $this->once() )
+			->method( 'create_campaign' )
+			->with( $campaign_data )
+			->willReturn( $expected );
+
+		$this->expect_track_event(
+			'created_campaign',
+			[
+				'id'                 => self::TEST_CAMPAIGN_ID,
+				'status'             => 'enabled',
+				'name'               => 'New Campaign',
+				'amount'             => 50,
+				'country'            => self::BASE_COUNTRY,
+				'targeted_locations' => 'US,GB',
+				'source'             => '',
+			]
+		);
+
+		$response = $this->do_request( self::ROUTE_CAMPAIGNS, 'POST', $campaign_data );
+
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Final URL and assets should not be returned in response.
+		$this->assertArrayNotHasKey( 'final_url', $response->get_data() );
+		$this->assertArrayNotHasKey( 'assets', $response->get_data() );
+	}
+
 	public function test_get_campaign() {
 		$campaign_data = [
 			'id'                                    => self::TEST_CAMPAIGN_ID,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-413/add-assets-during-non-retail-pmax-campaign-creation

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
