### PR TITLE
GOOWOO-623: MainTabBar intermittently disappears

### DIFF
--- a/js/src/components/main-tab-nav/main-tab-nav.js
+++ b/js/src/components/main-tab-nav/main-tab-nav.js
@@ -14,7 +14,7 @@ import useMenuEffect from '~/hooks/useMenuEffect';
 import GtinMigrationBanner from '~/components/gtin-migration-banner';
 import { getShippingUrl } from '~/utils/urls';
 
-let tabs = [
+export const ALL_TABS = [
 	{
 		key: 'dashboard',
 		title: __( 'Dashboard', 'google-listings-and-ads' ),
@@ -52,6 +52,8 @@ let tabs = [
 	},
 ];
 
+const MC_GATED_TAB_KEYS = [ 'dashboard', 'settings' ];
+
 const getSelectedTabKey = ( allTabs ) => {
 	const path = getPath();
 	return allTabs.find( ( el ) => path.includes( el.key ) )?.key;
@@ -63,15 +65,17 @@ const MainTabNav = () => {
 	const { hasGoogleMCConnection } = useGoogleMCAccount();
 	const hasMC = glaData.mcSetupComplete || hasGoogleMCConnection;
 
-	if ( ! glaData.enableReports ) {
-		tabs = tabs.filter( ( { key } ) => key !== 'reports' );
-	}
+	const tabs = ALL_TABS.filter( ( { key } ) => {
+		if ( ! glaData.enableReports && key === 'reports' ) {
+			return false;
+		}
 
-	if ( ! hasMC ) {
-		tabs = tabs.filter( ( { key } ) =>
-			[ 'dashboard', 'settings' ].includes( key )
-		);
-	}
+		if ( ! hasMC && ! MC_GATED_TAB_KEYS.includes( key ) ) {
+			return false;
+		}
+
+		return true;
+	} );
 
 	const selectedKey = getSelectedTabKey( tabs );
 

--- a/js/src/components/main-tab-nav/main-tab-nav.test.js
+++ b/js/src/components/main-tab-nav/main-tab-nav.test.js
@@ -1,0 +1,134 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+
+jest.mock( '~/hooks/useGoogleMCAccount' );
+jest.mock( '~/hooks/useMenuEffect' );
+jest.mock( '~/components/gtin-migration-banner', () => () => null );
+jest.mock( '@woocommerce/navigation', () => ( {
+	getNewPath: ( _query, path ) => path,
+	getPath: jest.fn().mockReturnValue( '/google/dashboard' ),
+} ) );
+
+const renderedTabKeys = ( container ) =>
+	Array.from( container.querySelectorAll( '[role="tab"]' ) ).map(
+		( el ) => el.id
+	);
+
+describe( 'MainTabNav', () => {
+	let MainTabNav;
+	let ALL_TABS;
+	let useGoogleMCAccount;
+	let getPath;
+
+	beforeEach( () => {
+		jest.resetModules();
+
+		window.glaData = {
+			...window.glaData,
+			mcSetupComplete: true,
+			enableReports: true,
+		};
+
+		useGoogleMCAccount = require( '~/hooks/useGoogleMCAccount' ).default;
+		useGoogleMCAccount.mockReturnValue( { hasGoogleMCConnection: false } );
+
+		( { getPath } = require( '@woocommerce/navigation' ) );
+		getPath.mockReturnValue( '/google/dashboard' );
+
+		const mod = require( './main-tab-nav' );
+		MainTabNav = mod.default;
+		ALL_TABS = mod.ALL_TABS;
+	} );
+
+	it( 'restores the full tab list when hasGoogleMCConnection flips false → true', () => {
+		window.glaData.mcSetupComplete = false;
+		useGoogleMCAccount.mockReturnValue( { hasGoogleMCConnection: false } );
+
+		const { container, rerender } = render( <MainTabNav /> );
+		const beforeFlip = new Set( renderedTabKeys( container ) );
+
+		useGoogleMCAccount.mockReturnValue( { hasGoogleMCConnection: true } );
+		rerender( <MainTabNav /> );
+		const afterFlip = new Set( renderedTabKeys( container ) );
+
+		// Every tab visible before the flip must still be visible after,
+		// and at least one previously-hidden tab must reappear.
+		for ( const key of beforeFlip ) {
+			expect( afterFlip.has( key ) ).toBe( true );
+		}
+		expect( afterFlip.size ).toBeGreaterThan( beforeFlip.size );
+	} );
+
+	it( 'a fresh instance reflects its own inputs, not the previous instance', () => {
+		window.glaData.mcSetupComplete = false;
+		useGoogleMCAccount.mockReturnValue( { hasGoogleMCConnection: false } );
+
+		const first = render( <MainTabNav /> );
+		const firstKeys = new Set( renderedTabKeys( first.container ) );
+		first.unmount();
+
+		useGoogleMCAccount.mockReturnValue( { hasGoogleMCConnection: true } );
+		const second = render( <MainTabNav /> );
+		const secondKeys = new Set( renderedTabKeys( second.container ) );
+
+		expect( secondKeys.size ).toBeGreaterThan( firstKeys.size );
+	} );
+
+	it( 'renders only dashboard and settings when there is no MC connection', () => {
+		window.glaData.mcSetupComplete = false;
+		useGoogleMCAccount.mockReturnValue( { hasGoogleMCConnection: false } );
+
+		const { container } = render( <MainTabNav /> );
+
+		expect( renderedTabKeys( container ) ).toEqual( [
+			'dashboard',
+			'settings',
+		] );
+	} );
+
+	it( 'hides exactly the reports tab when enableReports is false', () => {
+		const withReports = render( <MainTabNav /> );
+		const withReportsKeys = new Set(
+			renderedTabKeys( withReports.container )
+		);
+		withReports.unmount();
+
+		window.glaData.enableReports = false;
+
+		const withoutReports = render( <MainTabNav /> );
+		const withoutReportsKeys = new Set(
+			renderedTabKeys( withoutReports.container )
+		);
+
+		const removed = [ ...withReportsKeys ].filter(
+			( key ) => ! withoutReportsKeys.has( key )
+		);
+		const added = [ ...withoutReportsKeys ].filter(
+			( key ) => ! withReportsKeys.has( key )
+		);
+
+		expect( removed ).toEqual( [ 'reports' ] );
+		expect( added ).toEqual( [] );
+	} );
+
+	it( 'renders every tab from ALL_TABS in the default state', () => {
+		const { container } = render( <MainTabNav /> );
+
+		expect( renderedTabKeys( container ) ).toEqual(
+			ALL_TABS.map( ( t ) => t.key )
+		);
+	} );
+
+	it( 'marks the tab matching the current URL path as selected', () => {
+		getPath.mockReturnValue( '/google/product-feed' );
+
+		const { container } = render( <MainTabNav /> );
+		const selected = container.querySelector( '[aria-selected="true"]' );
+
+		expect( selected ).not.toBeNull();
+		expect( selected.id ).toBe( 'product-feed' );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-623.

`MainTabNav` is rendered from a module-scoped `let tabs` array that is reassigned (`tabs = tabs.filter(...)`) inside the component body on every render that hits the `!hasMC` branch. Once that mutation happens, the truncated array is reused for the rest of the page's lifetime — even after `useGoogleMCAccount` resolves and `hasGoogleMCConnection` flips to `true`, the `if` branches no longer run, but the source array stays filtered down to `[dashboard, settings]`. To the user, the tab they were on "disappears" from the nav.

The bug only fires when `glaData.mcSetupComplete === false` at first render and `hasGoogleMCConnection` flips `false` → `true` mid-session, which is why nobody could reproduce it from a fresh page load and a hard reload always "fixes" it.

This PR:

- Replaces the mutable module-scoped `let tabs` with an immutable `export const ALL_TABS`.
- Derives the visible tabs inside `MainTabNav` by filtering `ALL_TABS` on each render. Decided against `useMemo` — the runtime cost on a 7-8 element array is negligible and matches how the rest of the codebase handles trivial derivations.
- Removes both `if`-branch reassignments. The two visibility rules (`!enableReports` hides Reports, `!hasMC` keeps only Dashboard + Settings) are preserved as predicates inside the filter.
- Extracts `MC_GATED_TAB_KEYS` as a module-level const.
- Adds `js/src/components/main-tab-nav/main-tab-nav.test.js` (no prior coverage existed). Tests assert behavioral deltas and invariants rather than hardcoded counts, so adding or removing a tab in the future does not require touching the test file.

No public API changes. `<AppTabNav>`, `useGoogleMCAccount`, `useMenuEffect`, `glaData`, and every consumer of `<MainTabNav />` are untouched.


### Screenshots:

_N/A — visible behaviour is unchanged in the happy path; the regression manifests only under a specific async race that produces no observable styling difference per se._


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

**Automated:**

- `npm test -- js/src/components/main-tab-nav/main-tab-nav.test.js` – 6 new cases
- `npm test` — full suite

**Manual reproduction of the original bug (against develop):**

1. Use a WP install where the GLA plugin is installed and the merchant has not completed Merchant Center setup. Confirm `window.glaData.mcSetupComplete === false` in DevTools.
2. Partially connect Google so the `getGoogleMCAccount` resolver eventually returns `hasGoogleMCConnection: true`.
3. DevTools → Network → throttling Slow 3G.
4. Hard-reload to `wp-admin/admin.php?page=wc-admin&path=/google/dashboard`.
5. On `develop`, after the resolver returns, the nav stays at Dashboard, Settings even though all gated tabs should now be visible. Navigating to a deep-linked tab (e.g. Product Feed) shows the tab "missing" from the nav.

**Verifying the fix on this branch:**

1. Repeat steps 1–4 above on this branch.
2. After the resolver returns, the nav grows to all expected tabs (Dashboard, Reports, Product Feed, Price Benchmark, Attributes, Settings, Shipping).
3. Sign in as a merchant with no MC connection (`mcSetupComplete: false`, `hasGoogleMCConnection: false` permanently). Verify the nav shows exactly Dashboard + Settings on every page and on every navigation.
4. Apply `add_filter( 'woocommerce_gla_enable_reports', '__return_false' );`. Verify the Reports tab is missing on every page and no other tab is affected.
5. Navigate Dashboard → Product Feed → Settings → Product Feed. The active tab indicator must follow the URL on every step; no tab should ever vanish.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - MainTabNav intermittently rendering an incomplete tab list when a Merchant Center connection became available mid-session.
