### PR TITLE
Add time zone and language code fields when creating a merchant account for Merchant API compatibility

### DIFF
--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -166,16 +166,23 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 		} catch ( ClientExceptionInterface $e ) {
 			$message = $this->client_exception_message( $e, __( 'Error creating account', 'google-listings-and-ads' ) );
 
-			if ( preg_match( '/terms?.* are|is not allowed/', $message ) ) {
+			// Content API for Shopping: Invalid account name terms.
+			// Merchant API: Account name validation failed.
+			if ( preg_match( '/terms?.* are|is not allowed/', $message ) ||
+				preg_match( '/the account did not pass validation/i', $message ) ) {
 				throw InvalidTerm::contains_invalid_terms( $name );
 			}
 
+			$site_url = $this->strip_url_protocol( esc_url_raw( $this->get_site_url() ) );
+
+			// Content API for Shopping: Invalid top-level domain name.
 			if ( strpos( $message, 'URL ends with an invalid top-level domain name' ) !== false ) {
-				throw InvalidDomainName::create_account_failed_invalid_top_level_domain_name(
-					$this->strip_url_protocol(
-						esc_url_raw( $this->get_site_url() )
-					)
-				);
+				throw InvalidDomainName::create_account_failed_invalid_top_level_domain_name( $site_url );
+			}
+
+			// Merchant API: Invalid homepage URL.
+			if ( strpos( $message, 'Unable to set homepage URL' ) !== false ) {
+				throw InvalidDomainName::create_account_failed_invalid_homepage_url( $site_url );
 			}
 
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
@@ -613,11 +620,7 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 	 * @return string
 	 */
 	protected function default_account_name(): string {
-		return sprintf(
-			/* translators: 1: current date in the format Y-m-d */
-			__( 'Account %1$s', 'google-listings-and-ads' ),
-			( new DateTime() )->format( 'Y-m-d' )
-		);
+		return 'Account ' . gmdate( 'dMy' );
 	}
 
 	/**

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ISOUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\TosAccepted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerExceptionInterface;
@@ -33,6 +34,7 @@ defined( 'ABSPATH' ) || exit;
  * - Client
  * - DateTimeUtility
  * - GoogleHelper
+ * - ISOUtility
  * - Merchant
  * - WC
  * - WP
@@ -128,13 +130,22 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 		try {
 			/** @var Client $client */
 			$client = $this->container->get( Client::class );
+
+			/** @var ISOUtility $iso_utility */
+			$iso_utility = $this->container->get( ISOUtility::class );
+
+			/** @var WP $wp */
+			$wp = $this->container->get( WP::class );
+
 			$result = $client->post(
 				$this->get_manager_url( 'create-merchant' ),
 				[
 					'body' => wp_json_encode(
 						[
-							'name'       => $name,
-							'websiteUrl' => $site_url,
+							'name'         => $name,
+							'websiteUrl'   => $site_url,
+							'timeZone'     => $this->get_site_timezone_string(),
+							'languageCode' => $iso_utility->wp_locale_to_bcp47( $wp->get_user_locale() ),
 						]
 					),
 				]

--- a/src/Exception/InvalidDomainName.php
+++ b/src/Exception/InvalidDomainName.php
@@ -28,4 +28,19 @@ class InvalidDomainName extends InvalidArgumentException implements GoogleListin
 			sprintf( __( 'Unable to create an account, the domain name "%s" must end with a valid top-level domain name.', 'google-listings-and-ads' ), $domain_name )
 		);
 	}
+
+	/**
+	 * Create a new instance of the exception when a Merchant Center account can't be created
+	 * because of an invalid homepage URL.
+	 *
+	 * @param string $url The homepage URL.
+	 *
+	 * @return static
+	 */
+	public static function create_account_failed_invalid_homepage_url( string $url ): InvalidDomainName {
+		return new static(
+			/* translators: %s: The homepage URL. */
+			sprintf( __( 'Unable to create an account. The homepage URL "%s" is not valid.', 'google-listings-and-ads' ), $url )
+		);
+	}
 }

--- a/tests/Tools/HelperTrait/GuzzleClientTrait.php
+++ b/tests/Tools/HelperTrait/GuzzleClientTrait.php
@@ -22,6 +22,9 @@ trait GuzzleClientTrait {
 
 	protected $client;
 
+	/** @var array|null Captured request body from create account mock. */
+	protected $captured_request_body;
+
 	/**
 	 * Generate a mocked GuzzleClient.
 	 */
@@ -50,13 +53,15 @@ trait GuzzleClientTrait {
 	}
 
 	/**
-	 * Generates two mocked request for when we create an account.
+	 * Generates mocked requests for account creation and captures the request body.
 	 * 1. Accept TOS
-	 * 3. Created account
+	 * 2. Created account (captures request body to $this->captured_request_body)
 	 *
 	 * @param mixed $response
 	 */
 	protected function generate_create_account_mock( $response ) {
+		$this->captured_request_body = null;
+
 		$body = $this->createMock( StreamInterface::class );
 		$body->method( 'getContents' )
 			->will(
@@ -70,7 +75,15 @@ trait GuzzleClientTrait {
 		$result->method( 'getBody' )->willReturn( $body );
 		$result->method( 'getStatusCode' )->willReturn( 200 );
 
-		$this->client->method( 'post' )->willReturn( $result );
+		$this->client->method( 'post' )
+			->willReturnCallback(
+				function ( $url, $options ) use ( $result ) {
+					if ( preg_match( '/create-(merchant|customer)/', $url ) ) {
+						$this->captured_request_body = json_decode( $options['body'], true );
+					}
+					return $result;
+				}
+			);
 	}
 
 	/**

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -203,6 +203,25 @@ class MiddlewareTest extends UnitTest {
 		$this->middleware->create_merchant_account();
 	}
 
+	public function test_create_merchant_account_merchant_api_name_error() {
+		$this->generate_create_account_exception_mock(
+			'The account did not pass validation',
+			[ 'id' => self::TEST_MERCHANT_ID ]
+		);
+
+		$this->assertEquals( self::TEST_MERCHANT_ID, $this->middleware->create_merchant_account() );
+	}
+
+	public function test_create_merchant_account_merchant_api_invalid_homepage_url() {
+		$this->generate_create_account_exception_mock(
+			'Unable to set homepage URL'
+		);
+
+		$this->expectException( InvalidDomainName::class );
+		$this->expectExceptionMessage( 'The homepage URL' );
+		$this->middleware->create_merchant_account();
+	}
+
 	public function test_create_merchant_account_exception() {
 		$this->generate_create_account_exception_mock( 'error' );
 

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GuzzleClientTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
+use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ISOUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -39,6 +40,9 @@ class MiddlewareTest extends UnitTest {
 
 	/** @var MockObject|GoogleHelper $google_helper */
 	protected $google_helper;
+
+	/** @var MockObject|ISOUtility $iso_utility */
+	protected $iso_utility;
 
 	/** @var MockObject|Merchant $merchant */
 	protected $merchant;
@@ -98,6 +102,7 @@ class MiddlewareTest extends UnitTest {
 		$this->ads           = $this->createMock( Ads::class );
 		$this->date_utility  = $this->createMock( DateTimeUtility::class );
 		$this->google_helper = $this->createMock( GoogleHelper::class );
+		$this->iso_utility   = $this->createMock( ISOUtility::class );
 		$this->merchant      = $this->createMock( Merchant::class );
 		$this->options       = $this->createMock( OptionsInterface::class );
 		$this->transients    = $this->createMock( TransientsInterface::class );
@@ -107,6 +112,7 @@ class MiddlewareTest extends UnitTest {
 		$this->container->addShared( Ads::class, $this->ads );
 		$this->container->addShared( DateTimeUtility::class, $this->date_utility );
 		$this->container->addShared( GoogleHelper::class, $this->google_helper );
+		$this->container->addShared( ISOUtility::class, $this->iso_utility );
 		$this->container->addShared( Merchant::class, $this->merchant );
 		$this->container->addShared( TransientsInterface::class, $this->transients );
 		$this->container->addShared( WC::class, $this->wc );
@@ -216,11 +222,18 @@ class MiddlewareTest extends UnitTest {
 	}
 
 	public function test_create_merchant_account() {
-		$this->generate_create_account_mock(
-			[ 'id' => self::TEST_MERCHANT_ID ]
-		);
+		$test_timezone = 'America/New_York';
+		$test_bcp47    = 'en-US';
+
+		$this->wp->method( 'wp_timezone_string' )->willReturn( $test_timezone );
+		$this->date_utility->method( 'maybe_convert_tz_string' )->willReturn( $test_timezone );
+		$this->iso_utility->method( 'wp_locale_to_bcp47' )->willReturn( $test_bcp47 );
+
+		$this->generate_create_account_mock( [ 'id' => self::TEST_MERCHANT_ID ] );
 
 		$this->assertEquals( self::TEST_MERCHANT_ID, $this->middleware->create_merchant_account() );
+		$this->assertEquals( $test_timezone, $this->captured_request_body['timeZone'] );
+		$this->assertEquals( $test_bcp47, $this->captured_request_body['languageCode'] );
 	}
 
 	public function test_link_merchant_account() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds `timeZone` and `languageCode` fields when creating a merchant account via WCS. It's a part of the Merchant API migration. It also updates error detection to support both Content API and Merchant API error formats when creating a merchant account.

Merchant API Ref:
- [Method: accounts.createAndConfigure](https://developers.google.com/merchant/api/reference/rest/accounts_v1/accounts/createAndConfigure)
- [REST Resource: accounts](https://developers.google.com/merchant/api/reference/rest/accounts_v1/accounts#Account)

### Detailed test instructions:

1. Checkout [WCS #3071](https://github.com/Automattic/woocommerce-connect-server/pull/3071) and set up a local server according to that PR
2. Go to the Onboarding flow
3. Check if a new Google Merchant Center account can be created normally

### Changelog entry

> Update - Add `timeZone` and `languageCode` fields to create-merchant request for Merchant API compatibility.
