### PR TITLE
GOOWOO-433 Setup error with shopping eligible account

### DIFF
--- a/js/src/components/youtube-account-card/connected-youtube-account-card.js
+++ b/js/src/components/youtube-account-card/connected-youtube-account-card.js
@@ -3,8 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
-import { getQuery, getHistory } from '@woocommerce/navigation';
-import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,58 +11,73 @@ import AccountCard, { APPEARANCE } from '~/components/account-card';
 import ConnectedIconLabel from '~/components/connected-icon-label';
 import Section from '~/components/section';
 import DisconnectAccount from './disconnect-account';
+import AppButton from '~/components/app-button';
 import useYouTubeSetupCompleteCallback from '~/hooks/useYouTubeSetupCompleteCallback';
-import { getSettingsUrl } from '~/utils/urls';
+import { YOUTUBE_ACCOUNT_STATUS } from '~/constants';
 
 /**
  * @typedef { import('./youtube-account-card.js').YouTubeAccount } YouTubeAccount
  */
 
 /**
+ * Clicking on the button to link the YouTube account.
+ *
+ * @event gla_link_youtube_account_button_click
+ * @property {string} context Indicates from which page the button was clicked. Possible value: 'settings-youtube'.
+ */
+
+/**
  * Component to display a connected YouTube account.
  * Detects if setup completion is needed via URL query (youtube=connected) and triggers it.
+ *
+ * @fires gla_link_youtube_account_button_click When the user clicks on the button to link the YouTube account.
  *
  * @param {Object} props
  * @param {YouTubeAccount} props.youTubeAccount The connected YouTube account.
  */
 const ConnectedYouTubeAccountCard = ( { youTubeAccount } ) => {
-	const youTubeConnected = getQuery()?.youtube === 'connected';
-	const [ handleFinishSetup ] = useYouTubeSetupCompleteCallback();
-	const hasCompletedSetupRef = useRef( false );
+	const [ handleFinishSetup, { loading, error } ] =
+		useYouTubeSetupCompleteCallback();
+	const shouldLinkYouTubeAccount =
+		youTubeAccount.status === YOUTUBE_ACCOUNT_STATUS.INCOMPLETE;
 
-	useEffect( () => {
-		async function completeSetup() {
-			hasCompletedSetupRef.current = true;
-			await handleFinishSetup();
-			getHistory().replace( getSettingsUrl() );
-		}
+	let accountCardProps = {
+		description: youTubeAccount.channel.label,
+		indicator: <ConnectedIconLabel />,
+	};
 
-		if ( youTubeConnected && ! hasCompletedSetupRef.current ) {
-			completeSetup();
-		}
-	}, [ youTubeConnected, handleFinishSetup ] );
-
-	let accountCardProps = {};
-	if ( youTubeAccount?.channel?.id ) {
+	if ( shouldLinkYouTubeAccount ) {
 		accountCardProps = {
-			description: youTubeAccount.channel.label,
-			indicator: <ConnectedIconLabel />,
-		};
-	} else {
-		accountCardProps = {
-			actions: (
+			indicator: (
+				<AppButton
+					eventName="gla_link_youtube_account_button_click"
+					eventProps={ { context: 'settings-youtube' } }
+					onClick={ handleFinishSetup }
+					disabled={ loading }
+					loading={ loading }
+					isSecondary
+				>
+					{ __( 'Complete setup', 'google-listings-and-ads' ) }
+				</AppButton>
+			),
+			detail: error?.message ? (
 				<Notice status="error" isDismissible={ false }>
-					{ __(
-						'No channels found (or permission not granted).',
-						'google-listings-and-ads'
-					) }
+					{ error.message }
 				</Notice>
+			) : undefined,
+			description: __(
+				'Your YouTube account is connected, but setup isn’t complete yet.',
+				'google-listings-and-ads'
 			),
 		};
 	}
 
 	return (
-		<AccountCard appearance={ APPEARANCE.YOUTUBE } { ...accountCardProps }>
+		<AccountCard
+			appearance={ APPEARANCE.YOUTUBE }
+			expandedDetail
+			{ ...accountCardProps }
+		>
 			<Section.Card.Footer>
 				<DisconnectAccount />
 			</Section.Card.Footer>

--- a/js/src/components/youtube-account-card/connected-youtube-account-card.js
+++ b/js/src/components/youtube-account-card/connected-youtube-account-card.js
@@ -3,17 +3,21 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
+import { useReducedMotion } from '@wordpress/compose';
+import { useEffect, useRef } from '@wordpress/element';
+import { getQuery, getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
+import { getSettingsUrl } from '~/utils/urls';
+import { YOUTUBE_ACCOUNT_STATUS } from '~/constants';
 import AccountCard, { APPEARANCE } from '~/components/account-card';
 import ConnectedIconLabel from '~/components/connected-icon-label';
 import Section from '~/components/section';
 import DisconnectAccount from './disconnect-account';
 import AppButton from '~/components/app-button';
 import useYouTubeSetupCompleteCallback from '~/hooks/useYouTubeSetupCompleteCallback';
-import { YOUTUBE_ACCOUNT_STATUS } from '~/constants';
 
 /**
  * @typedef { import('./youtube-account-card.js').YouTubeAccount } YouTubeAccount
@@ -36,10 +40,41 @@ import { YOUTUBE_ACCOUNT_STATUS } from '~/constants';
  * @param {YouTubeAccount} props.youTubeAccount The connected YouTube account.
  */
 const ConnectedYouTubeAccountCard = ( { youTubeAccount } ) => {
+	const isReducedMotion = useReducedMotion();
+	const isYouTubeOAuthReturn = getQuery()?.youtube === 'connected';
+	const hasCompletedSetupRef = useRef( false );
+	const containerRef = useRef();
 	const [ handleFinishSetup, { loading, error } ] =
 		useYouTubeSetupCompleteCallback();
 	const shouldLinkYouTubeAccount =
 		youTubeAccount.status === YOUTUBE_ACCOUNT_STATUS.INCOMPLETE;
+
+	useEffect( () => {
+		async function completeSetup() {
+			containerRef.current.scrollIntoView( {
+				behavior: isReducedMotion ? 'auto' : 'smooth',
+				inline: 'nearest',
+				block: 'nearest',
+			} );
+
+			hasCompletedSetupRef.current = true;
+			await handleFinishSetup();
+			getHistory().replace( getSettingsUrl() );
+		}
+
+		if (
+			isYouTubeOAuthReturn &&
+			shouldLinkYouTubeAccount &&
+			! hasCompletedSetupRef.current
+		) {
+			completeSetup();
+		}
+	}, [
+		isYouTubeOAuthReturn,
+		handleFinishSetup,
+		shouldLinkYouTubeAccount,
+		isReducedMotion,
+	] );
 
 	let accountCardProps = {
 		description: youTubeAccount.channel.label,
@@ -65,23 +100,27 @@ const ConnectedYouTubeAccountCard = ( { youTubeAccount } ) => {
 					{ error.message }
 				</Notice>
 			) : undefined,
-			description: __(
-				'Your YouTube account is connected, but setup isn’t complete yet.',
-				'google-listings-and-ads'
-			),
+			description: loading
+				? __( 'Please wait…', 'google-listings-and-ads' )
+				: __(
+						'Your YouTube account is connected, but setup isn’t complete yet.',
+						'google-listings-and-ads'
+				  ),
 		};
 	}
 
 	return (
-		<AccountCard
-			appearance={ APPEARANCE.YOUTUBE }
-			expandedDetail
-			{ ...accountCardProps }
-		>
-			<Section.Card.Footer>
-				<DisconnectAccount />
-			</Section.Card.Footer>
-		</AccountCard>
+		<div ref={ containerRef }>
+			<AccountCard
+				appearance={ APPEARANCE.YOUTUBE }
+				expandedDetail
+				{ ...accountCardProps }
+			>
+				<Section.Card.Footer>
+					<DisconnectAccount />
+				</Section.Card.Footer>
+			</AccountCard>
+		</div>
 	);
 };
 

--- a/js/src/components/youtube-account-card/youtube-account-card.js
+++ b/js/src/components/youtube-account-card/youtube-account-card.js
@@ -30,7 +30,12 @@ const YouTubeAccountCard = () => {
 		return <SpinnerCard />;
 	}
 
-	if ( youTubeAccount?.status === YOUTUBE_ACCOUNT_STATUS.CONNECTED ) {
+	if (
+		[
+			YOUTUBE_ACCOUNT_STATUS.CONNECTED,
+			YOUTUBE_ACCOUNT_STATUS.INCOMPLETE,
+		].includes( youTubeAccount?.status )
+	) {
 		return (
 			<ConnectedYouTubeAccountCard youTubeAccount={ youTubeAccount } />
 		);

--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -88,6 +88,7 @@ export const GOOGLE_ADS_BILLING_STATUS = {
 export const YOUTUBE_ACCOUNT_STATUS = {
 	CONNECTED: 'connected',
 	DISCONNECTED: 'disconnected',
+	INCOMPLETE: 'incomplete',
 };
 
 // Attribute Mapping

--- a/js/src/hooks/useYouTubeSetupCompleteCallback.js
+++ b/js/src/hooks/useYouTubeSetupCompleteCallback.js
@@ -1,14 +1,11 @@
 /**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
+import { useAppDispatch } from '~/data';
 import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 
 export default function useYouTubeSetupCompleteCallback() {
+	const { invalidateResolution } = useAppDispatch();
 	const [ fetchCompleteYouTubeSetup, result ] = useApiFetchCallback( {
 		path: '/wc/gla/youtube/setup/complete',
 		method: 'POST',
@@ -17,6 +14,7 @@ export default function useYouTubeSetupCompleteCallback() {
 	const handleFinishSetup = async () => {
 		try {
 			await fetchCompleteYouTubeSetup();
+			invalidateResolution( 'getYouTubeAccount', [] );
 		} catch ( error ) {}
 	};
 

--- a/js/src/hooks/useYouTubeSetupCompleteCallback.js
+++ b/js/src/hooks/useYouTubeSetupCompleteCallback.js
@@ -7,10 +7,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useApiFetchCallback from '~/hooks/useApiFetchCallback';
-import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 
 export default function useYouTubeSetupCompleteCallback() {
-	const { createNotice } = useDispatchCoreNotices();
 	const [ fetchCompleteYouTubeSetup, result ] = useApiFetchCallback( {
 		path: '/wc/gla/youtube/setup/complete',
 		method: 'POST',
@@ -19,15 +17,7 @@ export default function useYouTubeSetupCompleteCallback() {
 	const handleFinishSetup = async () => {
 		try {
 			await fetchCompleteYouTubeSetup();
-		} catch ( error ) {
-			const message =
-				error.message ||
-				__(
-					'Unable to complete your YouTube setup. Please try again later.',
-					'google-listings-and-ads'
-				);
-			createNotice( 'error', message );
-		}
+		} catch ( error ) {}
 	};
 
 	return [ handleFinishSetup, result ];

--- a/src/API/Site/Controllers/YouTube/AccountController.php
+++ b/src/API/Site/Controllers/YouTube/AccountController.php
@@ -167,7 +167,7 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 			try {
 				$result = $this->connection->third_party_link();
 
-				if ( isset( $result['status']['linkedStatus'] ) && 'linked' === $result['status']['linkedStatus'] ) {
+				if ( isset( $result['status']['linkStatus'] ) && 'linked' === $result['status']['linkStatus'] ) {
 					return [
 						'status'  => 'success',
 						'message' => __( 'Successfully completed YouTube setup.', 'google-listings-and-ads' ),

--- a/src/API/Site/Controllers/YouTube/AccountController.php
+++ b/src/API/Site/Controllers/YouTube/AccountController.php
@@ -147,7 +147,17 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 						];
 					}
 
-					// Check third party link status.
+					/**
+					 * Check third party link.
+					 *
+					 * Check that the channel is elidgable for YouTube Shopping and the store has been linked.
+					 * This step is required for the plugin functionality to work.
+					 *
+					 * Connection status:
+					 * - Disconnected - Google account not connected with the Google Cloud app.
+					 * - Incomplete - Google account connected to Google Cloud app, store not linked to YouTube channel.
+					 * - Complete - Google account connected, store linked to YouTube channel.
+					 */
 					if ( ! $this->options->get( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK, false ) ) {
 						$connection = 'incomplete';
 					}
@@ -174,7 +184,7 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 				$result = $this->connection->third_party_link();
 
 				if ( isset( $result['status']['linkStatus'] ) && 'linked' === $result['status']['linkStatus'] ) {
-					$this->options->add( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK, $result );
+					$this->options->update( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK, $result );
 
 					return [
 						'status'  => 'success',

--- a/src/API/Site/Controllers/YouTube/AccountController.php
+++ b/src/API/Site/Controllers/YouTube/AccountController.php
@@ -150,7 +150,7 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 					/**
 					 * Check third party link.
 					 *
-					 * Check that the channel is elidgable for YouTube Shopping and the store has been linked.
+					 * Check that the channel is eligible for YouTube Shopping and the store has been linked.
 					 * This step is required for the plugin functionality to work.
 					 *
 					 * Connection status:

--- a/src/API/Site/Controllers/YouTube/AccountController.php
+++ b/src/API/Site/Controllers/YouTube/AccountController.php
@@ -3,18 +3,17 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\YouTube;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\ExceptionTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\YouTube\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Client\ClientExceptionInterface;
 use Exception;
-use WP_REST_Request as Request;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -23,9 +22,10 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\YouTube
  */
-class AccountController extends BaseController implements ContainerAwareInterface {
+class AccountController extends BaseController implements ContainerAwareInterface, OptionsAwareInterface {
 
 	use ContainerAwareTrait;
+	use OptionsAwareTrait;
 
 	/** @var Connection */
 	protected $connection;
@@ -113,6 +113,7 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 	protected function get_disconnect_callback(): callable {
 		return function () {
 			$this->connection->disconnect();
+			$this->options->delete( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK );
 
 			return [
 				'status'  => 'success',
@@ -145,6 +146,11 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 							'label' => $details['snippet']['title'],
 						];
 					}
+
+					// Check third party link status.
+					if ( ! $this->options->get( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK, false ) ) {
+						$connection = 'incomplete';
+					}
 				}
 
 				return [
@@ -168,6 +174,8 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 				$result = $this->connection->third_party_link();
 
 				if ( isset( $result['status']['linkStatus'] ) && 'linked' === $result['status']['linkStatus'] ) {
+					$this->options->add( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK, $result );
+
 					return [
 						'status'  => 'success',
 						'message' => __( 'Successfully completed YouTube setup.', 'google-listings-and-ads' ),

--- a/src/API/YouTube/Connection.php
+++ b/src/API/YouTube/Connection.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\YouTube;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\ExceptionTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
@@ -188,14 +189,16 @@ class Connection implements ContainerAwareInterface, OptionsAwareInterface {
 			do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
 
 			$message = $response['message'] ?? __( 'Unable to complete YouTube setup.', 'google-listings-and-ads' );
-			throw new Exception( $message, $result->getStatusCode() );
+			throw new ExceptionWithResponseData( $message, $result->getStatusCode(), null, $response );
 		} catch ( ClientExceptionInterface $e ) {
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
-			throw new Exception(
-				$this->client_exception_message( $e, __( 'Unable to complete YouTube setup.', 'google-listings-and-ads' ) ),
-				$e->getCode()
-			);
+			$response = json_decode( $e->getResponse()->getBody()->getContents(), true );
+
+			$message = $response['message'] ?? __( 'Unable to complete YouTube setup.', 'google-listings-and-ads' );
+			$message = $response['error']['message'] ?? $message;
+
+			throw new ExceptionWithResponseData( $message, $e->getCode(), $e, $response );
 		}
 	}
 

--- a/src/API/YouTube/Connection.php
+++ b/src/API/YouTube/Connection.php
@@ -195,8 +195,7 @@ class Connection implements ContainerAwareInterface, OptionsAwareInterface {
 
 			$response = json_decode( $e->getResponse()->getBody()->getContents(), true );
 
-			$message = $response['message'] ?? __( 'Unable to complete YouTube setup.', 'google-listings-and-ads' );
-			$message = $response['error']['message'] ?? $message;
+			$message = $response['error']['message'] ?? $response['message'] ?? __( 'Unable to complete YouTube setup.', 'google-listings-and-ads' );
 
 			throw new ExceptionWithResponseData( $message, $e->getCode(), $e, $response );
 		}

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -51,6 +51,7 @@ interface OptionsInterface {
 	public const API_PULL_SYNC_MODE                        = 'api_pull_sync_mode';
 	public const YOUTUBE_ORDER_IDS_CACHE                   = 'youtube_export_order_ids';
 	public const YOUTUBE_EXPORT_FILES                      = 'youtube_export_files';
+	public const YOUTUBE_THIRD_PARTY_LINK                  = 'youtube_third_party_link';
 
 	public const VALID_OPTIONS = [
 		self::ADS_ACCOUNT_CURRENCY                      => true,
@@ -92,6 +93,7 @@ interface OptionsInterface {
 		self::API_PULL_SYNC_MODE                        => true,
 		self::YOUTUBE_ORDER_IDS_CACHE                   => true,
 		self::YOUTUBE_EXPORT_FILES                      => true,
+		self::YOUTUBE_THIRD_PARTY_LINK                  => true,
 	];
 
 	public const OPTION_TYPES = [

--- a/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
@@ -111,7 +111,6 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			->method( 'get_channels' )
 			->willReturn( $channels );
 
-
 		$this->options->expects( $this->once() )
 			->method( 'get' )
 			->with( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK, false )
@@ -119,7 +118,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 				[
 					'status' => [
 						'linkStatus' => 'linked',
-					]
+					],
 				]
 			);
 

--- a/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
@@ -139,7 +139,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			->willReturn(
 				[
 					'status' => [
-						'linkedStatus' => 'linked',
+						'linkStatus' => 'linked',
 					],
 				]
 			);

--- a/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\YouTube\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\YouTube\AccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -22,6 +23,9 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	/** @var AccountController $controller */
 	protected $controller;
 
+	/** @var OptionsInterface */
+	protected $options;
+
 	protected const ROUTE_CONNECT        = '/wc/gla/youtube/connect';
 	protected const ROUTE_CONNECTION     = '/wc/gla/youtube/connection';
 	protected const ROUTE_SETUP_COMPLETE = '/wc/gla/youtube/setup/complete';
@@ -29,8 +33,10 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
+		$this->options    = $this->createMock( OptionsInterface::class );
 		$this->connection = $this->createMock( Connection::class );
 		$this->controller = new AccountController( $this->server, $this->connection );
+		$this->controller->set_options_object( $this->options );
 		$this->controller->register();
 	}
 
@@ -105,11 +111,67 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			->method( 'get_channels' )
 			->willReturn( $channels );
 
+
+		$this->options->expects( $this->once() )
+			->method( 'get' )
+			->with( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK, false )
+			->willReturn(
+				[
+					'status' => [
+						'linkStatus' => 'linked',
+					]
+				]
+			);
+
 		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
 
 		$this->assertEquals(
 			[
 				'status'  => 'connected',
+				'channel' => [
+					'id'    => 1234,
+					'label' => 'Channel 1',
+				],
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_incomplete() {
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturn(
+				[
+					'status' => 'connected',
+				]
+			);
+
+		$this->connection->expects( $this->once() )
+			->method( 'get_channels' )
+			->willReturn(
+				[
+					'items' => [
+						[
+							'id'      => 1234,
+							'snippet' => [
+								'title' => 'Channel 1',
+							],
+						],
+					],
+				]
+			);
+
+		$this->options->expects( $this->once() )
+			->method( 'get' )
+			->with( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK, false )
+			->willReturn( false );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
+
+		$this->assertEquals(
+			[
+				'status'  => 'incomplete',
 				'channel' => [
 					'id'    => 1234,
 					'label' => 'Channel 1',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-434/youtube-set-up-error-with-yppshopping-eligible-account

### Screenshots:
<img width="1706" height="1289" alt="Screenshot 2026-02-03 at 14 33 42" src="https://github.com/user-attachments/assets/fc3a3c9d-31db-4f42-b049-8ccd328ff615" />


### Detailed test instructions:

Note: You should use an ineligible YouTube account for this test. If your account is eligible, creating a new channel / account will by default start in the ineligible state.

1. On `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings` disconnect a Youtube account if one is already setup
2. On `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings`, in the YouTube section click Connect and follow the authorisation flow
3. Once back in WP Admin, confirm the YouTube account is connected (i.e. there is a "Disconnect YouTube account" link; confirm you also see an error message: "The channel is not eligible for the linking program:

Note: You should use an eligible YouTube account for this test. If your account is eligible, creating a new channel / account will by default start in the ineligible state.

1. On `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings` disconnect a Youtube account if one is already setup
2. On `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings`, in the YouTube section click Connect and follow the authorisation flow
3. Once back in WP Admin, confirm the YouTube account is connected (i.e. there is a "Disconnect YouTube account" link; confirm you do not see an error message: "The channel is not eligible for the linking program:

### Additional details:
