### PR TITLE
Fix website claim conflict detection for Content API error response change

### DIFF
--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -95,13 +95,70 @@ class Merchant implements OptionsAwareInterface {
 			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
 			do_action( 'woocommerce_gla_site_claim_failure', [ 'details' => 'google_proxy' ] );
 
-			$error_message = __( 'Unable to claim website.', 'google-listings-and-ads' );
-			if ( 403 === $e->getCode() ) {
-				$error_message = __( 'Website already claimed, use overwrite to complete the process.', 'google-listings-and-ads' );
+			if ( $this->is_website_claim_conflict_error( $e ) ) {
+				// Use 403 to maintain compatibility with AccountService which relies on this code to identify claim conflicts.
+				throw new Exception(
+					__( 'Website already claimed, use overwrite to complete the process.', 'google-listings-and-ads' ),
+					403
+				);
 			}
-			throw new Exception( $error_message, $e->getCode() );
+
+			throw new Exception(
+				__( 'Unable to claim website.', 'google-listings-and-ads' ),
+				$e->getCode()
+			);
 		}
 		return true;
+	}
+
+	/**
+	 * Check if the exception indicates a website claim conflict error.
+	 *
+	 * This handles Content API error format by checking structured error data.
+	 * The API used to return 403, but now returns 400 with specific error details.
+	 *
+	 * Content API error structure:
+	 * - code: 400
+	 * - errors[].domain: "content.ContentErrorDomain"
+	 * - errors[].message: contains "overwrite"
+	 *
+	 * TODO: When migrating to Merchant API, it may have a different error format.
+	 * Possible fields to check:
+	 * - code: 400
+	 * - status: "FAILED_PRECONDITION"
+	 * - details[].metadata.REASON: "INVALID_TRANSITION_CLAIMED_DESCENDANTS"
+	 *
+	 * @param GoogleException $e The exception to check.
+	 * @return bool True if the error indicates a claim conflict.
+	 */
+	private function is_website_claim_conflict_error( GoogleException $e ): bool {
+		$code = $e->getCode();
+
+		// The API used to return 403, kept here in case some undiscovered conditions still return it.
+		if ( $code === 403 ) {
+			return true;
+		}
+
+		if ( $code !== 400 ) {
+			return false;
+		}
+
+		// Check structured error data from Content API.
+		if ( $e instanceof GoogleServiceException ) {
+			$errors = $e->getErrors();
+			if ( is_array( $errors ) ) {
+				foreach ( $errors as $error ) {
+					$is_content_api_domain = isset( $error['domain'] ) && $error['domain'] === 'content.ContentErrorDomain';
+					$has_overwrite_message = isset( $error['message'] ) && stripos( $error['message'], 'overwrite' ) !== false;
+
+					if ( $is_content_api_domain && $has_overwrite_message ) {
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -81,15 +81,13 @@ class Merchant implements OptionsAwareInterface {
 	/**
 	 * Claim a website for the user's Merchant Center account.
 	 *
-	 * @param bool $overwrite Whether to include the overwrite directive.
 	 * @return bool
 	 * @throws Exception If the website claim fails.
 	 */
-	public function claimwebsite( bool $overwrite = false ): bool {
+	public function claimwebsite(): bool {
 		try {
-			$id     = $this->options->get_merchant_id();
-			$params = $overwrite ? [ 'overwrite' => true ] : [];
-			$this->service->accounts->claimwebsite( $id, $id, $params );
+			$id = $this->options->get_merchant_id();
+			$this->service->accounts->claimwebsite( $id, $id );
 			do_action( 'woocommerce_gla_site_claim_success', [ 'details' => 'google_proxy' ] );
 		} catch ( GoogleException $e ) {
 			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -146,14 +146,14 @@ class MerchantTest extends UnitTest {
 	public function test_claim_website() {
 		$this->service->accounts->expects( $this->once() )
 			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id, [] );
+			->with( $this->merchant_id, $this->merchant_id );
 		$this->assertTrue( $this->merchant->claimwebsite() );
 	}
 
 	public function test_claimwebsite_error() {
 		$this->service->accounts->expects( $this->once() )
 			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id, [] )
+			->with( $this->merchant_id, $this->merchant_id )
 			->will(
 				$this->throwException(
 					new GoogleException()
@@ -167,7 +167,7 @@ class MerchantTest extends UnitTest {
 	public function test_website_already_claimed() {
 		$this->service->accounts->expects( $this->once() )
 			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id, [] )
+			->with( $this->merchant_id, $this->merchant_id )
 			->will(
 				$this->throwException(
 					new GoogleException( 'claimed', 403 )
@@ -189,7 +189,7 @@ class MerchantTest extends UnitTest {
 
 		$this->service->accounts->expects( $this->once() )
 			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id, [] )
+			->with( $this->merchant_id, $this->merchant_id )
 			->will(
 				$this->throwException(
 					new GoogleServiceException( $message, 400, null, [ $error ] )
@@ -212,7 +212,7 @@ class MerchantTest extends UnitTest {
 
 		$this->service->accounts->expects( $this->once() )
 			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id, [] )
+			->with( $this->merchant_id, $this->merchant_id )
 			->will(
 				$this->throwException(
 					new GoogleServiceException( $message, 400, null, [ $error ] )
@@ -235,7 +235,7 @@ class MerchantTest extends UnitTest {
 
 		$this->service->accounts->expects( $this->once() )
 			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id, [] )
+			->with( $this->merchant_id, $this->merchant_id )
 			->will(
 				$this->throwException(
 					new GoogleServiceException( $message, 400, null, [ $error ] )

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -179,6 +179,75 @@ class MerchantTest extends UnitTest {
 		$this->merchant->claimwebsite();
 	}
 
+	public function test_website_claim_conflict_content_api() {
+		$message = "There exist other accounts with homepage that conflicts with the homepage of account 1234567890. Set the parameter 'overwrite' to true if you want to take the claim and remove it from these accounts: user@example.com";
+		$error   = [
+			'domain'  => 'content.ContentErrorDomain',
+			'reason'  => 'invalid_parameter',
+			'message' => $message,
+		];
+
+		$this->service->accounts->expects( $this->once() )
+			->method( 'claimwebsite' )
+			->with( $this->merchant_id, $this->merchant_id, [] )
+			->will(
+				$this->throwException(
+					new GoogleServiceException( $message, 400, null, [ $error ] )
+				)
+			);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionCode( 403 );
+		$this->expectExceptionMessage( 'Website already claimed, use overwrite to complete the process.' );
+		$this->merchant->claimwebsite();
+	}
+
+	public function test_claimwebsite_non_conflict_400_error() {
+		$message = 'Request contains an invalid argument.';
+		$error   = [
+			'domain'  => 'content.ContentErrorDomain',
+			'reason'  => 'invalid',
+			'message' => $message,
+		];
+
+		$this->service->accounts->expects( $this->once() )
+			->method( 'claimwebsite' )
+			->with( $this->merchant_id, $this->merchant_id, [] )
+			->will(
+				$this->throwException(
+					new GoogleServiceException( $message, 400, null, [ $error ] )
+				)
+			);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionCode( 400 );
+		$this->expectExceptionMessage( 'Unable to claim website.' );
+		$this->merchant->claimwebsite();
+	}
+
+	public function test_claimwebsite_non_content_api_domain_error() {
+		$message = "There exist other accounts with homepage that conflicts. Set the parameter 'overwrite' to true.";
+		$error   = [
+			'domain'  => 'global',
+			'reason'  => 'forbidden',
+			'message' => $message,
+		];
+
+		$this->service->accounts->expects( $this->once() )
+			->method( 'claimwebsite' )
+			->with( $this->merchant_id, $this->merchant_id, [] )
+			->will(
+				$this->throwException(
+					new GoogleServiceException( $message, 400, null, [ $error ] )
+				)
+			);
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionCode( 400 );
+		$this->expectExceptionMessage( 'Unable to claim website.' );
+		$this->merchant->claimwebsite();
+	}
+
 	public function test_request_phone_verification() {
 		$this->service->accounts->expects( $this->once() )
 								->method( 'requestphoneverification' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Google **Content API for Shopping** changed its error response for website claim conflicts from HTTP 403 to HTTP 400. I noticed this when working on the Merchant API migration for the WooCommerce Connect Server.

This PR updates the error detection logic to correctly identify claim conflicts by also checking the structured error data.

It also removes the unused `$overwrite` parameter from `Merchant::claimwebsite()` since the actual overwrite operation is handled through `Middleware::claim_merchant_website()`.

### Detailed test instructions:

1. Preparation
   1. If testing locally, ensure the site is accessible from the public internet
   2. If the current website URL is not currently claimed by any Google Merchant Center account, first create or connect a GMC account to claim it
3. Go to the Onboarding flow
4. Attempt to claim the same website URL by connecting to or creating another GMC account
5. Verify that the plugin correctly detects the conflict and prompts the user to overwrite
   <img width="697" height="362" alt="image" src="https://github.com/user-attachments/assets/40b91929-bf92-433e-abc5-0de4e306bbef" />

### Additional details:

Currently, when creating or connecting a Google Merchant Center account, if the website URL is already claimed by another account, users encounter the error "Unable to claim website." and the onboarding flow cannot be continued.

<img width="1334" height="838" alt="image" src="https://github.com/user-attachments/assets/d7e34197-903f-469d-b743-71c0a2033bfa" />

Current **Content API for Shopping** error response:
```json
{
  "error": {
    "code": 400,
    "message": "There exist other accounts with homepage that conflicts with the homepage of account 1234567890. Set the parameter 'overwrite' to true if you want to take the claim and remove it from these accounts: user@example.com",
    "errors": [
      {
        "message": "There exist other accounts with homepage that conflicts with the homepage of account 1234567890. Set the parameter 'overwrite' to true if you want to take the claim and remove it from these accounts: user@example.com",
        "domain": "content.ContentErrorDomain",
        "reason": "invalid_parameter"
      }
    ]
  }
}
```

### Changelog entry

> Fix - Resolve an issue where website claim conflicts were not detected correctly during Google Merchant Center account setup in the onboarding flow.
