### PR TITLE
GOOWOO-520: Hide YouTube Card if MC not connected

### DIFF
--- a/js/src/components/youtube-account-card/youtube-account-card.js
+++ b/js/src/components/youtube-account-card/youtube-account-card.js
@@ -6,6 +6,7 @@ import useYouTubeAccount from '~/hooks/useYouTubeAccount';
 import SpinnerCard from '~/components/spinner-card';
 import ConnectedYouTubeAccountCard from './connected-youtube-account-card';
 import ConnectYouTubeAccountCard from './connect-youtube-account-card';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 
 /**
  * @typedef {Object} YouTubeChannel
@@ -25,6 +26,11 @@ import ConnectYouTubeAccountCard from './connect-youtube-account-card';
  */
 const YouTubeAccountCard = () => {
 	const { youTubeAccount, hasFinishedResolution } = useYouTubeAccount();
+	const { hasGoogleMCConnection } = useGoogleMCAccount();
+
+	if ( ! hasGoogleMCConnection ) {
+		return null;
+	}
 
 	if ( ! hasFinishedResolution ) {
 		return <SpinnerCard />;

--- a/tests/e2e/specs/settings/settings.test.js
+++ b/tests/e2e/specs/settings/settings.test.js
@@ -244,5 +244,11 @@ test.describe( 'Settings', () => {
 				page.getByText( 'Tax rate (required for U.S. only)' )
 			).not.toBeVisible();
 		} );
+
+		test( 'should not show the YouTube Shopping section', async () => {
+			await expect(
+				page.getByText( 'YouTube Shopping' )
+			).not.toBeVisible();
+		} );
 	} );
 } );

--- a/tests/e2e/specs/settings/settings.test.js
+++ b/tests/e2e/specs/settings/settings.test.js
@@ -210,15 +210,59 @@ test.describe( 'Settings', () => {
 			await expect( disconnectButton ).toBeVisible();
 		} );
 
-		test( 'should show a notice if there are no channels when connected', async () => {
-			await settingsPage.mockYouTubeAccountNoChannels();
+		test( 'should show a notice if the YouTube account is incomplete', async () => {
+			await settingsPage.mockYouTubeAccountIncomplete();
 			await settingsPage.goto();
 
 			const notice = settingsPage.youTubeCard.getByText(
-				'No channels found (or permission not granted).'
+				'Your YouTube account is connected, but setup isn’t complete yet.'
 			);
 
 			await expect( notice ).toBeVisible();
+		} );
+
+		test( 'should display error message when "Complete setup" fails', async () => {
+			await settingsPage
+				.withFulfillTimes( 1 )
+				.mockNotEligibleYouTubeChannel();
+			const requestPromise =
+				settingsPage.registerYouTubeCompleteSetupRequest();
+
+			const completeSetupButton =
+				settingsPage.getYouTubeCompleteSetupButton();
+			await completeSetupButton.click();
+
+			await requestPromise;
+
+			await expect(
+				settingsPage.youTubeCard.getByText(
+					'The channel is not eligible for the linking program.'
+				)
+			).toBeVisible();
+		} );
+
+		test( 'should complete YouTube account setup successfully', async () => {
+			await settingsPage
+				.withFulfillTimes( 1 )
+				.mockYouTubeAccountIncomplete();
+			await settingsPage.mockEligibleYouTubeChannel();
+			await settingsPage.goto();
+
+			const requestPromise =
+				settingsPage.registerYouTubeCompleteSetupRequest();
+
+			const completeSetupButton =
+				settingsPage.getYouTubeCompleteSetupButton();
+			await completeSetupButton.click();
+
+			await requestPromise;
+
+			// Now mock as connected so re-renders show the channel name
+			await settingsPage.mockYouTubeAccountConnected();
+
+			await expect(
+				settingsPage.youTubeCard.getByText( 'My YouTube Channel' )
+			).toBeVisible();
 		} );
 	} );
 

--- a/tests/e2e/specs/settings/settings.test.js
+++ b/tests/e2e/specs/settings/settings.test.js
@@ -246,6 +246,11 @@ test.describe( 'Settings', () => {
 		} );
 
 		test( 'should not show the YouTube Shopping section', async () => {
+			// Wait for a stable element that's always present on a loaded page
+			await page
+				.getByRole( 'button', { name: 'Disconnect from all accounts' } )
+				.waitFor();
+
 			await expect(
 				page.getByText( 'YouTube Shopping' )
 			).not.toBeVisible();

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -1162,20 +1162,100 @@ export default class MockRequests {
 	}
 
 	/**
-	 * Mock a connected YouTube account that has no channels.
+	 * Mock helper that simulates an incomplete YouTube account connection by calling
+	 * `fulfillYouTubeAccountConnection` with a predefined payload.
 	 *
-	 * This asynchronous helper fulfills the YouTube account connection with a
-	 * status of "connected" and an explicit null channel value, simulating a
-	 * scenario where the account is connected but no channels are available or
-	 * accessible.
+	 * The payload sets `status` to `'incomplete'` while still providing channel metadata
+	 * (`id` and `label`), which may be used by consumers to determine that the account
+	 * connection process has been started but not completed.
 	 *
-	 * @return {Promise<void>} Resolves once the mock connection has been fulfilled.
+	 * This method is asynchronous and awaits the underlying fulfillment call.
+	 *
+	 * @return {Promise<*>} Resolves with whatever value `fulfillYouTubeAccountConnection` returns.
 	 */
-	async mockYouTubeAccountNoChannels() {
+	async mockYouTubeAccountIncomplete() {
 		await this.fulfillYouTubeAccountConnection( {
-			status: 'connected',
-			channel: [],
+			status: 'incomplete',
+			channel: {
+				id: 'a89ahifdaffe234',
+				label: 'My YouTube Channel',
+			},
 		} );
+	}
+
+	/**
+	 * Mock helper that simulates a YouTube account connection with an ineligible channel by calling
+	 * `fulfillYouTubeAccountConnection` with a predefined payload.
+	 * The payload includes an error message and code indicating that the channel is not eligible for the linking program.
+	 *
+	 * This method is asynchronous and awaits the underlying fulfillment call.
+	 *
+	 * @return {Promise<*>} Resolves with whatever value `fulfillYouTubeAccountConnection` returns.
+	 */
+	async mockNotEligibleYouTubeChannel() {
+		await this.fulfillYouTubeCompleteSetup(
+			{
+				message: 'The channel is not eligible for the linking program.',
+				error: {
+					code: 403,
+					message:
+						'The channel is not eligible for the linking program.',
+					errors: [
+						{
+							message:
+								'The channel is not eligible for the linking program.',
+							domain: 'youtube.thirdPartyLink',
+							reason: 'CHANNEL_NOT_ELIGIBLE',
+						},
+					],
+				},
+			},
+			403
+		);
+	}
+
+	/**
+	 * Mock helper that simulates a YouTube account connection with an eligible channel by calling
+	 * `fulfillYouTubeAccountConnection` with a predefined payload.
+	 * The payload includes a message indicating that the channel is eligible for the linking program.
+	 *
+	 * This method is asynchronous and awaits the underlying fulfillment call.
+	 *
+	 * @return {Promise<*>} Resolves with whatever value `fulfillYouTubeAccountConnection` returns.
+	 */
+	async mockEligibleYouTubeChannel() {
+		await this.fulfillYouTubeCompleteSetup( {
+			message: 'The channel is eligible for the linking program.',
+		} );
+	}
+
+	/**
+	 * Fulfills a mock request for the YouTube complete setup endpoint, simulating the completion of the YouTube setup process.
+	 *
+	 * @param {Object} payload - The mock response payload to be returned, which may include details about the completed setup.
+	 * @param {number} [status=200] - The HTTP status code to be returned. Defaults to 200.
+	 * @return {Promise<void>} A promise that resolves when the request is fulfilled.
+	 */
+	async fulfillYouTubeCompleteSetup( payload, status = 200 ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/youtube\/setup\/complete\b/,
+			payload,
+			status,
+			[ 'POST' ]
+		);
+	}
+
+	/**
+	 * Registers a wait for a request to the YouTube complete setup endpoint, allowing tests to wait until this specific request is made before proceeding.
+	 *
+	 * @return {Promise<import('playwright').Request>} A promise that resolves with the intercepted request object when a request matching the criteria is made.
+	 */
+	async registerYouTubeCompleteSetupRequest() {
+		return this.page.waitForRequest(
+			( request ) =>
+				request.url().includes( '/gla/youtube/setup/complete' ) &&
+				request.method() === 'POST'
+		);
 	}
 
 	/**

--- a/tests/e2e/utils/pages/settings.js
+++ b/tests/e2e/utils/pages/settings.js
@@ -13,9 +13,9 @@ export default class SettingsPage extends MockRequests {
 	constructor( page ) {
 		super( page );
 		this.page = page;
-		this.youTubeCard = this.page.locator(
-			'.gla-account-card:nth-child(4)'
-		);
+		this.youTubeCard = this.page
+			.locator( '.gla-account-card' )
+			.filter( { hasText: 'YouTube' } );
 	}
 
 	/**
@@ -92,6 +92,17 @@ export default class SettingsPage extends MockRequests {
 	getEnhancedConversionsCheckbox() {
 		return this.page.getByRole( 'checkbox', {
 			name: 'Send Enhanced Conversions data to Google Ads',
+		} );
+	}
+
+	/**
+	 * Get the Complete YouTube Setup button.
+	 *
+	 * @return {Promise<import('@playwright/test').Locator>} The Complete YouTube Setup button
+	 */
+	getYouTubeCompleteSetupButton() {
+		return this.youTubeCard.getByRole( 'button', {
+			name: 'Complete setup',
 		} );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-520/unable-to-connect-youtube-account-when-theres-no-connected-mc-account

Do not render YouTube card in Settings if Google Merchant Center is not connected

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Do the onboarding process but do not set Google Merchant Center
2. Go to the settings page
3. YouTube card should not be displayed

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
