### PR TITLE
[GOOWOO-453] Fix meta-boxes JS only on WC Edit Order screen

### DIFF
--- a/js/src/meta-boxes/index.js
+++ b/js/src/meta-boxes/index.js
@@ -1,8 +1,7 @@
 /**
  * Internal dependencies
  */
+import './order-attribution';
 
 // eslint-disable-next-line no-console
 console.log( 'Google for WooCommerce: meta-boxes script loaded' );
-
-import './order-attribution';

--- a/js/src/meta-boxes/index.js
+++ b/js/src/meta-boxes/index.js
@@ -1,0 +1,8 @@
+/**
+ * Internal dependencies
+ */
+
+// eslint-disable-next-line no-console
+console.log( 'Google for WooCommerce: meta-boxes script loaded' );
+
+import './order-attribution';

--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -223,14 +223,15 @@ class Admin implements OptionsAwareInterface, Registerable, Service {
 			$product_condition
 		) );
 
-		$assets[] = ( new AdminScriptWithBuiltDependenciesAsset(
-			'gla-order-attribution',
-			'js/build/order-attribution',
-			"{$build_dir}/order-attribution.asset.php",
+		$meta_boxes_asset_path = "{$this->get_root_dir()}/js/build/meta-boxes.js";
+		$assets[]              = ( new AdminScriptWithBuiltDependenciesAsset(
+			'gla-meta-boxes',
+			'js/build/meta-boxes',
+			"{$build_dir}/meta-boxes.asset.php",
 			new BuiltScriptDependencyArray(
 				[
 					'dependencies' => [],
-					'version'      => (string) filemtime( "{$this->get_root_dir()}/js/build/order-attribution.js" ),
+					'version'      => (string) ( file_exists( $meta_boxes_asset_path ) ? filemtime( $meta_boxes_asset_path ) : $this->get_version() ),
 				]
 			),
 			function (): bool {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -111,9 +111,9 @@ const webpackConfig = {
 			'js/src/notification-manager',
 			'index.js'
 		),
-		'order-attribution': path.resolve(
+		'meta-boxes': path.resolve(
 			process.cwd(),
-			'js/src/meta-boxes/order-attribution',
+			'js/src/meta-boxes',
 			'index.js'
 		),
 		'channel-visibility-meta-box': path.join(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-453/load-meta-boxes-js-asset-in-the-wc-edit-order-page-only

### Screenshots:

<img width="1708" height="904" alt="Screenshot 2026-03-10 at 14 27 02" src="https://github.com/user-attachments/assets/d1d2c2ae-7c8f-46f6-91ec-3eb45beea6ba" />

### Detailed test instructions:

1. Open WP admin, navigate to WooCommerce -> Settings -> Advanced -> Features
2. Confirm / set "Order data storage" is "High-performance order storage"
3. Navigate to WooCommerce -> Home
4. Open the inspector, confirm you do NOT see "Google for WooCommerce: meta-boxes script loaded"
5. Navigate to WooCommerce -> Orders and select an order (create one if need be)
6. Open the inspector, confirm you DO see "Google for WooCommerce: meta-boxes script loaded"
7. Navigate to WooCommerce -> Settings -> Advanced -> Features
8. Set "Order data storage" to "WordPress posts storage"
9. Navigate to WooCommerce -> Home
10. Open the inspector, confirm you do NOT see "Google for WooCommerce: meta-boxes script loaded"
11. Navigate to WooCommerce -> Orders and select an order (create one if need be)
12. Open the inspector, confirm you DO see "Google for WooCommerce: meta-boxes script loaded"


### Additional details:

> Add - Added new JS file for meta boxes; conditionally enqueued on the edit order page.