### PR TITLE
Add "Complete Setup" button to link YouTube account.

### DIFF
--- a/js/src/components/youtube-account-card/connected-youtube-account-card.js
+++ b/js/src/components/youtube-account-card/connected-youtube-account-card.js
@@ -3,8 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
-import { getQuery, getHistory } from '@woocommerce/navigation';
-import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,58 +11,73 @@ import AccountCard, { APPEARANCE } from '~/components/account-card';
 import ConnectedIconLabel from '~/components/connected-icon-label';
 import Section from '~/components/section';
 import DisconnectAccount from './disconnect-account';
+import AppButton from '~/components/app-button';
 import useYouTubeSetupCompleteCallback from '~/hooks/useYouTubeSetupCompleteCallback';
-import { getSettingsUrl } from '~/utils/urls';
+import { YOUTUBE_ACCOUNT_STATUS } from '~/constants';
 
 /**
  * @typedef { import('./youtube-account-card.js').YouTubeAccount } YouTubeAccount
  */
 
 /**
+ * Clicking on the button to link the YouTube account.
+ *
+ * @event gla_link_youtube_account_button_click
+ * @property {string} context Indicates from which page the button was clicked. Possible value: 'settings-youtube'.
+ */
+
+/**
  * Component to display a connected YouTube account.
  * Detects if setup completion is needed via URL query (youtube=connected) and triggers it.
+ *
+ * @fires gla_link_youtube_account_button_click When the user clicks on the button to link the YouTube account.
  *
  * @param {Object} props
  * @param {YouTubeAccount} props.youTubeAccount The connected YouTube account.
  */
 const ConnectedYouTubeAccountCard = ( { youTubeAccount } ) => {
-	const youTubeConnected = getQuery()?.youtube === 'connected';
-	const [ handleFinishSetup ] = useYouTubeSetupCompleteCallback();
-	const hasCompletedSetupRef = useRef( false );
+	const [ handleFinishSetup, { loading, error } ] =
+		useYouTubeSetupCompleteCallback();
+	const shouldLinkYouTubeAccount =
+		youTubeAccount.status === YOUTUBE_ACCOUNT_STATUS.INCOMPLETE;
 
-	useEffect( () => {
-		async function completeSetup() {
-			hasCompletedSetupRef.current = true;
-			await handleFinishSetup();
-			getHistory().replace( getSettingsUrl() );
-		}
+	let accountCardProps = {
+		description: youTubeAccount.channel.label,
+		indicator: <ConnectedIconLabel />,
+	};
 
-		if ( youTubeConnected && ! hasCompletedSetupRef.current ) {
-			completeSetup();
-		}
-	}, [ youTubeConnected, handleFinishSetup ] );
-
-	let accountCardProps = {};
-	if ( youTubeAccount?.channel?.id ) {
+	if ( shouldLinkYouTubeAccount ) {
 		accountCardProps = {
-			description: youTubeAccount.channel.label,
-			indicator: <ConnectedIconLabel />,
-		};
-	} else {
-		accountCardProps = {
-			actions: (
+			indicator: (
+				<AppButton
+					eventName="gla_link_youtube_account_button_click"
+					eventProps={ { context: 'settings-youtube' } }
+					onClick={ handleFinishSetup }
+					disabled={ loading }
+					loading={ loading }
+					isSecondary
+				>
+					{ __( 'Complete setup', 'google-listings-and-ads' ) }
+				</AppButton>
+			),
+			detail: error?.message ? (
 				<Notice status="error" isDismissible={ false }>
-					{ __(
-						'No channels found (or permission not granted).',
-						'google-listings-and-ads'
-					) }
+					{ error.message }
 				</Notice>
+			) : undefined,
+			description: __(
+				'Your YouTube account is connected, but setup isn’t complete yet.',
+				'google-listings-and-ads'
 			),
 		};
 	}
 
 	return (
-		<AccountCard appearance={ APPEARANCE.YOUTUBE } { ...accountCardProps }>
+		<AccountCard
+			appearance={ APPEARANCE.YOUTUBE }
+			expandedDetail
+			{ ...accountCardProps }
+		>
 			<Section.Card.Footer>
 				<DisconnectAccount />
 			</Section.Card.Footer>

--- a/js/src/components/youtube-account-card/connected-youtube-account-card.js
+++ b/js/src/components/youtube-account-card/connected-youtube-account-card.js
@@ -3,17 +3,21 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Notice } from '@wordpress/components';
+import { useReducedMotion } from '@wordpress/compose';
+import { useEffect, useRef } from '@wordpress/element';
+import { getQuery, getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
  */
+import { getSettingsUrl } from '~/utils/urls';
+import { YOUTUBE_ACCOUNT_STATUS } from '~/constants';
 import AccountCard, { APPEARANCE } from '~/components/account-card';
 import ConnectedIconLabel from '~/components/connected-icon-label';
 import Section from '~/components/section';
 import DisconnectAccount from './disconnect-account';
 import AppButton from '~/components/app-button';
 import useYouTubeSetupCompleteCallback from '~/hooks/useYouTubeSetupCompleteCallback';
-import { YOUTUBE_ACCOUNT_STATUS } from '~/constants';
 
 /**
  * @typedef { import('./youtube-account-card.js').YouTubeAccount } YouTubeAccount
@@ -36,10 +40,41 @@ import { YOUTUBE_ACCOUNT_STATUS } from '~/constants';
  * @param {YouTubeAccount} props.youTubeAccount The connected YouTube account.
  */
 const ConnectedYouTubeAccountCard = ( { youTubeAccount } ) => {
+	const isReducedMotion = useReducedMotion();
+	const isYouTubeOAuthReturn = getQuery()?.youtube === 'connected';
+	const hasCompletedSetupRef = useRef( false );
+	const containerRef = useRef();
 	const [ handleFinishSetup, { loading, error } ] =
 		useYouTubeSetupCompleteCallback();
 	const shouldLinkYouTubeAccount =
 		youTubeAccount.status === YOUTUBE_ACCOUNT_STATUS.INCOMPLETE;
+
+	useEffect( () => {
+		async function completeSetup() {
+			containerRef.current.scrollIntoView( {
+				behavior: isReducedMotion ? 'auto' : 'smooth',
+				inline: 'nearest',
+				block: 'nearest',
+			} );
+
+			hasCompletedSetupRef.current = true;
+			await handleFinishSetup();
+			getHistory().replace( getSettingsUrl() );
+		}
+
+		if (
+			isYouTubeOAuthReturn &&
+			shouldLinkYouTubeAccount &&
+			! hasCompletedSetupRef.current
+		) {
+			completeSetup();
+		}
+	}, [
+		isYouTubeOAuthReturn,
+		handleFinishSetup,
+		shouldLinkYouTubeAccount,
+		isReducedMotion,
+	] );
 
 	let accountCardProps = {
 		description: youTubeAccount.channel.label,
@@ -65,23 +100,27 @@ const ConnectedYouTubeAccountCard = ( { youTubeAccount } ) => {
 					{ error.message }
 				</Notice>
 			) : undefined,
-			description: __(
-				'Your YouTube account is connected, but setup isn’t complete yet.',
-				'google-listings-and-ads'
-			),
+			description: loading
+				? __( 'Please wait…', 'google-listings-and-ads' )
+				: __(
+						'Your YouTube account is connected, but setup isn’t complete yet.',
+						'google-listings-and-ads'
+				  ),
 		};
 	}
 
 	return (
-		<AccountCard
-			appearance={ APPEARANCE.YOUTUBE }
-			expandedDetail
-			{ ...accountCardProps }
-		>
-			<Section.Card.Footer>
-				<DisconnectAccount />
-			</Section.Card.Footer>
-		</AccountCard>
+		<div ref={ containerRef }>
+			<AccountCard
+				appearance={ APPEARANCE.YOUTUBE }
+				expandedDetail
+				{ ...accountCardProps }
+			>
+				<Section.Card.Footer>
+					<DisconnectAccount />
+				</Section.Card.Footer>
+			</AccountCard>
+		</div>
 	);
 };
 

--- a/js/src/components/youtube-account-card/youtube-account-card.js
+++ b/js/src/components/youtube-account-card/youtube-account-card.js
@@ -30,7 +30,12 @@ const YouTubeAccountCard = () => {
 		return <SpinnerCard />;
 	}
 
-	if ( youTubeAccount?.status === YOUTUBE_ACCOUNT_STATUS.CONNECTED ) {
+	if (
+		[
+			YOUTUBE_ACCOUNT_STATUS.CONNECTED,
+			YOUTUBE_ACCOUNT_STATUS.INCOMPLETE,
+		].includes( youTubeAccount?.status )
+	) {
 		return (
 			<ConnectedYouTubeAccountCard youTubeAccount={ youTubeAccount } />
 		);

--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -88,6 +88,7 @@ export const GOOGLE_ADS_BILLING_STATUS = {
 export const YOUTUBE_ACCOUNT_STATUS = {
 	CONNECTED: 'connected',
 	DISCONNECTED: 'disconnected',
+	INCOMPLETE: 'incomplete',
 };
 
 // Attribute Mapping

--- a/js/src/hooks/useYouTubeSetupCompleteCallback.js
+++ b/js/src/hooks/useYouTubeSetupCompleteCallback.js
@@ -1,14 +1,11 @@
 /**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
+import { useAppDispatch } from '~/data';
 import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 
 export default function useYouTubeSetupCompleteCallback() {
+	const { invalidateResolution } = useAppDispatch();
 	const [ fetchCompleteYouTubeSetup, result ] = useApiFetchCallback( {
 		path: '/wc/gla/youtube/setup/complete',
 		method: 'POST',
@@ -17,6 +14,7 @@ export default function useYouTubeSetupCompleteCallback() {
 	const handleFinishSetup = async () => {
 		try {
 			await fetchCompleteYouTubeSetup();
+			invalidateResolution( 'getYouTubeAccount', [] );
 		} catch ( error ) {}
 	};
 

--- a/js/src/hooks/useYouTubeSetupCompleteCallback.js
+++ b/js/src/hooks/useYouTubeSetupCompleteCallback.js
@@ -7,10 +7,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useApiFetchCallback from '~/hooks/useApiFetchCallback';
-import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 
 export default function useYouTubeSetupCompleteCallback() {
-	const { createNotice } = useDispatchCoreNotices();
 	const [ fetchCompleteYouTubeSetup, result ] = useApiFetchCallback( {
 		path: '/wc/gla/youtube/setup/complete',
 		method: 'POST',
@@ -19,15 +17,7 @@ export default function useYouTubeSetupCompleteCallback() {
 	const handleFinishSetup = async () => {
 		try {
 			await fetchCompleteYouTubeSetup();
-		} catch ( error ) {
-			const message =
-				error.message ||
-				__(
-					'Unable to complete your YouTube setup. Please try again later.',
-					'google-listings-and-ads'
-				);
-			createNotice( 'error', message );
-		}
+		} catch ( error ) {}
 	};
 
 	return [ handleFinishSetup, result ];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-434/youtube-set-up-error-with-yppshopping-eligible-account

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<img width="524" height="275" alt="image" src="https://github.com/user-attachments/assets/a87a0c43-4295-4d3e-afa6-b2af6aee8643" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the settings page and connect a YouTube account.
2. After the oAuth flow, the user is redirected to the settings page and is asked to complete setup.
3. Clicking the complete setup should display any errors and if successful, should display the connected state.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
