### PR TITLE
Increase headline asset max character count to 30

### DIFF
--- a/js/src/components/paid-ads/__snapshots__/validateAssetGroup.test.js.snap
+++ b/js/src/components/paid-ads/__snapshots__/validateAssetGroup.test.js.snap
@@ -52,12 +52,6 @@ exports[`validateAssetGroup Text assets When the first value of description is a
 ]
 `;
 
-exports[`validateAssetGroup Text assets When the first value of headline is an empty string, it should not pass 1`] = `
-[
-  "The headline in the first field is required",
-]
-`;
-
 exports[`validateAssetGroup Text assets When the length of values.business_name is less than 1 after omitting empty strings, it should not pass 1`] = `
 [
   "The business name is required",

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -212,7 +212,7 @@ const ASSET_TEXT_SPECS = [
 		key: ASSET_FORM_KEY.HEADLINE,
 		min: 3,
 		max: 5,
-		maxCharacterCounts: [ 30, 30, 30, 30, 30 ],
+		maxCharacterCounts: 30,
 		heading: _x(
 			'Headlines',
 			'Plural asset field name as the heading',

--- a/js/src/components/paid-ads/assetSpecs.js
+++ b/js/src/components/paid-ads/assetSpecs.js
@@ -212,7 +212,7 @@ const ASSET_TEXT_SPECS = [
 		key: ASSET_FORM_KEY.HEADLINE,
 		min: 3,
 		max: 5,
-		maxCharacterCounts: [ 15, 30, 30, 30, 30 ],
+		maxCharacterCounts: [ 30, 30, 30, 30, 30 ],
 		heading: _x(
 			'Headlines',
 			'Plural asset field name as the heading',

--- a/js/src/data/adapters.test.js
+++ b/js/src/data/adapters.test.js
@@ -345,23 +345,10 @@ describe( 'adaptAssetGroup', () => {
 
 		it( 'When the first text has an invalid character count, it should move the valid one to the first', () => {
 			assetGroup.assets[ DESCRIPTION ].reverse();
-			assetGroup.assets[ HEADLINE ] = [
-				{ content: text20Count },
-				{ content: text30Count },
-				{ content: text15Count },
-				{ content: text10Count },
-			];
 			const { assets } = adaptAssetGroup( assetGroup );
 			const descriptions = assets[ DESCRIPTION ].map( mapContent );
-			const headlines = assets[ HEADLINE ].map( mapContent );
 
 			expect( descriptions ).toEqual( [ text60Count, text90Count ] );
-			expect( headlines ).toEqual( [
-				text15Count,
-				text20Count,
-				text30Count,
-				text10Count,
-			] );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-468/first-headline-has-a-limit-of-15-characters-instead-of-30-and-cuts-the.

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a new campaign.
2. The first text input for Headline should have a max character count of 30 instead of 15.
3. Campaign creation should work as usual.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
