### PR TITLE
GOOWOO-227: Fix Shipping Tab not loading

### DIFF
--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -248,6 +248,7 @@ const SetupFreeListings = ( {
 							<Fill>
 								<AppButton
 									isPrimary
+									disabled={ ! isValidForm }
 									loading={ adapter.isSubmitting }
 									onClick={ handleSubmitClick }
 								>

--- a/js/src/hooks/useTargetAudienceFinalCountryCodes.js
+++ b/js/src/hooks/useTargetAudienceFinalCountryCodes.js
@@ -31,13 +31,19 @@ import useMCCountries from '~/hooks/useMCCountries';
  *
  */
 const useTargetAudienceFinalCountryCodes = () => {
-	const { data: supportedCountries, isResolving: countriesLoading } =
-		useMCCountries();
+	const {
+		data: supportedCountries,
+		isResolving: countriesLoading,
+		hasFinishedResolution: countriesLoaded,
+	} = useMCCountries();
 
 	function mapSelect( select ) {
-		const { getTargetAudience, isResolving } = select( STORE_KEY );
+		const { getTargetAudience, isResolving, hasFinishedResolution } =
+			select( STORE_KEY );
 		const storedTargetAudience = getTargetAudience();
 		const targetAudienceLoading = isResolving( 'getTargetAudience' );
+		const targetAudienceLoaded =
+			hasFinishedResolution( 'getTargetAudience' );
 
 		/**
 		 * Flag to indicate that the data is loading.
@@ -45,6 +51,14 @@ const useTargetAudienceFinalCountryCodes = () => {
 		 * @type {boolean}
 		 */
 		const loading = targetAudienceLoading || countriesLoading;
+
+		/**
+		 * Flag to indicate that the data has been loaded.
+		 *
+		 * @type {boolean}
+		 */
+		const loaded = countriesLoaded && targetAudienceLoaded;
+
 		const allCountries =
 			supportedCountries && Object.keys( supportedCountries );
 
@@ -71,13 +85,18 @@ const useTargetAudienceFinalCountryCodes = () => {
 
 		return {
 			loading,
+			loaded,
 			data,
 			targetAudience: storedTargetAudience,
 			getFinalCountries,
 		};
 	}
 
-	return useSelect( mapSelect, [ supportedCountries, countriesLoading ] );
+	return useSelect( mapSelect, [
+		supportedCountries,
+		countriesLoading,
+		countriesLoaded,
+	] );
 };
 
 export default useTargetAudienceFinalCountryCodes;

--- a/js/src/hooks/useTargetAudienceFinalCountryCodes.js
+++ b/js/src/hooks/useTargetAudienceFinalCountryCodes.js
@@ -16,9 +16,9 @@ import useMCCountries from '~/hooks/useMCCountries';
 /**
  * Gets the final country codes from the Target Audience page.
  * This will call the `getTargetAudience` selector and `useMCCountries` hook.
- * Returns `{ loading, data, targetAudience, getFinalCountries }`.
+ * Returns `{ loaded, data, targetAudience, getFinalCountries }`.
  *
- * `loading` is true when both `getTargetAudience` and `useMCCountries` are still resolving.
+ * `loaded` is true when both `getTargetAudience` and `useMCCountries` have finished resolving.
  *
  * `data` is:
  * - `undefined` when loading is in progress;
@@ -31,26 +31,15 @@ import useMCCountries from '~/hooks/useMCCountries';
  *
  */
 const useTargetAudienceFinalCountryCodes = () => {
-	const {
-		data: supportedCountries,
-		isResolving: countriesLoading,
-		hasFinishedResolution: countriesLoaded,
-	} = useMCCountries();
+	const { data: supportedCountries, hasFinishedResolution: countriesLoaded } =
+		useMCCountries();
 
 	function mapSelect( select ) {
-		const { getTargetAudience, isResolving, hasFinishedResolution } =
+		const { getTargetAudience, hasFinishedResolution } =
 			select( STORE_KEY );
 		const storedTargetAudience = getTargetAudience();
-		const targetAudienceLoading = isResolving( 'getTargetAudience' );
 		const targetAudienceLoaded =
 			hasFinishedResolution( 'getTargetAudience' );
-
-		/**
-		 * Flag to indicate that the data is loading.
-		 *
-		 * @type {boolean}
-		 */
-		const loading = targetAudienceLoading || countriesLoading;
 
 		/**
 		 * Flag to indicate that the data has been loaded.
@@ -84,7 +73,6 @@ const useTargetAudienceFinalCountryCodes = () => {
 		const data = getFinalCountries( storedTargetAudience );
 
 		return {
-			loading,
 			loaded,
 			data,
 			targetAudience: storedTargetAudience,
@@ -92,11 +80,7 @@ const useTargetAudienceFinalCountryCodes = () => {
 		};
 	}
 
-	return useSelect( mapSelect, [
-		supportedCountries,
-		countriesLoading,
-		countriesLoaded,
-	] );
+	return useSelect( mapSelect, [ supportedCountries, countriesLoaded ] );
 };
 
 export default useTargetAudienceFinalCountryCodes;

--- a/js/src/hooks/useTargetAudienceFinalCountryCodes.test.js
+++ b/js/src/hooks/useTargetAudienceFinalCountryCodes.test.js
@@ -8,13 +8,13 @@ import { renderHook } from '@testing-library/react';
  */
 import useTargetAudienceFinalCountryCodes from './useTargetAudienceFinalCountryCodes';
 describe( 'useTargetAudienceFinalCountryCodes', () => {
-	test( 'initially should return `{ loading: false, data: undefined }`', () => {
+	test( 'initially should return `{ loaded: false, data: undefined }`', () => {
 		const { result } = renderHook( () =>
 			useTargetAudienceFinalCountryCodes()
 		);
 
 		// assert initial state
-		expect( result.current.loading ).toBe( false );
+		expect( result.current.loaded ).toBe( false );
 		expect( result.current.data ).toBe( undefined );
 	} );
 } );

--- a/js/src/pages/shipping/index.js
+++ b/js/src/pages/shipping/index.js
@@ -44,8 +44,11 @@ import { recordGlaEvent } from '~/utils/tracks';
  * @fires gla_free_campaign_edited
  */
 export default function Shipping() {
-	const { targetAudience: savedTargetAudience, getFinalCountries } =
-		useTargetAudienceFinalCountryCodes();
+	const {
+		loaded: targetAudienceLoaded,
+		targetAudience: savedTargetAudience,
+		getFinalCountries,
+	} = useTargetAudienceFinalCountryCodes();
 
 	const {
 		settings: savedSettings,
@@ -186,29 +189,39 @@ export default function Shipping() {
 		}
 	};
 
-	const initialAudience = targetAudience?.countries ? targetAudience : null;
-	const initialSettings = settings?.shipping_rate ? settings : null;
-	const initialRates = hasResolvedShippingRates ? savedShippingRates : null;
-	const initialTimes = hasResolvedShippingTimes ? savedShippingTimes : null;
+	const initialAudience = targetAudience?.countries ? targetAudience : {};
+	const initialSettings = settings?.shipping_rate ? settings : {};
+	const initialRates = hasResolvedShippingRates ? savedShippingRates : {};
+	const initialTimes = hasResolvedShippingTimes ? savedShippingTimes : {};
+
+	const isLoaded =
+		targetAudienceLoaded &&
+		hasResolvedShippingRates &&
+		hasResolvedShippingTimes;
 
 	return (
 		<>
 			<ExperienceRatingBanner />
 			<MainTabNav />
-			<SetupFreeListings
-				targetAudience={ initialAudience }
-				resolveFinalCountries={ getFinalCountries }
-				onTargetAudienceChange={ updateTargetAudience }
-				settings={ initialSettings }
-				onSettingsChange={ updateSettings }
-				shippingRates={ initialRates }
-				onShippingRatesChange={ updateShippingRates }
-				shippingTimes={ initialTimes }
-				onShippingTimesChange={ updateShippingTimes }
-				onRequestSubmit={ handleRequestSubmit }
-				onContinue={ handleSetupFreeListingsContinue }
-				submitLabel={ __( 'Save changes', 'google-listings-and-ads' ) }
-			/>
+			{ isLoaded && (
+				<SetupFreeListings
+					targetAudience={ initialAudience }
+					resolveFinalCountries={ getFinalCountries }
+					onTargetAudienceChange={ updateTargetAudience }
+					settings={ initialSettings }
+					onSettingsChange={ updateSettings }
+					shippingRates={ initialRates }
+					onShippingRatesChange={ updateShippingRates }
+					shippingTimes={ initialTimes }
+					onShippingTimesChange={ updateShippingTimes }
+					onRequestSubmit={ handleRequestSubmit }
+					onContinue={ handleSetupFreeListingsContinue }
+					submitLabel={ __(
+						'Save changes',
+						'google-listings-and-ads'
+					) }
+				/>
+			) }
 			<Flex justify="flex-end">
 				<SetupFreeListings.SubmitButton />
 			</Flex>


### PR DESCRIPTION
…fetching

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-227/shipping-tab-not-loading

Adds a loaded state to indicate the component that all the data has been fetched and only render the shipping content tab when all data has resolved fetching.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

> Before switching to this branch, ensure you can reproduce the error so follow the steps using the `develop` branch and then switch to this one to spot the difference.

1. Go to the Shipping Tab under the Google Listing plugin (`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fshipping`)
2. Open Devtools and go to the Network tab, once there find the request to `/wp-json/wc/gla/mc/settings?_locale=user`
3. Right click on it and select Override content and add the following:
> Here's a guide that describes how to override this content https://developer.chrome.com/blog/devtools-tips-34.

<img width="452" height="607" alt="Screenshot 2026-03-06 at 13 13 13" src="https://github.com/user-attachments/assets/90940126-53a5-49b1-9e45-c0359e11facd" />

```json
{
    "shipping_rate": null,
    "shipping_time": null,
    "tax_rate": "destination",
    "shipping_rates_count": 0
}
```
4. When you refresh the page the loading spinner should be there forever and no content will load.
5. Now switch to this branch, restart the build/start command and refresh this page again keeping the overrides
6. You should now get the content of the Shipping tab loading properly


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Fix issue rendering Shipping tab when shipping options were not set
