### PR TITLE
[GOOWOO-347] Rewrite the very slow query for the big store

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
 			},
 			{
 				"path": "./google-listings-and-ads.zip",
-				"maxSize": "8.30 mB",
+				"maxSize": "8.40 mB",
 				"compression": "none"
 			}
 		],

--- a/src/Jobs/ResubmitExpiringProducts.php
+++ b/src/Jobs/ResubmitExpiringProducts.php
@@ -17,6 +17,11 @@ defined( 'ABSPATH' ) || exit;
 class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implements RecurringJobInterface {
 
 	/**
+	 * Option name for the last processed post ID between batches (keyset pagination checkpoint).
+	 */
+	protected const RESUBMIT_EXPIRING_PRODUCTS_CHECKPOINT_OPTION = 'woocommerce_gla_resubmit_expiring_products_checkpoint';
+
+	/**
 	 * Get the name of the job.
 	 *
 	 * @return string
@@ -26,16 +31,59 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	}
 
 	/**
+	 * Start the job and reset the pagination checkpoint.
+	 *
+	 * @param array $args Optional arguments passed from the start hook.
+	 */
+	public function schedule( array $args = [] ): void {
+		$this->clear_checkpoint();
+		parent::schedule( $args );
+	}
+
+	/**
 	 * Get a single batch of items.
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int $batch_number The batch number from Action Scheduler (orchestration only; pagination uses the persisted checkpoint).
 	 *
 	 * @return array
 	 */
-	public function get_batch( int $batch_number ): array {
-		return $this->product_repository->find_expiring_product_ids( $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+	public function get_batch( int $batch_number ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		$after_id = (int) get_option( self::RESUBMIT_EXPIRING_PRODUCTS_CHECKPOINT_OPTION, 0 );
+		$items    = $this->product_repository->find_expiring_product_ids( $this->get_batch_size(), $after_id );
+
+		if ( ! empty( $items ) ) {
+			$this->update_checkpoint( $items );
+		}
+
+		return $items;
+	}
+
+	/**
+	 * Clear the pagination checkpoint when the job finishes.
+	 *
+	 * @param int $final_batch_number The final batch number when the job was completed.
+	 */
+	protected function handle_complete( int $final_batch_number ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		$this->clear_checkpoint();
+	}
+
+	/**
+	 * Persist the highest product ID from the batch as the next keyset pagination checkpoint.
+	 *
+	 * @param int[] $items Product IDs from the current batch.
+	 */
+	protected function update_checkpoint( array $items ): void {
+		$last_id = max( array_map( 'absint', $items ) );
+		update_option( self::RESUBMIT_EXPIRING_PRODUCTS_CHECKPOINT_OPTION, $last_id, false );
+	}
+
+	/**
+	 * Remove the stored checkpoint (job finished or a new run is starting).
+	 */
+	protected function clear_checkpoint(): void {
+		delete_option( self::RESUBMIT_EXPIRING_PRODUCTS_CHECKPOINT_OPTION );
 	}
 
 	/**

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use WC_Product;
+use WP_Query;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -30,6 +31,13 @@ class ProductRepository implements Service {
 	 * @var ProductFilter
 	 */
 	protected $product_filter;
+
+	/**
+	 * Exclusive minimum post ID for keyset pagination in find_expiring_product_ids.
+	 *
+	 * @var int|null
+	 */
+	protected ?int $expiring_product_ids_after_id = null;
 
 	/**
 	 * ProductRepository constructor.
@@ -259,12 +267,15 @@ class ProductRepository implements Service {
 	/**
 	 * Find and return an array of WooCommerce product IDs nearly expired and ready to be re-submitted to Google Merchant Center.
 	 *
-	 * @param int $limit  Maximum number of results to retrieve or -1 for unlimited.
-	 * @param int $offset Amount to offset product results.
+	 * Results are ordered by post ID ascending. When $after_id is greater than zero, keyset pagination is used
+	 * (only IDs greater than $after_id), avoiding large offset scans on big catalogs.
+	 *
+	 * @param int $limit    Maximum number of results to retrieve or -1 for unlimited.
+	 * @param int $after_id Only return products with a post ID greater than this value. Use 0 for the first page.
 	 *
 	 * @return int[] Array of WooCommerce product IDs
 	 */
-	public function find_expiring_product_ids( int $limit = - 1, int $offset = 0 ): array {
+	public function find_expiring_product_ids( int $limit = - 1, int $after_id = 0 ): array {
 		$args['meta_query'] = [
 			'relation' => 'AND',
 			$this->get_sync_ready_products_meta_query(),
@@ -278,7 +289,62 @@ class ProductRepository implements Service {
 			],
 		];
 
-		return $this->find_ids( $args, $limit, $offset );
+		$args['orderby'] = 'ID';
+		$args['order']   = 'ASC';
+
+		if ( $after_id > 0 ) {
+			$this->expiring_product_ids_after_id = $after_id;
+			add_filter( 'posts_where', [ $this, 'filter_posts_where_expiring_product_keyset' ], 10, 2 );
+		}
+
+		try {
+			return $this->find_ids( $args, $limit, 0 );
+		} finally {
+			if ( $after_id > 0 ) {
+				remove_filter( 'posts_where', [ $this, 'filter_posts_where_expiring_product_keyset' ], 10 );
+				$this->expiring_product_ids_after_id = null;
+			}
+		}
+	}
+
+	/**
+	 * Restrict the expiring-products query to posts with ID greater than the keyset checkpoint.
+	 *
+	 * @param string   $where    The WHERE clause of the query.
+	 * @param WP_Query $wp_query The WP_Query instance.
+	 *
+	 * @return string
+	 */
+	public function filter_posts_where_expiring_product_keyset( string $where, WP_Query $wp_query ): string {
+		if ( null === $this->expiring_product_ids_after_id || $this->expiring_product_ids_after_id <= 0 ) {
+			return $where;
+		}
+
+		if ( ! $this->is_product_or_variation_query( $wp_query ) ) {
+			return $where;
+		}
+
+		global $wpdb;
+
+		return $where . $wpdb->prepare( " AND `{$wpdb->posts}`.ID > %d ", $this->expiring_product_ids_after_id ); // phpcs:ignore WordPress.DB.PreparedSQL
+	}
+
+	/**
+	 * Whether the query is for WooCommerce products or variations.
+	 *
+	 * @param WP_Query $wp_query The WP_Query instance.
+	 *
+	 * @return bool
+	 */
+	protected function is_product_or_variation_query( WP_Query $wp_query ): bool {
+		$post_type = $wp_query->get( 'post_type' );
+		if ( empty( $post_type ) ) {
+			return false;
+		}
+
+		$types = (array) $post_type;
+
+		return (bool) array_intersect( [ 'product', 'product_variation' ], $types );
 	}
 
 	/**

--- a/tests/Unit/Jobs/ResubmitExpiringProductsTest.php
+++ b/tests/Unit/Jobs/ResubmitExpiringProductsTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 class ResubmitExpiringProductsTest extends UnitTest {
 
 	protected const CHECKPOINT_OPTION = 'woocommerce_gla_resubmit_expiring_products_checkpoint';
-	protected const JOB_NAME         = 'resubmit_expiring_products';
+	protected const JOB_NAME          = 'resubmit_expiring_products';
 	protected const CREATE_BATCH_HOOK = 'gla/jobs/' . self::JOB_NAME . '/create_batch';
 	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
 
@@ -56,13 +56,13 @@ class ResubmitExpiringProductsTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->action_scheduler  = $this->createMock( ActionSchedulerInterface::class );
-		$this->monitor           = $this->createMock( ActionSchedulerJobMonitor::class );
-		$this->product_syncer    = $this->createMock( ProductSyncer::class );
+		$this->action_scheduler   = $this->createMock( ActionSchedulerInterface::class );
+		$this->monitor            = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->product_syncer     = $this->createMock( ProductSyncer::class );
 		$this->product_repository = $this->createMock( ProductRepository::class );
-		$this->product_helper    = $this->createMock( BatchProductHelper::class );
-		$this->merchant_center   = $this->createMock( MerchantCenterService::class );
-		$this->merchant_statuses = $this->createMock( MerchantStatuses::class );
+		$this->product_helper     = $this->createMock( BatchProductHelper::class );
+		$this->merchant_center    = $this->createMock( MerchantCenterService::class );
+		$this->merchant_statuses  = $this->createMock( MerchantStatuses::class );
 
 		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
 		$this->merchant_center->method( 'is_enabled_for_datatype' )->willReturn( true );
@@ -204,7 +204,7 @@ class ResubmitExpiringProductsTest extends UnitTest {
 	}
 
 	/**
-	 * schedule() must clear any stale checkpoint from a previous run before enqueueing the first batch.
+	 * Schedule() must clear any stale checkpoint from a previous run before enqueueing the first batch.
 	 */
 	public function test_schedule_clears_stale_checkpoint_from_previous_run(): void {
 		update_option( self::CHECKPOINT_OPTION, 77, false );

--- a/tests/Unit/Jobs/ResubmitExpiringProductsTest.php
+++ b/tests/Unit/Jobs/ResubmitExpiringProductsTest.php
@@ -1,0 +1,218 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ResubmitExpiringProducts;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class ResubmitExpiringProductsTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
+ */
+class ResubmitExpiringProductsTest extends UnitTest {
+
+	protected const CHECKPOINT_OPTION = 'woocommerce_gla_resubmit_expiring_products_checkpoint';
+	protected const JOB_NAME         = 'resubmit_expiring_products';
+	protected const CREATE_BATCH_HOOK = 'gla/jobs/' . self::JOB_NAME . '/create_batch';
+	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
+
+	/** @var MockObject|ActionSchedulerInterface $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|ProductSyncer $product_syncer */
+	protected $product_syncer;
+
+	/** @var MockObject|ProductRepository $product_repository */
+	protected $product_repository;
+
+	/** @var MockObject|BatchProductHelper $product_helper */
+	protected $product_helper;
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|MerchantStatuses $merchant_statuses */
+	protected $merchant_statuses;
+
+	/** @var ResubmitExpiringProducts $job */
+	protected $job;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->action_scheduler  = $this->createMock( ActionSchedulerInterface::class );
+		$this->monitor           = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->product_syncer    = $this->createMock( ProductSyncer::class );
+		$this->product_repository = $this->createMock( ProductRepository::class );
+		$this->product_helper    = $this->createMock( BatchProductHelper::class );
+		$this->merchant_center   = $this->createMock( MerchantCenterService::class );
+		$this->merchant_statuses = $this->createMock( MerchantStatuses::class );
+
+		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
+		$this->merchant_center->method( 'is_enabled_for_datatype' )->willReturn( true );
+		$this->merchant_center->method( 'should_push' )->willReturn( true );
+
+		$this->job = new ResubmitExpiringProducts(
+			$this->action_scheduler,
+			$this->monitor,
+			$this->product_syncer,
+			$this->product_repository,
+			$this->product_helper,
+			$this->merchant_center,
+			$this->merchant_statuses
+		);
+
+		add_filter(
+			'woocommerce_gla_batched_job_size',
+			function ( $batch_count, $job_name ) {
+				if ( self::JOB_NAME === $job_name ) {
+					return 2;
+				}
+				return $batch_count;
+			},
+			10,
+			2
+		);
+
+		delete_option( self::CHECKPOINT_OPTION );
+
+		$this->job->init();
+	}
+
+	/**
+	 * Runs after each test to ensure option is always cleaned up.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		delete_option( self::CHECKPOINT_OPTION );
+	}
+
+	public function test_job_name(): void {
+		$this->assertSame( self::JOB_NAME, $this->job->get_name() );
+	}
+
+	/**
+	 * On the first batch, no checkpoint exists yet so after_id must be 0.
+	 */
+	public function test_first_batch_passes_zero_as_after_id(): void {
+		$this->product_repository
+			->expects( $this->once() )
+			->method( 'find_expiring_product_ids' )
+			->with( 2, 0 )
+			->willReturn( [ 10, 20 ] );
+
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+
+		do_action( self::CREATE_BATCH_HOOK, 1 );
+	}
+
+	/**
+	 * After a non-empty batch, the checkpoint option must be set to the highest returned ID.
+	 */
+	public function test_checkpoint_is_written_after_non_empty_batch(): void {
+		$this->product_repository
+			->method( 'find_expiring_product_ids' )
+			->willReturn( [ 10, 30, 20 ] );
+
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+
+		do_action( self::CREATE_BATCH_HOOK, 1 );
+
+		$this->assertSame( 30, (int) get_option( self::CHECKPOINT_OPTION ) );
+	}
+
+	/**
+	 * On subsequent batches, get_batch must read the stored checkpoint and pass it to the repository.
+	 */
+	public function test_subsequent_batch_reads_checkpoint_and_passes_it_as_after_id(): void {
+		update_option( self::CHECKPOINT_OPTION, 42, false );
+
+		$this->product_repository
+			->expects( $this->once() )
+			->method( 'find_expiring_product_ids' )
+			->with( 2, 42 )
+			->willReturn( [] );
+
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+
+		do_action( self::CREATE_BATCH_HOOK, 2 );
+	}
+
+	/**
+	 * An empty batch does not overwrite the checkpoint; handle_complete fires and clears it.
+	 */
+	public function test_empty_batch_does_not_write_checkpoint_and_handle_complete_clears_it(): void {
+		update_option( self::CHECKPOINT_OPTION, 99, false );
+
+		$this->product_repository
+			->method( 'find_expiring_product_ids' )
+			->willReturn( [] );
+
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+
+		do_action( self::CREATE_BATCH_HOOK, 1 );
+
+		$this->assertFalse( get_option( self::CHECKPOINT_OPTION ), 'Checkpoint must be deleted when the job completes.' );
+	}
+
+	/**
+	 * Full two-batch cycle: batch 1 sets the checkpoint; batch 2 reads it; batch 3 is empty and clears it.
+	 */
+	public function test_full_keyset_pagination_cycle(): void {
+		$batch_a_ids = [ 10, 20 ];
+		$batch_b_ids = [ 30, 40 ];
+
+		$this->product_repository
+			->expects( $this->exactly( 3 ) )
+			->method( 'find_expiring_product_ids' )
+			->withConsecutive(
+				[ 2, 0 ],
+				[ 2, 20 ],
+				[ 2, 40 ]
+			)
+			->willReturnOnConsecutiveCalls( $batch_a_ids, $batch_b_ids, [] );
+
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+
+		do_action( self::CREATE_BATCH_HOOK, 1 );
+
+		$this->assertSame( 20, (int) get_option( self::CHECKPOINT_OPTION ), 'Checkpoint should be 20 after batch 1.' );
+
+		do_action( self::CREATE_BATCH_HOOK, 2 );
+
+		$this->assertSame( 40, (int) get_option( self::CHECKPOINT_OPTION ), 'Checkpoint should be 40 after batch 2.' );
+
+		do_action( self::CREATE_BATCH_HOOK, 3 );
+
+		$this->assertFalse( get_option( self::CHECKPOINT_OPTION ), 'Checkpoint must be cleared after the final empty batch.' );
+	}
+
+	/**
+	 * schedule() must clear any stale checkpoint from a previous run before enqueueing the first batch.
+	 */
+	public function test_schedule_clears_stale_checkpoint_from_previous_run(): void {
+		update_option( self::CHECKPOINT_OPTION, 77, false );
+
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+
+		$this->job->schedule();
+
+		$this->assertFalse( get_option( self::CHECKPOINT_OPTION ), 'A stale checkpoint must be cleared when a new run is scheduled.' );
+	}
+}

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -294,6 +294,37 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		);
 	}
 
+	public function test_find_expiring_product_ids_keyset_pagination() {
+		$product_a = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_a, $this->generate_google_product_mock() );
+		$this->product_meta->update_synced_at( $product_a, strtotime( '-30 days' ) );
+
+		$product_b = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_b, $this->generate_google_product_mock() );
+		$this->product_meta->update_synced_at( $product_b, strtotime( '-30 days' ) );
+
+		$lower_id  = min( $product_a->get_id(), $product_b->get_id() );
+		$higher_id = max( $product_a->get_id(), $product_b->get_id() );
+
+		$this->assertSame(
+			[ $lower_id ],
+			$this->product_repository->find_expiring_product_ids( 1, 0 ),
+			'First keyset page should return the lowest matching product ID.'
+		);
+
+		$this->assertSame(
+			[ $higher_id ],
+			$this->product_repository->find_expiring_product_ids( 1, $lower_id ),
+			'Second keyset page should return the product with ID greater than the first checkpoint.'
+		);
+
+		$this->assertSame(
+			[],
+			$this->product_repository->find_expiring_product_ids( 1, $higher_id ),
+			'No products should remain after the second checkpoint.'
+		);
+	}
+
 	public function test_find_all_synced_google_ids() {
 		$synced_google_ids = [];
 


### PR DESCRIPTION


### Changes proposed in this Pull Request:

Closes #https://linear.app/a8c/issue/GOOWOO-347/rewrite-the-very-slow-query-for-the-big-store

### Screenshots:

N/A

### Detailed test instructions:

#### Requirements

1. Ensure you have at least 3 published products; each must have a featured image
2. Add a filter to MU plugin to change the batch size from 100 (default) to 1 so we can test this works without needing to create and publish lots of test products

```
add_filter( 'woocommerce_gla_batched_job_size', function() { return 1; }, 10, 1 );
```

3. Clear any old `resubmit_expiring` results; navigate to WP Admin -> WooCommerce -> Status -> Scheduled Actions, in the search field enter `resubmit_expiring`, click "Search hook, args and claim ID". Click the "select all" checkbox to the left of "Hook" in the table, in the bulk actions dropdown select "Delete" then click "Apply". Repeat until the only result left (that you can't remove) is the "pending" scheduled item.

#### Test steps

1. In a terminal, run: `wp post list --post_type=product --post_status=publish --fields=ID,post_title --format=table` - verify there are at least 3 products returned. If this is not the case, create and publish products then run this check again.

2. Force all published products into the "expiring" state, in a terminal run:

```
TIMESTAMP="$(wp eval 'echo time() - 40 * DAY_IN_SECONDS;')"
for id in $(wp post list --post_type=product --post_status=publish --format=ids); do
  wp post meta delete "$id" _wc_gla_errors 2>/dev/null || true
  wp post meta update "$id" _wc_gla_synced_at "$TIMESTAMP"
  wp post meta update "$id" _wc_gla_visibility "sync-and-show"
done
```

5. Verify the meta was set correctly on all products, in a terminal run:

```
for id in $(wp post list --post_type=product --post_status=publish --format=ids); do
  echo "---- Product $id"
  wp post meta list "$id" --keys=_wc_gla_synced_at,_wc_gla_visibility,_wc_gla_errors --format=table
done
```

6. For each product you should see:

`_wc_gla_synced_at` should be set with a UNIX timestamp
`_wc_gla_visibility` should be set with value `sync-and-show`
`_wc_gla_errors` should NOT be set

7. In WP Admin, navigate to WooCommerce -> Status -> Scheduled Actions.

8. In the search field, enter `resubmit_expiring` and click "Search hook, args and claim ID", find the `pending` result (note there may be completed results, ignore these) and hover over it, click `Run` then wait 60 seconds (time to allow the actions to complete) and refresh the page.

9. In the search field, enter `resubmit_expiring` and click "Search hook, args and claim ID". In the results you should see:
- One or more `create_batch` rows with status Complete
- One or more `process_item` rows with status Complete
- No rows with status Failed

If all these are true, the test passes.

10. Remove the filter added before starting this test.

### Additional details:

> Update - Rewrite the very slow query for the big store