### PR TITLE
GOOWOO-611: Silence error when incentive cannot be applied

### DIFF
--- a/js/src/components/paid-ads/ads-campaign/ads-campaign.js
+++ b/js/src/components/paid-ads/ads-campaign/ads-campaign.js
@@ -37,8 +37,6 @@ import CyoIncentivePicker from './cyo-incentive-picker/cyo-incentive-picker';
  * @param {'create-ads'|'edit-ads'|'setup-ads'|'setup-mc'|'setup-ads-only'} props.context A context indicating which page this component is used on. This will be the value of `context` in the track event properties.
  * @param {(formContext: AdaptiveFormContext) => JSX.Element | JSX.Element} [props.skipButton] A React element or function to render the "Skip" button. If a function is passed, it receives the form context and returns the button element.
  * @param {(formContext: AdaptiveFormContext) => JSX.Element | JSX.Element} [props.continueButton] A React element or function to render the "Continue" button. If a function is passed, it receives the form context and returns the button element.
- * @param {Object} [props.incentiveResult] The result of applying a CYO incentive. This is passed down to the CyoIncentivePicker component to determine whether to show an error message after applying an incentive.
- * @param {Function} [props.onRetryIncentive] Callback to retry applying the incentive, receives the incentiveId.
  * @return {JSX.Element} The rendered component.
  */
 export default function AdsCampaign( {
@@ -46,8 +44,6 @@ export default function AdsCampaign( {
 	context,
 	skipButton,
 	continueButton,
-	incentiveResult,
-	onRetryIncentive,
 } ) {
 	const formContext = useAdaptiveFormContext();
 	const isOnboardingFlow =
@@ -109,13 +105,7 @@ export default function AdsCampaign( {
 				{ showCampaignPreviewCard && <CampaignPreviewCard /> }
 			</BudgetSection>
 
-			{ isOnboardingFlow && (
-				<CyoIncentivePicker
-					context={ context }
-					incentiveResult={ incentiveResult }
-					onRetry={ onRetryIncentive }
-				/>
-			) }
+			{ isOnboardingFlow && <CyoIncentivePicker context={ context } /> }
 
 			<EuRegulationsSection context={ context } />
 

--- a/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js
+++ b/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js
@@ -21,14 +21,16 @@ import { recordGlaEvent } from '~/utils/tracks';
 import './cyo-incentive-picker.scss';
 
 /**
+ * Fired when the CYO incentive picker is shown to the user.
+ *
  * @event gla_cyo_incentive_picker_shown
- * @description Fired when the CYO incentive picker is shown to the user.
  * @property {string} context The context in which the incentive picker is shown, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'.
  */
 
 /**
+ * Fired when the user selects an incentive offer.
+ *
  * @event gla_cyo_incentive_selected
- * @description Fired when the user selects an incentive offer.
  * @property {string} context The context in which the incentive offer is selected.
  * @property {string} level The level of the selected incentive offer, e.g. 'low', 'medium', or 'high'.
  */

--- a/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js
+++ b/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js
@@ -23,14 +23,14 @@ import './cyo-incentive-picker.scss';
 /**
  * @event gla_cyo_incentive_picker_shown
  * @description Fired when the CYO incentive picker is shown to the user.
- * @param {string} context - The context in which the incentive picker is shown, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'.
+ * @property {string} context The context in which the incentive picker is shown, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'.
  */
 
 /**
  * @event gla_cyo_incentive_selected
  * @description Fired when the user selects an incentive offer.
- * @param {string} context - The context in which the incentive offer is selected.
- * @param {string} level - The level of the selected incentive offer, e.g. 'low', 'medium', or 'high'.
+ * @property {string} context The context in which the incentive offer is selected.
+ * @property {string} level The level of the selected incentive offer, e.g. 'low', 'medium', or 'high'.
  */
 
 /**

--- a/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js
+++ b/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
-import { RadioControl, Notice, Flex, FlexItem } from '@wordpress/components';
+import { RadioControl } from '@wordpress/components';
 import {
 	createInterpolateElement,
 	useEffect,
@@ -14,10 +13,8 @@ import {
  * Internal dependencies
  */
 import { useAdaptiveFormContext } from '~/components/adaptive-form';
-import AppButton from '~/components/app-button';
 import Section from '~/components/section';
 import Subsection from '~/components/subsection';
-import AppDocumentationLink from '~/components/app-documentation-link';
 import useCYOIncentives from '~/hooks/useCYOIncentives';
 import useAdsCurrency from '~/hooks/useAdsCurrency';
 import { recordGlaEvent } from '~/utils/tracks';
@@ -26,13 +23,11 @@ import './cyo-incentive-picker.scss';
 /**
  * Renders the component for picking a "Choose Your Own" incentive for ads campaigns, which allows merchants to select from different ads credit offers based on their expected ad spend.
  *
- * @param {Object}   props React props.
- * @param {string}   props.context The context in which this component is used, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'. This is used for tracking purposes and may also be used to conditionally render content within the component.
- * @param {Object}   props.incentiveResult The result of applying a CYO incentive. This is used to determine whether to show an error message after applying an incentive.
- * @param {Function} props.onRetry Callback to retry applying the incentive.
+ * @param {Object} props React props.
+ * @param {string} props.context The context in which this component is used, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'. This is used for tracking purposes and may also be used to conditionally render content within the component.
  * @return {JSX.Element|null} The rendered component, or null if the incentives are still being resolved or if there are no incentives available.
  */
-const CyoIncentivePicker = ( { context, incentiveResult, onRetry = noop } ) => {
+const CyoIncentivePicker = ( { context } ) => {
 	const { getInputProps } = useAdaptiveFormContext();
 	const { data: incentives, hasFinishedResolution } = useCYOIncentives();
 	const { formatAmount } = useAdsCurrency();
@@ -57,10 +52,6 @@ const CyoIncentivePicker = ( { context, incentiveResult, onRetry = noop } ) => {
 	if ( ! shouldDisplay ) {
 		return null;
 	}
-
-	const handleOnRetryClick = () => {
-		onRetry( selectedIncentiveOffer );
-	};
 
 	const options = [ 'low', 'medium', 'high' ].reduce( ( acc, offer ) => {
 		const item = incentives.find(
@@ -172,48 +163,6 @@ const CyoIncentivePicker = ( { context, incentiveResult, onRetry = noop } ) => {
 							}
 						) }
 					</div>
-
-					{ incentiveResult?.error && (
-						<Notice status="error" isDismissible={ false }>
-							<p>
-								{ incentiveResult.error.message ||
-									__(
-										'There was an issue applying the selected offer. Please try again.',
-										'google-listings-and-ads'
-									) }
-							</p>
-
-							<Flex justify="flex-start" gap={ 2 }>
-								<FlexItem>
-									<AppButton
-										onClick={ handleOnRetryClick }
-										loading={ incentiveResult.loading }
-										eventName="gla_cyoi_apply_incentive_retry_click"
-										eventProps={ { context } }
-										isPrimary
-									>
-										{ __(
-											'Try again',
-											'google-listings-and-ads'
-										) }
-									</AppButton>
-								</FlexItem>
-
-								<FlexItem>
-									<AppDocumentationLink
-										href="https://ads.google.com/aw/overview"
-										linkId="apply-in-google-ads"
-										context={ context }
-									>
-										{ __(
-											'Apply in Google Ads',
-											'google-listings-and-ads'
-										) }
-									</AppDocumentationLink>
-								</FlexItem>
-							</Flex>
-						</Notice>
-					) }
 				</Section.Card.Body>
 			</Section.Card>
 		</Section>

--- a/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.test.js
+++ b/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.test.js
@@ -10,7 +10,6 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import CyoIncentivePicker from './cyo-incentive-picker';
 import { useAdaptiveFormContext } from '~/components/adaptive-form';
 import useCYOIncentives from '~/hooks/useCYOIncentives';
-import useGoogleAdsAccountBillingStatus from '~/hooks/useGoogleAdsAccountBillingStatus';
 import { recordGlaEvent } from '~/utils/tracks';
 import useAdsCurrency from '~/hooks/useAdsCurrency';
 
@@ -18,7 +17,6 @@ jest.mock( '~/components/adaptive-form', () => ( {
 	useAdaptiveFormContext: jest.fn(),
 } ) );
 jest.mock( '~/hooks/useCYOIncentives' );
-jest.mock( '~/hooks/useGoogleAdsAccountBillingStatus' );
 jest.mock( '~/utils/tracks', () => ( {
 	recordGlaEvent: jest.fn(),
 } ) );
@@ -103,10 +101,6 @@ describe( 'CyoIncentivePicker Component', () => {
 		useCYOIncentives.mockReturnValue( {
 			data: INCENTIVES_DATA,
 			hasFinishedResolution: true,
-		} );
-
-		useGoogleAdsAccountBillingStatus.mockReturnValue( {
-			billingStatus: { status: 'approved' },
 		} );
 	} );
 
@@ -236,7 +230,7 @@ describe( 'CyoIncentivePicker Component', () => {
 		);
 	} );
 
-	it( 'should track gla_cyo_incentive_picker_shown with isServiceBasedMerchant true', () => {
+	it( 'should track gla_cyo_incentive_picker_shown with the correct context', () => {
 		render( <CyoIncentivePicker context="setup-mc" /> );
 		expect( recordGlaEvent ).toHaveBeenCalledWith(
 			'gla_cyo_incentive_picker_shown',
@@ -244,7 +238,7 @@ describe( 'CyoIncentivePicker Component', () => {
 		);
 	} );
 
-	it( 'should track gla_cyo_incentive_picker_shown only once when isServiceBasedMerchant resolves after shouldDisplay', () => {
+	it( 'should track gla_cyo_incentive_picker_shown only once even when the component re-renders', () => {
 		const { rerender } = renderComponent();
 
 		expect( recordGlaEvent ).toHaveBeenCalledTimes( 1 );

--- a/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.test.js
+++ b/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.test.js
@@ -86,22 +86,13 @@ const INCENTIVES_DATA = [
 
 describe( 'CyoIncentivePicker Component', () => {
 	const onIncentiveIdChange = jest.fn();
-	const onRetry = jest.fn();
 
 	const renderComponent = ( props = {} ) =>
-		render(
-			<CyoIncentivePicker
-				context="setup-mc"
-				incentiveResult={ { error: null, loading: false } }
-				onRetry={ onRetry }
-				{ ...props }
-			/>
-		);
+		render( <CyoIncentivePicker context="setup-mc" { ...props } /> );
 
 	beforeEach( () => {
 		onIncentiveIdChange.mockReset();
 		recordGlaEvent.mockReset();
-		onRetry.mockReset();
 		useAdaptiveFormContext.mockReturnValue( {
 			getInputProps: jest.fn().mockReturnValue( {
 				value: null,
@@ -186,13 +177,7 @@ describe( 'CyoIncentivePicker Component', () => {
 			hasFinishedResolution: true,
 		} );
 
-		rerender(
-			<CyoIncentivePicker
-				context="setup-mc"
-				incentiveResult={ { error: null, loading: false } }
-				onRetry={ onRetry }
-			/>
-		);
+		rerender( <CyoIncentivePicker context="setup-mc" /> );
 		titleElement = screen.queryByText( 'Ads credit offer' );
 		expect( titleElement ).toBeInTheDocument();
 	} );
@@ -232,102 +217,15 @@ describe( 'CyoIncentivePicker Component', () => {
 		fireEvent.click( radioButtons[ 0 ] );
 		expect( onIncentiveIdChange ).toHaveBeenNthCalledWith( 1, 'low' );
 
-		rerender(
-			<CyoIncentivePicker
-				context="setup-mc"
-				incentiveResult={ { error: null, loading: false } }
-				onRetry={ onRetry }
-			/>
-		);
+		rerender( <CyoIncentivePicker context="setup-mc" /> );
 		radioButtons = screen.getAllByRole( 'radio' );
 		fireEvent.click( radioButtons[ 1 ] );
 		expect( onIncentiveIdChange ).toHaveBeenNthCalledWith( 2, 'medium' );
 
-		rerender(
-			<CyoIncentivePicker
-				context="setup-mc"
-				incentiveResult={ { error: null, loading: false } }
-				onRetry={ onRetry }
-			/>
-		);
+		rerender( <CyoIncentivePicker context="setup-mc" /> );
 		radioButtons = screen.getAllByRole( 'radio' );
 		fireEvent.click( radioButtons[ 2 ] );
 		expect( onIncentiveIdChange ).toHaveBeenNthCalledWith( 3, 'high' );
-	} );
-
-	describe( 'error state', () => {
-		it( 'should not show error notice when there is no error', () => {
-			renderComponent();
-			expect( screen.queryByText( 'Try again' ) ).not.toBeInTheDocument();
-		} );
-
-		it( 'should show error notice with the API error message', () => {
-			renderComponent( {
-				incentiveResult: {
-					error: { message: 'Something went wrong' },
-					loading: false,
-				},
-			} );
-			expect(
-				screen.getByText( 'Something went wrong' )
-			).toBeInTheDocument();
-		} );
-
-		it( 'should show fallback error message when error has no message', () => {
-			renderComponent( {
-				incentiveResult: { error: {}, loading: false },
-			} );
-			expect(
-				screen.getByText(
-					'There was an issue applying the selected offer. Please try again.'
-				)
-			).toBeInTheDocument();
-		} );
-
-		it( 'should call onRetry with the selected incentive ID when retry button is clicked', () => {
-			useAdaptiveFormContext.mockReturnValue( {
-				getInputProps: jest.fn().mockReturnValue( {
-					value: 456,
-					onChange: onIncentiveIdChange,
-				} ),
-			} );
-
-			renderComponent( {
-				incentiveResult: {
-					error: { message: 'API error' },
-					loading: false,
-				},
-			} );
-
-			fireEvent.click( screen.getByText( 'Try again' ) );
-
-			expect( onRetry ).toHaveBeenCalledWith( 456 );
-		} );
-
-		it( 'should disable the retry button in a loading state when incentiveResult.loading is true', () => {
-			renderComponent( {
-				incentiveResult: {
-					error: { message: 'API error' },
-					loading: true,
-				},
-			} );
-
-			const retryButton = screen.getByText( 'Try again' );
-			expect( retryButton ).toHaveAttribute( 'disabled' );
-		} );
-
-		it( 'should render the "Apply in Google Ads" link in the error notice', () => {
-			renderComponent( {
-				incentiveResult: {
-					error: { message: 'API error' },
-					loading: false,
-				},
-			} );
-
-			expect(
-				screen.getByText( 'Apply in Google Ads' )
-			).toBeInTheDocument();
-		} );
 	} );
 
 	it( 'should track gla_cyo_incentive_picker_shown when rendered', () => {
@@ -355,13 +253,7 @@ describe( 'CyoIncentivePicker Component', () => {
 			{ context: 'setup-mc' }
 		);
 
-		rerender(
-			<CyoIncentivePicker
-				context="setup-mc"
-				incentiveResult={ { error: null, loading: false } }
-				onRetry={ onRetry }
-			/>
-		);
+		rerender( <CyoIncentivePicker context="setup-mc" /> );
 
 		expect( recordGlaEvent ).toHaveBeenCalledTimes( 1 );
 	} );

--- a/js/src/hooks/useApplyCYOIncentive.js
+++ b/js/src/hooks/useApplyCYOIncentive.js
@@ -1,38 +1,30 @@
 /**
  * External dependencies
  */
-import { useCallback, useRef } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
 import { API_NAMESPACE } from '~/data/constants';
 import { GOOGLE_ADS_BILLING_STATUS } from '~/constants';
-import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 import useGoogleAdsAccountBillingStatus from './useGoogleAdsAccountBillingStatus';
 import useCYOIncentives from './useCYOIncentives';
 
 const useApplyCYOIncentive = () => {
 	const { billingStatus } = useGoogleAdsAccountBillingStatus();
 	const { data: incentives } = useCYOIncentives();
-	const [ fetchApplyIncentive, result ] = useApiFetchCallback( {
-		path: `${ API_NAMESPACE }/ads/incentive`,
-		method: 'POST',
-	} );
-	const appliedRef = useRef( false );
+	const [ loading, setLoading ] = useState( false );
 
 	/**
-	 * Makes the API request to redeem the incentive. Skips silently if already
-	 * redeemed, no matching incentive offer is found, or billing is not yet approved.
-	 * Returns `true` if the incentive was (or had already been) applied, `false` otherwise.
-	 * Use this for explicit retry attempts where a fresh API call is always intended.
+	 * Attempts to apply the incentive for the given offer. Skips silently if
+	 * no matching offer is found or billing is not approved.
+	 * Errors from the API are swallowed so onboarding is never blocked.
+	 * Returns `true` if applied, `false` otherwise.
 	 */
-	const redeemIncentive = useCallback(
+	const applyIncentive = useCallback(
 		async ( incentiveOffer ) => {
-			if ( appliedRef.current ) {
-				return true;
-			}
-
 			const isBillingCompleted =
 				billingStatus?.status === GOOGLE_ADS_BILLING_STATUS.APPROVED;
 
@@ -44,32 +36,26 @@ const useApplyCYOIncentive = () => {
 				return false;
 			}
 
-			await fetchApplyIncentive( { data: { id: incentiveId } } );
-			appliedRef.current = true;
-			return true;
-		},
-		[ billingStatus, fetchApplyIncentive, incentives ]
-	);
+			try {
+				setLoading( true );
 
-	/**
-	 * Wraps `redeemIncentive` for use in the normal onboarding flow (skip/continue).
-	 * If a previous redemption attempt errored, proceeds without retrying so the
-	 * merchant is not blocked — they can retry via the dedicated retry action.
-	 * Returns `true` if an incentive was applied, `false` otherwise.
-	 */
-	const applyIncentive = useCallback(
-		async ( incentiveOffer ) => {
-			if ( result.error ) {
-				// Proceed with onboarding since merchant can retry and proceed without the incentive.
+				await apiFetch( {
+					path: `${ API_NAMESPACE }/ads/incentive`,
+					method: 'POST',
+					data: { id: incentiveId },
+				} );
+
+				return true;
+			} catch {
 				return false;
+			} finally {
+				setLoading( false );
 			}
-
-			return redeemIncentive( incentiveOffer );
 		},
-		[ result.error, redeemIncentive ]
+		[ billingStatus, incentives ]
 	);
 
-	return { applyIncentive, redeemIncentive, result };
+	return { applyIncentive, loading };
 };
 
 export default useApplyCYOIncentive;

--- a/js/src/hooks/useApplyCYOIncentive.test.js
+++ b/js/src/hooks/useApplyCYOIncentive.test.js
@@ -1,58 +1,56 @@
 /**
  * External dependencies
  */
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
 import useApplyCYOIncentive from './useApplyCYOIncentive';
-import useApiFetchCallback from '~/hooks/useApiFetchCallback';
 import useGoogleAdsAccountBillingStatus from './useGoogleAdsAccountBillingStatus';
 import useCYOIncentives from './useCYOIncentives';
 import { GOOGLE_ADS_BILLING_STATUS } from '~/constants';
 import { API_NAMESPACE } from '~/data/constants';
 
-jest.mock( '~/hooks/useApiFetchCallback' );
+jest.mock( '@wordpress/api-fetch' );
 jest.mock( './useGoogleAdsAccountBillingStatus' );
 jest.mock( './useCYOIncentives' );
 
 describe( 'useApplyCYOIncentive', () => {
-	let fetchApplyIncentive;
-
 	beforeEach( () => {
 		jest.clearAllMocks();
-		fetchApplyIncentive = jest.fn().mockName( 'fetchApplyIncentive' );
-		useApiFetchCallback.mockReturnValue( [ fetchApplyIncentive, {} ] );
+		apiFetch.mockResolvedValue( {} );
 		useCYOIncentives.mockReturnValue( { data: [] } );
 	} );
 
-	it( 'initializes useApiFetchCallback with the correct path and method', () => {
-		useGoogleAdsAccountBillingStatus.mockReturnValue( {
-			billingStatus: undefined,
+	it( 'exposes result with loading state', async () => {
+		let resolveApiFetch;
+		const fetchPromise = new Promise( ( resolve ) => {
+			resolveApiFetch = resolve;
 		} );
-
-		renderHook( () => useApplyCYOIncentive() );
-
-		expect( useApiFetchCallback ).toHaveBeenCalledWith( {
-			path: `${ API_NAMESPACE }/ads/incentive`,
-			method: 'POST',
-		} );
-	} );
-
-	it( 'exposes result from useApiFetchCallback', () => {
-		const mockResult = { loading: false, error: null };
-		useApiFetchCallback.mockReturnValue( [
-			fetchApplyIncentive,
-			mockResult,
-		] );
+		apiFetch.mockReturnValue( fetchPromise );
 		useGoogleAdsAccountBillingStatus.mockReturnValue( {
-			billingStatus: undefined,
+			billingStatus: { status: GOOGLE_ADS_BILLING_STATUS.APPROVED },
+		} );
+		useCYOIncentives.mockReturnValue( {
+			data: [ { offer: 'incentive-123', id: 'incentive-123' } ],
 		} );
 
 		const { result } = renderHook( () => useApplyCYOIncentive() );
 
-		expect( result.current.result ).toBe( mockResult );
+		expect( result.current.loading ).toBe( false );
+
+		act( () => {
+			result.current.applyIncentive( 'incentive-123' );
+		} );
+		expect( result.current.loading ).toBe( true );
+
+		await act( async () => {
+			resolveApiFetch( {} );
+			await fetchPromise;
+		} );
+		expect( result.current.loading ).toBe( false );
 	} );
 
 	describe( 'applyIncentive', () => {
@@ -67,139 +65,69 @@ describe( 'useApplyCYOIncentive', () => {
 			} );
 		} );
 
-		it( 'delegates to redeemIncentive when there is no prior error', async () => {
-			useApiFetchCallback.mockReturnValue( [
-				fetchApplyIncentive,
-				{ error: null },
-			] );
+		it( 'calls apiFetch with the correct path, method, and incentive id', async () => {
 			const { result } = renderHook( () => useApplyCYOIncentive() );
 
-			await result.current.applyIncentive( 'incentive-123' );
+			await act( () => result.current.applyIncentive( 'incentive-123' ) );
 
-			expect( fetchApplyIncentive ).toHaveBeenCalledWith( {
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: `${ API_NAMESPACE }/ads/incentive`,
+				method: 'POST',
 				data: { id: 'incentive-123' },
 			} );
 		} );
 
-		it( 'returns false without fetching when there is a prior error', async () => {
-			useApiFetchCallback.mockReturnValue( [
-				fetchApplyIncentive,
-				{ error: new Error( 'prior error' ) },
-			] );
+		it( 'returns false when no matching incentive offer is found', async () => {
 			const { result } = renderHook( () => useApplyCYOIncentive() );
 
-			const returnValue =
-				await result.current.applyIncentive( 'incentive-123' );
+			const returnValue = await act( () =>
+				result.current.applyIncentive( undefined )
+			);
 
 			expect( returnValue ).toBe( false );
-			expect( fetchApplyIncentive ).not.toHaveBeenCalled();
-		} );
-	} );
-
-	describe( 'redeemIncentive', () => {
-		describe( 'when it should skip applying the incentive', () => {
-			it( 'returns false when no matching incentive offer is found', async () => {
-				useGoogleAdsAccountBillingStatus.mockReturnValue( {
-					billingStatus: {
-						status: GOOGLE_ADS_BILLING_STATUS.APPROVED,
-					},
-				} );
-
-				const { result } = renderHook( () => useApplyCYOIncentive() );
-				const returnValue =
-					await result.current.redeemIncentive( undefined );
-
-				expect( returnValue ).toBe( false );
-				expect( fetchApplyIncentive ).not.toHaveBeenCalled();
-			} );
-
-			it( 'returns false when billing status is not yet loaded', async () => {
-				useGoogleAdsAccountBillingStatus.mockReturnValue( {
-					billingStatus: undefined,
-				} );
-
-				const { result } = renderHook( () => useApplyCYOIncentive() );
-				const returnValue =
-					await result.current.redeemIncentive( 'incentive-123' );
-
-				expect( returnValue ).toBe( false );
-				expect( fetchApplyIncentive ).not.toHaveBeenCalled();
-			} );
-
-			it( 'returns false when billing is not approved', async () => {
-				useGoogleAdsAccountBillingStatus.mockReturnValue( {
-					billingStatus: { status: 'pending' },
-				} );
-
-				const { result } = renderHook( () => useApplyCYOIncentive() );
-				const returnValue =
-					await result.current.redeemIncentive( 'incentive-123' );
-
-				expect( returnValue ).toBe( false );
-				expect( fetchApplyIncentive ).not.toHaveBeenCalled();
-			} );
+			expect( apiFetch ).not.toHaveBeenCalled();
 		} );
 
-		describe( 'when billing is approved and incentiveId is provided', () => {
-			beforeEach( () => {
-				useGoogleAdsAccountBillingStatus.mockReturnValue( {
-					billingStatus: {
-						status: GOOGLE_ADS_BILLING_STATUS.APPROVED,
-					},
-				} );
-				useCYOIncentives.mockReturnValue( {
-					data: [ { offer: 'incentive-123', id: 'incentive-123' } ],
-				} );
+		it( 'returns false when billing status is not yet loaded', async () => {
+			useGoogleAdsAccountBillingStatus.mockReturnValue( {
+				billingStatus: undefined,
 			} );
 
-			it( 'calls fetchApplyIncentive with the incentive id', async () => {
-				const { result } = renderHook( () => useApplyCYOIncentive() );
+			const { result } = renderHook( () => useApplyCYOIncentive() );
 
-				await result.current.redeemIncentive( 'incentive-123' );
+			const returnValue = await act( () =>
+				result.current.applyIncentive( 'incentive-123' )
+			);
 
-				expect( fetchApplyIncentive ).toHaveBeenCalledWith( {
-					data: { id: 'incentive-123' },
-				} );
+			expect( returnValue ).toBe( false );
+			expect( apiFetch ).not.toHaveBeenCalled();
+		} );
+
+		it( 'returns false when billing is not approved', async () => {
+			useGoogleAdsAccountBillingStatus.mockReturnValue( {
+				billingStatus: { status: 'pending' },
 			} );
 
-			it( 'propagates errors thrown by fetchApplyIncentive', async () => {
-				const error = new Error( 'API error' );
-				fetchApplyIncentive.mockRejectedValue( error );
+			const { result } = renderHook( () => useApplyCYOIncentive() );
 
-				const { result } = renderHook( () => useApplyCYOIncentive() );
+			const returnValue = await act( () =>
+				result.current.applyIncentive( 'incentive-123' )
+			);
 
-				await expect(
-					result.current.redeemIncentive( 'incentive-123' )
-				).rejects.toThrow( 'API error' );
-			} );
+			expect( returnValue ).toBe( false );
+			expect( apiFetch ).not.toHaveBeenCalled();
+		} );
 
-			it( 'does not call fetchApplyIncentive again after successful application', async () => {
-				const { result } = renderHook( () => useApplyCYOIncentive() );
+		it( 'swallows API errors and returns false', async () => {
+			apiFetch.mockRejectedValue( new Error( 'API error' ) );
 
-				await result.current.redeemIncentive( 'incentive-123' );
-				const returnValue =
-					await result.current.redeemIncentive( 'incentive-123' );
+			const { result } = renderHook( () => useApplyCYOIncentive() );
 
-				expect( fetchApplyIncentive ).toHaveBeenCalledTimes( 1 );
-				expect( returnValue ).toBe( true );
-			} );
+			const returnValue = await act( () =>
+				result.current.applyIncentive( 'incentive-123' )
+			);
 
-			it( 'allows retry after a failed application', async () => {
-				const error = new Error( 'API error' );
-				fetchApplyIncentive
-					.mockRejectedValueOnce( error )
-					.mockResolvedValueOnce( {} );
-
-				const { result } = renderHook( () => useApplyCYOIncentive() );
-
-				await expect(
-					result.current.redeemIncentive( 'incentive-123' )
-				).rejects.toThrow( 'API error' );
-
-				await result.current.redeemIncentive( 'incentive-123' );
-
-				expect( fetchApplyIncentive ).toHaveBeenCalledTimes( 2 );
-			} );
+			expect( returnValue ).toBe( false );
 		} );
 	} );
 } );

--- a/js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/setup-paid-ads.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/setup-paid-ads.js
@@ -27,8 +27,19 @@ import clientSession from '../clientSession';
 import AppSpinner from '~/components/app-spinner';
 
 /**
+ * Selecting a "Choose Your Own" incentive offer when setting up paid ads during onboarding.
+ *
+ * @event gla_ads_only_onboarding_with_cyo_incentive_selected
+ * @property {string} context The context in which the incentive offer is selected, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'.
+ * @property {string} level The level of the selected incentive offer, e.g. 'low', 'medium', or 'high'.
+ */
+
+/**
  * Renders the onboarding step for setting up the paid ads (Google Ads account and paid campaign)
  * or skipping it, and then completing the onboarding flow.
+ *
+ * @fires gla_ads_only_onboarding_with_cyo_incentive_selected
+ *
  * @param {Object} props
  * @param {Function} props.onSubmit Callback fired when the user submits the paid ads creation form. Passes dailyBudget and hasConfirmedEuPoliticalContent.
  * @param {Function} props.onSkip Callback fired when the user chooses to skip creating paid ads.
@@ -38,7 +49,8 @@ export default function SetupPaidAds( { onSubmit, onSkip } ) {
 	const [ completing, setCompleting ] = useState( null );
 	const { data: countryCodes } = useTargetAudienceFinalCountryCodes();
 	const { billingStatus } = useGoogleAdsAccountBillingStatus();
-	const { applyIncentive } = useApplyCYOIncentive();
+	const { applyIncentive, loading: incentiveLoading } =
+		useApplyCYOIncentive();
 	const getEventProps = useEventPropertiesFilter(
 		FILTER_BUDGET_RECOMMENDATIONS
 	);
@@ -51,10 +63,13 @@ export default function SetupPaidAds( { onSubmit, onSkip } ) {
 
 		const applied = await applyIncentive( incentiveOffer );
 		if ( applied ) {
-			recordGlaEvent( 'gla_onboarding_with_cyo_incentive_selected', {
-				context: CONTEXT_ADS_ONLY_ONBOARDING,
-				level: incentiveOffer,
-			} );
+			recordGlaEvent(
+				'gla_ads_only_onboarding_with_cyo_incentive_selected',
+				{
+					context: CONTEXT_ADS_ONLY_ONBOARDING,
+					level: incentiveOffer,
+				}
+			);
 		}
 
 		onSkip();
@@ -80,9 +95,12 @@ export default function SetupPaidAds( { onSubmit, onSkip } ) {
 	const createContinueButton = ( formContext ) => {
 		const { isValidForm, values } = formContext;
 		const disabled =
-			completing === ACTION_SKIP || ! isValidForm || ! isBillingCompleted;
+			completing === ACTION_SKIP ||
+			! isValidForm ||
+			! isBillingCompleted ||
+			incentiveLoading;
 
-		const handleClick = async () => {
+		const handleClick = () => {
 			budgetPromptRef.current
 				.resolve( values.dailyBudget )
 				.then( ( amount ) => {
@@ -128,10 +146,13 @@ export default function SetupPaidAds( { onSubmit, onSkip } ) {
 
 		const applied = await applyIncentive( incentiveOffer );
 		if ( applied ) {
-			recordGlaEvent( 'gla_onboarding_with_cyo_incentive_selected', {
-				context: CONTEXT_ADS_ONLY_ONBOARDING,
-				level: incentiveOffer,
-			} );
+			recordGlaEvent(
+				'gla_ads_only_onboarding_with_cyo_incentive_selected',
+				{
+					context: CONTEXT_ADS_ONLY_ONBOARDING,
+					level: incentiveOffer,
+				}
+			);
 		}
 
 		recordGlaEvent(

--- a/js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/setup-paid-ads.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/setup-paid-ads.js
@@ -38,11 +38,8 @@ export default function SetupPaidAds( { onSubmit, onSkip } ) {
 	const [ completing, setCompleting ] = useState( null );
 	const { data: countryCodes } = useTargetAudienceFinalCountryCodes();
 	const { billingStatus } = useGoogleAdsAccountBillingStatus();
-	const {
-		applyIncentive,
-		redeemIncentive,
-		result: incentiveResult,
-	} = useApplyCYOIncentive();
+	const { applyIncentive, loading: incentiveLoading } =
+		useApplyCYOIncentive();
 	const getEventProps = useEventPropertiesFilter(
 		FILTER_BUDGET_RECOMMENDATIONS
 	);
@@ -53,18 +50,12 @@ export default function SetupPaidAds( { onSubmit, onSkip } ) {
 	const skipCreatePaidAds = async ( incentiveOffer ) => {
 		setCompleting( ACTION_SKIP );
 
-		try {
-			const applied = await applyIncentive( incentiveOffer );
-
-			if ( applied ) {
-				recordGlaEvent( 'gla_onboarding_with_cyo_incentive_selected', {
-					context: CONTEXT_ADS_ONLY_ONBOARDING,
-					level: incentiveOffer,
-				} );
-			}
-		} catch ( error ) {
-			setCompleting( null );
-			return;
+		const applied = await applyIncentive( incentiveOffer );
+		if ( applied ) {
+			recordGlaEvent( 'gla_onboarding_with_cyo_incentive_selected', {
+				context: CONTEXT_ADS_ONLY_ONBOARDING,
+				level: incentiveOffer,
+			} );
 		}
 
 		onSkip();
@@ -93,37 +84,29 @@ export default function SetupPaidAds( { onSubmit, onSkip } ) {
 			completing === ACTION_SKIP ||
 			! isValidForm ||
 			! isBillingCompleted ||
-			incentiveResult.loading;
+			incentiveLoading;
 
 		const handleClick = async () => {
-			try {
-				const applied = await applyIncentive( values.incentiveOffer );
-
-				if ( applied ) {
-					recordGlaEvent(
-						'gla_onboarding_with_cyo_incentive_selected',
-						{
-							context: CONTEXT_ADS_ONLY_ONBOARDING,
-							level: values.incentiveOffer,
-						}
-					);
-				}
-
-				budgetPromptRef.current
-					.resolve( values.dailyBudget )
-					.then( ( amount ) => {
-						if ( amount === null ) {
-							formContext.handleSubmit();
-						} else if ( Number.isFinite( amount ) ) {
-							formContext.setValues( {
-								level: 'custom',
-								amount,
-							} );
-						}
-					} );
-			} catch ( error ) {
-				// Error is intentionally swallowed — incentiveResult.error drives the retry UI.
+			const applied = await applyIncentive( values.incentiveOffer );
+			if ( applied ) {
+				recordGlaEvent( 'gla_onboarding_with_cyo_incentive_selected', {
+					context: CONTEXT_ADS_ONLY_ONBOARDING,
+					level: values.incentiveOffer,
+				} );
 			}
+
+			budgetPromptRef.current
+				.resolve( values.dailyBudget )
+				.then( ( amount ) => {
+					if ( amount === null ) {
+						formContext.handleSubmit();
+					} else if ( Number.isFinite( amount ) ) {
+						formContext.setValues( {
+							level: 'custom',
+							amount,
+						} );
+					}
+				} );
 		};
 
 		return (
@@ -131,9 +114,7 @@ export default function SetupPaidAds( { onSubmit, onSkip } ) {
 				isPrimary
 				disabled={ disabled }
 				onClick={ handleClick }
-				loading={
-					completing === ACTION_CONTINUE || incentiveResult.loading
-				}
+				loading={ completing === ACTION_CONTINUE || incentiveLoading }
 				text={ __( 'Continue', 'google-listings-and-ads' ) }
 			/>
 		);
@@ -183,8 +164,6 @@ export default function SetupPaidAds( { onSubmit, onSkip } ) {
 				) }
 				continueButton={ createContinueButton }
 				skipButton={ createSkipButton }
-				incentiveResult={ incentiveResult }
-				onRetryIncentive={ redeemIncentive }
 				context={ CONTEXT_ADS_ONLY_ONBOARDING }
 			/>
 			<BudgetIncentivePrompt

--- a/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
@@ -47,9 +47,18 @@ import useApplyCYOIncentive from '~/hooks/useApplyCYOIncentive';
  */
 
 /**
+ * Selecting a "Choose Your Own" incentive offer when setting up paid ads during onboarding.
+ *
+ * @event gla_onboarding_with_cyo_incentive_selected
+ * @property {string} context The context in which the incentive offer is selected, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'.
+ * @property {string} level The level of the selected incentive offer, e.g. 'low', 'medium', or 'high'.
+ */
+
+/**
  * Renders the onboarding step for setting up the paid ads (Google Ads account and paid campaign)
  * or skipping it, and then completing the onboarding flow.
  * @fires gla_onboarding_complete_with_paid_ads_button_click
+ * @fires gla_onboarding_with_cyo_incentive_selected
  */
 export default function SetupPaidAds() {
 	const budgetPromptRef = useRef();

--- a/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
@@ -15,6 +15,7 @@ import AdsCampaign from '~/components/paid-ads/ads-campaign';
 import BudgetIncentivePrompt from '~/components/paid-ads/budget-incentive-prompt';
 import CampaignAssetsForm from '~/components/paid-ads/campaign-assets-form';
 import AppButton from '~/components/app-button';
+import useGoogleAdsAccountBillingStatus from '~/hooks/useGoogleAdsAccountBillingStatus';
 import useEventPropertiesFilter from '~/hooks/useEventPropertiesFilter';
 import { getProductFeedUrl } from '~/utils/urls';
 import { handleApiError } from '~/utils/handleError';
@@ -26,6 +27,7 @@ import {
 import { useAppDispatch } from '~/data';
 import {
 	GUIDE_NAMES,
+	GOOGLE_ADS_BILLING_STATUS,
 	EU_POLITICAL_ADVERTISING_DECLARATION_REQUIRED_ERROR_CODE,
 } from '~/constants';
 import { ACTION_COMPLETE, ACTION_SKIP } from './constants';
@@ -66,6 +68,7 @@ export default function SetupPaidAds() {
 	const [ completing, setCompleting ] = useState( null );
 	const { data: countryCodes } = useTargetAudienceFinalCountryCodes();
 	const [ handleSetupComplete ] = useAdsSetupCompleteCallback();
+	const { billingStatus } = useGoogleAdsAccountBillingStatus();
 	const { syncSettings } = useAppDispatch();
 	const { handleError: handleEuPoliticalDeclarationError } =
 		useEuPoliticalDeclarationContext();
@@ -74,6 +77,9 @@ export default function SetupPaidAds() {
 	const getEventProps = useEventPropertiesFilter(
 		FILTER_BUDGET_RECOMMENDATIONS
 	);
+
+	const isBillingCompleted =
+		billingStatus?.status === GOOGLE_ADS_BILLING_STATUS.APPROVED;
 
 	const finishOnboardingSetup = async ( onBeforeFinish = noop ) => {
 		try {
@@ -138,7 +144,10 @@ export default function SetupPaidAds() {
 	const createContinueButton = ( formContext ) => {
 		const { isValidForm, values } = formContext;
 		const disabled =
-			completing === ACTION_SKIP || ! isValidForm || incentiveLoading;
+			completing === ACTION_SKIP ||
+			! isValidForm ||
+			! isBillingCompleted ||
+			incentiveLoading;
 
 		const handleClick = () => {
 			budgetPromptRef.current

--- a/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-paid-ads.js
@@ -60,11 +60,8 @@ export default function SetupPaidAds() {
 	const { syncSettings } = useAppDispatch();
 	const { handleError: handleEuPoliticalDeclarationError } =
 		useEuPoliticalDeclarationContext();
-	const {
-		applyIncentive,
-		redeemIncentive,
-		result: incentiveResult,
-	} = useApplyCYOIncentive();
+	const { applyIncentive, loading: incentiveLoading } =
+		useApplyCYOIncentive();
 	const getEventProps = useEventPropertiesFilter(
 		FILTER_BUDGET_RECOMMENDATIONS
 	);
@@ -100,18 +97,13 @@ export default function SetupPaidAds() {
 	const skipCreatePaidAds = async ( incentiveOffer ) => {
 		setCompleting( ACTION_SKIP );
 
-		try {
-			const applied = await applyIncentive( incentiveOffer );
+		const applied = await applyIncentive( incentiveOffer );
 
-			if ( applied ) {
-				recordGlaEvent( 'gla_onboarding_with_cyo_incentive_selected', {
-					context: CONTEXT_EXTENSION_ONBOARDING,
-					level: incentiveOffer,
-				} );
-			}
-		} catch ( error ) {
-			setCompleting( null );
-			return;
+		if ( applied ) {
+			recordGlaEvent( 'gla_onboarding_with_cyo_incentive_selected', {
+				context: CONTEXT_EXTENSION_ONBOARDING,
+				level: incentiveOffer,
+			} );
 		}
 
 		await finishOnboardingSetup();
@@ -137,9 +129,7 @@ export default function SetupPaidAds() {
 	const createContinueButton = ( formContext ) => {
 		const { isValidForm, values } = formContext;
 		const disabled =
-			completing === ACTION_SKIP ||
-			! isValidForm ||
-			incentiveResult.loading;
+			completing === ACTION_SKIP || ! isValidForm || incentiveLoading;
 
 		const handleClick = () => {
 			budgetPromptRef.current
@@ -178,40 +168,35 @@ export default function SetupPaidAds() {
 			hasConfirmedEuPoliticalContent,
 		} = values;
 
-		try {
-			const applied = await applyIncentive( incentiveOffer );
+		setCompleting( ACTION_COMPLETE );
 
-			if ( applied ) {
-				recordGlaEvent( 'gla_onboarding_with_cyo_incentive_selected', {
-					context: CONTEXT_EXTENSION_ONBOARDING,
-					level: incentiveOffer,
-				} );
-			}
-
-			setCompleting( ACTION_COMPLETE );
-
-			const onBeforeFinish = handleSetupComplete.bind(
-				null,
-				dailyBudget,
-				countryCodes,
-				hasConfirmedEuPoliticalContent
-			);
-
-			recordGlaEvent(
-				'gla_onboarding_complete_with_paid_ads_button_click',
-				getEventProps( {
-					level,
-					budget: dailyBudget,
-					audiences: countryCodes.join( ',' ),
-					has_confirmed_eu_political_content:
-						hasConfirmedEuPoliticalContent,
-				} )
-			);
-
-			await finishOnboardingSetup( onBeforeFinish );
-		} catch ( error ) {
-			setCompleting( null );
+		const applied = await applyIncentive( incentiveOffer );
+		if ( applied ) {
+			recordGlaEvent( 'gla_onboarding_with_cyo_incentive_selected', {
+				context: CONTEXT_EXTENSION_ONBOARDING,
+				level: incentiveOffer,
+			} );
 		}
+
+		const onBeforeFinish = handleSetupComplete.bind(
+			null,
+			dailyBudget,
+			countryCodes,
+			hasConfirmedEuPoliticalContent
+		);
+
+		recordGlaEvent(
+			'gla_onboarding_complete_with_paid_ads_button_click',
+			getEventProps( {
+				level,
+				budget: dailyBudget,
+				audiences: countryCodes.join( ',' ),
+				has_confirmed_eu_political_content:
+					hasConfirmedEuPoliticalContent,
+			} )
+		);
+
+		await finishOnboardingSetup( onBeforeFinish );
 	};
 
 	return (
@@ -230,8 +215,6 @@ export default function SetupPaidAds() {
 				) }
 				continueButton={ createContinueButton }
 				skipButton={ createSkipButton }
-				incentiveResult={ incentiveResult }
-				onRetryIncentive={ redeemIncentive }
 				context={ CONTEXT_EXTENSION_ONBOARDING }
 			/>
 			<BudgetIncentivePrompt

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -368,11 +368,20 @@ Triggered when the save button in contact information page is clicked.
 
 ### [`gla_cyo_incentive_picker_shown`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L23)
 Fired when the CYO incentive picker is shown to the user.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | The context in which the incentive picker is shown, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'.
 #### Emitters
 - [`CyoIncentivePicker`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L46) when the incentive picker is shown to the user.
 
 ### [`gla_cyo_incentive_selected`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L29)
 Fired when the user selects an incentive offer.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | The context in which the incentive offer is selected.
+`level` | `string` | The level of the selected incentive offer, e.g. 'low', 'medium', or 'high'.
 #### Emitters
 - [`CyoIncentivePicker`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L46) when the user selects an incentive offer.
 

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -373,9 +373,9 @@ Fired when the CYO incentive picker is shown to the user.
 | ---- | ---- | ----------- |
 `context` | `string` | The context in which the incentive picker is shown, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'.
 #### Emitters
-- [`CyoIncentivePicker`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L46) when the incentive picker is shown to the user.
+- [`CyoIncentivePicker`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L48) when the incentive picker is shown to the user.
 
-### [`gla_cyo_incentive_selected`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L29)
+### [`gla_cyo_incentive_selected`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L30)
 Fired when the user selects an incentive offer.
 #### Properties
 | name | type | description |
@@ -383,7 +383,7 @@ Fired when the user selects an incentive offer.
 `context` | `string` | The context in which the incentive offer is selected.
 `level` | `string` | The level of the selected incentive offer, e.g. 'low', 'medium', or 'high'.
 #### Emitters
-- [`CyoIncentivePicker`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L46) when the user selects an incentive offer.
+- [`CyoIncentivePicker`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L48) when the user selects an incentive offer.
 
 ### [`gla_dashboard_edit_program_click`](../../js/src/pages/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal.js#L16)
 Triggered when "continue" to edit program button is clicked.
@@ -815,7 +815,7 @@ Clicking on the skip paid ads button to complete the onboarding flow.
 `billing_method_status` | `string` | The status of billing method of merchant's Google Ads addcount e.g. 'unknown', 'pending', 'approved', 'cancelled'
 `campaign_form_validation` | `string` | Whether the entered paid campaign form data are valid, e.g. 'unknown', 'valid', 'invalid'
 
-### [`gla_onboarding_complete_with_paid_ads_button_click`](../../js/src/pages/onboarding/setup-stepper/setup-paid-ads.js#L38)
+### [`gla_onboarding_complete_with_paid_ads_button_click`](../../js/src/pages/onboarding/setup-stepper/setup-paid-ads.js#L40)
 Clicking on the "Complete setup" button to complete the onboarding flow with paid ads.
 #### Properties
 | name | type | description |
@@ -826,9 +826,9 @@ Clicking on the "Complete setup" button to complete the onboarding flow with pai
 `source` | `string` | The data source of the budget recommendations, e.g. 'google-ads-api', 'fallback-database'.
 `recommended_budget` | `number` | The recommended daily budget displayed to merchants regardless of the final amount they choose.
 #### Emitters
-- [`exports`](../../js/src/pages/onboarding/setup-stepper/setup-paid-ads.js#L63)
+- [`exports`](../../js/src/pages/onboarding/setup-stepper/setup-paid-ads.js#L65)
 
-### [`gla_onboarding_with_cyo_incentive_selected`](../../js/src/pages/onboarding/setup-stepper/setup-paid-ads.js#L49)
+### [`gla_onboarding_with_cyo_incentive_selected`](../../js/src/pages/onboarding/setup-stepper/setup-paid-ads.js#L51)
 Selecting a "Choose Your Own" incentive offer when setting up paid ads during onboarding.
 #### Properties
 | name | type | description |
@@ -836,7 +836,7 @@ Selecting a "Choose Your Own" incentive offer when setting up paid ads during on
 `context` | `string` | The context in which the incentive offer is selected, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'.
 `level` | `string` | The level of the selected incentive offer, e.g. 'low', 'medium', or 'high'.
 #### Emitters
-- [`exports`](../../js/src/pages/onboarding/setup-stepper/setup-paid-ads.js#L63)
+- [`exports`](../../js/src/pages/onboarding/setup-stepper/setup-paid-ads.js#L65)
 
 ### [`gla_open_ads_account_claim_invitation_button_click`](../../js/src/components/google-ads-account-card/claim-account-button.js#L15)
 Clicking on the button to open the invitation page for claiming the newly created Google Ads account.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -199,6 +199,16 @@ Received the data of budget recommendations.
 #### Emitters
 - [`recordGlaDataEventControl`](../../js/src/data/controls.js#L60)
 
+### [`gla_ads_only_onboarding_with_cyo_incentive_selected`](../../js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/setup-paid-ads.js#L29)
+Selecting a "Choose Your Own" incentive offer when setting up paid ads during onboarding.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | The context in which the incentive offer is selected, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'.
+`level` | `string` | The level of the selected incentive offer, e.g. 'low', 'medium', or 'high'.
+#### Emitters
+- [`exports`](../../js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/setup-paid-ads.js#L47)
+
 ### [`gla_ads_set_up_billing_click`](../../js/src/components/paid-ads/billing-card/billing-setup-card.js#L22)
 "Set up billing" button for Google Ads account is clicked.
 #### Properties
@@ -356,20 +366,15 @@ Triggered when the save button in contact information page is clicked.
 #### Emitters
 - [`EditStoreAddress`](../../js/src/pages/settings/edit-store-address.js#L41)
 
-### [`gla_cyo_incentive_apply_incentive_retry_click`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L39)
-Fired when the user clicks the retry button after a failed attempt to apply an incentive.
-#### Emitters
-- [`CyoIncentivePicker`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L58) when the user clicks the retry button after a failed attempt to apply an incentive.
-
-### [`gla_cyo_incentive_picker_shown`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L26)
+### [`gla_cyo_incentive_picker_shown`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L23)
 Fired when the CYO incentive picker is shown to the user.
 #### Emitters
-- [`CyoIncentivePicker`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L58) when the incentive picker is shown to the user.
+- [`CyoIncentivePicker`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L46) when the incentive picker is shown to the user.
 
-### [`gla_cyo_incentive_selected`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L32)
+### [`gla_cyo_incentive_selected`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L29)
 Fired when the user selects an incentive offer.
 #### Emitters
-- [`CyoIncentivePicker`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L58) when the user selects an incentive offer.
+- [`CyoIncentivePicker`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L46) when the user selects an incentive offer.
 
 ### [`gla_dashboard_edit_program_click`](../../js/src/pages/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal.js#L16)
 Triggered when "continue" to edit program button is clicked.
@@ -464,7 +469,7 @@ When a documentation link is clicked.
 - [`TermsModal`](../../js/src/components/google-mc-account-card/terms-modal/index.js#L29) with `{ context: 'setup-mc', link_id: 'google-mc-terms-of-service', href: 'https://support.google.com/merchants/answer/160173' }`
 - [`UnsupportedCountry`](../../js/src/pages/get-started/unsupported-notices/index.js#L73) with `{ context: "get-started", link_id: "supported-countries" }`
 - [`UnsupportedLanguage`](../../js/src/pages/get-started/unsupported-notices/index.js#L30) with `{ context: 'get-started', link_id: 'supported-languages', href: 'https://support.google.com/merchants/answer/160637' }`
-- [`exports`](../../js/src/components/paid-ads/ads-campaign/ads-campaign.js#L44) with `{ context: 'create-ads' | 'edit-ads' | 'setup-ads' | 'setup-ads-only', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
+- [`exports`](../../js/src/components/paid-ads/ads-campaign/ads-campaign.js#L42) with `{ context: 'create-ads' | 'edit-ads' | 'setup-ads' | 'setup-ads-only', link_id: 'see-what-ads-look-like', href: 'https://support.google.com/google-ads/answer/6275294' }`
 
 ### [`gla_edit_mc_store_address`](../../js/src/components/contact-information/store-address-card.js#L166)
 Trigger when store address edit button is clicked.
@@ -812,7 +817,17 @@ Clicking on the "Complete setup" button to complete the onboarding flow with pai
 `source` | `string` | The data source of the budget recommendations, e.g. 'google-ads-api', 'fallback-database'.
 `recommended_budget` | `number` | The recommended daily budget displayed to merchants regardless of the final amount they choose.
 #### Emitters
-- [`exports`](../../js/src/pages/onboarding/setup-stepper/setup-paid-ads.js#L54)
+- [`exports`](../../js/src/pages/onboarding/setup-stepper/setup-paid-ads.js#L63)
+
+### [`gla_onboarding_with_cyo_incentive_selected`](../../js/src/pages/onboarding/setup-stepper/setup-paid-ads.js#L49)
+Selecting a "Choose Your Own" incentive offer when setting up paid ads during onboarding.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | The context in which the incentive offer is selected, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'.
+`level` | `string` | The level of the selected incentive offer, e.g. 'low', 'medium', or 'high'.
+#### Emitters
+- [`exports`](../../js/src/pages/onboarding/setup-stepper/setup-paid-ads.js#L63)
 
 ### [`gla_open_ads_account_claim_invitation_button_click`](../../js/src/components/google-ads-account-card/claim-account-button.js#L15)
 Clicking on the button to open the invitation page for claiming the newly created Google Ads account.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-611/silence-fe-error-when-applying-an-incentive-in-cyoincentivepicker

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go through the onboarding flow (SBM and non SBM)
2. Simulate a HTTP 500 error using tweak for the `POST` `wc/gla/ads/incentive` endpoint
3. After choosing an incentive, either skip or create a paid ads. Even though the endpoint errors, nothing should be surfaced on the FE and the user should be able to complete the onboarding flow.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
