### PR TITLE
GOOWOO-482: Apply new customer field to Budget Recommendations

### DIFF
--- a/src/API/Google/BudgetMetrics.php
+++ b/src/API/Google/BudgetMetrics.php
@@ -43,12 +43,19 @@ class BudgetMetrics implements OptionsAwareInterface, TransientsAwareInterface {
 	protected $client;
 
 	/**
+	 * @var MerchantMetrics
+	 */
+	protected $merchant_metrics;
+
+	/**
 	 * BudgetMetrics constructor.
 	 *
 	 * @param GoogleAdsClient $client
+	 * @param MerchantMetrics $merchant_metrics
 	 */
-	public function __construct( GoogleAdsClient $client ) {
-		$this->client = $client;
+	public function __construct( GoogleAdsClient $client, MerchantMetrics $merchant_metrics ) {
+		$this->client           = $client;
+		$this->merchant_metrics = $merchant_metrics;
 	}
 
 	/**
@@ -60,8 +67,9 @@ class BudgetMetrics implements OptionsAwareInterface, TransientsAwareInterface {
 	 * @return array|null List of metrics.
 	 */
 	public function get_metrics( float $budget, array $country_codes ): ?array {
-		$cache_key = strtolower( join( '-', $country_codes ) . '-' . $budget );
-		$transient = $this->transients->get( TransientsInterface::ADS_BUDGET_METRICS );
+		$is_new_customer = 0 === $this->merchant_metrics->get_campaign_count();
+		$cache_key       = strtolower( join( '-', $country_codes ) . '-' . $budget ) . ( $is_new_customer ? '-new' : '-existing' );
+		$transient       = $this->transients->get( TransientsInterface::ADS_BUDGET_METRICS );
 
 		// Check if we have the budget metrics cached in the transient.
 		if ( $transient && ! empty( $transient[ $cache_key ] ) ) {
@@ -77,6 +85,7 @@ class BudgetMetrics implements OptionsAwareInterface, TransientsAwareInterface {
 			'advertising_channel_type' => AdvertisingChannelType::PERFORMANCE_MAX,
 			'positive_locations_ids'   => array_keys( $location_ids ),
 			'country_codes'            => $country_codes,
+			'is_new_customer'          => $is_new_customer,
 			'bidding_info'             => new BiddingInfo(
 				[
 					'bidding_strategy_type' => BiddingStrategyType::MAXIMIZE_CONVERSION_VALUE,

--- a/src/API/Google/BudgetRecommendations.php
+++ b/src/API/Google/BudgetRecommendations.php
@@ -43,12 +43,19 @@ class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInt
 	protected $client;
 
 	/**
+	 * @var MerchantMetrics
+	 */
+	protected $merchant_metrics;
+
+	/**
 	 * BudgetRecommendations constructor.
 	 *
 	 * @param GoogleAdsClient $client
+	 * @param MerchantMetrics $merchant_metrics
 	 */
-	public function __construct( GoogleAdsClient $client ) {
-		$this->client = $client;
+	public function __construct( GoogleAdsClient $client, MerchantMetrics $merchant_metrics ) {
+		$this->client           = $client;
+		$this->merchant_metrics = $merchant_metrics;
 	}
 
 	/**
@@ -60,8 +67,9 @@ class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInt
 	 * @return array|null List of recommendations (including metrics).
 	 */
 	public function get_recommendations( array $country_codes ): ?array {
-		$cache_key = strtolower( join( '-', $country_codes ) );
-		$transient = $this->transients->get( TransientsInterface::ADS_BUDGET_RECOMMENDATIONS );
+		$is_new_customer = 0 === $this->merchant_metrics->get_campaign_count();
+		$cache_key       = strtolower( join( '-', $country_codes ) ) . ( $is_new_customer ? '-new' : '-existing' );
+		$transient       = $this->transients->get( TransientsInterface::ADS_BUDGET_RECOMMENDATIONS );
 
 		// Check if we have the budget recommendations cached in the transient.
 		if ( $transient && ! empty( $transient[ $cache_key ] ) ) {
@@ -77,6 +85,7 @@ class BudgetRecommendations implements OptionsAwareInterface, TransientsAwareInt
 			'advertising_channel_type' => AdvertisingChannelType::PERFORMANCE_MAX,
 			'positive_locations_ids'   => array_keys( $location_ids ),
 			'country_codes'            => $country_codes,
+			'is_new_customer'          => $is_new_customer,
 			'bidding_info'             => new BiddingInfo(
 				[
 					'bidding_strategy_type' => BiddingStrategyType::MAXIMIZE_CONVERSION_VALUE,

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -134,8 +134,8 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( AdsReport::class, GoogleAdsClient::class );
 		$this->share( AdsRecommendationsService::class, GoogleAdsClient::class );
 		$this->share( AdsAssetGenerationService::class, GoogleAdsClient::class );
-		$this->share( BudgetMetrics::class, GoogleAdsClient::class );
-		$this->share( BudgetRecommendations::class, GoogleAdsClient::class );
+		$this->share( BudgetMetrics::class, GoogleAdsClient::class, MerchantMetrics::class );
+		$this->share( BudgetRecommendations::class, GoogleAdsClient::class, MerchantMetrics::class );
 
 		$this->share( Merchant::class, ShoppingContent::class );
 		$this->share( MerchantMetrics::class, ShoppingContent::class, GoogleAdsClient::class, WP::class, TransientsInterface::class );

--- a/tests/Unit/API/Google/BudgetMetricsTest.php
+++ b/tests/Unit/API/Google/BudgetMetricsTest.php
@@ -4,10 +4,12 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
+use Google\Ads\GoogleAds\V23\Services\GenerateRecommendationsResponse;
 use Google\ApiCore\ApiException;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -28,6 +30,9 @@ class BudgetMetricsTest extends UnitTest {
 	/** @var MockObject|TransientsInterface $transients */
 	protected $transients;
 
+	/** @var MockObject|MerchantMetrics $merchant_metrics */
+	protected $merchant_metrics;
+
 	/** @var BudgetMetrics $metrics */
 	protected $metrics;
 
@@ -47,10 +52,11 @@ class BudgetMetricsTest extends UnitTest {
 
 		$this->ads_client_setup();
 
-		$this->options    = $this->createMock( OptionsInterface::class );
-		$this->transients = $this->createMock( TransientsInterface::class );
+		$this->options          = $this->createMock( OptionsInterface::class );
+		$this->transients       = $this->createMock( TransientsInterface::class );
+		$this->merchant_metrics = $this->createMock( MerchantMetrics::class );
 
-		$this->metrics = new BudgetMetrics( $this->client );
+		$this->metrics = new BudgetMetrics( $this->client, $this->merchant_metrics );
 		$this->metrics->set_options_object( $this->options );
 		$this->metrics->set_transients_object( $this->transients );
 
@@ -59,8 +65,10 @@ class BudgetMetricsTest extends UnitTest {
 	}
 
 	public function test_get_metrics_cached() {
+		$this->merchant_metrics->method( 'get_campaign_count' )->willReturn( 0 );
+
 		$metrics = [
-			'us-12' => self::TEST_METRICS,
+			'us-12-new' => self::TEST_METRICS,
 		];
 
 		$this->transients->expects( $this->once() )
@@ -68,7 +76,66 @@ class BudgetMetricsTest extends UnitTest {
 			->with( TransientsInterface::ADS_BUDGET_METRICS )
 			->willReturn( $metrics );
 
-		$this->assertEquals( $metrics['us-12'], $this->metrics->get_metrics( 12, [ 'US' ] ) );
+		$this->assertEquals( $metrics['us-12-new'], $this->metrics->get_metrics( 12, [ 'US' ] ) );
+	}
+
+	public function test_get_metrics_cache_key_uses_existing_for_advertisers_with_campaigns() {
+		$this->merchant_metrics->method( 'get_campaign_count' )->willReturn( 4 );
+
+		$metrics = [
+			'us-12-existing' => self::TEST_METRICS,
+		];
+
+		$this->transients->expects( $this->once() )
+			->method( 'get' )
+			->with( TransientsInterface::ADS_BUDGET_METRICS )
+			->willReturn( $metrics );
+
+		$this->assertEquals( $metrics['us-12-existing'], $this->metrics->get_metrics( 12, [ 'US' ] ) );
+	}
+
+	public function test_get_metrics_sends_is_new_customer_true_when_no_campaigns() {
+		$this->merchant_metrics->method( 'get_campaign_count' )->willReturn( 0 );
+
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
+
+		$captured_request = null;
+		$this->recommendation_service->method( 'generateRecommendations' )
+			->willReturnCallback(
+				function ( $request ) use ( &$captured_request ) {
+					$captured_request = $request;
+					$response         = $this->createMock( GenerateRecommendationsResponse::class );
+					$response->method( 'getRecommendations' )->willReturn( [] );
+					return $response;
+				}
+			);
+
+		$this->metrics->get_metrics( 12, [ 'US' ] );
+
+		$this->assertNotNull( $captured_request );
+		$this->assertTrue( $captured_request->getIsNewCustomer() );
+	}
+
+	public function test_get_metrics_sends_is_new_customer_false_when_existing_campaigns() {
+		$this->merchant_metrics->method( 'get_campaign_count' )->willReturn( 7 );
+
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
+
+		$captured_request = null;
+		$this->recommendation_service->method( 'generateRecommendations' )
+			->willReturnCallback(
+				function ( $request ) use ( &$captured_request ) {
+					$captured_request = $request;
+					$response         = $this->createMock( GenerateRecommendationsResponse::class );
+					$response->method( 'getRecommendations' )->willReturn( [] );
+					return $response;
+				}
+			);
+
+		$this->metrics->get_metrics( 12, [ 'US' ] );
+
+		$this->assertNotNull( $captured_request );
+		$this->assertFalse( $captured_request->getIsNewCustomer() );
 	}
 
 	public function test_get_metrics_cached_locations() {

--- a/tests/Unit/API/Google/BudgetRecommendationsTest.php
+++ b/tests/Unit/API/Google/BudgetRecommendationsTest.php
@@ -4,10 +4,12 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
+use Google\Ads\GoogleAds\V23\Services\GenerateRecommendationsResponse;
 use Google\ApiCore\ApiException;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -27,6 +29,9 @@ class BudgetRecommendationsTest extends UnitTest {
 
 	/** @var MockObject|TransientsInterface $transients */
 	protected $transients;
+
+	/** @var MockObject|MerchantMetrics $merchant_metrics */
+	protected $merchant_metrics;
 
 	/** @var BudgetRecommendations $recommendations */
 	protected $recommendations;
@@ -52,10 +57,11 @@ class BudgetRecommendationsTest extends UnitTest {
 
 		$this->ads_client_setup();
 
-		$this->options    = $this->createMock( OptionsInterface::class );
-		$this->transients = $this->createMock( TransientsInterface::class );
+		$this->options          = $this->createMock( OptionsInterface::class );
+		$this->transients       = $this->createMock( TransientsInterface::class );
+		$this->merchant_metrics = $this->createMock( MerchantMetrics::class );
 
-		$this->recommendations = new BudgetRecommendations( $this->client );
+		$this->recommendations = new BudgetRecommendations( $this->client, $this->merchant_metrics );
 		$this->recommendations->set_options_object( $this->options );
 		$this->recommendations->set_transients_object( $this->transients );
 
@@ -64,8 +70,10 @@ class BudgetRecommendationsTest extends UnitTest {
 	}
 
 	public function test_get_recommendations_cached() {
+		$this->merchant_metrics->method( 'get_campaign_count' )->willReturn( 0 );
+
 		$recommendations = [
-			'us' => self::TEST_RECOMMENDATION,
+			'us-new' => self::TEST_RECOMMENDATION,
 		];
 
 		$this->transients->expects( $this->once() )
@@ -73,7 +81,66 @@ class BudgetRecommendationsTest extends UnitTest {
 			->with( TransientsInterface::ADS_BUDGET_RECOMMENDATIONS )
 			->willReturn( $recommendations );
 
-		$this->assertEquals( $recommendations['us'], $this->recommendations->get_recommendations( [ 'US' ] ) );
+		$this->assertEquals( $recommendations['us-new'], $this->recommendations->get_recommendations( [ 'US' ] ) );
+	}
+
+	public function test_get_recommendations_cache_key_uses_existing_for_advertisers_with_campaigns() {
+		$this->merchant_metrics->method( 'get_campaign_count' )->willReturn( 3 );
+
+		$recommendations = [
+			'us-existing' => self::TEST_RECOMMENDATION,
+		];
+
+		$this->transients->expects( $this->once() )
+			->method( 'get' )
+			->with( TransientsInterface::ADS_BUDGET_RECOMMENDATIONS )
+			->willReturn( $recommendations );
+
+		$this->assertEquals( $recommendations['us-existing'], $this->recommendations->get_recommendations( [ 'US' ] ) );
+	}
+
+	public function test_get_recommendations_sends_is_new_customer_true_when_no_campaigns() {
+		$this->merchant_metrics->method( 'get_campaign_count' )->willReturn( 0 );
+
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
+
+		$captured_request = null;
+		$this->recommendation_service->method( 'generateRecommendations' )
+			->willReturnCallback(
+				function ( $request ) use ( &$captured_request ) {
+					$captured_request = $request;
+					$response         = $this->createMock( GenerateRecommendationsResponse::class );
+					$response->method( 'getRecommendations' )->willReturn( [] );
+					return $response;
+				}
+			);
+
+		$this->recommendations->get_recommendations( [ 'US' ] );
+
+		$this->assertNotNull( $captured_request );
+		$this->assertTrue( $captured_request->getIsNewCustomer() );
+	}
+
+	public function test_get_recommendations_sends_is_new_customer_false_when_existing_campaigns() {
+		$this->merchant_metrics->method( 'get_campaign_count' )->willReturn( 5 );
+
+		$this->generate_location_ids_mock( [ 111 => 'US' ] );
+
+		$captured_request = null;
+		$this->recommendation_service->method( 'generateRecommendations' )
+			->willReturnCallback(
+				function ( $request ) use ( &$captured_request ) {
+					$captured_request = $request;
+					$response         = $this->createMock( GenerateRecommendationsResponse::class );
+					$response->method( 'getRecommendations' )->willReturn( [] );
+					return $response;
+				}
+			);
+
+		$this->recommendations->get_recommendations( [ 'US' ] );
+
+		$this->assertNotNull( $captured_request );
+		$this->assertFalse( $captured_request->getIsNewCustomer() );
 	}
 
 	public function test_get_recommendations_cached_locations() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-482/apply-new-customer-field-to-budget-recommendations

Adds the Google Ads API v23 `is_new_customer` field to `GenerateRecommendationsRequest` calls in `BudgetRecommendations` and `BudgetMetrics`. Also, the transient cache keys for `ADS_BUDGET_RECOMMENDATIONS` and `ADS_BUDGET_METRICS` now include a `-new`/`-existing` suffix so that a brand-new advertiser's recommendations don't get reused after their first campaign exists.


<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Clear cache
```
wp transient delete gla_ads_budget_recommendations
wp transient delete gla_ads_budget_metrics
wp transient delete gla_ads_campaign_count
```
2. Add a new campaign in admin, complete the wizard and submir
3. Verify cache exists
```
wp transient get gla_ads_budget_recommendations --format=json
wp transient get gla_ads_budget_metrics --format=json
```
Expect to see keys ending in `-new `(no campaigns existed ) or `-existing` (if a campaign already existed). Either way, the suffix should be present

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Apply the Google Ads API `is_new_customer` field to budget recommendation and metrics requests, and split their cache keys by new/existing advertiser so recommendations refresh correctly after the first campaign is created
