### PR TITLE
[GOOWOO-487] Fix failing E2E tests for 3.5.3 release

### DIFF
--- a/src/API/WP/NotificationsService.php
+++ b/src/API/WP/NotificationsService.php
@@ -226,7 +226,7 @@ class NotificationsService implements Service, OptionsAwareInterface {
 	 */
 	public function is_ready( ?string $data_type = null, bool $with_health_check = true ): bool {
 		$is_ready = $this->is_enabled() && $this->merchant_center->is_ready_for_syncing() && ( $with_health_check === false || $this->account_service->is_wpcom_api_status_healthy() );
-		return $is_ready && ( is_null( $data_type ) || $this->is_pull_enabled_for_datatype( $data_type ) );
+		return $is_ready && ( is_null( $data_type ) || $this->is_pull_enabled_for_datatype( $data_type ) || $this->is_push_enabled_for_datatype( $data_type ) );
 	}
 
 	/**

--- a/tests/Unit/API/WP/NotificationsServiceTest.php
+++ b/tests/Unit/API/WP/NotificationsServiceTest.php
@@ -207,16 +207,33 @@ class NotificationsServiceTest extends UnitTest {
 	}
 
 	/**
-	 * Test notify() function logs an error when disabled for a datatype
+	 * Test notify() function logs an error when both pull and push are disabled for a datatype
 	 */
 	public function test_notify_show_error_when_disabled_for_datatype() {
 		$this->service = $this->get_mock();
 		remove_filter( 'woocommerce_gla_is_pull_enabled_for_datatype', '__return_true', PHP_INT_MAX );
 		add_filter( 'woocommerce_gla_is_pull_enabled_for_datatype', '__return_false' );
+		add_filter( 'woocommerce_gla_is_push_enabled_for_datatype', '__return_false' );
 		$this->service->expects( $this->never() )->method( 'do_request' );
 		$this->assertFalse( $this->service->notify( 'product.create', 1 ) );
 		$this->assertEquals( did_action( 'woocommerce_gla_error' ), 1 );
 		remove_filter( 'woocommerce_gla_is_pull_enabled_for_datatype', '__return_false' );
+		remove_filter( 'woocommerce_gla_is_push_enabled_for_datatype', '__return_false' );
+		add_filter( 'woocommerce_gla_is_pull_enabled_for_datatype', '__return_true', PHP_INT_MAX );
+	}
+
+	/**
+	 * Test notify() function succeeds when pull is disabled but push is enabled for a datatype
+	 */
+	public function test_notify_succeeds_when_pull_disabled_but_push_enabled_for_datatype() {
+		$this->service = $this->get_mock();
+		remove_filter( 'woocommerce_gla_is_pull_enabled_for_datatype', '__return_true', PHP_INT_MAX );
+		add_filter( 'woocommerce_gla_is_pull_enabled_for_datatype', '__return_false' );
+		add_filter( 'woocommerce_gla_is_push_enabled_for_datatype', '__return_true' );
+		$this->service->expects( $this->once() )->method( 'do_request' )->willReturn( [ 'code' => 200 ] );
+		$this->assertTrue( $this->service->notify( 'product.create', 1 ) );
+		remove_filter( 'woocommerce_gla_is_pull_enabled_for_datatype', '__return_false' );
+		remove_filter( 'woocommerce_gla_is_push_enabled_for_datatype', '__return_true' );
 		add_filter( 'woocommerce_gla_is_pull_enabled_for_datatype', '__return_true', PHP_INT_MAX );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-487/fix-failing-e2e-tests-for-353-release

### Screenshots:

N/A


### Detailed test instructions:

1. Run `npm run test:e2e -- notifications`
2. Verify all 7 tests pass

### Additional details:

> Fix - Fix failing E2E tests for 3.5.3 release