### PR TITLE
GOOWOO-569: Add market feed settings notice

### DIFF
--- a/js/src/pages/onboarding/setup-stepper/setup-listings.js
+++ b/js/src/pages/onboarding/setup-stepper/setup-listings.js
@@ -1,6 +1,13 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
+import Section from '~/components/section';
 import StepContent from '~/components/stepper/step-content';
 import StepContentActions from '~/components/stepper/step-content-actions';
 import StepContentFooter from '~/components/stepper/step-content-footer';
@@ -18,6 +25,16 @@ export default function SetupListings( props ) {
 			<Hero />
 			<StepContent>
 				<SetupFreeListings { ...props } />
+
+				<Section>
+					<Notice isDismissible={ false }>
+						{ __(
+							'You can set up additional market feeds with custom shipping per country in Settings after completing this setup — including support for multiple languages and currencies.',
+							'google-listings-and-ads'
+						) }
+					</Notice>
+				</Section>
+
 				<StepContentFooter>
 					<StepContentActions>
 						<SetupFreeListings.SubmitButton />


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-569/add-add-new-markets-notice-in-configure-your-product-listings-step.

_Replace this with a good description of your changes & reasoning._


### Screenshots:
<img width="748" height="219" alt="image" src="https://github.com/user-attachments/assets/16174e35-d7ec-4bbd-812d-e0a7fbafd87a" />



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go through the normal onboarding flow.
2. Ensure the notice shows up in the second step of the flow and is rendered as per the designs in Figma.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
