### PR TITLE
Fix/GOOWOO-526: Channel visibility event name change

### DIFF
--- a/js/src/meta-boxes/channel-visibility/get-started-cta.js
+++ b/js/src/meta-boxes/channel-visibility/get-started-cta.js
@@ -13,7 +13,7 @@ import { CHANNEL_VISIBILITY_CONTEXT } from './constants';
 /**
  * Google Ads Promo "Get started" button is clicked.
  *
- * @event gla_google_ads_promo_create_campaign_click
+ * @event gla_google_ads_promo_get_started_click
  * @property {string} context Context of the Google Ads Promo.
  * @property {string} href URL of the "Get started" button.
  */
@@ -21,7 +21,7 @@ import { CHANNEL_VISIBILITY_CONTEXT } from './constants';
 /**
  * Get Started CTA component.
  *
- * @fires gla_google_ads_promo_create_campaign_click with `{ context: channel-visibility-meta-box, href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
+ * @fires gla_google_ads_promo_get_started_click with `{ context: channel-visibility-meta-box, href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
  *
  * @return {JSX.Element} The Get Started CTA component.
  */
@@ -31,7 +31,7 @@ const GetStartedCTA = () => {
 	return (
 		<AppButton
 			href={ getStartedUrl }
-			eventName="gla_google_ads_promo_create_campaign_click"
+			eventName="gla_google_ads_promo_get_started_click"
 			eventProps={ {
 				href: getStartedUrl,
 				context: CHANNEL_VISIBILITY_CONTEXT,

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -618,17 +618,6 @@ Clicking on the "connect to a different Google account" button.
 #### Emitters
 - [`SwitchAccountButton`](../../js/src/components/google-account-card/switch-account-button.js#L25)
 
-### [`gla_google_ads_promo_create_campaign_click`](../../js/src/meta-boxes/channel-visibility/get-started-cta.js#L13)
-Google Ads Promo "Get started" button is clicked.
-#### Properties
-| name | type | description |
-| ---- | ---- | ----------- |
-`context` | `string` | Context of the Google Ads Promo.
-`href` | `string` | URL of the "Get started" button.
-#### Emitters
-- [`GetStartedCTA`](../../js/src/meta-boxes/channel-visibility/get-started-cta.js#L28) with `{ context: channel-visibility-meta-box, href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L73) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&subpath=%2Fcampaigns%2Fcreate&path=%2Fgoogle%2Fdashboard' }`.
-
 ### [`gla_google_ads_promo_create_campaign_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L56)
 Google Ads Promo "Create campaign" button is clicked.
 #### Properties
@@ -637,7 +626,6 @@ Google Ads Promo "Create campaign" button is clicked.
 `context` | `string` | Context of the Google Ads Promo.
 `href` | `string` | URL of the "Create campaign" button.
 #### Emitters
-- [`GetStartedCTA`](../../js/src/meta-boxes/channel-visibility/get-started-cta.js#L28) with `{ context: channel-visibility-meta-box, href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
 - [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L73) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&subpath=%2Fcampaigns%2Fcreate&path=%2Fgoogle%2Fdashboard' }`.
 
 ### [`gla_google_ads_promo_dismiss_click`](../../js/src/meta-boxes/channel-visibility/promo-cta.js#L14)
@@ -649,6 +637,17 @@ Google Ads Promo "Dismiss" button is clicked.
 #### Emitters
 - [`PromoCTA`](../../js/src/meta-boxes/channel-visibility/promo-cta.js#L29) with `{ context: channel-visibility-meta-box }`.
 
+### [`gla_google_ads_promo_get_started_click`](../../js/src/meta-boxes/channel-visibility/get-started-cta.js#L13)
+Google Ads Promo "Get started" button is clicked.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Context of the Google Ads Promo.
+`href` | `string` | URL of the "Get started" button.
+#### Emitters
+- [`GetStartedCTA`](../../js/src/meta-boxes/channel-visibility/get-started-cta.js#L28) with `{ context: channel-visibility-meta-box, href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L73) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
+
 ### [`gla_google_ads_promo_get_started_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L48)
 Google Ads Promo "Get started" button is clicked.
 #### Properties
@@ -657,6 +656,7 @@ Google Ads Promo "Get started" button is clicked.
 `context` | `string` | Context of the Google Ads Promo.
 `href` | `string` | URL of the "Get started" button.
 #### Emitters
+- [`GetStartedCTA`](../../js/src/meta-boxes/channel-visibility/get-started-cta.js#L28) with `{ context: channel-visibility-meta-box, href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
 - [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L73) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fstart' }`.
 
 ### [`gla_google_ads_promo_shown`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L28)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-526/get-started-event-through-create-campaign-click-after-clicking-dismiss

Replaces the `gla_google_ads_promo_create_campaign_click` event in the Get started button within the channel visibility box with the event `gla_google_ads_promo_get_started_click`

### Screenshots:

<!--- Optional --->

<img width="1761" height="690" alt="Screenshot 2026-03-18 at 7 39 46 PM" src="https://github.com/user-attachments/assets/d9aeefce-ae16-4da7-a5ee-f800ffc29bd3" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.  Clicking  the "Get started" button in the channel visibility box should send the `wcadmin_gla_google_ads_promo_get_started_click` event

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
