### PR TITLE
Fix: Unschedule all Action Scheduler jobs on plugin deactivation

### DIFF
--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -82,6 +82,11 @@ register_deactivation_hook(
 	__FILE__,
 	function () {
 		PluginFactory::instance()->deactivate();
+
+		// Unschedule all pending ActionScheduler jobs for this plugin.
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( null, null, 'gla' );
+		}
 	}
 );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When the plugin is deactivated, recurring Action Scheduler jobs are not unscheduled. They continue to run and accumulate failure logs, adding unnecessary maintenance burden. The three actions specifically reported were:

- `gla/jobs/resubmit_expiring_products/start`
- `gla/jobs/update_merchant_price_benchmarks/start`
- `gla/jobs/update_merchant_price_benchmarks/process_item`

However, the root cause is broader — **no** Action Scheduler jobs were being cleaned up on deactivation. This adds a single `as_unschedule_all_actions( null, null, 'gla' )` call to the deactivation hook, clearing all pending jobs in the `gla` group. This matches the existing pattern already used in `uninstall.php`.

Jobs are automatically re-scheduled when the plugin is reactivated via `JobInitializer`.

### Detailed test instructions:

1. Activate Google for WooCommerce
2. Wait for cron to run or trigger it manually (`wp action-scheduler run`)
3. Verify `gla` jobs are scheduled: `wp db query "SELECT hook, status FROM wp_actionscheduler_actions WHERE group_id IN (SELECT group_id FROM wp_actionscheduler_groups WHERE slug='gla') AND status='pending'"`
4. Deactivate the plugin
5. Run the same query — **all `gla` pending actions should be gone**
6. Re-activate the plugin
7. Trigger cron again and verify jobs are re-scheduled automatically

### Changelog entry

> Fix - Unschedule all Action Scheduler jobs when the plugin is deactivated to prevent orphaned recurring tasks from accumulating failure logs.

---

Part of the [Woo Extensions Bug Blitz](https://woohappyp2.wordpress.com/2026/03/18/extensions-bug-blitz/)