### PR TITLE
Add Skip button to `GenAIProgress`

### DIFF
--- a/js/src/components/paid-ads/asset-group/asset-group-editor/gen-ai-image-picker/index.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-editor/gen-ai-image-picker/index.js
@@ -20,8 +20,19 @@ import AIIcon from '~/images/ai-icon.svg?inline';
 import './index.scss';
 
 /**
+ * Triggered when the "Add selected images" button is clicked.
+ *
+ * @event gla_gen_ai_image_picker_add_selected_images_click
+ * @property {string} finalUrl The final URL for which the images were generated.
+ * @property {string} assetKey The asset key for which the images were generated.
+ * @property {number} numberOfSelectedImages The number of images that were selected to be added.
+ */
+
+/**
  * GenAIImagePicker component.
  * Allows users to pick AI-generated images based on the final URL and the spec type.
+ *
+ * @fires gla_gen_ai_image_picker_add_selected_images_click when the "Add selected images" button is clicked.
  *
  * @param {Object} props Component props.
  * @param {string} props.assetKey Asset key.
@@ -124,6 +135,12 @@ export default function GenAIImagePicker( { assetKey, onAddSelectedImages } ) {
 					) }
 					onClick={ handleOnAddSelectedImages }
 					disabled={ selectedImages.length === 0 }
+					eventName="gla_gen_ai_image_picker_add_selected_images_click"
+					eventProps={ {
+						finalUrl,
+						assetKey,
+						numberOfSelectedImages: selectedImages.length,
+					} }
 				/>
 			</FlexBlock>
 		</Flex>

--- a/js/src/components/paid-ads/asset-group/asset-group-editor/images-selector.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-editor/images-selector.js
@@ -54,7 +54,7 @@ export default function ImagesSelector( {
 	const { values } = useAdaptiveFormContext();
 	const updateImagesRef = useRef();
 	const [ awaitingActionImage, setAwaitingActionImage ] = useState( null );
-	const [ generateAssets, isGeneratingAssets ] = useCreateGenAIAssets();
+	const { generateAssets, isGeneratingAssets } = useCreateGenAIAssets();
 	const { createNotice } = useDispatchCoreNotices();
 	const [ images, setImages ] = useState( () =>
 		// The asset images fetched from Google Ads are only URLs.

--- a/js/src/components/paid-ads/asset-group/asset-group-editor/texts-editor.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-editor/texts-editor.js
@@ -33,7 +33,17 @@ function normalizeNumberOfTexts( texts, minNumberOfTexts, maxNumberOfTexts ) {
 }
 
 /**
+ * Triggered when the generate texts button is clicked in the TextsEditor component. Event properties include finalUrl and assetKey.
+ *
+ * @event gla_texts_editor_generate_button_click
+ * @property {string} finalUrl The final URL for the ad.
+ * @property {string} assetKey The key of the text asset.
+ */
+
+/**
  * Renders a list of text inputs for managing the single type of asset texts.
+ *
+ * @fires gla_texts_editor_generate_button_click when the generate texts button is clicked in the TextsEditor component.
  *
  * @param {Object} props React props.
  * @param {string} props.assetKey Key of the text asset.
@@ -231,6 +241,11 @@ export default function TextsEditor( {
 					text={ generateButtonText }
 					onClick={ handleGenerateClick }
 					loading={ isGeneratingAssets }
+					eventName="gla_texts_editor_generate_button_click"
+					eventProps={ {
+						finalUrl,
+						assetKey,
+					} }
 				/>
 			) }
 		</div>

--- a/js/src/components/paid-ads/asset-group/asset-group-editor/texts-editor.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-editor/texts-editor.js
@@ -65,7 +65,7 @@ export default function TextsEditor( {
 } ) {
 	const updateTextsRef = useRef();
 	const { createNotice } = useDispatchCoreNotices();
-	const [ generateAssets, isGeneratingAssets ] = useCreateGenAIAssets();
+	const { generateAssets, isGeneratingAssets } = useCreateGenAIAssets();
 	const [ texts, setTexts ] = useState( initialTexts );
 	const { assets: genAITextAssets } = useGenAITextAssets(
 		finalUrl,

--- a/js/src/components/paid-ads/campaign-assets-form.js
+++ b/js/src/components/paid-ads/campaign-assets-form.js
@@ -204,7 +204,8 @@ export default function CampaignAssetsForm( {
 	countryCodes,
 	...adaptiveFormProps
 } ) {
-	const [ generateAssets ] = useCreateGenAIAssets();
+	const { generateAssets, isGeneratingAssets, abortGenerateAssets } =
+		useCreateGenAIAssets();
 	const [ isFetchingAssets, setIsFetchingAssets ] = useState( false );
 	const initialAssetGroup = useMemo( () => {
 		return convertAssetEntityGroupToFormValues( assetEntityGroup );
@@ -273,6 +274,10 @@ export default function CampaignAssetsForm( {
 						{ type: GEN_AI_ASSET_TYPES.TEXT },
 						{ type: GEN_AI_ASSET_TYPES.MEDIA },
 					] );
+
+					if ( ! generatedGenAIAssets ) {
+						return assetSuggestions;
+					}
 
 					const textAssetsData =
 						generatedGenAIAssets[ GEN_AI_ASSET_TYPES.TEXT ];
@@ -365,9 +370,11 @@ export default function CampaignAssetsForm( {
 				formContext.adapter.hideValidation();
 			},
 			isFetchingAssets,
+			isGeneratingAssets,
 			hasAISuggestedTextAssets,
 			hasAISuggestedMediaAssets,
 			fetchAssets,
+			abortGenerateAssets,
 		};
 	};
 

--- a/js/src/components/paid-ads/gen-ai-progress/index.js
+++ b/js/src/components/paid-ads/gen-ai-progress/index.js
@@ -9,8 +9,14 @@ import { ProgressBar } from '@wordpress/components';
  * Internal dependencies
  */
 import ProgressGraphics from '~/images/pmax-assets-improvements/gen-ai-progress.svg';
-import './gen-ai-progress.scss';
+import SkipButton from './skip-button';
+import './index.scss';
 
+/**
+ * Component to display the progress of Gen AI asset generation, including a progress bar and a skip button.
+ *
+ * @return {JSX.Element} The GenAIProgress component.
+ */
 const GenAIProgress = () => {
 	return (
 		<div className="gen-ai-progress">
@@ -34,6 +40,10 @@ const GenAIProgress = () => {
 						'google-listings-and-ads'
 					) }
 				</p>
+
+				<div className="gen-ai-progress__actions">
+					<SkipButton />
+				</div>
 			</div>
 		</div>
 	);

--- a/js/src/components/paid-ads/gen-ai-progress/index.scss
+++ b/js/src/components/paid-ads/gen-ai-progress/index.scss
@@ -21,4 +21,8 @@
 			margin: $grid-unit-20 0 0;
 		}
 	}
+
+	.gen-ai-progress__actions {
+		min-height: $gla-size-control-height;
+	}
 }

--- a/js/src/components/paid-ads/gen-ai-progress/index.scss
+++ b/js/src/components/paid-ads/gen-ai-progress/index.scss
@@ -23,6 +23,7 @@
 	}
 
 	.gen-ai-progress__actions {
+		margin-block-start: $grid-unit-10;
 		min-height: $gla-size-control-height;
 	}
 }

--- a/js/src/components/paid-ads/gen-ai-progress/skip-button.js
+++ b/js/src/components/paid-ads/gen-ai-progress/skip-button.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import AppButton from '~/components/app-button';
+
+/**
+ * Component for the skip button displayed during Gen AI asset generation progress.
+ *
+ * This button allows users to abort the asset generation process if they choose to skip it.
+ *
+ * @return {JSX.Element|null} The SkipButton component, or null if not currently generating assets.
+ */
+const SkipButton = () => {
+	const { adapter } = useAdaptiveFormContext();
+	const { abortGenerateAssets, isGeneratingAssets } = adapter;
+
+	if ( ! isGeneratingAssets ) {
+		return null;
+	}
+
+	return (
+		<AppButton onClick={ abortGenerateAssets } variant="tertiary">
+			{ __( 'Skip', 'google-listings-and-ads' ) }
+		</AppButton>
+	);
+};
+
+export default SkipButton;

--- a/js/src/components/paid-ads/gen-ai-progress/skip-button.js
+++ b/js/src/components/paid-ads/gen-ai-progress/skip-button.js
@@ -10,9 +10,17 @@ import { useAdaptiveFormContext } from '~/components/adaptive-form';
 import AppButton from '~/components/app-button';
 
 /**
+ * Triggered when the skip button is clicked during Gen AI asset generation progress.
+ *
+ * @event gla_gen_ai_progress_skip_button_click
+ */
+
+/**
  * Component for the skip button displayed during Gen AI asset generation progress.
  *
  * This button allows users to abort the asset generation process if they choose to skip it.
+ *
+ * @fires gla_gen_ai_progress_skip_button_click when the skip button is clicked.
  *
  * @return {JSX.Element|null} The SkipButton component, or null if not currently generating assets.
  */
@@ -25,7 +33,11 @@ const SkipButton = () => {
 	}
 
 	return (
-		<AppButton onClick={ abortGenerateAssets } variant="tertiary">
+		<AppButton
+			onClick={ abortGenerateAssets }
+			variant="tertiary"
+			eventName="gla_gen_ai_progress_skip_button_click"
+		>
 			{ __( 'Skip', 'google-listings-and-ads' ) }
 		</AppButton>
 	);

--- a/js/src/hooks/useCreateGenAIAssets.js
+++ b/js/src/hooks/useCreateGenAIAssets.js
@@ -3,7 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useState, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,13 +16,23 @@ import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 /**
  * Custom hook to generate Gen AI assets for a given URL and asset requests.
  *
- * @return {Array} - An array containing the generateAssets function and a boolean indicating if assets are currently being generated.
+ * @return {Object} An object containing the generateAssets function, isGeneratingAssets boolean, and abortGenerateAssets function.
  */
 const useCreateGenAIAssets = () => {
 	const [ isGeneratingAssets, setIsGeneratingAssets ] = useState( false );
 	const { createNotice } = useDispatchCoreNotices();
+	const abortControllerRef = useRef( null );
 	const { receiveGenAITextAssets, receiveGenAIMediaAssets } =
 		useAppDispatch();
+
+	/**
+	 * Aborts any ongoing Gen AI asset generation requests.
+	 */
+	const abortGenerateAssets = useCallback( () => {
+		if ( abortControllerRef.current ) {
+			abortControllerRef.current.abort();
+		}
+	}, [] );
 
 	/**
 	 * Helper function to process Gen AI API responses, handling both success and error cases.
@@ -84,6 +94,9 @@ const useCreateGenAIAssets = () => {
 				return;
 			}
 
+			abortControllerRef.current = new AbortController();
+			const { signal } = abortControllerRef.current;
+
 			setIsGeneratingAssets( true );
 
 			// Initialize as empty arrays to avoid overwriting multiple requests of same type
@@ -101,6 +114,7 @@ const useCreateGenAIAssets = () => {
 
 					return apiFetch( {
 						path,
+						signal,
 						method: REQUEST_ACTIONS.POST,
 						parse: false,
 						data: {
@@ -113,6 +127,10 @@ const useCreateGenAIAssets = () => {
 				} );
 
 				const results = await Promise.allSettled( promises );
+
+				if ( signal.aborted ) {
+					return;
+				}
 
 				for ( let index = 0; index < results.length; index++ ) {
 					const { type, assetKey } = requests[ index ];
@@ -150,6 +168,10 @@ const useCreateGenAIAssets = () => {
 
 				return generatedAssets;
 			} catch ( error ) {
+				if ( signal.aborted ) {
+					return;
+				}
+
 				// Catch unexpected runtime errors
 				createNotice(
 					'error',
@@ -170,7 +192,7 @@ const useCreateGenAIAssets = () => {
 		]
 	);
 
-	return [ generateAssets, isGeneratingAssets ];
+	return { generateAssets, isGeneratingAssets, abortGenerateAssets };
 };
 
 export default useCreateGenAIAssets;

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
 			},
 			{
 				"path": "./google-listings-and-ads.zip",
-				"maxSize": "8.27 mB",
+				"maxSize": "8.28 mB",
 				"compression": "none"
 			}
 		],

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
 			},
 			{
 				"path": "./google-listings-and-ads.zip",
-				"maxSize": "8.26 mB",
+				"maxSize": "8.27 mB",
 				"compression": "none"
 			}
 		],

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -552,6 +552,22 @@ Saving changes of audience and/or shipping settings to the product feed.
 #### Emitters
 - [`exports`](../../js/src/pages/shipping/index.js#L46)
 
+### [`gla_gen_ai_image_picker_add_selected_images_click`](../../js/src/components/paid-ads/asset-group/asset-group-editor/gen-ai-image-picker/index.js#L22)
+Triggered when the "Add selected images" button is clicked.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`finalUrl` | `string` | The final URL for which the images were generated.
+`assetKey` | `string` | The asset key for which the images were generated.
+`numberOfSelectedImages` | `number` | The number of images that were selected to be added.
+#### Emitters
+- [`exports`](../../js/src/components/paid-ads/asset-group/asset-group-editor/gen-ai-image-picker/index.js#L41) when the "Add selected images" button is clicked.
+
+### [`gla_gen_ai_progress_skip_button_click`](../../js/src/components/paid-ads/gen-ai-progress/skip-button.js#L12)
+Triggered when the skip button is clicked during Gen AI asset generation progress.
+#### Emitters
+- [`SkipButton`](../../js/src/components/paid-ads/gen-ai-progress/skip-button.js#L27) when the skip button is clicked.
+
 ### [`gla_google_account_connect_button_click`](../../js/src/utils/tracks.js#L185)
 Clicking on the button to connect Google account.
 #### Properties
@@ -592,14 +608,14 @@ Clicking on a Google Merchant Center link.
 #### Emitters
 - [`HelpIconButton`](../../js/src/components/help-icon-button/index.js#L31)
 
-### [`gla_import_assets_by_final_url_button_click`](../../js/src/components/paid-ads/asset-group/asset-group-header/assets-loader.js#L80)
+### [`gla_import_assets_by_final_url_button_click`](../../js/src/components/paid-ads/asset-group/asset-group-header/assets-loader.js#L83)
 Clicking on the "Scan for assets" button.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `type` | `string` | The type of the selected Final URL suggestion to be imported. Possible values: `post`, `term`, `homepage`.
 #### Emitters
-- [`exports`](../../js/src/components/paid-ads/asset-group/asset-group-header/assets-loader.js#L96)
+- [`exports`](../../js/src/components/paid-ads/asset-group/asset-group-header/assets-loader.js#L99)
 
 ### [`gla_launch_paid_campaign_button_click`](../../js/src/utils/tracks.js#L173)
 Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign in the Google Ads setup flow.
@@ -912,10 +928,10 @@ Triggered when the request review is successful
 #### Emitters
 - [`ReviewRequestModal`](../../js/src/pages/product-feed/review-request/review-request-modal.js#L58)
 
-### [`gla_reselect_another_final_url_button_click`](../../js/src/components/paid-ads/asset-group/asset-group-header/final-url-card.js#L23)
+### [`gla_reselect_another_final_url_button_click`](../../js/src/components/paid-ads/asset-group/asset-group-header/final-url-card.js#L24)
 Clicking on the "Or, select another page" button.
 #### Emitters
-- [`exports`](../../js/src/components/paid-ads/asset-group/asset-group-header/final-url-card.js#L39)
+- [`exports`](../../js/src/components/paid-ads/asset-group/asset-group-header/final-url-card.js#L40)
 
 ### [`gla_setup_ads`](../../js/src/utils/tracks.js#L203)
 Triggered on events during ads onboarding
@@ -1051,6 +1067,16 @@ Sorting table
 #### Emitters
 - [`AppTableCard`](../../js/src/components/app-table-card/index.js#L74) upon sorting table by column
 - [`recordTableSortEvent`](../../js/src/components/app-table-card/index.js#L55) with given props.
+
+### [`gla_texts_editor_generate_button_click`](../../js/src/components/paid-ads/asset-group/asset-group-editor/texts-editor.js#L35)
+Triggered when the generate texts button is clicked in the TextsEditor component. Event properties include finalUrl and assetKey.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`finalUrl` | `string` | The final URL for the ad.
+`assetKey` | `string` | The key of the text asset.
+#### Emitters
+- [`exports`](../../js/src/components/paid-ads/asset-group/asset-group-editor/texts-editor.js#L62) when the generate texts button is clicked in the TextsEditor component.
 
 ### [`gla_tooltip_viewed`](../../js/src/components/help-popover/index.js#L16)
 Viewing tooltip


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-506/provide-a-skip-action-for-genai-generated-asset-creation

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<img width="1271" height="858" alt="image" src="https://github.com/user-attachments/assets/19f67727-8779-42e1-80ad-6aaf430268d3" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Navigate to the SBM onboarding flow or Create Campaign flow and proceed to the last step.
2. A Gen AI progress screen will appear. Note that the Skip button is not immediately visible. It only appears once the asset generation process begins (after the initial `/suggestions` endpoint call completes).
3. Once the Skip button appears, clicking it should abort all ongoing Gen AI requests and display the campaign form immediately.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
