### PR TITLE
Adds new filters to the Jetpack and Google OAuth flows

### DIFF
--- a/src/API/Site/Controllers/Google/AccountController.php
+++ b/src/API/Site/Controllers/Google/AccountController.php
@@ -102,11 +102,14 @@ class AccountController extends BaseController {
 				$next       = $request->get_param( 'next_page_name' );
 				$login_hint = $request->get_param( 'login_hint' ) ?: '';
 				$path       = self::NEXT_PATH_MAPPING[ $next ];
+
+				/**
+				 * Filter the return-URL, which is called at the end of the OAuth onboarding process.
+				 */
+				$return_url = apply_filters( 'woocommerce_gla_google_connect_return_url', admin_url( "admin.php?page=wc-admin&path={$path}" ), $next );
+
 				return [
-					'url' => $this->connection->connect(
-						admin_url( "admin.php?page=wc-admin&path={$path}" ),
-						$login_hint
-					),
+					'url' => $this->connection->connect( $return_url, $login_hint ),
 				];
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -122,8 +122,8 @@ class AccountController extends BaseOptionsController {
 			}
 
 			// Get an authorization URL which will redirect back to our page.
-			$next     = $request->get_param( 'next_page_name' );
-			$path     = self::NEXT_PATH_MAPPING[ $next ];
+			$next = $request->get_param( 'next_page_name' );
+			$path = self::NEXT_PATH_MAPPING[ $next ];
 
 			/**
 			 * Filter the return-URL, which is called at the end of the OAuth onboarding process.

--- a/src/API/Site/Controllers/Jetpack/AccountController.php
+++ b/src/API/Site/Controllers/Jetpack/AccountController.php
@@ -124,7 +124,12 @@ class AccountController extends BaseOptionsController {
 			// Get an authorization URL which will redirect back to our page.
 			$next     = $request->get_param( 'next_page_name' );
 			$path     = self::NEXT_PATH_MAPPING[ $next ];
-			$redirect = admin_url( "admin.php?page=wc-admin&path={$path}" );
+
+			/**
+			 * Filter the return-URL, which is called at the end of the OAuth onboarding process.
+			 */
+			$redirect = apply_filters( 'woocommerce_gla_jetpack_connect_return_url', admin_url( "admin.php?page=wc-admin&path={$path}" ), $next );
+
 			$auth_url = $this->manager->get_authorization_url( null, $redirect );
 
 			// Payments flow allows redirect back to the site without showing plans. Escaping the URL preventing XSS.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of [ADS-671](https://linear.app/a8c/issue/ADS-671/google-account-connection-connect)

This PR incorporates two new filters:
* `woocommerce_gla_google_connect_return_url`
* `woocommerce_gla_jetpack_connect_return_url`

Those filters will allow us to override the return URL from the Jetpack/Google OAuth flow to a different page, helping us better integrate this plugin in other experiences. 

### Detailed test instructions:

Everything should work as before if those filters were not configured on the store; regular testing will suffice.

1. Build this version of the plugin and install it on any ephemeral site (or just use your local env)
2. Test the Jetpack and Google connection flow. After OAuth finishes, you should be redirected to the correct WPADMIN page to continue to setup flow

If you want to test the filter, you can include it in the `google-listings-and-ads.php` file and run the same test. This time, you should get redirected to the chosen URL instead:
```
(
    'woocommerce_gla_google_connect_return_url',
    function ( $url, $path_key ) {
        return admin_url( "index.php?path_key=" . urlencode( $path_key ) );
    },
    10,
    2
);

``` 


### Changelog entry

> Dev - Added two new filters to the Jetpack and Google OAuth flows.
