### PR TITLE
Add filter to disable legacy conversion events

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -371,19 +371,30 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		$order->update_meta_data( self::ORDER_CONVERSION_META_KEY, 1 );
 		$order->save_meta_data();
 
-		$conversion_gtag_info =
-		sprintf(
-			'gtag("event", "conversion", {
-			send_to: "%s",
-			value: %f,
-			currency: "%s",
-			transaction_id: "%s"});',
-			esc_js( "{$ads_conversion_id}/{$ads_conversion_label}" ),
-			$order->get_total(),
-			esc_js( $order->get_currency() ),
-			esc_js( $order->get_id() ),
-		);
-		$this->add_inline_event_script( $conversion_gtag_info );
+		/**
+		 * Track the legacy conversion event.
+		 *
+		 * The legacy conversion event is kept for backward compatibility with existing setups.
+		 * New implementations should rely on the 'purchase' event for conversion tracking.
+		 * In a future release, this may be removed.
+		 */
+		$add_legacy_conversion_event = apply_filters( 'woocommerce_gla_add_legacy_conversion_event', true );
+
+		if ( $add_legacy_conversion_event ) {
+			$conversion_gtag_info =
+			sprintf(
+				'gtag("event", "conversion", {
+				send_to: "%s",
+				value: %f,
+				currency: "%s",
+				transaction_id: "%s"});',
+				esc_js( "{$ads_conversion_id}/{$ads_conversion_label}" ),
+				$order->get_total(),
+				esc_js( $order->get_currency() ),
+				esc_js( $order->get_id() ),
+			);
+			$this->add_inline_event_script( $conversion_gtag_info );
+		}
 
 		// Get the item info in the order
 		$item_info = [];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-348. See #3169.

This adds a new filter, `woocommerce_gla_add_legacy_conversion_event` to be able to disable legacy conversion events.

Given that removing these events entirely could have unknown side effects, this change allows users who are currently seeing issues with deduplication not working properly to disable these events while we plan a deprecation path for these events in a future release.


### Screenshots:

N/A

### Detailed test instructions:

1. After completing a purchase, see that the `gtag("event", "conversion", {...})` script is included in the thank you page.
2. Add a filter like `add_filter( 'woocommerce_gla_add_legacy_conversion_event', '__return_false' );` to disable the feature.
3. Complete another purchase and confirm that the gtag event is not included in the thank you page.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Update - Allow legacy conversion events to be disabled via a filter.
