### PR TITLE
Reset GenAI Add image button state

### DIFF
--- a/js/src/components/paid-ads/asset-group/asset-group-editor/gen-ai-image-picker/index.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-editor/gen-ai-image-picker/index.js
@@ -36,6 +36,7 @@ export default function GenAIImagePicker( { assetKey, onAddSelectedImages } ) {
 
 	const handleOnAddSelectedImages = () => {
 		onAddSelectedImages( selectedImages );
+		setSelectedImages( [] );
 	};
 
 	const toggleImageSelection = ( src ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-449/add-images-button-remains-enabled-after-adding-images

Empties the selected images array once the images are selected to reset the "Add image" button status


### Screenshots:

<img width="704" height="547" alt="image" src="https://github.com/user-attachments/assets/7082cf55-0413-4a39-a89c-2d2368ca9ce5" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a new campaign via the "Add campaign" button on the dashboard.
2. Go to the second step of the creation flow.
3. Mock images (if none are generated following the [instructions here](https://github.com/woocommerce/google-listings-and-ads/pull/3207#issue-3807809976)).
4. Select a single image from the list
5. Click on the "Add selected images" button
6. The image should be added to the list above and the "Add selected images" button be **disabled**


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry


