### PR TITLE
GOOWOO-510: Enable brand guidelines for non-shopping campaigns

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -752,9 +752,6 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 					'feed_label'  => $country,
 				]
 			);
-		} else {
-			// Turn off brand guidelines for non-shopping campaigns.
-			$campaign_data['brand_guidelines_enabled'] = false;
 		}
 
 		$campaign = new Campaign( $campaign_data );

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -649,6 +649,62 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	}
 
 	/**
+	 * Split an assets array into brand assets (business name, logo) and the rest
+	 *
+	 * @param array $assets
+	 *
+	 * @return array{0: array, 1: array} [brand_assets, asset_group_assets]
+	 */
+	protected function partition_brand_assets( array $assets ): array {
+		$brand             = [];
+		$asset_group_level = [];
+
+		foreach ( $assets as $asset ) {
+			$field_type = $asset['field_type'] ?? '';
+			if ( AssetFieldType::BUSINESS_NAME === $field_type || AssetFieldType::LOGO === $field_type ) {
+				$brand[] = $asset;
+			} else {
+				$asset_group_level[] = $asset;
+			}
+		}
+
+		return [ $brand, $asset_group_level ];
+	}
+
+	/**
+	 * Build Asset create operations and matching CampaignAsset link operations for brand assets.
+	 *
+	 * @param array $brand_assets
+	 *
+	 * @return MutateOperation[]
+	 */
+	protected function create_brand_asset_operations( array $brand_assets ): array {
+		$asset_ops = $this->container->get( AdsAsset::class )->create_operations( $brand_assets );
+
+		$business_name_resources = [];
+		$logo_resources          = [];
+
+		foreach ( $asset_ops as $i => $asset_op ) {
+			$asset_resource = $asset_op->getAssetOperation()->getCreate()->getResourceName();
+			$field_type     = $brand_assets[ $i ]['field_type'] ?? '';
+
+			if ( AssetFieldType::BUSINESS_NAME === $field_type ) {
+				$business_name_resources[] = $asset_resource;
+			} elseif ( AssetFieldType::LOGO === $field_type ) {
+				$logo_resources[] = $asset_resource;
+			}
+		}
+
+		$link_ops = $this->campaign_asset->create_link_operations_for_resources(
+			$this->temporary_resource_name(),
+			$business_name_resources,
+			$logo_resources
+		);
+
+		return array_merge( $asset_ops, $link_ops );
+	}
+
+	/**
 	 * Returns a campaign create operation.
 	 *
 	 * @param string      $campaign_name

--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -298,14 +298,24 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			// Create asset group operations.
 			$ad_asset_group = $this->container->get( AdsAssetGroup::class );
 
+			// Brand assets (business name, logo) must be linked at the campaign level when
+			// brand_guidelines_enabled is true. All other assets are linked at the asset group level.
+			$brand_operations = [];
+
 			// If final URL and assets are passed create operations for those.
 			if ( isset( $params['final_url'] ) && isset( $params['assets'] ) ) {
+				[ $brand_assets, $asset_group_assets ] = $this->partition_brand_assets( $params['assets'] );
+
 				$asset_group_operations = $ad_asset_group->create_operations_with_assets(
 					$this->temporary_resource_name(),
 					$params['name'],
 					$params['final_url'],
-					$params['assets']
+					$asset_group_assets
 				);
+
+				if ( ! empty( $brand_assets ) ) {
+					$brand_operations = $this->create_brand_asset_operations( $brand_assets );
+				}
 			} else {
 				// Create "empty" asset group operations.
 				$asset_group_operations = $ad_asset_group->create_operations(
@@ -325,6 +335,7 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 				$budget_operations,
 				$campaign_operations,
 				$asset_group_operations,
+				$brand_operations,
 				$criteria_operations
 			);
 

--- a/src/API/Google/AdsCampaignAsset.php
+++ b/src/API/Google/AdsCampaignAsset.php
@@ -75,6 +75,37 @@ class AdsCampaignAsset implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Create operations to link newly created brand assets to a campaign.
+	 *
+	 * @param string $campaign_resource_name  Campaign resource name.
+	 * @param array  $business_name_resources Array of asset resource names to link as BUSINESS_NAME.
+	 * @param array  $logo_resources          Array of asset resource names to link as LOGO.
+	 *
+	 * @return MutateOperation[]
+	 */
+	public function create_link_operations_for_resources( string $campaign_resource_name, array $business_name_resources = [], array $logo_resources = [] ): array {
+		$operations = [];
+
+		foreach ( $business_name_resources as $asset_resource ) {
+			$operations[] = $this->create_campaign_asset_operation_for_resource(
+				$campaign_resource_name,
+				$asset_resource,
+				AssetFieldTypeEnum::BUSINESS_NAME
+			);
+		}
+
+		foreach ( $logo_resources as $asset_resource ) {
+			$operations[] = $this->create_campaign_asset_operation_for_resource(
+				$campaign_resource_name,
+				$asset_resource,
+				AssetFieldTypeEnum::LOGO
+			);
+		}
+
+		return $operations;
+	}
+
+	/**
 	 * Create a campaign asset link operation.
 	 *
 	 * @param string $campaign_resource Campaign resource name.
@@ -85,7 +116,19 @@ class AdsCampaignAsset implements OptionsAwareInterface {
 	 */
 	protected function create_campaign_asset_operation( string $campaign_resource, int $asset_id, int $field_type ): MutateOperation {
 		$asset_resource = ResourceNames::forAsset( $this->options->get_ads_id(), $asset_id );
+		return $this->create_campaign_asset_operation_for_resource( $campaign_resource, $asset_resource, $field_type );
+	}
 
+	/**
+	 * Create a campaign asset link operation from resource names.
+	 *
+	 * @param string $campaign_resource Campaign resource name.
+	 * @param string $asset_resource    Asset resource name.
+	 * @param int    $field_type        Asset field type enum value.
+	 *
+	 * @return MutateOperation
+	 */
+	protected function create_campaign_asset_operation_for_resource( string $campaign_resource, string $asset_resource, int $field_type ): MutateOperation {
 		$campaign_asset = new CampaignAsset(
 			[
 				'campaign'   => $campaign_resource,

--- a/tests/Unit/API/Google/AdsCampaignAssetTest.php
+++ b/tests/Unit/API/Google/AdsCampaignAssetTest.php
@@ -1,0 +1,114 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignAsset;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
+use Google\Ads\GoogleAds\Util\V22\ResourceNames;
+use Google\Ads\GoogleAds\V22\Enums\AssetFieldTypeEnum\AssetFieldType as AssetFieldTypeEnum;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AdsCampaignAssetTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ */
+class AdsCampaignAssetTest extends UnitTest {
+
+	use GoogleAdsClientTrait;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var AdsCampaignAsset $campaign_asset */
+	protected $campaign_asset;
+
+	protected const TEST_CAMPAIGN_ID             = 1234567890;
+	protected const TEST_BUSINESS_NAME_ID        = 1111111111;
+	protected const TEST_LOGO_ID                 = 2222222222;
+	protected const TEST_CAMPAIGN_ASSET_RESOURCE = 'customers/12345/campaignAssets/1234567890~1111111111~2';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->ads_client_setup();
+
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_ads_id' )->willReturn( $this->ads_id );
+
+		$this->campaign_asset = new AdsCampaignAsset( $this->client );
+		$this->campaign_asset->set_options_object( $this->options );
+	}
+
+	public function test_create_link_operations_returns_expected_operations() {
+		$operations = $this->campaign_asset->create_link_operations(
+			self::TEST_CAMPAIGN_ID,
+			[ self::TEST_BUSINESS_NAME_ID ],
+			[ self::TEST_LOGO_ID ]
+		);
+
+		$this->assertCount( 2, $operations );
+
+		$expected_campaign_resource = ResourceNames::forCampaign( $this->ads_id, self::TEST_CAMPAIGN_ID );
+
+		$business_name_asset = $operations[0]->getCampaignAssetOperation()->getCreate();
+		$this->assertEquals( $expected_campaign_resource, $business_name_asset->getCampaign() );
+		$this->assertEquals( ResourceNames::forAsset( $this->ads_id, self::TEST_BUSINESS_NAME_ID ), $business_name_asset->getAsset() );
+		$this->assertEquals( AssetFieldTypeEnum::BUSINESS_NAME, $business_name_asset->getFieldType() );
+
+		$logo_asset = $operations[1]->getCampaignAssetOperation()->getCreate();
+		$this->assertEquals( $expected_campaign_resource, $logo_asset->getCampaign() );
+		$this->assertEquals( ResourceNames::forAsset( $this->ads_id, self::TEST_LOGO_ID ), $logo_asset->getAsset() );
+		$this->assertEquals( AssetFieldTypeEnum::LOGO, $logo_asset->getFieldType() );
+	}
+
+	public function test_create_link_operations_empty_arrays_returns_no_operations() {
+		$operations = $this->campaign_asset->create_link_operations( self::TEST_CAMPAIGN_ID );
+
+		$this->assertEquals( [], $operations );
+	}
+
+	public function test_create_link_operations_for_resources_returns_expected_operations() {
+		$campaign_resource      = 'customers/12345/campaigns/-1';
+		$business_name_resource = 'customers/12345/assets/-7';
+		$logo_resource          = 'customers/12345/assets/-8';
+
+		$operations = $this->campaign_asset->create_link_operations_for_resources(
+			$campaign_resource,
+			[ $business_name_resource ],
+			[ $logo_resource ]
+		);
+
+		$this->assertCount( 2, $operations );
+
+		$business_name_asset = $operations[0]->getCampaignAssetOperation()->getCreate();
+		$this->assertEquals( $campaign_resource, $business_name_asset->getCampaign() );
+		$this->assertEquals( $business_name_resource, $business_name_asset->getAsset() );
+		$this->assertEquals( AssetFieldTypeEnum::BUSINESS_NAME, $business_name_asset->getFieldType() );
+
+		$logo_asset = $operations[1]->getCampaignAssetOperation()->getCreate();
+		$this->assertEquals( $campaign_resource, $logo_asset->getCampaign() );
+		$this->assertEquals( $logo_resource, $logo_asset->getAsset() );
+		$this->assertEquals( AssetFieldTypeEnum::LOGO, $logo_asset->getFieldType() );
+	}
+
+	public function test_create_link_operations_for_resources_empty_arrays_returns_no_operations() {
+		$operations = $this->campaign_asset->create_link_operations_for_resources( 'customers/12345/campaigns/-1' );
+
+		$this->assertEquals( [], $operations );
+	}
+
+	public function test_create_remove_operation_returns_expected_operation() {
+		$operation = $this->campaign_asset->create_remove_operation( self::TEST_CAMPAIGN_ASSET_RESOURCE );
+
+		$this->assertEquals( self::TEST_CAMPAIGN_ASSET_RESOURCE, $operation->getCampaignAssetOperation()->getRemove() );
+	}
+}

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -3,9 +3,11 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAssetGroup;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignAsset;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignBudget;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignCriterion;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaignLabel;
@@ -804,6 +806,77 @@ class AdsCampaignTest extends UnitTest {
 		$this->campaign_label->expects( $this->once() )
 			->method( 'assign_label_to_campaign_by_label_name' )
 			->with( self::TEST_CAMPAIGN_ID, 'wc-gla' );
+
+		$this->assertEquals(
+			$expected,
+			$this->campaign->create_campaign( $campaign_data )
+		);
+	}
+
+	public function test_create_campaign_with_brand_assets() {
+		$business_name_asset = [
+			'field_type' => AssetFieldType::BUSINESS_NAME,
+			'content'    => 'My Shop',
+		];
+		$logo_asset          = [
+			'field_type' => AssetFieldType::LOGO,
+			'content'    => 'https://example.com/logo.png',
+		];
+		$headline_asset      = [
+			'field_type' => AssetFieldType::HEADLINE,
+			'content'    => 'Test headline',
+		];
+
+		$campaign_data = [
+			'name'                                  => 'New Campaign',
+			'amount'                                => 20,
+			'targeted_locations'                    => [ 'US' ],
+			'eu_political_advertising_confirmation' => false,
+			'final_url'                             => 'https://example.com',
+			'assets'                                => [ $business_name_asset, $headline_asset, $logo_asset ],
+		];
+
+		$this->wc->expects( $this->once() )
+			->method( 'get_base_country' )
+			->willReturn( self::BASE_COUNTRY );
+
+		$this->asset_group->expects( $this->once() )
+			->method( 'create_operations_with_assets' )
+			->with(
+				$this->anything(),
+				'New Campaign',
+				'https://example.com',
+				[ $headline_asset ]
+			)
+			->willReturn( [] );
+
+		$business_name_op = $this->generate_asset_create_operation( -10, AssetFieldType::BUSINESS_NAME, 'My Shop' );
+		$logo_op          = $this->generate_asset_create_operation( -11, AssetFieldType::LOGO, 'https://example.com/logo.png' );
+
+		$ads_asset = $this->createMock( AdsAsset::class );
+		$ads_asset->expects( $this->once() )
+			->method( 'create_operations' )
+			->with( [ $business_name_asset, $logo_asset ] )
+			->willReturn( [ $business_name_op, $logo_op ] );
+		$this->container->addShared( AdsAsset::class, $ads_asset );
+
+		$this->campaign_asset->expects( $this->once() )
+			->method( 'create_link_operations_for_resources' )
+			->with(
+				$this->anything(),
+				[ $business_name_op->getAssetOperation()->getCreate()->getResourceName() ],
+				[ $logo_op->getAssetOperation()->getCreate()->getResourceName() ]
+			)
+			->willReturn( [] );
+
+		$this->generate_campaign_mutate_mock( 'create', self::TEST_CAMPAIGN_ID );
+
+		$expected = [
+			'id'      => self::TEST_CAMPAIGN_ID,
+			'status'  => 'enabled',
+			'type'    => 'performance_max',
+			'country' => self::BASE_COUNTRY,
+		] + $campaign_data;
 
 		$this->assertEquals(
 			$expected,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-510/enable-brand-guidelines-for-non-shopping-campaigns-sbms

Removes a temporary workaround that forced `brand_guidelines_enabled = false` on non-shopping campaigns.
`AdsCampaign::create_campaign` now partitions the incoming assets: business name + logo are linked at the **campaign** level via `CampaignAsset`, and all other assets continue to the asset group via `AssetGroupAsset`
### Screenshots:


| Assets table | Campaign Settings |
| --- | --- |
| <img width="1175" height="798" alt="image" src="https://github.com/user-attachments/assets/931c7669-672a-4867-b5e8-c8c1ff0e61bc" /> | <img width="1175" height="798" alt="image" src="https://github.com/user-attachments/assets/39d153da-d60e-424f-8214-df719c4b86c6" /> |


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Create the campaign from WP Admin
Complete the wizard (budget, business name, logo, etc.)
Submit

Verify in Google Ads UI
Select Campaign -> Assets
Confirm logo and business nameare in the  assets table:

Additionally, go to Campaign Settings -> Brand Guidelines and confirm that business name and logo are there

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Enable brand guidelines on non-shopping campaigns.