### PR TITLE
Hide Skip button for SBM

### DIFF
--- a/js/src/components/paid-ads/asset-group/asset-group.js
+++ b/js/src/components/paid-ads/asset-group/asset-group.js
@@ -20,6 +20,7 @@ import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCo
 import AssetGroupHeader from './asset-group-header';
 import AssetGroupEditor from './asset-group-editor';
 import { upsertActionedCampaign } from '~/utils/actionedCampaignsCache';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import './asset-group.scss';
 
 export const ACTION_SUBMIT_CAMPAIGN_AND_ASSETS = 'submit-campaign-and-assets';
@@ -78,6 +79,7 @@ export default function AssetGroup( {
 	const { isValidForm, handleSubmit, adapter, values } =
 		useAdaptiveFormContext();
 	const { data: countryCodes } = useTargetAudienceFinalCountryCodes();
+	const { hasGoogleMCConnection } = useGoogleMCAccount();
 	const { isValidAssetGroup, isSubmitting, isSubmitted, submitter } = adapter;
 	const currentAction = submitter?.dataset.action;
 
@@ -170,31 +172,33 @@ export default function AssetGroup( {
 
 			<StepContentFooter>
 				<StepContentActions>
-					{ ( isCreation || adapter.isEmptyAssetEntityGroup ) && (
-						// Currently, the PMax Assets feature in this extension doesn't offer the function
-						// to delete the asset entity group, so it needs to hide the skip button if the editing
-						// asset group is not considered empty.
-						<AppButton
-							isTertiary
-							data-action={ ACTION_SUBMIT_CAMPAIGN_ONLY }
-							disabled={
-								! isValidForm ||
-								isSubmitted ||
-								currentAction ===
-									ACTION_SUBMIT_CAMPAIGN_AND_ASSETS
-							}
-							loading={
-								isSubmitting &&
-								currentAction === ACTION_SUBMIT_CAMPAIGN_ONLY
-							}
-							onClick={ handleSkipClick }
-						>
-							{ __(
-								'Skip this step',
-								'google-listings-and-ads'
-							) }
-						</AppButton>
-					) }
+					{ ( isCreation || adapter.isEmptyAssetEntityGroup ) &&
+						hasGoogleMCConnection && (
+							// Currently, the PMax Assets feature in this extension doesn't offer the function
+							// to delete the asset entity group, so it needs to hide the skip button if the editing
+							// asset group is not considered empty.
+							<AppButton
+								isTertiary
+								data-action={ ACTION_SUBMIT_CAMPAIGN_ONLY }
+								disabled={
+									! isValidForm ||
+									isSubmitted ||
+									currentAction ===
+										ACTION_SUBMIT_CAMPAIGN_AND_ASSETS
+								}
+								loading={
+									isSubmitting &&
+									currentAction ===
+										ACTION_SUBMIT_CAMPAIGN_ONLY
+								}
+								onClick={ handleSkipClick }
+							>
+								{ __(
+									'Skip this step',
+									'google-listings-and-ads'
+								) }
+							</AppButton>
+						) }
 					<AppButton
 						isPrimary
 						data-action={ ACTION_SUBMIT_CAMPAIGN_AND_ASSETS }

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -156,7 +156,7 @@ class Admin implements OptionsAwareInterface, Registerable, Service {
 				'dateFormat'               => get_option( 'date_format' ),
 				'timeFormat'               => get_option( 'time_format' ),
 				'siteLogoUrl'              => wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ), 'full' ),
-				'serviceBasedMerchant'     => true,
+				'serviceBasedMerchant'     => $this->service_based_merchant_state->is_service_based_merchant(),
 				'initialWpData'            => [
 					'version' => $this->get_version(),
 					'mcId'    => $this->options->get_merchant_id() ?: null,

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -156,7 +156,7 @@ class Admin implements OptionsAwareInterface, Registerable, Service {
 				'dateFormat'               => get_option( 'date_format' ),
 				'timeFormat'               => get_option( 'time_format' ),
 				'siteLogoUrl'              => wp_get_attachment_image_url( get_theme_mod( 'custom_logo' ), 'full' ),
-				'serviceBasedMerchant'     => $this->service_based_merchant_state->is_service_based_merchant(),
+				'serviceBasedMerchant'     => true,
 				'initialWpData'            => [
 					'version' => $this->get_version(),
 					'mcId'    => $this->options->get_merchant_id() ?: null,

--- a/tests/e2e/specs/onboarding-ads-only/step-3-optimize-campaign.test.js
+++ b/tests/e2e/specs/onboarding-ads-only/step-3-optimize-campaign.test.js
@@ -132,21 +132,12 @@ test.describe( 'Optimize campaign for Ads only merchants', () => {
 			await expect( createCampaignButton ).toBeDisabled();
 		} );
 
-		test( 'Clicking the "Skip this step" button navigates to the dashboard', async () => {
-			await goToOptimizeStep();
-			await optimizeCampaignPage.clickSkipThisStepButton();
-
-			await page.waitForURL( /path=%2Fgoogle%2Fdashboard/ );
-			expect( page.url() ).toMatch( /path=%2Fgoogle%2Fdashboard/ );
-		} );
-
-		test( 'should see the setup success modal', async () => {
-			const setupSuccessModal = createCampaignPage.getSetupSuccessModal();
-			await expect( setupSuccessModal ).toBeVisible();
+		test( '"Skip this step" button should not be present in the last step of onboarding', async () => {
+			const skipThisStepButton = page.locator( 'text="Skip this step"' );
+			await expect( skipThisStepButton ).toHaveCount( 0 );
 		} );
 
 		test( 'Clicking the "Create Campaign" button navigates to the dashboard and should see the setup success modal', async () => {
-			await goToOptimizeStep();
 			await optimizeCampaignPage.selectUrlOption();
 			const createCampaignButton =
 				optimizeCampaignPage.getCreateCampaignButton();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-426/qa-bb-invalid-parameters-final-url-error-when-merchant-creates

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. After onboarding, create a new campaign via the "Add campaign" button from the dashboard.
2. On the last step of the campaign creation flow, there should not be any skip button.
3. The skip button should be present for the non SBM campaign creation flow.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
