### PR TITLE
GOOWOO-620: Track failed incentive applications and recover unclaimed incentives via background job

### DIFF
--- a/src/API/Google/AdsIncentives.php
+++ b/src/API/Google/AdsIncentives.php
@@ -6,7 +6,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Google\Ads\GoogleAds\V23\Services\ApplyIncentiveRequest;
@@ -199,9 +198,6 @@ class AdsIncentives implements OptionsAwareInterface {
 			];
 		} catch ( ApiException $e ) {
 			do_action( 'woocommerce_gla_ads_client_exception', $e, __METHOD__ );
-
-			// Set a flag to indicate an error occurred during incentive application.
-			$this->options->update( OptionsInterface::ADS_INCENTIVE_APPLY_ERROR, $incentive_id );
 
 			$errors = $this->get_exception_errors( $e );
 

--- a/tests/Unit/API/Google/AdsIncentivesTest.php
+++ b/tests/Unit/API/Google/AdsIncentivesTest.php
@@ -215,23 +215,9 @@ class AdsIncentivesTest extends UnitTest {
 		$this->assertEquals( '2026-03-15 15:33:21', $result['creation_time'] );
 	}
 
-	public function test_apply_incentive_sets_error_flag_on_api_error() {
-		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
-
-		$this->options->expects( $this->once() )
-			->method( 'update' )
-			->with( OptionsInterface::ADS_INCENTIVE_APPLY_ERROR, self::TEST_INCENTIVE_ID );
-
-		$this->incentive_service->method( 'applyIncentive' )
-			->willThrowException( new ApiException( 'PERMISSION_DENIED', 7, 'PERMISSION_DENIED' ) );
-
-		$this->expectException( ExceptionWithResponseData::class );
-		$this->ads_incentives->apply_incentive( self::TEST_INCENTIVE_ID, self::TEST_COUNTRY );
-	}
-
 	public function test_apply_incentive_throws_exception_on_api_error() {
 		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
-		$this->options->method( 'update' );
+		$this->options->expects( $this->never() )->method( 'update' );
 
 		$this->incentive_service->method( 'applyIncentive' )
 			->willThrowException( new ApiException( 'PERMISSION_DENIED', 7, 'PERMISSION_DENIED' ) );

--- a/tests/Unit/API/Site/Controllers/Ads/IncentivesControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/IncentivesControllerTest.php
@@ -279,6 +279,14 @@ class IncentivesControllerTest extends RESTControllerUnitTest {
 				)
 			);
 
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::ADS_INCENTIVE_APPLY_ERROR, 'error' );
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with( 'gla/jobs/check_unclaimed_incentive/start' );
+
 		$response = $this->do_request(
 			self::ROUTE_INCENTIVES,
 			'POST',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a follow-up PR to resolve this comment https://linear.app/a8c/issue/GOOWOO-620/track-failed-incentive-applications-and-recover-unclaimed-incentives#comment-7e207aba

Closes https://linear.app/a8c/issue/GOOWOO-620/track-failed-incentive-applications-and-recover-unclaimed-incentives

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
