### PR TITLE
Fix CSS lint error in raise-budget-recommendation-banner

### DIFF
--- a/js/src/components/raise-budget-recommendation-banner/index.scss
+++ b/js/src/components/raise-budget-recommendation-banner/index.scss
@@ -49,7 +49,7 @@
 	:where(p) {
 		margin: 0;
 
-		& + p {
+		+ p {
 			margin-top: $grid-unit-10;
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove unnecessary `&` nesting selector in `raise-budget-recommendation-banner/index.scss` to fix `scss/selector-no-redundant-nesting-selector` lint error.

No impact on compiled CSS output (verified by comparing `npm run dev` build results before and after).

### Detailed test instructions:

1. Run `npm run lint:css`
2. Confirm no errors are reported

<img width="1435" height="516" alt="image" src="https://github.com/user-attachments/assets/a3a39107-befd-4b53-84c3-99658402205e" />

### Changelog entry

> Fix – CSS lint error in raise-budget-recommendation-banner.