### PR TITLE
GOOWOO-568: Add Google shipping preview for free shipping

### DIFF
--- a/js/src/components/order-value-condition-section/minimum-order-card/google-shipping-preview.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/google-shipping-preview.js
@@ -3,7 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Flex, FlexBlock, FlexItem } from '@wordpress/components';
-import GridiconShipping from 'gridicons/dist/shipping';
+import { Icon, shipping as shippingIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -41,7 +41,11 @@ const GoogleShippingPreview = ( { threshold } ) => {
 				<FlexBlock>
 					<Flex gap={ 1 }>
 						<FlexItem>
-							<GridiconShipping />
+							<Icon
+								icon={ shippingIcon }
+								width={ 20 }
+								height={ 20 }
+							/>
 						</FlexItem>
 						<FlexBlock>
 							<p>

--- a/js/src/components/order-value-condition-section/minimum-order-card/google-shipping-preview.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/google-shipping-preview.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Flex, FlexBlock, FlexItem } from '@wordpress/components';
+import GridiconShipping from 'gridicons/dist/shipping';
+
+/**
+ * Internal dependencies
+ */
+import useAdsCurrency from '~/hooks/useAdsCurrency';
+import './google-shipping-preview.scss';
+
+/**
+ * Renders a preview of how the free shipping offer will look on Google.
+ *
+ * @param {Object} props React props.
+ * @param {number} props.threshold The order value threshold for free shipping.
+ * @return {JSX.Element|null} The rendered component or null if no threshold is provided.
+ */
+const GoogleShippingPreview = ( { threshold } ) => {
+	const { formatAmount } = useAdsCurrency();
+
+	if ( ! threshold ) {
+		return null;
+	}
+
+	return (
+		<div className="gla-google-shipping-preview">
+			<Flex justify="flex-start">
+				<FlexItem>
+					<p>
+						<em>
+							{ __(
+								'Example of what your customers will see on Google:',
+								'google-listings-and-ads'
+							) }
+						</em>
+					</p>
+				</FlexItem>
+				<FlexBlock>
+					<Flex gap={ 1 }>
+						<FlexItem>
+							<GridiconShipping />
+						</FlexItem>
+						<FlexBlock>
+							<p>
+								<strong>
+									{ sprintf(
+										/* translators: %s is the order value threshold for free shipping. */
+										__(
+											'Ships free over %s',
+											'google-listings-and-ads'
+										),
+										formatAmount( threshold )
+									) }
+								</strong>
+							</p>
+						</FlexBlock>
+					</Flex>
+				</FlexBlock>
+			</Flex>
+		</div>
+	);
+};
+
+export default GoogleShippingPreview;

--- a/js/src/components/order-value-condition-section/minimum-order-card/google-shipping-preview.scss
+++ b/js/src/components/order-value-condition-section/minimum-order-card/google-shipping-preview.scss
@@ -1,0 +1,5 @@
+.gla-google-shipping-preview {
+	p {
+		margin: 0;
+	}
+}

--- a/js/src/components/order-value-condition-section/minimum-order-card/google-shipping-preview.scss
+++ b/js/src/components/order-value-condition-section/minimum-order-card/google-shipping-preview.scss
@@ -1,5 +1,15 @@
 .gla-google-shipping-preview {
+	background-color: $gla-color-gray-0;
+	border: 1px solid $gla-color-gray-5;
+	padding: $grid-unit-15;
+
 	p {
+		font-size: $gla-font-smaller;
+		line-height: $gla-line-height-smaller;
 		margin: 0;
+	}
+
+	svg {
+		display: block;
 	}
 }

--- a/js/src/components/order-value-condition-section/minimum-order-card/google-shipping-preview.test.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/google-shipping-preview.test.js
@@ -32,7 +32,9 @@ describe( 'GoogleShippingPreview', () => {
 		render( <GoogleShippingPreview threshold={ 50 } /> );
 
 		expect(
-			screen.getByText( /Example of what your customers will see on Google:/ )
+			screen.getByText(
+				/Example of what your customers will see on Google:/
+			)
 		).toBeInTheDocument();
 		expect(
 			screen.getByText( 'Ships free over $50.00' )

--- a/js/src/components/order-value-condition-section/minimum-order-card/google-shipping-preview.test.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/google-shipping-preview.test.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import GoogleShippingPreview from './google-shipping-preview';
+
+jest.mock( '~/hooks/useAdsCurrency', () =>
+	jest.fn().mockReturnValue( {
+		formatAmount: jest.fn( ( amount ) => `$${ amount.toFixed( 2 ) }` ),
+	} )
+);
+
+describe( 'GoogleShippingPreview', () => {
+	it( 'renders null when threshold is not provided', () => {
+		const { container } = render( <GoogleShippingPreview /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders null when threshold is 0', () => {
+		const { container } = render(
+			<GoogleShippingPreview threshold={ 0 } />
+		);
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'renders the preview when a threshold is provided', () => {
+		render( <GoogleShippingPreview threshold={ 50 } /> );
+
+		expect(
+			screen.getByText( /Example of what your customers will see on Google:/ )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Ships free over $50.00' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'formats the threshold amount using useAdsCurrency', () => {
+		render( <GoogleShippingPreview threshold={ 123.45 } /> );
+
+		expect(
+			screen.getByText( 'Ships free over $123.45' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders with the correct CSS class', () => {
+		const { container } = render(
+			<GoogleShippingPreview threshold={ 50 } />
+		);
+
+		expect(
+			container.querySelector( '.gla-google-shipping-preview' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-card.js
+++ b/js/src/components/order-value-condition-section/minimum-order-card/minimum-order-card.js
@@ -20,6 +20,7 @@ import {
 import OfferFreeShippingCheckbox from '~/components/order-value-condition-section/offer-free-shipping-checkbox';
 import isNonFreeShippingRate from '~/utils/isNonFreeShippingRate';
 import './minimum-order-card.scss';
+import GoogleShippingPreview from './google-shipping-preview';
 
 /**
  * Renders a Card UI to set a single free shipping threshold applied to all countries.
@@ -74,12 +75,19 @@ const MinimumOrderCard = ( { value = [], helper, onChange } ) => {
 						{ ...offerFreeShippingInputProps }
 					/>
 					{ values.offer_free_shipping && (
-						<AppInputPriceControl
-							label={ __( 'Cost', 'google-listings-and-ads' ) }
-							suffix={ currency }
-							value={ threshold }
-							onBlur={ handleBlur }
-						/>
+						<>
+							<AppInputPriceControl
+								label={ __(
+									'Cost',
+									'google-listings-and-ads'
+								) }
+								suffix={ currency }
+								value={ threshold }
+								onBlur={ handleBlur }
+							/>
+
+							<GoogleShippingPreview threshold={ threshold } />
+						</>
 					) }
 				</VerticalGapLayout>
 				{ helper }

--- a/js/src/css/abstracts/_colors.scss
+++ b/js/src/css/abstracts/_colors.scss
@@ -12,5 +12,6 @@ $gla-color-yellow-70: #614200;
 $gla-color-red-0: #fcf0f1;
 $gla-color-red-70: #8a2424;
 $gla-color-gray-0: #f6f7f7;
+$gla-color-gray-5: #dcdcde;
 $gla-color-blue-0: #f0f6fc;
 $gla-color-blue-70: #0a4b78;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-568/add-free-shipping-above-a-certain-amount-notice.

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go through the onboarding flow.
2. For the shipping rate section, for the flat rate option when selected, enter an estimate shipping rate > 0
3. Check the "Free shipping over a specific order value" checkbox and enter a value
4. Ensure the notice render as per the designs in Figma


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
