### PR TITLE
Add MarketNotice component (GOOWOO-589)

### DIFF
--- a/js/src/components/market-notice/index.js
+++ b/js/src/components/market-notice/index.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AppNotice from '~/components/app-notice';
+
+const VARIANT_MAP = {
+	shippingManaged: {
+		title: __( 'Shipping managed by Google', 'google-listings-and-ads' ),
+		description: __(
+			'Your shipping settings are managed through Google Merchant Center.',
+			'google-listings-and-ads'
+		),
+	},
+	automaticShipping: {
+		title: __( 'Automatic shipping', 'google-listings-and-ads' ),
+		description: __(
+			'Shipping rates and times are automatically synced from your store settings.',
+			'google-listings-and-ads'
+		),
+	},
+};
+
+/**
+ * Renders an info notice whose title and description are resolved from a
+ * built-in variant map, so all copy lives in one place.
+ *
+ * @param {Object} props
+ * @param {string} props.variant One of the keys defined in VARIANT_MAP.
+ * @return {JSX.Element|null} The notice, or null for an unrecognised variant.
+ */
+const MarketNotice = ( { variant } ) => {
+	const notice = VARIANT_MAP[ variant ];
+
+	if ( ! notice ) {
+		return null;
+	}
+
+	const { title, description } = notice;
+
+	return (
+		<AppNotice status="info" isDismissible={ false }>
+			<strong>{ title }</strong>
+			<p>{ description }</p>
+		</AppNotice>
+	);
+};
+
+export default MarketNotice;

--- a/js/src/components/market-notice/index.test.js
+++ b/js/src/components/market-notice/index.test.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import MarketNotice from './index';
+
+jest.mock( '~/components/app-notice', () => ( { children } ) => (
+	<div>{ children }</div>
+) );
+
+describe( 'MarketNotice', () => {
+	it( 'renders the shippingManaged variant', () => {
+		render( <MarketNotice variant="shippingManaged" /> );
+		expect(
+			screen.getByText( 'Shipping managed by Google' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'Your shipping settings are managed through Google Merchant Center.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders the automaticShipping variant', () => {
+		render( <MarketNotice variant="automaticShipping" /> );
+		expect(
+			screen.getByText( 'Automatic shipping' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'Shipping rates and times are automatically synced from your store settings.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing for an unrecognised variant', () => {
+		const { container } = render( <MarketNotice variant="unknown" /> );
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'renders nothing when variant is omitted', () => {
+		const { container } = render( <MarketNotice /> );
+		expect( container.firstChild ).toBeNull();
+	} );
+} );


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/GOOWOO-589/rename-shippingnotice-to-marketnotice-and-support-custom-messages

### Changes proposed in this Pull Request

Introduces `MarketNotice`, a generic info notice component for the Markets feature. Title and description strings are resolved from an internal `VARIANT_MAP` keyed by `variant` prop — so all copy lives in one place and adding a new notice requires only a new map entry.

### Implementation notes

- `ShippingNotice` / `shipping-notice.js` does not exist on any branch — this is a greenfield implementation, not a rename
- `EditMarketModal` (the primary consumer named in the ticket) does not exist yet; call-site integration is out of scope for this PR
- Returns `null` for unrecognised variants rather than throwing, for safe forward-compatibility as new variants are added
- Wraps `AppNotice` (not `@wordpress/components` `Notice` directly) to stay consistent with the rest of the codebase

### Test instructions

```
npm run test:js -- --testPathPattern="market-notice" --no-coverage
```

All 4 tests pass: `shippingManaged` variant, `automaticShipping` variant, unknown variant (renders nothing), missing variant (renders nothing).

### Changelog entry

> Add - `MarketNotice` component with `VARIANT_MAP` for centralised market notice copy management.