### PR TITLE
Update GMC merchant id for YouTube Shopping exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
 			},
 			{
 				"path": "./google-listings-and-ads.zip",
-				"maxSize": "8.30 mB",
+				"maxSize": "8.40 mB",
 				"compression": "none"
 			}
 		],

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -789,8 +789,8 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 	/**
 	 * Return the MCA ID for the WooCommerce Connect Server.
 	 *
-	 * @return integer
-	 * @throws Exception When an error response occurs.
+	 * @return int Positive MCA ID.
+	 * @throws Exception When the HTTP response is invalid, mcaId is missing, or mcaId is not a positive integer.
 	 */
 	public function get_wcs_mca_id(): int {
 		try {
@@ -806,7 +806,24 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 				);
 			}
 
-			return absint( $response['mcaId'] );
+			$mca_id = filter_var(
+				$response['mcaId'],
+				FILTER_VALIDATE_INT,
+				[
+					'options' => [
+						'min_range' => 1,
+					],
+				]
+			);
+
+			if ( false === $mca_id ) {
+				throw new Exception(
+					__( 'Invalid response when retrieving MCA ID from WooCommerce Connect Server.', 'google-listings-and-ads' ),
+					$result->getStatusCode()
+				);
+			}
+
+			return $mca_id;
 		} catch ( ClientExceptionInterface $e ) {
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -790,6 +790,7 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 	 * Return the MCA ID for the WooCommerce Connect Server.
 	 *
 	 * @return integer
+	 * @throws Exception When an error response occurs.
 	 */
 	public function get_wcs_mca_id(): int {
 		try {

--- a/src/API/Google/Middleware.php
+++ b/src/API/Google/Middleware.php
@@ -21,7 +21,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerExceptionInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\NotFoundExceptionInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Client\ClientExceptionInterface;
-use DateTime;
 use Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -782,6 +781,36 @@ class Middleware implements ContainerAwareInterface, OptionsAwareInterface {
 
 			throw new Exception(
 				$this->client_exception_message( $e, __( 'Error fetching incentive credits.', 'google-listings-and-ads' ) ),
+				$e->getCode()
+			);
+		}
+	}
+
+	/**
+	 * Return the MCA ID for the WooCommerce Connect Server.
+	 *
+	 * @return integer
+	 */
+	public function get_wcs_mca_id(): int {
+		try {
+			/** @var Client $client */
+			$client   = $this->container->get( Client::class );
+			$result   = $client->get( $this->get_manager_url( 'mca' ) );
+			$response = json_decode( $result->getBody()->getContents(), true );
+
+			if ( 200 !== $result->getStatusCode() || ! is_array( $response ) || ! isset( $response['mcaId'] ) ) {
+				throw new Exception(
+					__( 'Invalid response when retrieving MCA ID from WooCommerce Connect Server.', 'google-listings-and-ads' ),
+					$result->getStatusCode()
+				);
+			}
+
+			return absint( $response['mcaId'] );
+		} catch ( ClientExceptionInterface $e ) {
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
+
+			throw new Exception(
+				$this->client_exception_message( $e, __( 'Error retrieving MCA ID from WooCommerce Connect Server', 'google-listings-and-ads' ) ),
 				$e->getCode()
 			);
 		}

--- a/src/Admin/Exports/RowBuilder/OrderItemRowBuilder.php
+++ b/src/Admin/Exports/RowBuilder/OrderItemRowBuilder.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\RowBuilder;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\Contracts\ExportableRowBuilderInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use WC_Order_Item;
 use WC_Order_Refund;
 
@@ -15,6 +16,26 @@ defined( 'ABSPATH' ) || exit;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\RowBuilder
  */
 class OrderItemRowBuilder implements ExportableRowBuilderInterface {
+
+	/**
+	 * @var Middleware
+	 */
+	protected $middleware;
+
+	/**
+	 * @var int|null
+	 */
+	protected $wcs_mca_id;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Middleware $middleware
+	 */
+	public function __construct( Middleware $middleware ) {
+		$this->middleware = $middleware;
+		$this->wcs_mca_id = null;
+	}
 
 	/**
 	 * Create a row of an order item for the Merchant Reported Conversions CSV.
@@ -57,7 +78,7 @@ class OrderItemRowBuilder implements ExportableRowBuilderInterface {
 			 *
 			 * @param int
 			 */
-			'gmc_merchant_id'            => get_option( 'gla_merchant_id', '' ),
+			'gmc_merchant_id'            => $this->get_google_merchant_id(),
 
 			/**
 			 * Merchant specific unique identifier of this transaction.
@@ -313,5 +334,19 @@ class OrderItemRowBuilder implements ExportableRowBuilderInterface {
 			 */
 			'reversal_reason'            => $is_refund ? $refund->get_reason() : '',
 		];
+	}
+
+	/**
+	 * Get the Google Merchant ID for gmc_merchant_id row.
+	 *
+	 * @return integer
+	 */
+	public function get_google_merchant_id() {
+		if ( null !== $this->wcs_mca_id ) {
+			return $this->wcs_mca_id;
+		}
+
+		$this->wcs_mca_id = $this->middleware->get_wcs_mca_id();
+		return $this->wcs_mca_id;
 	}
 }

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\Writer\CsvExportWr
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantReport;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidClass;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
@@ -204,7 +205,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 
 		// YouTube Merchant Reported Conversions.
 		$this->share_with_tags( YouTubeOrders::class );
-		$this->share_with_tags( OrderItemRowBuilder::class );
+		$this->share_with_tags( OrderItemRowBuilder::class, Middleware::class );
 		$this->share_with_tags( CsvExportWriter::class );
 
 		$this->share_action_scheduler_job( CreateYouTubeOrderIdsCache::class, YouTubeOrders::class, JobRepository::class );

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -656,4 +656,65 @@ class MiddlewareTest extends UnitTest {
 
 		$this->assertFalse( $this->middleware->is_subaccount() );
 	}
+
+	public function test_get_wcs_mca_id() {
+		$mca_id = 987654321;
+		$this->generate_request_mock( [ 'mcaId' => $mca_id ] );
+
+		$this->assertSame( $mca_id, $this->middleware->get_wcs_mca_id() );
+	}
+
+	public function test_get_wcs_mca_id_accepts_numeric_string() {
+		$this->generate_request_mock( [ 'mcaId' => '987654321' ] );
+
+		$this->assertSame( 987654321, $this->middleware->get_wcs_mca_id() );
+	}
+
+	/**
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function invalid_wcs_mca_id_provider(): array {
+		return [
+			'zero'         => [ 0 ],
+			'negative'     => [ -1 ],
+			'non_numeric'  => [ 'not-a-number' ],
+			'empty_string' => [ '' ],
+			'array'        => [ [] ],
+			'object'       => [ new \stdClass() ],
+		];
+	}
+
+	/**
+	 * @dataProvider invalid_wcs_mca_id_provider
+	 *
+	 * @param mixed $mca_id Invalid mcaId from the connect server response.
+	 */
+	public function test_get_wcs_mca_id_throws_when_mca_id_not_positive_integer( $mca_id ): void {
+		$this->generate_request_mock( [ 'mcaId' => $mca_id ] );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Invalid response when retrieving MCA ID from WooCommerce Connect Server.' );
+
+		$this->middleware->get_wcs_mca_id();
+	}
+
+	public function test_get_wcs_mca_id_exception() {
+		$this->generate_request_mock_exception( 'error' );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Error retrieving MCA ID from WooCommerce Connect Server' );
+		$this->expectExceptionCode( 400 );
+
+		$this->middleware->get_wcs_mca_id();
+	}
+
+	public function test_get_wcs_mca_id_invalid_http_status() {
+		$this->generate_request_mock( [ 'mcaId' => 123456 ], 'get', 500 );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Invalid response when retrieving MCA ID from WooCommerce Connect Server.' );
+		$this->expectExceptionCode( 500 );
+
+		$this->middleware->get_wcs_mca_id();
+	}
 }

--- a/tests/Unit/Admin/Exports/RowBuilder/OrderItemRowBuilderTest.php
+++ b/tests/Unit/Admin/Exports/RowBuilder/OrderItemRowBuilderTest.php
@@ -4,7 +4,9 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin\Exports\RowBuilder;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\RowBuilder\OrderItemRowBuilder;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Exception;
 use WC_Helper_Product;
 use WC_Helper_Order;
 use WC_Helper_Coupon;
@@ -18,15 +20,21 @@ use WC_Order_Item_Coupon;
  */
 class OrderItemRowBuilderTest extends UnitTest {
 	/** @var OrderItemRowBuilder $builder */
-	protected static $builder;
+	protected $builder;
 
-	public static function setUpBeforeClass(): void {
-		parent::setUpBeforeClass();
-		self::$builder = new OrderItemRowBuilder();
+	/** @var MockObject|Middleware $middleware */
+	protected $middleware;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->middleware = $this->createMock( Middleware::class );
+
+		$this->builder = new OrderItemRowBuilder( $this->middleware );
 	}
 
 	public function test_returns_null_if_instance_not_wc_order_item() {
-		$row = self::$builder->build_row( [] );
+		$row = $this->builder->build_row( [] );
 
 		$this->assertNull( $row );
 	}
@@ -73,7 +81,7 @@ class OrderItemRowBuilderTest extends UnitTest {
 		$order->save();
 
 		// Build the CSV row.
-		$row = self::$builder->build_row( $item );
+		$row = $this->builder->build_row( $item );
 
 		// Assert.
 		$this->assertEquals( $row['transaction_type'], 'purchase' );
@@ -149,7 +157,7 @@ class OrderItemRowBuilderTest extends UnitTest {
 		$refund_item = array_values( $refund->get_items() )[0];
 
 		// Build the CSV row.
-		$row = self::$builder->build_row( $refund_item );
+		$row = $this->builder->build_row( $refund_item );
 
 		// Assert.
 		$this->assertEquals( $row['transaction_type'], 'refund' );
@@ -173,5 +181,56 @@ class OrderItemRowBuilderTest extends UnitTest {
 		$this->assertEquals( $row['country_code'], 'US' );
 		$this->assertEquals( $row['subaccount_id'], '' );
 		$this->assertEquals( $row['reversal_reason'], 'Test refund' );
+	}
+
+	public function test_exception_thrown_if_mca_id_cannot_be_retrieved() {
+		$this->middleware->method( 'get_wcs_mca_id' )
+			->willThrowException( new Exception( 'Invalid response when retrieving MCA ID from WooCommerce Connect Server.' ) );
+
+		// Create a test product.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 50 );
+		$product->set_sale_price( 40 );
+		$product->save();
+
+		// Create a test order.
+		$order = WC_Helper_Order::create_order();
+
+		// Remove the auto-added default item
+		foreach ( $order->get_items() as $existing_item ) {
+			$order->remove_item( $existing_item->get_id() );
+		}
+
+		// Add test product to the test order.
+		$item = new WC_Order_Item_Product();
+		$item->set_product( $product );
+		$item->set_quantity( 2 );
+		$item->set_total( 80 );
+		$item->set_subtotal( 100 );
+		$order->add_item( $item );
+
+		// Add a coupon.
+		$coupon      = WC_Helper_Coupon::create_coupon();
+		$coupon_item = new WC_Order_Item_Coupon();
+		$coupon_item->set_code( $coupon->get_code() );
+		$coupon_item->set_discount( 10 );
+		$order->add_item( $coupon_item );
+
+		// Add tax and shipping.
+		$order->set_shipping_total( 10 );
+
+		// Add attribution metadata.
+		$order->update_meta_data( '_wc_order_attribution_utm_source', 'youtube' );
+		$order->update_meta_data( '_wc_order_attribution_utm_content', 'YT-TEST-ID' );
+		$order->update_meta_data( '_wc_order_attribution_session_entry', 'https://example.com?utm_content=YT-TEST-ID' );
+
+		$order->calculate_totals();
+		$order->save();
+
+		$this->expectException( \Exception::class );
+		$this->expectExceptionMessage( 'Invalid response when retrieving MCA ID from WooCommerce Connect Server.' );
+
+		// Build the CSV row.
+		$this->builder->build_row( $item );
 	}
 }

--- a/tests/Unit/Admin/Exports/RowBuilder/OrderItemRowBuilderTest.php
+++ b/tests/Unit/Admin/Exports/RowBuilder/OrderItemRowBuilderTest.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\RowBuilder\OrderIt
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
 use WC_Helper_Product;
 use WC_Helper_Order;
 use WC_Helper_Coupon;
@@ -19,6 +20,9 @@ use WC_Order_Item_Coupon;
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin\Exports\RowBuilder
  */
 class OrderItemRowBuilderTest extends UnitTest {
+
+	protected const TEST_WCS_MCA_ID = 987654321;
+
 	/** @var OrderItemRowBuilder $builder */
 	protected $builder;
 
@@ -80,11 +84,14 @@ class OrderItemRowBuilderTest extends UnitTest {
 		$order->calculate_totals();
 		$order->save();
 
+		$this->middleware->method( 'get_wcs_mca_id' )->willReturn( self::TEST_WCS_MCA_ID );
+
 		// Build the CSV row.
 		$row = $this->builder->build_row( $item );
 
 		// Assert.
 		$this->assertEquals( $row['transaction_type'], 'purchase' );
+		$this->assertSame( self::TEST_WCS_MCA_ID, $row['gmc_merchant_id'] );
 		$this->assertEquals( $row['transaction_id'], $order->get_id() );
 		$this->assertEquals( $row['item_id'], $item->get_product_id() );
 		$this->assertEquals( $row['item_name'], $product->get_name() );
@@ -138,6 +145,8 @@ class OrderItemRowBuilderTest extends UnitTest {
 		$order->calculate_totals();
 		$order->save();
 
+		$this->middleware->method( 'get_wcs_mca_id' )->willReturn( self::TEST_WCS_MCA_ID );
+
 		// Add the refund.
 		$refund = wc_create_refund(
 			[
@@ -161,6 +170,7 @@ class OrderItemRowBuilderTest extends UnitTest {
 
 		// Assert.
 		$this->assertEquals( $row['transaction_type'], 'refund' );
+		$this->assertSame( self::TEST_WCS_MCA_ID, $row['gmc_merchant_id'] );
 		$this->assertEquals( $row['transaction_id'], $refund->get_id() );
 		$this->assertEquals( $row['item_id'], $item->get_product_id() );
 		$this->assertEquals( $row['item_name'], $product->get_name() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-552/update-gmc-merchant-id-for-youtube-shopping

- Add new method to Middleware to retrieve the MCA ID for the WooCommerce Connect Server.
- Use the ID in the YouTube Shopping conversion reports.


### Detailed test instructions:

1. Make sure the Order Attribution setting is enabled in WooCommerce > Settings > Advanced > Features
2. Create at least 1 orders via a YouTube link by visiting the test using the the correct UTM query parameters. For example https://www.example.com/product/item?utm_source=youtube&utm_content=YT3-test-attribution.
3. Use the woocommerce_gla_youtube_order_ids_job_date filter to return the date matching when both orders were created. The date returned should be a string following the format Y-m-d, e.g 2025-12-01.
4. Schedule and run the job CreateYouTubeOrderIdsCache. This will capture the order IDs needed for the export and save them to the options table under the key youtube_export_order_ids. Once the job is complete, the CreateMerchantReportedConversionReport job will run immediately after.
5. The CreateMerchantReportedConversionReport job will create the CSV which can be found in the /wp-content/uploads/gla-exports/youtube-merchant-conversion-report-{date}.csv where is the same date used in the filter (eg 2026-04-09).

Check the following:
- A CSV was generated successfully and remains the `gla-exports` folder.
- The `gmc_merchant_id` row has the correct MCA ID for all order rows.

### Changelog entry

> Fix - Update gmc_merchant_id in YouTube Shopping reports.
