### PR TITLE
[GOOWOO-560] Create Markets REST Controller Amends

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/MarketsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/MarketsController.php
@@ -130,13 +130,10 @@ class MarketsController extends BaseController {
 	protected function get_create_market_callback(): callable {
 		return function ( Request $request ) {
 			$config = [
-				'country'       => $request->get_param( 'country' ),
-				'language'      => $request->get_param( 'language' ),
-				'currency'      => $request->get_param( 'currency' ),
-				'feed_label'    => strtoupper( $request->get_param( 'country' ) ),
-				'shipping_rate' => $request->get_param( 'shipping_rate' ),
-				'shipping_time' => $request->get_param( 'shipping_time' ),
-				'free_shipping' => $request->get_param( 'free_shipping' ),
+				'country'    => $request->get_param( 'country' ),
+				'language'   => $request->get_param( 'language' ),
+				'currency'   => $request->get_param( 'currency' ),
+				'feed_label' => strtoupper( $request->get_param( 'country' ) ),
 			];
 
 			// TODO: Move ID generation into MarketService::generate_market_id().
@@ -289,12 +286,9 @@ class MarketsController extends BaseController {
 		$schema = $this->get_schema_properties();
 
 		return [
-			'country'       => array_merge( $schema['country'], [ 'required' => true ] ),
-			'language'      => array_merge( $schema['language'], [ 'required' => true ] ),
-			'currency'      => array_merge( $schema['currency'], [ 'required' => true ] ),
-			'shipping_rate' => array_merge( $schema['shipping_rate'], [ 'required' => true ] ),
-			'shipping_time' => array_merge( $schema['shipping_time'], [ 'required' => true ] ),
-			'free_shipping' => $schema['free_shipping'],
+			'country'  => array_merge( $schema['country'], [ 'required' => true ] ),
+			'language' => array_merge( $schema['language'], [ 'required' => true ] ),
+			'currency' => array_merge( $schema['currency'], [ 'required' => true ] ),
 		];
 	}
 
@@ -409,7 +403,8 @@ class MarketsController extends BaseController {
 			'free_shipping' => [
 				'type'              => [ 'number', 'null' ],
 				'description'       => __( 'Free shipping threshold amount, or null when unset.', 'google-listings-and-ads' ),
-				'context'           => [ 'view', 'edit' ],
+				'context'           => [ 'view' ],
+				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 		];

--- a/src/API/Site/Controllers/MerchantCenter/MarketsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/MarketsController.php
@@ -133,7 +133,7 @@ class MarketsController extends BaseController {
 				'country'    => $request->get_param( 'country' ),
 				'language'   => $request->get_param( 'language' ),
 				'currency'   => $request->get_param( 'currency' ),
-				'feed_label' => strtoupper( $request->get_param( 'country' ) ),
+				'feed_label' => $request->get_param( 'country' ),
 			];
 
 			// TODO: Move ID generation into MarketService::generate_market_id().
@@ -398,13 +398,6 @@ class MarketsController extends BaseController {
 				'description'       => __( 'Shipping time configuration type.', 'google-listings-and-ads' ),
 				'context'           => [ 'view', 'edit' ],
 				'enum'              => [ 'flat', 'manual' ],
-				'validate_callback' => 'rest_validate_request_arg',
-			],
-			'free_shipping' => [
-				'type'              => [ 'number', 'null' ],
-				'description'       => __( 'Free shipping threshold amount, or null when unset.', 'google-listings-and-ads' ),
-				'context'           => [ 'view' ],
-				'readonly'          => true,
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 		];

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -244,7 +244,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( TargetAudience::class, WC::class, OptionsInterface::class, GoogleHelper::class );
 
 		// Set up the MarketService.
-		$this->share_with_tags( MarketService::class, TargetAudience::class, ShippingRateQuery::class, ShippingTimeQuery::class );
+		$this->share_with_tags( MarketService::class, TargetAudience::class, ShippingRateQuery::class, ShippingTimeQuery::class, WC::class );
 
 		// Set up MerchantCenter service, and inflect classes that need it.
 		$this->share_with_tags( MerchantCenterService::class );

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -47,20 +48,28 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	protected ShippingTimeQuery $shipping_time_query;
 
 	/**
+	 * @var WC
+	 */
+	protected WC $wc;
+
+	/**
 	 * MarketService constructor.
 	 *
 	 * @param TargetAudience    $target_audience
 	 * @param ShippingRateQuery $shipping_rate_query
 	 * @param ShippingTimeQuery $shipping_time_query
+	 * @param WC                $wc
 	 */
 	public function __construct(
 		TargetAudience $target_audience,
 		ShippingRateQuery $shipping_rate_query,
-		ShippingTimeQuery $shipping_time_query
+		ShippingTimeQuery $shipping_time_query,
+		WC $wc
 	) {
 		$this->target_audience     = $target_audience;
 		$this->shipping_rate_query = $shipping_rate_query;
 		$this->shipping_time_query = $shipping_time_query;
+		$this->wc                  = $wc;
 	}
 
 	/**
@@ -79,6 +88,21 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		$stored    = $this->options->get( OptionsInterface::MARKETS );
 		$secondary = is_array( $stored ) ? $stored : [];
 		unset( $secondary['primary'] );
+
+		$all_rates     = $this->shipping_rate_query->get_all_shipping_rates();
+		$all_countries = $this->wc->get_countries();
+
+		foreach ( $secondary as &$market ) {
+			$country = $market['country'] ?? null;
+
+			$market['free_shipping'] = ( $country && isset( $all_rates[ $country ]['free_shipping_threshold'] ) )
+				? (float) $all_rates[ $country ]['free_shipping_threshold']
+				: null;
+
+			$market['countries'] = $country ? [ $country ] : [];
+			$market['label']     = $country ? ( $all_countries[ $country ] ?? null ) : null;
+		}
+		unset( $market );
 
 		return [ 'primary' => $this->get_primary_market() ] + $secondary;
 	}
@@ -174,6 +198,16 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			throw new InvalidValue(
 				sprintf( 'The market ID "%s" is reserved and cannot be added.', $id )
 			);
+		}
+
+		$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
+		if ( ! isset( $config['shipping_rate'] ) ) {
+			$config['shipping_rate'] = $mc_settings['shipping_rate'] ?? 'flat';
+		}
+
+		if ( ! isset( $config['shipping_time'] ) ) {
+			$config['shipping_time'] = $mc_settings['shipping_time'] ?? 'flat';
 		}
 
 		$this->validate_secondary_market_config( $config );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -95,7 +95,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertArrayHasKey( 'countries', $primary );
 		$this->assertArrayHasKey( 'shipping_rate', $primary );
 		$this->assertArrayHasKey( 'shipping_time', $primary );
-		$this->assertArrayHasKey( 'free_shipping', $primary );
 	}
 
 	public function test_get_markets_primary_values_from_market_service(): void {
@@ -107,7 +106,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( [ 'US' ], $primary['countries'] );
 		$this->assertEquals( 'flat', $primary['shipping_rate'] );
 		$this->assertEquals( 'flat', $primary['shipping_time'] );
-		$this->assertEquals( 50.0, $primary['free_shipping'] );
 	}
 
 	public function test_get_languages_currencies_returns_200(): void {
@@ -428,7 +426,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertArrayHasKey( 'id', $secondary );
 		$this->assertArrayHasKey( 'label', $secondary );
 		$this->assertArrayHasKey( 'countries', $secondary );
-		$this->assertArrayHasKey( 'free_shipping', $secondary );
 		$this->assertEquals( 'gb', $secondary['id'] );
 		$this->assertEquals( 'United Kingdom (UK)', $secondary['label'] );
 		$this->assertEquals( [ 'GB' ], $secondary['countries'] );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -43,6 +43,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 	protected const SECONDARY_MARKET = [
 		'country'       => 'GB',
+		'label'         => 'United Kingdom (UK)',
+		'countries'     => [ 'GB' ],
 		'language'      => 'en',
 		'currency'      => 'GBP',
 		'feed_label'    => 'GB',
@@ -170,11 +172,9 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			self::ROUTE_MARKETS,
 			'POST',
 			[
-				'country'       => 'DE',
-				'language'      => 'de',
-				'currency'      => 'EUR',
-				'shipping_rate' => 'flat',
-				'shipping_time' => 'flat',
+				'country'  => 'DE',
+				'language' => 'de',
+				'currency' => 'EUR',
 			]
 		);
 
@@ -192,10 +192,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			self::ROUTE_MARKETS,
 			'POST',
 			[
-				'language'      => 'en',
-				'currency'      => 'GBP',
-				'shipping_rate' => 'flat',
-				'shipping_time' => 'flat',
+				'language' => 'en',
+				'currency' => 'GBP',
 			]
 		);
 
@@ -213,11 +211,9 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			self::ROUTE_MARKETS,
 			'POST',
 			[
-				'country'       => 'DE',
-				'language'      => 'de',
-				'currency'      => 'EUR',
-				'shipping_rate' => 'flat',
-				'shipping_time' => 'flat',
+				'country'  => 'DE',
+				'language' => 'de',
+				'currency' => 'EUR',
 			]
 		);
 
@@ -233,11 +229,9 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			self::ROUTE_MARKETS,
 			'POST',
 			[
-				'country'       => 'GB',
-				'language'      => 'en',
-				'currency'      => 'GBP',
-				'shipping_rate' => 'flat',
-				'shipping_time' => 'flat',
+				'country'  => 'GB',
+				'language' => 'en',
+				'currency' => 'GBP',
 			]
 		);
 
@@ -395,11 +389,9 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			self::ROUTE_MARKETS,
 			'POST',
 			[
-				'country'       => 'GB',
-				'language'      => 'en',
-				'currency'      => 'GBP',
-				'shipping_rate' => 'flat',
-				'shipping_time' => 'flat',
+				'country'  => 'GB',
+				'language' => 'en',
+				'currency' => 'GBP',
 			]
 		);
 
@@ -428,6 +420,90 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 403, $response->get_status() );
 	}
 
+	public function test_get_markets_secondary_has_correct_keys(): void {
+		$response  = $this->do_request( self::ROUTE_MARKETS );
+		$data      = $response->get_data();
+		$secondary = $data[1];
+
+		$this->assertArrayHasKey( 'id', $secondary );
+		$this->assertArrayHasKey( 'label', $secondary );
+		$this->assertArrayHasKey( 'countries', $secondary );
+		$this->assertArrayHasKey( 'free_shipping', $secondary );
+		$this->assertEquals( 'gb', $secondary['id'] );
+		$this->assertEquals( 'United Kingdom (UK)', $secondary['label'] );
+		$this->assertEquals( [ 'GB' ], $secondary['countries'] );
+	}
+
+	public function test_post_market_without_shipping_mode_succeeds(): void {
+		$created_market = [
+			'country'       => 'JP',
+			'language'      => 'ja',
+			'currency'      => 'JPY',
+			'feed_label'    => 'JP',
+			'shipping_rate' => 'flat',
+			'shipping_time' => 'flat',
+			'free_shipping' => null,
+		];
+
+		$created = false;
+
+		$this->market_service->method( 'add_market' )
+			->willReturnCallback(
+				function () use ( &$created ) {
+					$created = true;
+				}
+			);
+
+		$this->market_service->method( 'get_market' )
+			->willReturnCallback(
+				function ( string $id ) use ( &$created, $created_market ) {
+					if ( 'jp' === $id && $created ) {
+						return $created_market;
+					}
+					return null;
+				}
+			);
+
+		$response = $this->do_request(
+			self::ROUTE_MARKETS,
+			'POST',
+			[
+				'country'  => 'JP',
+				'language' => 'ja',
+				'currency' => 'JPY',
+			]
+		);
+
+		$this->assertEquals( 201, $response->get_status() );
+	}
+
+	public function test_post_market_free_shipping_cannot_be_set_in_payload(): void {
+		$this->market_service->method( 'get_market' )
+			->willReturnOnConsecutiveCalls( null, [] );
+
+		$this->market_service->expects( $this->once() )
+			->method( 'add_market' )
+			->with(
+				$this->anything(),
+				$this->callback(
+					function ( $config ) {
+						return ! array_key_exists( 'free_shipping', $config );
+					}
+				)
+			);
+
+		$this->do_request(
+			self::ROUTE_MARKETS,
+			'POST',
+			[
+				'country'       => 'JP',
+				'language'      => 'ja',
+				'currency'      => 'JPY',
+				'free_shipping' => 99.0,
+			]
+		);
+	}
+
 	public function test_put_only_sends_writable_params(): void {
 		$this->market_service->method( 'get_market' )
 			->with( 'primary' )
@@ -442,7 +518,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 						return isset( $params['shipping_rate'] )
 							&& ! isset( $params['id'] )
 							&& ! isset( $params['label'] )
-							&& ! isset( $params['feed_label'] );
+							&& ! isset( $params['feed_label'] )
+							&& ! isset( $params['free_shipping'] );
 					}
 				)
 			)

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -33,6 +34,9 @@ class MarketServiceTest extends UnitTest {
 	/** @var MockObject|ShippingTimeQuery */
 	protected $shipping_time_query;
 
+	/** @var MockObject|WC */
+	protected $wc;
+
 	/** @var MarketService */
 	protected $market_service;
 
@@ -43,11 +47,13 @@ class MarketServiceTest extends UnitTest {
 		$this->options             = $this->createMock( OptionsInterface::class );
 		$this->shipping_rate_query = $this->createMock( ShippingRateQuery::class );
 		$this->shipping_time_query = $this->createMock( ShippingTimeQuery::class );
+		$this->wc                  = $this->createMock( WC::class );
 
 		$this->market_service = new MarketService(
 			$this->target_audience,
 			$this->shipping_rate_query,
-			$this->shipping_time_query
+			$this->shipping_time_query,
+			$this->wc
 		);
 		$this->market_service->set_options_object( $this->options );
 	}
@@ -275,7 +281,13 @@ class MarketServiceTest extends UnitTest {
 		$this->market_service->add_market( 'gb', $config );
 
 		$this->assertArrayHasKey( OptionsInterface::MARKETS, $update_calls );
-		$this->assertSame( $config, $update_calls[ OptionsInterface::MARKETS ]['gb'] );
+		$stored_gb = $update_calls[ OptionsInterface::MARKETS ]['gb'];
+		$this->assertSame( 'GB', $stored_gb['country'] );
+		$this->assertSame( 'en', $stored_gb['language'] );
+		$this->assertSame( 'GBP', $stored_gb['currency'] );
+		$this->assertSame( 'GB', $stored_gb['feed_label'] );
+		$this->assertSame( 'flat', $stored_gb['shipping_rate'] );
+		$this->assertSame( 'flat', $stored_gb['shipping_time'] );
 
 		$this->assertArrayHasKey( OptionsInterface::TARGET_AUDIENCE, $update_calls );
 		$this->assertSame( [ 'US', 'CA' ], $update_calls[ OptionsInterface::TARGET_AUDIENCE ]['countries'] );
@@ -621,6 +633,150 @@ class MarketServiceTest extends UnitTest {
 		$this->assertArrayHasKey( 'currency', $result['primary'] );
 	}
 
+	public function test_get_markets_secondary_enriched_with_free_shipping_countries_and_label(): void {
+		$secondary = [
+			'de' => [
+				'country'    => 'DE',
+				'language'   => 'de',
+				'currency'   => 'EUR',
+				'feed_label' => 'DE',
+			],
+		];
+
+		$rates = [
+			'DE' => [
+				'country_code'            => 'DE',
+				'currency'                => 'EUR',
+				'rate'                    => '5.00',
+				'free_shipping_threshold' => 75.0,
+			],
+		];
+
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => $secondary ] );
+		$this->set_up_primary_market_dependencies(
+			'US',
+			[ 'US' ],
+			$rates,
+			[
+				'DE' => 'Germany',
+				'US' => 'United States (US)',
+			]
+		);
+
+		$result = $this->market_service->get_markets();
+
+		$this->assertSame( [ 'DE' ], $result['de']['countries'] );
+		$this->assertSame( 'Germany', $result['de']['label'] );
+		$this->assertSame( 75.0, $result['de']['free_shipping'] );
+	}
+
+	public function test_get_markets_secondary_free_shipping_null_when_no_rate_entry(): void {
+		$secondary = [
+			'fr' => [
+				'country'    => 'FR',
+				'language'   => 'fr',
+				'currency'   => 'EUR',
+				'feed_label' => 'FR',
+			],
+		];
+
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => $secondary ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$result = $this->market_service->get_markets();
+
+		$this->assertNull( $result['fr']['free_shipping'] );
+		$this->assertSame( [ 'FR' ], $result['fr']['countries'] );
+	}
+
+	public function test_add_market_defaults_shipping_mode_from_mc_settings_when_omitted(): void {
+		$mc_settings = [
+			'shipping_rate' => 'automatic',
+			'shipping_time' => 'manual',
+		];
+
+		$ta = [
+			'location'  => 'selected',
+			'countries' => [ 'US' ],
+		];
+
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [],
+				OptionsInterface::MERCHANT_CENTER => $mc_settings,
+				OptionsInterface::TARGET_AUDIENCE => $ta,
+			]
+		);
+
+		$update_calls = [];
+		$this->options->method( 'update' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$update_calls ) {
+					$update_calls[ $key ] = $value;
+					return true;
+				}
+			);
+
+		$this->market_service->add_market(
+			'jp',
+			[
+				'country'    => 'JP',
+				'language'   => 'ja',
+				'currency'   => 'JPY',
+				'feed_label' => 'JP',
+			]
+		);
+
+		$stored_jp = $update_calls[ OptionsInterface::MARKETS ]['jp'];
+		$this->assertSame( 'automatic', $stored_jp['shipping_rate'] );
+		$this->assertSame( 'manual', $stored_jp['shipping_time'] );
+	}
+
+	public function test_add_market_explicit_shipping_mode_takes_precedence_over_mc_settings(): void {
+		$mc_settings = [
+			'shipping_rate' => 'automatic',
+			'shipping_time' => 'automatic',
+		];
+
+		$ta = [
+			'location'  => 'selected',
+			'countries' => [ 'US' ],
+		];
+
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [],
+				OptionsInterface::MERCHANT_CENTER => $mc_settings,
+				OptionsInterface::TARGET_AUDIENCE => $ta,
+			]
+		);
+
+		$update_calls = [];
+		$this->options->method( 'update' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$update_calls ) {
+					$update_calls[ $key ] = $value;
+					return true;
+				}
+			);
+
+		$this->market_service->add_market(
+			'jp',
+			[
+				'country'       => 'JP',
+				'language'      => 'ja',
+				'currency'      => 'JPY',
+				'feed_label'    => 'JP',
+				'shipping_rate' => 'flat',
+				'shipping_time' => 'flat',
+			]
+		);
+
+		$stored_jp = $update_calls[ OptionsInterface::MARKETS ]['jp'];
+		$this->assertSame( 'flat', $stored_jp['shipping_rate'] );
+		$this->assertSame( 'flat', $stored_jp['shipping_time'] );
+	}
+
 	public function test_has_multilingual_support_returns_false(): void {
 		$this->assertFalse( $this->market_service->has_multilingual_support() );
 	}
@@ -670,16 +826,18 @@ class MarketServiceTest extends UnitTest {
 	}
 
 	/**
-	 * Sets up the TargetAudience and ShippingRateQuery mocks for primary market composition.
+	 * Sets up the TargetAudience, ShippingRateQuery, and WC mocks for primary market composition.
 	 *
 	 * @param string   $main_country     The main target country code.
 	 * @param string[] $target_countries  All target countries.
 	 * @param array    $shipping_rates    Optional shipping rates keyed by country.
+	 * @param array    $country_names     Optional map of country code => full name for WC::get_countries().
 	 */
 	private function set_up_primary_market_dependencies(
 		string $main_country,
 		array $target_countries,
-		array $shipping_rates = []
+		array $shipping_rates = [],
+		array $country_names = []
 	): void {
 		$this->target_audience->method( 'get_main_target_country' )
 			->willReturn( $main_country );
@@ -687,5 +845,7 @@ class MarketServiceTest extends UnitTest {
 			->willReturn( $target_countries );
 		$this->shipping_rate_query->method( 'get_all_shipping_rates' )
 			->willReturn( $shipping_rates );
+		$this->wc->method( 'get_countries' )
+			->willReturn( $country_names );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-560/create-markets-rest-controller
Related PR: https://github.com/woocommerce/google-listings-and-ads/pull/3361

### Screenshots:

N/A

### Detailed test instructions:

See the [previous PR](https://github.com/woocommerce/google-listings-and-ads/pull/3361) for the full original test steps. The following cover new and updated behaviour in this PR.                                                                                   
                                                            
  Before you start:                                                                                                                                                                                                
   
  *   Login to WP Admin                                                                                                                                                                                            
  *   Open the console                                      
  *   Verify `wp.apiFetch` is available by typing `wp.apiFetch` and pressing Enter; it should not return `undefined`.                                                                                              
                                                                                                                                                                                                                   
  1.  POST `/wc/gla/mc/markets`
                                                                                                                                                                                                                   
  Run this in console:                                      

```
     wp.apiFetch({
        path: '/wc/gla/mc/markets',
        method: 'POST',
        data: { country: 'DE', language: 'de', currency: 'EUR' }
      }).then(console.log).catch(console.error);                                                                                                                                                                   
```

Expectation: Response logged with status `201`. `shipping_rate` and `shipping_time` are present in the response, automatically inherited from the existing MC

<img width="745" height="376" alt="Screenshot 2026-05-12 at 13 34 27" src="https://github.com/user-attachments/assets/94271021-05e9-423e-8103-2b5e8981827c" />
settings — they do not need to be passed.          
                                                                                                                                                                                                                                                                                                                                                                                                                                     
  2.  GET `/wc/gla/mc/markets` (verify secondary market shape)

  After step 1, run: `wp.apiFetch({ path: '/wc/gla/mc/markets' }).then(console.log).catch(console.error);`                                                                                                         
   
  Expectation: The secondary market created in step 1 is present and has:                                                                                                                                          
                                                            
  *   `label` is the full country name (e.g. `"Germany"`)                                                                                                                                                          
  *   `countries` is a single-element array (e.g. `["DE"]`)
  *   `free_shipping` is null or a number

<img width="636" height="692" alt="Screenshot 2026-05-12 at 13 36 01" src="https://github.com/user-attachments/assets/aa70320e-acf8-43bf-b530-2ef1a5b95cfa" />

  3.  POST `/wc/gla/mc/markets` (free_shipping ignored in payload)                                                                                                                                                 
   
  Run this in console:                                                                                                                                                                                             

```                                                            
      wp.apiFetch({
        path: '/wc/gla/mc/markets',
        method: 'POST',
        data: { country: 'FR', language: 'fr', currency: 'EUR', free_shipping: 99 }
      }).then(console.log).catch(console.error);                                                                                                                                                                   
```

Expectation: Response logged with status `201`. The `free_shipping` value in the response comes from the shipping rates table, not the payload; passing it has no effect.                                       

<img width="749" height="384" alt="Screenshot 2026-05-12 at 13 37 17" src="https://github.com/user-attachments/assets/75d8fdf8-171b-46ae-a9d0-5f636797480c" />

  4.  POST `/wc/gla/mc/markets` (missing required field)                                                                                                                                                           
                                                            
  Run this in console:

```
     wp.apiFetch({
        path: '/wc/gla/mc/markets',
        method: 'POST',
        data: { language: 'en', currency: 'GBP' }
      }).then(console.log).catch(console.error);                                                                                                                                                                   
```

Expectation: Error response (400); response data will state `Missing parameter(s): country`                                                                                                                      

<img width="750" height="685" alt="Screenshot 2026-05-12 at 13 38 29" src="https://github.com/user-attachments/assets/4ff4d35c-96d3-4621-a6d3-af6de0df9d17" />

### Additional details:

> Add - Added Markets REST Controller