### PR TITLE
fix(paid-ads): Reset AI asset flags on import failure

### DIFF
--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -284,6 +284,9 @@ export default function CampaignAssetsForm( {
 					...( hasSuggestedTextAssets ? textAssetsData : {} ),
 				};
 			} catch ( error ) {
+				setHasAISuggestedTextAssets( false );
+				setHasAISuggestedMediaAssets( false );
+
 				createNotice(
 					'error',
 					__(
@@ -334,8 +337,6 @@ export default function CampaignAssetsForm( {
 
 				setHasImportedAssets( hasNonEmptyAssets );
 				setBaseAssetGroup( nextAssetGroup );
-				setHasAISuggestedTextAssets( false );
-				setHasAISuggestedMediaAssets( false );
 
 				formContext.adapter.hideValidation();
 			},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-401/add-new-genaiimagesnotice-component

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
