### PR TITLE
Hide the  on Settings screen

### DIFF
--- a/js/src/pages/settings/linked-accounts.js
+++ b/js/src/pages/settings/linked-accounts.js
@@ -104,18 +104,22 @@ export default function LinkedAccounts() {
 							googleAdsAccount={ googleAdsAccount }
 							hideAccountSwitch
 						>
-							<Section.Card.Footer>
-								<AppButton
-									isDestructive
-									isLink
-									onClick={ openDisconnectAdsAccountModal }
-								>
-									{ __(
-										'Disconnect Google Ads account only',
-										'google-listings-and-ads'
-									) }
-								</AppButton>
-							</Section.Card.Footer>
+							{ hasGoogleMCConnection && (
+								<Section.Card.Footer>
+									<AppButton
+										isDestructive
+										isLink
+										onClick={
+											openDisconnectAdsAccountModal
+										}
+									>
+										{ __(
+											'Disconnect Google Ads account only',
+											'google-listings-and-ads'
+										) }
+									</AppButton>
+								</Section.Card.Footer>
+							) }
 						</ConnectedGoogleAdsAccountCard>
 					) }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes: https://linear.app/a8c/issue/GOOWOO-442/hide-the-disconnect-google-ads-account-only-on-settings-screen
Closes: https://linear.app/a8c/issue/GOOWOO-424/qa-bb-02-continue-button-remains-disabled-even-when-all-required

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<img width="909" height="524" alt="Screenshot 2026-01-22 at 4 26 48 PM" src="https://github.com/user-attachments/assets/006667c3-1775-4016-92be-30e9bc74cde3" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Complete the SBM onboarding flow.
2. Go to Settings screen
3. Ensure that `Disconnect Google Ads account only` button is no longer visible on Google Ads account card.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
