### PR TITLE
Fix: cache miss for empty recommendations on every admin page load

### DIFF
--- a/src/Ads/AdsRecommendationsService.php
+++ b/src/Ads/AdsRecommendationsService.php
@@ -80,7 +80,7 @@ class AdsRecommendationsService implements ContainerAwareInterface, OptionsAware
 		$transient = $this->transients->get( TransientsInterface::ADS_RECOMMENDATIONS );
 		$cache_key = md5( wp_json_encode( $args ) );
 
-		if ( $transient && ! empty( $transient[ $cache_key ] ) ) {
+		if ( is_array( $transient ) && array_key_exists( $cache_key, $transient ) ) {
 			return $transient[ $cache_key ];
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #3184.

The `get_recommendations()` method in `AdsRecommendationsService` used `! empty( $transient[ $cache_key ] )` to check for a cached result. This evaluates to `false` for an empty array, meaning stores with no active recommendations always miss the cache and trigger a live Google Ads API call on **every admin page load**, including products, orders, settings, and all WooCommerce admin pages.

The fix changes the check to `array_key_exists()`, matching the pattern already used in `AdsCampaign::get_highest_spend_campaign()` (introduced in #3263). This ensures an empty recommendations result is correctly served from the transient cache.

**Before:** ~1000–1500ms added to every admin page load for stores with no recommendations.
**After:** ~0.45ms (transient read) on all subsequent loads within the 12-hour TTL.


### Screenshots:

Before (without fix — 3 consecutive admin page loads):
[GLA] 1539.73ms
[GLA] 1010.05ms
[GLA]  977.48ms

After (with fix):
[GLA] 1360.28ms  ← cold cache, expected
[GLA]    0.45ms  ← cache hit

### Detailed test instructions:
  
1. Install the timing MU plugin to measure filter execution on every admin page load:
  ```php
  <?php
  // wp-content/mu-plugins/gla-perf-test.php
  add_action( 'admin_menu', function () {
      $t0 = microtime( true );
      apply_filters( 'google_for_woocommerce_admin_menu_notification_count', 0 );
      error_log( sprintf( '[GLA] %.2fms', ( microtime( true ) - $t0 ) * 1000 ) );
  }, 19 );
```
2. Clear the relevant transients: `wp transient delete gla_ads_recommendations` && `wp transient delete gla_ads_highest_spend_campaign`.
3. Tail your debug log: `tail -f /path/to/debug.log | grep "[GLA]"`
4. Load any WP admin page twice, confirm first load is slow (API call), second load is ~1ms (cache hit).
5. Test in `develop` without the fix and confirm that second load remains slow (~1000ms) without the fix.

### Changelog entry

> Fix - Cache miss for empty recommendations causing live Ads API calls on every admin page load.
