### PR TITLE
Dev - Remove API Pull sync status rows from debug tool

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -734,42 +734,6 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 							</td>
 						</tr>
 						<tr>
-							<th><label>Products API PULL Sync:</label></th>
-							<td>
-								<p>
-
-									<code><?php echo $this->enabled_or_disabled( $notification_service->is_pull_enabled_for_datatype( NotificationsService::DATATYPE_PRODUCT ) ); ?></code>
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<th><label>Coupons API PULL Sync:</label></th>
-							<td>
-								<p>
-
-									<code><?php echo $this->enabled_or_disabled( $notification_service->is_pull_enabled_for_datatype( NotificationsService::DATATYPE_COUPON ) ); ?></code>
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<th><label>Shipping API PULL Sync:</label></th>
-							<td>
-								<p>
-
-									<code><?php echo $this->enabled_or_disabled( $notification_service->is_pull_enabled_for_datatype( NotificationsService::DATATYPE_SHIPPING ) ); ?></code>
-								</p>
-							</td>
-						</tr>
-						<tr>
-							<th><label>Settings API PULL Sync:</label></th>
-							<td>
-								<p>
-
-									<code><?php echo $this->enabled_or_disabled( $notification_service->is_pull_enabled_for_datatype( NotificationsService::DATATYPE_SETTINGS ) ); ?></code>
-								</p>
-							</td>
-						</tr>
-						<tr>
 							<th><label>WPCOM REST API Status:</label></th>
 							<td>
 								<p>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removes the four per-datatype API Pull sync status rows from the `ConnectionTest.php` debug tool:

- Products API PULL Sync
- Coupons API PULL Sync
- Shipping API PULL Sync
- Settings API PULL Sync

These rows always display as "Disabled" since PR #3273 (GOOWOO-483) permanently disabled pull mode for all users. They are unnecessary and confusing to users who see them in the debug panel.

### Screenshots:

N/A

### Detailed test instructions:

1. Open the debug tool at `wp-admin/admin.php?page=connection-test-admin-page`
2. Scroll to the "Partner API Pull Integration" section
3. Verify the four per-datatype pull status rows are no longer shown
4. Verify the remaining rows (Notification Service Enabled, Notification Service Ready, WPCOM REST API Status, Send notification form, API Pull Integration Status button) are still present and functional

### Additional details:

Follow-up cleanup to GOOWOO-483 / PR #3273.

### Changelog entry

> Dev - Remove API Pull sync status rows from the Connection Test page.