### PR TITLE
Improved find expiring products query

### DIFF
--- a/src/Jobs/ResubmitExpiringProducts.php
+++ b/src/Jobs/ResubmitExpiringProducts.php
@@ -26,6 +26,21 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	}
 
 	/**
+	 * Check if the job can be scheduled.
+	 *
+	 * Because cursor values vary between runs, we pass null to check for ANY pending
+	 * create_batch action, not just one with matching args. This prevents a second
+	 * concurrent run from being enqueued while the job is already in progress.
+	 *
+	 * @param array|null $args Ignored.
+	 *
+	 * @return bool
+	 */
+	public function can_schedule( $args = [] ): bool {
+		return ! $this->is_running( null );
+	}
+
+	/**
 	 * Schedule the job to start, using cursor 0 so keyset pagination begins from the first product.
 	 *
 	 * @param array $args Unused; kept for interface compatibility.

--- a/src/Jobs/ResubmitExpiringProducts.php
+++ b/src/Jobs/ResubmitExpiringProducts.php
@@ -26,16 +26,60 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	}
 
 	/**
+	 * Schedule the job to start, using cursor 0 so keyset pagination begins from the first product.
+	 *
+	 * @param array $args Unused; kept for interface compatibility.
+	 */
+	public function schedule( array $args = [] ) {
+		$this->schedule_create_batch_action( 0 );
+	}
+
+	/**
+	 * Handle the "create batch" action using keyset (cursor) pagination.
+	 *
+	 * The $last_id argument acts as a cursor: we fetch products with ID > $last_id, then schedule
+	 * the next batch starting from the highest ID seen in this batch. This avoids the O(offset)
+	 * cost of traditional OFFSET-based pagination.
+	 *
+	 * @hooked gla/jobs/resubmit_expiring_products/create_batch
+	 *
+	 * @param int $last_id The highest product ID processed so far (0 on first run).
+	 *
+	 * @throws \Exception If an error occurs.
+	 * @throws JobException If the job failure rate is too high.
+	 */
+	public function handle_create_batch_action( int $last_id ) {
+		$create_batch_hook = $this->get_create_batch_hook();
+		$create_batch_args = [ $last_id ];
+
+		$this->monitor->validate_failure_rate( $this, $create_batch_hook, $create_batch_args );
+		if ( $this->retry_on_timeout ) {
+			$this->monitor->attach_timeout_monitor( $create_batch_hook, $create_batch_args );
+		}
+
+		$items = $this->get_batch( $last_id );
+
+		if ( empty( $items ) ) {
+			$this->handle_complete( $last_id );
+		} else {
+			$this->schedule_process_action( $items );
+			$this->schedule_create_batch_action( max( $items ) );
+		}
+
+		$this->monitor->detach_timeout_monitor( $create_batch_hook, $create_batch_args );
+	}
+
+	/**
 	 * Get a single batch of items.
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int $last_id The cursor: fetch products with ID strictly greater than this value.
 	 *
-	 * @return array
+	 * @return int[] Array of product IDs ordered ASC.
 	 */
-	public function get_batch( int $batch_number ): array {
-		return $this->product_repository->find_expiring_product_ids( $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+	public function get_batch( int $last_id ): array {
+		return $this->product_repository->find_expiring_product_ids( $last_id, $this->get_batch_size() );
 	}
 
 	/**

--- a/src/Jobs/ResubmitExpiringProducts.php
+++ b/src/Jobs/ResubmitExpiringProducts.php
@@ -26,26 +26,23 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	}
 
 	/**
-	 * Check if the job can be scheduled.
-	 *
-	 * Because cursor values vary between runs, we pass null to check for ANY pending
-	 * create_batch action, not just one with matching args. This prevents a second
-	 * concurrent run from being enqueued while the job is already in progress.
-	 *
-	 * @param array|null $args Ignored.
-	 *
-	 * @return bool
-	 */
-	public function can_schedule( $args = [] ): bool {
-		return ! $this->is_running( null );
-	}
-
-	/**
 	 * Schedule the job to start, using cursor 0 so keyset pagination begins from the first product.
 	 *
-	 * @param array $args Unused; kept for interface compatibility.
+	 * The initial scheduling is additionally guarded to avoid starting a second concurrent run
+	 * while another `create_batch` action for this job is already scheduled or running.
+	 *
+	 * @param array $args Optional arguments passed to the base can_schedule() logic.
 	 */
 	public function schedule( array $args = [] ) {
+		// Respect Merchant Center readiness/enablement checks from the base class.
+		if ( ! parent::can_schedule( $args ) ) {
+			return;
+		}
+
+		// Prevent a second concurrent run by checking for ANY existing create_batch action.
+		if ( $this->is_running( null ) ) {
+			return;
+		}
 		$this->schedule_create_batch_action( 0 );
 	}
 

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -279,11 +279,9 @@ class ProductRepository implements Service {
 				$this->get_sync_ready_products_meta_query(),
 				$this->get_valid_products_meta_query(),
 				[
-					[
-						'key'     => ProductMetaHandler::KEY_SYNCED_AT,
-						'compare' => '<',
-						'value'   => strtotime( '-25 days' ),
-					],
+					'key'     => ProductMetaHandler::KEY_SYNCED_AT,
+					'compare' => '<',
+					'value'   => strtotime( '-25 days' ),
 				],
 			],
 		];
@@ -295,8 +293,11 @@ class ProductRepository implements Service {
 		};
 
 		add_filter( 'posts_where', $cursor_filter );
-		$results = $this->find_ids( $args, $limit );
-		remove_filter( 'posts_where', $cursor_filter );
+		try {
+			$results = $this->find_ids( $args, $limit );
+		} finally {
+			remove_filter( 'posts_where', $cursor_filter );
+		}
 
 		return $results;
 	}

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -259,26 +259,46 @@ class ProductRepository implements Service {
 	/**
 	 * Find and return an array of WooCommerce product IDs nearly expired and ready to be re-submitted to Google Merchant Center.
 	 *
-	 * @param int $limit  Maximum number of results to retrieve or -1 for unlimited.
-	 * @param int $offset Amount to offset product results.
+	 * Uses keyset (cursor) pagination: instead of OFFSET (which must scan and skip rows), this method
+	 * uses "WHERE ID > $last_id ORDER BY ID ASC" so each batch starts exactly where the previous one
+	 * left off at O(log n) cost regardless of how deep into the result set we are.
 	 *
-	 * @return int[] Array of WooCommerce product IDs
+	 * @param int $last_id The last product ID processed in the previous batch (0 to start from the beginning).
+	 * @param int $limit   Maximum number of results to retrieve or -1 for unlimited.
+	 *
+	 * @return int[] Array of WooCommerce product IDs ordered by ID ASC.
 	 */
-	public function find_expiring_product_ids( int $limit = - 1, int $offset = 0 ): array {
-		$args['meta_query'] = [
-			'relation' => 'AND',
-			$this->get_sync_ready_products_meta_query(),
-			$this->get_valid_products_meta_query(),
-			[
+	public function find_expiring_product_ids( int $last_id = 0, int $limit = -1 ): array {
+		global $wpdb;
+
+		$args = [
+			'orderby'    => 'ID',
+			'order'      => 'ASC',
+			'meta_query' => [
+				'relation' => 'AND',
+				$this->get_sync_ready_products_meta_query(),
+				$this->get_valid_products_meta_query(),
 				[
-					'key'     => ProductMetaHandler::KEY_SYNCED_AT,
-					'compare' => '<',
-					'value'   => strtotime( '-25 days' ),
+					[
+						'key'     => ProductMetaHandler::KEY_SYNCED_AT,
+						'compare' => '<',
+						'value'   => strtotime( '-25 days' ),
+					],
 				],
 			],
 		];
 
-		return $this->find_ids( $args, $limit, $offset );
+		// Add a temporary WHERE clause to implement keyset pagination (ID > $last_id).
+		$cursor_filter = function ( string $where ) use ( $wpdb, $last_id ): string {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			return $where . $wpdb->prepare( " AND {$wpdb->posts}.ID > %d", $last_id );
+		};
+
+		add_filter( 'posts_where', $cursor_filter );
+		$results = $this->find_ids( $args, $limit );
+		remove_filter( 'posts_where', $cursor_filter );
+
+		return $results;
 	}
 
 	/**

--- a/tests/Unit/Jobs/ResubmitExpiringProductsTest.php
+++ b/tests/Unit/Jobs/ResubmitExpiringProductsTest.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\JobTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -24,6 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 class ResubmitExpiringProductsTest extends UnitTest {
 
 	use JobTrait;
+	use ProductTrait;
 
 	/** @var MockObject|ActionScheduler $action_scheduler */
 	protected $action_scheduler;
@@ -155,9 +157,9 @@ class ResubmitExpiringProductsTest extends UnitTest {
 		$this->action_scheduler->expects( $this->exactly( 3 ) )
 			->method( 'schedule_immediate' )
 			->withConsecutive(
-				[ self::CREATE_BATCH_HOOK, [ 0 ] ],         // schedule()
-				[ self::PROCESS_ITEM_HOOK, [ $ids ] ],      // process batch
-				[ self::CREATE_BATCH_HOOK, [ 20 ] ]         // next cursor = max(ids)
+				[ self::CREATE_BATCH_HOOK, [ 0 ] ],         // Initial scheduling.
+				[ self::PROCESS_ITEM_HOOK, [ $ids ] ],      // Process the batch.
+				[ self::CREATE_BATCH_HOOK, [ 20 ] ]         // Next cursor is the max ID.
 			);
 
 		$this->job->schedule();
@@ -183,11 +185,11 @@ class ResubmitExpiringProductsTest extends UnitTest {
 		$this->action_scheduler->expects( $this->exactly( 5 ) )
 			->method( 'schedule_immediate' )
 			->withConsecutive(
-				[ self::CREATE_BATCH_HOOK, [ 0 ] ],      // schedule()
+				[ self::CREATE_BATCH_HOOK, [ 0 ] ],      // Initial scheduling.
 				[ self::PROCESS_ITEM_HOOK, [ $batch_a ] ],
-				[ self::CREATE_BATCH_HOOK, [ 20 ] ],     // cursor = max(batch_a)
+				[ self::CREATE_BATCH_HOOK, [ 20 ] ],     // Cursor advances to max of batch A.
 				[ self::PROCESS_ITEM_HOOK, [ $batch_b ] ],
-				[ self::CREATE_BATCH_HOOK, [ 40 ] ]      // cursor = max(batch_b)
+				[ self::CREATE_BATCH_HOOK, [ 40 ] ]      // Cursor advances to max of batch B.
 			);
 
 		$this->job->schedule();

--- a/tests/Unit/Jobs/ResubmitExpiringProductsTest.php
+++ b/tests/Unit/Jobs/ResubmitExpiringProductsTest.php
@@ -143,7 +143,7 @@ class ResubmitExpiringProductsTest extends UnitTest {
 	 * and then schedule one more create_batch with max(ids) as the cursor.
 	 */
 	public function test_single_partial_batch() {
-		$ids = [ 10, 20 ];
+		$ids = [ 10 ];
 
 		$this->product_repository->expects( $this->once() )
 			->method( 'find_expiring_product_ids' )
@@ -159,7 +159,7 @@ class ResubmitExpiringProductsTest extends UnitTest {
 			->withConsecutive(
 				[ self::CREATE_BATCH_HOOK, [ 0 ] ],         // Initial scheduling.
 				[ self::PROCESS_ITEM_HOOK, [ $ids ] ],      // Process the batch.
-				[ self::CREATE_BATCH_HOOK, [ 20 ] ]         // Next cursor is the max ID.
+				[ self::CREATE_BATCH_HOOK, [ 10 ] ]         // Next cursor is the max ID.
 			);
 
 		$this->job->schedule();

--- a/tests/Unit/Jobs/ResubmitExpiringProductsTest.php
+++ b/tests/Unit/Jobs/ResubmitExpiringProductsTest.php
@@ -1,0 +1,222 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ResubmitExpiringProducts;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\JobTrait;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class ResubmitExpiringProductsTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
+ */
+class ResubmitExpiringProductsTest extends UnitTest {
+
+	use JobTrait;
+
+	/** @var MockObject|ActionScheduler $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|ProductSyncer $product_syncer */
+	protected $product_syncer;
+
+	/** @var MockObject|ProductRepository $product_repository */
+	protected $product_repository;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var MockObject|BatchProductHelper $product_helper */
+	protected $product_helper;
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|MerchantStatuses $merchant_statuses */
+	protected $merchant_statuses;
+
+	/** @var ResubmitExpiringProducts $job */
+	protected $job;
+
+	protected const JOB_NAME          = 'resubmit_expiring_products';
+	protected const CREATE_BATCH_HOOK = 'gla/jobs/' . self::JOB_NAME . '/create_batch';
+	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
+
+	/**
+	 * Runs before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->options            = $this->createMock( OptionsInterface::class );
+		$this->action_scheduler   = $this->createMock( ActionSchedulerInterface::class );
+		$this->monitor            = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->product_syncer     = $this->createMock( ProductSyncer::class );
+		$this->product_repository = $this->createMock( ProductRepository::class );
+		$this->product_helper     = $this->createMock( BatchProductHelper::class );
+		$this->merchant_center    = $this->createMock( MerchantCenterService::class );
+		$this->merchant_statuses  = $this->createMock( MerchantStatuses::class );
+
+		$this->job = new ResubmitExpiringProducts(
+			$this->action_scheduler,
+			$this->monitor,
+			$this->product_syncer,
+			$this->product_repository,
+			$this->product_helper,
+			$this->merchant_center,
+			$this->merchant_statuses
+		);
+
+		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
+		$this->merchant_center->method( 'is_enabled_for_datatype' )->willReturn( true );
+
+		add_filter(
+			'woocommerce_gla_batched_job_size',
+			function ( $batch_count, $job_name ) {
+				if ( self::JOB_NAME === $job_name ) {
+					return 2;
+				}
+				return $batch_count;
+			},
+			10,
+			2
+		);
+
+		$this->job->set_options_object( $this->options );
+		$this->job->init();
+	}
+
+	public function test_job_name() {
+		$this->assertEquals( self::JOB_NAME, $this->job->get_name() );
+	}
+
+	/**
+	 * schedule() must enqueue the first batch with cursor 0, not batch number 1.
+	 */
+	public function test_schedule_starts_at_cursor_zero() {
+		$this->action_scheduler
+			->method( 'has_scheduled_action' )
+			->willReturn( false );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with( self::CREATE_BATCH_HOOK, [ 0 ] );
+
+		$this->job->schedule();
+	}
+
+	/**
+	 * When the first batch is empty the job must stop without scheduling a next batch.
+	 */
+	public function test_empty_first_batch_stops_job() {
+		$this->product_repository->expects( $this->once() )
+			->method( 'find_expiring_product_ids' )
+			->with( 0, 2 )
+			->willReturn( [] );
+
+		$this->action_scheduler
+			->method( 'has_scheduled_action' )
+			->willReturn( false );
+
+		// Only the initial schedule_immediate call; no further scheduling.
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with( self::CREATE_BATCH_HOOK, [ 0 ] );
+
+		$this->job->schedule();
+		do_action( self::CREATE_BATCH_HOOK, 0 );
+	}
+
+	/**
+	 * A single partial batch (fewer items than batch size) must process its items
+	 * and then schedule one more create_batch with max(ids) as the cursor.
+	 */
+	public function test_single_partial_batch() {
+		$ids = [ 10, 20 ];
+
+		$this->product_repository->expects( $this->once() )
+			->method( 'find_expiring_product_ids' )
+			->with( 0, 2 )
+			->willReturn( $ids );
+
+		$this->action_scheduler
+			->method( 'has_scheduled_action' )
+			->willReturn( false );
+
+		$this->action_scheduler->expects( $this->exactly( 3 ) )
+			->method( 'schedule_immediate' )
+			->withConsecutive(
+				[ self::CREATE_BATCH_HOOK, [ 0 ] ],         // schedule()
+				[ self::PROCESS_ITEM_HOOK, [ $ids ] ],      // process batch
+				[ self::CREATE_BATCH_HOOK, [ 20 ] ]         // next cursor = max(ids)
+			);
+
+		$this->job->schedule();
+		do_action( self::CREATE_BATCH_HOOK, 0 );
+	}
+
+	/**
+	 * Two full batches followed by an empty batch: cursor advances correctly each time.
+	 */
+	public function test_multiple_full_batches_advance_cursor() {
+		$batch_a = [ 10, 20 ];
+		$batch_b = [ 30, 40 ];
+
+		$this->product_repository->expects( $this->exactly( 3 ) )
+			->method( 'find_expiring_product_ids' )
+			->withConsecutive( [ 0, 2 ], [ 20, 2 ], [ 40, 2 ] )
+			->willReturnOnConsecutiveCalls( $batch_a, $batch_b, [] );
+
+		$this->action_scheduler
+			->method( 'has_scheduled_action' )
+			->willReturn( false );
+
+		$this->action_scheduler->expects( $this->exactly( 5 ) )
+			->method( 'schedule_immediate' )
+			->withConsecutive(
+				[ self::CREATE_BATCH_HOOK, [ 0 ] ],      // schedule()
+				[ self::PROCESS_ITEM_HOOK, [ $batch_a ] ],
+				[ self::CREATE_BATCH_HOOK, [ 20 ] ],     // cursor = max(batch_a)
+				[ self::PROCESS_ITEM_HOOK, [ $batch_b ] ],
+				[ self::CREATE_BATCH_HOOK, [ 40 ] ]      // cursor = max(batch_b)
+			);
+
+		$this->job->schedule();
+		do_action( self::CREATE_BATCH_HOOK, 0 );
+		do_action( self::CREATE_BATCH_HOOK, 20 );
+		do_action( self::CREATE_BATCH_HOOK, 40 );
+	}
+
+	/**
+	 * process_items must call product_syncer->update() with the loaded WC_Product objects.
+	 */
+	public function test_process_items_calls_product_syncer() {
+		$ids      = [ 10, 20 ];
+		$products = $this->generate_simple_product_mocks_set( 2 );
+
+		$this->product_repository->method( 'find_by_ids' )
+			->with( $ids )
+			->willReturn( $products );
+
+		$this->product_syncer->expects( $this->once() )
+			->method( 'update' )
+			->with( $products );
+
+		do_action( self::PROCESS_ITEM_HOOK, $ids );
+	}
+}

--- a/tests/Unit/Jobs/ResubmitExpiringProductsTest.php
+++ b/tests/Unit/Jobs/ResubmitExpiringProductsTest.php
@@ -9,7 +9,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ResubmitExpiringProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -38,9 +37,6 @@ class ResubmitExpiringProductsTest extends UnitTest {
 	/** @var MockObject|ProductRepository $product_repository */
 	protected $product_repository;
 
-	/** @var MockObject|OptionsInterface $options */
-	protected $options;
-
 	/** @var MockObject|BatchProductHelper $product_helper */
 	protected $product_helper;
 
@@ -63,7 +59,6 @@ class ResubmitExpiringProductsTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->options            = $this->createMock( OptionsInterface::class );
 		$this->action_scheduler   = $this->createMock( ActionSchedulerInterface::class );
 		$this->monitor            = $this->createMock( ActionSchedulerJobMonitor::class );
 		$this->product_syncer     = $this->createMock( ProductSyncer::class );
@@ -97,7 +92,6 @@ class ResubmitExpiringProductsTest extends UnitTest {
 			2
 		);
 
-		$this->job->set_options_object( $this->options );
 		$this->job->init();
 	}
 
@@ -106,7 +100,7 @@ class ResubmitExpiringProductsTest extends UnitTest {
 	}
 
 	/**
-	 * schedule() must enqueue the first batch with cursor 0, not batch number 1.
+	 * The schedule() must enqueue the first batch with cursor 0, not batch number 1.
 	 */
 	public function test_schedule_starts_at_cursor_zero() {
 		$this->action_scheduler
@@ -203,7 +197,7 @@ class ResubmitExpiringProductsTest extends UnitTest {
 	}
 
 	/**
-	 * process_items must call product_syncer->update() with the loaded WC_Product objects.
+	 * The process_items must call product_syncer->update() with the loaded WC_Product objects.
 	 */
 	public function test_process_items_calls_product_syncer() {
 		$ids      = [ 10, 20 ];

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -294,27 +294,6 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		);
 	}
 
-	public function test_find_expiring_product_ids_returns_expiring_product() {
-		// Recently synced – should NOT be returned.
-		$product_1 = WC_Helper_Product::create_simple_product();
-		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );
-
-		// Synced 30 days ago – SHOULD be returned.
-		$product_2 = WC_Helper_Product::create_simple_product();
-		$this->product_helper->mark_as_synced( $product_2, $this->generate_google_product_mock() );
-		$this->product_meta->update_synced_at( $product_2, strtotime( '-30 days' ) );
-
-		// Has errors – should NOT be returned.
-		$product_3 = WC_Helper_Product::create_simple_product();
-		$this->product_helper->mark_as_invalid( $product_3, [ 'Error 1' ] );
-		$this->product_meta->update_synced_at( $product_3, strtotime( '-30 days' ) );
-
-		$this->assertEquals(
-			[ $product_2->get_id() ],
-			$this->product_repository->find_expiring_product_ids()
-		);
-	}
-
 	public function test_find_expiring_product_ids_respects_cursor() {
 		$product_1 = WC_Helper_Product::create_simple_product();
 		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -294,6 +294,82 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		);
 	}
 
+	public function test_find_expiring_product_ids_returns_expiring_product() {
+		// Recently synced – should NOT be returned.
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );
+
+		// Synced 30 days ago – SHOULD be returned.
+		$product_2 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_2, $this->generate_google_product_mock() );
+		$this->product_meta->update_synced_at( $product_2, strtotime( '-30 days' ) );
+
+		// Has errors – should NOT be returned.
+		$product_3 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_invalid( $product_3, [ 'Error 1' ] );
+
+		$this->assertEquals(
+			[ $product_2->get_id() ],
+			$this->product_repository->find_expiring_product_ids()
+		);
+	}
+
+	public function test_find_expiring_product_ids_respects_cursor() {
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );
+		$this->product_meta->update_synced_at( $product_1, strtotime( '-30 days' ) );
+
+		$product_2 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_2, $this->generate_google_product_mock() );
+		$this->product_meta->update_synced_at( $product_2, strtotime( '-30 days' ) );
+
+		// Both products are expiring; passing the first ID as cursor should only return the second.
+		$ids = $this->product_repository->find_expiring_product_ids( $product_1->get_id() );
+
+		$this->assertEquals( [ $product_2->get_id() ], $ids );
+	}
+
+	public function test_find_expiring_product_ids_respects_limit() {
+		for ( $i = 0; $i < 3; $i++ ) {
+			$p = WC_Helper_Product::create_simple_product();
+			$this->product_helper->mark_as_synced( $p, $this->generate_google_product_mock() );
+			$this->product_meta->update_synced_at( $p, strtotime( '-30 days' ) );
+		}
+
+		$ids = $this->product_repository->find_expiring_product_ids( 0, 2 );
+
+		$this->assertCount( 2, $ids );
+	}
+
+	public function test_find_expiring_product_ids_excludes_dont_sync_visibility() {
+		$product = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
+		$this->product_meta->update_synced_at( $product, strtotime( '-30 days' ) );
+		$this->product_meta->update_visibility( $product, \Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility::DONT_SYNC_AND_SHOW );
+
+		$ids = $this->product_repository->find_expiring_product_ids();
+
+		$this->assertNotContains( $product->get_id(), $ids );
+	}
+
+	public function test_find_expiring_product_ids_results_are_ordered_asc() {
+		$ids_created = [];
+		for ( $i = 0; $i < 3; $i++ ) {
+			$p = WC_Helper_Product::create_simple_product();
+			$this->product_helper->mark_as_synced( $p, $this->generate_google_product_mock() );
+			$this->product_meta->update_synced_at( $p, strtotime( '-30 days' ) );
+			$ids_created[] = $p->get_id();
+		}
+
+		$ids_found = $this->product_repository->find_expiring_product_ids();
+
+		// Returned IDs should be a sorted subset of what was created.
+		$intersection = array_values( array_intersect( $ids_found, $ids_created ) );
+		$sorted       = $intersection;
+		sort( $sorted );
+		$this->assertEquals( $sorted, $intersection );
+	}
+
 	public function test_find_all_synced_google_ids() {
 		$synced_google_ids = [];
 

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -307,6 +307,7 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		// Has errors – should NOT be returned.
 		$product_3 = WC_Helper_Product::create_simple_product();
 		$this->product_helper->mark_as_invalid( $product_3, [ 'Error 1' ] );
+		$this->product_meta->update_synced_at( $product_3, strtotime( '-30 days' ) );
 
 		$this->assertEquals(
 			[ $product_2->get_id() ],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Stores with large catalogs (50k+ products) experience severe performance degradation from the `ResubmitExpiringProducts` job. The root cause is **OFFSET-based pagination** as later batches must scan and discard progressively more rows, causing slow queries and CPU spikes.

This PR replaces OFFSET pagination with **keyset (cursor) pagination** (`WHERE ID > $last_id ORDER BY ID ASC`), so every batch starts exactly where the previous one left off at O(log n) cost, regardless of depth into the result set.

**Benchmarks** on a test site with ~5k products showed a **38× speedup** overall, with the improvement growing as dataset size increases.

<img width="2018" height="1346" alt="image" src="https://github.com/user-attachments/assets/0603090d-221e-4539-9a2d-033f12c5410e" />

Closes #3146 

### Technical Details

- **`ProductRepository::find_expiring_product_ids()`** — Changed signature from `($limit, $offset)` to `($last_id, $limit)`. Adds a temporary `posts_where` filter to inject `AND wp_posts.ID > $last_id`, combined with `ORDER BY ID ASC`, to implement keyset pagination while preserving the existing `WP_Query` logic.
- **`ResubmitExpiringProducts`** — Overrides `schedule()` to start with cursor `0` and `handle_create_batch_action()` to pass `max($ids)` as the cursor for the next batch, instead of incrementing a batch number/offset.

### Detailed test instructions:

- [ ] Unit tests pass: `vendor/bin/phpunit tests/Unit/Product/ProductRepositoryTest.php` and `vendor/bin/phpunit tests/Unit/Jobs/ResubmitExpiringProductsTest.php`
- [ ] Benchmark with the snippet below on a large catalog to confirm speedup

<details>
<summary>Benchmark snippet (Code Snippets / mu-plugin)</summary>

```php
add_action( 'admin_init', function () {
    if ( empty( $_GET['gla_benchmark_expiring'] ) || ! current_user_can( 'manage_options' ) ) {
        return;
    }
    $repo       = woogle_get_container()->get(
        Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository::class
    );
    $batch_size = absint( $_GET['batch_size'] ?? 100 ) ?: 100;
    $batches    = absint( $_GET['batches'] ?? 5 ) ?: 5;
    $ms         = fn( float $s ) => number_format( $s * 1000, 2 ) . ' ms';

    $repo->find_expiring_product_ids( 0, 1 ); // warmup

    $lines = [];
    $times = [];
    $arg   = 0;
    for ( $i = 0; $i < $batches; $i++ ) {
        $t0      = microtime( true );
        $ids     = $repo->find_expiring_product_ids( $arg, $batch_size );
        $elapsed = microtime( true ) - $t0;
        $times[] = $elapsed;
        $lines[] = sprintf( '  Batch %d (arg=%6d) → %4d rows · %s', $i + 1, $arg, count( $ids ), $ms( $elapsed ) );
        if ( empty( $ids ) ) { $lines[] = '  No more rows.'; break; }
        $arg = max( $ids );
    }
    $total = array_sum( $times );
    $avg   = $total / max( 1, count( $times ) );
    $lines[] = '';
    $lines[] = sprintf( 'Total: %s | Average: %s | Batches: %d', $ms( $total ), $ms( $avg ), count( $times ) );
    wp_die( '<pre>' . esc_html( implode( "\n", $lines ) ) . '</pre>', 'GLA Benchmark' );
} );
```

Switch between `develop` and this branch to compare results.
</details>

<details>
<summary>Snippet to make existing products expire (Code Snippets / mu-plugin)</summary>

```php
add_action( 'admin_init', function () {
	if ( empty( $_GET['gla_make_expiring'] ) || ! current_user_can( 'manage_options' ) ) {
		return;
	}

	$count     = absint( $_GET['count'] ?? 5000 ) ?: 5000;
	$synced_at = strtotime( '-30 days' );
	$meta_key  = '_wc_gla_synced_at';

	global $wpdb;

	// Update products whose synced_at is recent (not yet expiring).
	$updated = $wpdb->query( $wpdb->prepare(
		"UPDATE {$wpdb->postmeta}
		 SET meta_value = %d
		 WHERE meta_key = %s
		   AND meta_value >= %d
		 LIMIT %d",
		$synced_at,
		$meta_key,
		strtotime( '-25 days' ),
		$count
	) );

	wp_die(
		sprintf( '<pre>Done. Backdated %d products to synced_at = %s (30 days ago).</pre>', $updated, date( 'Y-m-d', $synced_at ) ),
		'GLA Make Expiring'
	);
} );
```

</details>

### Changelog entry

> Update - Improved performance of the expiring products query for large catalogs.
