### PR TITLE
[GOOWOO-474] Performance: Avoid uncached Ads API request in NotificationManager

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -320,12 +320,12 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 				$operations[] = $this->edit_operation( $campaign_id, $campaign_fields );
 			}
 
+			$this->container->get( TransientsInterface::class )->delete( TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN );
+
 			if ( ! empty( $operations ) ) {
-				$this->container->get( TransientsInterface::class )->delete( TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN );
 				return $this->mutate( $operations ) ?: $campaign_id;
 			}
 
-			$this->container->get( TransientsInterface::class )->delete( TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN );
 			return $campaign_id;
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
@@ -424,7 +424,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 		$transients->set(
 			TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN,
 			[ 'campaign' => $result ],
-			HOUR_IN_SECONDS
+			HOUR_IN_SECONDS * 12
 		);
 
 		return $result;

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -253,8 +253,10 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 				$this->campaign_label->assign_label_to_campaign_by_label_name( $campaign_id, $params['label'] );
 			}
 
-			// Clear cached campaign count.
-			$this->container->get( TransientsInterface::class )->delete( TransientsInterface::ADS_CAMPAIGN_COUNT );
+			// Clear cached campaign count and highest spend campaign.
+			$transients = $this->container->get( TransientsInterface::class );
+			$transients->delete( TransientsInterface::ADS_CAMPAIGN_COUNT );
+			$transients->delete( TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN );
 
 			return [
 				'id'      => $campaign_id,
@@ -319,9 +321,11 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			}
 
 			if ( ! empty( $operations ) ) {
+				$this->container->get( TransientsInterface::class )->delete( TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN );
 				return $this->mutate( $operations ) ?: $campaign_id;
 			}
 
+			$this->container->get( TransientsInterface::class )->delete( TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN );
 			return $campaign_id;
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
@@ -356,8 +360,10 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 				$this->delete_operation( $campaign_resource_name ),
 			];
 
-			// Clear cached campaign count.
-			$this->container->get( TransientsInterface::class )->delete( TransientsInterface::ADS_CAMPAIGN_COUNT );
+			// Clear cached campaign count and highest spend campaign.
+			$transients = $this->container->get( TransientsInterface::class );
+			$transients->delete( TransientsInterface::ADS_CAMPAIGN_COUNT );
+			$transients->delete( TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN );
 
 			return $this->mutate( $operations );
 		} catch ( ApiException $e ) {
@@ -385,17 +391,25 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 
 	/**
 	 * Retrieve the enabled campaign with the highest spend amount.
+	 * Result is cached to avoid Ads API requests on every admin page load.
 	 *
 	 * @return array
 	 */
 	public function get_highest_spend_campaign(): array {
+		$transients = $this->container->get( TransientsInterface::class );
+		$cached     = $transients->get( TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN );
+
+		if ( is_array( $cached ) && array_key_exists( 'campaign', $cached ) ) {
+			return $cached['campaign'];
+		}
+
 		try {
 			$campaigns = $this->get_campaigns();
 		} catch ( Exception $e ) {
 			return [];
 		}
 
-		return array_reduce(
+		$result = array_reduce(
 			$campaigns,
 			function ( $highest, $campaign ) {
 				if ( CampaignStatus::ENABLED === $campaign['status'] && ( empty( $highest ) || $campaign['amount'] > $highest['amount'] ) ) {
@@ -406,6 +420,14 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			},
 			[]
 		);
+
+		$transients->set(
+			TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN,
+			[ 'campaign' => $result ],
+			HOUR_IN_SECONDS
+		);
+
+		return $result;
 	}
 
 	/**

--- a/src/Options/TransientsInterface.php
+++ b/src/Options/TransientsInterface.php
@@ -12,6 +12,7 @@ interface TransientsInterface {
 
 	public const ADS_BUDGET_METRICS         = 'ads_budget_metrics';
 	public const ADS_CAMPAIGN_COUNT         = 'ads_campaign_count';
+	public const ADS_HIGHEST_SPEND_CAMPAIGN = 'ads_highest_spend_campaign';
 	public const ADS_LOCATION_IDS           = 'ads_location_ids';
 	public const ADS_METRICS                = 'ads_metrics';
 	public const ADS_BUDGET_RECOMMENDATIONS = 'ads_budget_recommendations';
@@ -26,6 +27,7 @@ interface TransientsInterface {
 	public const VALID_OPTIONS = [
 		self::ADS_BUDGET_METRICS         => true,
 		self::ADS_CAMPAIGN_COUNT         => true,
+		self::ADS_HIGHEST_SPEND_CAMPAIGN => true,
 		self::ADS_LOCATION_IDS           => true,
 		self::ADS_METRICS                => true,
 		self::ADS_RECOMMENDATIONS        => true,

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -304,6 +304,80 @@ class AdsCampaignTest extends UnitTest {
 		$this->assertEquals( $campaign_data, $this->campaign->get_campaign( self::TEST_CAMPAIGN_ID ) );
 	}
 
+	public function test_get_highest_spend_campaign_returns_cached_value() {
+		$cached_campaign = [
+			'id'      => 5678901234,
+			'name'    => 'Cached Campaign',
+			'status'  => 'enabled',
+			'type'    => 'performance_max',
+			'amount'  => 50,
+			'country' => 'US',
+		];
+
+		$this->transients->expects( $this->once() )
+			->method( 'get' )
+			->with( TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN )
+			->willReturn( [ 'campaign' => $cached_campaign ] );
+		$this->transients->expects( $this->never() )->method( 'set' );
+
+		$this->assertEquals( $cached_campaign, $this->campaign->get_highest_spend_campaign() );
+	}
+
+	public function test_get_highest_spend_campaign_fetches_and_caches_on_miss() {
+		$campaigns_data = [
+			[
+				'id'                                    => self::TEST_CAMPAIGN_ID,
+				'name'                                  => 'Campaign One',
+				'status'                                => 'paused',
+				'type'                                  => 'performance_max',
+				'amount'                                => 10,
+				'country'                               => 'US',
+				'targeted_locations'                    => [],
+				'eu_political_advertising_confirmation' => false,
+			],
+			[
+				'id'                                    => 5678901234,
+				'name'                                  => 'Campaign Two',
+				'status'                                => 'enabled',
+				'type'                                  => 'performance_max',
+				'amount'                                => 20,
+				'country'                               => 'UK',
+				'targeted_locations'                    => [],
+				'eu_political_advertising_confirmation' => false,
+			],
+		];
+
+		$expected_highest = $campaigns_data[1];
+
+		$this->transients->expects( $this->once() )
+			->method( 'get' )
+			->with( TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN )
+			->willReturn( null );
+		// set() may be called twice: ADS_HIGHEST_SPEND_CAMPAIGN (our cache) and possibly ADS_CAMPAIGN_COUNT from get_campaigns().
+		$this->transients->expects( $this->atLeastOnce() )
+			->method( 'set' )
+			->willReturnCallback(
+				function ( string $name, $value, int $expiration ) use ( $expected_highest ) {
+					if ( $name === TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN ) {
+						$this->assertIsArray( $value );
+						$this->assertArrayHasKey( 'campaign', $value );
+						$campaign = $value['campaign'];
+						$this->assertEquals( $expected_highest['id'], $campaign['id'] );
+						$this->assertEquals( $expected_highest['status'], $campaign['status'] );
+						$this->assertEqualsWithDelta( $expected_highest['amount'], $campaign['amount'] ?? 0, 0.01 );
+					}
+					return true;
+				}
+			);
+
+		$this->generate_ads_campaign_query_mock( $campaigns_data, [] );
+
+		$result = $this->campaign->get_highest_spend_campaign();
+		$this->assertEquals( $expected_highest['id'], $result['id'] );
+		$this->assertEquals( $expected_highest['status'], $result['status'] );
+		$this->assertEqualsWithDelta( $expected_highest['amount'], $result['amount'] ?? 0, 0.01 );
+	}
+
 	public function test_get_campaign_exception() {
 		$this->generate_ads_query_mock_exception( new ApiException( 'not found', 5, 'NOT_FOUND' ) );
 
@@ -344,7 +418,12 @@ class AdsCampaignTest extends UnitTest {
 			'eu_political_advertising_confirmation' => false,
 		] + $campaign_data;
 
-		$this->transients->expects( $this->once() )->method( 'delete' )->with( TransientsInterface::ADS_CAMPAIGN_COUNT );
+		$this->transients->expects( $this->exactly( 2 ) )
+			->method( 'delete' )
+			->withConsecutive(
+				[ TransientsInterface::ADS_CAMPAIGN_COUNT ],
+				[ TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN ]
+			);
 
 		$this->assertEquals(
 			$expected,
@@ -467,6 +546,10 @@ class AdsCampaignTest extends UnitTest {
 
 		$this->generate_campaign_mutate_mock( 'update', self::TEST_CAMPAIGN_ID );
 
+		$this->transients->expects( $this->once() )
+			->method( 'delete' )
+			->with( TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN );
+
 		$this->assertEquals(
 			self::TEST_CAMPAIGN_ID,
 			$this->campaign->edit_campaign( self::TEST_CAMPAIGN_ID, $campaign_data )
@@ -498,7 +581,12 @@ class AdsCampaignTest extends UnitTest {
 	public function test_delete_campaign() {
 		$this->generate_campaign_mutate_mock( 'remove', self::TEST_CAMPAIGN_ID );
 
-		$this->transients->expects( $this->once() )->method( 'delete' )->with( TransientsInterface::ADS_CAMPAIGN_COUNT );
+		$this->transients->expects( $this->exactly( 2 ) )
+			->method( 'delete' )
+			->withConsecutive(
+				[ TransientsInterface::ADS_CAMPAIGN_COUNT ],
+				[ TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN ]
+			);
 
 		$this->assertEquals(
 			self::TEST_CAMPAIGN_ID,
@@ -701,7 +789,12 @@ class AdsCampaignTest extends UnitTest {
 			'country' => self::BASE_COUNTRY,
 		] + $campaign_data;
 
-		$this->transients->expects( $this->once() )->method( 'delete' )->with( TransientsInterface::ADS_CAMPAIGN_COUNT );
+		$this->transients->expects( $this->exactly( 2 ) )
+			->method( 'delete' )
+			->withConsecutive(
+				[ TransientsInterface::ADS_CAMPAIGN_COUNT ],
+				[ TransientsInterface::ADS_HIGHEST_SPEND_CAMPAIGN ]
+			);
 		$this->campaign_label->expects( $this->once() )
 			->method( 'assign_label_to_campaign_by_label_name' )
 			->with( self::TEST_CAMPAIGN_ID, 'wc-gla' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-474/performance-avoid-uncached-ads-api-request-in-notificationmanager

### Screenshots:

<img width="595" height="357" alt="Screenshot 2026-02-19 at 15 42 07" src="https://github.com/user-attachments/assets/ee965b9d-46a7-407e-967e-880aca0a0b22" />


Before clearing transient cache:
<img width="1708" height="1323" alt="Screenshot 2026-02-23 at 13 57 25" src="https://github.com/user-attachments/assets/548b5fe2-9d48-4ada-b083-6b7dcbae8092" />

After clearing transient cache (i.e. the data is looked up and stored):
<img width="1707" height="1322" alt="Screenshot 2026-02-23 at 13 58 05" src="https://github.com/user-attachments/assets/dd411602-c484-4a94-82f1-630b1fb83f3d" />

### Detailed test instructions:

1. In terminal run: `wp transient get gla_ads_highest_spend_campaign` - the transient should not exist at this point so expect the output to be: `Warning: Transient with key "gla_ads_highest_spend_campaign" is not set.`
2. Open WP Admin, navigate to Marketing -> Google for WooCommerce and select any campaign (or create one if need be). This process should set the transient.
3. In terminal run: `wp transient get gla_ads_highest_spend_campaign` You should see array data set now, for example:

```
array (
  'campaign' => 
  array (
    'id' => 23349407739,
    'name' => 'Campaign 2025-12-11 15:09:02',
    'status' => 'enabled',
    'type' => 'performance_max',
    'targeted_locations' => 
    array (
      0 => 'GB',
    ),
    'eu_political_advertising_confirmation' => false,
    'amount' => 14.0,
    'country' => 'GB',
  ),
)
```

### Additional details:

### Changelog entry

> Fix - Cache GAQL query for highest spend campaign.