### PR TITLE
GOOWOO-383 GenAI compatibility with GOOWOO-337 Service Based Merchants

### DIFF
--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -4,8 +4,8 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Google\Ads\GoogleAds\V22\Services\GoogleAdsRow;
 use Google\Ads\GoogleAds\V22\Enums\AssetTypeEnum\AssetType;
 use Google\Ads\GoogleAds\V22\Resources\Asset;
@@ -212,6 +212,38 @@ class AdsAsset implements OptionsAwareInterface {
 		}
 
 		return $arns;
+	}
+
+	/**
+	 * Returns an array of operations to create assets (for use in a batch mutate, e.g. with asset group).
+	 *
+	 * @param array $assets An array of assets, each containing content and field_type keys.
+	 * @return MutateOperation[] An array of MutateOperation.
+	 * @throws Exception If the asset type is not supported or image url is invalid.
+	 */
+	public function create_operations( array $assets ): array {
+		if ( empty( $assets ) ) {
+			return [];
+		}
+
+		$operations  = [];
+		$image_types = [
+			AssetFieldType::LOGO,
+			AssetFieldType::MARKETING_IMAGE,
+			AssetFieldType::SQUARE_MARKETING_IMAGE,
+			AssetFieldType::PORTRAIT_MARKETING_IMAGE,
+		];
+
+		foreach ( $assets as $asset ) {
+			if ( in_array( $asset['field_type'], $image_types, true ) ) {
+				$image_data    = $this->get_image_data( $asset['content'] );
+				$asset['body'] = $image_data['body'];
+			}
+
+			$operations[] = $this->create_operation( $asset, self::$temporary_id-- );
+		}
+
+		return $operations;
 	}
 
 	/**

--- a/src/API/Google/AdsAssetGroup.php
+++ b/src/API/Google/AdsAssetGroup.php
@@ -5,9 +5,13 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Query\AdsAssetGroupQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Google\Ads\GoogleAds\Util\V22\ResourceNames;
+use Google\Ads\GoogleAds\V22\Resources\AssetGroupAsset;
+use Google\Ads\GoogleAds\V22\Services\AssetGroupAssetOperation;
 use Google\Ads\GoogleAds\V22\Enums\ListingGroupFilterListingSourceEnum\ListingGroupFilterListingSource;
 use Google\Ads\GoogleAds\V22\Enums\AssetGroupStatusEnum\AssetGroupStatus;
 use Google\Ads\GoogleAds\V22\Enums\ListingGroupFilterTypeEnum\ListingGroupFilterType;
@@ -36,8 +40,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseD
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */
-class AdsAssetGroup implements OptionsAwareInterface {
+class AdsAssetGroup implements ContainerAwareInterface, OptionsAwareInterface {
 
+	use ContainerAwareTrait;
 	use ExceptionTrait;
 	use OptionsAwareTrait;
 
@@ -132,16 +137,77 @@ class AdsAssetGroup implements OptionsAwareInterface {
 	/**
 	 * Returns a set of operations to create an asset group.
 	 *
+	 * Only adds listing group for retail (Performance Max with product feed); omit for standard PMax (e.g. SBM without Merchant Center).
+	 *
 	 * @param string $campaign_resource_name
 	 * @param string $asset_group_name The asset group name.
 	 * @return array
 	 */
 	public function create_operations( string $campaign_resource_name, string $asset_group_name ): array {
-		// Asset must be created before listing group.
-		return [
+		$operations = [
 			$this->asset_group_create_operation( $campaign_resource_name, $asset_group_name ),
-			$this->listing_group_create_operation(),
 		];
+
+		if ( $this->options->get_merchant_id() > 0 ) {
+			$operations[] = $this->listing_group_create_operation();
+		}
+
+		return $operations;
+	}
+
+	/**
+	 * Returns a set of operations to create an asset group with assets (for standard PMax / SBM).
+	 *
+	 * @param string $campaign_resource_name
+	 * @param string $campaign_name
+	 * @param string $final_url
+	 * @param array  $asset_group_assets
+	 * @return array
+	 */
+	public function create_operations_with_assets( string $campaign_resource_name, string $campaign_name, string $final_url, array $asset_group_assets ): array {
+		$operations = [];
+
+		$asset_group_resource_name = $this->temporary_resource_name();
+
+		$asset_group = new AssetGroup(
+			[
+				'resource_name' => $asset_group_resource_name,
+				'name'          => $campaign_name . ' Asset Group',
+				'campaign'      => $campaign_resource_name,
+				'status'        => AssetGroupStatus::ENABLED,
+				'final_urls'    => [ $final_url ],
+			]
+		);
+
+		$operations[] = ( new MutateOperation() )->setAssetGroupOperation(
+			( new AssetGroupOperation() )->setCreate( $asset_group )
+		);
+
+		$asset_ops  = $this->container->get( AdsAsset::class )->create_operations( $asset_group_assets );
+		$operations = array_merge( $operations, $asset_ops );
+
+		foreach ( $asset_ops as $i => $asset_op ) {
+			$asset_resource_name = $asset_op
+				->getAssetOperation()
+				->getCreate()
+				->getResourceName();
+
+			$operations[] = ( new MutateOperation() )->setAssetGroupAssetOperation(
+				( new AssetGroupAssetOperation() )->setCreate(
+					new AssetGroupAsset(
+						[
+							'asset_group' => $asset_group_resource_name,
+							'asset'       => $asset_resource_name,
+							'field_type'  => AssetFieldType::number(
+								$asset_group_assets[ $i ]['field_type']
+							),
+						]
+					)
+				)
+			);
+		}
+
+		return $operations;
 	}
 
 	/**

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -225,6 +225,23 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	 */
 	public function create_campaign( array $params ): array {
 		try {
+			// Standard PMax (no Merchant Center) requires assets in the same request; only retail can use "empty" asset group.
+			if ( $this->options->get_merchant_id() <= 0 && ( ! isset( $params['final_url'] ) || ! isset( $params['assets'] ) ) ) {
+				throw new ExceptionWithResponseData(
+					__( 'Add assets or use Generate with AI to create your campaign.', 'google-listings-and-ads' ),
+					400,
+					null,
+					[
+						'errors' => [
+							'INVALID_ARGUMENT' => __(
+								'Campaigns without a product feed require assets. Add assets or use Generate with AI to create your campaign.',
+								'google-listings-and-ads'
+							),
+						],
+					]
+				);
+			}
+
 			$base_country = $this->container->get( WC::class )->get_base_country();
 
 			$location_ids = array_map(
@@ -236,14 +253,26 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 
 			$location_ids = array_filter( $location_ids );
 
+			$asset_group = $this->container->get( AdsAssetGroup::class );
+			if ( isset( $params['final_url'] ) && isset( $params['assets'] ) ) {
+				$asset_operations = $asset_group->create_operations_with_assets(
+					$this->temporary_resource_name(),
+					$params['name'],
+					$params['final_url'],
+					$params['assets']
+				);
+			} else {
+				$asset_operations = $asset_group->create_operations(
+					$this->temporary_resource_name(),
+					$params['name']
+				);
+			}
+
 			// Operations must be in a specific order to match the temporary ID's.
 			$operations = array_merge(
 				[ $this->budget->create_operation( $params['name'], $params['amount'] ) ],
 				[ $this->create_operation( $params['name'], $base_country, $params['eu_political_advertising_confirmation'] ) ],
-				$this->container->get( AdsAssetGroup::class )->create_operations(
-					$this->temporary_resource_name(),
-					$params['name']
-				),
+				$asset_operations,
 				$this->criterion->create_operations(
 					$this->temporary_resource_name(),
 					$location_ids
@@ -490,32 +519,34 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	 * @return MutateOperation
 	 */
 	protected function create_operation( string $campaign_name, string $country, bool $is_eu_political ): MutateOperation {
-		$campaign = new Campaign(
-			[
-				'resource_name'                     => $this->temporary_resource_name(),
-				'name'                              => $campaign_name,
-				'advertising_channel_type'          => AdvertisingChannelType::PERFORMANCE_MAX,
-				'status'                            => CampaignStatus::number( 'enabled' ),
-				'campaign_budget'                   => $this->budget->temporary_resource_name(),
-				'maximize_conversion_value'         => new MaximizeConversionValue(),
-				'asset_automation_settings'         => [
-					new AssetAutomationSetting(
-						[
-							'asset_automation_type'   => AssetAutomationType::FINAL_URL_EXPANSION_TEXT_ASSET_AUTOMATION,
-							'asset_automation_status' => AssetAutomationStatus::OPTED_IN,
-						]
-					),
-				],
-				'shopping_setting'                  => new ShoppingSetting(
+		$campaign_data = [
+			'resource_name'                     => $this->temporary_resource_name(),
+			'name'                              => $campaign_name,
+			'advertising_channel_type'          => AdvertisingChannelType::PERFORMANCE_MAX,
+			'status'                            => CampaignStatus::number( 'enabled' ),
+			'campaign_budget'                   => $this->budget->temporary_resource_name(),
+			'maximize_conversion_value'         => new MaximizeConversionValue(),
+			'asset_automation_settings'         => [
+				new AssetAutomationSetting(
 					[
-						'merchant_id' => $this->options->get_merchant_id(),
-						'feed_label'  => $country,
+						'asset_automation_type'   => AssetAutomationType::FINAL_URL_EXPANSION_TEXT_ASSET_AUTOMATION,
+						'asset_automation_status' => AssetAutomationStatus::OPTED_IN,
 					]
 				),
-				'contains_eu_political_advertising' => $is_eu_political ? EuPoliticalAdvertisingStatus::CONTAINS_EU_POLITICAL_ADVERTISING : EuPoliticalAdvertisingStatus::DOES_NOT_CONTAIN_EU_POLITICAL_ADVERTISING,
-			]
-		);
+			],
+			'contains_eu_political_advertising' => $is_eu_political ? EuPoliticalAdvertisingStatus::CONTAINS_EU_POLITICAL_ADVERTISING : EuPoliticalAdvertisingStatus::DOES_NOT_CONTAIN_EU_POLITICAL_ADVERTISING,
+		];
 
+		if ( $this->options->get_merchant_id() > 0 ) {
+			$campaign_data['shopping_setting'] = new ShoppingSetting(
+				[
+					'merchant_id' => $this->options->get_merchant_id(),
+					'feed_label'  => $country,
+				]
+			);
+		}
+
+		$campaign  = new Campaign( $campaign_data );
 		$operation = ( new CampaignOperation() )->setCreate( $campaign );
 		return ( new MutateOperation() )->setCampaignOperation( $operation );
 	}

--- a/tests/Unit/API/Google/AdsAssetGroupTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupTest.php
@@ -52,6 +52,7 @@ class AdsAssetGroupTest extends UnitTest {
 		$this->asset_group_asset = $this->createMock( AdsAssetGroupAsset::class );
 		$this->options           = $this->createMock( OptionsInterface::class );
 		$this->options->method( 'get_ads_id' )->willReturn( $this->ads_id );
+		$this->options->method( 'get_merchant_id' )->willReturn( 12345 );
 
 		$this->asset_group = new AdsAssetGroup( $this->client, $this->asset_group_asset );
 		$this->asset_group->set_options_object( $this->options );
@@ -83,6 +84,32 @@ class AdsAssetGroupTest extends UnitTest {
 		$this->assertEquals( $asset_group_resource_name, $listing_group->getAssetGroup() );
 		$this->assertEquals( ListingGroupFilterType::UNIT_INCLUDED, $listing_group->getType() );
 		$this->assertEquals( ListingGroupFilterListingSource::SHOPPING, $listing_group->getListingSource() );
+	}
+
+	public function test_create_operations_without_merchant_center() {
+		$options_no_merchant = $this->createMock( OptionsInterface::class );
+		$options_no_merchant->method( 'get_ads_id' )->willReturn( $this->ads_id );
+		$options_no_merchant->method( 'get_merchant_id' )->willReturn( 0 );
+		$this->asset_group->set_options_object( $options_no_merchant );
+
+		$campaign_resource_name    = $this->generate_campaign_resource_name( self::TEST_CAMPAIGN_ID );
+		$asset_group_resource_name = $this->generate_asset_group_resource_name( -3 );
+
+		$operations = $this->asset_group->create_operations(
+			$campaign_resource_name,
+			'New Campaign'
+		);
+
+		$this->assertCount( 1, $operations );
+
+		$operation_asset_group = $operations[0]->getAssetGroupOperation();
+		$this->assertTrue( $operation_asset_group->hasCreate() );
+
+		$asset_group = $operation_asset_group->getCreate();
+		$this->assertEquals( 'New Campaign Asset Group', $asset_group->getName() );
+		$this->assertEquals( $campaign_resource_name, $asset_group->getCampaign() );
+		$this->assertEquals( $asset_group_resource_name, $asset_group->getResourceName() );
+		$this->assertEquals( AssetGroupStatus::ENABLED, $asset_group->getStatus() );
 	}
 
 	public function test_get_asset_groups_by_campaign_id_with_assets() {

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -19,6 +19,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAd
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Google\ApiCore\ApiException;
 use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionMethod;
 use Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -83,6 +84,8 @@ class AdsCampaignTest extends UnitTest {
 		$this->wc            = $this->createMock( WC::class );
 		$this->google_helper = new GoogleHelper( $this->wc );
 
+		$this->asset_group->method( 'create_operations' )->willReturn( [] );
+
 		$this->container = new Container();
 		$this->container->addShared( AdsAssetGroup::class, $this->asset_group );
 		$this->container->addShared( TransientsInterface::class, $this->transients );
@@ -93,6 +96,7 @@ class AdsCampaignTest extends UnitTest {
 		$this->campaign->set_container( $this->container );
 
 		$this->options->method( 'get_ads_id' )->willReturn( $this->ads_id );
+		$this->options->method( 'get_merchant_id' )->willReturn( 12345 );
 	}
 
 	public function test_get_campaigns_empty_list() {
@@ -744,5 +748,53 @@ class AdsCampaignTest extends UnitTest {
 			);
 			$this->assertEquals( 404, $e->getCode() );
 		}
+	}
+
+	public function test_create_campaign_throws_when_no_merchant_and_no_assets() {
+		$options_no_merchant = $this->createMock( OptionsInterface::class );
+		$options_no_merchant->method( 'get_ads_id' )->willReturn( $this->ads_id );
+		$options_no_merchant->method( 'get_merchant_id' )->willReturn( 0 );
+		$this->campaign->set_options_object( $options_no_merchant );
+
+		$campaign_data = [
+			'name'                                  => 'New Campaign',
+			'amount'                                => 20,
+			'targeted_locations'                    => [ 'US', 'GB' ],
+			'eu_political_advertising_confirmation' => false,
+		];
+
+		$this->expectException( ExceptionWithResponseData::class );
+		$this->expectExceptionMessage( 'Add assets or use Generate with AI to create your campaign.' );
+
+		$this->campaign->create_campaign( $campaign_data );
+	}
+
+	public function test_create_operation_includes_shopping_setting_when_merchant_id_set() {
+		$this->options->method( 'get_merchant_id' )->willReturn( 12345 );
+
+		$method = new ReflectionMethod( AdsCampaign::class, 'create_operation' );
+		$method->setAccessible( true );
+		/** @var \Google\Ads\GoogleAds\V22\Services\MutateOperation $mutate_op */
+		$mutate_op = $method->invoke( $this->campaign, 'Test Campaign', 'US', false );
+
+		$campaign = $mutate_op->getCampaignOperation()->getCreate();
+		$this->assertTrue( $campaign->hasShoppingSetting() );
+		$this->assertEquals( 12345, $campaign->getShoppingSetting()->getMerchantId() );
+		$this->assertEquals( 'US', $campaign->getShoppingSetting()->getFeedLabel() );
+	}
+
+	public function test_create_operation_omits_shopping_setting_when_merchant_id_zero() {
+		$options_no_merchant = $this->createMock( OptionsInterface::class );
+		$options_no_merchant->method( 'get_ads_id' )->willReturn( $this->ads_id );
+		$options_no_merchant->method( 'get_merchant_id' )->willReturn( 0 );
+		$this->campaign->set_options_object( $options_no_merchant );
+
+		$method = new ReflectionMethod( AdsCampaign::class, 'create_operation' );
+		$method->setAccessible( true );
+		/** @var \Google\Ads\GoogleAds\V22\Services\MutateOperation $mutate_op */
+		$mutate_op = $method->invoke( $this->campaign, 'Test Campaign', 'US', false );
+
+		$campaign = $mutate_op->getCampaignOperation()->getCreate();
+		$this->assertFalse( $campaign->hasShoppingSetting() );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-473/ensure-genai-works-together-with-sbm
See also: https://github.com/woocommerce/google-listings-and-ads/pull/3268

### Screenshots:

N/A


### Detailed test instructions:

#### Before you start

- You need two test sites:
  - **One:** Google account connected **with** Merchant Center (product feed).
  - **Two:** Google account connected **without** Merchant Center (Ads only; “service-based” style).
- In both setups, ensure you can open **WooCommerce → Marketing → Google** (or the main Google for WooCommerce screen) without errors.
- This branch includes **Generate with AI** for campaign assets; you may see that option when creating campaigns.

#### Part 1: With Merchant Center connected (Site One)

1. Log in to WordPress admin.
2. Go to **WooCommerce → Marketing → Google** (or the Google Listings and Ads / “Google for WooCommerce” area).
3. Confirm the connection shows Merchant Center as connected (no errors on the main screen).
4. Open the **Campaigns** or **Ads** section and start **creating a new Performance Max campaign**.
5. Fill in the basics (name, budget, locations). **Do not** add a final URL or extra assets (and do not use Generate with AI for this check).
6. Submit/save the campaign.
7. **Expected:** The campaign is created successfully and appears in the list. **No** error about adding assets or using Generate with AI.
8. Optionally open the new campaign and confirm you can view/edit it without errors.

#### Without Merchant Center (Ads only – Site Two)

1. Log in to WordPress admin on the site where **only** Google Ads is connected (no Merchant Center).
2. Go to **WooCommerce → Marketing → Google** and confirm you see no Merchant Center connection (or an “Ads only” style setup).
3. Open the **Campaigns** / **Ads** section and start **creating a new Performance Max campaign**.
4. Fill in name, budget, and locations. **Do not** add a final URL, any assets, or use Generate with AI.
5. Try to submit/save the campaign.
6. **Expected:** An error appears. The message must be exactly: **“Add assets or use Generate with AI to create your campaign.”** (If an error-detail section is shown, it may also say: “Campaigns without a product feed require assets. Add assets or use Generate with AI to create your campaign.”) The campaign must **not** be created.
7. Start creating a new Performance Max campaign again. This time **either** add a final URL and at least one asset (e.g. headline, image, or description) **or** use **Generate with AI** to create assets, then submit/save.
8. **Expected:** The campaign is created successfully and appears in the list. No errors.

#### Part 3: General checks (no errors in admin)

Run these on either setup to confirm nothing is broken:

1. **Campaign list**  
   - Open the screen that lists all Google Ads campaigns.  
   - **Expected:** The list loads with no PHP errors, white screen, or warning messages.

2. **View a campaign**  
   - Open a single existing campaign (view/details).  
   - **Expected:** The page loads with no errors.

3. **Edit a campaign**  
   - Edit an existing campaign (e.g. change budget or name) and save.  
   - **Expected:** Save succeeds and no errors appear.

4. **Dashboard / overview**  
   - Go back to the main Google for WooCommerce / Marketing dashboard.  
   - **Expected:** The dashboard loads with no errors; numbers or cards may be empty but there are no PHP or JavaScript errors.

### Additional details:

> Update - Compatibility with Service Based Merchants
