### PR TITLE
GOOWOO-460: Add tracking to GoogleAdsPromo component

### DIFF
--- a/js/src/meta-boxes/order-attribution/google-ads-promo.js
+++ b/js/src/meta-boxes/order-attribution/google-ads-promo.js
@@ -116,7 +116,7 @@ const GoogleAdsPromo = () => {
 				),
 				cta: (
 					<AppButton
-						href={ campaignUrl }
+						href={ getStartedUrl }
 						eventName="gla_google_ads_promo_get_started_click"
 						eventProps={ {
 							...GOOGLE_ADS_PROMO_EVENT_PROPS,

--- a/js/src/meta-boxes/order-attribution/google-ads-promo.js
+++ b/js/src/meta-boxes/order-attribution/google-ads-promo.js
@@ -1,19 +1,19 @@
 /**
  * External dependencies
  */
-import { Flex, FlexBlock, FlexItem } from '@wordpress/components';
-import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useEffect, useRef } from '@wordpress/element';
+import { Flex, FlexBlock, FlexItem } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import AppButton from '~/components/app-button';
 import { glaData } from '~/constants';
-import useAdsCampaigns from '~/hooks/useAdsCampaigns';
-import googleLogoURL from '~/images/logo/gogole-g-logo.svg';
 import { recordGlaEvent } from '~/utils/tracks';
 import { getCreateCampaignUrl, getGetStartedUrl } from '~/utils/urls';
+import AppButton from '~/components/app-button';
+import useAdsCampaigns from '~/hooks/useAdsCampaigns';
+import googleLogoURL from '~/images/logo/gogole-g-logo.svg';
 import './google-ads-promo.scss';
 
 /**
@@ -65,8 +65,8 @@ const hasRecentPaidCampaigns = ( campaigns ) => {
  * Google Ads Promo component.
  *
  * @fires gla_google_ads_promo_shown with `{ context: 'order-attribution-meta-box' }`.
- * @fires gla_google_ads_promo_get_started_click with `{ context: 'order-attribution-meta-box', href: '/get-started' }`.
- * @fires gla_google_ads_promo_create_campaign_click with `{ context: 'order-attribution-meta-box', href: '/create-campaign' }`.
+ * @fires gla_google_ads_promo_get_started_click with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
+ * @fires gla_google_ads_promo_create_campaign_click with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&subpath=%2Fcampaigns%2Fcreate&path=%2Fgoogle%2Fdashboard' }`.
  *
  * @return {JSX.Element|null} The Google Ads Promo component or null.
  */

--- a/js/src/meta-boxes/order-attribution/google-ads-promo.js
+++ b/js/src/meta-boxes/order-attribution/google-ads-promo.js
@@ -1,19 +1,19 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { useEffect, useRef } from '@wordpress/element';
 import { Flex, FlexBlock, FlexItem } from '@wordpress/components';
+import { useEffect, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { glaData } from '~/constants';
-import { getCreateCampaignUrl, getGetStartedUrl } from '~/utils/urls';
-import { recordGlaEvent } from '~/utils/tracks';
 import AppButton from '~/components/app-button';
+import { glaData } from '~/constants';
 import useAdsCampaigns from '~/hooks/useAdsCampaigns';
 import googleLogoURL from '~/images/logo/gogole-g-logo.svg';
+import { recordGlaEvent } from '~/utils/tracks';
+import { getCreateCampaignUrl, getGetStartedUrl } from '~/utils/urls';
 import './google-ads-promo.scss';
 
 /**
@@ -39,7 +39,34 @@ const hasRecentPaidCampaigns = ( campaigns ) => {
 };
 
 /**
+ * Google Ads Promo component is shown.
+ *
+ * @event gla_google_ads_promo_shown
+ * @property {string} context Context of the Google Ads Promo.
+ */
+
+/**
+ * Google Ads Promo "Get started" button is clicked.
+ *
+ * @event gla_google_ads_promo_get_started_click
+ * @property {string} context Context of the Google Ads Promo.
+ * @property {string} href URL of the "Get started" button.
+ */
+
+/**
+ * Google Ads Promo "Create campaign" button is clicked.
+ *
+ * @event gla_google_ads_promo_create_campaign_click
+ * @property {string} context Context of the Google Ads Promo.
+ * @property {string} href URL of the "Create campaign" button.
+ */
+
+/**
  * Google Ads Promo component.
+ *
+ * @fires gla_google_ads_promo_shown with `{ context: 'order-attribution-meta-box' }`.
+ * @fires gla_google_ads_promo_get_started_click with `{ context: 'order-attribution-meta-box', href: '/get-started' }`.
+ * @fires gla_google_ads_promo_create_campaign_click with `{ context: 'order-attribution-meta-box', href: '/create-campaign' }`.
  *
  * @return {JSX.Element|null} The Google Ads Promo component or null.
  */

--- a/js/src/meta-boxes/order-attribution/google-ads-promo.js
+++ b/js/src/meta-boxes/order-attribution/google-ads-promo.js
@@ -76,6 +76,9 @@ const GoogleAdsPromo = () => {
 		return null;
 	}
 
+	const campaignUrl = getCreateCampaignUrl();
+	const getStartedUrl = getGetStartedUrl();
+
 	const content = adsSetupComplete
 		? {
 				title: __(
@@ -88,9 +91,12 @@ const GoogleAdsPromo = () => {
 				),
 				cta: (
 					<AppButton
-						href={ getCreateCampaignUrl() }
+						href={ campaignUrl }
 						eventName="gla_google_ads_promo_create_campaign_click"
-						eventProps={ GOOGLE_ADS_PROMO_EVENT_PROPS }
+						eventProps={ {
+							...GOOGLE_ADS_PROMO_EVENT_PROPS,
+							href: campaignUrl,
+						} }
 						isSecondary
 					>
 						{ __( 'Create campaign', 'google-listings-and-ads' ) }
@@ -108,9 +114,12 @@ const GoogleAdsPromo = () => {
 				),
 				cta: (
 					<AppButton
-						href={ getGetStartedUrl() }
+						href={ campaignUrl }
 						eventName="gla_google_ads_promo_get_started_click"
-						eventProps={ GOOGLE_ADS_PROMO_EVENT_PROPS }
+						eventProps={ {
+							...GOOGLE_ADS_PROMO_EVENT_PROPS,
+							href: getStartedUrl,
+						} }
 						isSecondary
 					>
 						{ __( 'Get started', 'google-listings-and-ads' ) }

--- a/js/src/meta-boxes/order-attribution/google-ads-promo.js
+++ b/js/src/meta-boxes/order-attribution/google-ads-promo.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Flex, FlexBlock, FlexItem } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -27,7 +27,7 @@ const hasRecentPaidCampaigns = ( campaigns ) => {
 	const fourteenDaysAgo = new Date();
 	fourteenDaysAgo.setDate( fourteenDaysAgo.getDate() - 14 );
 
-	return campaigns?.some( ( campaign ) => {
+	return campaigns.some( ( campaign ) => {
 		const campaignDate = new Date( campaign.start_date );
 
 		return (
@@ -55,24 +55,26 @@ const GOOGLE_ADS_PROMO_EVENT_PROPS = {
 const GoogleAdsPromo = () => {
 	const { adsSetupComplete } = glaData;
 	const { data: campaigns, loading } = useAdsCampaigns();
-	const [ isVisible, setIsVisible ] = useState( false );
+	const hasTrackedRef = useRef( false );
 
-	// Set visibility and fire event once when component mounts
+	// Checks if the component is ready to render
+	const isReadyToRender =
+		! loading &&
+		Array.isArray( campaigns ) &&
+		! hasRecentPaidCampaigns( campaigns );
+
 	useEffect( () => {
-		if ( ! isVisible ) {
-			setIsVisible( true );
+		// Only fire if all conditions for rendering are met and not already tracked
+		if ( ! hasTrackedRef.current && isReadyToRender ) {
 			recordGlaEvent(
 				'gla_google_ads_promo_shown',
 				GOOGLE_ADS_PROMO_EVENT_PROPS
 			);
+			hasTrackedRef.current = true;
 		}
-	}, [ isVisible ] );
+	}, [ isReadyToRender ] );
 
-	if (
-		loading ||
-		! Array.isArray( campaigns ) ||
-		hasRecentPaidCampaigns( campaigns )
-	) {
+	if ( ! isReadyToRender ) {
 		return null;
 	}
 

--- a/js/src/meta-boxes/order-attribution/google-ads-promo.js
+++ b/js/src/meta-boxes/order-attribution/google-ads-promo.js
@@ -39,15 +39,6 @@ const hasRecentPaidCampaigns = ( campaigns ) => {
 };
 
 /**
- * Event properties for Google Ads Promo.
- *
- * @type {Object}
- */
-const GOOGLE_ADS_PROMO_EVENT_PROPS = {
-	context: 'order-attribution-meta-box',
-};
-
-/**
  * Google Ads Promo component.
  *
  * @return {JSX.Element|null} The Google Ads Promo component or null.
@@ -66,10 +57,9 @@ const GoogleAdsPromo = () => {
 	useEffect( () => {
 		// Only fire if all conditions for rendering are met and not already tracked
 		if ( ! hasTrackedRef.current && isReadyToRender ) {
-			recordGlaEvent(
-				'gla_google_ads_promo_shown',
-				GOOGLE_ADS_PROMO_EVENT_PROPS
-			);
+			recordGlaEvent( 'gla_google_ads_promo_shown', {
+				context: 'order-attribution-meta-box',
+			} );
 			hasTrackedRef.current = true;
 		}
 	}, [ isReadyToRender ] );
@@ -96,7 +86,7 @@ const GoogleAdsPromo = () => {
 						href={ campaignUrl }
 						eventName="gla_google_ads_promo_create_campaign_click"
 						eventProps={ {
-							...GOOGLE_ADS_PROMO_EVENT_PROPS,
+							context: 'order-attribution-meta-box',
 							href: campaignUrl,
 						} }
 						isSecondary
@@ -119,7 +109,7 @@ const GoogleAdsPromo = () => {
 						href={ getStartedUrl }
 						eventName="gla_google_ads_promo_get_started_click"
 						eventProps={ {
-							...GOOGLE_ADS_PROMO_EVENT_PROPS,
+							context: 'order-attribution-meta-box',
 							href: getStartedUrl,
 						} }
 						isSecondary

--- a/js/src/meta-boxes/order-attribution/google-ads-promo.js
+++ b/js/src/meta-boxes/order-attribution/google-ads-promo.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Flex, FlexBlock, FlexItem } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -11,6 +12,7 @@ import AppButton from '~/components/app-button';
 import { glaData } from '~/constants';
 import useAdsCampaigns from '~/hooks/useAdsCampaigns';
 import googleLogoURL from '~/images/logo/gogole-g-logo.svg';
+import { recordGlaEvent } from '~/utils/tracks';
 import { getCreateCampaignUrl, getGetStartedUrl } from '~/utils/urls';
 import './google-ads-promo.scss';
 
@@ -25,7 +27,7 @@ const hasRecentPaidCampaigns = ( campaigns ) => {
 	const fourteenDaysAgo = new Date();
 	fourteenDaysAgo.setDate( fourteenDaysAgo.getDate() - 14 );
 
-	return campaigns.some( ( campaign ) => {
+	return campaigns?.some( ( campaign ) => {
 		const campaignDate = new Date( campaign.start_date );
 
 		return (
@@ -37,6 +39,15 @@ const hasRecentPaidCampaigns = ( campaigns ) => {
 };
 
 /**
+ * Event properties for Google Ads Promo.
+ *
+ * @type {Object}
+ */
+const GOOGLE_ADS_PROMO_EVENT_PROPS = {
+	context: 'order-attribution-meta-box',
+};
+
+/**
  * Google Ads Promo component.
  *
  * @return {JSX.Element|null} The Google Ads Promo component or null.
@@ -44,6 +55,18 @@ const hasRecentPaidCampaigns = ( campaigns ) => {
 const GoogleAdsPromo = () => {
 	const { adsSetupComplete } = glaData;
 	const { data: campaigns, loading } = useAdsCampaigns();
+	const [ isVisible, setIsVisible ] = useState( false );
+
+	// Set visibility and fire event once when component mounts
+	useEffect( () => {
+		if ( ! isVisible ) {
+			setIsVisible( true );
+			recordGlaEvent(
+				'gla_google_ads_promo_shown',
+				GOOGLE_ADS_PROMO_EVENT_PROPS
+			);
+		}
+	}, [ isVisible ] );
 
 	if (
 		loading ||
@@ -67,6 +90,7 @@ const GoogleAdsPromo = () => {
 					<AppButton
 						href={ getCreateCampaignUrl() }
 						eventName="gla_google_ads_promo_create_campaign_click"
+						eventProps={ GOOGLE_ADS_PROMO_EVENT_PROPS }
 						isSecondary
 					>
 						{ __( 'Create campaign', 'google-listings-and-ads' ) }
@@ -86,6 +110,7 @@ const GoogleAdsPromo = () => {
 					<AppButton
 						href={ getGetStartedUrl() }
 						eventName="gla_google_ads_promo_get_started_click"
+						eventProps={ GOOGLE_ADS_PROMO_EVENT_PROPS }
 						isSecondary
 					>
 						{ __( 'Get started', 'google-listings-and-ads' ) }

--- a/js/src/meta-boxes/order-attribution/google-ads-promo.test.js
+++ b/js/src/meta-boxes/order-attribution/google-ads-promo.test.js
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
 import { glaData } from '~/constants';
 import useAdsCampaigns from '~/hooks/useAdsCampaigns';
+import { recordGlaEvent } from '~/utils/tracks';
 import GoogleAdsPromo from './google-ads-promo';
 
 // Mock campaign data
@@ -31,6 +32,15 @@ const mockCampaignExact14DaysAgo = {
 jest.mock( '~/hooks/useAdsCampaigns', () =>
 	jest.fn().mockName( 'useAdsCampaigns' )
 );
+
+jest.mock( '~/utils/tracks', () => ( {
+	recordGlaEvent: jest.fn(),
+} ) );
+
+jest.mock( '~/utils/urls', () => ( {
+	getGetStartedUrl: jest.fn( () => '/get-started' ),
+	getCreateCampaignUrl: jest.fn( () => '/create-campaign' ),
+} ) );
 
 describe( 'GoogleAdsPromo Component', () => {
 	beforeAll( () => {
@@ -171,6 +181,91 @@ describe( 'GoogleAdsPromo Component', () => {
 
 			const { container } = render( <GoogleAdsPromo /> );
 			expect( container.firstChild ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Tracking events', () => {
+		test( 'Fires gla_google_ads_promo_shown event when component successfully renders', () => {
+			useAdsCampaigns.mockReturnValue( {
+				data: [],
+				loading: false,
+			} );
+
+			render( <GoogleAdsPromo /> );
+
+			expect( recordGlaEvent ).toHaveBeenCalledWith(
+				'gla_google_ads_promo_shown',
+				{
+					context: 'order-attribution-meta-box',
+				}
+			);
+			expect( recordGlaEvent ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'Does not fire tracking event when loading', () => {
+			useAdsCampaigns.mockReturnValue( {
+				data: [],
+				loading: true,
+			} );
+
+			render( <GoogleAdsPromo /> );
+
+			expect( recordGlaEvent ).not.toHaveBeenCalled();
+		} );
+
+		test( 'Fires tracking event only once when component re-renders with same data', () => {
+			useAdsCampaigns.mockReturnValue( {
+				data: [],
+				loading: false,
+			} );
+
+			const { rerender } = render( <GoogleAdsPromo /> );
+
+			expect( recordGlaEvent ).toHaveBeenCalledTimes( 1 );
+
+			rerender( <GoogleAdsPromo /> );
+
+			expect( recordGlaEvent ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'Fires gla_google_ads_promo_create_campaign_click event when Create campaign button is clicked', () => {
+			glaData.adsSetupComplete = true;
+
+			useAdsCampaigns.mockReturnValue( {
+				data: [],
+				loading: false,
+			} );
+
+			render( <GoogleAdsPromo /> );
+
+			fireEvent.click(
+				screen.getByRole( 'link', { name: 'Create campaign' } )
+			);
+
+			expect( recordGlaEvent ).toHaveBeenCalledWith(
+				'gla_google_ads_promo_create_campaign_click',
+				{
+					context: 'order-attribution-meta-box',
+					href: '/create-campaign',
+				}
+			);
+		} );
+
+		test( 'Fires gla_google_ads_promo_get_started_click event when Get started button is clicked', () => {
+			useAdsCampaigns.mockReturnValue( {
+				data: [],
+				loading: false,
+			} );
+
+			render( <GoogleAdsPromo /> );
+			fireEvent.click(
+				screen.getByRole( 'link', { name: 'Get started' } )
+			);
+
+			expect( recordGlaEvent ).toHaveBeenCalledWith(
+				'gla_google_ads_promo_get_started_click',
+				{ context: 'order-attribution-meta-box', href: '/get-started' }
+			);
 		} );
 	} );
 } );

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -51,7 +51,11 @@ export const getEditCampaignUrl = ( programId, initialStep ) => {
 };
 
 export const getCreateCampaignUrl = () => {
-	return getNewPath( { subpath: subpaths.createCampaign }, dashboardPath );
+	return getNewPath(
+		{ subpath: subpaths.createCampaign },
+		dashboardPath,
+		null
+	);
 };
 
 export const getGetStartedUrl = () => {

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -576,7 +576,7 @@ Google Ads Promo "Create campaign" button is clicked.
 `context` | `string` | Context of the Google Ads Promo.
 `href` | `string` | URL of the "Create campaign" button.
 #### Emitters
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L73) with `{ context: 'order-attribution-meta-box', href: '/create-campaign' }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L73) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&subpath=%2Fcampaigns%2Fcreate&path=%2Fgoogle%2Fdashboard' }`.
 
 ### [`gla_google_ads_promo_get_started_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L48)
 Google Ads Promo "Get started" button is clicked.
@@ -586,7 +586,7 @@ Google Ads Promo "Get started" button is clicked.
 `context` | `string` | Context of the Google Ads Promo.
 `href` | `string` | URL of the "Get started" button.
 #### Emitters
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L73) with `{ context: 'order-attribution-meta-box', href: '/get-started' }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L73) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
 
 ### [`gla_google_ads_promo_shown`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L41)
 Google Ads Promo component is shown.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -443,7 +443,7 @@ When a documentation link is clicked.
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
 - [`ShippingTimeSection`](../../js/src/components/free-listings/configure-product-listings/shipping-time-section.js#L17) with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
-- [`SurveyModal`](../../js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey-modal.js#L47) with `{ context: 'skip-paid-ads-survey-modal', link_id: 'paid-ads-with-performance-max-campaigns-learn-more', href: 'https://support.google.com/google-ads/answer/10724817' }`
+- [`SurveyModal`](../../js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey-modal.js#L50) with `{ context: 'skip-paid-ads-survey-modal', link_id: 'paid-ads-with-performance-max-campaigns-learn-more', href: 'https://support.google.com/google-ads/answer/10724817' }`
 - [`TermsModal`](../../js/src/components/google-ads-account-card/terms-modal/index.js#L36)
 	- with `{ context: 'setup-ads', link_id: 'shopping-ads-policies', href: 'https://support.google.com/merchants/answer/6149970' }`
 	- with `{ context: 'setup-ads', link_id: 'google-ads-terms-of-service', href: 'https://support.google.com/adspolicy/answer/54818' }`
@@ -567,6 +567,35 @@ Clicking on the button to connect Google account.
 Clicking on the "connect to a different Google account" button.
 #### Emitters
 - [`SwitchAccountButton`](../../js/src/components/google-account-card/switch-account-button.js#L25)
+
+### [`gla_google_ads_promo_create_campaign_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L56)
+Google Ads Promo "Create campaign" button is clicked.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Context of the Google Ads Promo.
+`href` | `string` | URL of the "Create campaign" button.
+#### Emitters
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L73) with `{ context: 'order-attribution-meta-box', href: '/create-campaign' }`.
+
+### [`gla_google_ads_promo_get_started_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L48)
+Google Ads Promo "Get started" button is clicked.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Context of the Google Ads Promo.
+`href` | `string` | URL of the "Get started" button.
+#### Emitters
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L73) with `{ context: 'order-attribution-meta-box', href: '/get-started' }`.
+
+### [`gla_google_ads_promo_shown`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L41)
+Google Ads Promo component is shown.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Context of the Google Ads Promo.
+#### Emitters
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L73) with `{ context: 'order-attribution-meta-box' }`.
 
 ### [`gla_google_mc_link_click`](../../js/src/utils/tracks.js#L194)
 Clicking on a Google Merchant Center link.
@@ -834,7 +863,7 @@ When the "Improve Assets" button is clicked.
 #### Emitters
 - [`PriceBenchmarkSuggestions`](../../js/src/pages/price-benchmark/price-benchmark-suggestions/index.js#L199) with `{ context: 'price-benchmark-suggestions' }` and the suggestions count.
 
-### [`gla_raise_budget_recommendation_badge_campaigns`](../../js/src/pages/dashboard/all-programs-table-card/index.js#L72)
+### [`gla_raise_budget_recommendation_badge_campaigns`](../../js/src/pages/dashboard/all-programs-table-card/index.js#L57)
 When there are campaigns with budget recommendations in the table.
 #### Properties
 | name | type | description |
@@ -842,18 +871,18 @@ When there are campaigns with budget recommendations in the table.
 `context` | `string` | The context in which the banner was dismissed. Set to 'programs-table-card'.
 `campaign_ids` | `Array<number>` | The IDs of the campaigns with budget recommendations.
 #### Emitters
-- [`AllProgramsTableCard`](../../js/src/pages/dashboard/all-programs-table-card/index.js#L88) when there are campaigns with budget recommendations in the table.
+- [`AllProgramsTableCard`](../../js/src/pages/dashboard/all-programs-table-card/index.js#L73) when there are campaigns with budget recommendations in the table.
 
-### [`gla_raise_budget_recommendation_banner_shown`](../../js/src/components/raise-budget-recommendation-banner/banner.js#L25)
+### [`gla_raise_budget_recommendation_banner_shown`](../../js/src/components/raise-budget-recommendation-banner/banner.js#L24)
 When the banner is shown.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the banner is shown. Set to 'raise_budget_recommendation_banner'.
 #### Emitters
-- [`Banner`](../../js/src/components/raise-budget-recommendation-banner/banner.js#L66) when the banner is displayed.
+- [`Banner`](../../js/src/components/raise-budget-recommendation-banner/banner.js#L65) when the banner is displayed.
 
-### [`gla_raise_budget_recommendation_banner_view_recommendation_clicked`](../../js/src/components/raise-budget-recommendation-banner/banner.js#L32)
+### [`gla_raise_budget_recommendation_banner_view_recommendation_clicked`](../../js/src/components/raise-budget-recommendation-banner/banner.js#L31)
 When the "View recommendation" button is clicked.
 #### Properties
 | name | type | description |
@@ -861,9 +890,9 @@ When the "View recommendation" button is clicked.
 `context` | `string` | The context in which the banner is shown. Set to 'raise_budget_recommendation_banner'.
 `campaign_id` | `number` | The ID of the campaign for which the recommendation is being viewed.
 #### Emitters
-- [`Banner`](../../js/src/components/raise-budget-recommendation-banner/banner.js#L66) when the "View recommendation" button is clicked.
+- [`Banner`](../../js/src/components/raise-budget-recommendation-banner/banner.js#L65) when the "View recommendation" button is clicked.
 
-### [`gla_raise_budget_recommendation_dismiss_clicked`](../../js/src/components/raise-budget-recommendation-banner/banner.js#L40)
+### [`gla_raise_budget_recommendation_dismiss_clicked`](../../js/src/components/raise-budget-recommendation-banner/banner.js#L39)
 When the banner is dismissed by clicking the "Dismiss" button or the close icon.
 #### Properties
 | name | type | description |
@@ -871,7 +900,7 @@ When the banner is dismissed by clicking the "Dismiss" button or the close icon.
 `context` | `string` | The context in which the banner was dismissed. Set to 'raise_budget_recommendation_banner'.
 `campaign_id` | `number` | The ID of the campaign for which the banner was dismissed.
 #### Emitters
-- [`Banner`](../../js/src/components/raise-budget-recommendation-banner/banner.js#L66) when the banner is dismissed.
+- [`Banner`](../../js/src/components/raise-budget-recommendation-banner/banner.js#L65) when the banner is dismissed.
 
 ### [`gla_raise_budget_recommendation_option_selected`](../../js/src/components/paid-ads/budget-setup/budget-setup.js#L62)
 
@@ -958,6 +987,8 @@ Send survey responses when the user skips the paid ads setup.
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | Name of the context where the survey was triggered (e.g. 'skip-paid-ads-survey-modal').
+`your_role` | `string` | The role of the user (e.g. 'owner', 'developer', 'agency', 'marketing_lead', 'other').
+`your_role_text` | `string` | Text input for the user's role if 'other' is selected.
 `i_already_have_ads_on_google` | `boolean` | Indicates if the user already has ads on Google.
 `i_dont_have_the_budget_to_create_ads_now` | `boolean` | Indicates if the user doesn't have the budget to create ads now.
 `ive_tried_google_ads_before_without_success` | `boolean` | Indicates if the user has tried Google ads before without success.
@@ -965,12 +996,13 @@ Send survey responses when the user skips the paid ads setup.
 `i_dont_want_ads_on_google_text` | `string` | Text input for the reason why the user doesn't want ads on Google.
 `ill_create_ads_later` | `boolean` | Indicates if the user will create ads later.
 `ill_create_ads_later_text` | `string` | Text input for the reason why the user will create ads later.
+`i_dont_have_time` | `boolean` | Indicates if the user doesn't have time.
 `other` | `boolean` | Indicates if the user has another reason.
 `other_text` | `string` | Text input for the user's other reason.
 #### Emitters
-- [`SurveyModal`](../../js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey-modal.js#L47) with the survey responses and context 'skip-paid-ads-survey-modal'.
+- [`SurveyModal`](../../js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey-modal.js#L50) with the survey responses and context 'skip-paid-ads-survey-modal'.
 
-### [`gla_submit_campaign_button_click`](../../js/src/components/paid-ads/asset-group/asset-group.js#L30)
+### [`gla_submit_campaign_button_click`](../../js/src/components/paid-ads/asset-group/asset-group.js#L31)
 Clicking on the submit button on the campaign creation or editing page.
  If a value is recorded as `unknown`, it's because no assets are imported and therefore unknown.
 #### Properties
@@ -997,7 +1029,7 @@ Clicking on the submit button on the campaign creation or editing page.
 `has_raise_budget_recommendation` | `boolean` | Whether there is a budget recommendation that suggests raising the budget.
 `level` | `string` | The budget recommendation level selected by the user. Possible values: `low`, `current`, `recommended`, `high`, or `custom`.
 #### Emitters
-- [`exports`](../../js/src/components/paid-ads/asset-group/asset-group.js#L68)
+- [`exports`](../../js/src/components/paid-ads/asset-group/asset-group.js#L69)
 
 ### [`gla_table_go_to_page`](../../js/src/utils/tracks.js#L47)
 When table pagination is changed by entering page via "Go to page" input.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-460/add-tracking-to-googleadspromo

Adds tracking events to GoogleAdsPromo component.

### Screenshots:

<!--- Optional --->

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Enabled [Woo Usage Tracking](https://woocommerce.com/usage-tracking/).
2. Open the browser console and run the following so that events are logged: localStorage.setItem( 'debug', 'wc-admin:*' );
3. Go to the detail page of a Google created order under Woocommerce > Orders
4. Based on the visibility of the block (see [Acceptance criteria](https://linear.app/a8c/issue/GOOWOO-458/create-googleadspromo-component)) it should trigger the following events upon load and click.
5. Events that are fired:
  - On component visible:
    - Event name: `gla_google_ads_promo_shown`
    - Context: `order-attribution-meta-box`
  - On Create campaign CTA click:
    - Event name: `gla_google_ads_promo_create_campaign_click`
    - Context: `order-attribution-meta-box`
    - Link: The CTA URL
  - On Get started CTA click:
    - Event name: `gla_google_ads_promo_get_started_click`
    - Context: `order-attribution-meta-box`
    - Link: The CTA URL
6. Ensure the events are fired as per the AC.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Adds tracking events to GoogleAdsPromo component
