### PR TITLE
[PoC] Replace league/container with a lightweight custom DI container

### DIFF
--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -37,11 +37,6 @@ $packages = [
 		'strict'    => false,
 	],
 	[
-		'namespace' => 'League\\Container',
-		'package'   => 'league/container',
-		'strict'    => false,
-	],
-	[
 		'namespace' => 'League\\ISO3166',
 		'package'   => 'league/iso3166',
 		'strict'    => false,
@@ -94,9 +89,6 @@ $dependencies = [
 		'google/apiclient',
 		'google/auth',
 		'google/gax',
-	],
-	'psr/container'    => [
-		'league/container',
 	],
 	'psr/http-client'  => [
 		'firebase/php-jwt',

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
 		"google/apiclient": "^2.16",
 		"google/apiclient-services": "^0.350.0",
 		"googleads/google-ads-php": "dev-legacy-v31.1.0",
-		"league/container": "^4.2",
 		"league/iso3166": "^4.1",
 		"phpseclib/bcmath_compat": "^2.0",
 		"psr/container": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29f7915131697943e319a56e9a05e9a0",
+    "content-hash": "024620cd97ceb83b00f5be6c9ea36022",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -823,88 +823,6 @@
                 }
             ],
             "time": "2025-08-23T21:21:41+00:00"
-        },
-        {
-            "name": "league/container",
-            "version": "4.2.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/container.git",
-                "reference": "d3cebb0ff4685ff61c749e54b27db49319e2ec00"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/container/zipball/d3cebb0ff4685ff61c749e54b27db49319e2ec00",
-                "reference": "d3cebb0ff4685ff61c749e54b27db49319e2ec00",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0",
-                "psr/container": "^1.1 || ^2.0"
-            },
-            "provide": {
-                "psr/container-implementation": "^1.0"
-            },
-            "replace": {
-                "orno/di": "~2.0"
-            },
-            "require-dev": {
-                "nette/php-generator": "^3.4",
-                "nikic/php-parser": "^4.10",
-                "phpstan/phpstan": "^0.12.47",
-                "phpunit/phpunit": "^8.5.17",
-                "roave/security-advisories": "dev-latest",
-                "scrutinizer/ocular": "^1.8",
-                "squizlabs/php_codesniffer": "^3.6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev",
-                    "dev-2.x": "2.x-dev",
-                    "dev-3.x": "3.x-dev",
-                    "dev-4.x": "4.x-dev",
-                    "dev-master": "4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "League\\Container\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Phil Bennett",
-                    "email": "mail@philbennett.co.uk",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A fast and intuitive dependency injection container.",
-            "homepage": "https://github.com/thephpleague/container",
-            "keywords": [
-                "container",
-                "dependency",
-                "di",
-                "injection",
-                "league",
-                "provider",
-                "service"
-            ],
-            "support": {
-                "issues": "https://github.com/thephpleague/container/issues",
-                "source": "https://github.com/thephpleague/container/tree/4.2.5"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/philipobenito",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-05-20T12:55:37+00:00"
         },
         {
             "name": "league/iso3166",
@@ -5426,5 +5344,5 @@
     "platform-overrides": {
         "php": "7.4.30"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -93,7 +93,7 @@ final class Container implements ContainerInterface {
 		// Classes that implement ContainerAwareInterface receive the
 		// container via set_container() immediately after construction.
 		$this->container->inflector( ContainerAwareInterface::class )
-			->invokeMethod( 'set_container', [ ContainerInterface::class ] );
+			->invoke_method( 'set_container', [ ContainerInterface::class ] );
 
 		foreach ( $this->service_providers as $service_provider_class ) {
 			$service_provider = new $service_provider_class();

--- a/src/Container.php
+++ b/src/Container.php
@@ -6,6 +6,7 @@
 namespace Automattic\WooCommerce\GoogleListingsAndAds;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\AdminServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\CoreServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\DBServiceProvider;
@@ -16,10 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\Pr
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\RESTServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\ThirdPartyServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container as LeagueContainer;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerExceptionInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\NotFoundExceptionInterface;
 
 /**
  * PSR11 compliant dependency injection container for Google for WooCommerce.
@@ -33,9 +31,26 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\NotFoundExc
  * can be used directly.
  *
  * Class registration should be done via service providers that inherit from
- * \Automattic\WooCommerce\Internal\DependencyManagement and those should go in the
- * `src/Internal/DependencyManagement/ServiceProviders` folder unless there's a good reason to put them elsewhere.
- * All the service provider class names must be in the `$service_providers` array.
+ * Internal\DependencyManagement\AbstractServiceProvider and live under
+ * src/Internal/DependencyManagement/. All concrete provider classes must be listed in $service_providers.
+ *
+ * ---
+ *
+ * This class is a thin PSR-11 adapter on top of PluginContainer. The real
+ * container logic (definitions, arguments resolution, inflectors, tagging)
+ * lives in Internal\Container\PluginContainer. This class:
+ *
+ *   1. Constructs a PluginContainer instance.
+ *   2. Registers itself on that inner container as ContainerInterface::class,
+ *      so any service that depends on ContainerInterface receives this
+ *      public wrapper (not the internal implementation).
+ *   3. Installs the ContainerAwareInterface inflector so classes implementing
+ *      that interface have set_container() called after construction.
+ *   4. Eagerly instantiates every configured ServiceProvider, respects the
+ *      Conditional::is_needed() gate, and passes each one through
+ *      addServiceProvider() — which calls the provider's register() method
+ *      immediately. Unlike the previous League-based implementation, there
+ *      is no deferred booting.
  */
 final class Container implements ContainerInterface {
 
@@ -57,20 +72,26 @@ final class Container implements ContainerInterface {
 	];
 
 	/**
-	 * The underlying container.
+	 * The underlying plugin container.
 	 *
-	 * @var LeagueContainer
+	 * @var PluginContainer
 	 */
 	private $container;
 
 	/**
 	 * Container constructor.
-	 *
-	 * @param LeagueContainer|null $container
 	 */
-	public function __construct( ?LeagueContainer $container = null ) {
-		$this->container = $container ?? new LeagueContainer();
+	public function __construct() {
+		$this->container = new PluginContainer();
+
+		// Any service that depends on ContainerInterface receives this
+		// wrapper, not the inner container. Callers use only PSR-11 methods
+		// so the wrapper is a complete substitute for the inner container
+		// from the outside.
 		$this->container->addShared( ContainerInterface::class, $this );
+
+		// Classes that implement ContainerAwareInterface receive the
+		// container via set_container() immediately after construction.
 		$this->container->inflector( ContainerAwareInterface::class )
 			->invokeMethod( 'set_container', [ ContainerInterface::class ] );
 
@@ -81,6 +102,8 @@ final class Container implements ContainerInterface {
 				continue;
 			}
 
+			// Eager registration: this immediately calls the provider's
+			// register() method and wires up all its bindings.
 			$this->container->addServiceProvider( $service_provider );
 		}
 	}
@@ -90,8 +113,8 @@ final class Container implements ContainerInterface {
 	 *
 	 * @param string $id Identifier of the entry to look for.
 	 *
-	 * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
-	 * @throws ContainerExceptionInterface Error while retrieving the entry.
+	 * @throws \Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\NotFoundExceptionInterface  No entry was found for **this** identifier.
+	 * @throws \Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerExceptionInterface Error while retrieving the entry.
 	 *
 	 * @return mixed Entry.
 	 */
@@ -104,7 +127,7 @@ final class Container implements ContainerInterface {
 	 * Returns false otherwise.
 	 *
 	 * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
-	 * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
+	 * It does however mean that `get($id)` will not throw a NotFoundExceptionInterface.
 	 *
 	 * @param string $id Identifier of the entry to look for.
 	 *

--- a/src/Infrastructure/GoogleListingsAndAdsPlugin.php
+++ b/src/Infrastructure/GoogleListingsAndAdsPlugin.php
@@ -88,7 +88,13 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 		add_action(
 			self::SERVICE_REGISTRATION_HOOK,
 			function () {
+				if(function_exists('spx_profiler_start')) {
+					spx_profiler_start();
+				}
 				$this->maybe_register_services();
+				if(function_exists('spx_profiler_stop')) {
+					spx_profiler_stop();
+				}
 			},
 			20
 		);

--- a/src/Infrastructure/GoogleListingsAndAdsPlugin.php
+++ b/src/Infrastructure/GoogleListingsAndAdsPlugin.php
@@ -88,11 +88,11 @@ final class GoogleListingsAndAdsPlugin implements Plugin {
 		add_action(
 			self::SERVICE_REGISTRATION_HOOK,
 			function () {
-				if(function_exists('spx_profiler_start')) {
+				if ( function_exists( 'spx_profiler_start' ) ) {
 					spx_profiler_start();
 				}
 				$this->maybe_register_services();
-				if(function_exists('spx_profiler_stop')) {
+				if ( function_exists( 'spx_profiler_stop' ) ) {
 					spx_profiler_stop();
 				}
 			},

--- a/src/Internal/Container/ContainerException.php
+++ b/src/Internal/Container/ContainerException.php
@@ -1,0 +1,16 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerExceptionInterface;
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Thrown for container errors that are not "not found" — for example,
+ * trying to instantiate an abstract class or a circular dependency.
+ */
+class ContainerException extends Exception implements ContainerExceptionInterface {
+}

--- a/src/Internal/Container/Definition.php
+++ b/src/Internal/Container/Definition.php
@@ -66,9 +66,9 @@ class Definition {
 
 		// Unwrap nested Definition wrappers. Providers sometimes build a
 		// Definition to pass to share_concrete():
-		//   share_concrete( X::class, new Definition( X::class, $closure ) )
+		// share_concrete( X::class, new Definition( X::class, $closure ) )
 		// We flatten that into this definition so the caller can still chain
-		// addMethodCall() etc. on what they receive.
+		// add_method_call() etc. on what they receive.
 		if ( $concrete instanceof self ) {
 			$this->concrete     = $concrete->concrete;
 			$this->arguments    = $concrete->arguments;
@@ -80,15 +80,25 @@ class Definition {
 		$this->concrete = $concrete ?? $id;
 	}
 
-	public function getId(): string {
+	/**
+	 * @return string
+	 */
+	public function get_id(): string {
 		return $this->id;
 	}
 
-	public function isShared(): bool {
+	/**
+	 * @return bool
+	 */
+	public function is_shared(): bool {
 		return $this->shared;
 	}
 
-	public function setShared( bool $shared ): self {
+	/**
+	 * @param bool $shared
+	 * @return self
+	 */
+	public function set_shared( bool $shared ): self {
 		$this->shared = $shared;
 		return $this;
 	}
@@ -96,15 +106,23 @@ class Definition {
 	/**
 	 * @return array<int, string>
 	 */
-	public function getTags(): array {
+	public function get_tags(): array {
 		return $this->tags;
 	}
 
-	public function hasTag( string $tag ): bool {
+	/**
+	 * @param string $tag
+	 * @return bool
+	 */
+	public function has_tag( string $tag ): bool {
 		return in_array( $tag, $this->tags, true );
 	}
 
-	public function addTag( string $tag ): self {
+	/**
+	 * @param string $tag
+	 * @return self
+	 */
+	public function add_tag( string $tag ): self {
 		if ( ! in_array( $tag, $this->tags, true ) ) {
 			$this->tags[] = $tag;
 		}
@@ -115,8 +133,9 @@ class Definition {
 	 * Append a single positional argument.
 	 *
 	 * @param mixed $argument
+	 * @return self
 	 */
-	public function addArgument( $argument ): self {
+	public function add_argument( $argument ): self {
 		$this->arguments[] = $argument;
 		return $this;
 	}
@@ -125,8 +144,9 @@ class Definition {
 	 * Append multiple positional arguments.
 	 *
 	 * @param array<int, mixed> $arguments
+	 * @return self
 	 */
-	public function addArguments( array $arguments ): self {
+	public function add_arguments( array $arguments ): self {
 		foreach ( $arguments as $argument ) {
 			$this->arguments[] = $argument;
 		}
@@ -137,10 +157,11 @@ class Definition {
 	 * Register a method to call on the built instance, with arguments that
 	 * will be resolved through the container at build time.
 	 *
-	 * @param string             $method
-	 * @param array<int, mixed>  $args
+	 * @param string            $method
+	 * @param array<int, mixed> $args
+	 * @return self
 	 */
-	public function addMethodCall( string $method, array $args = [] ): self {
+	public function add_method_call( string $method, array $args = [] ): self {
 		$this->method_calls[] = [
 			'method' => $method,
 			'args'   => $args,
@@ -152,6 +173,7 @@ class Definition {
 	 * Build the instance (or return the literal value) this definition
 	 * represents.
 	 *
+	 * @param PluginContainer $container
 	 * @return mixed
 	 */
 	public function build( PluginContainer $container ) {
@@ -182,16 +204,19 @@ class Definition {
 	}
 
 	/**
+	 * @param string          $class_name
+	 * @param PluginContainer $container
 	 * @return object
+	 * @throws ContainerException When the class cannot be instantiated or arguments are insufficient.
 	 */
-	private function instantiate_class( string $class, PluginContainer $container ) {
-		$reflection = new ReflectionClass( $class );
+	private function instantiate_class( string $class_name, PluginContainer $container ) {
+		$reflection = new ReflectionClass( $class_name );
 
 		if ( ! $reflection->isInstantiable() ) {
 			throw new ContainerException(
 				sprintf(
 					'Cannot instantiate %s while building "%s": class is abstract, an interface, or has a non-public constructor.',
-					$class,
+					$class_name,
 					$this->id
 				)
 			);
@@ -205,7 +230,7 @@ class Definition {
 				throw new ContainerException(
 					sprintf(
 						'%s has no constructor but %d argument(s) were declared in the definition for "%s".',
-						$class,
+						$class_name,
 						count( $this->arguments ),
 						$this->id
 					)
@@ -227,7 +252,7 @@ class Definition {
 				sprintf(
 					'Not enough arguments to instantiate %s (binding "%s"): %d required, %d provided. ' .
 					'Declare the missing dependencies in the provider\'s share()/add() call.',
-					$class,
+					$class_name,
 					$this->id,
 					$required,
 					count( $this->arguments )
@@ -237,15 +262,16 @@ class Definition {
 
 		$resolved = $container->resolve_arguments(
 			$this->arguments,
-			sprintf( '%s::__construct', $class )
+			sprintf( '%s::__construct', $class_name )
 		);
 
 		return $reflection->newInstanceArgs( $resolved );
 	}
 
 	/**
-	 * @param object $instance
-	 * @return object
+	 * @param mixed           $instance
+	 * @param PluginContainer $container
+	 * @return mixed
 	 */
 	private function apply_method_calls( $instance, PluginContainer $container ) {
 		if ( empty( $this->method_calls ) ) {

--- a/src/Internal/Container/Definition.php
+++ b/src/Internal/Container/Definition.php
@@ -1,0 +1,266 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container;
+
+use Closure;
+use ReflectionClass;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * A binding definition.
+ *
+ * Holds the metadata a service provider declares via share()/add(): the id,
+ * the concrete value (class name, closure, object, or literal), the
+ * constructor-argument list, method-call list, tags, and shared flag.
+ *
+ * `build()` produces the actual instance when the container asks for it.
+ */
+class Definition {
+
+	/**
+	 * @var string
+	 */
+	private $id;
+
+	/**
+	 * What this definition produces when resolved. May be a class name
+	 * string, a Closure factory, an already-constructed object, or a literal
+	 * value (scalar, array, or non-class string).
+	 *
+	 * @var mixed
+	 */
+	private $concrete;
+
+	/**
+	 * Positional constructor arguments (or factory arguments for closures).
+	 *
+	 * @var array<int, mixed>
+	 */
+	private $arguments = [];
+
+	/**
+	 * Method calls to run after construction.
+	 *
+	 * @var array<int, array{method:string, args:array}>
+	 */
+	private $method_calls = [];
+
+	/**
+	 * @var array<int, string>
+	 */
+	private $tags = [];
+
+	/**
+	 * @var bool
+	 */
+	private $shared = false;
+
+	/**
+	 * @param string $id       The container identifier this definition is bound to.
+	 * @param mixed  $concrete The concrete value. null means "use $id as a class name".
+	 */
+	public function __construct( string $id, $concrete = null ) {
+		$this->id = $id;
+
+		// Unwrap nested Definition wrappers. Providers sometimes build a
+		// Definition to pass to share_concrete():
+		//   share_concrete( X::class, new Definition( X::class, $closure ) )
+		// We flatten that into this definition so the caller can still chain
+		// addMethodCall() etc. on what they receive.
+		if ( $concrete instanceof self ) {
+			$this->concrete     = $concrete->concrete;
+			$this->arguments    = $concrete->arguments;
+			$this->method_calls = $concrete->method_calls;
+			$this->tags         = $concrete->tags;
+			return;
+		}
+
+		$this->concrete = $concrete ?? $id;
+	}
+
+	public function getId(): string {
+		return $this->id;
+	}
+
+	public function isShared(): bool {
+		return $this->shared;
+	}
+
+	public function setShared( bool $shared ): self {
+		$this->shared = $shared;
+		return $this;
+	}
+
+	/**
+	 * @return array<int, string>
+	 */
+	public function getTags(): array {
+		return $this->tags;
+	}
+
+	public function hasTag( string $tag ): bool {
+		return in_array( $tag, $this->tags, true );
+	}
+
+	public function addTag( string $tag ): self {
+		if ( ! in_array( $tag, $this->tags, true ) ) {
+			$this->tags[] = $tag;
+		}
+		return $this;
+	}
+
+	/**
+	 * Append a single positional argument.
+	 *
+	 * @param mixed $argument
+	 */
+	public function addArgument( $argument ): self {
+		$this->arguments[] = $argument;
+		return $this;
+	}
+
+	/**
+	 * Append multiple positional arguments.
+	 *
+	 * @param array<int, mixed> $arguments
+	 */
+	public function addArguments( array $arguments ): self {
+		foreach ( $arguments as $argument ) {
+			$this->arguments[] = $argument;
+		}
+		return $this;
+	}
+
+	/**
+	 * Register a method to call on the built instance, with arguments that
+	 * will be resolved through the container at build time.
+	 *
+	 * @param string             $method
+	 * @param array<int, mixed>  $args
+	 */
+	public function addMethodCall( string $method, array $args = [] ): self {
+		$this->method_calls[] = [
+			'method' => $method,
+			'args'   => $args,
+		];
+		return $this;
+	}
+
+	/**
+	 * Build the instance (or return the literal value) this definition
+	 * represents.
+	 *
+	 * @return mixed
+	 */
+	public function build( PluginContainer $container ) {
+		$concrete = $this->concrete;
+
+		// Closure → factory. Pass the container for classes that want to
+		// resolve things dynamically inside their factory.
+		if ( $concrete instanceof Closure ) {
+			$instance = $concrete( $container );
+			return $this->apply_method_calls( $instance, $container );
+		}
+
+		// Already an object → use it as-is.
+		if ( is_object( $concrete ) ) {
+			return $this->apply_method_calls( $concrete, $container );
+		}
+
+		// String concretes that name an actual class or interface → build
+		// via reflection with the configured arguments.
+		if ( is_string( $concrete ) && ( class_exists( $concrete ) || interface_exists( $concrete ) ) ) {
+			$instance = $this->instantiate_class( $concrete, $container );
+			return $this->apply_method_calls( $instance, $container );
+		}
+
+		// Everything else (non-class strings, scalars, arrays, null) is a
+		// literal value. Return as-is; method calls don't make sense here.
+		return $concrete;
+	}
+
+	/**
+	 * @return object
+	 */
+	private function instantiate_class( string $class, PluginContainer $container ) {
+		$reflection = new ReflectionClass( $class );
+
+		if ( ! $reflection->isInstantiable() ) {
+			throw new ContainerException(
+				sprintf(
+					'Cannot instantiate %s while building "%s": class is abstract, an interface, or has a non-public constructor.',
+					$class,
+					$this->id
+				)
+			);
+		}
+
+		$constructor = $reflection->getConstructor();
+
+		// No constructor → nothing to resolve, nothing to re-enter.
+		if ( null === $constructor ) {
+			if ( ! empty( $this->arguments ) ) {
+				throw new ContainerException(
+					sprintf(
+						'%s has no constructor but %d argument(s) were declared in the definition for "%s".',
+						$class,
+						count( $this->arguments ),
+						$this->id
+					)
+				);
+			}
+			return $reflection->newInstance();
+		}
+
+		// Verify we either have args for every required parameter, or those
+		// parameters have defaults we can rely on.
+		$required = 0;
+		foreach ( $constructor->getParameters() as $param ) {
+			if ( ! $param->isOptional() ) {
+				++$required;
+			}
+		}
+		if ( count( $this->arguments ) < $required ) {
+			throw new ContainerException(
+				sprintf(
+					'Not enough arguments to instantiate %s (binding "%s"): %d required, %d provided. ' .
+					'Declare the missing dependencies in the provider\'s share()/add() call.',
+					$class,
+					$this->id,
+					$required,
+					count( $this->arguments )
+				)
+			);
+		}
+
+		$resolved = $container->resolve_arguments(
+			$this->arguments,
+			sprintf( '%s::__construct', $class )
+		);
+
+		return $reflection->newInstanceArgs( $resolved );
+	}
+
+	/**
+	 * @param object $instance
+	 * @return object
+	 */
+	private function apply_method_calls( $instance, PluginContainer $container ) {
+		if ( empty( $this->method_calls ) ) {
+			return $instance;
+		}
+		if ( ! is_object( $instance ) ) {
+			return $instance;
+		}
+		foreach ( $this->method_calls as $call ) {
+			$resolved = $container->resolve_arguments(
+				$call['args'],
+				sprintf( '%s::%s()', get_class( $instance ), $call['method'] )
+			);
+			$instance->{$call['method']}( ...$resolved );
+		}
+		return $instance;
+	}
+}

--- a/src/Internal/Container/Inflector.php
+++ b/src/Internal/Container/Inflector.php
@@ -1,0 +1,75 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Post-construction setter injection for every instance that implements a
+ * given interface.
+ *
+ * Used by providers via:
+ *
+ *     $this->getContainer()
+ *         ->inflector( OptionsAwareInterface::class )
+ *         ->invokeMethod( 'set_options_object', [ OptionsInterface::class ] );
+ *
+ * The container calls Inflector::inflect() on every just-built instance, so
+ * every *AwareInterface-implementing service gets its setter called with the
+ * resolved dependency, without having to thread that dependency through its
+ * constructor.
+ */
+class Inflector {
+
+	/**
+	 * The interface (or parent class) an instance must implement for this
+	 * inflector to apply.
+	 *
+	 * @var string
+	 */
+	private $type;
+
+	/**
+	 * @var array<int, array{method:string, args:array}>
+	 */
+	private $method_calls = [];
+
+	public function __construct( string $type ) {
+		$this->type = $type;
+	}
+
+	public function getType(): string {
+		return $this->type;
+	}
+
+	/**
+	 * Register a setter method to call on matching instances. Arguments are
+	 * resolved through the container at inflection time, just like
+	 * constructor arguments.
+	 *
+	 * @param string            $method
+	 * @param array<int, mixed> $args
+	 */
+	public function invokeMethod( string $method, array $args = [] ): self {
+		$this->method_calls[] = [
+			'method' => $method,
+			'args'   => $args,
+		];
+		return $this;
+	}
+
+	public function applies( object $instance ): bool {
+		return $instance instanceof $this->type;
+	}
+
+	public function inflect( object $instance, PluginContainer $container ): void {
+		foreach ( $this->method_calls as $call ) {
+			$resolved = $container->resolve_arguments(
+				$call['args'],
+				sprintf( 'inflector %s::%s()', $this->type, $call['method'] )
+			);
+			$instance->{$call['method']}( ...$resolved );
+		}
+	}
+}

--- a/src/Internal/Container/Inflector.php
+++ b/src/Internal/Container/Inflector.php
@@ -11,9 +11,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * Used by providers via:
  *
- *     $this->getContainer()
+ *     $this->get_container()
  *         ->inflector( OptionsAwareInterface::class )
- *         ->invokeMethod( 'set_options_object', [ OptionsInterface::class ] );
+ *         ->invoke_method( 'set_options_object', [ OptionsInterface::class ] );
  *
  * The container calls Inflector::inflect() on every just-built instance, so
  * every *AwareInterface-implementing service gets its setter called with the
@@ -35,11 +35,17 @@ class Inflector {
 	 */
 	private $method_calls = [];
 
+	/**
+	 * @param string $type Interface or class name instances must implement.
+	 */
 	public function __construct( string $type ) {
 		$this->type = $type;
 	}
 
-	public function getType(): string {
+	/**
+	 * @return string
+	 */
+	public function get_type(): string {
 		return $this->type;
 	}
 
@@ -50,8 +56,9 @@ class Inflector {
 	 *
 	 * @param string            $method
 	 * @param array<int, mixed> $args
+	 * @return self
 	 */
-	public function invokeMethod( string $method, array $args = [] ): self {
+	public function invoke_method( string $method, array $args = [] ): self {
 		$this->method_calls[] = [
 			'method' => $method,
 			'args'   => $args,
@@ -59,10 +66,18 @@ class Inflector {
 		return $this;
 	}
 
+	/**
+	 * @param object $instance
+	 * @return bool
+	 */
 	public function applies( object $instance ): bool {
 		return $instance instanceof $this->type;
 	}
 
+	/**
+	 * @param object          $instance
+	 * @param PluginContainer $container
+	 */
 	public function inflect( object $instance, PluginContainer $container ): void {
 		foreach ( $this->method_calls as $call ) {
 			$resolved = $container->resolve_arguments(

--- a/src/Internal/Container/NotFoundException.php
+++ b/src/Internal/Container/NotFoundException.php
@@ -1,0 +1,18 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\NotFoundExceptionInterface;
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Thrown when the container cannot resolve a requested identifier.
+ *
+ * Implements PSR-11's NotFoundExceptionInterface so callers can rely on the
+ * standard contract regardless of which container implementation produced it.
+ */
+class NotFoundException extends Exception implements NotFoundExceptionInterface {
+}

--- a/src/Internal/Container/PluginContainer.php
+++ b/src/Internal/Container/PluginContainer.php
@@ -1,0 +1,339 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * The plugin's dependency-injection container.
+ *
+ * Replaces league/container with a simpler implementation tuned to how this
+ * plugin actually uses DI. The public API is deliberately compatible with
+ * the subset of League's API the service providers rely on — share()/add(),
+ * addShared()/add() with a concrete, addServiceProvider(), and inflector() —
+ * so providers don't need to change.
+ *
+ * Key design differences from League:
+ *
+ *   1. Eager provider registration. addServiceProvider() immediately calls
+ *      the provider's register() method. There is no deferred-boot mechanism
+ *      and no $provides array. This eliminates a whole class of ordering
+ *      bugs where has() would return false for a deferred binding and cause
+ *      its string ID to be passed literally as a constructor argument.
+ *
+ *   2. Strict argument resolution. When a definition lists a string as a
+ *      constructor/method argument, the container treats it as a container
+ *      ID if a binding exists, passes it through as a literal if it's not
+ *      a known class or interface name, and throws NotFoundException if it
+ *      IS a known class/interface but no binding exists. This makes the
+ *      BatchProductHelper → AttributeMappingRulesQuery class of bugs
+ *      impossible — you get an explicit error at the point of the missing
+ *      binding instead of a mystery TypeError later.
+ *
+ *   3. No autowiring. Constructor arguments must be declared explicitly in
+ *      the provider's share()/add() call. (This matches the current plugin
+ *      behaviour, which never enabled League's ReflectionContainer delegate.)
+ *
+ *   4. No cycle detection. A service whose constructor triggers WordPress
+ *      hooks that transitively need the same service is a legitimate
+ *      pattern (see RESTServer + rest_api_init) and the recursion
+ *      terminates naturally. Genuine circular dependencies (A ctor wants
+ *      B, B ctor wants A) would infinite-recurse and be surfaced by PHP's
+ *      stack limit — the same behaviour as league/container.
+ */
+class PluginContainer implements ContainerInterface {
+
+	/**
+	 * Map of id → Definition.
+	 *
+	 * @var array<string, Definition>
+	 */
+	private $definitions = [];
+
+	/**
+	 * Cache of already-built instances for shared definitions.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $shared_instances = [];
+
+	/**
+	 * Map of tag name → list of ids tagged with it.
+	 *
+	 * @var array<string, array<int, string>>
+	 */
+	private $tags = [];
+
+	/**
+	 * Inflectors, keyed by the interface/class they match.
+	 *
+	 * @var array<string, Inflector>
+	 */
+	private $inflectors = [];
+
+
+	/**
+	 * Whether the tag index may be stale. Set to true whenever a definition
+	 * is added (which might be followed by Definition::addTag() chaining
+	 * that the container can't observe directly). Reset to false whenever
+	 * the tag index is fully rebuilt.
+	 *
+	 * @var bool
+	 */
+	private $tags_dirty = false;
+
+	// -------------------------------------------------------------------- //
+	// Registration API (called by providers during register())              //
+	// -------------------------------------------------------------------- //
+
+	/**
+	 * Register a transient binding. Each get() returns a new instance.
+	 *
+	 * @param string $id       Container identifier (typically a class or interface name).
+	 * @param mixed  $concrete Optional concrete. If null, $id is treated as the class to instantiate.
+	 */
+	public function add( string $id, $concrete = null ): Definition {
+		$definition = new Definition( $id, $concrete );
+		$definition->setShared( false );
+		$this->definitions[ $id ] = $definition;
+		$this->tags_dirty         = true;
+		return $definition;
+	}
+
+	/**
+	 * Register a shared (singleton) binding. The instance is built on first
+	 * get() and cached for subsequent calls.
+	 *
+	 * @param string $id       Container identifier.
+	 * @param mixed  $concrete Optional concrete. If null, $id is treated as the class to instantiate.
+	 */
+	public function addShared( string $id, $concrete = null ): Definition {
+		$definition = new Definition( $id, $concrete );
+		$definition->setShared( true );
+		$this->definitions[ $id ] = $definition;
+		$this->tags_dirty         = true;
+		return $definition;
+	}
+
+	/**
+	 * Return the inflector for the given type, creating one on first use.
+	 *
+	 * @param string $type Interface or class name. Instances matching this
+	 *                     type will have the inflector's method calls
+	 *                     applied after construction.
+	 */
+	public function inflector( string $type ): Inflector {
+		if ( ! isset( $this->inflectors[ $type ] ) ) {
+			$this->inflectors[ $type ] = new Inflector( $type );
+		}
+		return $this->inflectors[ $type ];
+	}
+
+	/**
+	 * Register a service provider and eagerly call its register() method.
+	 *
+	 * Unlike League, there is no deferred booting — providers are registered
+	 * in the order they are added.
+	 */
+	public function addServiceProvider( ServiceProvider $provider ): void {
+		$provider->setContainer( $this );
+		$provider->register();
+	}
+
+	// -------------------------------------------------------------------- //
+	// PSR-11 resolution API                                                  //
+	// -------------------------------------------------------------------- //
+
+	/**
+	 * Resolve an identifier.
+	 *
+	 * Resolution order:
+	 *   1. Pre-built shared instance cache.
+	 *   2. Direct definition (built now, cached if shared).
+	 *   3. Tag collection (array of all instances tagged with $id).
+	 *
+	 * @param string $id
+	 * @return mixed
+	 */
+	public function get( $id ) {
+		if ( array_key_exists( $id, $this->shared_instances ) ) {
+			return $this->shared_instances[ $id ];
+		}
+
+		if ( isset( $this->definitions[ $id ] ) ) {
+			return $this->build_from_definition( $id );
+		}
+
+		$this->ensure_tags_indexed();
+		if ( isset( $this->tags[ $id ] ) ) {
+			return $this->build_tag_collection( $id );
+		}
+
+		throw new NotFoundException(
+			sprintf( 'No binding registered for "%s".', $id )
+		);
+	}
+
+	/**
+	 * Whether the container can resolve an identifier.
+	 *
+	 * Returns true for direct definitions, pre-cached shared instances,
+	 * and tag collections.
+	 *
+	 * @param string $id
+	 */
+	public function has( $id ): bool {
+		if ( array_key_exists( $id, $this->shared_instances ) ) {
+			return true;
+		}
+		if ( isset( $this->definitions[ $id ] ) ) {
+			return true;
+		}
+		$this->ensure_tags_indexed();
+		return isset( $this->tags[ $id ] );
+	}
+
+	// -------------------------------------------------------------------- //
+	// Internal helpers                                                       //
+	// -------------------------------------------------------------------- //
+
+	/**
+	 * Resolve a list of raw arguments, turning strings that match bindings
+	 * into their resolved values and passing everything else through.
+	 *
+	 * Rules:
+	 *   - Non-string values (objects, scalars, arrays) pass through literally.
+	 *   - Strings matching an existing binding are resolved via get().
+	 *   - Strings that name a real class or interface but have NO binding
+	 *     throw NotFoundException — this is the strictness that prevents
+	 *     cross-provider dependency bugs.
+	 *   - Other strings (e.g. URLs, slugs) pass through literally.
+	 *
+	 * @param array<int, mixed> $arguments
+	 * @param string            $context   Human description of where the
+	 *                                     arguments come from, used in error
+	 *                                     messages (e.g. "Foo::__construct").
+	 *
+	 * @return array<int, mixed>
+	 *
+	 * @internal Used by Definition and Inflector.
+	 */
+	public function resolve_arguments( array $arguments, string $context ): array {
+		$resolved = [];
+		foreach ( $arguments as $index => $argument ) {
+			$resolved[] = $this->resolve_argument( $argument, $context, $index );
+		}
+		return $resolved;
+	}
+
+	/**
+	 * @param mixed $argument
+	 * @return mixed
+	 */
+	private function resolve_argument( $argument, string $context, int $index ) {
+		if ( ! is_string( $argument ) ) {
+			return $argument;
+		}
+
+		if ( $this->has( $argument ) ) {
+			return $this->get( $argument );
+		}
+
+		if ( class_exists( $argument ) || interface_exists( $argument ) ) {
+			throw new NotFoundException(
+				sprintf(
+					'%s: argument #%d references "%s", which is a known class or interface but has no binding in the container. Declare it via share()/add() in a ServiceProvider::register().',
+					$context,
+					$index,
+					$argument
+				)
+			);
+		}
+
+		// Literal string (slug, URL, etc.).
+		return $argument;
+	}
+
+	/**
+	 * @param string $id
+	 * @return mixed
+	 */
+	private function build_from_definition( string $id ) {
+		$definition = $this->definitions[ $id ];
+
+		// No cycle detection here on purpose. A service's constructor may
+		// legitimately trigger re-entrant get() calls for the same id via
+		// WordPress hooks (e.g. RESTServer's __construct calls
+		// rest_get_server() which fires rest_api_init whose callbacks
+		// iterate the rest_controller tag, each of whose constructors
+		// takes a RESTServer). In that pattern the recursion terminates
+		// because rest_get_server() is idempotent after its first call.
+		// For a genuine circular dependency (A ctor wants B, B ctor wants
+		// A), recursion is unbounded and PHP's stack overflow will
+		// surface it. league/container behaved the same way.
+		$instance = $definition->build( $this );
+
+		// Cache BEFORE applying inflectors so a re-entrant get() for this
+		// id from inside a setter finds the instance instead of starting
+		// another build.
+		if ( $definition->isShared() ) {
+			$this->shared_instances[ $id ] = $instance;
+		}
+
+		// Apply every matching inflector to objects only. Literal values
+		// (scalars, non-class strings) obviously don't get inflected.
+		if ( is_object( $instance ) ) {
+			$this->apply_inflectors( $instance );
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Resolve every id in a tag into an array of instances.
+	 *
+	 * @param string $tag
+	 * @return array<int, mixed>
+	 */
+	private function build_tag_collection( string $tag ): array {
+		$instances = [];
+		foreach ( $this->tags[ $tag ] as $id ) {
+			$instances[] = $this->get( $id );
+		}
+		return $instances;
+	}
+
+	private function apply_inflectors( object $instance ): void {
+		foreach ( $this->inflectors as $inflector ) {
+			if ( $inflector->applies( $instance ) ) {
+				$inflector->inflect( $instance, $this );
+			}
+		}
+	}
+
+	/**
+	 * Rebuild the tag index from every known definition if any definitions
+	 * have been added or modified since the last index build.
+	 *
+	 * Deferred rebuilding is necessary because providers use chained
+	 * addTag() calls on the Definition returned from addShared()/add(), and
+	 * the container has no hook to observe those fluent modifications. The
+	 * tags_dirty flag covers the worst case: any container mutation
+	 * invalidates the index until we rebuild.
+	 */
+	private function ensure_tags_indexed(): void {
+		if ( ! $this->tags_dirty ) {
+			return;
+		}
+		$this->tags = [];
+		foreach ( $this->definitions as $id => $definition ) {
+			foreach ( $definition->getTags() as $tag ) {
+				$this->tags[ $tag ][] = $id;
+			}
+		}
+		$this->tags_dirty = false;
+	}
+}

--- a/src/Internal/Container/PluginContainer.php
+++ b/src/Internal/Container/PluginContainer.php
@@ -97,7 +97,7 @@ class PluginContainer implements ContainerInterface {
 	 */
 	public function add( string $id, $concrete = null ): Definition {
 		$definition = new Definition( $id, $concrete );
-		$definition->setShared( false );
+		$definition->set_shared( false );
 		$this->definitions[ $id ] = $definition;
 		$this->tags_dirty         = true;
 		return $definition;
@@ -112,7 +112,7 @@ class PluginContainer implements ContainerInterface {
 	 */
 	public function addShared( string $id, $concrete = null ): Definition {
 		$definition = new Definition( $id, $concrete );
-		$definition->setShared( true );
+		$definition->set_shared( true );
 		$this->definitions[ $id ] = $definition;
 		$this->tags_dirty         = true;
 		return $definition;
@@ -137,9 +137,11 @@ class PluginContainer implements ContainerInterface {
 	 *
 	 * Unlike League, there is no deferred booting — providers are registered
 	 * in the order they are added.
+	 *
+	 * @param ServiceProvider $provider
 	 */
 	public function addServiceProvider( ServiceProvider $provider ): void {
-		$provider->setContainer( $this );
+		$provider->set_container( $this );
 		$provider->register();
 	}
 
@@ -157,6 +159,7 @@ class PluginContainer implements ContainerInterface {
 	 *
 	 * @param string $id
 	 * @return mixed
+	 * @throws NotFoundException When no binding, cached instance, or tag collection matches $id.
 	 */
 	public function get( $id ) {
 		if ( array_key_exists( $id, $this->shared_instances ) ) {
@@ -230,8 +233,11 @@ class PluginContainer implements ContainerInterface {
 	}
 
 	/**
-	 * @param mixed $argument
+	 * @param mixed  $argument
+	 * @param string $context
+	 * @param int    $index
 	 * @return mixed
+	 * @throws NotFoundException When a string argument is a known class/interface with no binding.
 	 */
 	private function resolve_argument( $argument, string $context, int $index ) {
 		if ( ! is_string( $argument ) ) {
@@ -279,7 +285,7 @@ class PluginContainer implements ContainerInterface {
 		// Cache BEFORE applying inflectors so a re-entrant get() for this
 		// id from inside a setter finds the instance instead of starting
 		// another build.
-		if ( $definition->isShared() ) {
+		if ( $definition->is_shared() ) {
 			$this->shared_instances[ $id ] = $instance;
 		}
 
@@ -306,6 +312,9 @@ class PluginContainer implements ContainerInterface {
 		return $instances;
 	}
 
+	/**
+	 * @param object $instance
+	 */
 	private function apply_inflectors( object $instance ): void {
 		foreach ( $this->inflectors as $inflector ) {
 			if ( $inflector->applies( $instance ) ) {
@@ -330,7 +339,7 @@ class PluginContainer implements ContainerInterface {
 		}
 		$this->tags = [];
 		foreach ( $this->definitions as $id => $definition ) {
-			foreach ( $definition->getTags() as $tag ) {
+			foreach ( $definition->get_tags() as $tag ) {
 				$this->tags[ $tag ][] = $id;
 			}
 		}

--- a/src/Internal/Container/ServiceProvider.php
+++ b/src/Internal/Container/ServiceProvider.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * Replaces League's AbstractServiceProvider so the plugin no longer depends
  * on league/container. The API surface is intentionally narrow: providers
- * receive the container via setContainer() and implement register() to
+ * receive the container via set_container() and implement register() to
  * declare their bindings.
  *
  * Unlike League's deferred-provider model, every provider's register() is
@@ -24,15 +24,22 @@ abstract class ServiceProvider {
 	 */
 	protected $container;
 
-	public function setContainer( PluginContainer $container ): void {
+	/**
+	 * @param PluginContainer $container
+	 */
+	public function set_container( PluginContainer $container ): void {
 		$this->container = $container;
 	}
 
-	public function getContainer(): PluginContainer {
+	/**
+	 * @return PluginContainer
+	 * @throws ContainerException When called before the provider is registered with a container.
+	 */
+	public function get_container(): PluginContainer {
 		if ( null === $this->container ) {
 			throw new ContainerException(
 				sprintf(
-					'%s::getContainer() called before the provider was registered with a container.',
+					'%s::get_container() called before the provider was registered with a container.',
 					static::class
 				)
 			);

--- a/src/Internal/Container/ServiceProvider.php
+++ b/src/Internal/Container/ServiceProvider.php
@@ -1,0 +1,48 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Base class for all service providers.
+ *
+ * Replaces League's AbstractServiceProvider so the plugin no longer depends
+ * on league/container. The API surface is intentionally narrow: providers
+ * receive the container via setContainer() and implement register() to
+ * declare their bindings.
+ *
+ * Unlike League's deferred-provider model, every provider's register() is
+ * called eagerly when the container is constructed — there is no $provides
+ * array and no lazy booting. See docs in PluginContainer for the rationale.
+ */
+abstract class ServiceProvider {
+
+	/**
+	 * @var PluginContainer|null
+	 */
+	protected $container;
+
+	public function setContainer( PluginContainer $container ): void {
+		$this->container = $container;
+	}
+
+	public function getContainer(): PluginContainer {
+		if ( null === $this->container ) {
+			throw new ContainerException(
+				sprintf(
+					'%s::getContainer() called before the provider was registered with a container.',
+					static::class
+				)
+			);
+		}
+		return $this->container;
+	}
+
+	/**
+	 * Declare the provider's bindings on $this->container. Called exactly
+	 * once per container, at container construction time.
+	 */
+	abstract public function register(): void;
+}

--- a/src/Internal/DependencyManagement/AbstractServiceProvider.php
+++ b/src/Internal/DependencyManagement/AbstractServiceProvider.php
@@ -4,121 +4,125 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\DefinitionInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\ServiceProvider\AbstractServiceProvider as LeagueProvider;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\Definition;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\ServiceProvider;
+
+defined( 'ABSPATH' ) || exit;
 
 /**
- * Class AbstractServiceProvider
+ * Base service provider for this plugin.
  *
- * @package Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement
+ * Extends the plugin's own ServiceProvider base (src/Internal/Container/)
+ * rather than league/container's AbstractServiceProvider — the plugin no
+ * longer depends on league/container. See PluginContainer for the rationale.
+ *
+ * The share/share_with_tags/share_concrete/add helpers keep the same
+ * signatures as before so concrete provider classes do not need to change.
+ * The only visible difference is the return type: a plugin-local Definition
+ * instead of League's DefinitionInterface. Methods called on that return
+ * value (addArguments, addArgument, addTag, addMethodCall) are identical.
  */
-abstract class AbstractServiceProvider extends LeagueProvider {
+abstract class AbstractServiceProvider extends ServiceProvider {
 
 	/**
-	 * Array of classes provided by this container.
+	 * Array of classes this provider declares it provides.
 	 *
-	 * Keys should be the class name, and the value can be anything (like `true`).
+	 * Historically this drove League's deferred-provider boot machinery.
+	 * With the plugin's own container this field is unused at runtime — all
+	 * providers are registered eagerly — but it is kept as documentation of
+	 * intent and in case external tooling inspects it.
 	 *
 	 * @var array
 	 */
 	protected $provides = [];
 
 	/**
-	 * Returns a boolean if checking whether this provider provides a specific
-	 * service or returns an array of provided services if no argument passed.
-	 *
-	 * @param string $service
-	 *
-	 * @return boolean
+	 * Historical provides() check. Not called by the plugin's container,
+	 * kept for compatibility with any external caller that inspects it.
 	 */
 	public function provides( string $service ): bool {
 		return array_key_exists( $service, $this->provides );
 	}
 
 	/**
-	 * Use the register method to register items with the container via the
-	 * protected $this->container property or the `getContainer` method
-	 * from the ContainerAwareTrait.
+	 * Share a class with a concrete implementation. Used for interface
+	 * bindings and for wrapping factory closures.
 	 *
-	 * @return void
+	 * @param string $interface_name The identifier (typically an interface).
+	 * @param mixed  $concrete       A class name, closure, object, or Definition.
 	 */
-	public function register(): void {
-		foreach ( $this->provides as $class => $provided ) {
-			$this->share( $class );
-		}
-	}
-
-	/**
-	 * Add an interface to the container.
-	 *
-	 * @param string      $interface_name The interface to add.
-	 * @param string|null $concrete       (Optional) The concrete class.
-	 *
-	 * @return DefinitionInterface
-	 */
-	protected function share_concrete( string $interface_name, $concrete = null ): DefinitionInterface {
+	protected function share_concrete( string $interface_name, $concrete = null ): Definition {
 		return $this->getContainer()->addShared( $interface_name, $concrete );
 	}
 
 	/**
-	 * Share a class and add interfaces as tags.
+	 * Share a class and auto-tag it with every interface it implements.
+	 * `get($interface_name)` will then return the collection of all services
+	 * tagged with that interface.
 	 *
-	 * @param string $class_name   The class name to add.
-	 * @param mixed  ...$arguments Constructor arguments for the class.
-	 *
-	 * @return DefinitionInterface
+	 * @param string $class_name   The class to share.
+	 * @param mixed  ...$arguments Constructor arguments.
 	 */
-	protected function share_with_tags( string $class_name, ...$arguments ): DefinitionInterface {
+	protected function share_with_tags( string $class_name, ...$arguments ): Definition {
 		$definition = $this->share( $class_name, ...$arguments );
 		foreach ( class_implements( $class_name ) as $interface_name ) {
 			$definition->addTag( $interface_name );
 		}
-
 		return $definition;
 	}
 
 	/**
-	 * Share a class.
+	 * Share a class via a factory closure, auto-tagging it with every
+	 * interface it implements (same tagging semantics as share_with_tags).
 	 *
-	 * Shared classes will always return the same instance of the class when the class is requested
-	 * from the container.
+	 * Unlike share_with_tags, the factory is called lazily — the first time
+	 * the service is resolved, not when the provider's register() runs. This
+	 * is the right choice when the concrete construction depends on state
+	 * that isn't available at registration time (for example, classes from
+	 * another plugin that loads after ours in plugins_loaded order).
 	 *
-	 * @param string $class_name   The class name to add.
-	 * @param mixed  ...$arguments Constructor arguments for the class.
-	 *
-	 * @return DefinitionInterface
+	 * @param string   $class_name The class the factory returns.
+	 * @param callable $factory    Factory closure. Receives the container as its only argument.
 	 */
-	protected function share( string $class_name, ...$arguments ): DefinitionInterface {
+	protected function share_factory_with_tags( string $class_name, callable $factory ): Definition {
+		$definition = $this->share_concrete( $class_name, $factory );
+		foreach ( class_implements( $class_name ) as $interface_name ) {
+			$definition->addTag( $interface_name );
+		}
+		return $definition;
+	}
+
+	/**
+	 * Share a class as a singleton. Every get() returns the same instance.
+	 *
+	 * @param string $class_name   The class to share.
+	 * @param mixed  ...$arguments Constructor arguments.
+	 */
+	protected function share( string $class_name, ...$arguments ): Definition {
 		return $this->getContainer()->addShared( $class_name )->addArguments( $arguments );
 	}
 
 	/**
-	 * Add a class.
+	 * Add a class as a transient binding. Every get() returns a new instance.
 	 *
-	 * Classes will return a new instance of the class when the class is requested from the container.
-	 *
-	 * @param string $class_name   The class name to add.
-	 * @param mixed  ...$arguments Constructor arguments for the class.
-	 *
-	 * @return DefinitionInterface
+	 * @param string $class_name   The class to add.
+	 * @param mixed  ...$arguments Constructor arguments.
 	 */
-	protected function add( string $class_name, ...$arguments ): DefinitionInterface {
+	protected function add( string $class_name, ...$arguments ): Definition {
 		return $this->getContainer()->add( $class_name )->addArguments( $arguments );
 	}
 
 	/**
-	 * Maybe share a class and add interfaces as tags.
+	 * Share a class with tags only if its Conditional::is_needed() returns
+	 * true. Classes that do not implement Conditional are shared unconditionally.
 	 *
-	 * This will also check any classes that implement the Conditional interface and only add them if
-	 * they are needed.
-	 *
-	 * @param string $class_name   The class name to add.
-	 * @param mixed  ...$arguments Constructor arguments for the class.
+	 * @param string $class_name   The class to share.
+	 * @param mixed  ...$arguments Constructor arguments.
 	 */
 	protected function conditionally_share_with_tags( string $class_name, ...$arguments ) {
 		$implements = class_implements( $class_name );
 		if ( array_key_exists( Conditional::class, $implements ) ) {
-			/** @var Conditional $class */
+			/** @var Conditional $class_name */
 			if ( ! $class_name::is_needed() ) {
 				return;
 			}

--- a/src/Internal/DependencyManagement/AbstractServiceProvider.php
+++ b/src/Internal/DependencyManagement/AbstractServiceProvider.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
  * signatures as before so concrete provider classes do not need to change.
  * The only visible difference is the return type: a plugin-local Definition
  * instead of League's DefinitionInterface. Methods called on that return
- * value (addArguments, addArgument, addTag, addMethodCall) are identical.
+ * value (add_arguments, add_argument, add_tag, add_method_call) are identical.
  */
 abstract class AbstractServiceProvider extends ServiceProvider {
 
@@ -39,6 +39,9 @@ abstract class AbstractServiceProvider extends ServiceProvider {
 	/**
 	 * Historical provides() check. Not called by the plugin's container,
 	 * kept for compatibility with any external caller that inspects it.
+	 *
+	 * @param string $service
+	 * @return bool
 	 */
 	public function provides( string $service ): bool {
 		return array_key_exists( $service, $this->provides );
@@ -52,7 +55,7 @@ abstract class AbstractServiceProvider extends ServiceProvider {
 	 * @param mixed  $concrete       A class name, closure, object, or Definition.
 	 */
 	protected function share_concrete( string $interface_name, $concrete = null ): Definition {
-		return $this->getContainer()->addShared( $interface_name, $concrete );
+		return $this->get_container()->addShared( $interface_name, $concrete );
 	}
 
 	/**
@@ -66,7 +69,7 @@ abstract class AbstractServiceProvider extends ServiceProvider {
 	protected function share_with_tags( string $class_name, ...$arguments ): Definition {
 		$definition = $this->share( $class_name, ...$arguments );
 		foreach ( class_implements( $class_name ) as $interface_name ) {
-			$definition->addTag( $interface_name );
+			$definition->add_tag( $interface_name );
 		}
 		return $definition;
 	}
@@ -87,7 +90,7 @@ abstract class AbstractServiceProvider extends ServiceProvider {
 	protected function share_factory_with_tags( string $class_name, callable $factory ): Definition {
 		$definition = $this->share_concrete( $class_name, $factory );
 		foreach ( class_implements( $class_name ) as $interface_name ) {
-			$definition->addTag( $interface_name );
+			$definition->add_tag( $interface_name );
 		}
 		return $definition;
 	}
@@ -99,7 +102,7 @@ abstract class AbstractServiceProvider extends ServiceProvider {
 	 * @param mixed  ...$arguments Constructor arguments.
 	 */
 	protected function share( string $class_name, ...$arguments ): Definition {
-		return $this->getContainer()->addShared( $class_name )->addArguments( $arguments );
+		return $this->get_container()->addShared( $class_name )->add_arguments( $arguments );
 	}
 
 	/**
@@ -109,7 +112,7 @@ abstract class AbstractServiceProvider extends ServiceProvider {
 	 * @param mixed  ...$arguments Constructor arguments.
 	 */
 	protected function add( string $class_name, ...$arguments ): Definition {
-		return $this->getContainer()->add( $class_name )->addArguments( $arguments );
+		return $this->get_container()->add( $class_name )->add_arguments( $arguments );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -79,7 +79,7 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 
 	/**
 	 * Use the register method to register items with the container via the
-	 * protected $this->container property or the `getContainer` method
+	 * protected $this->container property or the `get_container` method
 	 * from the ContainerAwareTrait.
 	 *
 	 * @return void

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -203,7 +203,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 
 	/**
 	 * Use the register method to register items with the container via the
-	 * protected $this->container property or the `getContainer` method
+	 * protected $this->container property or the `get_container` method
 	 * from the ContainerAwareTrait.
 	 *
 	 * @return void
@@ -220,21 +220,21 @@ class CoreServiceProvider extends AbstractServiceProvider {
 
 		// Set up Options, and inflect classes that need options.
 		$this->share_concrete( OptionsInterface::class, Options::class );
-		$this->getContainer()
+		$this->get_container()
 			->inflector( OptionsAwareInterface::class )
-			->invokeMethod( 'set_options_object', [ OptionsInterface::class ] );
+			->invoke_method( 'set_options_object', [ OptionsInterface::class ] );
 
 		// Set up Transients, and inflect classes that need transients.
 		$this->share_concrete( TransientsInterface::class, Transients::class );
-		$this->getContainer()
+		$this->get_container()
 			->inflector( TransientsAwareInterface::class )
-			->invokeMethod( 'set_transients_object', [ TransientsInterface::class ] );
+			->invoke_method( 'set_transients_object', [ TransientsInterface::class ] );
 
 		// Share helper classes, and inflect classes that need it.
 		$this->share_with_tags( GoogleHelper::class, WC::class );
-		$this->getContainer()
+		$this->get_container()
 			->inflector( GoogleHelperAwareInterface::class )
-			->invokeMethod( 'set_google_helper_object', [ GoogleHelper::class ] );
+			->invoke_method( 'set_google_helper_object', [ GoogleHelper::class ] );
 
 		// Set up the TargetAudience service.
 		$this->share_with_tags( TargetAudience::class, WC::class, OptionsInterface::class, GoogleHelper::class );
@@ -248,20 +248,20 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		// Set up OAuthService service.
 		$this->share_with_tags( OAuthService::class );
 
-		$this->getContainer()
+		$this->get_container()
 			->inflector( MerchantCenterAwareInterface::class )
-			->invokeMethod( 'set_merchant_center_object', [ MerchantCenterService::class ] );
+			->invoke_method( 'set_merchant_center_object', [ MerchantCenterService::class ] );
 
-		$this->getContainer()
+		$this->get_container()
 			->inflector( WPAwareInterface::class )
-			->invokeMethod( 'set_wp_proxy_object', [ WP::class ] );
+			->invoke_method( 'set_wp_proxy_object', [ WP::class ] );
 
 		// Set up Ads service, and inflect classes that need it.
 		$this->share_with_tags( AdsAccountState::class );
 		$this->share_with_tags( AdsService::class, AdsAccountState::class );
-		$this->getContainer()
+		$this->get_container()
 			->inflector( AdsAwareInterface::class )
-			->invokeMethod( 'set_ads_object', [ AdsService::class ] );
+			->invoke_method( 'set_ads_object', [ AdsService::class ] );
 		$this->share_with_tags( AssetSuggestionsService::class, WP::class, WC::class, ImageUtility::class, wpdb::class, AdsAssetGroupAsset::class );
 
 		// Set up the installer.
@@ -357,9 +357,9 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		);
 
 		// Set up inflector for tracks classes.
-		$this->getContainer()
+		$this->get_container()
 			->inflector( TracksAwareInterface::class )
-			->invokeMethod( 'set_tracks', [ TracksInterface::class ] );
+			->invoke_method( 'set_tracks', [ TracksInterface::class ] );
 
 		// Share other classes.
 		$this->share_with_tags( ActivatedEvents::class, $_SERVER );

--- a/src/Internal/DependencyManagement/DBServiceProvider.php
+++ b/src/Internal/DependencyManagement/DBServiceProvider.php
@@ -32,7 +32,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\DefinitionInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\Definition;
 use wpdb;
 
 defined( 'ABSPATH' ) || exit;
@@ -125,9 +125,9 @@ class DBServiceProvider extends AbstractServiceProvider {
 	 * @param string $class_name
 	 * @param mixed  ...$arguments
 	 *
-	 * @return DefinitionInterface
+	 * @return Definition
 	 */
-	protected function add_query_class( string $class_name, ...$arguments ): DefinitionInterface {
+	protected function add_query_class( string $class_name, ...$arguments ): Definition {
 		return $this->add( $class_name, wpdb::class, ...$arguments )->addTag( 'db_query' );
 	}
 
@@ -140,9 +140,9 @@ class DBServiceProvider extends AbstractServiceProvider {
 	 * @param string $class_name   The class name to add.
 	 * @param mixed  ...$arguments Constructor arguments for the class.
 	 *
-	 * @return DefinitionInterface
+	 * @return Definition
 	 */
-	protected function share_table_class( string $class_name, ...$arguments ): DefinitionInterface {
+	protected function share_table_class( string $class_name, ...$arguments ): Definition {
 		return parent::share( $class_name, WP::class, wpdb::class, ...$arguments )->addTag( 'db_table' );
 	}
 

--- a/src/Internal/DependencyManagement/DBServiceProvider.php
+++ b/src/Internal/DependencyManagement/DBServiceProvider.php
@@ -86,7 +86,7 @@ class DBServiceProvider extends AbstractServiceProvider {
 
 	/**
 	 * Use the register method to register items with the container via the
-	 * protected $this->container property or the `getContainer` method
+	 * protected $this->container property or the `get_container` method
 	 * from the ContainerAwareTrait.
 	 *
 	 * @return void
@@ -128,7 +128,7 @@ class DBServiceProvider extends AbstractServiceProvider {
 	 * @return Definition
 	 */
 	protected function add_query_class( string $class_name, ...$arguments ): Definition {
-		return $this->add( $class_name, wpdb::class, ...$arguments )->addTag( 'db_query' );
+		return $this->add( $class_name, wpdb::class, ...$arguments )->add_tag( 'db_query' );
 	}
 
 	/**
@@ -143,7 +143,7 @@ class DBServiceProvider extends AbstractServiceProvider {
 	 * @return Definition
 	 */
 	protected function share_table_class( string $class_name, ...$arguments ): Definition {
-		return parent::share( $class_name, WP::class, wpdb::class, ...$arguments )->addTag( 'db_table' );
+		return parent::share( $class_name, WP::class, wpdb::class, ...$arguments )->add_tag( 'db_table' );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -48,7 +48,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client as Guzz
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\ClientInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\RequestException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\Definition;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\Definition;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\RequestInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\ResponseInterface;
 use Google\Ads\GoogleAds\Util\V22\GoogleAdsFailures;

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -105,7 +105,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 
 	/**
 	 * Use the register method to register items with the container via the
-	 * protected $this->container property or the `getContainer` method
+	 * protected $this->container property or the `get_container` method
 	 * from the ContainerAwareTrait.
 	 *
 	 * @return void
@@ -142,7 +142,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 
 		$this->share( SiteVerification::class );
 
-		$this->getContainer()->add( 'connect_server_root', $this->get_connect_server_url_root() );
+		$this->get_container()->add( 'connect_server_root', $this->get_connect_server_url_root() );
 	}
 
 	/**
@@ -179,14 +179,14 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share_concrete(
 			GoogleAdsClient::class,
 			new Definition( GoogleAdsClient::class, $callback )
-		)->addMethodCall( 'setHttpClient', [ ClientInterface::class ] );
+		)->add_method_call( 'setHttpClient', [ ClientInterface::class ] );
 	}
 
 	/**
 	 * Register the various Google classes we use.
 	 */
 	protected function register_google_classes() {
-		$this->add( Client::class )->addMethodCall( 'setHttpClient', [ ClientInterface::class ] );
+		$this->add( Client::class )->add_method_call( 'setHttpClient', [ ClientInterface::class ] );
 		$this->add(
 			ShoppingContent::class,
 			Client::class,
@@ -328,7 +328,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 */
 	protected function generate_auth_header(): string {
 		/** @var Manager $manager */
-		$manager = $this->getContainer()->get( Manager::class );
+		$manager = $this->get_container()->get( Manager::class );
 		$token   = $manager->get_tokens()->get_access_token( false, false, false );
 		$this->check_for_wp_error( $token );
 
@@ -390,7 +390,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 */
 	protected function set_google_disconnected() {
 		/** @var Options $options */
-		$options = $this->getContainer()->get( OptionsInterface::class );
+		$options = $this->get_container()->get( OptionsInterface::class );
 		$options->update( OptionsInterface::GOOGLE_CONNECTED, false );
 	}
 
@@ -403,7 +403,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 */
 	protected function set_jetpack_connected( bool $connected ) {
 		/** @var Options $options */
-		$options = $this->getContainer()->get( OptionsInterface::class );
+		$options = $this->get_container()->get( OptionsInterface::class );
 
 		// Save previous connected status before updating.
 		$previous_connected = boolval( $options->get( OptionsInterface::JETPACK_CONNECTED ) );
@@ -424,7 +424,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 */
 	protected function jetpack_connected_change( bool $connected ) {
 		/** @var ReconnectWordPress $note */
-		$note = $this->getContainer()->get( ReconnectWordPress::class );
+		$note = $this->get_container()->get( ReconnectWordPress::class );
 
 		if ( $connected ) {
 			$note->delete();

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -104,10 +104,22 @@ class JobServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register(): void {
-		$this->share_with_tags(
+		// AsyncActionRunner must be constructed lazily because its
+		// dependencies (QueueRunnerAsyncRequest + ActionSchedulerCore) are
+		// provided by the ActionScheduler plugin, which may not have loaded
+		// yet at the point where the container's service providers run
+		// (plugins_loaded priority 1). The old League-based container hid
+		// this ordering dependency by deferring provider booting; the new
+		// eager container makes it explicit. Wrapping the instantiation in
+		// a factory closure defers it to first get(AsyncActionRunner::class).
+		$this->share_factory_with_tags(
 			AsyncActionRunner::class,
-			new QueueRunnerAsyncRequest( ActionSchedulerCore::store() ),
-			ActionSchedulerCore::lock()
+			static function () {
+				return new AsyncActionRunner(
+					new QueueRunnerAsyncRequest( ActionSchedulerCore::store() ),
+					ActionSchedulerCore::lock()
+				);
+			}
 		);
 		$this->share_with_tags( ActionScheduler::class, AsyncActionRunner::class );
 		$this->share_with_tags( ActionSchedulerJobMonitor::class, ActionScheduler::class );

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -98,7 +98,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 
 	/**
 	 * Use the register method to register items with the container via the
-	 * protected $this->container property or the `getContainer` method
+	 * protected $this->container property or the `get_container` method
 	 * from the ContainerAwareTrait.
 	 *
 	 * @return void

--- a/src/Internal/DependencyManagement/ProxyServiceProvider.php
+++ b/src/Internal/DependencyManagement/ProxyServiceProvider.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\Tracks;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC as WCProxy;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\Jetpack;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\Definition;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\Definition;
 use wpdb;
 
 use function WC;

--- a/src/Internal/DependencyManagement/ProxyServiceProvider.php
+++ b/src/Internal/DependencyManagement/ProxyServiceProvider.php
@@ -37,7 +37,7 @@ class ProxyServiceProvider extends AbstractServiceProvider {
 
 	/**
 	 * Use the register method to register items with the container via the
-	 * protected $this->container property or the `getContainer` method
+	 * protected $this->container property or the `get_container` method
 	 * from the ContainerAwareTrait.
 	 *
 	 * @return void

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -89,7 +89,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingSuggestionService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\AddressUtility;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\DefinitionInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\Definition;
 
 /**
  * Class RESTServiceProvider
@@ -176,9 +176,9 @@ class RESTServiceProvider extends AbstractServiceProvider {
 	 * @param string $class_name   The class name to add.
 	 * @param mixed  ...$arguments Constructor arguments for the class.
 	 *
-	 * @return DefinitionInterface
+	 * @return Definition
 	 */
-	protected function share( string $class_name, ...$arguments ): DefinitionInterface {
+	protected function share( string $class_name, ...$arguments ): Definition {
 		return parent::share( $class_name, RESTServer::class, ...$arguments )->addTag( 'rest_controller' );
 	}
 }

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -112,7 +112,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 
 	/**
 	 * Use the register method to register items with the container via the
-	 * protected $this->container property or the `getContainer` method
+	 * protected $this->container property or the `get_container` method
 	 * from the ContainerAwareTrait.
 	 *
 	 * @return void
@@ -179,6 +179,6 @@ class RESTServiceProvider extends AbstractServiceProvider {
 	 * @return Definition
 	 */
 	protected function share( string $class_name, ...$arguments ): Definition {
-		return parent::share( $class_name, RESTServer::class, ...$arguments )->addTag( 'rest_controller' );
+		return parent::share( $class_name, RESTServer::class, ...$arguments )->add_tag( 'rest_controller' );
 	}
 }

--- a/src/Internal/DependencyManagement/ThirdPartyServiceProvider.php
+++ b/src/Internal/DependencyManagement/ThirdPartyServiceProvider.php
@@ -39,16 +39,16 @@ class ThirdPartyServiceProvider extends AbstractServiceProvider {
 
 	/**
 	 * Use the register method to register items with the container via the
-	 * protected $this->container property or the `getContainer` method
+	 * protected $this->container property or the `get_container` method
 	 * from the ContainerAwareTrait.
 	 *
 	 * @return void
 	 */
 	public function register(): void {
 		$jetpack_id = 'google-listings-and-ads';
-		$this->share( Manager::class )->addArgument( $jetpack_id );
+		$this->share( Manager::class )->add_argument( $jetpack_id );
 
-		$this->share( Config::class )->addMethodCall(
+		$this->share( Config::class )->add_method_call(
 			'ensure',
 			[
 				'connection',
@@ -60,9 +60,9 @@ class ThirdPartyServiceProvider extends AbstractServiceProvider {
 		);
 
 		$this->share_concrete( ISO3166DataProvider::class, ISO3166::class );
-		$this->getContainer()
+		$this->get_container()
 			->inflector( ISO3166AwareInterface::class )
-			->invokeMethod( 'set_iso3166_provider', [ ISO3166DataProvider::class ] );
+			->invoke_method( 'set_iso3166_provider', [ ISO3166DataProvider::class ] );
 
 		$this->share_concrete(
 			ValidatorInterface::class,
@@ -77,7 +77,7 @@ class ThirdPartyServiceProvider extends AbstractServiceProvider {
 		add_action(
 			'init',
 			function () {
-				$manager = $this->getContainer()->get( Manager::class );
+				$manager = $this->get_container()->get( Manager::class );
 				$manager->get_plugin()->add(
 					__( 'Google for WooCommerce', 'google-listings-and-ads' )
 				);

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -17,7 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Handler\MockHa
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Request;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Response;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use ReflectionMethod;
 

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -66,7 +66,7 @@ class ClientTest extends UnitTest {
 		$this->container->addShared( OptionsInterface::class, $this->options );
 
 		$this->provider = new GoogleServiceProvider();
-		$this->provider->setContainer( $this->container );
+		$this->provider->set_container( $this->container );
 	}
 
 	/**

--- a/tests/Unit/API/Google/AdsAssetGroupTest.php
+++ b/tests/Unit/API/Google/AdsAssetGroupTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Google\ApiCore\ApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -17,7 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Google\ApiCore\ApiException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Exception;

--- a/tests/Unit/API/Google/AdsReportTest.php
+++ b/tests/Unit/API/Google/AdsReportTest.php
@@ -10,7 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Google\ApiCore\ApiException;
 use PHPUnit\Framework\MockObject\MockObject;
 

--- a/tests/Unit/API/Google/MiddlewareTest.php
+++ b/tests/Unit/API/Google/MiddlewareTest.php
@@ -16,7 +16,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GuzzleCl
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\DateTimeUtility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\ISOUtility;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 

--- a/tests/Unit/API/Google/SiteVerificationTest.php
+++ b/tests/Unit/API/Google/SiteVerificationTest.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseD
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\MerchantTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\Exception as GoogleServiceException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\SiteVerification as SiteVerificationService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\SiteVerification\Resource\WebResource;

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetMetricsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetMetricsControllerTest.php
@@ -7,7 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\BudgetMetricsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 

--- a/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/BudgetRecommendationControllerTest.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\BudgetRecommendationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\BudgetRecommendationQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/API/Site/Controllers/Ads/IncentiveCreditsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/IncentiveCreditsControllerTest.php
@@ -6,7 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\IncentiveCreditsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use PHPUnit\Framework\MockObject\MockObject;
 use Exception;
 

--- a/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/RecommendationsControllerTest.php
@@ -7,7 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AccountService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\RecommendationsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use WP_REST_Response as Response;

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/PriceBenchmarksControllerTest.php
@@ -4,7 +4,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantPriceBenchmar
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PriceBenchmarks;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use PHPUnit\Framework\MockObject\MockObject;
 /**
  * Test class for PriceBenchmarksController.

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/ShippingTimeControllerTest.php
@@ -4,7 +4,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\ShippingTimeController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\ISO3166\ISO3166DataProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidQuery;

--- a/tests/Unit/API/WP/OAuthServiceTest.php
+++ b/tests/Unit/API/WP/OAuthServiceTest.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\OAuthService;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities as UtilitiesTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Deactivateable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\Jetpack;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;

--- a/tests/Unit/API/YouTube/ConnectionTest.php
+++ b/tests/Unit/API/YouTube/ConnectionTest.php
@@ -11,7 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Handler\MockHa
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Request;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Response;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionMethod;
 

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -15,7 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/DB/ProductFeedQueryHelperTest.php
+++ b/tests/Unit/DB/ProductFeedQueryHelperTest.php
@@ -11,7 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_Helper_Product;
 use WP_REST_Request;

--- a/tests/Unit/Integration/WPCOMProxyTest.php
+++ b/tests/Unit/Integration/WPCOMProxyTest.php
@@ -17,7 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPCOMProxy;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\AttributeMappingRulesTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingTimeTable;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use WC_Meta_Data;
 use WP_REST_Response;
 use WP_REST_Request;

--- a/tests/Unit/Jobs/JobInitializerTest.php
+++ b/tests/Unit/Jobs/JobInitializerTest.php
@@ -12,7 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ResubmitExpiringProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -24,7 +24,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\MerchantTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\TrackingTrait;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -21,7 +21,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\MerchantTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Utility\AddressUtility;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use DateTime;
 use PHPUnit\Framework\MockObject\MockObject;
 

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -15,7 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ProductstatusesCustomBatchResponse;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ProductstatusesCustomBatchResponseEntry;

--- a/tests/Unit/MerchantCenter/PriceBenchmarksTest.php
+++ b/tests/Unit/MerchantCenter/PriceBenchmarksTest.php
@@ -10,7 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PriceBenchmarks;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Container\PluginContainer as Container;
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_Helper_Product;
 


### PR DESCRIPTION
## Summary

This is a proof of concept that replaces the `league/container` package with a lightweight, purpose-built DI container (`PluginContainer`) that is PSR-11 compliant and API-compatible with the existing service provider patterns.

## Motivation

The plugin uses a small subset of League's features (shared/transient bindings, inflectors, tags, method calls). The generic library brings overhead (wrapper classes, argument aggregators, provider aggregates, and a deferred-boot mechanism) that we don't need. More importantly, the deferred-boot model was silently masking real dependency-wiring bugs (see below).

[php-spx](https://github.com/NoiseByNorthwest/php-spx) yields the following results for the `GoogleListingsAndAdsPlugin::maybe_register_services` method, which runs on each request and handles all the container registrations, in a local environment:

Before:

- Time: ~50ms
- Memory: 22MB
- Recorde calls: 137K

After:

- Time: ~7ms
- Memory:  12MB
- Recorded calls: 8K

## Changes

### New: `src/Internal/Container/`

- **PluginContainer**: core container implementing `Psr\Container\ContainerInterface`. Manages definitions, shared-instance cache, tag index, and inflectors. Supports the same `addShared()`/`add()`/`inflector()`/`addServiceProvider()` surface the providers already use.
- **Definition**: holds binding metadata (concrete, constructor args, method calls, tags, shared flag). Builds instances via reflection or closure factories.
- **Inflector**: applies setter injection (e.g. `set_options()`, `set_container()`) to every instance that implements a given interface.
- **ServiceProvider**: minimal base class with `setContainer()`/`getContainer()` and abstract `register()`.
- **NotFoundException / ContainerException**: PSR-11 exception classes.

### Eager provider registration

`addServiceProvider()` calls `register()` immediately instead of deferring it. This eliminates a class of ordering bugs where `has()` would return `false` for a deferred binding, causing the string ID to be passed literally as a constructor argument instead of being resolved.

### Strict argument resolution

When a definition lists a string constructor argument, the container now:
1. Resolves it via `get()` if a binding exists.
2. **Throws `NotFoundException`** if the string names a known class/interface with no binding, this is the key strictness guarantee that prevents silent mis-wiring.
3. Passes it through as a literal otherwise (URLs, slugs, option keys, etc.).

### Fix: latent ActionScheduler ordering dependency in `JobServiceProvider`

Eager registration surfaced a pre-existing bug: `JobServiceProvider::register()` was calling `ActionSchedulerCore::store()` and `ActionSchedulerCore::lock()` at registration time, but ActionScheduler isn't fully loaded until `plugins_loaded` priority 1. With League's deferred model this worked by accident because the provider's `register()` ran lazily at first resolution. The fix wraps these in closure factories (`share_factory_with_tags()`) so instantiation is deferred to resolution time, when ActionScheduler is guaranteed to be loaded.

### Re-entrant resolution support

No cycle detection is applied. `RESTServer::__construct` calls `rest_get_server()` which fires `rest_api_init`, whose callbacks resolve REST controllers that themselves depend on `RESTServer`. This is a legitimate re-entrant pattern (not a cycle) that terminates naturally because `rest_get_server()` is idempotent after its first call. Shared instances are cached *before* inflectors run so that re-entrant lookups during setter injection find the already-built instance.

### Removed `league/container`

- Removed from `composer.json`.
- Removed from `bin/prefix-vendor-namespace.php` (`$packages` and `$dependencies` arrays).
- Updated 22 test files to import `PluginContainer as Container` instead of League's `Container`.
