### PR TITLE
Fix: Disconnect Google Ads account modal shows incorrect content

### DIFF
--- a/js/src/pages/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.js
@@ -102,10 +102,14 @@ export default function ConfirmModal( {
 	const dispatcher = useAppDispatch();
 	const { hasGoogleMCConnection } = useGoogleMCAccount();
 
-	const targetTextDict =
-		disconnectTarget === ALL_ACCOUNTS && ! hasGoogleMCConnection
-			? ADS_ONLY
-			: ALL_ACCOUNTS;
+	const getTargetTextKey = () => {
+    	if (disconnectTarget === ADS_ACCOUNT) return ADS_ACCOUNT;
+    	if (disconnectTarget === ALL_ACCOUNTS && !hasGoogleMCConnection) return ADS_ONLY;
+    
+    	return ALL_ACCOUNTS;
+	};
+
+	const targetTextDict = getTargetTextKey();
 
 	const { title, confirmButton, confirmation, contents } =
 		textDict[ targetTextDict ];

--- a/js/src/pages/settings/disconnect-modal/confirm-modal.test.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.test.js
@@ -1,0 +1,122 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ConfirmModal from './confirm-modal';
+import { useAppDispatch } from '~/data';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+import { ALL_ACCOUNTS, ADS_ACCOUNT, ADS_ONLY } from './constants';
+
+jest.mock( '~/data', () => ( {
+	useAppDispatch: jest.fn(),
+} ) );
+
+jest.mock( '~/hooks/useGoogleMCAccount', () =>
+	jest.fn().mockName( 'useGoogleMCAccount' )
+);
+
+describe( 'ConfirmModal', () => {
+	beforeEach( () => {
+		useAppDispatch.mockReturnValue( {
+			disconnectAllAccounts: jest.fn(),
+			disconnectGoogleAdsAccount: jest.fn(),
+		} );
+	} );
+
+	describe( `when disconnectTarget is "${ ADS_ACCOUNT }"`, () => {
+		it( 'should show the Google Ads-specific modal title', () => {
+			useGoogleMCAccount.mockReturnValue( { hasGoogleMCConnection: true } );
+
+			render(
+				<ConfirmModal
+					disconnectTarget={ ADS_ACCOUNT }
+					onRequestClose={ jest.fn() }
+					onDisconnected={ jest.fn() }
+				/>
+			);
+
+			expect(
+				screen.getByText( 'Disconnect Google Ads account' )
+			).toBeInTheDocument();
+		} );
+
+		it( 'should not show the "disconnect all accounts" title', () => {
+			useGoogleMCAccount.mockReturnValue( { hasGoogleMCConnection: true } );
+
+			render(
+				<ConfirmModal
+					disconnectTarget={ ADS_ACCOUNT }
+					onRequestClose={ jest.fn() }
+					onDisconnected={ jest.fn() }
+				/>
+			);
+
+			expect(
+				screen.queryByText( 'Disconnect all accounts' )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'should show the Google Ads-specific confirmation checkbox text', () => {
+			useGoogleMCAccount.mockReturnValue( { hasGoogleMCConnection: true } );
+
+			render(
+				<ConfirmModal
+					disconnectTarget={ ADS_ACCOUNT }
+					onRequestClose={ jest.fn() }
+					onDisconnected={ jest.fn() }
+				/>
+			);
+
+			expect(
+				screen.getByText(
+					'Yes, I want to disconnect my Google Ads account.'
+				)
+			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( `when disconnectTarget is "${ ALL_ACCOUNTS }" with MC connected`, () => {
+		it( 'should show the "disconnect all accounts" modal title', () => {
+			useGoogleMCAccount.mockReturnValue( { hasGoogleMCConnection: true } );
+
+			render(
+				<ConfirmModal
+					disconnectTarget={ ALL_ACCOUNTS }
+					onRequestClose={ jest.fn() }
+					onDisconnected={ jest.fn() }
+				/>
+			);
+
+			expect(
+				screen.getByRole( 'heading', { name: /Disconnect all accounts/ } )
+			).toBeInTheDocument();
+		} );
+	} );
+
+	describe( `when disconnectTarget is "${ ALL_ACCOUNTS }" without MC connected`, () => {
+		it( 'should show the ads-only variant of the modal', () => {
+			useGoogleMCAccount.mockReturnValue( {
+				hasGoogleMCConnection: false,
+			} );
+
+			render(
+				<ConfirmModal
+					disconnectTarget={ ALL_ACCOUNTS }
+					onRequestClose={ jest.fn() }
+					onDisconnected={ jest.fn() }
+				/>
+			);
+
+			// ADS_ONLY variant still says "Disconnect all accounts" in the title
+			// but only mentions Google Ads in the body content (no MC mention)
+			expect(
+				screen.queryByText( /Google Merchant Center/ )
+			).not.toBeInTheDocument();
+		} );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When clicking "Disconnect Google Ads account only" in Settings → Linked Accounts, the modal was displaying the "Disconnect all accounts" content instead of the Google Ads-specific content.

The bug was in `confirm-modal.js` — the `targetTextDict` ternary only checked for `ALL_ACCOUNTS` and never considered `ADS_ACCOUNT`, so it always fell back to `ALL_ACCOUNTS` text:

```js
// Before (buggy):
const targetTextDict =
    disconnectTarget === ALL_ACCOUNTS && ! hasGoogleMCConnection
        ? ADS_ONLY
        : ALL_ACCOUNTS; // ADS_ACCOUNT always ended up here

// After:
const targetTextDict =
    disconnectTarget === ADS_ACCOUNT
        ? ADS_ACCOUNT
        : disconnectTarget === ALL_ACCOUNTS && ! hasGoogleMCConnection
        ? ADS_ONLY
        : ALL_ACCOUNTS;
```

Note: the actual disconnect action was already correct — only the modal display content was wrong.

### Detailed test instructions:

1. Connect a Google Ads account in Google for WooCommerce
2. Navigate to **WooCommerce → Google Listings & Ads → Settings**
3. Scroll to the Google Ads account card
4. Click **"Disconnect Google Ads account only"**
5. Verify the modal title reads **"Disconnect Google Ads account"** (not "Disconnect all accounts")
6. Verify the checkbox reads **"Yes, I want to disconnect my Google Ads account."**
7. Verify the body content only mentions Google Ads (no mention of WordPress.com, Google account, or Merchant Center)

### Changelog entry

> Fix - Show the correct modal content when disconnecting only the Google Ads account from Settings.

Closes #3344