### PR TITLE
GOOWOO-554: Increase ins API MutateError.MUTATE_NOT_ALLOWED errors

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -197,11 +197,22 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 			$campaigns = [];
 
 			foreach ( $results->iterateAllElements() as $row ) {
-				$campaign    = $row->getCampaign();
+				$campaign = $row->getCampaign();
+
+				// Skip VIDEO campaigns
+				if ( AdvertisingChannelType::VIDEO === $campaign->getAdvertisingChannelType() ) {
+					continue;
+				}
+
 				$campaigns[] = [
 					'id'   => $campaign->getId(),
 					'name' => $campaign->getName(),
 				];
+			}
+
+			// When no campaigns need the declaration, record that so the recurring job can stop scheduling
+			if ( empty( $campaigns ) ) {
+				$this->options->update( OptionsInterface::ADS_EU_POLITICAL_DECLARATIONS_COMPLETE, true );
 			}
 
 			return $campaigns;

--- a/src/API/Google/Query/AdsMissingEuDeclarationQuery.php
+++ b/src/API/Google/Query/AdsMissingEuDeclarationQuery.php
@@ -28,6 +28,6 @@ class AdsMissingEuDeclarationQuery extends AdsQuery {
 	 * @return string
 	 */
 	protected function build_query(): string {
-		return 'SELECT campaign.id, campaign.name FROM campaign WHERE campaign.missing_eu_political_advertising_declaration = true';
+		return 'SELECT campaign.id, campaign.name, campaign.advertising_channel_type FROM campaign WHERE campaign.missing_eu_political_advertising_declaration = true';
 	}
 }

--- a/src/Ads/AccountService.php
+++ b/src/Ads/AccountService.php
@@ -303,6 +303,7 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		$this->options->delete( OptionsInterface::ADS_BILLING_URL );
 		$this->options->delete( OptionsInterface::ADS_CONVERSION_ACTION );
 		$this->options->delete( OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED );
+		$this->options->delete( OptionsInterface::ADS_EU_POLITICAL_DECLARATIONS_COMPLETE );
 		$this->options->delete( OptionsInterface::ADS_ID );
 		$this->options->delete( OptionsInterface::ADS_SETUP_COMPLETED_AT );
 		$this->options->delete( OptionsInterface::CAMPAIGN_CONVERT_STATUS );

--- a/src/Jobs/UpdateEuPoliticalCampaigns.php
+++ b/src/Jobs/UpdateEuPoliticalCampaigns.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\AbstractBatchedActionSchedu
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -56,6 +57,12 @@ class UpdateEuPoliticalCampaigns extends AbstractBatchedActionSchedulerJob imple
 	 * @return bool Returns true if the job can be scheduled.
 	 */
 	public function can_schedule( $args = [] ): bool {
+		// Stop scheduling once this Ads account has no more campaigns needing the EU political declaration.
+		// The flag is cleared on Ads disconnect, so reconnecting a different account re-enables the job.
+		if ( $this->options->get( OptionsInterface::ADS_EU_POLITICAL_DECLARATIONS_COMPLETE ) ) {
+			return false;
+		}
+
 		return parent::can_schedule( $args ) && $this->ads_service->is_connected();
 	}
 

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -19,6 +19,7 @@ interface OptionsInterface {
 	public const ADS_BILLING_URL                           = 'ads_billing_url';
 	public const ADS_ID                                    = 'ads_id';
 	public const ADS_CONVERSION_ACTION                     = 'ads_conversion_action';
+	public const ADS_EU_POLITICAL_DECLARATIONS_COMPLETE    = 'ads_eu_political_declarations_complete';
 	public const ADS_SETUP_COMPLETED_AT                    = 'ads_setup_completed_at';
 	public const CAMPAIGN_CONVERT_STATUS                   = 'campaign_convert_status';
 	public const CLAIMED_URL_HASH                          = 'claimed_url_hash';
@@ -63,6 +64,7 @@ interface OptionsInterface {
 		self::ADS_BILLING_URL                           => true,
 		self::ADS_ID                                    => true,
 		self::ADS_CONVERSION_ACTION                     => true,
+		self::ADS_EU_POLITICAL_DECLARATIONS_COMPLETE    => true,
 		self::ADS_SETUP_COMPLETED_AT                    => true,
 		self::CAMPAIGN_CONVERT_STATUS                   => true,
 		self::CLAIMED_URL_HASH                          => true,

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -402,6 +402,92 @@ class AdsCampaignTest extends UnitTest {
 		}
 	}
 
+	public function test_get_campaigns_missing_eu_political_declaration_skips_video_campaigns() {
+		$campaigns_data = [
+			[
+				'id'      => 111,
+				'name'    => 'Non-shopping PMax',
+				'status'  => 'enabled',
+				'type'    => CampaignType::PERFORMANCE_MAX,
+				'country' => 'US',
+				'amount'  => 10,
+			],
+			[
+				'id'      => 222,
+				'name'    => 'Video',
+				'status'  => 'enabled',
+				'type'    => CampaignType::VIDEO,
+				'country' => 'US',
+				'amount'  => 10,
+			],
+			[
+				'id'      => 333,
+				'name'    => 'Shopping',
+				'status'  => 'enabled',
+				'type'    => CampaignType::SHOPPING,
+				'country' => 'US',
+				'amount'  => 10,
+			],
+		];
+
+		$rows = array_map( [ $this, 'generate_campaign_row_mock' ], $campaigns_data );
+		$this->generate_ads_query_mock( $rows );
+
+		$this->options->expects( $this->never() )
+			->method( 'update' )
+			->with( OptionsInterface::ADS_EU_POLITICAL_DECLARATIONS_COMPLETE );
+
+		$result = $this->campaign->get_campaigns_missing_eu_political_declaration();
+
+		$this->assertCount( 2, $result );
+		$this->assertEquals(
+			[
+				'id'   => 111,
+				'name' => 'Non-shopping PMax',
+			],
+			$result[0]
+		);
+		$this->assertEquals(
+			[
+				'id'   => 333,
+				'name' => 'Shopping',
+			],
+			$result[1]
+		);
+	}
+
+	public function test_get_campaigns_missing_eu_political_declaration_sets_complete_flag_when_empty() {
+		$this->generate_ads_query_mock( [] );
+
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::ADS_EU_POLITICAL_DECLARATIONS_COMPLETE, true );
+
+		$this->assertEquals( [], $this->campaign->get_campaigns_missing_eu_political_declaration() );
+	}
+
+	public function test_get_campaigns_missing_eu_political_declaration_sets_complete_flag_when_only_video_campaigns() {
+		$campaigns_data = [
+			[
+				'id'      => 222,
+				'name'    => 'Video',
+				'status'  => 'enabled',
+				'type'    => CampaignType::VIDEO,
+				'country' => 'US',
+				'amount'  => 10,
+			],
+		];
+
+		$rows = array_map( [ $this, 'generate_campaign_row_mock' ], $campaigns_data );
+		$this->generate_ads_query_mock( $rows );
+
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::ADS_EU_POLITICAL_DECLARATIONS_COMPLETE, true );
+
+		$this->assertEquals( [], $this->campaign->get_campaigns_missing_eu_political_declaration() );
+	}
+
 	public function test_create_campaign() {
 		$campaign_data = [
 			'name'                                  => 'New Campaign',

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -754,7 +754,7 @@ class AccountServiceTest extends UnitTest {
 	}
 
 	public function test_disconnect() {
-		$this->options->expects( $this->exactly( 9 ) )
+		$this->options->expects( $this->exactly( 10 ) )
 			->method( 'delete' )
 			->withConsecutive(
 				[ OptionsInterface::ADS_ACCOUNT_CURRENCY ],
@@ -763,6 +763,7 @@ class AccountServiceTest extends UnitTest {
 				[ OptionsInterface::ADS_BILLING_URL ],
 				[ OptionsInterface::ADS_CONVERSION_ACTION ],
 				[ OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED ],
+				[ OptionsInterface::ADS_EU_POLITICAL_DECLARATIONS_COMPLETE ],
 				[ OptionsInterface::ADS_ID ],
 				[ OptionsInterface::ADS_SETUP_COMPLETED_AT ],
 				[ OptionsInterface::CAMPAIGN_CONVERT_STATUS ]

--- a/tests/Unit/Jobs/UpdateEuPoliticalCampaignsTest.php
+++ b/tests/Unit/Jobs/UpdateEuPoliticalCampaignsTest.php
@@ -87,6 +87,14 @@ class UpdateEuPoliticalCampaignsTest extends UnitTest {
 		$this->assertFalse( $this->job->can_schedule() );
 	}
 
+	public function test_cannot_schedule_when_declarations_complete_flag_is_set() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::ADS_EU_POLITICAL_DECLARATIONS_COMPLETE )
+			->willReturn( true );
+
+		$this->assertFalse( $this->job->can_schedule() );
+	}
+
 	public function test_updates_campaigns_not_targeting_eu_counties() {
 		$campaigns = [
 			[


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-554/increase-ins-api-mutateerrormutate-not-allowed-errors

Skipping VIDEO campaigns when fetching campaigns missing the EU political declaration.
Stopping the recurring UpdateEuPoliticalCampaigns job from scheduling once the account has zero undeclared campaigns to process. The flag is cleared on Ads account disconnect so reconnecting a different account re-enables the job

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

I'm not quite sure how to test this


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Improve scheduling for job that updates non-EU campaigns.
