### PR TITLE
Fix PR creation in prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -97,6 +97,9 @@ jobs:
     name: Create Pull Request
     needs: generate-changelog
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - name: Create Pull Request
         uses: actions/github-script@v7
@@ -105,7 +108,6 @@ jobs:
           SOURCE_BRANCH: ${{ inputs.source_branch }}
           CHANGELOG_BLOCK: ${{ needs.generate-changelog.outputs.changelog_block }}
         with:
-          github-token: ${{ secrets.ORG_DEPLOY_SECRET }}
           script: |
             const version = process.env.VERSION;
             const sourceBranch = process.env.SOURCE_BRANCH;


### PR DESCRIPTION
## What changed

In the `create-pr` job of `.github/workflows/prepare-release.yml`:
- Added `permissions: pull-requests: write, contents: read` to the job
- Removed `github-token: ${{ secrets.ORG_DEPLOY_SECRET }}` from the `actions/github-script` step

## Why

The workflow was failing with a 403 when attempting to create a pull request:

> Resource not accessible by personal access token

`ORG_DEPLOY_SECRET` is a PAT, and the `woocommerce` org restricts PATs from writing to pull requests. Switching to `GITHUB_TOKEN` (an installation token, exempt from PAT restrictions) with an explicit `pull-requests: write` permission grant fixes this.

## Notes for reviewer

- All other jobs (`create-branch`, `bump-versions`, `generate-changelog`) still use `ORG_DEPLOY_SECRET` — they push commits/branches which requires the PAT. Only PR creation is affected by the org PAT restriction.
- `GITHUB_TOKEN` is scoped to the repo and expires at the end of the workflow run.