### PR TITLE
Remove Google Merchant Center references on Settings screen

### DIFF
--- a/js/src/pages/settings/linked-accounts-section-wrapper.js
+++ b/js/src/pages/settings/linked-accounts-section-wrapper.js
@@ -6,13 +6,13 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import Section from '~/components/section';
-import { glaData } from '~/constants';
 
 export default function LinkedAccountsSectionWrapper( props ) {
-	const { serviceBasedMerchant } = glaData;
+	const { hasGoogleMCConnection } = useGoogleMCAccount();
 
-	const description = serviceBasedMerchant
+	const description = hasGoogleMCConnection
 		? __(
 				'A WordPress.com account, Google account and Google Ads account are required to use this extension in WooCommerce.',
 				'google-listings-and-ads'

--- a/js/src/pages/settings/linked-accounts-section-wrapper.js
+++ b/js/src/pages/settings/linked-accounts-section-wrapper.js
@@ -14,11 +14,11 @@ export default function LinkedAccountsSectionWrapper( props ) {
 
 	const description = hasGoogleMCConnection
 		? __(
-				'A WordPress.com account, Google account and Google Ads account are required to use this extension in WooCommerce.',
+				'A WordPress.com account, Google account, Google Merchant Center account, and Google Ads account are required to use this extension in WooCommerce.',
 				'google-listings-and-ads'
 		  )
 		: __(
-				'A WordPress.com account, Google account, Google Merchant Center account, and Google Ads account are required to use this extension in WooCommerce.',
+				'A WordPress.com account, Google account and Google Ads account are required to use this extension in WooCommerce.',
 				'google-listings-and-ads'
 		  );
 

--- a/js/src/pages/settings/linked-accounts-section-wrapper.js
+++ b/js/src/pages/settings/linked-accounts-section-wrapper.js
@@ -7,15 +7,25 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Section from '~/components/section';
+import { glaData } from '~/constants';
 
 export default function LinkedAccountsSectionWrapper( props ) {
+	const { serviceBasedMerchant } = glaData;
+
+	const description = serviceBasedMerchant
+		? __(
+				'A WordPress.com account, Google account and Google Ads account are required to use this extension in WooCommerce.',
+				'google-listings-and-ads'
+		  )
+		: __(
+				'A WordPress.com account, Google account, Google Merchant Center account, and Google Ads account are required to use this extension in WooCommerce.',
+				'google-listings-and-ads'
+		  );
+
 	return (
 		<Section
 			title={ __( 'Linked accounts', 'google-listings-and-ads' ) }
-			description={ __(
-				'A WordPress.com account, Google account, Google Merchant Center account, and Google Ads account are required to use this extension in WooCommerce.',
-				'google-listings-and-ads'
-			) }
+			description={ description }
 			{ ...props }
 		/>
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes: https://linear.app/a8c/issue/GOOWOO-441/remove-google-merchant-center-references-on-settings-screen

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<img width="1043" height="427" alt="Screenshot 2026-01-22 at 10 25 05 AM" src="https://github.com/user-attachments/assets/32512012-bf18-449b-bc8b-954f2063615f" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Complete the onboarding in SBM flow.
2. There should not be a reference to Merchant Centre in settings section.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
