### PR TITLE
GOOWOO-618: Conditionally register channel visibility metabox

### DIFF
--- a/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
+++ b/src/Admin/MetaBox/ChannelVisibilityMetaBox.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\ServiceBasedMerchantState;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
@@ -51,18 +52,32 @@ class ChannelVisibilityMetaBox extends SubmittableMetaBox {
 	protected $merchant_center;
 
 	/**
+	 * @var ServiceBasedMerchantState
+	 */
+	protected $service_based_merchant_state;
+
+	/**
 	 * ChannelVisibilityMetaBox constructor.
 	 *
-	 * @param Admin                 $admin
-	 * @param ProductMetaHandler    $meta_handler
-	 * @param ProductHelper         $product_helper
-	 * @param MerchantCenterService $merchant_center
+	 * @param Admin                     $admin
+	 * @param ProductMetaHandler        $meta_handler
+	 * @param ProductHelper             $product_helper
+	 * @param MerchantCenterService     $merchant_center
+	 * @param ServiceBasedMerchantState $service_based_merchant_state
 	 */
-	public function __construct( Admin $admin, ProductMetaHandler $meta_handler, ProductHelper $product_helper, MerchantCenterService $merchant_center ) {
-		$this->meta_handler    = $meta_handler;
-		$this->product_helper  = $product_helper;
-		$this->merchant_center = $merchant_center;
+	public function __construct( Admin $admin, ProductMetaHandler $meta_handler, ProductHelper $product_helper, MerchantCenterService $merchant_center, ServiceBasedMerchantState $service_based_merchant_state ) {
+		$this->meta_handler                 = $meta_handler;
+		$this->product_helper               = $product_helper;
+		$this->merchant_center              = $merchant_center;
+		$this->service_based_merchant_state = $service_based_merchant_state;
 		parent::__construct( $admin );
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function can_register(): bool {
+		return ! $this->service_based_merchant_state->is_service_based_merchant();
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -102,7 +102,7 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 		$this->share_with_tags( BulkEditInitializer::class );
 
 		// Share admin meta boxes
-		$this->share_with_tags( ChannelVisibilityMetaBox::class, Admin::class, ProductMetaHandler::class, ProductHelper::class, MerchantCenterService::class );
+		$this->share_with_tags( ChannelVisibilityMetaBox::class, Admin::class, ProductMetaHandler::class, ProductHelper::class, MerchantCenterService::class, ServiceBasedMerchantState::class );
 		$this->share_with_tags( CouponChannelVisibilityMetaBox::class, Admin::class, CouponMetaHandler::class, CouponHelper::class, MerchantCenterService::class, TargetAudience::class );
 		$this->share_with_tags( MetaBoxInitializer::class, Admin::class, MetaBoxInterface::class, MerchantCenterService::class );
 

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -25,6 +25,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\ServiceBasedMerchantState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
@@ -290,6 +291,8 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		$this->container->get( TransientsInterface::class )->delete( TransientsInterface::MC_ACCOUNT_REVIEW );
 		$this->container->get( TransientsInterface::class )->delete( TransientsInterface::URL_MATCHES );
 		$this->container->get( TransientsInterface::class )->delete( TransientsInterface::MC_IS_SUBACCOUNT );
+
+		$this->container->get( ServiceBasedMerchantState::class )->reset_service_based_merchant_status();
 	}
 
 	/**
@@ -465,7 +468,6 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		/** @var Merchant $merchant */
 		$merchant = $this->container->get( Merchant::class );
 
-		/** @var Account $account */
 		$account     = $merchant->get_account( $merchant_id );
 		$account_url = $account->getWebsiteUrl() ?: '';
 

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -21,6 +21,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\ServiceBasedMerchantState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\MerchantTrait;
@@ -88,6 +89,9 @@ class AccountServiceTest extends UnitTest {
 	/** @var MockObject|NotificationsService $transients */
 	protected $notifications_service;
 
+	/** @var MockObject|ServiceBasedMerchantState $service_based_merchant_state */
+	protected $service_based_merchant_state;
+
 	/** @var AccountService $account */
 	protected $account;
 
@@ -125,21 +129,22 @@ class AccountServiceTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->ads                   = $this->createMock( Ads::class );
-		$this->cleanup_synced        = $this->createMock( CleanupSyncedProducts::class );
-		$this->merchant              = $this->createMock( Merchant::class );
-		$this->mc_service            = $this->createMock( MerchantCenterService::class );
-		$this->issue_table           = $this->createMock( MerchantIssueTable::class );
-		$this->merchant_statuses     = $this->createMock( MerchantStatuses::class );
-		$this->middleware            = $this->createMock( Middleware::class );
-		$this->site_verification     = $this->createMock( SiteVerification::class );
-		$this->rate_table            = $this->createMock( ShippingRateTable::class );
-		$this->time_table            = $this->createMock( ShippingTimeTable::class );
-		$this->state                 = $this->createMock( MerchantAccountState::class );
-		$this->ads_state             = $this->createMock( AdsAccountState::class );
-		$this->options               = $this->createMock( OptionsInterface::class );
-		$this->transients            = $this->createMock( TransientsInterface::class );
-		$this->notifications_service = $this->createMock( NotificationsService::class );
+		$this->ads                          = $this->createMock( Ads::class );
+		$this->cleanup_synced               = $this->createMock( CleanupSyncedProducts::class );
+		$this->merchant                     = $this->createMock( Merchant::class );
+		$this->mc_service                   = $this->createMock( MerchantCenterService::class );
+		$this->issue_table                  = $this->createMock( MerchantIssueTable::class );
+		$this->merchant_statuses            = $this->createMock( MerchantStatuses::class );
+		$this->middleware                   = $this->createMock( Middleware::class );
+		$this->site_verification            = $this->createMock( SiteVerification::class );
+		$this->rate_table                   = $this->createMock( ShippingRateTable::class );
+		$this->time_table                   = $this->createMock( ShippingTimeTable::class );
+		$this->state                        = $this->createMock( MerchantAccountState::class );
+		$this->ads_state                    = $this->createMock( AdsAccountState::class );
+		$this->options                      = $this->createMock( OptionsInterface::class );
+		$this->transients                   = $this->createMock( TransientsInterface::class );
+		$this->notifications_service        = $this->createMock( NotificationsService::class );
+		$this->service_based_merchant_state = $this->createMock( ServiceBasedMerchantState::class );
 
 		$this->container = new Container();
 		$this->container->addShared( Ads::class, $this->ads );
@@ -155,7 +160,7 @@ class AccountServiceTest extends UnitTest {
 		$this->container->addShared( ShippingRateTable::class, $this->rate_table );
 		$this->container->addShared( ShippingTimeTable::class, $this->time_table );
 		$this->container->addShared( TransientsInterface::class, $this->transients );
-		$this->container->addShared( TransientsInterface::class, $this->transients );
+		$this->container->addShared( ServiceBasedMerchantState::class, $this->service_based_merchant_state );
 
 		$this->job_repository = new JobRepository();
 		$this->job_repository->set_container( $this->container );
@@ -969,6 +974,9 @@ class AccountServiceTest extends UnitTest {
 				[ TransientsInterface::URL_MATCHES ],
 				[ TransientsInterface::MC_IS_SUBACCOUNT ]
 			);
+
+		$this->service_based_merchant_state->expects( $this->once() )
+			->method( 'reset_service_based_merchant_status' );
 
 		$this->account->disconnect();
 	}

--- a/tests/Unit/Product/ChannelVisibilityMetaBoxTest.php
+++ b/tests/Unit/Product/ChannelVisibilityMetaBoxTest.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\ChannelVisibilityMetaBox;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\ServiceBasedMerchantState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
@@ -33,22 +34,27 @@ class ChannelVisibilityMetaBoxTest extends UnitTest {
 	/** @var \PHPUnit\Framework\MockObject\Stub|MerchantCenterService $merchant_center */
 	protected $merchant_center;
 
+	/** @var \PHPUnit\Framework\MockObject\Stub|ServiceBasedMerchantState $service_based_merchant_state */
+	protected $service_based_merchant_state;
+
 	/** @var ChannelVisibilityMetaBox $channel_visibility_meta_box */
 	protected $channel_visibility_meta_box;
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->admin           = $this->createStub( Admin::class );
-		$this->meta_handler    = $this->createMock( ProductMetaHandler::class );
-		$this->product_helper  = $this->createStub( ProductHelper::class );
-		$this->merchant_center = $this->createStub( MerchantCenterService::class );
+		$this->admin                        = $this->createStub( Admin::class );
+		$this->meta_handler                 = $this->createMock( ProductMetaHandler::class );
+		$this->product_helper               = $this->createStub( ProductHelper::class );
+		$this->merchant_center              = $this->createStub( MerchantCenterService::class );
+		$this->service_based_merchant_state = $this->createStub( ServiceBasedMerchantState::class );
 
 		$this->channel_visibility_meta_box = new ChannelVisibilityMetaBox(
 			$this->admin,
 			$this->meta_handler,
 			$this->product_helper,
-			$this->merchant_center
+			$this->merchant_center,
+			$this->service_based_merchant_state
 		);
 	}
 
@@ -88,7 +94,15 @@ class ChannelVisibilityMetaBoxTest extends UnitTest {
 		];
 	}
 
-	public function test_can_register_always_returns_true() {
+	public function test_can_register_returns_false_for_service_based_merchant() {
+		$this->service_based_merchant_state->method( 'is_service_based_merchant' )->willReturn( true );
+
+		$this->assertFalse( $this->channel_visibility_meta_box->can_register() );
+	}
+
+	public function test_can_register_returns_true_for_non_service_based_merchant() {
+		$this->service_based_merchant_state->method( 'is_service_based_merchant' )->willReturn( false );
+
 		$this->assertTrue( $this->channel_visibility_meta_box->can_register() );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-618/hide-channel-visibility-metabox-for-service-based-merchants .

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

#### Setup
- A test site with the Google for WooCommerce plugin installed and the connect-to-Google flow available.
- The ability to add and delete WooCommerce products (Products → Add new).
- Note: the option this PR cares about is named gla_is_service_based_merchant.


Test 1 - channel visibility
1. The Channel Visibility should not be visible when editing a product for service based merchants.
2. For non service based merchants, the metabox should render as usual


Test 2 - Service-based merchant (existing behaviour)
1. Make sure the store has no physical products. If it does, either delete them or mark them all as Virtual (Edit product → Product data → tick "Virtual").
2. Complete the Google for WooCommerce connection flow.
3. Go to Products → All products and edit any product.

Expected: the Channel visibility metabox is not shown.

Test 3 - Non-service-based merchant (existing behaviour)
1. Add at least one physical product (a regular product with Virtual unticked).
2. Edit that product.

Expected: the Channel visibility metabox is shown as usual.

Test 4 - Disconnect clears the cached state ← new
1. Starting from the setup in Test 2 (service-based merchant, connected).
2. Inspect wp_options and confirm that a row exists with option_name = 'gla_is_service_based_merchant' and option_value = 'yes'.
3. Go to Marketing → Google for WooCommerce → Settings.
4. Click Disconnect all accounts and confirm.

Expected:
- The disconnect completes successfully.
- The gla_is_service_based_merchant row is no longer present in wp_options.

Test 5 - Reconnect repopulates the cached state ← new
- Continuing from Test 4 (disconnected, option cleared).
- Reconnect by completing the connect-to-Google flow again.
- Visit any admin page that involves the plugin (e.g. Marketing → Google for WooCommerce, or edit any product).

Expected:
- The gla_is_service_based_merchant row exists again in wp_options and its value matches the current product catalogue: 'yes' if the store still has no physical products / 'no' if the store now has at least one physical product.
- Editing a product shows the Channel visibility metabox if and only if the merchant currently has at least one physical product.

Test 6 - Recovery from a stuck state ← new (the original concern)
This verifies that a merchant who became service-based, then later started selling physical products, can recover by disconnecting and reconnecting.

- Start from a service-based store as in Test 2, fully connected.
- Edit a product → the Channel visibility metabox is hidden. Good.
- Without disconnecting, add a new physical (non-virtual) product.
- Edit that physical product. (For information only — pre-fix behaviour: the Channel visibility metabox stays hidden because the cached state is stale. This is the bug that prompted the fix.)
- Disconnect all accounts (as in Test 4), then reconnect (as in Test 5).
- Edit the physical product again.

Expected: the Channel visibility metabox is now shown, because the cached state was reset by the disconnect and recomputed after reconnect to reflect the real product mix.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
