### PR TITLE
Fix generate changelog workflow

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -183,8 +183,8 @@ jobs:
             const changelogBlock = process.env.CHANGELOG_BLOCK;
             const content = fs.readFileSync('changelog.txt', 'utf8');
             const newlineIdx = content.indexOf('\n');
-            const header = content.slice(0, newlineIdx);
-            const existingBody = content.slice(newlineIdx).replace(/^\n+/, '');
+            const header = newlineIdx === -1 ? content : content.slice(0, newlineIdx);
+            const existingBody = newlineIdx === -1 ? '' : content.slice(newlineIdx).replace(/^\n+/, '');
             const updatedContent = `${header}\n\n${changelogBlock}\n\n${existingBody}`;
             fs.writeFileSync('changelog.txt', updatedContent.endsWith('\n') ? updatedContent : `${updatedContent}\n`);
 

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -185,7 +185,8 @@ jobs:
             const newlineIdx = content.indexOf('\n');
             const header = content.slice(0, newlineIdx);
             const existingBody = content.slice(newlineIdx).replace(/^\n+/, '');
-            fs.writeFileSync('changelog.txt', `${header}\n\n${changelogBlock}\n\n${existingBody}`);
+            const updatedContent = `${header}\n\n${changelogBlock}\n\n${existingBody}`;
+            fs.writeFileSync('changelog.txt', updatedContent.endsWith('\n') ? updatedContent : `${updatedContent}\n`);
 
       - name: Insert changelog entry into readme.txt
         env:

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -144,7 +144,7 @@ jobs:
                 if (match) {
                   entry = match[1]
                     .split('\n')
-                    .map(l => l.replace(/^[\s*\-]+/, '').trim())
+                    .map(l => l.replace(/^[\s*\->]+/, '').trim())
                     .find(l => l && l.toLowerCase() !== 'n/a') ?? null;
                 }
               }
@@ -176,48 +176,44 @@ jobs:
       - name: Prepend changelog entry to changelog.txt
         env:
           CHANGELOG_BLOCK: ${{ steps.generate.outputs.changelog_block }}
-        run: |
-          python3 - <<'PYEOF'
-          import os
-          import re
-          from pathlib import Path
-
-          changelog_path = Path('changelog.txt')
-          content = changelog_path.read_text()
-          lines = content.splitlines()
-
-          header = lines[0] if lines else '*** Changelog ***'
-          existing_body = '\n'.join(lines[1:]).lstrip('\n')
-          new_block = os.environ['CHANGELOG_BLOCK'].strip()
-
-          combined_body = f"{new_block}\n\n{existing_body}".strip()
-          entry_pattern = re.compile(r'^= .+? =\n.*?(?=^= .+? =\n|\Z)', re.M | re.S)
-          entries = [entry.strip() for entry in entry_pattern.findall(combined_body)]
-          kept_entries = entries[:3]
-
-          updated = f"{header}\n\n" + '\n\n'.join(kept_entries).rstrip() + '\n'
-          changelog_path.write_text(updated)
-          PYEOF
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const changelogBlock = process.env.CHANGELOG_BLOCK;
+            const content = fs.readFileSync('changelog.txt', 'utf8');
+            const newlineIdx = content.indexOf('\n');
+            const header = content.slice(0, newlineIdx);
+            const existingBody = content.slice(newlineIdx).replace(/^\n+/, '');
+            fs.writeFileSync('changelog.txt', `${header}\n\n${changelogBlock}\n\n${existingBody}`);
 
       - name: Insert changelog entry into readme.txt
         env:
           CHANGELOG_BLOCK: ${{ steps.generate.outputs.changelog_block }}
-        run: |
-          python3 - <<'PYEOF'
-          import os, re
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const changelogBlock = process.env.CHANGELOG_BLOCK;
+            const lines = fs.readFileSync('readme.txt', 'utf8').split('\n');
+            const output = [];
+            let inChangelog = false;
+            let releases = 0;
 
-          entry = os.environ['CHANGELOG_BLOCK'].strip()
-          content = open('readme.txt').read()
+            for (const line of lines) {
+              if (/^== Changelog ==$/.test(line)) {
+                output.push(line, '', ...changelogBlock.split('\n'));
+                inChangelog = true;
+                releases = 0;
+                continue;
+              }
+              if (inChangelog && /^== .+ ==$/.test(line)) inChangelog = false;
+              if (inChangelog && /^= .+ =$/.test(line)) releases++;
+              if (inChangelog && releases > 2) continue;
+              output.push(line);
+            }
 
-          updated = re.sub(
-            r'(== Changelog ==\n)',
-            f'\\1\n{entry}\n',
-            content,
-            count=1,
-          )
-
-          open('readme.txt', 'w').write(updated)
-          PYEOF
+            fs.writeFileSync('readme.txt', output.join('\n'));
 
       - name: Commit and push
         env:

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -198,19 +198,36 @@ jobs:
             const changelogBlock = process.env.CHANGELOG_BLOCK;
             const lines = fs.readFileSync('readme.txt', 'utf8').split('\n');
             const output = [];
+            const releaseHeaderPattern = /^= .+ =$/;
+            const releaseBlockContentPattern = /^(?:\s*$|\s+.*|[-*]\s+.*)$/;
             let inChangelog = false;
             let releases = 0;
+            let skippingOldRelease = false;
 
             for (const line of lines) {
               if (/^== Changelog ==$/.test(line)) {
                 output.push(line, '', ...changelogBlock.split('\n'));
                 inChangelog = true;
                 releases = 0;
+                skippingOldRelease = false;
                 continue;
               }
-              if (inChangelog && /^== .+ ==$/.test(line)) inChangelog = false;
-              if (inChangelog && /^= .+ =$/.test(line)) releases++;
-              if (inChangelog && releases > 2) continue;
+
+              if (inChangelog && /^== .+ ==$/.test(line)) {
+                inChangelog = false;
+                skippingOldRelease = false;
+              }
+
+              if (inChangelog && releaseHeaderPattern.test(line)) {
+                releases++;
+                skippingOldRelease = releases > 2;
+                if (skippingOldRelease) continue;
+              }
+
+              if (inChangelog && skippingOldRelease) {
+                if (releaseBlockContentPattern.test(line)) continue;
+                skippingOldRelease = false;
+              }
               output.push(line);
             }
 

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -214,7 +214,8 @@ jobs:
               output.push(line);
             }
 
-            fs.writeFileSync('readme.txt', output.join('\n'));
+            const readmeContent = output.join('\n');
+            fs.writeFileSync('readme.txt', readmeContent.endsWith('\n') ? readmeContent : `${readmeContent}\n`);
 
       - name: Commit and push
         env:

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -144,7 +144,7 @@ jobs:
                 if (match) {
                   entry = match[1]
                     .split('\n')
-                    .map(l => l.replace(/^[\s*\->]+/, '').trim())
+                    .map(l => l.replace(/^[\s*>-]+/, '').trim())
                     .find(l => l && l.toLowerCase() !== 'n/a') ?? null;
                 }
               }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This is a follow-up to #3347 to fix the following issues with the output of the generated changelog files.

- Better parsing of prefixes in changelog entries in PR descriptions.
- Keeps all changelogs entries in changelog.txt and limits readme.txt to 3 recent entries.
- Prefers a JS approach over Python for text manipulation.

See GOOWOO-562.


