### PR TITLE
Add deduplication logic for selected items in CompareFilter component

### DIFF
--- a/js/src/components/external/woocommerce/compare-filter/index.js
+++ b/js/src/components/external/woocommerce/compare-filter/index.js
@@ -41,6 +41,7 @@ class CompareFilter extends Component {
 		this.updateQuery = this.updateQuery.bind( this );
 		this.updateLabels = this.updateLabels.bind( this );
 		this.onButtonClicked = this.onButtonClicked.bind( this );
+		this.onSearchChange = this.onSearchChange.bind( this );
 		if ( query[ param ] ) {
 			getLabels( query[ param ], query ).then( this.updateLabels );
 		}
@@ -96,25 +97,15 @@ class CompareFilter extends Component {
 	}
 
 	/**
-	 * Remove duplicate items based on their 'key' attribute.
-	 *
-	 * @param {Array} items - Array of items to deduplicate.
-	 * @return {Array} Deduplicated array.
-	 */
-	removeDuplicateValues( items ) {
-		return Array.from(
-			new Map( items.map( ( item ) => [ item.key, item ] ) ).values()
-		);
-	}
-
-	/**
 	 * Update the selected items and remove duplicates.
 	 *
-	 * @param {Array} value Array of selected items ( { key: string, label: string } )
+	 * @param {Array} items Array of selected items ( { key: string, label: string } )
 	 */
-	onSearchChange( value ) {
-		const deduplicated = this.removeDuplicateValues( value );
-		this.setState( { selected: deduplicated } );
+	onSearchChange( items ) {
+		const deduplicatedValues = Array.from(
+			new Map( items.map( ( item ) => [ item.key, item ] ) ).values()
+		);
+		this.setState( { selected: deduplicatedValues } );
 	}
 
 	render() {

--- a/js/src/components/external/woocommerce/compare-filter/index.js
+++ b/js/src/components/external/woocommerce/compare-filter/index.js
@@ -103,7 +103,7 @@ class CompareFilter extends Component {
 	 */
 	removeDuplicateValues( items ) {
 		return Array.from(
-			new Map(items.map( ( item ) => [ item.key, item ] )).values()
+			new Map( items.map( ( item ) => [ item.key, item ] ) ).values()
 		);
 	}
 
@@ -117,7 +117,9 @@ class CompareFilter extends Component {
 		this.setState( { selected: deduplicated } );
 	}
 
-	render() { const { labels, type, autocompleter } = this.props; const { selected } = this.state;
+	render() {
+		const { labels, type, autocompleter } = this.props;
+		const { selected } = this.state;
 		return (
 			<Card className="woocommerce-filters__compare">
 				<CardHeader>

--- a/js/src/components/external/woocommerce/compare-filter/index.js
+++ b/js/src/components/external/woocommerce/compare-filter/index.js
@@ -95,9 +95,29 @@ class CompareFilter extends Component {
 		}
 	}
 
-	render() {
-		const { labels, type, autocompleter } = this.props;
-		const { selected } = this.state;
+	/**
+	 * Remove duplicate items based on their 'key' attribute.
+	 *
+	 * @param {Array} items - Array of items to deduplicate.
+	 * @return {Array} Deduplicated array.
+	 */
+	removeDuplicateValues( items ) {
+		return Array.from(
+			new Map(items.map( ( item ) => [ item.key, item ] )).values()
+		);
+	}
+
+	/**
+	 * Update the selected items and remove duplicates.
+	 *
+	 * @param {Array} value Array of selected items ( { key: string, label: string } )
+	 */
+	onSearchChange( value ) {
+		const deduplicated = this.removeDuplicateValues( value );
+		this.setState( { selected: deduplicated } );
+	}
+
+	render() { const { labels, type, autocompleter } = this.props; const { selected } = this.state;
 		return (
 			<Card className="woocommerce-filters__compare">
 				<CardHeader>
@@ -109,9 +129,7 @@ class CompareFilter extends Component {
 						type={ type }
 						selected={ selected }
 						placeholder={ labels.placeholder }
-						onChange={ ( value ) => {
-							this.setState( { selected: value } );
-						} }
+						onChange={ this.onSearchChange }
 					/>
 				</CardBody>
 				<CardFooter justify="flex-start">

--- a/js/src/components/external/woocommerce/compare-filter/index.js
+++ b/js/src/components/external/woocommerce/compare-filter/index.js
@@ -41,7 +41,7 @@ class CompareFilter extends Component {
 		this.updateQuery = this.updateQuery.bind( this );
 		this.updateLabels = this.updateLabels.bind( this );
 		this.onButtonClicked = this.onButtonClicked.bind( this );
-		this.onSearchChange = this.onSearchChange.bind( this );
+		this.handleSearchChange = this.handleSearchChange.bind( this );
 		if ( query[ param ] ) {
 			getLabels( query[ param ], query ).then( this.updateLabels );
 		}
@@ -101,7 +101,7 @@ class CompareFilter extends Component {
 	 *
 	 * @param {Array} items Array of selected items ( { key: string, label: string } )
 	 */
-	onSearchChange( items ) {
+	handleSearchChange( items ) {
 		const deduplicatedValues = Array.from(
 			new Map( items.map( ( item ) => [ item.key, item ] ) ).values()
 		);
@@ -122,7 +122,7 @@ class CompareFilter extends Component {
 						type={ type }
 						selected={ selected }
 						placeholder={ labels.placeholder }
-						onChange={ this.onSearchChange }
+						onChange={ this.handleSearchChange }
 					/>
 				</CardBody>
 				<CardFooter justify="flex-start">


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

The Programs Comparison filter allows duplicate program selections, leading to console errors when trying to compare as well as duplicates in the selected filters. This PR filters the response from the Woocommerce Search component and removes duplicated items.

Closes https://linear.app/a8c/issue/GOOWOO-314/duplicate-programs-can-be-selected-in-the-comparison-filter-causing

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->

<img width="600" height="360" alt="image" src="https://github.com/user-attachments/assets/2bdf62d3-2866-44dd-9fd6-8355fa556ad1" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Navigate to the Reports → Programs tab.
2. Click on the Programs filter and choose the Comparison filter.
3. Use the search input to select a campaign.
4. Search again and select the same campaign (duplicate)
5. Ensure no duplicate filters are added to the list below
6. Click the Compare button.
7. Observe there's no error in the browser console

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Duplicated values in the report comparison filters.
