### PR TITLE
Only schedule UpdateEuPoliticalCampaigns jobs with an Ads connection

### DIFF
--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\AsyncActionRunne
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\RowBuilder\OrderItemRowBuilder;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\Services\YouTubeOrders;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\Writer\CsvExportWriter;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantReport;
@@ -214,7 +215,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 
 		$this->share_action_scheduler_job( UpdateMerchantPriceBenchmarks::class, MerchantCenterService::class, PriceBenchmarks::class );
 
-		$this->share_action_scheduler_job( UpdateEuPoliticalCampaigns::class, AdsCampaign::class );
+		$this->share_action_scheduler_job( UpdateEuPoliticalCampaigns::class, AdsCampaign::class, AdsService::class );
 	}
 
 	/**

--- a/src/Jobs/UpdateEuPoliticalCampaigns.php
+++ b/src/Jobs/UpdateEuPoliticalCampaigns.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\AbstractBatchedActionSchedulerJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
@@ -29,15 +30,33 @@ class UpdateEuPoliticalCampaigns extends AbstractBatchedActionSchedulerJob imple
 	protected $ads_campaign;
 
 	/**
+	 * @var AdsService
+	 */
+	protected $ads_service;
+
+	/**
 	 * CreateYouTubeOrderIdsCache constructor.
 	 *
 	 * @param ActionSchedulerInterface  $action_scheduler
 	 * @param ActionSchedulerJobMonitor $monitor
 	 * @param AdsCampaign               $ads_campaign
+	 * @param AdsService                $ads_service
 	 */
-	public function __construct( ActionSchedulerInterface $action_scheduler, ActionSchedulerJobMonitor $monitor, AdsCampaign $ads_campaign ) {
+	public function __construct( ActionSchedulerInterface $action_scheduler, ActionSchedulerJobMonitor $monitor, AdsCampaign $ads_campaign, AdsService $ads_service ) {
 		parent::__construct( $action_scheduler, $monitor );
 		$this->ads_campaign = $ads_campaign;
+		$this->ads_service  = $ads_service;
+	}
+
+	/**
+	 * Can the job be scheduled.
+	 *
+	 * @param array|null $args
+	 *
+	 * @return bool Returns true if the job can be scheduled.
+	 */
+	public function can_schedule( $args = [] ): bool {
+		return parent::can_schedule( $args ) && $this->ads_service->is_connected();
 	}
 
 	/**

--- a/tests/Unit/Jobs/UpdateEuPoliticalCampaignsTest.php
+++ b/tests/Unit/Jobs/UpdateEuPoliticalCampaignsTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
@@ -31,6 +32,9 @@ class UpdateEuPoliticalCampaignsTest extends UnitTest {
 	/** @var MockObject|AdsCampaign */
 	protected $ads_campaign;
 
+	/** @var MockObject|AdsService */
+	protected $ads_service;
+
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
@@ -46,12 +50,14 @@ class UpdateEuPoliticalCampaignsTest extends UnitTest {
 		$this->action_scheduler = $this->createMock( ActionSchedulerInterface::class );
 		$this->monitor          = $this->createMock( ActionSchedulerJobMonitor::class );
 		$this->ads_campaign     = $this->createMock( AdsCampaign::class );
+		$this->ads_service      = $this->createMock( AdsService::class );
 		$this->options          = $this->createMock( OptionsInterface::class );
 
 		$this->job = new UpdateEuPoliticalCampaigns(
 			$this->action_scheduler,
 			$this->monitor,
 			$this->ads_campaign,
+			$this->ads_service,
 		);
 
 		$this->job->set_options_object( $this->options );
@@ -59,6 +65,26 @@ class UpdateEuPoliticalCampaignsTest extends UnitTest {
 
 	public function tearDown(): void {
 		parent::tearDown();
+	}
+
+	public function test_can_schedule_when_ads_connected() {
+		$this->ads_service->method( 'is_connected' )->willReturn( true );
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+
+		$this->assertTrue( $this->job->can_schedule() );
+	}
+
+	public function test_cannot_schedule_when_ads_not_connected() {
+		$this->ads_service->method( 'is_connected' )->willReturn( false );
+
+		$this->assertFalse( $this->job->can_schedule() );
+	}
+
+	public function test_cannot_schedule_when_already_running() {
+		$this->ads_service->method( 'is_connected' )->willReturn( true );
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( true );
+
+		$this->assertFalse( $this->job->can_schedule() );
 	}
 
 	public function test_updates_campaigns_not_targeting_eu_counties() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-595.

This adds a `UpdateEuPoliticalCampaigns::can_schedule()` method that checks for an Ads account connection before scheduling the batch job.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check out develop: Disconnect an Ads account and check to see that the `update_eu_political_campaigns` job is schedule anyway
2. Remove jobs
3. Check out this branch: See that the batch job is not scheduled 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Only schedule UpdateEuPoliticalCampaigns jobs with an Ads connection
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Only schedule UpdateEuPoliticalCampaigns jobs with an Ads connection
