### PR TITLE
GOOWOO-337 Service Based Merchants compatibility with GOOWOO-383 GenAI

### DIFF
--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -142,11 +142,16 @@ class AdsAssetGroup implements OptionsAwareInterface, ContainerAwareInterface {
 	 * @return array
 	 */
 	public function create_operations( string $campaign_resource_name, string $asset_group_name ): array {
-		// Asset must be created before listing group.
-		return [
+		$operations = [
 			$this->asset_group_create_operation( $campaign_resource_name, $asset_group_name ),
-			$this->listing_group_create_operation(),
 		];
+
+		// Only add listing group for retail (Performance Max with product feed); omit for standard PMax (e.g. SBM without Merchant Center).
+		if ( $this->options->get_merchant_id() > 0 ) {
+			$operations[] = $this->listing_group_create_operation();
+		}
+
+		return $operations;
 	}
 
 	/**

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -225,6 +225,16 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	 */
 	public function create_campaign( array $params ): array {
 		try {
+			// Standard PMax (no Merchant Center) requires assets in the same request; only retail can use "empty" asset group.
+			if ( $this->options->get_merchant_id() <= 0 && ( ! isset( $params['final_url'] ) || ! isset( $params['assets'] ) ) ) {
+				throw new ExceptionWithResponseData(
+					__( 'Add assets to create your campaign.', 'google-listings-and-ads' ),
+					400,
+					null,
+					[ 'errors' => [ 'INVALID_ARGUMENT' => __( 'Campaigns without a product feed require assets. Add assets to create your campaign.', 'google-listings-and-ads' ) ] ]
+				);
+			}
+
 			$base_country = $this->container->get( WC::class )->get_base_country();
 
 			$location_ids = array_map(

--- a/tests/Unit/API/Google/AdsAssetGroupTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupTest.php
@@ -104,6 +104,30 @@ class AdsAssetGroupTest extends UnitTest {
 		$this->assertEquals( ListingGroupFilterListingSource::SHOPPING, $listing_group->getListingSource() );
 	}
 
+	public function test_create_operations_without_merchant_center() {
+		$this->options->method( 'get_merchant_id' )->willReturn( 0 );
+
+		$campaign_resource_name    = $this->generate_campaign_resource_name( self::TEST_CAMPAIGN_ID );
+		$asset_group_resource_name = $this->generate_asset_group_resource_name( -3 );
+
+		$operations = $this->asset_group->create_operations(
+			$campaign_resource_name,
+			'New Campaign'
+		);
+
+		// Standard PMax: only asset group operation, no listing group filter.
+		$this->assertCount( 1, $operations );
+
+		$operation_asset_group = $operations[0]->getAssetGroupOperation();
+		$this->assertTrue( $operation_asset_group->hasCreate() );
+
+		$asset_group = $operation_asset_group->getCreate();
+		$this->assertEquals( 'New Campaign Asset Group', $asset_group->getName() );
+		$this->assertEquals( $campaign_resource_name, $asset_group->getCampaign() );
+		$this->assertEquals( $asset_group_resource_name, $asset_group->getResourceName() );
+		$this->assertEquals( AssetGroupStatus::ENABLED, $asset_group->getStatus() );
+	}
+
 	public function test_get_asset_groups_by_campaign_id_with_assets() {
 		$assets_data = [
 			self::TEST_ASSET_GROUP_ID   => [

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -19,6 +19,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAd
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Google\ApiCore\ApiException;
 use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionMethod;
 use Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -93,6 +94,7 @@ class AdsCampaignTest extends UnitTest {
 		$this->campaign->set_container( $this->container );
 
 		$this->options->method( 'get_ads_id' )->willReturn( $this->ads_id );
+		$this->options->method( 'get_merchant_id' )->willReturn( 12345 );
 	}
 
 	public function test_get_campaigns_empty_list() {
@@ -417,6 +419,54 @@ class AdsCampaignTest extends UnitTest {
 			);
 			$this->assertEquals( 400, $e->getCode() );
 		}
+	}
+
+	public function test_create_campaign_throws_when_no_merchant_and_no_assets() {
+		$options_no_merchant = $this->createMock( OptionsInterface::class );
+		$options_no_merchant->method( 'get_ads_id' )->willReturn( $this->ads_id );
+		$options_no_merchant->method( 'get_merchant_id' )->willReturn( 0 );
+		$this->campaign->set_options_object( $options_no_merchant );
+
+		$campaign_data = [
+			'name'                                  => 'New Campaign',
+			'amount'                                => 20,
+			'targeted_locations'                    => [ 'US', 'GB' ],
+			'eu_political_advertising_confirmation' => false,
+		];
+
+		$this->expectException( ExceptionWithResponseData::class );
+		$this->expectExceptionMessage( 'Add assets to create your campaign.' );
+
+		$this->campaign->create_campaign( $campaign_data );
+	}
+
+	public function test_create_operation_includes_shopping_setting_when_merchant_id_set() {
+		$this->options->method( 'get_merchant_id' )->willReturn( 12345 );
+
+		$method = new ReflectionMethod( AdsCampaign::class, 'create_operation' );
+		$method->setAccessible( true );
+		/** @var \Google\Ads\GoogleAds\V20\Services\MutateOperation $mutate_op */
+		$mutate_op = $method->invoke( $this->campaign, 'Test Campaign', 'US', false );
+
+		$campaign = $mutate_op->getCampaignOperation()->getCreate();
+		$this->assertTrue( $campaign->hasShoppingSetting() );
+		$this->assertEquals( 12345, $campaign->getShoppingSetting()->getMerchantId() );
+		$this->assertEquals( 'US', $campaign->getShoppingSetting()->getFeedLabel() );
+	}
+
+	public function test_create_operation_omits_shopping_setting_when_merchant_id_zero() {
+		$options_no_merchant = $this->createMock( OptionsInterface::class );
+		$options_no_merchant->method( 'get_ads_id' )->willReturn( $this->ads_id );
+		$options_no_merchant->method( 'get_merchant_id' )->willReturn( 0 );
+		$this->campaign->set_options_object( $options_no_merchant );
+
+		$method = new ReflectionMethod( AdsCampaign::class, 'create_operation' );
+		$method->setAccessible( true );
+		/** @var \Google\Ads\GoogleAds\V20\Services\MutateOperation $mutate_op */
+		$mutate_op = $method->invoke( $this->campaign, 'Test Campaign', 'US', false );
+
+		$campaign = $mutate_op->getCampaignOperation()->getCreate();
+		$this->assertFalse( $campaign->hasShoppingSetting() );
 	}
 
 	public function test_create_campaign_exception_invalid_location_id() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-473/ensure-genai-works-together-with-sbm
See also: https://github.com/woocommerce/google-listings-and-ads/pull/3269

### Screenshots:

N/A


### Detailed test instructions:

#### Before you start

- You need two test sites:
  - **One:** Google account connected **with** Merchant Center (product feed).
  - **Two:** Google account connected **without** Merchant Center (Ads only; “service-based” style).
- In both setups, ensure you can open **WooCommerce → Marketing → Google** (or the main Google for WooCommerce screen) without errors.

#### With Merchant Center connected (Site One)

1. Log in to WordPress admin.
2. Go to **WooCommerce → Marketing → Google** (or the Google Listings and Ads / “Google for WooCommerce” area).
3. Confirm the connection shows Merchant Center as connected (no errors on the main screen).
4. Open the **Campaigns** or **Ads** section and start **creating a new Performance Max campaign**.
5. Fill in the basics (name, budget, locations). **Do not** add a final URL or extra assets.
6. Submit/save the campaign.
7. **Expected:** The campaign is created successfully and appears in the list. **No** error about “Add assets”.
8. Optionally open the new campaign and confirm you can view/edit it without errors.

#### Without Merchant Center (Ads only – Site Two)

1. Log in to WordPress admin on the site where **only** Google Ads is connected (no Merchant Center).
2. Go to **WooCommerce → Marketing → Google** and confirm you see no Merchant Center connection (or an “Ads only” style setup).
3. Open the **Campaigns** / **Ads** section and start **creating a new Performance Max campaign**.
4. Fill in name, budget, and locations. **Do not** add a final URL or any assets.
5. Try to submit/save the campaign.
6. **Expected:** An error appears. The message should say something like **“Add assets to create your campaign.”** (or that campaigns without a product feed require assets). The campaign must **not** be created.
7. Start creating a new Performance Max campaign again. This time **add** a final URL and at least one asset (e.g. headline, image, or description).
8. Submit/save the campaign.
9. **Expected:** The campaign is created successfully and appears in the list. No errors.

#### General checks (no errors in admin)

Run these on either setup to confirm nothing is broken:

1. **Campaign list**  
   - Open the screen that lists all Google Ads campaigns.  
   - **Expected:** The list loads with no PHP errors, white screen, or warning messages.

2. **View a campaign**  
   - Open a single existing campaign (view/details).  
   - **Expected:** The page loads with no errors.

3. **Edit a campaign**  
   - Edit an existing campaign (e.g. change budget or name) and save.  
   - **Expected:** Save succeeds and no errors appear.

4. **Dashboard / overview**  
   - Go back to the main Google for WooCommerce / Marketing dashboard.  
   - **Expected:** The dashboard loads with no errors; numbers or cards may be empty but there are no PHP or JavaScript errors.

### Additional details:

> Update - Compatibility with Service Based Merchants
