### PR TITLE
Restrict routes and fix E2E tests.

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -15,6 +15,7 @@ import './css/index.scss';
 import withAdminPageShell from '~/components/withAdminPageShell';
 import './data';
 import { addBaseEventProperties } from '~/utils/tracks';
+import { glaData } from './constants';
 
 const Dashboard = lazy( () =>
 	import( /* webpackChunkName: "dashboard" */ './pages/dashboard' )
@@ -72,6 +73,7 @@ const PAGES_FILTER = 'woocommerce_admin_pages_list';
 let hasAddedPluginAdminPages = false;
 
 const registerPluginAdminPages = () => {
+	const { serviceBasedMerchant } = glaData;
 	const namespace = 'woocommerce/google-listings-and-ads/add-page-routes';
 
 	addFilter( PAGES_FILTER, namespace, ( pages ) => {
@@ -81,7 +83,7 @@ const registerPluginAdminPages = () => {
 			__( 'Google for WooCommerce', 'google-listings-and-ads' ),
 		];
 
-		const pluginAdminPages = [
+		let pluginAdminPages = [
 			{
 				breadcrumbs: [ ...initialBreadcrumbs ],
 				container: GetStartedPage,
@@ -168,6 +170,20 @@ const registerPluginAdminPages = () => {
 				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
 			},
 		];
+
+		const adsOnlyRoutes = [
+			'/google/start',
+			'/google/setup-mc',
+			'/google/setup-ads',
+			'/google/dashboard',
+			'/google/settings',
+		];
+
+		if ( serviceBasedMerchant ) {
+			pluginAdminPages = pluginAdminPages.filter( ( page ) =>
+				adsOnlyRoutes.includes( page.path )
+			);
+		}
 
 		pluginAdminPages.forEach( ( page ) => {
 			page.container = withAdminPageShell( page.container );

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
 			},
 			{
 				"path": "./js/build/index.js",
-				"maxSize": "18.88 kB"
+				"maxSize": "18.89 kB"
 			},
 			{
 				"path": "./js/build/commons.js",

--- a/tests/e2e/specs/app-ratings-overview/experience-rating-banner.test.js
+++ b/tests/e2e/specs/app-ratings-overview/experience-rating-banner.test.js
@@ -6,7 +6,11 @@ import { expect, test } from '@playwright/test';
 /**
  * Internal dependencies
  */
-import { clearOnboardedMerchant, setOnboardedMerchant } from '../../utils/api';
+import {
+	clearOnboardedMerchant,
+	setOnboardedMerchant,
+	clearServiceBasedMerchant,
+} from '../../utils/api';
 import AppRatingsOverview from '../../utils/app-ratings-overview';
 import adsReportProductsData from '../../utils/__fixtures__/ads-report-products.json';
 
@@ -30,6 +34,7 @@ test.describe( 'App Ratings Banner', () => {
 		page = await browser.newPage();
 		appRatingsOverview = new AppRatingsOverview( page );
 		await Promise.all( [
+			clearServiceBasedMerchant(),
 			appRatingsOverview.mockRequests(),
 			setOnboardedMerchant(),
 		] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes: https://linear.app/a8c/issue/GOOWOO-415/restrict-routes-when-there-is-no-connected-mc-account

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Following routes should not be accessible for SBM setup

  - `/google/attribute-mapping`
  - `/google/shipping`
  - `/google/price-benchmark`
  - `/google/product-feed`
  - `/google/reports`


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
