### PR TITLE
GOOWOO-435 No CSV in generated in local youtube-merchant-conversion-report

### DIFF
--- a/src/Admin/Exports/ExportException.php
+++ b/src/Admin/Exports/ExportException.php
@@ -1,0 +1,57 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\GoogleListingsAndAdsException;
+use RuntimeException;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ExportException
+ *
+ * Exception thrown when export operations fail.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports
+ */
+class ExportException extends RuntimeException implements GoogleListingsAndAdsException {
+	/**
+	 * Return a new instance for upload directory errors.
+	 *
+	 * @param string $error The error message from wp_upload_dir().
+	 * @return static
+	 */
+	public static function upload_directory_error( string $error ): ExportException {
+		return new static( $error );
+	}
+
+	/**
+	 * Return a new instance when unable to determine upload directory.
+	 *
+	 * @return static
+	 */
+	public static function invalid_upload_directory(): ExportException {
+		return new static( 'Unable to determine upload directory.' );
+	}
+
+	/**
+	 * Return a new instance when export directory creation fails.
+	 *
+	 * @param string $directory_path The path that failed to be created.
+	 * @return static
+	 */
+	public static function failed_to_create_directory( string $directory_path ): ExportException {
+		return new static( sprintf( 'Failed to create export directory: %s', esc_html( $directory_path ) ) );
+	}
+
+	/**
+	 * Return a new instance when file creation fails.
+	 *
+	 * @param string $file_path The file path that failed to be created.
+	 * @return static
+	 */
+	public static function failed_to_create_file( string $file_path ): ExportException {
+		return new static( sprintf( 'Failed to create CSV file: %s', esc_html( $file_path ) ) );
+	}
+}

--- a/src/Admin/Exports/Writer/CsvExportWriter.php
+++ b/src/Admin/Exports/Writer/CsvExportWriter.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\Writer;
 
-use RuntimeException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\ExportException;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -46,14 +46,17 @@ class CsvExportWriter {
 	 *
 	 * @return string
 	 *
-	 * @throws RuntimeException When unable to create a directory or file.
+	 * @throws ExportException When unable to create a directory or file.
 	 */
 	public function create_file( string $filename ): string {
 		$upload_dir = wp_upload_dir();
 
+		if ( ! empty( $upload_dir['error'] ) ) {
+			throw ExportException::upload_directory_error( $upload_dir['error'] );
+		}
+
 		if ( empty( $upload_dir['basedir'] ) || ! is_dir( $upload_dir['basedir'] ) ) {
-			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-			throw new RuntimeException( 'Unable to determine upload directory.' );
+			throw ExportException::invalid_upload_directory();
 		}
 
 		$dir_path = trailingslashit( $upload_dir['basedir'] ) . self::EXPORT_FOLDER;
@@ -62,8 +65,7 @@ class CsvExportWriter {
 			wp_mkdir_p( $dir_path );
 
 			if ( ! $this->fs->is_dir( $dir_path ) ) {
-				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-				throw new RuntimeException( sprintf( 'Failed to create export directory: %s', esc_html( $dir_path ) ) );
+				throw ExportException::failed_to_create_directory( $dir_path );
 			}
 		}
 
@@ -77,8 +79,7 @@ class CsvExportWriter {
 		$success = $this->fs->put_contents( $file, '' );
 
 		if ( ! $success ) {
-			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-			throw new RuntimeException( sprintf( 'Failed to create CSV file: %s', esc_html( $file ) ) );
+			throw ExportException::failed_to_create_file( $file );
 		}
 
 		return $file;
@@ -141,10 +142,16 @@ class CsvExportWriter {
 	 *
 	 * @param string $file_path
 	 * @return string
+	 * @throws ExportException When upload directory has an error.
 	 */
 	public function generate_url( string $file_path ): string {
 		$upload_dir = wp_upload_dir();
-		$relative   = str_replace( $upload_dir['basedir'], '', $file_path );
+
+		if ( ! empty( $upload_dir['error'] ) ) {
+			throw ExportException::upload_directory_error( $upload_dir['error'] );
+		}
+
+		$relative = str_replace( $upload_dir['basedir'], '', $file_path );
 
 		return trailingslashit( $upload_dir['baseurl'] ) . ltrim( $relative, '/' );
 	}

--- a/src/Jobs/CreateMerchantReportedConversionReport.php
+++ b/src/Jobs/CreateMerchantReportedConversionReport.php
@@ -239,7 +239,9 @@ class CreateMerchantReportedConversionReport extends AbstractBatchedActionSchedu
 			if ( $results['success'] ) {
 				// Delete CSV files.
 				foreach ( $file_paths as $file_path ) {
-					$this->writer->delete_file( $file_path );
+					if ( apply_filters( 'woocommerce_gla_youtube_orders_csv_delete_on_complete', true ) ) {
+						$this->writer->delete_file( $file_path );
+					}
 				}
 
 				// Remove file state for this date.

--- a/src/Jobs/CreateMerchantReportedConversionReport.php
+++ b/src/Jobs/CreateMerchantReportedConversionReport.php
@@ -238,8 +238,8 @@ class CreateMerchantReportedConversionReport extends AbstractBatchedActionSchedu
 
 			if ( $results['success'] ) {
 				// Delete CSV files.
-				foreach ( $file_paths as $file_path ) {
-					if ( apply_filters( 'woocommerce_gla_youtube_orders_csv_delete_on_complete', true ) ) {
+				if ( apply_filters( 'woocommerce_gla_youtube_orders_csv_delete_on_complete', true ) ) {
+					foreach ( $file_paths as $file_path ) {
 						$this->writer->delete_file( $file_path );
 					}
 				}

--- a/src/Jobs/CreateMerchantReportedConversionReport.php
+++ b/src/Jobs/CreateMerchantReportedConversionReport.php
@@ -134,48 +134,26 @@ class CreateMerchantReportedConversionReport extends AbstractBatchedActionSchedu
 	 * when the size threshold is exceeded.
 	 *
 	 * @param int[] $items A single batch of WooCommerce Order IDs from the get_batch() method.
+	 *
+	 * @throws \Exception If an error occurs during CSV creation or writing.
 	 */
 	protected function process_items( array $items ) {
 		$date = $this->get_date();
 
-		// Get or initialise file state.
-		$export_state = $this->options->get( OptionsInterface::YOUTUBE_EXPORT_FILES, [] );
-		if ( ! isset( $export_state[ $date ] ) ) {
-			$export_state[ $date ] = [
-				'files'        => [],
-				'current_file' => '',
-				'current_part' => 0,
-			];
-		}
-
-		// Create first file if needed.
-		if ( empty( $export_state[ $date ]['current_file'] ) ) {
-			$filename  = 'youtube-merchant-conversion-report-' . $date;
-			$file_path = $this->writer->create_file( $filename );
-
-			$export_state[ $date ]['current_file'] = $file_path;
-			$export_state[ $date ]['files'][]      = $file_path;
-
-			$this->options->update( OptionsInterface::YOUTUBE_EXPORT_FILES, $export_state );
-		}
-
-		foreach ( $items as $order_id ) {
-			$order = wc_get_order( $order_id );
-
-			if ( ! $order ) {
-				continue;
+		try {
+			// Get or initialise file state.
+			$export_state = $this->options->get( OptionsInterface::YOUTUBE_EXPORT_FILES, [] );
+			if ( ! isset( $export_state[ $date ] ) ) {
+				$export_state[ $date ] = [
+					'files'        => [],
+					'current_file' => '',
+					'current_part' => 0,
+				];
 			}
 
-			// Check file size before processing this order.
-			$current_file = $export_state[ $date ]['current_file'];
-			$file_size    = $this->writer->get_file_size( $current_file );
-
-			if ( $file_size >= self::FILE_SIZE_THRESHOLD ) {
-				// Create new file with part suffix.
-				++$export_state[ $date ]['current_part'];
-				$part     = $export_state[ $date ]['current_part'];
-				$filename = 'youtube-merchant-conversion-report-' . $date . '-' . $part;
-
+			// Create first file if needed.
+			if ( empty( $export_state[ $date ]['current_file'] ) ) {
+				$filename  = 'youtube-merchant-conversion-report-' . $date;
 				$file_path = $this->writer->create_file( $filename );
 
 				$export_state[ $date ]['current_file'] = $file_path;
@@ -184,16 +162,56 @@ class CreateMerchantReportedConversionReport extends AbstractBatchedActionSchedu
 				$this->options->update( OptionsInterface::YOUTUBE_EXPORT_FILES, $export_state );
 			}
 
-			// Get items from the order.
-			$line_items = $order->get_items();
+			foreach ( $items as $order_id ) {
+				$order = wc_get_order( $order_id );
 
-			foreach ( $line_items as $line_item ) {
-				$row = $this->row_builder->build_row( $line_item );
+				if ( ! $order ) {
+					continue;
+				}
 
-				if ( is_array( $row ) ) {
-					$this->writer->append_row( $export_state[ $date ]['current_file'], $row );
+				// Check file size before processing this order.
+				$current_file = $export_state[ $date ]['current_file'];
+				$file_size    = $this->writer->get_file_size( $current_file );
+
+				if ( $file_size >= self::FILE_SIZE_THRESHOLD ) {
+					// Create new file with part suffix.
+					++$export_state[ $date ]['current_part'];
+					$part     = $export_state[ $date ]['current_part'];
+					$filename = 'youtube-merchant-conversion-report-' . $date . '-' . $part;
+
+					$file_path = $this->writer->create_file( $filename );
+
+					$export_state[ $date ]['current_file'] = $file_path;
+					$export_state[ $date ]['files'][]      = $file_path;
+
+					$this->options->update( OptionsInterface::YOUTUBE_EXPORT_FILES, $export_state );
+				}
+
+				// Get items from the order.
+				$line_items = $order->get_items();
+
+				foreach ( $line_items as $line_item ) {
+					$row = $this->row_builder->build_row( $line_item );
+
+					if ( is_array( $row ) ) {
+						$this->writer->append_row( $export_state[ $date ]['current_file'], $row );
+					}
 				}
 			}
+		} catch ( \Exception $e ) {
+			// Log error to WooCommerce logs before re-throwing.
+			do_action(
+				'woocommerce_gla_error',
+				sprintf(
+					'YouTube merchant conversion report generation failed for %s: %s',
+					$date,
+					$e->getMessage()
+				),
+				__METHOD__
+			);
+
+			// Re-throw so Action Scheduler marks the job as failed.
+			throw $e;
 		}
 	}
 

--- a/src/Jobs/CreateYouTubeOrderIdsCache.php
+++ b/src/Jobs/CreateYouTubeOrderIdsCache.php
@@ -128,7 +128,7 @@ class CreateYouTubeOrderIdsCache extends AbstractBatchedActionSchedulerJob imple
 				'woocommerce_gla_error',
 				sprintf(
 					'YouTube order IDs cache update failed for %s: %s',
-					$date(),
+					$date,
 					$e->getMessage()
 				),
 				__METHOD__

--- a/src/Jobs/CreateYouTubeOrderIdsCache.php
+++ b/src/Jobs/CreateYouTubeOrderIdsCache.php
@@ -128,7 +128,7 @@ class CreateYouTubeOrderIdsCache extends AbstractBatchedActionSchedulerJob imple
 				'woocommerce_gla_error',
 				sprintf(
 					'YouTube order IDs cache update failed for %s: %s',
-					$this->get_date(),
+					$date(),
 					$e->getMessage()
 				),
 				__METHOD__

--- a/src/Jobs/CreateYouTubeOrderIdsCache.php
+++ b/src/Jobs/CreateYouTubeOrderIdsCache.php
@@ -102,23 +102,41 @@ class CreateYouTubeOrderIdsCache extends AbstractBatchedActionSchedulerJob imple
 	 * Process batch items.
 	 *
 	 * @param int[] $items A single batch of WooCommerce Order IDs from the get_batch() method.
+	 *
+	 * @throws \Exception If an error occurs during caching.
 	 */
 	protected function process_items( array $items ) {
-		// Get the date for the orders.
-		$date = $this->get_date();
+		try {
+			// Get the date for the orders.
+			$date = $this->get_date();
 
-		// Get the existing order IDs cache.
-		$youtube_cache = $this->options->get( OptionsInterface::YOUTUBE_ORDER_IDS_CACHE, [] );
+			// Get the existing order IDs cache.
+			$youtube_cache = $this->options->get( OptionsInterface::YOUTUBE_ORDER_IDS_CACHE, [] );
 
-		// Create the date key if not already set.
-		if ( ! isset( $youtube_cache[ $date ] ) || ! is_array( $youtube_cache[ $date ] ) ) {
-			$youtube_cache[ $date ] = [];
+			// Create the date key if not already set.
+			if ( ! isset( $youtube_cache[ $date ] ) || ! is_array( $youtube_cache[ $date ] ) ) {
+				$youtube_cache[ $date ] = [];
+			}
+
+			// Update the order IDs in the option cache.
+			$youtube_cache[ $date ] = array_unique( array_merge( $youtube_cache[ $date ], $items ) );
+
+			$this->options->update( OptionsInterface::YOUTUBE_ORDER_IDS_CACHE, $youtube_cache );
+		} catch ( \Exception $e ) {
+			// Log error to WooCommerce logs before re-throwing.
+			do_action(
+				'woocommerce_gla_error',
+				sprintf(
+					'YouTube order IDs cache update failed for %s: %s',
+					$this->get_date(),
+					$e->getMessage()
+				),
+				__METHOD__
+			);
+
+			// Re-throw so Action Scheduler marks the job as failed.
+			throw $e;
 		}
-
-		// Update the order IDs in the option cache.
-		$youtube_cache[ $date ] = array_unique( array_merge( $youtube_cache[ $date ], $items ) );
-
-		$this->options->update( OptionsInterface::YOUTUBE_ORDER_IDS_CACHE, $youtube_cache );
 	}
 
 	/**

--- a/tests/Unit/Admin/Exports/Writer/CsvExportWriterTest.php
+++ b/tests/Unit/Admin/Exports/Writer/CsvExportWriterTest.php
@@ -3,9 +3,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin\Exports\Writer;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\ExportException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\Writer\CsvExportWriter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use RuntimeException;
 
 /**
  * Class CsvExportWriterTest
@@ -86,6 +86,23 @@ class CsvExportWriterTest extends UnitTest {
 		$this->assertFileExists( $file_path_1 );
 	}
 
+	public function test_create_file_throws_exception_when_wp_upload_dir_has_error() {
+		// Override upload_dir to return an error.
+		add_filter(
+			'upload_dir',
+			function ( $dirs ) {
+				$dirs['error'] = 'Unable to create directory wp-content/uploads. Is its parent directory writable by the server?';
+				return $dirs;
+			},
+			20
+		);
+
+		$this->expectException( ExportException::class );
+		$this->expectExceptionMessage( 'Unable to create directory wp-content/uploads. Is its parent directory writable by the server?' );
+
+		$this->writer->create_file( 'test' );
+	}
+
 	public function test_create_file_throws_exception_when_upload_directory_invalid() {
 		// Override upload_dir to return invalid directory.
 		add_filter(
@@ -97,7 +114,7 @@ class CsvExportWriterTest extends UnitTest {
 			20
 		);
 
-		$this->expectException( RuntimeException::class );
+		$this->expectException( ExportException::class );
 		$this->expectExceptionMessage( 'Unable to determine upload directory.' );
 
 		$this->writer->create_file( 'test' );
@@ -115,7 +132,7 @@ class CsvExportWriterTest extends UnitTest {
 		// Create a new writer instance to use the mocked filesystem.
 		$writer = new CsvExportWriter();
 
-		$this->expectException( RuntimeException::class );
+		$this->expectException( ExportException::class );
 		$this->expectExceptionMessage( 'Failed to create export directory' );
 
 		try {
@@ -139,7 +156,7 @@ class CsvExportWriterTest extends UnitTest {
 		// Create a new writer instance to use the mocked filesystem.
 		$writer = new CsvExportWriter();
 
-		$this->expectException( RuntimeException::class );
+		$this->expectException( ExportException::class );
 		$this->expectExceptionMessage( 'Failed to create CSV file' );
 
 		try {
@@ -294,6 +311,26 @@ class CsvExportWriterTest extends UnitTest {
 		$this->assertStringNotContainsString( $this->test_upload_dir, $url );
 		// URL should be a valid URL format.
 		$this->assertStringStartsWith( 'http://', $url );
+	}
+
+	public function test_generate_url_throws_exception_when_wp_upload_dir_has_error() {
+		$filename  = 'test-url-error';
+		$file_path = $this->test_upload_dir . '/gla-exports/' . $filename . '.csv';
+
+		// Override upload_dir to return an error.
+		add_filter(
+			'upload_dir',
+			function ( $dirs ) {
+				$dirs['error'] = 'Unable to create directory wp-content/uploads. Is its parent directory writable by the server?';
+				return $dirs;
+			},
+			20
+		);
+
+		$this->expectException( ExportException::class );
+		$this->expectExceptionMessage( 'Unable to create directory wp-content/uploads. Is its parent directory writable by the server?' );
+
+		$this->writer->generate_url( $file_path );
 	}
 
 	public function test_append_row_preserves_existing_content() {

--- a/tests/Unit/Jobs/CreateMerchantReportedConversionReportTest.php
+++ b/tests/Unit/Jobs/CreateMerchantReportedConversionReportTest.php
@@ -213,6 +213,86 @@ class CreateMerchantReportedConversionReportTest extends UnitTest {
 		$method->invoke( $this->job, 5 );
 	}
 
+	public function test_handle_complete_respects_filter_when_deletion_disabled() {
+		$file_paths = [
+			'/path/to/youtube-merchant-conversion-report-2026-01-07.csv',
+			'/path/to/youtube-merchant-conversion-report-2026-01-07-1.csv',
+		];
+
+		$export_state = [
+			self::TEST_DATE => [
+				'files'        => $file_paths,
+				'current_file' => $file_paths[1],
+				'current_part' => 1,
+			],
+		];
+
+		$youtube_cache = [
+			self::TEST_DATE => [ 100, 101, 102 ],
+		];
+
+		$this->options->method( 'get' )
+			->willReturnMap(
+				[
+					[ OptionsInterface::YOUTUBE_EXPORT_FILES, [], $export_state ],
+					[ OptionsInterface::YOUTUBE_ORDER_IDS_CACHE, [], $youtube_cache ],
+				]
+			);
+
+		// Successful upload.
+		$this->connection->expects( $this->once() )
+			->method( 'upload_reports' )
+			->with( $file_paths, self::TEST_DATE )
+			->willReturn(
+				[
+					'success'  => true,
+					'uploaded' => 2,
+					'failed'   => 0,
+					'errors'   => [],
+				]
+			);
+
+		// Add filter to disable deletion.
+		add_filter(
+			'woocommerce_gla_youtube_orders_csv_delete_on_complete',
+			'__return_false'
+		);
+
+		// Should NOT delete files when filter returns false.
+		$this->writer->expects( $this->never() )
+			->method( 'delete_file' );
+
+		// Should still update options (remove date entries).
+		$update_count = 0;
+		$this->options->expects( $this->exactly( 2 ) )
+			->method( 'update' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$update_count ) {
+					++$update_count;
+					if ( 1 === $update_count ) {
+						$this->assertEquals( OptionsInterface::YOUTUBE_EXPORT_FILES, $key );
+						$this->assertArrayNotHasKey( self::TEST_DATE, $value );
+					}
+					if ( 2 === $update_count ) {
+						$this->assertEquals( OptionsInterface::YOUTUBE_ORDER_IDS_CACHE, $key );
+						$this->assertArrayNotHasKey( self::TEST_DATE, $value );
+					}
+					return true;
+				}
+			);
+
+		// Call handle_complete through reflection since it's protected.
+		$method = new \ReflectionMethod( CreateMerchantReportedConversionReport::class, 'handle_complete' );
+		$method->setAccessible( true );
+		$method->invoke( $this->job, 5 );
+
+		// Clean up filter.
+		remove_filter(
+			'woocommerce_gla_youtube_orders_csv_delete_on_complete',
+			'__return_false'
+		);
+	}
+
 	public function test_get_name_returns_correct_job_name() {
 		$this->assertEquals(
 			'create_youtube_merchant_reported_conversions_report',

--- a/tests/Unit/Jobs/CreateMerchantReportedConversionReportTest.php
+++ b/tests/Unit/Jobs/CreateMerchantReportedConversionReportTest.php
@@ -219,4 +219,89 @@ class CreateMerchantReportedConversionReportTest extends UnitTest {
 			$this->job->get_name()
 		);
 	}
+
+	public function test_process_items_logs_error_on_exception() {
+		$order_ids = [ 100 ];
+
+		// Set up empty export state.
+		$this->options->method( 'get' )
+			->with( OptionsInterface::YOUTUBE_EXPORT_FILES, [] )
+			->willReturn( [] );
+
+		// Make writer throw an exception when creating file.
+		$this->writer->method( 'create_file' )
+			->willThrowException( new \Exception( 'Failed to create CSV file: Permission denied' ) );
+
+		// Track that do_action was called with the error.
+		$error_logged = false;
+		add_action(
+			'woocommerce_gla_error',
+			function ( $message, $method ) use ( &$error_logged ) {
+				$error_logged = true;
+				$this->assertStringContainsString( 'YouTube merchant conversion report generation failed', $message );
+				$this->assertStringContainsString( self::TEST_DATE, $message );
+				$this->assertStringContainsString( 'Permission denied', $message );
+				$this->assertEquals( 'Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CreateMerchantReportedConversionReport::process_items', $method );
+			},
+			10,
+			2
+		);
+
+		// Call process_items through reflection since it's protected.
+		$method = new \ReflectionMethod( CreateMerchantReportedConversionReport::class, 'process_items' );
+		$method->setAccessible( true );
+
+		// Expect exception to be re-thrown after logging.
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Failed to create CSV file: Permission denied' );
+
+		try {
+			$method->invoke( $this->job, $order_ids );
+		} finally {
+			// Verify error was logged.
+			$this->assertTrue( $error_logged, 'Error should be logged via do_action' );
+			remove_all_actions( 'woocommerce_gla_error' );
+		}
+	}
+
+	public function test_process_items_logs_error_when_options_update_fails() {
+		$order_ids = [ 100 ];
+
+		// Make options->get work initially.
+		$this->options->method( 'get' )
+			->with( OptionsInterface::YOUTUBE_EXPORT_FILES, [] )
+			->willReturn( [] );
+
+		// Make create_file succeed but options->update throw exception.
+		$this->writer->method( 'create_file' )
+			->willReturn( '/path/to/report.csv' );
+
+		$this->options->method( 'update' )
+			->willThrowException( new \Exception( 'Failed to update options in database' ) );
+
+		// Track that error was logged.
+		$error_logged = false;
+		add_action(
+			'woocommerce_gla_error',
+			function ( $message ) use ( &$error_logged ) {
+				$error_logged = true;
+				$this->assertStringContainsString( 'YouTube merchant conversion report generation failed', $message );
+				$this->assertStringContainsString( 'Failed to update options in database', $message );
+			},
+			10,
+			2
+		);
+
+		$method = new \ReflectionMethod( CreateMerchantReportedConversionReport::class, 'process_items' );
+		$method->setAccessible( true );
+
+		$this->expectException( \Exception::class );
+
+		try {
+			$method->invoke( $this->job, $order_ids );
+		} finally {
+			$this->assertTrue( $error_logged, 'Options update error should be logged' );
+			remove_all_actions( 'woocommerce_gla_error' );
+		}
+	}
 }

--- a/tests/Unit/Jobs/CreateYouTubeOrderIdsCacheTest.php
+++ b/tests/Unit/Jobs/CreateYouTubeOrderIdsCacheTest.php
@@ -1,0 +1,182 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\Services\YouTubeOrders;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CreateYouTubeOrderIdsCache;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class CreateYouTubeOrderIdsCacheTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
+ */
+class CreateYouTubeOrderIdsCacheTest extends UnitTest {
+
+	/** @var MockObject|ActionSchedulerInterface $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|YouTubeOrders $youtube_orders */
+	protected $youtube_orders;
+
+	/** @var MockObject|JobRepository $job_repository */
+	protected $job_repository;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var CreateYouTubeOrderIdsCache $job */
+	protected $job;
+
+	protected const TEST_DATE = '2026-01-07';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->action_scheduler = $this->createMock( ActionSchedulerInterface::class );
+		$this->monitor          = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->youtube_orders   = $this->createMock( YouTubeOrders::class );
+		$this->job_repository   = $this->createMock( JobRepository::class );
+		$this->options          = $this->createMock( OptionsInterface::class );
+
+		$this->job = new CreateYouTubeOrderIdsCache(
+			$this->action_scheduler,
+			$this->monitor,
+			$this->youtube_orders,
+			$this->job_repository
+		);
+
+		$this->job->set_options_object( $this->options );
+
+		// Override date for testing.
+		add_filter(
+			'woocommerce_gla_youtube_order_ids_job_date',
+			function () {
+				return self::TEST_DATE;
+			}
+		);
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'woocommerce_gla_youtube_order_ids_job_date' );
+		parent::tearDown();
+	}
+
+	public function test_get_batch_finds_youtube_orders() {
+		$order_ids = [ 100, 101, 102 ];
+
+		$this->youtube_orders->expects( $this->once() )
+			->method( 'find_orders' )
+			->with( self::TEST_DATE, 100, 0 )
+			->willReturn( $order_ids );
+
+		$batch = $this->job->get_batch( 1 );
+
+		$this->assertEquals( $order_ids, $batch );
+	}
+
+	public function test_get_name_returns_correct_job_name() {
+		$this->assertEquals(
+			'create_youtube_order_ids_cache',
+			$this->job->get_name()
+		);
+	}
+
+	public function test_process_items_caches_order_ids() {
+		$order_ids = [ 100, 101, 102 ];
+
+		// Mock existing empty cache.
+		$this->options->expects( $this->once() )
+			->method( 'get' )
+			->with( OptionsInterface::YOUTUBE_ORDER_IDS_CACHE, [] )
+			->willReturn( [] );
+
+		// Expect cache to be updated with new order IDs.
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				OptionsInterface::YOUTUBE_ORDER_IDS_CACHE,
+				[ self::TEST_DATE => $order_ids ]
+			);
+
+		// Call process_items through reflection since it's protected.
+		$method = new \ReflectionMethod( CreateYouTubeOrderIdsCache::class, 'process_items' );
+		$method->setAccessible( true );
+		$method->invoke( $this->job, $order_ids );
+	}
+
+	public function test_process_items_merges_with_existing_cache() {
+		$existing_order_ids = [ 100, 101 ];
+		$new_order_ids      = [ 102, 103 ];
+		$expected_merged    = [ 100, 101, 102, 103 ];
+
+		// Mock existing cache with some order IDs.
+		$this->options->expects( $this->once() )
+			->method( 'get' )
+			->with( OptionsInterface::YOUTUBE_ORDER_IDS_CACHE, [] )
+			->willReturn( [ self::TEST_DATE => $existing_order_ids ] );
+
+		// Expect merged cache.
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				OptionsInterface::YOUTUBE_ORDER_IDS_CACHE,
+				[ self::TEST_DATE => $expected_merged ]
+			);
+
+		$method = new \ReflectionMethod( CreateYouTubeOrderIdsCache::class, 'process_items' );
+		$method->setAccessible( true );
+		$method->invoke( $this->job, $new_order_ids );
+	}
+
+	public function test_process_items_logs_error_on_exception() {
+		$order_ids = [ 100 ];
+
+		// Make options->get throw an exception.
+		$this->options->method( 'get' )
+			->willThrowException( new \Exception( 'Database connection failed' ) );
+
+		// Track that do_action was called with the error.
+		$error_logged = false;
+		add_action(
+			'woocommerce_gla_error',
+			function ( $message, $method ) use ( &$error_logged ) {
+				$error_logged = true;
+				$this->assertStringContainsString( 'YouTube order IDs cache update failed', $message );
+				$this->assertStringContainsString( self::TEST_DATE, $message );
+				$this->assertStringContainsString( 'Database connection failed', $message );
+				$this->assertEquals( 'Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CreateYouTubeOrderIdsCache::process_items', $method );
+			},
+			10,
+			2
+		);
+
+		// Call process_items through reflection.
+		$method = new \ReflectionMethod( CreateYouTubeOrderIdsCache::class, 'process_items' );
+		$method->setAccessible( true );
+
+		// Expect exception to be re-thrown after logging.
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Database connection failed' );
+
+		try {
+			$method->invoke( $this->job, $order_ids );
+		} finally {
+			// Verify error was logged.
+			$this->assertTrue( $error_logged, 'Error should be logged via do_action' );
+			remove_all_actions( 'woocommerce_gla_error' );
+		}
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-435/no-csv-in-generatead-in-local-youtube-merchant-conversion-report

### Screenshots:

### Detailed test instructions:

**Note:** This testing triggers the process which would normally run at 3am via cron; this does replicate the production process, a better test is to create the orders on day 1, let the cron run and test on day 2.

## Test: Permission Error Handling

**1. Create test data:**

Follow [original PR instructions](https://github.com/woocommerce/google-listings-and-ads/pull/3159):
- Create 2 orders via YouTube link: `https://example.com/product?utm_source=youtube`
- Refund one order (with line item quantities)

**2. Simulate permission issue:**

Remove the uploads directory, change the permissions so WordPress cannot create the directories:
```bash
cd /path/to/wordpress
chmod 555 wp-content/uploads/gla-exports
```

**3. Run the export job:**

```bash
# Schedule the job to run
wp eval '
add_filter("woocommerce_gla_youtube_order_ids_job_date", function() {
    return gmdate("Y-m-d");
});

$container = woogle_get_container();
$job = $container->get(Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CreateMerchantReportedConversionReport::class);
$job->schedule();

echo "Job scheduled\n";
'

# Now run Action Scheduler which will execute process_items() with the try/catch
wp action-scheduler run --hooks=gla/jobs/create_youtube_merchant_reported_conversions_report/process_item
```

**Expected error message in debug.log:**
```
ERROR Automattic\WooCommerce\GoogleListingsAndAds\API\YouTube\Connection::upload_reports Unable to read file: wp-content/uploads/gla-exports/youtube-merchant-conversion-report-2026-01-21.csv

# and / or

ERROR Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CreateMerchantReportedConversionReport::handle_complete Conversion report upload failed: Error uploading wp-content/uploads/gla-exports/youtube-merchant-conversion-report-2026-01-21.csv: Unable to read file: wp-content/uploads/gla-exports/youtube-merchant-conversion-report-2026-01-21.csv
```

**4. Fix the uploads directory permissions:**

```bash
chmod 755 wp-content/uploads/gla-exports
```

**5. Prevent CSV deletion to verify file creation:**

```bash
# Add filter to prevent CSV deletion after upload
wp eval 'add_filter("woocommerce_gla_youtube_orders_csv_delete_on_complete", "__return_false");'
```

Re-run the commands from step 3

Confirm the CSV was created

