### PR TITLE
GOOWOO-570: Add Markets tab and page route

### DIFF
--- a/js/src/components/main-tab-nav/main-tab-nav.js
+++ b/js/src/components/main-tab-nav/main-tab-nav.js
@@ -41,6 +41,11 @@ let tabs = [
 		href: getNewPath( {}, '/google/attribute-mapping', {} ),
 	},
 	{
+		key: 'markets',
+		title: __( 'Markets', 'google-listings-and-ads' ),
+		href: getNewPath( {}, '/google/markets', {} ),
+	},
+	{
 		key: 'settings',
 		title: __( 'Settings', 'google-listings-and-ads' ),
 		href: getNewPath( {}, '/google/settings', {} ),

--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -39,7 +39,9 @@ export const API_RESPONSE_CODES = {
 };
 
 export const SHIPPING_RATE_METHOD = {
-	FLAT_RATE: 'flat_rate',
+	FLAT: 'flat',
+	MANUAL: 'manual',
+	AUTOMATIC: 'automatic',
 };
 
 // Stepper key related

--- a/js/src/hooks/useDataViewsScript.js
+++ b/js/src/hooks/useDataViewsScript.js
@@ -8,54 +8,79 @@ import { useState, useEffect } from '@wordpress/element';
  */
 import { glaData } from '~/constants';
 
+const isDataViewsReady = () =>
+	typeof window.wp?.dataviews?.filterSortAndPaginate === 'function';
+
+// Module-level singleton: deduplicates concurrent loads across hook instances
+// and across tab switches that happen mid-load.
+let loadPromise;
+
+// Test-only: resets the singleton so each test starts from a clean state.
+// Not part of the public API; do not call from production code.
+export const __resetLoadPromiseForTesting = () => {
+	loadPromise = undefined;
+};
+
+const ensureDataViewsScript = ( url ) => {
+	if ( isDataViewsReady() ) {
+		return Promise.resolve( true );
+	}
+	if ( loadPromise ) {
+		return loadPromise;
+	}
+	if ( ! url ) {
+		return Promise.resolve( false );
+	}
+
+	loadPromise = new Promise( ( resolve ) => {
+		const script = document.createElement( 'script' );
+		script.src = url;
+		script.async = true;
+		script.onload = () => resolve( isDataViewsReady() );
+		script.onerror = () => {
+			// Reset so a future mount can retry.
+			loadPromise = undefined;
+			resolve( false );
+		};
+		document.head.appendChild( script );
+	} );
+
+	return loadPromise;
+};
+
 /**
  * Ensures `@wordpress/dataviews` is available: uses an existing global or loads
- * the script from `glaData.dataViewsScriptUrl`.
+ * the script from `glaData.dataViewsScriptUrl`. The script URL is expected to
+ * match the `wp-dataviews` version shipped by the host WordPress instance.
  *
- * @return {{
- *   dataViewIsLoading: boolean,
- *   dataViewHasFailed: boolean,
- *   dataViewIsReady: boolean
- * }} Loading flags for UI.
+ * @return {'loading' | 'ready' | 'failed'} Current load status.
  */
 const useDataViewsScript = () => {
-	const [ dataViewLoaded, setDataViewLoaded ] = useState(
-		window.wp?.dataviews
+	const [ status, setStatus ] = useState( () =>
+		isDataViewsReady() ? 'ready' : 'loading'
 	);
 	const { dataViewsScriptUrl } = glaData;
 
 	useEffect( () => {
-		if ( dataViewLoaded === undefined && dataViewsScriptUrl ) {
-			const script = document.createElement( 'script' );
-			script.src = dataViewsScriptUrl;
-			script.async = true;
-
-			script.onload = () => {
-				setDataViewLoaded(
-					typeof window.wp?.dataviews?.filterSortAndPaginate ===
-						'function'
-				);
-			};
-
-			script.onerror = () => {
-				setDataViewLoaded( false );
-			};
-
-			document.head.appendChild( script );
+		if ( status === 'ready' ) {
+			return;
 		}
 
-		return () => {
-			if ( dataViewLoaded === false ) {
-				setDataViewLoaded( undefined );
-			}
-		};
-	}, [ dataViewLoaded, dataViewsScriptUrl ] );
+		let isMounted = true;
 
-	return {
-		dataViewIsLoading: dataViewLoaded === undefined,
-		dataViewHasFailed: dataViewLoaded === false,
-		dataViewIsReady: Boolean( dataViewLoaded ),
-	};
+		ensureDataViewsScript( dataViewsScriptUrl ).then( ( ok ) => {
+			if ( ! isMounted ) {
+				return;
+			}
+			setStatus( ok ? 'ready' : 'failed' );
+		} );
+
+		return () => {
+			isMounted = false;
+		};
+	}, [ status, dataViewsScriptUrl ] );
+
+	return status;
 };
 
 export default useDataViewsScript;

--- a/js/src/hooks/useDataViewsScript.js
+++ b/js/src/hooks/useDataViewsScript.js
@@ -11,23 +11,21 @@ import { glaData } from '~/constants';
 const isDataViewsReady = () =>
 	typeof window.wp?.dataviews?.filterSortAndPaginate === 'function';
 
-// Module-level singleton: deduplicates concurrent loads across hook instances
-// and across tab switches that happen mid-load.
+/**
+ * Module-level singleton: deduplicates concurrent loads across hook instances
+ * and across tab switches that happen mid-load.
+ */
 let loadPromise;
-
-// Test-only: resets the singleton so each test starts from a clean state.
-// Not part of the public API; do not call from production code.
-export const __resetLoadPromiseForTesting = () => {
-	loadPromise = undefined;
-};
 
 const ensureDataViewsScript = ( url ) => {
 	if ( isDataViewsReady() ) {
 		return Promise.resolve( true );
 	}
+
 	if ( loadPromise ) {
 		return loadPromise;
 	}
+
 	if ( ! url ) {
 		return Promise.resolve( false );
 	}
@@ -38,8 +36,7 @@ const ensureDataViewsScript = ( url ) => {
 		script.async = true;
 		script.onload = () => resolve( isDataViewsReady() );
 		script.onerror = () => {
-			// Reset so a future mount can retry.
-			loadPromise = undefined;
+			loadPromise = undefined; // Reset so a future mount can retry.
 			resolve( false );
 		};
 		document.head.appendChild( script );
@@ -72,6 +69,7 @@ const useDataViewsScript = () => {
 			if ( ! isMounted ) {
 				return;
 			}
+
 			setStatus( ok ? 'ready' : 'failed' );
 		} );
 

--- a/js/src/hooks/useDataViewsScript.js
+++ b/js/src/hooks/useDataViewsScript.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { glaData } from '~/constants';
+
+/**
+ * Ensures `@wordpress/dataviews` is available: uses an existing global or loads
+ * the script from `glaData.dataViewsScriptUrl`.
+ *
+ * @return {{
+ *   dataViewIsLoading: boolean,
+ *   dataViewHasFailed: boolean,
+ *   dataViewIsReady: boolean
+ * }} Loading flags for UI.
+ */
+const useDataViewsScript = () => {
+	const [ dataViewLoaded, setDataViewLoaded ] = useState(
+		window.wp?.dataviews
+	);
+	const { dataViewsScriptUrl } = glaData;
+
+	useEffect( () => {
+		if ( dataViewLoaded === undefined && dataViewsScriptUrl ) {
+			const script = document.createElement( 'script' );
+			script.src = dataViewsScriptUrl;
+			script.async = true;
+
+			script.onload = () => {
+				setDataViewLoaded(
+					typeof window.wp?.dataviews?.filterSortAndPaginate ===
+						'function'
+				);
+			};
+
+			script.onerror = () => {
+				setDataViewLoaded( false );
+			};
+
+			document.head.appendChild( script );
+		}
+
+		return () => {
+			if ( dataViewLoaded === false ) {
+				setDataViewLoaded( undefined );
+			}
+		};
+	}, [ dataViewLoaded, dataViewsScriptUrl ] );
+
+	return {
+		dataViewIsLoading: dataViewLoaded === undefined,
+		dataViewHasFailed: dataViewLoaded === false,
+		dataViewIsReady: Boolean( dataViewLoaded ),
+	};
+};
+
+export default useDataViewsScript;

--- a/js/src/hooks/useDataViewsScript.test.js
+++ b/js/src/hooks/useDataViewsScript.test.js
@@ -1,0 +1,132 @@
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useDataViewsScript, {
+	__resetLoadPromiseForTesting,
+} from './useDataViewsScript';
+
+const SCRIPT_URL = 'https://example.test/dataviews.js';
+
+let mockGlaData;
+
+jest.mock( '~/constants', () => ( {
+	get glaData() {
+		return mockGlaData;
+	},
+} ) );
+
+const flushPromises = () =>
+	new Promise( ( resolve ) => setImmediate( resolve ) );
+
+const setReadyGlobal = () => {
+	window.wp = {
+		dataviews: { filterSortAndPaginate: jest.fn() },
+	};
+};
+
+describe( 'useDataViewsScript', () => {
+	let appendedScripts;
+	let appendChildSpy;
+
+	beforeEach( () => {
+		mockGlaData = { dataViewsScriptUrl: SCRIPT_URL };
+		appendedScripts = [];
+		__resetLoadPromiseForTesting();
+
+		appendChildSpy = jest
+			.spyOn( document.head, 'appendChild' )
+			.mockImplementation( ( node ) => {
+				appendedScripts.push( node );
+				return node;
+			} );
+	} );
+
+	afterEach( () => {
+		delete window.wp;
+		appendChildSpy.mockRestore();
+	} );
+
+	it( 'returns "ready" synchronously when window.wp.dataviews is already available', () => {
+		setReadyGlobal();
+
+		const { result } = renderHook( () => useDataViewsScript() );
+
+		expect( result.current ).toBe( 'ready' );
+		expect( appendedScripts ).toHaveLength( 0 );
+	} );
+
+	it( 'injects exactly one <script> tag for two concurrent hook instances', () => {
+		renderHook( () => useDataViewsScript() );
+		renderHook( () => useDataViewsScript() );
+
+		expect( appendedScripts ).toHaveLength( 1 );
+		expect( appendedScripts[ 0 ].src ).toBe( SCRIPT_URL );
+	} );
+
+	it( 'resolves both concurrent instances to "ready" after a single onload', async () => {
+		const a = renderHook( () => useDataViewsScript() );
+		const b = renderHook( () => useDataViewsScript() );
+
+		expect( a.result.current ).toBe( 'loading' );
+		expect( b.result.current ).toBe( 'loading' );
+
+		await act( async () => {
+			setReadyGlobal();
+			appendedScripts[ 0 ].onload();
+			await flushPromises();
+		} );
+
+		expect( a.result.current ).toBe( 'ready' );
+		expect( b.result.current ).toBe( 'ready' );
+	} );
+
+	it( 'resolves to "failed" on onerror and allows a subsequent mount to retry', async () => {
+		const first = renderHook( () => useDataViewsScript() );
+		expect( first.result.current ).toBe( 'loading' );
+
+		await act( async () => {
+			appendedScripts[ 0 ].onerror();
+			await flushPromises();
+		} );
+
+		expect( first.result.current ).toBe( 'failed' );
+
+		// A subsequent mount should attempt to load again, not return cached failure.
+		renderHook( () => useDataViewsScript() );
+		expect( appendedScripts ).toHaveLength( 2 );
+	} );
+
+	// `@wordpress/jest-console` (preset) auto-fails the test if any
+	// `console.error` is emitted, e.g. React's "setState after unmount"
+	// warning, so this test relies on that side effect.
+	it( 'does not warn when onload fires after unmount', async () => {
+		const { result, unmount } = renderHook( () => useDataViewsScript() );
+		expect( result.current ).toBe( 'loading' );
+
+		unmount();
+
+		await act( async () => {
+			setReadyGlobal();
+			appendedScripts[ 0 ].onload();
+			await flushPromises();
+		} );
+	} );
+
+	it( 'returns "failed" when no script URL is configured', async () => {
+		mockGlaData = {};
+
+		const { result } = renderHook( () => useDataViewsScript() );
+
+		await act( async () => {
+			await flushPromises();
+		} );
+
+		expect( result.current ).toBe( 'failed' );
+		expect( appendedScripts ).toHaveLength( 0 );
+	} );
+} );

--- a/js/src/hooks/useDataViewsScript.test.js
+++ b/js/src/hooks/useDataViewsScript.test.js
@@ -3,14 +3,15 @@
  */
 import { renderHook, act } from '@testing-library/react';
 
-/**
- * Internal dependencies
- */
-import useDataViewsScript, {
-	__resetLoadPromiseForTesting,
-} from './useDataViewsScript';
-
 const SCRIPT_URL = 'https://example.test/dataviews.js';
+
+// Pin `@wordpress/element` to the same React instance that
+// `@testing-library/react` uses, so that re-importing the hook via
+// `jest.isolateModules` (to reset its module-level singleton) doesn't
+// produce a second React copy and trigger "Invalid hook call" errors.
+// `mock`-prefixed identifiers are exempt from jest.mock's hoist guard.
+const mockReact = jest.requireActual( 'react' );
+jest.mock( '@wordpress/element', () => mockReact );
 
 let mockGlaData;
 
@@ -29,6 +30,14 @@ const setReadyGlobal = () => {
 	};
 };
 
+const loadHook = () => {
+	let hook;
+	jest.isolateModules( () => {
+		hook = require( './useDataViewsScript' ).default;
+	} );
+	return hook;
+};
+
 describe( 'useDataViewsScript', () => {
 	let appendedScripts;
 	let appendChildSpy;
@@ -36,7 +45,6 @@ describe( 'useDataViewsScript', () => {
 	beforeEach( () => {
 		mockGlaData = { dataViewsScriptUrl: SCRIPT_URL };
 		appendedScripts = [];
-		__resetLoadPromiseForTesting();
 
 		appendChildSpy = jest
 			.spyOn( document.head, 'appendChild' )
@@ -53,6 +61,7 @@ describe( 'useDataViewsScript', () => {
 
 	it( 'returns "ready" synchronously when window.wp.dataviews is already available', () => {
 		setReadyGlobal();
+		const useDataViewsScript = loadHook();
 
 		const { result } = renderHook( () => useDataViewsScript() );
 
@@ -61,6 +70,8 @@ describe( 'useDataViewsScript', () => {
 	} );
 
 	it( 'injects exactly one <script> tag for two concurrent hook instances', () => {
+		const useDataViewsScript = loadHook();
+
 		renderHook( () => useDataViewsScript() );
 		renderHook( () => useDataViewsScript() );
 
@@ -69,6 +80,8 @@ describe( 'useDataViewsScript', () => {
 	} );
 
 	it( 'resolves both concurrent instances to "ready" after a single onload', async () => {
+		const useDataViewsScript = loadHook();
+
 		const a = renderHook( () => useDataViewsScript() );
 		const b = renderHook( () => useDataViewsScript() );
 
@@ -86,6 +99,8 @@ describe( 'useDataViewsScript', () => {
 	} );
 
 	it( 'resolves to "failed" on onerror and allows a subsequent mount to retry', async () => {
+		const useDataViewsScript = loadHook();
+
 		const first = renderHook( () => useDataViewsScript() );
 		expect( first.result.current ).toBe( 'loading' );
 
@@ -105,6 +120,8 @@ describe( 'useDataViewsScript', () => {
 	// `console.error` is emitted, e.g. React's "setState after unmount"
 	// warning, so this test relies on that side effect.
 	it( 'does not warn when onload fires after unmount', async () => {
+		const useDataViewsScript = loadHook();
+
 		const { result, unmount } = renderHook( () => useDataViewsScript() );
 		expect( result.current ).toBe( 'loading' );
 
@@ -119,6 +136,7 @@ describe( 'useDataViewsScript', () => {
 
 	it( 'returns "failed" when no script URL is configured', async () => {
 		mockGlaData = {};
+		const useDataViewsScript = loadHook();
 
 		const { result } = renderHook( () => useDataViewsScript() );
 

--- a/js/src/hooks/useMarkets.js
+++ b/js/src/hooks/useMarkets.js
@@ -13,9 +13,14 @@ import { __ } from '@wordpress/i18n';
  * - `data`: an array of market objects (`{ id, market, country, shipping }`).
  * - `hasFinishedResolution`: a boolean mirroring the `@wordpress/data`
  *   resolution flag used by `useAppSelectDispatch`.
+ * - `invalidateResolution`: a no-op callback today; will trigger a refetch of
+ *   the markets list once `useMarkets` is wired to a real selector.
  *
- * @return {{ data: Array<{ id: string, market: string, country: string, shipping: string }>, hasFinishedResolution: boolean }}
- *         Markets data and resolution flag.
+ * @return {{
+ *   data: Array<{ id: string, market: string, country: string, shipping: string }>,
+ *   hasFinishedResolution: boolean,
+ *   invalidateResolution: () => void,
+ * }} Markets data, resolution flag, and refetch callback.
  */
 const useMarkets = () => {
 	return {
@@ -28,6 +33,7 @@ const useMarkets = () => {
 			},
 		],
 		hasFinishedResolution: true,
+		invalidateResolution: () => {},
 	};
 };
 

--- a/js/src/hooks/useMarkets.js
+++ b/js/src/hooks/useMarkets.js
@@ -1,23 +1,28 @@
 /**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Placeholder hook for the markets list.
  *
  * Returns a hardcoded sample so the Markets dashboard can render a realistic
  * row in dev and reviews. The shape matches the contract the real selector is
  * expected to expose, so the consumer can stay unchanged when the API lands:
  *
- * - `data`: an array of market objects (`{ id, market, country, shipping }`).
+ * - `data`: an array of market objects with the fields documented below.
  * - `hasFinishedResolution`: a boolean mirroring the `@wordpress/data`
  *   resolution flag used by `useAppSelectDispatch`.
  * - `invalidateResolution`: a no-op callback today; will trigger a refetch of
  *   the markets list once `useMarkets` is wired to a real selector.
  *
  * @return {{
- *   data: Array<{ id: string, market: string, country: string, shipping: string }>,
+ *   data: Array<{
+ *     id: string,
+ *     label: string,
+ *     countries: string[],
+ *     language: string,
+ *     currency: string,
+ *     feedLabel: string,
+ *     shipping_rate: string,
+ *     shipping_time: string,
+ *     free_shipping: ?number,
+ *   }>,
  *   hasFinishedResolution: boolean,
  *   invalidateResolution: () => void,
  * }} Markets data, resolution flag, and refetch callback.
@@ -27,9 +32,14 @@ const useMarkets = () => {
 		data: [
 			{
 				id: 'primary',
-				market: __( 'Primary market', 'google-listings-and-ads' ),
-				country: __( '20 Countries', 'google-listings-and-ads' ),
-				shipping: __( 'Managed in Google', 'google-listings-and-ads' ),
+				label: 'Primary Market',
+				countries: [ 'MU', 'ZW' ],
+				language: 'en',
+				currency: 'USD',
+				feedLabel: 'ZW',
+				shipping_rate: 'flat',
+				shipping_time: 'flat',
+				free_shipping: null,
 			},
 		],
 		hasFinishedResolution: true,

--- a/js/src/hooks/useMarkets.js
+++ b/js/src/hooks/useMarkets.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Placeholder hook for the markets list.
+ *
+ * Returns a hardcoded sample so the Markets dashboard can render a realistic
+ * row in dev and reviews. The shape matches the contract the real selector is
+ * expected to expose, so the consumer can stay unchanged when the API lands:
+ *
+ * - `data`: an array of market objects (`{ id, market, country, shipping }`).
+ * - `hasFinishedResolution`: a boolean mirroring the `@wordpress/data`
+ *   resolution flag used by `useAppSelectDispatch`.
+ *
+ * @return {{ data: Array<{ id: string, market: string, country: string, shipping: string }>, hasFinishedResolution: boolean }}
+ *         Markets data and resolution flag.
+ */
+const useMarkets = () => {
+	return {
+		data: [
+			{
+				id: 'primary',
+				market: __( 'Primary market', 'google-listings-and-ads' ),
+				country: __( '20 Countries', 'google-listings-and-ads' ),
+				shipping: __( 'Managed in Google', 'google-listings-and-ads' ),
+			},
+		],
+		hasFinishedResolution: true,
+	};
+};
+
+export default useMarkets;

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -53,6 +53,10 @@ const PriceBenchmark = lazy( () =>
 	)
 );
 
+const Markets = lazy( () =>
+	import( /* webpackChunkName: "markets" */ './pages/markets' )
+);
+
 const Settings = lazy( () =>
 	import( /* webpackChunkName: "settings" */ './pages/settings' )
 );
@@ -149,6 +153,15 @@ const registerPluginAdminPages = () => {
 				],
 				container: AttributeMapping,
 				path: '/google/attribute-mapping',
+				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
+			},
+			{
+				breadcrumbs: [
+					...initialBreadcrumbs,
+					__( 'Markets', 'google-listings-and-ads' ),
+				],
+				container: Markets,
+				path: '/google/markets',
 				wpOpenMenu: 'toplevel_page_woocommerce-marketing',
 			},
 			{

--- a/js/src/pages/markets/constants.js
+++ b/js/src/pages/markets/constants.js
@@ -20,3 +20,11 @@ export const WC_SHIPPING_SETTINGS_URL =
 	getSetting( 'adminUrl' ) + 'admin.php?page=wc-settings&tab=shipping';
 
 export const GOOGLE_MERCHANT_CENTER_URL = 'https://merchants.google.com/';
+
+/**
+ * Identifier of the always-present "primary" market.
+ *
+ * Several actions (e.g. delete) are not applicable to the primary market and
+ * use this constant to short-circuit their eligibility.
+ */
+export const PRIMARY_MARKET_ID = 'primary';

--- a/js/src/pages/markets/constants.js
+++ b/js/src/pages/markets/constants.js
@@ -1,0 +1,16 @@
+/**
+ * Shipping rate selection made by the merchant during onboarding.
+ *
+ * Mirrors the radio values rendered by
+ * `~/components/shipping-rate-section/shipping-rate-section.js`.
+ */
+export const SHIPPING_RATE_OPTION = {
+	AUTOMATIC: 'automatic',
+	FLAT: 'flat',
+	MANUAL: 'manual',
+};
+
+export const WC_SHIPPING_SETTINGS_URL =
+	'/wp-admin/admin.php?page=wc-settings&tab=shipping';
+
+export const GOOGLE_MERCHANT_CENTER_URL = 'https://merchants.google.com/';

--- a/js/src/pages/markets/constants.js
+++ b/js/src/pages/markets/constants.js
@@ -4,18 +4,6 @@
 import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
 // The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
 
-/**
- * Shipping rate selection made by the merchant during onboarding.
- *
- * Mirrors the radio values rendered by
- * `~/components/shipping-rate-section/shipping-rate-section.js`.
- */
-export const SHIPPING_RATE_OPTION = {
-	AUTOMATIC: 'automatic',
-	FLAT: 'flat',
-	MANUAL: 'manual',
-};
-
 export const WC_SHIPPING_SETTINGS_URL =
 	getSetting( 'adminUrl' ) + 'admin.php?page=wc-settings&tab=shipping';
 

--- a/js/src/pages/markets/constants.js
+++ b/js/src/pages/markets/constants.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { getSetting } from '@woocommerce/settings'; // eslint-disable-line import/no-unresolved
+// The above is an unpublished package, delivered with WC, we use Dependency Extraction Webpack Plugin to import it.
+
+/**
  * Shipping rate selection made by the merchant during onboarding.
  *
  * Mirrors the radio values rendered by
@@ -11,6 +17,6 @@ export const SHIPPING_RATE_OPTION = {
 };
 
 export const WC_SHIPPING_SETTINGS_URL =
-	'/wp-admin/admin.php?page=wc-settings&tab=shipping';
+	getSetting( 'adminUrl' ) + 'admin.php?page=wc-settings&tab=shipping';
 
 export const GOOGLE_MERCHANT_CENTER_URL = 'https://merchants.google.com/';

--- a/js/src/pages/markets/index.js
+++ b/js/src/pages/markets/index.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import MainTabNav from '~/components/main-tab-nav';
+import ExperienceRatingBanner from '~/components/experience-rating-banner';
+import MarketsDashboard from './markets-dashboard';
+import './index.scss';
+
+const Markets = () => {
+	return (
+		<div className="gla-markets">
+			<ExperienceRatingBanner />
+			<MainTabNav />
+			<MarketsDashboard />
+		</div>
+	);
+};
+
+export default Markets;

--- a/js/src/pages/markets/index.scss
+++ b/js/src/pages/markets/index.scss
@@ -1,0 +1,1 @@
+// Styles for the Markets page will be added here as the page gains content.

--- a/js/src/pages/markets/index.test.js
+++ b/js/src/pages/markets/index.test.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Markets from './';
+
+jest.mock( '~/components/main-tab-nav', () =>
+	jest.fn().mockReturnValue( <div data-testid="main-tab-nav" /> )
+);
+
+jest.mock( '~/components/experience-rating-banner', () =>
+	jest.fn().mockReturnValue( null ).mockName( 'ExperienceRatingBanner' )
+);
+
+// TODO: Subject to change as the page gains content.
+describe( 'Markets page', () => {
+	test( 'renders the main tab navigation', () => {
+		render( <Markets /> );
+		expect( screen.getByTestId( 'main-tab-nav' ) ).toBeInTheDocument();
+	} );
+
+	test( 'renders the MarketsDashboard placeholder heading', () => {
+		render( <Markets /> );
+		expect(
+			screen.getByRole( 'heading', { name: 'Markets' } )
+		).toBeInTheDocument();
+	} );
+} );

--- a/js/src/pages/markets/index.test.js
+++ b/js/src/pages/markets/index.test.js
@@ -17,17 +17,18 @@ jest.mock( '~/components/experience-rating-banner', () =>
 	jest.fn().mockReturnValue( null ).mockName( 'ExperienceRatingBanner' )
 );
 
-// TODO: Subject to change as the page gains content.
+jest.mock( './markets-dashboard', () =>
+	jest.fn().mockReturnValue( <div data-testid="markets-dashboard" /> )
+);
+
 describe( 'Markets page', () => {
 	test( 'renders the main tab navigation', () => {
 		render( <Markets /> );
 		expect( screen.getByTestId( 'main-tab-nav' ) ).toBeInTheDocument();
 	} );
 
-	test( 'renders the MarketsDashboard placeholder heading', () => {
+	test( 'renders the MarketsDashboard', () => {
 		render( <Markets /> );
-		expect(
-			screen.getByRole( 'heading', { name: 'Markets' } )
-		).toBeInTheDocument();
+		expect( screen.getByTestId( 'markets-dashboard' ) ).toBeInTheDocument();
 	} );
 } );

--- a/js/src/pages/markets/markets-dashboard/add-market-modal/index.js
+++ b/js/src/pages/markets/markets-dashboard/add-market-modal/index.js
@@ -24,7 +24,6 @@ import AppButton from '~/components/app-button';
 const AddMarketModal = ( { onRequestClose } ) => {
 	return (
 		<AppModal
-			className="gla-add-market-modal"
 			title={ __( 'Add market', 'google-listings-and-ads' ) }
 			onRequestClose={ onRequestClose }
 			buttons={ [

--- a/js/src/pages/markets/markets-dashboard/add-market-modal/index.js
+++ b/js/src/pages/markets/markets-dashboard/add-market-modal/index.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AppModal from '~/components/app-modal';
+import AppButton from '~/components/app-button';
+
+/**
+ * Placeholder for the Add Market modal.
+ *
+ * The follow-up task will replace this with a real form (country selector,
+ * shipping configuration, validation, and a save handler that triggers a
+ * markets refetch). For now, the modal renders a short placeholder body and a
+ * Close button so the open / close wiring from `AddMarket` can be reviewed
+ * end-to-end.
+ *
+ * @param {Object} props
+ * @param {() => void} props.onRequestClose Called when the user closes the modal.
+ */
+const AddMarketModal = ( { onRequestClose } ) => {
+	return (
+		<AppModal
+			className="gla-add-market-modal"
+			title={ __( 'Add market', 'google-listings-and-ads' ) }
+			onRequestClose={ onRequestClose }
+			buttons={ [
+				<AppButton
+					key="close"
+					variant="tertiary"
+					onClick={ onRequestClose }
+				>
+					{ __( 'Close', 'google-listings-and-ads' ) }
+				</AppButton>,
+			] }
+		>
+			<p>{ __( 'Adding a new market.', 'google-listings-and-ads' ) }</p>
+		</AppModal>
+	);
+};
+
+export default AddMarketModal;

--- a/js/src/pages/markets/markets-dashboard/add-market-modal/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/add-market-modal/index.test.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import AddMarketModal from './';
+
+describe( 'AddMarketModal', () => {
+	test( 'renders the title and the placeholder body', () => {
+		render( <AddMarketModal onRequestClose={ () => {} } /> );
+
+		expect(
+			screen.getByRole( 'dialog', { name: 'Add market' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Adding a new market.' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'invokes onRequestClose when the footer Close button is clicked', async () => {
+		const user = userEvent.setup();
+		const onRequestClose = jest.fn();
+		render( <AddMarketModal onRequestClose={ onRequestClose } /> );
+
+		// `getByRole('button', { name: 'Close' })` matches both the
+		// `<Modal>`'s X button (aria-label) and the footer button. Use the
+		// `is-tertiary` variant class to target only our footer button.
+		const footerCloseButton = document.querySelector(
+			'.app-modal__footer .is-tertiary'
+		);
+		await user.click( footerCloseButton );
+
+		expect( onRequestClose ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/js/src/pages/markets/markets-dashboard/add-market/index.js
+++ b/js/src/pages/markets/markets-dashboard/add-market/index.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '~/components/app-button';
+
+/**
+ * Placeholder for the "Add market" CTA on the Markets dashboard.
+ *
+ * The button is wired with a no-op handler for now. The follow-up task
+ * will introduce `AddMarketModal` and replace the handler.
+ */
+const AddMarket = () => {
+	return (
+		<AppButton variant="primary" onClick={ () => {} }>
+			{ __( 'Add market', 'google-listings-and-ads' ) }
+		</AppButton>
+	);
+};
+
+export default AddMarket;

--- a/js/src/pages/markets/markets-dashboard/add-market/index.js
+++ b/js/src/pages/markets/markets-dashboard/add-market/index.js
@@ -2,23 +2,32 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useState, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import AppButton from '~/components/app-button';
+import AddMarketModal from '../add-market-modal';
 
 /**
- * Placeholder for the "Add market" CTA on the Markets dashboard.
- *
- * The button is wired with a no-op handler for now. The follow-up task
- * will introduce `AddMarketModal` and replace the handler.
+ * Owns the open / close state for `AddMarketModal`. The modal itself is a
+ * placeholder today; the follow-up task will replace its body with a real
+ * country / shipping form and a save handler.
  */
 const AddMarket = () => {
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const handleOpen = useCallback( () => setIsOpen( true ), [] );
+	const handleClose = useCallback( () => setIsOpen( false ), [] );
+
 	return (
-		<AppButton variant="primary" onClick={ () => {} }>
-			{ __( 'Add market', 'google-listings-and-ads' ) }
-		</AppButton>
+		<>
+			<AppButton variant="primary" onClick={ handleOpen }>
+				{ __( 'Add market', 'google-listings-and-ads' ) }
+			</AppButton>
+			{ isOpen && <AddMarketModal onRequestClose={ handleClose } /> }
+		</>
 	);
 };
 

--- a/js/src/pages/markets/markets-dashboard/add-market/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/add-market/index.test.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import AddMarket from './';
+
+jest.mock( '../add-market-modal', () =>
+	jest.fn( ( { onRequestClose } ) => (
+		<div data-testid="add-market-modal">
+			<button onClick={ onRequestClose }>Close modal</button>
+		</div>
+	) )
+);
+
+describe( 'AddMarket', () => {
+	test( 'renders the primary "Add market" button', () => {
+		render( <AddMarket /> );
+
+		const button = screen.getByRole( 'button', { name: 'Add market' } );
+		expect( button ).toBeInTheDocument();
+		expect( button ).toHaveClass( 'is-primary' );
+	} );
+
+	test( 'does not render the modal until the button is clicked', () => {
+		render( <AddMarket /> );
+
+		expect(
+			screen.queryByTestId( 'add-market-modal' )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'opens AddMarketModal when the button is clicked', async () => {
+		const user = userEvent.setup();
+		render( <AddMarket /> );
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Add market' } )
+		);
+
+		expect( screen.getByTestId( 'add-market-modal' ) ).toBeInTheDocument();
+	} );
+
+	test( 'closes the modal when AddMarketModal calls onRequestClose', async () => {
+		const user = userEvent.setup();
+		render( <AddMarket /> );
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Add market' } )
+		);
+		expect( screen.getByTestId( 'add-market-modal' ) ).toBeInTheDocument();
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Close modal' } )
+		);
+		expect(
+			screen.queryByTestId( 'add-market-modal' )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/js/src/pages/markets/markets-dashboard/edit-market-modal/index.js
+++ b/js/src/pages/markets/markets-dashboard/edit-market-modal/index.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import AppModal from '~/components/app-modal';
+import AppButton from '~/components/app-button';
+
+/**
+ * Placeholder for the Edit Market modal.
+ *
+ * The follow-up task will replace this with a real form. For now, the modal
+ * renders the selected market's name and a Close button so the open/close
+ * wiring from `MarketDataViews` can be reviewed end-to-end.
+ *
+ * @param {Object} props
+ * @param {{ id: string, market: string }} props.market The market being edited.
+ * @param {() => void} props.onRequestClose Called when the user closes the modal.
+ */
+const EditMarketModal = ( { market, onRequestClose } ) => {
+	return (
+		<AppModal
+			className="gla-edit-market-modal"
+			title={ __( 'Edit market', 'google-listings-and-ads' ) }
+			onRequestClose={ onRequestClose }
+			buttons={ [
+				<AppButton
+					key="close"
+					variant="tertiary"
+					onClick={ onRequestClose }
+				>
+					{ __( 'Close', 'google-listings-and-ads' ) }
+				</AppButton>,
+			] }
+		>
+			<p>
+				{ sprintf(
+					// translators: %s is the name of the market being edited.
+					__( 'Editing %s.', 'google-listings-and-ads' ),
+					market.market
+				) }
+			</p>
+		</AppModal>
+	);
+};
+
+export default EditMarketModal;

--- a/js/src/pages/markets/markets-dashboard/edit-market-modal/index.js
+++ b/js/src/pages/markets/markets-dashboard/edit-market-modal/index.js
@@ -17,7 +17,7 @@ import AppButton from '~/components/app-button';
  * wiring from `MarketDataViews` can be reviewed end-to-end.
  *
  * @param {Object} props
- * @param {{ id: string, market: string }} props.market The market being edited.
+ * @param {{ id: string, label: string }} props.market The market being edited.
  * @param {() => void} props.onRequestClose Called when the user closes the modal.
  */
 const EditMarketModal = ( { market, onRequestClose } ) => {
@@ -40,7 +40,7 @@ const EditMarketModal = ( { market, onRequestClose } ) => {
 				{ sprintf(
 					// translators: %s is the name of the market being edited.
 					__( 'Editing %s.', 'google-listings-and-ads' ),
-					market.market
+					market.label
 				) }
 			</p>
 		</AppModal>

--- a/js/src/pages/markets/markets-dashboard/edit-market-modal/index.js
+++ b/js/src/pages/markets/markets-dashboard/edit-market-modal/index.js
@@ -23,7 +23,6 @@ import AppButton from '~/components/app-button';
 const EditMarketModal = ( { market, onRequestClose } ) => {
 	return (
 		<AppModal
-			className="gla-edit-market-modal"
 			title={ __( 'Edit market', 'google-listings-and-ads' ) }
 			onRequestClose={ onRequestClose }
 			buttons={ [

--- a/js/src/pages/markets/markets-dashboard/edit-market-modal/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/edit-market-modal/index.test.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import EditMarketModal from './';
+
+const market = { id: 'primary', market: 'Primary market' };
+
+describe( 'EditMarketModal', () => {
+	test( 'renders the title and the market name being edited', () => {
+		render(
+			<EditMarketModal market={ market } onRequestClose={ () => {} } />
+		);
+
+		expect(
+			screen.getByRole( 'dialog', { name: 'Edit market' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Editing Primary market.' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'invokes onRequestClose when the footer Close button is clicked', async () => {
+		const user = userEvent.setup();
+		const onRequestClose = jest.fn();
+		render(
+			<EditMarketModal
+				market={ market }
+				onRequestClose={ onRequestClose }
+			/>
+		);
+
+		// `getByRole('button', { name: 'Close' })` matches both the
+		// `<Modal>`'s X button (aria-label) and the footer button. Use the
+		// `is-tertiary` variant class to target only our footer button.
+		const footerCloseButton = document.querySelector(
+			'.app-modal__footer .is-tertiary'
+		);
+		await user.click( footerCloseButton );
+
+		expect( onRequestClose ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/js/src/pages/markets/markets-dashboard/edit-market-modal/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/edit-market-modal/index.test.js
@@ -10,7 +10,7 @@ import userEvent from '@testing-library/user-event';
  */
 import EditMarketModal from './';
 
-const market = { id: 'primary', market: 'Primary market' };
+const market = { id: 'primary', label: 'Primary Market' };
 
 describe( 'EditMarketModal', () => {
 	test( 'renders the title and the market name being edited', () => {
@@ -22,7 +22,7 @@ describe( 'EditMarketModal', () => {
 			screen.getByRole( 'dialog', { name: 'Edit market' } )
 		).toBeInTheDocument();
 		expect(
-			screen.getByText( 'Editing Primary market.' )
+			screen.getByText( 'Editing Primary Market.' )
 		).toBeInTheDocument();
 	} );
 

--- a/js/src/pages/markets/markets-dashboard/index.js
+++ b/js/src/pages/markets/markets-dashboard/index.js
@@ -1,10 +1,72 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import { Card } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { glaData } from '~/constants';
+import AppSpinner from '~/components/app-spinner';
+import useSettings from '~/hooks/useSettings';
+import MarketsHeader from './markets-header';
+import MarketDataViews from './market-data-views';
+import './index.scss';
 
 const MarketsDashboard = () => {
-	return <h1>{ __( 'Markets', 'google-listings-and-ads' ) }</h1>;
+	const { settings } = useSettings();
+	const shippingRate = settings?.shipping_rate;
+
+	const [ dataViewLoaded, setDataViewLoaded ] = useState(
+		window.wp?.dataviews
+	);
+	const { dataViewsScriptUrl } = glaData;
+
+	useEffect( () => {
+		if ( dataViewLoaded === undefined && dataViewsScriptUrl ) {
+			const script = document.createElement( 'script' );
+			script.src = dataViewsScriptUrl;
+			script.async = true;
+
+			script.onload = () => {
+				setDataViewLoaded(
+					typeof window.wp?.dataviews?.filterSortAndPaginate ===
+						'function'
+				);
+			};
+
+			script.onerror = () => {
+				setDataViewLoaded( false );
+			};
+
+			document.head.appendChild( script );
+		}
+
+		return () => {
+			if ( dataViewLoaded === false ) {
+				setDataViewLoaded( undefined );
+			}
+		};
+	}, [ dataViewLoaded, dataViewsScriptUrl ] );
+
+	const isLoading = dataViewLoaded === undefined;
+	const hasFailed = dataViewLoaded === false;
+
+	return (
+		<div className="gla-markets-dashboard">
+			<MarketsHeader shippingRate={ shippingRate } />
+
+			{ ! hasFailed && (
+				<Card className="gla-markets-dashboard__card">
+					{ isLoading && <AppSpinner /> }
+					{ dataViewLoaded && (
+						<MarketDataViews shippingRate={ shippingRate } />
+					) }
+				</Card>
+			) }
+		</div>
+	);
 };
 
 export default MarketsDashboard;

--- a/js/src/pages/markets/markets-dashboard/index.js
+++ b/js/src/pages/markets/markets-dashboard/index.js
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
 import { Card } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { glaData } from '~/constants';
 import AppSpinner from '~/components/app-spinner';
+import useDataViewsScript from '~/hooks/useDataViewsScript';
 import useSettings from '~/hooks/useSettings';
 import MarketsHeader from './markets-header';
 import MarketDataViews from './market-data-views';
@@ -18,49 +17,17 @@ const MarketsDashboard = () => {
 	const { settings } = useSettings();
 	const shippingRate = settings?.shipping_rate;
 
-	const [ dataViewLoaded, setDataViewLoaded ] = useState(
-		window.wp?.dataviews
-	);
-	const { dataViewsScriptUrl } = glaData;
-
-	useEffect( () => {
-		if ( dataViewLoaded === undefined && dataViewsScriptUrl ) {
-			const script = document.createElement( 'script' );
-			script.src = dataViewsScriptUrl;
-			script.async = true;
-
-			script.onload = () => {
-				setDataViewLoaded(
-					typeof window.wp?.dataviews?.filterSortAndPaginate ===
-						'function'
-				);
-			};
-
-			script.onerror = () => {
-				setDataViewLoaded( false );
-			};
-
-			document.head.appendChild( script );
-		}
-
-		return () => {
-			if ( dataViewLoaded === false ) {
-				setDataViewLoaded( undefined );
-			}
-		};
-	}, [ dataViewLoaded, dataViewsScriptUrl ] );
-
-	const isLoading = dataViewLoaded === undefined;
-	const hasFailed = dataViewLoaded === false;
+	const { dataViewIsLoading, dataViewHasFailed, dataViewIsReady } =
+		useDataViewsScript();
 
 	return (
 		<div className="gla-markets-dashboard">
 			<MarketsHeader shippingRate={ shippingRate } />
 
-			{ ! hasFailed && (
+			{ ! dataViewHasFailed && (
 				<Card className="gla-markets-dashboard__card">
-					{ isLoading && <AppSpinner /> }
-					{ dataViewLoaded && (
+					{ dataViewIsLoading && <AppSpinner /> }
+					{ dataViewIsReady && (
 						<MarketDataViews shippingRate={ shippingRate } />
 					) }
 				</Card>

--- a/js/src/pages/markets/markets-dashboard/index.js
+++ b/js/src/pages/markets/markets-dashboard/index.js
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const MarketsDashboard = () => {
+	return <h1>{ __( 'Markets', 'google-listings-and-ads' ) }</h1>;
+};
+
+export default MarketsDashboard;

--- a/js/src/pages/markets/markets-dashboard/index.js
+++ b/js/src/pages/markets/markets-dashboard/index.js
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Card } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import AppNotice from '~/components/app-notice';
 import AppSpinner from '~/components/app-spinner';
 import useDataViewsScript from '~/hooks/useDataViewsScript';
 import useSettings from '~/hooks/useSettings';
@@ -17,17 +19,29 @@ const MarketsDashboard = () => {
 	const { settings } = useSettings();
 	const shippingRate = settings?.shipping_rate;
 
-	const { dataViewIsLoading, dataViewHasFailed, dataViewIsReady } =
-		useDataViewsScript();
+	const dataViewStatus = useDataViewsScript();
 
 	return (
 		<div className="gla-markets-dashboard">
 			<MarketsHeader shippingRate={ shippingRate } />
 
-			{ ! dataViewHasFailed && (
+			{ dataViewStatus === 'failed' && (
+				<AppNotice
+					status="warning"
+					isDismissible={ false }
+					className="gla-markets-dashboard__error-message"
+				>
+					{ __(
+						'There was an error loading the markets dashboard.',
+						'google-listings-and-ads'
+					) }
+				</AppNotice>
+			) }
+
+			{ dataViewStatus !== 'failed' && (
 				<Card className="gla-markets-dashboard__card">
-					{ dataViewIsLoading && <AppSpinner /> }
-					{ dataViewIsReady && (
+					{ dataViewStatus === 'loading' && <AppSpinner /> }
+					{ dataViewStatus === 'ready' && (
 						<MarketDataViews shippingRate={ shippingRate } />
 					) }
 				</Card>

--- a/js/src/pages/markets/markets-dashboard/index.scss
+++ b/js/src/pages/markets/markets-dashboard/index.scss
@@ -5,8 +5,6 @@
 
 	&__card {
 		min-height: $grid-unit-60;
-		border-radius: 0;
-		box-shadow: none;
 		padding: $grid-unit-20;
 	}
 }

--- a/js/src/pages/markets/markets-dashboard/index.scss
+++ b/js/src/pages/markets/markets-dashboard/index.scss
@@ -1,0 +1,12 @@
+.gla-markets-dashboard {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-20;
+
+	&__card {
+		min-height: $grid-unit-60;
+		border-radius: 0;
+		box-shadow: none;
+		padding: $grid-unit-20;
+	}
+}

--- a/js/src/pages/markets/markets-dashboard/index.scss
+++ b/js/src/pages/markets/markets-dashboard/index.scss
@@ -3,7 +3,7 @@
 	flex-direction: column;
 	gap: $grid-unit-20;
 
-	&__card {
+	.gla-markets-dashboard__card {
 		min-height: $grid-unit-60;
 		padding: $grid-unit-20;
 	}

--- a/js/src/pages/markets/markets-dashboard/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/index.test.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import MarketsDashboard from './';
+
+// TODO: Subject to change as the page gains content.
+describe( 'MarketsDashboard', () => {
+	test( 'renders the placeholder heading', () => {
+		render( <MarketsDashboard /> );
+		expect(
+			screen.getByRole( 'heading', { name: 'Markets' } )
+		).toBeInTheDocument();
+	} );
+} );

--- a/js/src/pages/markets/markets-dashboard/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/index.test.js
@@ -8,13 +8,95 @@ import { render, screen } from '@testing-library/react';
  * Internal dependencies
  */
 import MarketsDashboard from './';
+import useSettings from '~/hooks/useSettings';
+import { SHIPPING_RATE_OPTION } from '../constants';
 
-// TODO: Subject to change as the page gains content.
+jest.mock( '~/hooks/useSettings' );
+
+const mockShippingRate = ( shippingRate ) =>
+	useSettings.mockReturnValue( {
+		settings: shippingRate ? { shipping_rate: shippingRate } : undefined,
+	} );
+
+beforeEach( () => {
+	delete window.wp;
+	window.glaData.dataViewsScriptUrl = '';
+	mockShippingRate();
+} );
+
+afterEach( () => {
+	useSettings.mockReset();
+} );
+
 describe( 'MarketsDashboard', () => {
-	test( 'renders the placeholder heading', () => {
-		render( <MarketsDashboard /> );
-		expect(
-			screen.getByRole( 'heading', { name: 'Markets' } )
-		).toBeInTheDocument();
+	describe( 'DataViews shim loading', () => {
+		test( 'renders a spinner while the shim has not loaded yet', () => {
+			render( <MarketsDashboard /> );
+
+			expect(
+				screen.getByRole( 'status', { name: 'Loading…' } )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByText( 'MarketDataViews placeholder' )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'renders MarketDataViews once the shim is available', () => {
+			window.wp = {
+				dataviews: { filterSortAndPaginate: jest.fn() },
+			};
+
+			render( <MarketsDashboard /> );
+
+			expect(
+				screen.getByText( 'MarketDataViews placeholder' )
+			).toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'status', { name: 'Loading…' } )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Shipping rate description', () => {
+		test( 'renders the "automatic" description', () => {
+			mockShippingRate( SHIPPING_RATE_OPTION.AUTOMATIC );
+			const { container } = render( <MarketsDashboard /> );
+
+			expect(
+				container.querySelector( '.gla-markets-header__description' )
+					.textContent
+			).toBe(
+				'Shipping rates are synced from your WooCommerce settings.'
+			);
+		} );
+
+		test( 'renders the "flat" description', () => {
+			mockShippingRate( SHIPPING_RATE_OPTION.FLAT );
+			render( <MarketsDashboard /> );
+
+			expect(
+				screen.getByText(
+					'Shipping rates are manually configured per market.'
+				)
+			).toBeInTheDocument();
+		} );
+
+		test( 'renders the "manual" description', () => {
+			mockShippingRate( SHIPPING_RATE_OPTION.MANUAL );
+			const { container } = render( <MarketsDashboard /> );
+
+			expect(
+				container.querySelector( '.gla-markets-header__description' )
+					.textContent
+			).toContain( 'Shipping is managed in Google Merchant Center' );
+		} );
+
+		test( 'renders no description when settings have not resolved', () => {
+			const { container } = render( <MarketsDashboard /> );
+
+			expect(
+				container.querySelector( '.gla-markets-header__description' )
+			).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/js/src/pages/markets/markets-dashboard/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/index.test.js
@@ -9,9 +9,11 @@ import { render, screen } from '@testing-library/react';
  */
 import MarketsDashboard from './';
 import MarketsHeader from './markets-header';
+import useDataViewsScript from '~/hooks/useDataViewsScript';
 import useSettings from '~/hooks/useSettings';
 import { SHIPPING_RATE_OPTION } from '../constants';
 
+jest.mock( '~/hooks/useDataViewsScript' );
 jest.mock( '~/hooks/useSettings' );
 
 jest.mock( './market-data-views', () =>
@@ -27,13 +29,21 @@ const mockShippingRate = ( shippingRate ) =>
 		settings: shippingRate ? { shipping_rate: shippingRate } : undefined,
 	} );
 
+const mockDataViewState = ( state = {} ) =>
+	useDataViewsScript.mockReturnValue( {
+		dataViewIsLoading: false,
+		dataViewHasFailed: false,
+		dataViewIsReady: false,
+		...state,
+	} );
+
 beforeEach( () => {
-	delete window.wp;
-	window.glaData.dataViewsScriptUrl = '';
 	mockShippingRate();
+	mockDataViewState();
 } );
 
 afterEach( () => {
+	useDataViewsScript.mockReset();
 	useSettings.mockReset();
 	MarketsHeader.mockClear();
 } );
@@ -41,6 +51,7 @@ afterEach( () => {
 describe( 'MarketsDashboard', () => {
 	describe( 'DataViews shim loading', () => {
 		test( 'renders a spinner while the shim has not loaded yet', () => {
+			mockDataViewState( { dataViewIsLoading: true } );
 			render( <MarketsDashboard /> );
 
 			expect(
@@ -52,15 +63,25 @@ describe( 'MarketsDashboard', () => {
 		} );
 
 		test( 'renders MarketDataViews once the shim is available', () => {
-			window.wp = {
-				dataviews: { filterSortAndPaginate: jest.fn() },
-			};
+			mockDataViewState( { dataViewIsReady: true } );
 
 			render( <MarketsDashboard /> );
 
 			expect(
 				screen.getByTestId( 'market-data-views' )
 			).toBeInTheDocument();
+			expect(
+				screen.queryByRole( 'status', { name: 'Loading…' } )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'does not render data views card when script load failed', () => {
+			mockDataViewState( { dataViewHasFailed: true } );
+			render( <MarketsDashboard /> );
+
+			expect(
+				screen.queryByTestId( 'market-data-views' )
+			).not.toBeInTheDocument();
 			expect(
 				screen.queryByRole( 'status', { name: 'Loading…' } )
 			).not.toBeInTheDocument();

--- a/js/src/pages/markets/markets-dashboard/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/index.test.js
@@ -29,17 +29,12 @@ const mockShippingRate = ( shippingRate ) =>
 		settings: shippingRate ? { shipping_rate: shippingRate } : undefined,
 	} );
 
-const mockDataViewState = ( state = {} ) =>
-	useDataViewsScript.mockReturnValue( {
-		dataViewIsLoading: false,
-		dataViewHasFailed: false,
-		dataViewIsReady: false,
-		...state,
-	} );
+const mockDataViewStatus = ( status = 'loading' ) =>
+	useDataViewsScript.mockReturnValue( status );
 
 beforeEach( () => {
 	mockShippingRate();
-	mockDataViewState();
+	mockDataViewStatus();
 } );
 
 afterEach( () => {
@@ -51,7 +46,7 @@ afterEach( () => {
 describe( 'MarketsDashboard', () => {
 	describe( 'DataViews shim loading', () => {
 		test( 'renders a spinner while the shim has not loaded yet', () => {
-			mockDataViewState( { dataViewIsLoading: true } );
+			mockDataViewStatus( 'loading' );
 			render( <MarketsDashboard /> );
 
 			expect(
@@ -63,7 +58,7 @@ describe( 'MarketsDashboard', () => {
 		} );
 
 		test( 'renders MarketDataViews once the shim is available', () => {
-			mockDataViewState( { dataViewIsReady: true } );
+			mockDataViewStatus( 'ready' );
 
 			render( <MarketsDashboard /> );
 
@@ -75,10 +70,15 @@ describe( 'MarketsDashboard', () => {
 			).not.toBeInTheDocument();
 		} );
 
-		test( 'does not render data views card when script load failed', () => {
-			mockDataViewState( { dataViewHasFailed: true } );
+		test( 'renders a warning notice and hides card when DataViews script fails', () => {
+			mockDataViewStatus( 'failed' );
 			render( <MarketsDashboard /> );
 
+			expect(
+				screen.getAllByText(
+					'There was an error loading the markets dashboard.'
+				).length
+			).toBeGreaterThan( 0 );
 			expect(
 				screen.queryByTestId( 'market-data-views' )
 			).not.toBeInTheDocument();

--- a/js/src/pages/markets/markets-dashboard/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/index.test.js
@@ -8,6 +8,7 @@ import { render, screen } from '@testing-library/react';
  * Internal dependencies
  */
 import MarketsDashboard from './';
+import MarketsHeader from './markets-header';
 import useSettings from '~/hooks/useSettings';
 import { SHIPPING_RATE_OPTION } from '../constants';
 
@@ -15,6 +16,10 @@ jest.mock( '~/hooks/useSettings' );
 
 jest.mock( './market-data-views', () =>
 	jest.fn().mockReturnValue( <div data-testid="market-data-views" /> )
+);
+
+jest.mock( './markets-header', () =>
+	jest.fn().mockReturnValue( <div data-testid="markets-header" /> )
 );
 
 const mockShippingRate = ( shippingRate ) =>
@@ -30,6 +35,7 @@ beforeEach( () => {
 
 afterEach( () => {
 	useSettings.mockReset();
+	MarketsHeader.mockClear();
 } );
 
 describe( 'MarketsDashboard', () => {
@@ -61,47 +67,26 @@ describe( 'MarketsDashboard', () => {
 		} );
 	} );
 
-	describe( 'Shipping rate description', () => {
-		test( 'renders the "automatic" description', () => {
+	describe( 'Shipping rate wiring', () => {
+		test( 'forwards the resolved shipping rate from useSettings to MarketsHeader', () => {
 			mockShippingRate( SHIPPING_RATE_OPTION.AUTOMATIC );
-			const { container } = render( <MarketsDashboard /> );
+			render( <MarketsDashboard /> );
 
-			expect(
-				container.querySelector( '.gla-markets-header__description' )
-					.textContent
-			).toBe(
-				'Shipping rates are synced from your WooCommerce settings.'
+			expect( MarketsHeader ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					shippingRate: SHIPPING_RATE_OPTION.AUTOMATIC,
+				} ),
+				expect.anything()
 			);
 		} );
 
-		test( 'renders the "flat" description', () => {
-			mockShippingRate( SHIPPING_RATE_OPTION.FLAT );
+		test( 'forwards `undefined` to MarketsHeader when settings have not resolved', () => {
 			render( <MarketsDashboard /> );
 
-			expect(
-				screen.getByText(
-					'Shipping rates are manually configured per market.'
-				)
-			).toBeInTheDocument();
-		} );
-
-		test( 'renders the "manual" description', () => {
-			mockShippingRate( SHIPPING_RATE_OPTION.MANUAL );
-			const { container } = render( <MarketsDashboard /> );
-
-			expect(
-				container.querySelector( '.gla-markets-header__description' )
-					.textContent
-			).toContain( 'Shipping is managed in Google Merchant Center' );
-		} );
-
-		test( 'renders the "..." placeholder description when settings have not resolved', () => {
-			const { container } = render( <MarketsDashboard /> );
-
-			expect(
-				container.querySelector( '.gla-markets-header__description' )
-					.textContent
-			).toBe( '...' );
+			expect( MarketsHeader ).toHaveBeenCalledWith(
+				expect.objectContaining( { shippingRate: undefined } ),
+				expect.anything()
+			);
 		} );
 	} );
 } );

--- a/js/src/pages/markets/markets-dashboard/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/index.test.js
@@ -11,7 +11,7 @@ import MarketsDashboard from './';
 import MarketsHeader from './markets-header';
 import useDataViewsScript from '~/hooks/useDataViewsScript';
 import useSettings from '~/hooks/useSettings';
-import { SHIPPING_RATE_OPTION } from '../constants';
+import { SHIPPING_RATE_METHOD } from '~/constants';
 
 jest.mock( '~/hooks/useDataViewsScript' );
 jest.mock( '~/hooks/useSettings' );
@@ -90,12 +90,12 @@ describe( 'MarketsDashboard', () => {
 
 	describe( 'Shipping rate wiring', () => {
 		test( 'forwards the resolved shipping rate from useSettings to MarketsHeader', () => {
-			mockShippingRate( SHIPPING_RATE_OPTION.AUTOMATIC );
+			mockShippingRate( SHIPPING_RATE_METHOD.AUTOMATIC );
 			render( <MarketsDashboard /> );
 
 			expect( MarketsHeader ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					shippingRate: SHIPPING_RATE_OPTION.AUTOMATIC,
+					shippingRate: SHIPPING_RATE_METHOD.AUTOMATIC,
 				} ),
 				expect.anything()
 			);

--- a/js/src/pages/markets/markets-dashboard/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/index.test.js
@@ -13,6 +13,10 @@ import { SHIPPING_RATE_OPTION } from '../constants';
 
 jest.mock( '~/hooks/useSettings' );
 
+jest.mock( './market-data-views', () =>
+	jest.fn().mockReturnValue( <div data-testid="market-data-views" /> )
+);
+
 const mockShippingRate = ( shippingRate ) =>
 	useSettings.mockReturnValue( {
 		settings: shippingRate ? { shipping_rate: shippingRate } : undefined,
@@ -37,7 +41,7 @@ describe( 'MarketsDashboard', () => {
 				screen.getByRole( 'status', { name: 'Loading…' } )
 			).toBeInTheDocument();
 			expect(
-				screen.queryByText( 'MarketDataViews placeholder' )
+				screen.queryByTestId( 'market-data-views' )
 			).not.toBeInTheDocument();
 		} );
 
@@ -49,7 +53,7 @@ describe( 'MarketsDashboard', () => {
 			render( <MarketsDashboard /> );
 
 			expect(
-				screen.getByText( 'MarketDataViews placeholder' )
+				screen.getByTestId( 'market-data-views' )
 			).toBeInTheDocument();
 			expect(
 				screen.queryByRole( 'status', { name: 'Loading…' } )
@@ -91,12 +95,13 @@ describe( 'MarketsDashboard', () => {
 			).toContain( 'Shipping is managed in Google Merchant Center' );
 		} );
 
-		test( 'renders no description when settings have not resolved', () => {
+		test( 'renders the "..." placeholder description when settings have not resolved', () => {
 			const { container } = render( <MarketsDashboard /> );
 
 			expect(
 				container.querySelector( '.gla-markets-header__description' )
-			).not.toBeInTheDocument();
+					.textContent
+			).toBe( '...' );
 		} );
 	} );
 } );

--- a/js/src/pages/markets/markets-dashboard/market-data-views/index.js
+++ b/js/src/pages/markets/markets-dashboard/market-data-views/index.js
@@ -66,7 +66,7 @@ const isPrimaryMarket = ( market ) => market.id === PRIMARY_MARKET_ID;
  *   wired up.
  *
  * @param {Object} props
- * @param {string} [props.shippingRate] One of the values defined in `SHIPPING_RATE_OPTION`.
+ * @param {string} [props.shippingRate] One of the values defined in `SHIPPING_RATE_METHOD`.
  */
 const MarketDataViews = ( { shippingRate } ) => {
 	// Reserved; will drive view variants in a follow-up task.

--- a/js/src/pages/markets/markets-dashboard/market-data-views/index.js
+++ b/js/src/pages/markets/markets-dashboard/market-data-views/index.js
@@ -60,11 +60,10 @@ const isPrimaryMarket = ( market ) => market.id === PRIMARY_MARKET_ID;
  *   buttons until the row is hovered. We therefore ship an icon-only Edit that
  *   appears on hover; matching the Figma exactly would require dropping the
  *   built-in component, which isn't worth it for now.
- * - DataViews' `disabled` flag on actions is per-action, not per-item, so we
- *   model "Delete is disabled on the primary market" with two eligibility-
- *   gated entries: an enabled `delete` for non-primary rows and a disabled
- *   `delete-disabled` twin for the primary row. The Delete callback is a
- *   placeholder until the real deletion flow is wired up.
+ * - The primary market cannot be deleted, so the Delete action is gated by
+ *   `isEligible` and simply omitted on the primary row (only Edit shows).
+ *   The Delete callback is a placeholder until the real deletion flow is
+ *   wired up.
  *
  * @param {Object} props
  * @param {string} [props.shippingRate] One of the values defined in `SHIPPING_RATE_OPTION`.

--- a/js/src/pages/markets/markets-dashboard/market-data-views/index.js
+++ b/js/src/pages/markets/markets-dashboard/market-data-views/index.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Placeholder for the Markets data table.
+ *
+ * The follow-up task will replace this with a real DataViews-powered table.
+ * The `shippingRate` is accepted now so that the next task can vary the
+ * column set (see designs: `automatic`, `flat`, and `manual` show different
+ * columns) without changing the parent.
+ *
+ * @param {Object} props
+ * @param {string} [props.shippingRate] One of the values defined in `SHIPPING_RATE_OPTION`.
+ */
+const MarketDataViews = ( { shippingRate } ) => {
+	return (
+		<div
+			className="gla-market-data-views"
+			data-shipping-rate={ shippingRate }
+		>
+			{ __( 'MarketDataViews placeholder', 'google-listings-and-ads' ) }
+		</div>
+	);
+};
+
+export default MarketDataViews;

--- a/js/src/pages/markets/markets-dashboard/market-data-views/index.js
+++ b/js/src/pages/markets/markets-dashboard/market-data-views/index.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { useState, useCallback } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -18,14 +18,8 @@ const FIELDS = [
 		enableSorting: false,
 	},
 	{
-		id: 'country',
-		label: __( 'Country', 'google-listings-and-ads' ),
-		enableHiding: false,
-		enableSorting: false,
-	},
-	{
-		id: 'shipping',
-		label: __( 'Shipping', 'google-listings-and-ads' ),
+		id: 'shippingTime',
+		label: __( 'Shipping times', 'google-listings-and-ads' ),
 		enableHiding: false,
 		enableSorting: false,
 	},
@@ -41,24 +35,38 @@ const DEFAULT_VIEW = {
 /**
  * Markets data table.
  *
- * Renders a basic three-column table (Market, Country, Shipping) with an Edit
+ * Renders the default two-column view (Market, Shipping times) with an Edit
  * action per row. Custom DataViews variants per shipping rate / multilingual
- * store will be added in a follow-up task; the parent passes `shippingRate`
- * today, but this placeholder ignores it.
+ * store will be added in a follow-up task; `shippingRate` is accepted today
+ * but currently ignored.
+ *
+ * @param {Object} props
+ * @param {string} [props.shippingRate] One of the values defined in `SHIPPING_RATE_OPTION`.
  */
-const MarketDataViews = () => {
+const MarketDataViews = ( { shippingRate } ) => {
+	// Reserved; will drive view variants in a follow-up task.
+	void shippingRate;
+
 	const { DataViews } = window.wp.dataviews;
 	const { data: markets, hasFinishedResolution } = useMarkets();
 	const [ view, setView ] = useState( DEFAULT_VIEW );
 	const [ editingMarket, setEditingMarket ] = useState( null );
 
-	const handleChangeView = useCallback( ( nextView ) => {
-		setView( nextView );
-	}, [] );
-
-	const handleCloseEditModal = useCallback( () => {
-		setEditingMarket( null );
-	}, [] );
+	const rows = markets.map( ( market ) => ( {
+		...market,
+		market: sprintf(
+			// translators: 1: market label, 2: number of countries.
+			_n(
+				'%1$s (%2$d country)',
+				'%1$s (%2$d countries)',
+				market.countries.length,
+				'google-listings-and-ads'
+			),
+			market.label,
+			market.countries.length
+		),
+		shippingTime: market.shipping_time,
+	} ) );
 
 	const ACTIONS = [
 		{
@@ -75,11 +83,11 @@ const MarketDataViews = () => {
 				getItemId={ ( item ) => item.id }
 				fields={ FIELDS }
 				actions={ ACTIONS }
-				data={ markets }
+				data={ rows }
 				view={ view }
-				onChangeView={ handleChangeView }
+				onChangeView={ setView }
 				paginationInfo={ {
-					totalItems: markets.length,
+					totalItems: rows.length,
 					totalPages: 1,
 				} }
 				defaultLayouts={ { table: {} } }
@@ -88,7 +96,7 @@ const MarketDataViews = () => {
 			{ editingMarket && (
 				<EditMarketModal
 					market={ editingMarket }
-					onRequestClose={ handleCloseEditModal }
+					onRequestClose={ () => setEditingMarket( null ) }
 				/>
 			) }
 		</>

--- a/js/src/pages/markets/markets-dashboard/market-data-views/index.js
+++ b/js/src/pages/markets/markets-dashboard/market-data-views/index.js
@@ -2,26 +2,96 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useState, useCallback } from '@wordpress/element';
 
 /**
- * Placeholder for the Markets data table.
- *
- * The follow-up task will replace this with a real DataViews-powered table.
- * The `shippingRate` is accepted now so that the next task can vary the
- * column set (see designs: `automatic`, `flat`, and `manual` show different
- * columns) without changing the parent.
- *
- * @param {Object} props
- * @param {string} [props.shippingRate] One of the values defined in `SHIPPING_RATE_OPTION`.
+ * Internal dependencies
  */
-const MarketDataViews = ( { shippingRate } ) => {
+import useMarkets from '~/hooks/useMarkets';
+import EditMarketModal from '../edit-market-modal';
+
+const FIELDS = [
+	{
+		id: 'market',
+		label: __( 'Market', 'google-listings-and-ads' ),
+		enableHiding: false,
+		enableSorting: false,
+	},
+	{
+		id: 'country',
+		label: __( 'Country', 'google-listings-and-ads' ),
+		enableHiding: false,
+		enableSorting: false,
+	},
+	{
+		id: 'shipping',
+		label: __( 'Shipping', 'google-listings-and-ads' ),
+		enableHiding: false,
+		enableSorting: false,
+	},
+];
+
+const DEFAULT_VIEW = {
+	type: 'table',
+	fields: FIELDS.map( ( field ) => field.id ),
+	page: 1,
+	perPage: 10,
+};
+
+/**
+ * Markets data table.
+ *
+ * Renders a basic three-column table (Market, Country, Shipping) with an Edit
+ * action per row. Custom DataViews variants per shipping rate / multilingual
+ * store will be added in a follow-up task; the parent passes `shippingRate`
+ * today, but this placeholder ignores it.
+ */
+const MarketDataViews = () => {
+	const { DataViews } = window.wp.dataviews;
+	const { data: markets, hasFinishedResolution } = useMarkets();
+	const [ view, setView ] = useState( DEFAULT_VIEW );
+	const [ editingMarket, setEditingMarket ] = useState( null );
+
+	const handleChangeView = useCallback( ( nextView ) => {
+		setView( nextView );
+	}, [] );
+
+	const handleCloseEditModal = useCallback( () => {
+		setEditingMarket( null );
+	}, [] );
+
+	const ACTIONS = [
+		{
+			id: 'edit',
+			label: __( 'Edit', 'google-listings-and-ads' ),
+			isPrimary: true,
+			callback: ( [ market ] ) => setEditingMarket( market ),
+		},
+	];
+
 	return (
-		<div
-			className="gla-market-data-views"
-			data-shipping-rate={ shippingRate }
-		>
-			{ __( 'MarketDataViews placeholder', 'google-listings-and-ads' ) }
-		</div>
+		<>
+			<DataViews
+				getItemId={ ( item ) => item.id }
+				fields={ FIELDS }
+				actions={ ACTIONS }
+				data={ markets }
+				view={ view }
+				onChangeView={ handleChangeView }
+				paginationInfo={ {
+					totalItems: markets.length,
+					totalPages: 1,
+				} }
+				defaultLayouts={ { table: {} } }
+				isLoading={ ! hasFinishedResolution }
+			/>
+			{ editingMarket && (
+				<EditMarketModal
+					market={ editingMarket }
+					onRequestClose={ handleCloseEditModal }
+				/>
+			) }
+		</>
 	);
 };
 

--- a/js/src/pages/markets/markets-dashboard/market-data-views/index.js
+++ b/js/src/pages/markets/markets-dashboard/market-data-views/index.js
@@ -3,12 +3,15 @@
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { edit, trash } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import useMarkets from '~/hooks/useMarkets';
+import { PRIMARY_MARKET_ID } from '../../constants';
 import EditMarketModal from '../edit-market-modal';
+import './index.scss';
 
 const FIELDS = [
 	{
@@ -16,6 +19,11 @@ const FIELDS = [
 		label: __( 'Market', 'google-listings-and-ads' ),
 		enableHiding: false,
 		enableSorting: false,
+		render: ( { item } ) => (
+			<span className="gla-markets-table__market-cell">
+				{ item.market }
+			</span>
+		),
 	},
 	{
 		id: 'shippingTime',
@@ -32,13 +40,31 @@ const DEFAULT_VIEW = {
 	perPage: 10,
 };
 
+const isPrimaryMarket = ( market ) => market.id === PRIMARY_MARKET_ID;
+
 /**
  * Markets data table.
  *
- * Renders the default two-column view (Market, Shipping times) with an Edit
- * action per row. Custom DataViews variants per shipping rate / multilingual
- * store will be added in a follow-up task; `shippingRate` is accepted today
- * but currently ignored.
+ * Renders the default two-column view (Market, Shipping times) plus a per-row
+ * actions column managed by `@wordpress/dataviews`. Custom DataViews variants
+ * per shipping rate / multilingual store will be added in a follow-up task;
+ * `shippingRate` is accepted today but currently ignored.
+ *
+ * Known design / implementation mismatches we are intentionally accepting to
+ * stay on the built-in DataViews UI:
+ *
+ * - Figma asks for an always-visible "Edit" text button. DataViews only lifts
+ *   actions out of the kebab menu when both `isPrimary` and `icon` are set,
+ *   and renders them as an icon-only button (the label is exposed only as
+ *   `aria-label`). The built-in stylesheet additionally hides primary action
+ *   buttons until the row is hovered. We therefore ship an icon-only Edit that
+ *   appears on hover; matching the Figma exactly would require dropping the
+ *   built-in component, which isn't worth it for now.
+ * - DataViews' `disabled` flag on actions is per-action, not per-item, so we
+ *   model "Delete is disabled on the primary market" with two eligibility-
+ *   gated entries: an enabled `delete` for non-primary rows and a disabled
+ *   `delete-disabled` twin for the primary row. The Delete callback is a
+ *   placeholder until the real deletion flow is wired up.
  *
  * @param {Object} props
  * @param {string} [props.shippingRate] One of the values defined in `SHIPPING_RATE_OPTION`.
@@ -72,8 +98,17 @@ const MarketDataViews = ( { shippingRate } ) => {
 		{
 			id: 'edit',
 			label: __( 'Edit', 'google-listings-and-ads' ),
+			icon: edit,
 			isPrimary: true,
 			callback: ( [ market ] ) => setEditingMarket( market ),
+		},
+		{
+			id: 'delete',
+			label: __( 'Delete', 'google-listings-and-ads' ),
+			icon: trash,
+			isDestructive: true,
+			isEligible: ( market ) => ! isPrimaryMarket( market ),
+			callback: () => {},
 		},
 	];
 

--- a/js/src/pages/markets/markets-dashboard/market-data-views/index.scss
+++ b/js/src/pages/markets/markets-dashboard/market-data-views/index.scss
@@ -1,0 +1,3 @@
+.gla-markets-table__market-cell {
+	color: $gray-900;
+}

--- a/js/src/pages/markets/markets-dashboard/market-data-views/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/market-data-views/index.test.js
@@ -16,7 +16,7 @@ jest.mock( '~/hooks/useMarkets' );
 jest.mock( '../edit-market-modal', () =>
 	jest.fn( ( { market, onRequestClose } ) => (
 		<div data-testid="edit-market-modal">
-			<span data-testid="edit-market-modal-name">{ market.market }</span>
+			<span data-testid="edit-market-modal-name">{ market.label }</span>
 			<button onClick={ onRequestClose }>Close modal</button>
 		</div>
 	) )
@@ -25,15 +25,25 @@ jest.mock( '../edit-market-modal', () =>
 const SAMPLE_MARKETS = [
 	{
 		id: 'primary',
-		market: 'Primary market',
-		country: '20 Countries',
-		shipping: 'Managed in Google',
+		label: 'Primary Market',
+		countries: [ 'MU', 'ZW' ],
+		language: 'en',
+		currency: 'USD',
+		feedLabel: 'ZW',
+		shipping_rate: 'flat',
+		shipping_time: 'flat',
+		free_shipping: null,
 	},
 	{
 		id: 'secondary',
-		market: 'Secondary market',
-		country: '5 Countries',
-		shipping: 'Flat rate',
+		label: 'Secondary Market',
+		countries: [ 'FR' ],
+		language: 'fr',
+		currency: 'EUR',
+		feedLabel: 'FR',
+		shipping_rate: 'table',
+		shipping_time: 'table',
+		free_shipping: null,
 	},
 ];
 
@@ -106,17 +116,36 @@ afterEach( () => {
 } );
 
 describe( 'MarketDataViews', () => {
-	test( 'renders three column headers: Market, Country, Shipping', () => {
+	test( 'renders two column headers: Market, Shipping times', () => {
 		render( <MarketDataViews /> );
 
 		expect(
 			screen.getByRole( 'columnheader', { name: 'Market' } )
 		).toBeInTheDocument();
 		expect(
-			screen.getByRole( 'columnheader', { name: 'Country' } )
+			screen.getByRole( 'columnheader', { name: 'Shipping times' } )
+		).toBeInTheDocument();
+	} );
+
+	test( 'renders the Market cell as "<label> (<n> countries)"', () => {
+		render( <MarketDataViews /> );
+
+		expect(
+			screen.getByRole( 'cell', { name: 'Primary Market (2 countries)' } )
 		).toBeInTheDocument();
 		expect(
-			screen.getByRole( 'columnheader', { name: 'Shipping' } )
+			screen.getByRole( 'cell', { name: 'Secondary Market (1 country)' } )
+		).toBeInTheDocument();
+	} );
+
+	test( 'renders the Shipping times cell from shipping_time', () => {
+		render( <MarketDataViews /> );
+
+		expect(
+			screen.getByRole( 'cell', { name: 'flat' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'cell', { name: 'table' } )
 		).toBeInTheDocument();
 	} );
 
@@ -163,7 +192,7 @@ describe( 'MarketDataViews', () => {
 		expect( screen.getByTestId( 'edit-market-modal' ) ).toBeInTheDocument();
 		expect(
 			screen.getByTestId( 'edit-market-modal-name' ).textContent
-		).toBe( SAMPLE_MARKETS[ 0 ].market );
+		).toBe( SAMPLE_MARKETS[ 0 ].label );
 	} );
 
 	test( 'closes EditMarketModal when onRequestClose is invoked', async () => {

--- a/js/src/pages/markets/markets-dashboard/market-data-views/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/market-data-views/index.test.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
@@ -81,19 +81,30 @@ const DataViewsStub = ( props ) => {
 				{ data.map( ( item ) => (
 					<tr key={ item.id }>
 						{ fields.map( ( field ) => (
-							<td key={ field.id }>{ item[ field.id ] }</td>
-						) ) }
-						{ actions?.map( ( action ) => (
-							<td key={ action.id }>
-								<button
-									onClick={ () =>
-										action.callback( [ item ] )
-									}
-								>
-									{ action.label }
-								</button>
+							<td key={ field.id }>
+								{ field.render
+									? field.render( { item } )
+									: item[ field.id ] }
 							</td>
 						) ) }
+						{ actions
+							?.filter(
+								( action ) =>
+									! action.isEligible ||
+									action.isEligible( item )
+							)
+							.map( ( action ) => (
+								<td key={ action.id }>
+									<button
+										disabled={ !! action.disabled }
+										onClick={ () =>
+											action.callback( [ item ] )
+										}
+									>
+										{ action.label }
+									</button>
+								</td>
+							) ) }
 					</tr>
 				) ) }
 			</tbody>
@@ -159,14 +170,20 @@ describe( 'MarketDataViews', () => {
 		} );
 	} );
 
-	test( 'exposes a single Edit action', () => {
+	test( 'exposes a primary Edit action with an icon', () => {
 		render( <MarketDataViews /> );
 
-		expect( dataViewsCalls[ 0 ].actions ).toHaveLength( 1 );
-		expect( dataViewsCalls[ 0 ].actions[ 0 ] ).toMatchObject( {
+		const editAction = dataViewsCalls[ 0 ].actions.find(
+			( action ) => action.id === 'edit'
+		);
+		expect( editAction ).toMatchObject( {
 			id: 'edit',
 			label: 'Edit',
+			isPrimary: true,
 		} );
+		// `icon` is required for DataViews to render a primary action outside
+		// the kebab menu, so guard against it being dropped.
+		expect( editAction.icon ).toBeTruthy();
 	} );
 
 	test( 'renders an Edit action button on each row', () => {
@@ -174,6 +191,76 @@ describe( 'MarketDataViews', () => {
 
 		const editButtons = screen.getAllByRole( 'button', { name: 'Edit' } );
 		expect( editButtons ).toHaveLength( SAMPLE_MARKETS.length );
+	} );
+
+	test( 'exposes an enabled Delete action only for non-primary markets', () => {
+		render( <MarketDataViews /> );
+
+		const deleteAction = dataViewsCalls[ 0 ].actions.find(
+			( action ) => action.id === 'delete'
+		);
+		expect( deleteAction ).toMatchObject( {
+			id: 'delete',
+			label: 'Delete',
+			isDestructive: true,
+		} );
+		expect( deleteAction.isPrimary ).toBeFalsy();
+		expect( deleteAction.disabled ).toBeFalsy();
+		expect( deleteAction.isEligible( { id: 'primary' } ) ).toBe( false );
+		expect( deleteAction.isEligible( { id: 'secondary' } ) ).toBe( true );
+	} );
+
+	test( 'exposes a disabled Delete action only for the primary market', () => {
+		render( <MarketDataViews /> );
+
+		const disabledDeleteAction = dataViewsCalls[ 0 ].actions.find(
+			( action ) => action.id === 'delete-disabled'
+		);
+		expect( disabledDeleteAction ).toMatchObject( {
+			label: 'Delete',
+			disabled: true,
+		} );
+		expect( disabledDeleteAction.isEligible( { id: 'primary' } ) ).toBe(
+			true
+		);
+		expect( disabledDeleteAction.isEligible( { id: 'secondary' } ) ).toBe(
+			false
+		);
+	} );
+
+	test( 'renders Delete disabled on the primary market row and enabled elsewhere', () => {
+		render( <MarketDataViews /> );
+
+		const deleteButtons = screen.getAllByRole( 'button', {
+			name: 'Delete',
+		} );
+		expect( deleteButtons ).toHaveLength( SAMPLE_MARKETS.length );
+
+		const primaryRow = screen
+			.getByRole( 'cell', { name: 'Primary Market (2 countries)' } )
+			.closest( 'tr' );
+		const secondaryRow = screen
+			.getByRole( 'cell', { name: 'Secondary Market (1 country)' } )
+			.closest( 'tr' );
+
+		expect(
+			within( primaryRow ).getByRole( 'button', { name: 'Delete' } )
+		).toBeDisabled();
+		expect(
+			within( secondaryRow ).getByRole( 'button', { name: 'Delete' } )
+		).toBeEnabled();
+	} );
+
+	test( 'renders the Market cell wrapped in the gray-900 helper class', () => {
+		const { container } = render( <MarketDataViews /> );
+
+		const marketCells = container.querySelectorAll(
+			'.gla-markets-table__market-cell'
+		);
+		expect( marketCells ).toHaveLength( SAMPLE_MARKETS.length );
+		expect( marketCells[ 0 ] ).toHaveTextContent(
+			'Primary Market (2 countries)'
+		);
 	} );
 
 	test( 'opens EditMarketModal with the clicked row when Edit is pressed', async () => {

--- a/js/src/pages/markets/markets-dashboard/market-data-views/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/market-data-views/index.test.js
@@ -1,0 +1,220 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import MarketDataViews from './';
+import useMarkets from '~/hooks/useMarkets';
+
+jest.mock( '~/hooks/useMarkets' );
+
+jest.mock( '../edit-market-modal', () =>
+	jest.fn( ( { market, onRequestClose } ) => (
+		<div data-testid="edit-market-modal">
+			<span data-testid="edit-market-modal-name">{ market.market }</span>
+			<button onClick={ onRequestClose }>Close modal</button>
+		</div>
+	) )
+);
+
+const SAMPLE_MARKETS = [
+	{
+		id: 'primary',
+		market: 'Primary market',
+		country: '20 Countries',
+		shipping: 'Managed in Google',
+	},
+	{
+		id: 'secondary',
+		market: 'Secondary market',
+		country: '5 Countries',
+		shipping: 'Flat rate',
+	},
+];
+
+/**
+ * Stub for `window.wp.dataviews.DataViews` that captures the props it receives
+ * and renders a minimal table so click flows can be exercised.
+ */
+const dataViewsCalls = [];
+const DataViewsStub = ( props ) => {
+	dataViewsCalls.push( props );
+
+	const { fields, data, actions, isLoading } = props;
+
+	if ( isLoading ) {
+		return <div data-testid="dataviews-loading">Loading…</div>;
+	}
+
+	if ( ! data?.length ) {
+		return <div data-testid="dataviews-empty">No items</div>;
+	}
+
+	return (
+		<table>
+			<thead>
+				<tr>
+					{ fields.map( ( field ) => (
+						<th key={ field.id } scope="col">
+							{ field.label }
+						</th>
+					) ) }
+					{ actions?.length > 0 && <th scope="col">Actions</th> }
+				</tr>
+			</thead>
+			<tbody>
+				{ data.map( ( item ) => (
+					<tr key={ item.id }>
+						{ fields.map( ( field ) => (
+							<td key={ field.id }>{ item[ field.id ] }</td>
+						) ) }
+						{ actions?.map( ( action ) => (
+							<td key={ action.id }>
+								<button
+									onClick={ () =>
+										action.callback( [ item ] )
+									}
+								>
+									{ action.label }
+								</button>
+							</td>
+						) ) }
+					</tr>
+				) ) }
+			</tbody>
+		</table>
+	);
+};
+
+beforeEach( () => {
+	dataViewsCalls.length = 0;
+	window.wp = { dataviews: { DataViews: DataViewsStub } };
+	useMarkets.mockReturnValue( {
+		data: SAMPLE_MARKETS,
+		hasFinishedResolution: true,
+	} );
+} );
+
+afterEach( () => {
+	useMarkets.mockReset();
+	delete window.wp;
+} );
+
+describe( 'MarketDataViews', () => {
+	test( 'renders three column headers: Market, Country, Shipping', () => {
+		render( <MarketDataViews /> );
+
+		expect(
+			screen.getByRole( 'columnheader', { name: 'Market' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'columnheader', { name: 'Country' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole( 'columnheader', { name: 'Shipping' } )
+		).toBeInTheDocument();
+	} );
+
+	test( 'configures every field with enableHiding=false and enableSorting=false', () => {
+		render( <MarketDataViews /> );
+
+		expect( dataViewsCalls ).toHaveLength( 1 );
+		dataViewsCalls[ 0 ].fields.forEach( ( field ) => {
+			expect( field.enableHiding ).toBe( false );
+			expect( field.enableSorting ).toBe( false );
+		} );
+	} );
+
+	test( 'exposes a single Edit action', () => {
+		render( <MarketDataViews /> );
+
+		expect( dataViewsCalls[ 0 ].actions ).toHaveLength( 1 );
+		expect( dataViewsCalls[ 0 ].actions[ 0 ] ).toMatchObject( {
+			id: 'edit',
+			label: 'Edit',
+		} );
+	} );
+
+	test( 'renders an Edit action button on each row', () => {
+		render( <MarketDataViews /> );
+
+		const editButtons = screen.getAllByRole( 'button', { name: 'Edit' } );
+		expect( editButtons ).toHaveLength( SAMPLE_MARKETS.length );
+	} );
+
+	test( 'opens EditMarketModal with the clicked row when Edit is pressed', async () => {
+		const user = userEvent.setup();
+		render( <MarketDataViews /> );
+
+		expect(
+			screen.queryByTestId( 'edit-market-modal' )
+		).not.toBeInTheDocument();
+
+		const [ firstEditButton ] = screen.getAllByRole( 'button', {
+			name: 'Edit',
+		} );
+		await user.click( firstEditButton );
+
+		expect( screen.getByTestId( 'edit-market-modal' ) ).toBeInTheDocument();
+		expect(
+			screen.getByTestId( 'edit-market-modal-name' ).textContent
+		).toBe( SAMPLE_MARKETS[ 0 ].market );
+	} );
+
+	test( 'closes EditMarketModal when onRequestClose is invoked', async () => {
+		const user = userEvent.setup();
+		render( <MarketDataViews /> );
+
+		const [ firstEditButton ] = screen.getAllByRole( 'button', {
+			name: 'Edit',
+		} );
+		await user.click( firstEditButton );
+		expect( screen.getByTestId( 'edit-market-modal' ) ).toBeInTheDocument();
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Close modal' } )
+		);
+		expect(
+			screen.queryByTestId( 'edit-market-modal' )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'passes isLoading=!hasFinishedResolution to DataViews', () => {
+		useMarkets.mockReturnValue( {
+			data: [],
+			hasFinishedResolution: false,
+		} );
+
+		render( <MarketDataViews /> );
+
+		expect( dataViewsCalls[ 0 ].isLoading ).toBe( true );
+	} );
+
+	test( 'renders the DataViews empty state when markets is []', () => {
+		useMarkets.mockReturnValue( {
+			data: [],
+			hasFinishedResolution: true,
+		} );
+
+		render( <MarketDataViews /> );
+
+		expect( screen.getByTestId( 'dataviews-empty' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByTestId( 'edit-market-modal' )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'derives paginationInfo from markets.length', () => {
+		render( <MarketDataViews /> );
+
+		expect( dataViewsCalls[ 0 ].paginationInfo ).toEqual( {
+			totalItems: SAMPLE_MARKETS.length,
+			totalPages: 1,
+		} );
+	} );
+} );

--- a/js/src/pages/markets/markets-dashboard/market-data-views/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/market-data-views/index.test.js
@@ -210,31 +210,13 @@ describe( 'MarketDataViews', () => {
 		expect( deleteAction.isEligible( { id: 'secondary' } ) ).toBe( true );
 	} );
 
-	test( 'exposes a disabled Delete action only for the primary market', () => {
-		render( <MarketDataViews /> );
-
-		const disabledDeleteAction = dataViewsCalls[ 0 ].actions.find(
-			( action ) => action.id === 'delete-disabled'
-		);
-		expect( disabledDeleteAction ).toMatchObject( {
-			label: 'Delete',
-			disabled: true,
-		} );
-		expect( disabledDeleteAction.isEligible( { id: 'primary' } ) ).toBe(
-			true
-		);
-		expect( disabledDeleteAction.isEligible( { id: 'secondary' } ) ).toBe(
-			false
-		);
-	} );
-
-	test( 'renders Delete disabled on the primary market row and enabled elsewhere', () => {
+	test( 'renders Delete only on non-primary market rows', () => {
 		render( <MarketDataViews /> );
 
 		const deleteButtons = screen.getAllByRole( 'button', {
 			name: 'Delete',
 		} );
-		expect( deleteButtons ).toHaveLength( SAMPLE_MARKETS.length );
+		expect( deleteButtons ).toHaveLength( 1 );
 
 		const primaryRow = screen
 			.getByRole( 'cell', { name: 'Primary Market (2 countries)' } )
@@ -244,8 +226,8 @@ describe( 'MarketDataViews', () => {
 			.closest( 'tr' );
 
 		expect(
-			within( primaryRow ).getByRole( 'button', { name: 'Delete' } )
-		).toBeDisabled();
+			within( primaryRow ).queryByRole( 'button', { name: 'Delete' } )
+		).not.toBeInTheDocument();
 		expect(
 			within( secondaryRow ).getByRole( 'button', { name: 'Delete' } )
 		).toBeEnabled();

--- a/js/src/pages/markets/markets-dashboard/markets-header/index.js
+++ b/js/src/pages/markets/markets-dashboard/markets-header/index.js
@@ -30,11 +30,18 @@ const MarketsHeader = ( { shippingRate } ) => {
 				<h1 className="gla-markets-header__title">
 					{ __( 'Markets', 'google-listings-and-ads' ) }
 				</h1>
-				{ description && (
-					<p className="gla-markets-header__description">
-						{ description }
-					</p>
-				) }
+				<p className="gla-markets-header__description">
+					{ description ?? (
+						<span
+							className="gla-markets-header__description-placeholder"
+							aria-busy="true"
+							title={ __(
+								'Loading…',
+								'google-listings-and-ads'
+							) }
+						/>
+					) }
+				</p>
 			</FlexBlock>
 			<FlexItem>
 				<AddMarket />

--- a/js/src/pages/markets/markets-dashboard/markets-header/index.js
+++ b/js/src/pages/markets/markets-dashboard/markets-header/index.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Flex, FlexBlock, FlexItem } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import AddMarket from '../add-market';
+import { getShippingRateLabel } from '../../utils';
+import './index.scss';
+
+/**
+ * Header for the Markets dashboard.
+ *
+ * @param {Object} props
+ * @param {string} [props.shippingRate] One of the values defined in `SHIPPING_RATE_OPTION`.
+ */
+const MarketsHeader = ( { shippingRate } ) => {
+	const description = getShippingRateLabel( shippingRate );
+
+	return (
+		<Flex
+			className="gla-markets-header"
+			align="center"
+			justify="space-between"
+		>
+			<FlexBlock>
+				<h1 className="gla-markets-header__title">
+					{ __( 'Markets', 'google-listings-and-ads' ) }
+				</h1>
+				{ description && (
+					<p className="gla-markets-header__description">
+						{ description }
+					</p>
+				) }
+			</FlexBlock>
+			<FlexItem>
+				<AddMarket />
+			</FlexItem>
+		</Flex>
+	);
+};
+
+export default MarketsHeader;

--- a/js/src/pages/markets/markets-dashboard/markets-header/index.js
+++ b/js/src/pages/markets/markets-dashboard/markets-header/index.js
@@ -15,7 +15,7 @@ import './index.scss';
  * Header for the Markets dashboard.
  *
  * @param {Object} props
- * @param {string} [props.shippingRate] One of the values defined in `SHIPPING_RATE_OPTION`.
+ * @param {string} [props.shippingRate] One of the values defined in `SHIPPING_RATE_METHOD`.
  */
 const MarketsHeader = ( { shippingRate } ) => {
 	const description = getShippingRateLabel( shippingRate );

--- a/js/src/pages/markets/markets-dashboard/markets-header/index.scss
+++ b/js/src/pages/markets/markets-dashboard/markets-header/index.scss
@@ -1,5 +1,5 @@
 .gla-markets-header {
-	h1#{&}__title {
+	.gla-markets-header__title {
 		font-size: 16px;
 		font-weight: 600;
 		line-height: 24px;
@@ -7,13 +7,13 @@
 		padding: 0;
 	}
 
-	&__description {
+	.gla-markets-header__description {
 		margin: 0;
 		line-height: $gla-line-height-smaller;
 		color: $gray-700;
 	}
 
-	&__description-placeholder {
+	.gla-markets-header__description-placeholder {
 		display: inline-block;
 		width: 36ch;
 		max-width: 100%;

--- a/js/src/pages/markets/markets-dashboard/markets-header/index.scss
+++ b/js/src/pages/markets/markets-dashboard/markets-header/index.scss
@@ -1,0 +1,15 @@
+.gla-markets-header {
+	h1#{&}__title {
+		font-size: 16px;
+		font-weight: 600;
+		line-height: 24px;
+		margin: 0 0 $grid-unit;
+		padding: 0;
+	}
+
+	&__description {
+		margin: 0;
+		line-height: $gla-line-height-smaller;
+		color: $gray-700;
+	}
+}

--- a/js/src/pages/markets/markets-dashboard/markets-header/index.scss
+++ b/js/src/pages/markets/markets-dashboard/markets-header/index.scss
@@ -12,4 +12,17 @@
 		line-height: $gla-line-height-smaller;
 		color: $gray-700;
 	}
+
+	&__description-placeholder {
+		display: inline-block;
+		width: 36ch;
+		max-width: 100%;
+
+		@include placeholder;
+		// The mixin's default `$gray-100` matches the WP admin page background,
+		// so bump it one shade darker to keep the skeleton visible here.
+		& {
+			background-color: $gray-200;
+		}
+	}
 }

--- a/js/src/pages/markets/markets-dashboard/markets-header/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/markets-header/index.test.js
@@ -7,8 +7,8 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
+import { SHIPPING_RATE_METHOD } from '~/constants';
 import MarketsHeader from './';
-import { SHIPPING_RATE_OPTION } from '../../constants';
 
 jest.mock( '../add-market', () =>
 	jest.fn().mockReturnValue( <div data-testid="add-market" /> )
@@ -42,7 +42,7 @@ describe( 'MarketsHeader', () => {
 
 	test( 'renders the "automatic" description when shippingRate is "automatic"', () => {
 		const { container } = render(
-			<MarketsHeader shippingRate={ SHIPPING_RATE_OPTION.AUTOMATIC } />
+			<MarketsHeader shippingRate={ SHIPPING_RATE_METHOD.AUTOMATIC } />
 		);
 
 		expect(
@@ -55,7 +55,7 @@ describe( 'MarketsHeader', () => {
 	} );
 
 	test( 'renders the "flat" description when shippingRate is "flat"', () => {
-		render( <MarketsHeader shippingRate={ SHIPPING_RATE_OPTION.FLAT } /> );
+		render( <MarketsHeader shippingRate={ SHIPPING_RATE_METHOD.FLAT } /> );
 
 		expect(
 			screen.getByText(
@@ -66,7 +66,7 @@ describe( 'MarketsHeader', () => {
 
 	test( 'renders the "manual" description when shippingRate is "manual"', () => {
 		const { container } = render(
-			<MarketsHeader shippingRate={ SHIPPING_RATE_OPTION.MANUAL } />
+			<MarketsHeader shippingRate={ SHIPPING_RATE_METHOD.MANUAL } />
 		);
 
 		expect(

--- a/js/src/pages/markets/markets-dashboard/markets-header/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/markets-header/index.test.js
@@ -24,12 +24,13 @@ describe( 'MarketsHeader', () => {
 		expect( screen.getByTestId( 'add-market' ) ).toBeInTheDocument();
 	} );
 
-	test( 'omits the description when shippingRate is undefined', () => {
+	test( 'renders the "..." placeholder description when shippingRate is undefined', () => {
 		const { container } = render( <MarketsHeader /> );
 
 		expect(
 			container.querySelector( '.gla-markets-header__description' )
-		).not.toBeInTheDocument();
+				.textContent
+		).toBe( '...' );
 	} );
 
 	test( 'renders the "automatic" description when shippingRate is "automatic"', () => {

--- a/js/src/pages/markets/markets-dashboard/markets-header/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/markets-header/index.test.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import MarketsHeader from './';
+import { SHIPPING_RATE_OPTION } from '../../constants';
+
+jest.mock( '../add-market', () =>
+	jest.fn().mockReturnValue( <div data-testid="add-market" /> )
+);
+
+describe( 'MarketsHeader', () => {
+	test( 'renders the "Markets" heading and the AddMarket CTA', () => {
+		render( <MarketsHeader /> );
+
+		expect(
+			screen.getByRole( 'heading', { name: 'Markets', level: 1 } )
+		).toBeInTheDocument();
+		expect( screen.getByTestId( 'add-market' ) ).toBeInTheDocument();
+	} );
+
+	test( 'omits the description when shippingRate is undefined', () => {
+		const { container } = render( <MarketsHeader /> );
+
+		expect(
+			container.querySelector( '.gla-markets-header__description' )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'renders the "automatic" description when shippingRate is "automatic"', () => {
+		const { container } = render(
+			<MarketsHeader shippingRate={ SHIPPING_RATE_OPTION.AUTOMATIC } />
+		);
+
+		expect(
+			container.querySelector( '.gla-markets-header__description' )
+				.textContent
+		).toBe( 'Shipping rates are synced from your WooCommerce settings.' );
+		expect(
+			screen.getByRole( 'link', { name: 'WooCommerce settings' } )
+		).toBeInTheDocument();
+	} );
+
+	test( 'renders the "flat" description when shippingRate is "flat"', () => {
+		render( <MarketsHeader shippingRate={ SHIPPING_RATE_OPTION.FLAT } /> );
+
+		expect(
+			screen.getByText(
+				'Shipping rates are manually configured per market.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	test( 'renders the "manual" description when shippingRate is "manual"', () => {
+		const { container } = render(
+			<MarketsHeader shippingRate={ SHIPPING_RATE_OPTION.MANUAL } />
+		);
+
+		expect(
+			container.querySelector( '.gla-markets-header__description' )
+				.textContent
+		).toContain( 'Shipping is managed in Google Merchant Center' );
+		expect(
+			screen.getByRole( 'link', { name: /Google Merchant Center/ } )
+		).toBeInTheDocument();
+	} );
+} );

--- a/js/src/pages/markets/markets-dashboard/markets-header/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/markets-header/index.test.js
@@ -24,13 +24,20 @@ describe( 'MarketsHeader', () => {
 		expect( screen.getByTestId( 'add-market' ) ).toBeInTheDocument();
 	} );
 
-	test( 'renders the "..." placeholder description when shippingRate is undefined', () => {
+	test( 'renders a loading skeleton inside the description when shippingRate is undefined', () => {
 		const { container } = render( <MarketsHeader /> );
 
-		expect(
-			container.querySelector( '.gla-markets-header__description' )
-				.textContent
-		).toBe( '...' );
+		const description = container.querySelector(
+			'.gla-markets-header__description'
+		);
+		const placeholder = container.querySelector(
+			'.gla-markets-header__description-placeholder'
+		);
+
+		expect( description ).toBeInTheDocument();
+		expect( description.textContent ).toBe( '' );
+		expect( placeholder ).toBeInTheDocument();
+		expect( placeholder ).toHaveAttribute( 'aria-busy', 'true' );
 	} );
 
 	test( 'renders the "automatic" description when shippingRate is "automatic"', () => {

--- a/js/src/pages/markets/utils.js
+++ b/js/src/pages/markets/utils.js
@@ -20,9 +20,10 @@ import {
  * for the given shipping rate selection.
  *
  * @param {string|undefined} shippingRate One of the values defined in `SHIPPING_RATE_OPTION`.
- * @return {JSX.Element|string} A localized description, or a `'...'` placeholder when the value
- *                              is unknown (e.g. settings are still resolving or the merchant
- *                              skipped onboarding) so the layout stays stable while loading.
+ * @return {JSX.Element|string|null} A localized description, or `null` when the value
+ *                                   is unknown (e.g. settings are still resolving or the
+ *                                   merchant skipped onboarding) so the caller can render
+ *                                   a loading skeleton in its place.
  */
 export const getShippingRateLabel = ( shippingRate ) => {
 	switch ( shippingRate ) {
@@ -60,6 +61,6 @@ export const getShippingRateLabel = ( shippingRate ) => {
 			);
 
 		default:
-			return '...';
+			return null;
 	}
 };

--- a/js/src/pages/markets/utils.js
+++ b/js/src/pages/markets/utils.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { ExternalLink } from '@wordpress/components';
+import { Link } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import {
+	SHIPPING_RATE_OPTION,
+	WC_SHIPPING_SETTINGS_URL,
+	GOOGLE_MERCHANT_CENTER_URL,
+} from './constants';
+
+/**
+ * Returns the description shown under the "Markets" heading
+ * for the given shipping rate selection.
+ *
+ * @param {string|undefined} shippingRate One of the values defined in `SHIPPING_RATE_OPTION`.
+ * @return {JSX.Element|null} A localized description, or `null` when the value is unknown
+ *                            (e.g. settings are still resolving or the merchant skipped onboarding).
+ */
+export const getShippingRateLabel = ( shippingRate ) => {
+	switch ( shippingRate ) {
+		case SHIPPING_RATE_OPTION.AUTOMATIC:
+			return createInterpolateElement(
+				__(
+					'Shipping rates are synced from your <link>WooCommerce settings</link>.',
+					'google-listings-and-ads'
+				),
+				{
+					link: (
+						<Link
+							type="wp-admin"
+							href={ WC_SHIPPING_SETTINGS_URL }
+						/>
+					),
+				}
+			);
+
+		case SHIPPING_RATE_OPTION.FLAT:
+			return __(
+				'Shipping rates are manually configured per market.',
+				'google-listings-and-ads'
+			);
+
+		case SHIPPING_RATE_OPTION.MANUAL:
+			return createInterpolateElement(
+				__(
+					'Shipping is managed in <link>Google Merchant Center</link>.',
+					'google-listings-and-ads'
+				),
+				{
+					link: <ExternalLink href={ GOOGLE_MERCHANT_CENTER_URL } />,
+				}
+			);
+
+		default:
+			return '...';
+	}
+};

--- a/js/src/pages/markets/utils.js
+++ b/js/src/pages/markets/utils.js
@@ -10,9 +10,9 @@ import { Link } from '@woocommerce/components';
  * Internal dependencies
  */
 import {
+	GOOGLE_MERCHANT_CENTER_URL,
 	SHIPPING_RATE_OPTION,
 	WC_SHIPPING_SETTINGS_URL,
-	GOOGLE_MERCHANT_CENTER_URL,
 } from './constants';
 
 /**

--- a/js/src/pages/markets/utils.js
+++ b/js/src/pages/markets/utils.js
@@ -9,9 +9,9 @@ import { Link } from '@woocommerce/components';
 /**
  * Internal dependencies
  */
+import { SHIPPING_RATE_METHOD } from '~/constants';
 import {
 	GOOGLE_MERCHANT_CENTER_URL,
-	SHIPPING_RATE_OPTION,
 	WC_SHIPPING_SETTINGS_URL,
 } from './constants';
 
@@ -19,7 +19,7 @@ import {
  * Returns the description shown under the "Markets" heading
  * for the given shipping rate selection.
  *
- * @param {string|undefined} shippingRate One of the values defined in `SHIPPING_RATE_OPTION`.
+ * @param {string|undefined} shippingRate One of the values defined in `SHIPPING_RATE_METHOD`.
  * @return {JSX.Element|string|null} A localized description, or `null` when the value
  *                                   is unknown (e.g. settings are still resolving or the
  *                                   merchant skipped onboarding) so the caller can render
@@ -27,7 +27,7 @@ import {
  */
 export const getShippingRateLabel = ( shippingRate ) => {
 	switch ( shippingRate ) {
-		case SHIPPING_RATE_OPTION.AUTOMATIC:
+		case SHIPPING_RATE_METHOD.AUTOMATIC:
 			return createInterpolateElement(
 				__(
 					'Shipping rates are synced from your <link>WooCommerce settings</link>.',
@@ -43,13 +43,13 @@ export const getShippingRateLabel = ( shippingRate ) => {
 				}
 			);
 
-		case SHIPPING_RATE_OPTION.FLAT:
+		case SHIPPING_RATE_METHOD.FLAT:
 			return __(
 				'Shipping rates are manually configured per market.',
 				'google-listings-and-ads'
 			);
 
-		case SHIPPING_RATE_OPTION.MANUAL:
+		case SHIPPING_RATE_METHOD.MANUAL:
 			return createInterpolateElement(
 				__(
 					'Shipping is managed in <link>Google Merchant Center</link>.',

--- a/js/src/pages/markets/utils.js
+++ b/js/src/pages/markets/utils.js
@@ -20,8 +20,9 @@ import {
  * for the given shipping rate selection.
  *
  * @param {string|undefined} shippingRate One of the values defined in `SHIPPING_RATE_OPTION`.
- * @return {JSX.Element|null} A localized description, or `null` when the value is unknown
- *                            (e.g. settings are still resolving or the merchant skipped onboarding).
+ * @return {JSX.Element|string} A localized description, or a `'...'` placeholder when the value
+ *                              is unknown (e.g. settings are still resolving or the merchant
+ *                              skipped onboarding) so the layout stays stable while loading.
  */
 export const getShippingRateLabel = ( shippingRate ) => {
 	switch ( shippingRate ) {

--- a/js/src/pages/markets/utils.test.js
+++ b/js/src/pages/markets/utils.test.js
@@ -55,7 +55,7 @@ describe( 'getShippingRateLabel', () => {
 		).toHaveAttribute( 'href', GOOGLE_MERCHANT_CENTER_URL );
 	} );
 
-	test( 'returns placeholder for an unknown / undefined value', () => {
+	test( 'returns the "..." loading placeholder for an unknown / undefined value', () => {
 		expect( getShippingRateLabel( undefined ) ).toBe( '...' );
 		expect( getShippingRateLabel( 'not-a-real-option' ) ).toBe( '...' );
 	} );

--- a/js/src/pages/markets/utils.test.js
+++ b/js/src/pages/markets/utils.test.js
@@ -55,8 +55,8 @@ describe( 'getShippingRateLabel', () => {
 		).toHaveAttribute( 'href', GOOGLE_MERCHANT_CENTER_URL );
 	} );
 
-	test( 'returns the "..." loading placeholder for an unknown / undefined value', () => {
-		expect( getShippingRateLabel( undefined ) ).toBe( '...' );
-		expect( getShippingRateLabel( 'not-a-real-option' ) ).toBe( '...' );
+	test( 'returns null for an unknown / undefined value so callers can render a skeleton', () => {
+		expect( getShippingRateLabel( undefined ) ).toBeNull();
+		expect( getShippingRateLabel( 'not-a-real-option' ) ).toBeNull();
 	} );
 } );

--- a/js/src/pages/markets/utils.test.js
+++ b/js/src/pages/markets/utils.test.js
@@ -8,9 +8,9 @@ import { render } from '@testing-library/react';
  * Internal dependencies
  */
 import { getShippingRateLabel } from './utils';
+import { SHIPPING_RATE_METHOD } from '~/constants';
 import {
 	GOOGLE_MERCHANT_CENTER_URL,
-	SHIPPING_RATE_OPTION,
 	WC_SHIPPING_SETTINGS_URL,
 } from './constants';
 
@@ -20,7 +20,7 @@ const renderLabel = ( shippingRate ) =>
 describe( 'getShippingRateLabel', () => {
 	test( 'returns the WooCommerce-synced label for the "automatic" option', () => {
 		const { container, getByRole } = renderLabel(
-			SHIPPING_RATE_OPTION.AUTOMATIC
+			SHIPPING_RATE_METHOD.AUTOMATIC
 		);
 
 		expect( container.textContent ).toBe(
@@ -33,7 +33,7 @@ describe( 'getShippingRateLabel', () => {
 
 	test( 'returns the per-market label (no link) for the "flat" option', () => {
 		const { container, queryByRole } = renderLabel(
-			SHIPPING_RATE_OPTION.FLAT
+			SHIPPING_RATE_METHOD.FLAT
 		);
 
 		expect( container.textContent ).toBe(
@@ -44,7 +44,7 @@ describe( 'getShippingRateLabel', () => {
 
 	test( 'returns the Google-Merchant-Center label for the "manual" option', () => {
 		const { container, getByRole } = renderLabel(
-			SHIPPING_RATE_OPTION.MANUAL
+			SHIPPING_RATE_METHOD.MANUAL
 		);
 
 		expect( container.textContent ).toContain(

--- a/js/src/pages/markets/utils.test.js
+++ b/js/src/pages/markets/utils.test.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { getShippingRateLabel } from './utils';
+import {
+	SHIPPING_RATE_OPTION,
+	WC_SHIPPING_SETTINGS_URL,
+	GOOGLE_MERCHANT_CENTER_URL,
+} from './constants';
+
+const renderLabel = ( shippingRate ) =>
+	render( <div>{ getShippingRateLabel( shippingRate ) }</div> );
+
+describe( 'getShippingRateLabel', () => {
+	test( 'returns the WooCommerce-synced label for the "automatic" option', () => {
+		const { container, getByRole } = renderLabel(
+			SHIPPING_RATE_OPTION.AUTOMATIC
+		);
+
+		expect( container.textContent ).toBe(
+			'Shipping rates are synced from your WooCommerce settings.'
+		);
+		expect(
+			getByRole( 'link', { name: 'WooCommerce settings' } )
+		).toHaveAttribute( 'href', WC_SHIPPING_SETTINGS_URL );
+	} );
+
+	test( 'returns the per-market label (no link) for the "flat" option', () => {
+		const { container, queryByRole } = renderLabel(
+			SHIPPING_RATE_OPTION.FLAT
+		);
+
+		expect( container.textContent ).toBe(
+			'Shipping rates are manually configured per market.'
+		);
+		expect( queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'returns the Google-Merchant-Center label for the "manual" option', () => {
+		const { container, getByRole } = renderLabel(
+			SHIPPING_RATE_OPTION.MANUAL
+		);
+
+		expect( container.textContent ).toContain(
+			'Shipping is managed in Google Merchant Center'
+		);
+		expect(
+			getByRole( 'link', { name: /Google Merchant Center/ } )
+		).toHaveAttribute( 'href', GOOGLE_MERCHANT_CENTER_URL );
+	} );
+
+	test( 'returns placeholder for an unknown / undefined value', () => {
+		expect( getShippingRateLabel( undefined ) ).toBe( '...' );
+		expect( getShippingRateLabel( 'not-a-real-option' ) ).toBe( '...' );
+	} );
+} );

--- a/js/src/pages/markets/utils.test.js
+++ b/js/src/pages/markets/utils.test.js
@@ -9,9 +9,9 @@ import { render } from '@testing-library/react';
  */
 import { getShippingRateLabel } from './utils';
 import {
+	GOOGLE_MERCHANT_CENTER_URL,
 	SHIPPING_RATE_OPTION,
 	WC_SHIPPING_SETTINGS_URL,
-	GOOGLE_MERCHANT_CENTER_URL,
 } from './constants';
 
 const renderLabel = ( shippingRate ) =>

--- a/js/src/pages/price-benchmark/index.js
+++ b/js/src/pages/price-benchmark/index.js
@@ -18,8 +18,7 @@ import ProductComparisonChart from './product-comparison-chart';
 import './index.scss';
 
 const PriceBenchmark = () => {
-	const { dataViewIsLoading, dataViewHasFailed, dataViewIsReady } =
-		useDataViewsScript();
+	const dataViewStatus = useDataViewsScript();
 
 	return (
 		<div className="gla-price-benchmark">
@@ -28,7 +27,7 @@ const PriceBenchmark = () => {
 			<Banner />
 			<ProductComparisonChart />
 
-			{ dataViewHasFailed && (
+			{ dataViewStatus === 'failed' && (
 				<AppNotice
 					status="warning"
 					isDismissible={ false }
@@ -41,10 +40,12 @@ const PriceBenchmark = () => {
 				</AppNotice>
 			) }
 
-			{ ! dataViewHasFailed && (
+			{ dataViewStatus !== 'failed' && (
 				<Card className="gla-price-benchmark__card">
-					{ dataViewIsLoading && <AppSpinner /> }
-					{ dataViewIsReady && <PriceBenchmarkSuggestions /> }
+					{ dataViewStatus === 'loading' && <AppSpinner /> }
+					{ dataViewStatus === 'ready' && (
+						<PriceBenchmarkSuggestions />
+					) }
 				</Card>
 			) }
 		</div>

--- a/js/src/pages/price-benchmark/index.js
+++ b/js/src/pages/price-benchmark/index.js
@@ -2,15 +2,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
 import { Card } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { glaData } from '~/constants';
 import AppNotice from '~/components/app-notice';
 import AppSpinner from '~/components/app-spinner';
+import useDataViewsScript from '~/hooks/useDataViewsScript';
 import Banner from './banner';
 import ExperienceRatingBanner from '~/components/experience-rating-banner';
 import MainTabNav from '~/components/main-tab-nav';
@@ -19,37 +18,8 @@ import ProductComparisonChart from './product-comparison-chart';
 import './index.scss';
 
 const PriceBenchmark = () => {
-	const [ dataViewLoaded, setDataViewLoaded ] = useState(
-		window.wp?.dataviews
-	);
-	const { dataViewsScriptUrl } = glaData;
-
-	useEffect( () => {
-		if ( dataViewLoaded === undefined && dataViewsScriptUrl ) {
-			const script = document.createElement( 'script' );
-			script.src = dataViewsScriptUrl;
-			script.async = true;
-
-			script.onload = () => {
-				setDataViewLoaded(
-					typeof window.wp?.dataviews?.filterSortAndPaginate ===
-						'function'
-				);
-			};
-
-			script.onerror = () => {
-				setDataViewLoaded( false );
-			};
-
-			document.head.appendChild( script );
-		}
-
-		return () => {
-			if ( dataViewLoaded === false ) {
-				setDataViewLoaded( undefined );
-			}
-		};
-	}, [ dataViewLoaded, dataViewsScriptUrl ] );
+	const { dataViewIsLoading, dataViewHasFailed, dataViewIsReady } =
+		useDataViewsScript();
 
 	return (
 		<div className="gla-price-benchmark">
@@ -58,7 +28,7 @@ const PriceBenchmark = () => {
 			<Banner />
 			<ProductComparisonChart />
 
-			{ dataViewLoaded === false && (
+			{ dataViewHasFailed && (
 				<AppNotice
 					status="warning"
 					isDismissible={ false }
@@ -71,11 +41,10 @@ const PriceBenchmark = () => {
 				</AppNotice>
 			) }
 
-			{ ( dataViewLoaded || dataViewLoaded === undefined ) && (
+			{ ! dataViewHasFailed && (
 				<Card className="gla-price-benchmark__card">
-					{ dataViewLoaded === undefined && <AppSpinner /> }
-
-					{ dataViewLoaded && <PriceBenchmarkSuggestions /> }
+					{ dataViewIsLoading && <AppSpinner /> }
+					{ dataViewIsReady && <PriceBenchmarkSuggestions /> }
 				</Card>
 			) }
 		</div>

--- a/js/src/pages/price-benchmark/index.test.js
+++ b/js/src/pages/price-benchmark/index.test.js
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import PriceBenchmark from './';
+import useDataViewsScript from '~/hooks/useDataViewsScript';
+
+jest.mock( '~/hooks/useDataViewsScript' );
+
+jest.mock( './banner', () =>
+	jest.fn().mockReturnValue( <div data-testid="price-benchmark-banner" /> )
+);
+
+jest.mock( '~/components/experience-rating-banner', () =>
+	jest.fn().mockReturnValue( <div data-testid="experience-rating-banner" /> )
+);
+
+jest.mock( '~/components/main-tab-nav', () =>
+	jest.fn().mockReturnValue( <div data-testid="main-tab-nav" /> )
+);
+
+jest.mock( './product-comparison-chart', () =>
+	jest.fn().mockReturnValue( <div data-testid="product-comparison-chart" /> )
+);
+
+jest.mock( './price-benchmark-suggestions', () =>
+	jest
+		.fn()
+		.mockReturnValue( <div data-testid="price-benchmark-suggestions" /> )
+);
+
+const mockDataViewState = ( state = {} ) =>
+	useDataViewsScript.mockReturnValue( {
+		dataViewIsLoading: false,
+		dataViewHasFailed: false,
+		dataViewIsReady: false,
+		...state,
+	} );
+
+beforeEach( () => {
+	mockDataViewState();
+} );
+
+afterEach( () => {
+	useDataViewsScript.mockReset();
+} );
+
+describe( 'PriceBenchmark', () => {
+	test( 'renders spinner while DataViews script is loading', () => {
+		mockDataViewState( { dataViewIsLoading: true } );
+
+		render( <PriceBenchmark /> );
+
+		expect(
+			screen.getByRole( 'status', { name: 'Loading…' } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByTestId( 'price-benchmark-suggestions' )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'renders suggestions once DataViews script is ready', () => {
+		mockDataViewState( { dataViewIsReady: true } );
+
+		render( <PriceBenchmark /> );
+
+		expect(
+			screen.getByTestId( 'price-benchmark-suggestions' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'status', { name: 'Loading…' } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'renders a warning notice and hides card when DataViews script fails', () => {
+		mockDataViewState( { dataViewHasFailed: true } );
+
+		render( <PriceBenchmark /> );
+
+		expect(
+			screen.getAllByText(
+				'There was an error loading the price benchmark suggestions.'
+			).length
+		).toBeGreaterThan( 0 );
+		expect(
+			screen.queryByRole( 'status', { name: 'Loading…' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByTestId( 'price-benchmark-suggestions' )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/js/src/pages/price-benchmark/index.test.js
+++ b/js/src/pages/price-benchmark/index.test.js
@@ -34,16 +34,11 @@ jest.mock( './price-benchmark-suggestions', () =>
 		.mockReturnValue( <div data-testid="price-benchmark-suggestions" /> )
 );
 
-const mockDataViewState = ( state = {} ) =>
-	useDataViewsScript.mockReturnValue( {
-		dataViewIsLoading: false,
-		dataViewHasFailed: false,
-		dataViewIsReady: false,
-		...state,
-	} );
+const mockDataViewStatus = ( status = 'loading' ) =>
+	useDataViewsScript.mockReturnValue( status );
 
 beforeEach( () => {
-	mockDataViewState();
+	mockDataViewStatus();
 } );
 
 afterEach( () => {
@@ -52,7 +47,7 @@ afterEach( () => {
 
 describe( 'PriceBenchmark', () => {
 	test( 'renders spinner while DataViews script is loading', () => {
-		mockDataViewState( { dataViewIsLoading: true } );
+		mockDataViewStatus( 'loading' );
 
 		render( <PriceBenchmark /> );
 
@@ -65,7 +60,7 @@ describe( 'PriceBenchmark', () => {
 	} );
 
 	test( 'renders suggestions once DataViews script is ready', () => {
-		mockDataViewState( { dataViewIsReady: true } );
+		mockDataViewStatus( 'ready' );
 
 		render( <PriceBenchmark /> );
 
@@ -78,7 +73,7 @@ describe( 'PriceBenchmark', () => {
 	} );
 
 	test( 'renders a warning notice and hides card when DataViews script fails', () => {
-		mockDataViewState( { dataViewHasFailed: true } );
+		mockDataViewStatus( 'failed' );
 
 		render( <PriceBenchmark /> );
 

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
 			},
 			{
 				"path": "./js/build/index.js",
-				"maxSize": "20.10 kB"
+				"maxSize": "20.20 kB"
 			},
 			{
 				"path": "./js/build/commons.js",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR adds the Markets tab to the GLA admin (between Attributes and Settings), backed by:

- A new page at `/google/markets` rendering a `MarketsDashboard` (header + Add Market button + modal + DataViews table).
- A new `useDataViewsScript` hook that loads `@wordpress/dataviews` on demand from `glaData.dataViewsScriptUrl`, deduplicated across hook instances and tab switches 
- The same DataViews-loading hook is also wired into the existing Price Benchmark tab (replaces an inline copy of the same logic), and both tabs now show a warning notice if the script fails to load.
- A `useMarkets` placeholder hook (hardcoded primary market) mirroring the eventual real selector shape.
- Constants/utilities for the WC Shipping settings URL (built via `getSetting('adminUrl')`) and shipping-rate description copy.
- The Add / Edit Market modals and the Delete callback are intentional placeholders — only open/close wiring is in scope for this PR.

Closes:
- GOOWOO-570
- GOOWOO-572 (partially, adds `useMarkets` hook)
- GOOWOO-573
- GOOWOO-574
- GOOWOO-575
- GOOWOO-576

### Screenshots:

<img width="3456" height="1980" alt="CleanShot 2026-04-27 at 21 06 33@2x" src="https://github.com/user-attachments/assets/3a685f0c-e986-44e1-a81b-de8cf676f3d3" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Tab order is Dashboard, Reports, Product Feed, Price Benchmark, Attributes, Markets, Settings.
2. Clicking Markets navigates to `path=/google/markets` and renders the page; reloading the URL directly works too.
3. Browser back/forward across Markets and other tabs works without console errors.
4. Markets table shows one row: "Primary Market (2 countries)", shipping time "flat".
5. Header description matches the merchant's shipping rate setting:
  - `automatic` – "synced from your WooCommerce settings" — link goes to `wc-settings&tab=shipping`.
  - `flat` – "manually configured per market".
  - `manual` – "managed in Google Merchant Center" — link opens `merchants.google.com` in a new tab.
6. Before the rate resolves, a placeholder skeleton shows under the heading.
7. Add market button opens a modal; closes via X, Close button, and Esc.
8. Hovering the Primary Market row reveals an Edit (pencil) icon; clicking opens an "Edit market" modal showing the market name. Closes the same three ways.
9. Primary Market row has no Delete action (kebab or button) — only Edit.
10. In DevTools Network: switching between Markets and Price Benchmark loads the `dataviews` script at most once per session.
11. Block `dataViewsScriptUrl` in Network and reload Markets – warning "There was an error loading the markets dashboard." Same on Price Benchmark with its own copy.
12. Unblock and switch tabs away and back – script reloads successfully and the table renders.
13. Other tabs (Dashboard, Reports, Product Feed, Attributes, Settings, Shipping) behave identically to develop, no regressions.
14. No console errors or React warnings on Markets screen.
15. Markets table is keyboard-navigable; Edit button has accessible name "Edit"; modals trap focus.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
