### PR TITLE
Fix condition to render disconnect modal

### DIFF
--- a/js/src/pages/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.js
@@ -102,10 +102,12 @@ export default function ConfirmModal( {
 	const dispatcher = useAppDispatch();
 	const { hasGoogleMCConnection } = useGoogleMCAccount();
 
-	const targetTextDict =
-		disconnectTarget === ALL_ACCOUNTS && ! hasGoogleMCConnection
-			? ADS_ONLY
-			: ALL_ACCOUNTS;
+	let targetTextDict = ALL_ACCOUNTS;
+	if ( disconnectTarget === ADS_ACCOUNT ) {
+		targetTextDict = ADS_ACCOUNT;
+	} else if ( disconnectTarget === ALL_ACCOUNTS && ! hasGoogleMCConnection ) {
+		targetTextDict = ADS_ONLY;
+	}
 
 	const { title, confirmButton, confirmation, contents } =
 		textDict[ targetTextDict ];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-551/pressing-disconnect-google-ads-account-only-from-admin-prompts-the

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Complete the standard onboarding flow, then navigate to Settings. Disconnect both Google Ads and All Accounts, and verify that both actions work as expected.
2. Repeat the same process for SBM, ensuring the disconnect functionality behaves correctly.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Disconnect modal now shows Google Ads-specific copy and confirmation text when disconnecting only the Google Ads account, instead of always falling back to the "all accounts" variant.

