### PR TITLE
Use variations IDs in conversion events

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -399,7 +399,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		// Get the item info in the order
 		$item_info = [];
 		foreach ( $order->get_items() as $item_id => $item ) {
-			$product_id   = $item->get_product_id();
+			$product_id   = $item->get_variation_id() ?: $item->get_product_id();
 			$product_name = $item->get_name();
 			$quantity     = $item->get_quantity();
 			$price        = $order->get_item_total( $item );
@@ -505,7 +505,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 
 		foreach ( WC()->cart->get_cart() as $cart_item ) {
 			// gets the product id
-			$id = $cart_item['product_id'];
+			$id = ! empty( $cart_item['variation_id'] ) ? $cart_item['variation_id'] : $cart_item['product_id'];
 
 			// gets the product object
 			$product = $cart_item['data'];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes woocommerce/google-listings-and-ads#3290

woocommerce/google-listings-and-ads#3290

*Replace this with a good description of your changes & reasoning.*

### Detailed test instructions:

1. Add a variable product to the cart.
2. Go to the Cart page and view the page source and confirm that the gtag page view event uses the correct variation ID for the items ID.
3. Proceed to checkout and complete the order.
4. On the Order Received page, view the page source and confirm that the gtag purchase event uses the correct variation ID for the items ID.

### Changelog entry

> Fix - Conversion events use product variation ID in purchase events.