### PR TITLE
Add Linear releases workflow for scheduled pipeline

### DIFF
--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,0 +1,37 @@
+name: Linear Release
+
+on:
+  workflow_run:
+    workflows:
+      - Deploy Product
+    types:
+      - completed
+
+jobs:
+  complete:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Sync release
+        id: release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: sync
+
+      - name: Mark release complete
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: complete
+
+      - name: Print release URL
+        if: steps.release.outputs.release-url != ''
+        run: echo "Linear release ${{ steps.release.outputs.release-name }} → ${{ steps.release.outputs.release-url }}"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Triggers after a successful Deploy Product run, syncs commits to the Linear scheduled pipeline, then marks the release as complete.

Requires LINEAR_ACCESS_KEY repo secret (pipeline key from Linear Settings → Releases).

Based on: https://github.com/marketplace/actions/linear-release and https://linear.app/docs/releases