### PR TITLE
GOOWOO-592: Add delete market action

### DIFF
--- a/js/src/pages/markets/markets-dashboard/delete-market-modal/index.js
+++ b/js/src/pages/markets/markets-dashboard/delete-market-modal/index.js
@@ -20,7 +20,7 @@ import AppButton from '~/components/app-button';
  * @param {() => void} props.onRequestClose Called when the user cancels or after a successful delete.
  */
 const DeleteMarketModal = ( { market, onRequestClose } ) => {
-	const { deleteMarket } = useAppDispatch();
+	const { deleteMarket, invalidateResolution } = useAppDispatch();
 	const countryNames = useCountryKeyNameMap();
 	const [ deleting, setDeleting ] = useState( false );
 
@@ -30,6 +30,7 @@ const DeleteMarketModal = ( { market, onRequestClose } ) => {
 		setDeleting( true );
 		try {
 			await deleteMarket( market.id );
+			invalidateResolution( 'getTargetAudience', [] );
 			onRequestClose();
 		} catch ( error ) {
 			// `handleApiError` in the store action already dispatches an error
@@ -55,10 +56,10 @@ const DeleteMarketModal = ( { market, onRequestClose } ) => {
 				<AppButton
 					key="delete"
 					variant="primary"
-					isDestructive
 					onClick={ handleConfirm }
 					disabled={ deleting }
 					loading={ deleting }
+					isDestructive
 				>
 					{ __( 'Delete', 'google-listings-and-ads' ) }
 				</AppButton>,

--- a/js/src/pages/markets/markets-dashboard/delete-market-modal/index.js
+++ b/js/src/pages/markets/markets-dashboard/delete-market-modal/index.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useAppDispatch } from '~/data';
+import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
+import AppModal from '~/components/app-modal';
+import AppButton from '~/components/app-button';
+
+/**
+ * Confirmation modal for deleting a non-primary market.
+ *
+ * @param {Object} props
+ * @param {{ id: string, country?: string }} props.market The non-primary market being deleted.
+ * @param {() => void} props.onRequestClose Called when the user cancels or after a successful delete.
+ */
+const DeleteMarketModal = ( { market, onRequestClose } ) => {
+	const { deleteMarket } = useAppDispatch();
+	const countryNames = useCountryKeyNameMap();
+	const [ deleting, setDeleting ] = useState( false );
+
+	const marketName = countryNames[ market.country ];
+
+	const handleConfirm = async () => {
+		setDeleting( true );
+		try {
+			await deleteMarket( market.id );
+			onRequestClose();
+		} catch ( error ) {
+			// `handleApiError` in the store action already dispatches an error
+			// notice. We just need to re-enable the buttons so the user can
+			// retry or cancel.
+			setDeleting( false );
+		}
+	};
+
+	return (
+		<AppModal
+			title={ __( 'Delete market', 'google-listings-and-ads' ) }
+			onRequestClose={ deleting ? () => {} : onRequestClose }
+			buttons={ [
+				<AppButton
+					key="cancel"
+					variant="tertiary"
+					onClick={ onRequestClose }
+					disabled={ deleting }
+				>
+					{ __( 'Cancel', 'google-listings-and-ads' ) }
+				</AppButton>,
+				<AppButton
+					key="delete"
+					variant="primary"
+					isDestructive
+					onClick={ handleConfirm }
+					disabled={ deleting }
+					loading={ deleting }
+				>
+					{ __( 'Delete', 'google-listings-and-ads' ) }
+				</AppButton>,
+			] }
+		>
+			<p>
+				{ sprintf(
+					/* translators: %s: market name */
+					__(
+						'Are you sure you want to delete %s? This action cannot be undone.',
+						'google-listings-and-ads'
+					),
+					marketName
+				) }
+			</p>
+		</AppModal>
+	);
+};
+
+export default DeleteMarketModal;

--- a/js/src/pages/markets/markets-dashboard/delete-market-modal/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/delete-market-modal/index.test.js
@@ -1,0 +1,153 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import DeleteMarketModal from './';
+import { useAppDispatch } from '~/data';
+import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
+
+jest.mock( '~/data', () => ( {
+	useAppDispatch: jest.fn(),
+} ) );
+jest.mock( '~/hooks/useCountryKeyNameMap' );
+
+const NON_PRIMARY_MARKET = {
+	id: 'fr',
+	country: 'FR',
+	feed_label: 'FR',
+	language: 'fr',
+	currency: 'EUR',
+	shipping_rate: 'flat',
+	shipping_time: 'flat',
+	free_shipping: null,
+};
+
+describe( 'DeleteMarketModal', () => {
+	let deleteMarketMock;
+	let onRequestCloseMock;
+
+	beforeEach( () => {
+		deleteMarketMock = jest.fn().mockResolvedValue( undefined );
+		onRequestCloseMock = jest.fn();
+		useAppDispatch.mockReturnValue( { deleteMarket: deleteMarketMock } );
+		useCountryKeyNameMap.mockReturnValue( { FR: 'France' } );
+	} );
+
+	afterEach( () => {
+		useAppDispatch.mockReset();
+		useCountryKeyNameMap.mockReset();
+	} );
+
+	test( 'names the market in the body using the country name from the map', () => {
+		render(
+			<DeleteMarketModal
+				market={ NON_PRIMARY_MARKET }
+				onRequestClose={ onRequestCloseMock }
+			/>
+		);
+
+		expect( screen.getByText( /France/ ) ).toBeInTheDocument();
+	} );
+
+	test( 'Cancel calls onRequestClose without dispatching deleteMarket', async () => {
+		const user = userEvent.setup();
+		render(
+			<DeleteMarketModal
+				market={ NON_PRIMARY_MARKET }
+				onRequestClose={ onRequestCloseMock }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( onRequestCloseMock ).toHaveBeenCalledTimes( 1 );
+		expect( deleteMarketMock ).not.toHaveBeenCalled();
+	} );
+
+	test( 'Confirm dispatches deleteMarket( market.id ) and closes on success', async () => {
+		const user = userEvent.setup();
+		render(
+			<DeleteMarketModal
+				market={ NON_PRIMARY_MARKET }
+				onRequestClose={ onRequestCloseMock }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Delete' } ) );
+
+		await waitFor( () => {
+			expect( deleteMarketMock ).toHaveBeenCalledTimes( 1 );
+		} );
+		expect( deleteMarketMock ).toHaveBeenCalledWith(
+			NON_PRIMARY_MARKET.id
+		);
+		await waitFor( () => {
+			expect( onRequestCloseMock ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	test( 'disables both buttons while the request is in flight', async () => {
+		// Hold the promise open so we can observe the in-flight state.
+		let resolveDelete;
+		deleteMarketMock.mockReturnValue(
+			new Promise( ( resolve ) => {
+				resolveDelete = resolve;
+			} )
+		);
+
+		const user = userEvent.setup();
+		render(
+			<DeleteMarketModal
+				market={ NON_PRIMARY_MARKET }
+				onRequestClose={ onRequestCloseMock }
+			/>
+		);
+
+		const cancelButton = screen.getByRole( 'button', { name: 'Cancel' } );
+		const deleteButton = screen.getByRole( 'button', { name: 'Delete' } );
+
+		await user.click( deleteButton );
+
+		await waitFor( () => {
+			expect( deleteButton ).toBeDisabled();
+		} );
+		expect( cancelButton ).toBeDisabled();
+
+		resolveDelete();
+		await waitFor( () => {
+			expect( onRequestCloseMock ).toHaveBeenCalled();
+		} );
+	} );
+
+	test( 'on error, modal stays open and buttons are re-enabled', async () => {
+		deleteMarketMock.mockRejectedValue( new Error( 'boom' ) );
+
+		const user = userEvent.setup();
+		render(
+			<DeleteMarketModal
+				market={ NON_PRIMARY_MARKET }
+				onRequestClose={ onRequestCloseMock }
+			/>
+		);
+
+		const deleteButton = screen.getByRole( 'button', { name: 'Delete' } );
+		await user.click( deleteButton );
+
+		await waitFor( () => {
+			expect( deleteMarketMock ).toHaveBeenCalledTimes( 1 );
+		} );
+		expect( onRequestCloseMock ).not.toHaveBeenCalled();
+		await waitFor( () => {
+			expect( deleteButton ).toBeEnabled();
+		} );
+		expect(
+			screen.getByRole( 'button', { name: 'Cancel' } )
+		).toBeEnabled();
+	} );
+} );

--- a/js/src/pages/markets/markets-dashboard/delete-market-modal/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/delete-market-modal/index.test.js
@@ -35,7 +35,10 @@ describe( 'DeleteMarketModal', () => {
 	beforeEach( () => {
 		deleteMarketMock = jest.fn().mockResolvedValue( undefined );
 		onRequestCloseMock = jest.fn();
-		useAppDispatch.mockReturnValue( { deleteMarket: deleteMarketMock } );
+		useAppDispatch.mockReturnValue( {
+			deleteMarket: deleteMarketMock,
+			invalidateResolution: jest.fn(),
+		} );
 		useCountryKeyNameMap.mockReturnValue( { FR: 'France' } );
 	} );
 

--- a/js/src/pages/markets/markets-dashboard/market-data-views/index.js
+++ b/js/src/pages/markets/markets-dashboard/market-data-views/index.js
@@ -11,8 +11,10 @@ import { edit, trash } from '@wordpress/icons';
  */
 import { PRIMARY_MARKET_ID } from '../../constants';
 import useMarkets from '~/hooks/useMarkets';
+import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
 import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 import EditMarketModal from '../edit-market-modal';
+import DeleteMarketModal from '../delete-market-modal';
 import './index.scss';
 
 const FIELDS = [
@@ -52,21 +54,6 @@ const isPrimaryMarket = ( market ) => market.id === PRIMARY_MARKET_ID;
  * per shipping rate / multilingual store will be added in a follow-up task;
  * `shippingRate` is accepted today but currently ignored.
  *
- * Known design / implementation mismatches we are intentionally accepting to
- * stay on the built-in DataViews UI:
- *
- * - Figma asks for an always-visible "Edit" text button. DataViews only lifts
- *   actions out of the kebab menu when both `isPrimary` and `icon` are set,
- *   and renders them as an icon-only button (the label is exposed only as
- *   `aria-label`). The built-in stylesheet additionally hides primary action
- *   buttons until the row is hovered. We therefore ship an icon-only Edit that
- *   appears on hover; matching the Figma exactly would require dropping the
- *   built-in component, which isn't worth it for now.
- * - The primary market cannot be deleted, so the Delete action is gated by
- *   `isEligible` and simply omitted on the primary row (only Edit shows).
- *   The Delete callback is a placeholder until the real deletion flow is
- *   wired up.
- *
  * @param {Object} props
  * @param {string} [props.shippingRate] One of the values defined in `SHIPPING_RATE_METHOD`.
  */
@@ -78,23 +65,31 @@ const MarketDataViews = ( { shippingRate } ) => {
 	const { data: markets, hasFinishedResolution } = useMarkets();
 	const [ view, setView ] = useState( DEFAULT_VIEW );
 	const [ editingMarket, setEditingMarket ] = useState( null );
+	const [ deletingMarket, setDeletingMarket ] = useState( null );
 	const { targetAudience, loaded } = useTargetAudienceFinalCountryCodes();
+	const countryNames = useCountryKeyNameMap();
 
-	const rows = markets.map( ( market ) => ( {
-		...market,
-		market: sprintf(
-			// translators: 1: market label, 2: number of countries.
-			_n(
-				'%1$s (%2$d country)',
-				'%1$s (%2$d countries)',
-				market.countries.length,
-				'google-listings-and-ads'
-			),
-			market.label,
-			market.countries.length
-		),
-		shippingTime: market.shipping_time,
-	} ) );
+	const rows = markets.map( ( market ) => {
+		const marketCell = isPrimaryMarket( market )
+			? sprintf(
+					// translators: 1: market label, 2: number of countries.
+					_n(
+						'%1$s (%2$d country)',
+						'%1$s (%2$d countries)',
+						market.countries.length,
+						'google-listings-and-ads'
+					),
+					market.label,
+					market.countries.length
+			  )
+			: countryNames[ market.country ];
+
+		return {
+			...market,
+			market: marketCell,
+			shippingTime: market.shipping_time,
+		};
+	} );
 
 	const ACTIONS = [
 		{
@@ -112,7 +107,7 @@ const MarketDataViews = ( { shippingRate } ) => {
 			icon: trash,
 			isDestructive: true,
 			isEligible: ( market ) => ! isPrimaryMarket( market ),
-			callback: () => {},
+			callback: ( [ market ] ) => setDeletingMarket( market ),
 		},
 	];
 
@@ -138,6 +133,13 @@ const MarketDataViews = ( { shippingRate } ) => {
 					market={ editingMarket }
 					onRequestClose={ () => setEditingMarket( null ) }
 					targetAudience={ targetAudience }
+				/>
+			) }
+
+			{ deletingMarket && (
+				<DeleteMarketModal
+					market={ deletingMarket }
+					onRequestClose={ () => setDeletingMarket( null ) }
 				/>
 			) }
 		</>

--- a/js/src/pages/markets/markets-dashboard/market-data-views/index.test.js
+++ b/js/src/pages/markets/markets-dashboard/market-data-views/index.test.js
@@ -10,8 +10,10 @@ import userEvent from '@testing-library/user-event';
  */
 import MarketDataViews from './';
 import useMarkets from '~/hooks/useMarkets';
+import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
 
 jest.mock( '~/hooks/useMarkets' );
+jest.mock( '~/hooks/useCountryKeyNameMap' );
 
 jest.mock( '../edit-market-modal', () =>
 	jest.fn( ( { market, onRequestClose } ) => (
@@ -22,25 +24,34 @@ jest.mock( '../edit-market-modal', () =>
 	) )
 );
 
+jest.mock( '../delete-market-modal', () =>
+	jest.fn( ( { market, onRequestClose } ) => (
+		<div data-testid="delete-market-modal">
+			<span data-testid="delete-market-modal-id">{ market.id }</span>
+			<button onClick={ onRequestClose }>Close delete modal</button>
+		</div>
+	) )
+);
+
 const SAMPLE_MARKETS = [
 	{
 		id: 'primary',
 		label: 'Primary Market',
 		countries: [ 'MU', 'ZW' ],
+		country: 'ZW',
 		language: 'en',
 		currency: 'USD',
-		feedLabel: 'ZW',
+		feed_label: 'ZW',
 		shipping_rate: 'flat',
 		shipping_time: 'flat',
 		free_shipping: null,
 	},
 	{
-		id: 'secondary',
-		label: 'Secondary Market',
-		countries: [ 'FR' ],
+		id: 'fr',
+		country: 'FR',
 		language: 'fr',
 		currency: 'EUR',
-		feedLabel: 'FR',
+		feed_label: 'FR',
 		shipping_rate: 'table',
 		shipping_time: 'table',
 		free_shipping: null,
@@ -119,10 +130,16 @@ beforeEach( () => {
 		data: SAMPLE_MARKETS,
 		hasFinishedResolution: true,
 	} );
+	useCountryKeyNameMap.mockReturnValue( {
+		FR: 'France',
+		MU: 'Mauritius',
+		ZW: 'Zimbabwe',
+	} );
 } );
 
 afterEach( () => {
 	useMarkets.mockReset();
+	useCountryKeyNameMap.mockReset();
 	delete window.wp;
 } );
 
@@ -138,14 +155,19 @@ describe( 'MarketDataViews', () => {
 		).toBeInTheDocument();
 	} );
 
-	test( 'renders the Market cell as "<label> (<n> countries)"', () => {
+	test( 'renders the primary Market cell as "<label> (<n> countries)"', () => {
 		render( <MarketDataViews /> );
 
 		expect(
 			screen.getByRole( 'cell', { name: 'Primary Market (2 countries)' } )
 		).toBeInTheDocument();
+	} );
+
+	test( 'renders a non-primary Market cell as the country name', () => {
+		render( <MarketDataViews /> );
+
 		expect(
-			screen.getByRole( 'cell', { name: 'Secondary Market (1 country)' } )
+			screen.getByRole( 'cell', { name: 'France' } )
 		).toBeInTheDocument();
 	} );
 
@@ -207,7 +229,7 @@ describe( 'MarketDataViews', () => {
 		expect( deleteAction.isPrimary ).toBeFalsy();
 		expect( deleteAction.disabled ).toBeFalsy();
 		expect( deleteAction.isEligible( { id: 'primary' } ) ).toBe( false );
-		expect( deleteAction.isEligible( { id: 'secondary' } ) ).toBe( true );
+		expect( deleteAction.isEligible( { id: 'fr' } ) ).toBe( true );
 	} );
 
 	test( 'renders Delete only on non-primary market rows', () => {
@@ -222,7 +244,7 @@ describe( 'MarketDataViews', () => {
 			.getByRole( 'cell', { name: 'Primary Market (2 countries)' } )
 			.closest( 'tr' );
 		const secondaryRow = screen
-			.getByRole( 'cell', { name: 'Secondary Market (1 country)' } )
+			.getByRole( 'cell', { name: 'France' } )
 			.closest( 'tr' );
 
 		expect(
@@ -262,6 +284,51 @@ describe( 'MarketDataViews', () => {
 		expect(
 			screen.getByTestId( 'edit-market-modal-name' ).textContent
 		).toBe( SAMPLE_MARKETS[ 0 ].label );
+	} );
+
+	test( 'opens DeleteMarketModal with the clicked row when Delete is pressed', async () => {
+		const user = userEvent.setup();
+		render( <MarketDataViews /> );
+
+		expect(
+			screen.queryByTestId( 'delete-market-modal' )
+		).not.toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: 'Delete' } ) );
+
+		expect(
+			screen.getByTestId( 'delete-market-modal' )
+		).toBeInTheDocument();
+		expect(
+			screen.getByTestId( 'delete-market-modal-id' ).textContent
+		).toBe( 'fr' );
+	} );
+
+	test( 'closes DeleteMarketModal when onRequestClose is invoked', async () => {
+		const user = userEvent.setup();
+		render( <MarketDataViews /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Delete' } ) );
+		expect(
+			screen.getByTestId( 'delete-market-modal' )
+		).toBeInTheDocument();
+
+		await user.click(
+			screen.getByRole( 'button', { name: 'Close delete modal' } )
+		);
+		expect(
+			screen.queryByTestId( 'delete-market-modal' )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'opening Delete does not open Edit, and vice versa', async () => {
+		const user = userEvent.setup();
+		render( <MarketDataViews /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Delete' } ) );
+		expect(
+			screen.queryByTestId( 'edit-market-modal' )
+		).not.toBeInTheDocument();
 	} );
 
 	test( 'closes EditMarketModal when onRequestClose is invoked', async () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:


Closes GOOWOO-592.

Adds a confirmation modal for deleting non-primary markets from the Markets table, wired to the existing deleteMarket store action. Also branches the Market-cell rendering: primary keeps <label> (N countries), non-primary shows the country name (was crashing because both shapes used the primary's plural-array path).


### Screenshots:

<!--- Optional --->
<img width="3456" height="1986" alt="CleanShot 2026-05-08 at 18 34 38@2x" src="https://github.com/user-attachments/assets/f9cc93e6-f3ac-469c-8df9-c52734244ff4" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Until backend part is done, seed a market via the console:

```javascript
await wp.data.dispatch('wc/gla').createMarket({
    country: 'DE', language: 'en', currency: 'EUR',
    shipping_rate: 'flat', shipping_time: 'flat', free_shipping: null,
});
```

1. Primary row's kebab menu shows only Edit. Non-primary row shows Edit + Delete.
2. Delete → Cancel: modal closes, no request, row stays.
3. Delete → Delete: `DELETE /wc/gla/mc/markets/de` fires, modal closes, row disappears after the auto-refetch.
4. Throttle to Slow 3G and repeat (3): Delete button shows spinner, both buttons disabled, modal not dismissible until the request resolves.
5. Force a 500 error (block `*/mc/markets/de` in DevTools): modal stays open, buttons re-enable, error snackbar appears.
6. Edit on either row still opens the existing Edit modal.
7. `npm test` passes.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
