### PR TITLE
Fix/goowoo 526 campaign track event

### DIFF
--- a/js/src/meta-boxes/order-attribution/google-ads-promo.js
+++ b/js/src/meta-boxes/order-attribution/google-ads-promo.js
@@ -48,7 +48,7 @@ const hasRecentPaidCampaigns = ( campaigns ) => {
 /**
  * Google Ads Promo "Get started" button is clicked.
  *
- * @event gla_google_ads_promo_get_started_click
+ * @event wcadmin_gla_google_ads_promo_create_campaign_click
  * @property {string} context Context of the Google Ads Promo.
  * @property {string} href URL of the "Get started" button.
  */
@@ -65,7 +65,7 @@ const hasRecentPaidCampaigns = ( campaigns ) => {
  * Google Ads Promo component.
  *
  * @fires gla_google_ads_promo_shown with `{ context: 'order-attribution-meta-box' }`.
- * @fires gla_google_ads_promo_get_started_click with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
+ * @fires wcadmin_gla_google_ads_promo_create_campaign_click with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
  * @fires gla_google_ads_promo_create_campaign_click with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&subpath=%2Fcampaigns%2Fcreate&path=%2Fgoogle%2Fdashboard' }`.
  *
  * @return {JSX.Element|null} The Google Ads Promo component or null.
@@ -135,7 +135,7 @@ const GoogleAdsPromo = () => {
 				cta: (
 					<AppButton
 						href={ getStartedUrl }
-						eventName="gla_google_ads_promo_get_started_click"
+						eventName="wcadmin_gla_google_ads_promo_create_campaign_click"
 						eventProps={ {
 							href: getStartedUrl,
 							context,

--- a/js/src/meta-boxes/order-attribution/google-ads-promo.test.js
+++ b/js/src/meta-boxes/order-attribution/google-ads-promo.test.js
@@ -248,7 +248,7 @@ describe( 'GoogleAdsPromo Component', () => {
 			);
 		} );
 
-		test( 'Fires gla_google_ads_promo_get_started_click event when Get started button is clicked', () => {
+		test( 'Fires wcadmin_gla_google_ads_promo_create_campaign_click event when Get started button is clicked', () => {
 			useAdsCampaigns.mockReturnValue( {
 				data: [],
 				loading: false,
@@ -260,7 +260,7 @@ describe( 'GoogleAdsPromo Component', () => {
 			);
 
 			expect( recordGlaEvent ).toHaveBeenCalledWith(
-				'gla_google_ads_promo_get_started_click',
+				'wcadmin_gla_google_ads_promo_create_campaign_click',
 				{ context: 'order-attribution-meta-box', href: '/get-started' }
 			);
 		} );

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -649,16 +649,6 @@ Google Ads Promo "Dismiss" button is clicked.
 #### Emitters
 - [`PromoCTA`](../../js/src/meta-boxes/channel-visibility/promo-cta.js#L29) with `{ context: channel-visibility-meta-box }`.
 
-### [`gla_google_ads_promo_get_started_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L48)
-Google Ads Promo "Get started" button is clicked.
-#### Properties
-| name | type | description |
-| ---- | ---- | ----------- |
-`context` | `string` | Context of the Google Ads Promo.
-`href` | `string` | URL of the "Get started" button.
-#### Emitters
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L73) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
-
 ### [`gla_google_ads_promo_shown`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L28)
 Google Ads Promo banner is shown.
 #### Properties
@@ -1244,6 +1234,16 @@ When the tour is shown.
 `context` | `string` | The tour context, e.g. "youtube_shopping_tour"
 #### Emitters
 - [`exports`](../../js/src/components/tours/youtube-shopping-tour.js#L39) with `{ context: "youtube_shopping_tour" }`
+
+### [`wcadmin_gla_google_ads_promo_create_campaign_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L48)
+Google Ads Promo "Get started" button is clicked.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Context of the Google Ads Promo.
+`href` | `string` | URL of the "Get started" button.
+#### Emitters
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L73) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
 
 <!---
 End of `woocommerce-grow-tracking-jsdoc`-generated content.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-526/get-started-event-through-create-campaign-click-after-clicking-dismiss

Replaces `gla_google_ads_promo_get_started_click` track event with `wcadmin_gla_google_ads_promo_create_campaign_click`

### Screenshots:

<!--- Optional --->

<img width="1761" height="690" alt="Screenshot 2026-03-18 at 7 39 46 PM" src="https://github.com/user-attachments/assets/d9aeefce-ae16-4da7-a5ee-f800ffc29bd3" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  Clicking  the "Get started" button in the channel visibility box should send the `wcadmin_gla_google_ads_promo_get_started_click` event


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
