### PR TITLE
GOOWOO-567: Hide flat shipping rate option for multi-lingual stores

### DIFF
--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -303,8 +303,7 @@ const SetupFreeListings = ( {
 					// These are the fields for settings.
 					shipping_rate:
 						glaData.isMultiLingualStore &&
-						settings.shipping_rate ===
-							SHIPPING_RATE_METHOD.FLAT_RATE
+						settings.shipping_rate === SHIPPING_RATE_METHOD.FLAT
 							? SHIPPING_RATE_METHOD.MANUAL
 							: settings.shipping_rate,
 					shipping_time: settings.shipping_time,

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -13,6 +13,7 @@ import AppButton from '~/components/app-button';
 import AdaptiveForm from '~/components/adaptive-form';
 import ValidationErrors from '~/components/validation-errors';
 import checkErrors from '~/components/free-listings/configure-product-listings/checkErrors';
+import { glaData, SHIPPING_RATE_METHOD } from '~/constants';
 import getOfferFreeShippingInitialValue from '~/utils/getOfferFreeShippingInitialValue';
 import isNonFreeShippingRate from '~/utils/isNonFreeShippingRate';
 import FormContent from './form-content';
@@ -300,7 +301,12 @@ const SetupFreeListings = ( {
 					location: targetAudience.location,
 					countries: targetAudience.countries || [],
 					// These are the fields for settings.
-					shipping_rate: settings.shipping_rate,
+					shipping_rate:
+						glaData.isMultiLingualStore &&
+						settings.shipping_rate ===
+							SHIPPING_RATE_METHOD.FLAT_RATE
+							? SHIPPING_RATE_METHOD.MANUAL
+							: settings.shipping_rate,
 					shipping_time: settings.shipping_time,
 					// This is used in UI only, not used in API.
 					offer_free_shipping:

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -8,6 +8,7 @@ import { createInterpolateElement } from '@wordpress/element';
  * Internal dependencies
  */
 import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import { glaData, SHIPPING_RATE_METHOD } from '~/constants';
 import Section from '~/components/section';
 import AppRadioContentControl from '~/components/app-radio-content-control';
 import RadioHelperText from '~/components/radio-helper-text';
@@ -27,6 +28,7 @@ const ShippingRateSection = () => {
 	const { settings } = useSettings();
 	const { hasFinishedResolution, data: mcSetup } = useMCSetup();
 	const inputProps = getInputProps( 'shipping_rate' );
+	const { isMultiLingualStore } = glaData;
 
 	// Hide the automatic shipping rate option if there are no shipping rates and the merchant is onboarding.
 	const hideAutomatticShippingRate =
@@ -78,15 +80,19 @@ const ShippingRateSection = () => {
 								</RadioHelperText>
 							</AppRadioContentControl>
 						) }
-						<AppRadioContentControl
-							{ ...inputProps }
-							label={ __(
-								'My shipping settings are simple. I can manually estimate flat shipping rates.',
-								'google-listings-and-ads'
-							) }
-							value="flat"
-							collapsible
-						/>
+
+						{ ! isMultiLingualStore && (
+							<AppRadioContentControl
+								{ ...inputProps }
+								label={ __(
+									'My shipping settings are simple. I can manually estimate flat shipping rates.',
+									'google-listings-and-ads'
+								) }
+								value="flat"
+								collapsible
+							/>
+						) }
+
 						<AppRadioContentControl
 							{ ...inputProps }
 							label={ __(
@@ -117,9 +123,10 @@ const ShippingRateSection = () => {
 					</VerticalGapLayout>
 				</Section.Card.Body>
 			</Section.Card>
-			{ values.shipping_rate === 'flat' && (
-				<FlatShippingRatesInputCards />
-			) }
+			{ ! isMultiLingualStore &&
+				values.shipping_rate === SHIPPING_RATE_METHOD.FLAT_RATE && (
+					<FlatShippingRatesInputCards />
+				) }
 		</Section>
 	);
 };

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -69,7 +69,7 @@ const ShippingRateSection = () => {
 									'Automatically sync my store’s shipping settings to Google.',
 									'google-listings-and-ads'
 								) }
-								value="automatic"
+								value={ SHIPPING_RATE_METHOD.AUTOMATIC }
 								collapsible
 							>
 								<RadioHelperText>
@@ -88,7 +88,7 @@ const ShippingRateSection = () => {
 									'My shipping settings are simple. I can manually estimate flat shipping rates.',
 									'google-listings-and-ads'
 								) }
-								value="flat"
+								value={ SHIPPING_RATE_METHOD.FLAT }
 								collapsible
 							/>
 						) }
@@ -99,7 +99,7 @@ const ShippingRateSection = () => {
 								'My shipping settings are complex. I will enter my shipping rates and times manually in Google Merchant Center.',
 								'google-listings-and-ads'
 							) }
-							value="manual"
+							value={ SHIPPING_RATE_METHOD.MANUAL }
 							collapsible
 						>
 							<RadioHelperText>
@@ -124,7 +124,7 @@ const ShippingRateSection = () => {
 				</Section.Card.Body>
 			</Section.Card>
 			{ ! isMultiLingualStore &&
-				values.shipping_rate === SHIPPING_RATE_METHOD.FLAT_RATE && (
+				values.shipping_rate === SHIPPING_RATE_METHOD.FLAT && (
 					<FlatShippingRatesInputCards />
 				) }
 		</Section>

--- a/js/src/components/shipping-rate-section/shipping-rate-section.test.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.test.js
@@ -49,6 +49,14 @@ jest.mock( '~/hooks/useSettings' );
 jest.mock( '~/hooks/useMCSetup' );
 
 describe( 'ShippingRateSection', () => {
+	beforeEach( () => {
+		global.glaData.isMultiLingualStore = false;
+	} );
+
+	afterEach( () => {
+		delete global.glaData.isMultiLingualStore;
+	} );
+
 	it( 'shouldnt render automatic rates if there are not shipping rates and it is onboarding', () => {
 		useMCSetup.mockImplementation( () => {
 			return {
@@ -203,5 +211,50 @@ describe( 'ShippingRateSection', () => {
 				'Automatically sync my store’s shipping settings to Google.'
 			)
 		).toBeInTheDocument();
+	} );
+
+	describe( 'when glaData.isMultiLingualStore is true', () => {
+		beforeEach( () => {
+			global.glaData.isMultiLingualStore = true;
+
+			useMCSetup.mockImplementation( () => {
+				return {
+					hasFinishedResolution: true,
+					data: { status: 'completed' },
+				};
+			} );
+
+			useSettings.mockImplementation( () => {
+				return {
+					settings: { shipping_rates_count: 1 },
+				};
+			} );
+		} );
+
+		it( 'should not render the flat shipping rate option', () => {
+			const { queryByText } = render( <ShippingRateSection /> );
+
+			expect(
+				queryByText(
+					'My shipping settings are simple. I can manually estimate flat shipping rates.'
+				)
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'should still render the automatic and manual shipping rate options', () => {
+			const { getByText } = render( <ShippingRateSection /> );
+
+			expect(
+				getByText(
+					'Automatically sync my store’s shipping settings to Google.'
+				)
+			).toBeInTheDocument();
+
+			expect(
+				getByText(
+					'My shipping settings are complex. I will enter my shipping rates and times manually in Google Merchant Center.'
+				)
+			).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -39,7 +39,7 @@ export const API_RESPONSE_CODES = {
 };
 
 export const SHIPPING_RATE_METHOD = {
-	FLAT_RATE: 'flat_rate',
+	FLAT: 'flat',
 	MANUAL: 'manual',
 	AUTOMATIC: 'automatic',
 };

--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -40,6 +40,8 @@ export const API_RESPONSE_CODES = {
 
 export const SHIPPING_RATE_METHOD = {
 	FLAT_RATE: 'flat_rate',
+	MANUAL: 'manual',
+	AUTOMATIC: 'automatic',
 };
 
 // Stepper key related


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-567/hide-manual-flat-rate-option-for-multilingual-stores.

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

* Non-multilingual store
	* Setup free listings shipping step shows all three options: automatic, flat rate, manual during onboarding
	* Selecting flat rate and saving works as before
* Multilingual store (`glaData.isMultiLingualStore = true`)
	* Flat rate radio option is absent from the shipping rate section
	* `FlatShippingRatesInputCards` is not rendered
	* If a previously saved shipping_rate is `flat_rate`, the form initializes with `manual` instead (no flat rate state bleeds through)
	* Automatic and manual options function normally


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
