### PR TITLE
Fix: Submenu URL post onboarding.

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -230,7 +230,7 @@ class Admin implements OptionsAwareInterface, Registerable, Service {
 		$plugin_links = [];
 
 		// Display settings url if setup is complete otherwise link to get started page
-		if ( $this->merchant_center->is_setup_complete() ) {
+		if ( $this->onboarding_completed->is_onboarding_complete() ) {
 			$plugin_links[] = sprintf(
 				'<a href="%1$s">%2$s</a>',
 				esc_attr( $this->get_settings_url() ),

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -109,9 +109,9 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 		$this->share_with_tags( ConnectionTest::class );
 
 		$this->share_with_tags( AttributeMapping::class );
-		$this->share_with_tags( Dashboard::class );
+		$this->share_with_tags( Dashboard::class, OnboardingCompleted::class );
 		$this->share_with_tags( NotificationManager::class, AssetsHandlerInterface::class );
-		$this->share_with_tags( GetStarted::class );
+		$this->share_with_tags( GetStarted::class, OnboardingCompleted::class );
 		$this->share_with_tags( ProductFeed::class );
 		$this->share_with_tags( Reports::class );
 		$this->share_with_tags( Settings::class );

--- a/src/Menu/Dashboard.php
+++ b/src/Menu/Dashboard.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
 
 /**
  * Class Dashboard
@@ -23,10 +24,26 @@ class Dashboard implements Service, Registerable, MerchantCenterAwareInterface {
 	public const MARKETING_MENU_SLUG = 'woocommerce-marketing';
 
 	/**
+	 * Onboarding completed status.
+	 *
+	 * @var OnboardingCompleted
+	 */
+	private OnboardingCompleted $onboarding_completed;
+
+	/**
+	 * Dashboard constructor.
+	 *
+	 * @param OnboardingCompleted $onboarding_completed Onboarding completed status.
+	 */
+	public function __construct( OnboardingCompleted $onboarding_completed ) {
+		$this->onboarding_completed = $onboarding_completed;
+	}
+
+	/**
 	 * Register a service.
 	 */
 	public function register(): void {
-		if ( ! $this->merchant_center->is_setup_complete() ) {
+		if ( ! $this->onboarding_completed->is_onboarding_complete() ) {
 			return;
 		}
 

--- a/src/Menu/Dashboard.php
+++ b/src/Menu/Dashboard.php
@@ -5,8 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Menu;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
 
 /**
@@ -14,10 +12,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Menu
  */
-class Dashboard implements Service, Registerable, MerchantCenterAwareInterface {
+class Dashboard implements Service, Registerable {
 
 	use MenuFixesTrait;
-	use MerchantCenterAwareTrait;
 
 	public const PATH = '/google/dashboard';
 

--- a/src/Menu/Dashboard.php
+++ b/src/Menu/Dashboard.php
@@ -25,7 +25,7 @@ class Dashboard implements Service, Registerable {
 	 *
 	 * @var OnboardingCompleted
 	 */
-	private OnboardingCompleted $onboarding_completed;
+	private $onboarding_completed;
 
 	/**
 	 * Dashboard constructor.

--- a/src/Menu/GetStarted.php
+++ b/src/Menu/GetStarted.php
@@ -5,8 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Menu;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
 
 /**
@@ -14,10 +12,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Menu
  */
-class GetStarted implements Service, Registerable, MerchantCenterAwareInterface {
+class GetStarted implements Service, Registerable {
 
 	use MenuFixesTrait;
-	use MerchantCenterAwareTrait;
 
 	public const PATH = '/google/start';
 

--- a/src/Menu/GetStarted.php
+++ b/src/Menu/GetStarted.php
@@ -26,7 +26,7 @@ class GetStarted implements Service, Registerable {
 	private OnboardingCompleted $onboarding_completed;
 
 	/**
-	 * Dashboard constructor.
+	 * GetStarted constructor.
 	 *
 	 * @param OnboardingCompleted $onboarding_completed Onboarding completed status.
 	 */

--- a/src/Menu/GetStarted.php
+++ b/src/Menu/GetStarted.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
 
 /**
  * Class GetStarted
@@ -21,10 +22,26 @@ class GetStarted implements Service, Registerable, MerchantCenterAwareInterface 
 	public const PATH = '/google/start';
 
 	/**
+	 * Onboarding completed status.
+	 *
+	 * @var OnboardingCompleted
+	 */
+	private OnboardingCompleted $onboarding_completed;
+
+	/**
+	 * Dashboard constructor.
+	 *
+	 * @param OnboardingCompleted $onboarding_completed Onboarding completed status.
+	 */
+	public function __construct( OnboardingCompleted $onboarding_completed ) {
+		$this->onboarding_completed = $onboarding_completed;
+	}
+
+	/**
 	 * Register a service.
 	 */
 	public function register(): void {
-		if ( $this->merchant_center->is_setup_complete() ) {
+		if ( $this->onboarding_completed->is_onboarding_complete() ) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes: https://linear.app/a8c/issue/GOOWOO-421/bb-04-left-menu-link-still-redirects-onboarded-users-to-googlestart

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Complete the onboarding in SBM flow.
2. Ensure that the submenu link points to dashboard page.
3. In the plugins list page, the link should be `Settings` instead of `Get Started`, post-onboarding.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
