### PR TITLE
GOOWOO-630: Update CYOI terms and conditions link

### DIFF
--- a/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js
+++ b/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js
@@ -41,7 +41,7 @@ import './cyo-incentive-picker.scss';
  *
  * @fires gla_cyo_incentive_picker_shown when the incentive picker is shown to the user.
  * @fires gla_cyo_incentive_selected when the user selects an incentive offer.
- * @fires gla_documentation_link_click with `{ context: 'setup-ads' | 'setup-ads-only', link_id: 'incentives-terms-and-conditions-apply', href: 'https://ads.google.com/home/terms-and-conditions/incentives/' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-ads' | 'setup-ads-only', link_id: 'incentives-terms-and-conditions-apply', href: termsAndConditionsUrl }`
  *
  * @param {Object} props React props.
  * @param {string} props.context The context in which this component is used, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'. This is used for tracking purposes and may also be used to conditionally render content within the component.
@@ -59,6 +59,7 @@ const CyoIncentivePicker = ( { context } ) => {
 	} = getInputProps( 'incentiveOffer' );
 
 	const shouldDisplay = hasFinishedResolution && incentives?.length > 0;
+	const termsAndConditionsUrl = incentives?.[ 0 ]?.termsAndConditionsUrl;
 	const hasTrackedShownRef = useRef( false );
 
 	useEffect( () => {
@@ -133,7 +134,7 @@ const CyoIncentivePicker = ( { context } ) => {
 									<AppDocumentationLink
 										context={ context }
 										linkId="incentives-terms-and-conditions-apply"
-										href="https://ads.google.com/home/terms-and-conditions/incentives/"
+										href={ termsAndConditionsUrl }
 									/>
 								),
 							}

--- a/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.test.js
+++ b/js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.test.js
@@ -264,6 +264,17 @@ describe( 'CyoIncentivePicker Component', () => {
 		);
 	} );
 
+	it( 'should render the terms and conditions link with the URL from the API response', () => {
+		renderComponent();
+		const tcLink = screen.getByRole( 'link', {
+			name: /terms and conditions apply/i,
+		} );
+		expect( tcLink ).toHaveAttribute(
+			'href',
+			'https://example.com/terms-1'
+		);
+	} );
+
 	it( 'should track gla_cyo_incentive_selected with offer level when selecting a radio', () => {
 		render( <CyoIncentivePicker context="setup-mc" /> );
 		const radioButtons = screen.getAllByRole( 'radio' );

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -438,7 +438,7 @@ When a documentation link is clicked.
 	- with `{ context: 'setup-mc-accounts', link_id: 'google-mc-terms-of-service', href: 'https://support.google.com/merchants/answer/160173' }`
 	- with `{ context: 'setup-ads', link_id: 'google-ads-terms-of-service', href: 'https://support.google.com/adspolicy/answer/54818' }`
 - [`ConnectYouTubeAccountCard`](../../js/src/components/youtube-account-card/connect-youtube-account-card.js#L32) with `{ context: 'settings-connect-youtube-account-card', link_id: 'youtube-merchant-terms' }` and the URL.
-- [`CyoIncentivePicker`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L50) with `{ context: 'setup-ads' | 'setup-ads-only', link_id: 'incentives-terms-and-conditions-apply', href: 'https://ads.google.com/home/terms-and-conditions/incentives/' }`
+- [`CyoIncentivePicker`](../../js/src/components/paid-ads/ads-campaign/cyo-incentive-picker/cyo-incentive-picker.js#L50) with `{ context: 'setup-ads' | 'setup-ads-only', link_id: 'incentives-terms-and-conditions-apply', href: termsAndConditionsUrl }`
 - [`DifferentCurrencyNotice`](../../js/src/components/different-currency-notice.js#L28)
 	- with `{ context: "dashboard", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`
 	- with `{ context: "reports-products", link_id: "setting-up-currency", href: "https://support.google.com/google-ads/answer/9841530" }`


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-630/update-tc-urls

Dynamically changes the Terms and conditions URL based on the server response.


### Screenshots:

<img width="1065" height="412" alt="Screenshot 2026-05-08 at 16 05 37" src="https://github.com/user-attachments/assets/c238d44d-91d9-4747-8ae0-d2e47448040b" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the onboarding flow
2. In the description of the section "Ads credit offer", the "Terms and conditions apply" link should point to a URL locale based. E.g. `https://ads.google.com/intl/en_es/home/terms-and-conditions/incentives/?bc=ES&bid=s500g500%7Cib:6653296821%7C` instead of just `https://ads.google.com/home/terms-and-conditions/incentives/`


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Locale based terms & conditions link
