### PR TITLE
Cache AdsReport queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
 			},
 			{
 				"path": "./google-listings-and-ads.zip",
-				"maxSize": "8.33 mB",
+				"maxSize": "8.34 mB",
 				"compression": "none"
 			}
 		],

--- a/src/API/Google/AdsReport.php
+++ b/src/API/Google/AdsReport.php
@@ -68,13 +68,17 @@ class AdsReport implements ContainerAwareInterface, OptionsAwareInterface {
 	 * @throws ExceptionWithResponseData If the report data can't be retrieved.
 	 */
 	public function get_report_data( string $type, array $args ): array {
-		$cache_key    = 'gla_ads_report_' . $type . '_' . md5( serialize( $args ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$ads_id       = (string) $this->options->get_ads_id();
+		$cache_key    = 'gla_ads_report_' . $type . '_' . md5( serialize( [ 'ads_id' => $ads_id, 'args' => $args ] ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 		$cached_value = get_transient( $cache_key );
 
-		if ( false !== $cached_value ) {
+		if ( is_array( $cached_value ) ) {
 			return $cached_value;
 		}
 
+		if ( false !== $cached_value ) {
+			delete_transient( $cache_key );
+		}
 		try {
 			$this->has_converted = 'converted' === $this->container->get( AdsCampaign::class )->get_campaign_convert_status();
 

--- a/src/API/Google/AdsReport.php
+++ b/src/API/Google/AdsReport.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwa
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use DateTime;
+use DateTimeInterface;
 use Google\Ads\GoogleAds\V22\Common\Segments;
 use Google\Ads\GoogleAds\V22\Services\GoogleAdsRow;
 use Google\ApiCore\ApiException;
@@ -69,7 +70,14 @@ class AdsReport implements ContainerAwareInterface, OptionsAwareInterface {
 	 */
 	public function get_report_data( string $type, array $args ): array {
 		$ads_id       = (string) $this->options->get_ads_id();
-		$cache_key    = 'gla_ads_report_' . $type . '_' . md5( serialize( [ 'ads_id' => $ads_id, 'args' => $args ] ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$cache_key    = 'gla_ads_report_' . $type . '_' . md5(
+			wp_json_encode(
+				[
+					'ads_id' => $ads_id,
+					'args'   => $this->normalize_args_for_cache( $args ),
+				]
+			)
+		);
 		$cached_value = get_transient( $cache_key );
 
 		if ( is_array( $cached_value ) ) {
@@ -130,6 +138,39 @@ class AdsReport implements ContainerAwareInterface, OptionsAwareInterface {
 				]
 			);
 		}
+	}
+
+	/**
+	 * Normalize query args for stable cache key generation.
+	 *
+	 * Converts DateTime values to 'Y-m-d' strings (matching how ReportQueryTrait
+	 * formats them for the actual query) and applies a recursive ksort so that
+	 * argument key ordering does not affect the cache key.
+	 *
+	 * @param array $args Raw query arguments.
+	 * @return array Normalized args safe for hashing.
+	 */
+	private function normalize_args_for_cache( array $args ): array {
+		array_walk_recursive(
+			$args,
+			function ( &$value ) {
+				if ( $value instanceof DateTimeInterface ) {
+					$value = $value->format( 'Y-m-d' );
+				}
+			}
+		);
+
+		$sort_recursive = function ( array &$arr ) use ( &$sort_recursive ) {
+			ksort( $arr );
+			foreach ( $arr as &$value ) {
+				if ( is_array( $value ) ) {
+					$sort_recursive( $value );
+				}
+			}
+		};
+		$sort_recursive( $args );
+
+		return $args;
 	}
 
 	/**

--- a/src/API/Google/AdsReport.php
+++ b/src/API/Google/AdsReport.php
@@ -68,6 +68,13 @@ class AdsReport implements ContainerAwareInterface, OptionsAwareInterface {
 	 * @throws ExceptionWithResponseData If the report data can't be retrieved.
 	 */
 	public function get_report_data( string $type, array $args ): array {
+		$cache_key    = 'gla_ads_report_' . $type . '_' . md5( serialize( $args ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$cached_value = get_transient( $cache_key );
+
+		if ( false !== $cached_value ) {
+			return $cached_value;
+		}
+
 		try {
 			$this->has_converted = 'converted' === $this->container->get( AdsCampaign::class )->get_campaign_convert_status();
 
@@ -99,6 +106,8 @@ class AdsReport implements ContainerAwareInterface, OptionsAwareInterface {
 			}
 
 			$this->remove_report_indexes( [ 'products', 'campaigns', 'intervals' ] );
+
+			set_transient( $cache_key, $this->report_data, HOUR_IN_SECONDS );
 
 			return $this->report_data;
 		} catch ( ApiException $e ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-613.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Review the API requests for fetching program data from dev tools `programs?after={date}...` and see that the requests return more quickly once this change is introduced. 
2. E2E tests related to dashboard metrics should still work as expected.


### Additional details:

- Cache key: `gla_ads_report_{type}_{md5_hash}` — unique per $type and $args combination, well within WordPress's 172-character transient key limit.
Cache read: Checks for an existing transient before executing any API queries; returns immediately on a hit.
- Cache write: Stores the assembled report data with a 1-hour expiration after a successful API call, consistent with the freshest data in an Ads metrics data ([reference](https://support.google.com/google-ads/answer/2544985))
- No caching on failure: An ApiException skips `set_transient`, so errors are never cached.
The `phpcs:ignore` comment suppresses the serialize warning, consistent with how other serialized cache keys are used in similar projects.

There is an existing `Transients` class in this project for consistent data, but is based on an allow list of key names. Since this cache requires the ability to store variable key names, this approach doesn't work in it's current form.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Cache AdsReport queries to reduce API requests
