### PR TITLE
[GOOWOO-501] PHP Fatal error in 3.5.3 on CouponChannelVisibilityMetaBox - missing is_setup_complete context property

### DIFF
--- a/tests/Unit/Admin/MetaBox/CouponChannelVisibilityMetaBoxTest.php
+++ b/tests/Unit/Admin/MetaBox/CouponChannelVisibilityMetaBoxTest.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use ReflectionClass;
+use WP_Post;
 
 /**
  * Class CouponChannelVisibilityMetaBoxTest
@@ -76,6 +78,60 @@ class CouponChannelVisibilityMetaBoxTest extends UnitTest {
 		return [
 			'connected'     => [ true ],
 			'not_connected' => [ false ],
+		];
+	}
+
+	public function test_get_view_context_returns_expected_keys(): void {
+		$post = $this->createMock( WP_Post::class );
+
+		// Use Reflection to access protected method.
+		$reflection = new ReflectionClass( $this->coupon_channel_visibility_meta_box );
+		$method     = $reflection->getMethod( 'get_view_context' );
+		$method->setAccessible( true );
+
+		$context = $method->invoke( $this->coupon_channel_visibility_meta_box, $post, [] );
+
+		$this->assertIsArray( $context );
+		$this->assertEqualsCanonicalizing(
+			[ 'field_id', 'coupon_id', 'coupon', 'channel_visibility', 'sync_status', 'issues', 'is_channel_supported', 'get_started_url' ],
+			array_keys( $context )
+		);
+		$this->assertArrayNotHasKey( 'is_setup_complete', $context );
+	}
+
+	/**
+	 * @dataProvider data_provider_is_channel_supported
+	 *
+	 * @param bool $is_supported
+	 */
+	public function test_get_view_context_includes_is_channel_supported( bool $is_supported ): void {
+		$post = $this->createMock( WP_Post::class );
+
+		$this->merchant_center
+			->method( 'is_promotion_supported_country' )
+			->willReturn( $is_supported );
+
+		// Use Reflection to access protected method.
+		$reflection = new ReflectionClass( $this->coupon_channel_visibility_meta_box );
+		$method     = $reflection->getMethod( 'get_view_context' );
+		$method->setAccessible( true );
+
+		$context = $method->invoke( $this->coupon_channel_visibility_meta_box, $post, [] );
+
+		$this->assertIsArray( $context );
+		$this->assertArrayHasKey( 'is_channel_supported', $context );
+		$this->assertSame( $is_supported, $context['is_channel_supported'] );
+	}
+
+	/**
+	 * Data provider for test_get_view_context_includes_is_channel_supported.
+	 *
+	 * @return array
+	 */
+	public function data_provider_is_channel_supported(): array {
+		return [
+			'supported'     => [ true ],
+			'not_supported' => [ false ],
 		];
 	}
 }

--- a/tests/Unit/Admin/MetaBox/CouponChannelVisibilityMetaBoxTest.php
+++ b/tests/Unit/Admin/MetaBox/CouponChannelVisibilityMetaBoxTest.php
@@ -96,7 +96,6 @@ class CouponChannelVisibilityMetaBoxTest extends UnitTest {
 			[ 'field_id', 'coupon_id', 'coupon', 'channel_visibility', 'sync_status', 'issues', 'is_channel_supported', 'get_started_url' ],
 			array_keys( $context )
 		);
-		$this->assertArrayNotHasKey( 'is_setup_complete', $context );
 	}
 
 	/**

--- a/views/meta-box/coupon_channel_visibility.php
+++ b/views/meta-box/coupon_channel_visibility.php
@@ -37,12 +37,6 @@ $field_id = $this->field_id;
  *
  * @var bool
  */
-$is_setup_complete = $this->is_setup_complete;
-
-/**
- *
- * @var bool
- */
 $is_channel_supported = $this->is_channel_supported;
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-501/php-fatal-error-in-353-on-couponchannelvisibilitymetabox-missing-is and https://github.com/woocommerce/google-listings-and-ads/issues/3287

### Screenshots:

Before:
<img width="1708" height="1289" alt="Screenshot 2026-03-09 at 14 07 25" src="https://github.com/user-attachments/assets/81a6f473-8611-488a-a754-1a8674fe326a" />

After:
<img width="1707" height="902" alt="Screenshot 2026-03-09 at 14 08 09" src="https://github.com/user-attachments/assets/7cd9c383-4a6a-4992-8f06-9ec4c8040483" />


### Detailed test instructions:

1. Open `/wp-admin/post-new.php?post_type=shop_coupon`
2. Verify there is no error in the Channel Visibility box
3. Verify a coupon can be created


### Additional details:

> Fix - Resolved fatal error in Channel Visibility when creating coupons