### PR TITLE
GW-683: Fix onboarding Continue button disabled when shipping times have default values

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/shipping-time-setup/shipping-countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time-setup/shipping-countries-form.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import VerticalGapLayout from '~/components/vertical-gap-layout';
@@ -25,6 +30,7 @@ export default function ShippingCountriesForm( {
 	audienceCountries,
 	onChange,
 } ) {
+	const mountedRef = useRef( false );
 	const actualCountryCount = shippingTimes.length;
 	const actualCountries = new Map(
 		shippingTimes.map( ( time ) => [ time.countryCode, time ] )
@@ -37,14 +43,23 @@ export default function ShippingCountriesForm( {
 	// Group countries with the same time.
 	const countriesTimeArray = getShippingTimesGroups( shippingTimes );
 
-	// Prefill to-be-added time.
-	if ( countriesTimeArray.length === 0 ) {
-		countriesTimeArray.push( {
-			countries: audienceCountries,
-			time: 1,
-			maxTime: 5,
-		} );
-	}
+	useEffect( () => {
+		if ( mountedRef.current ) {
+			return;
+		}
+		mountedRef.current = true;
+
+		// Prefill to-be-added time if there are selected audience countries, but no times provided yet.
+		if ( actualCountryCount === 0 && audienceCountries.length > 0 ) {
+			onChange(
+				audienceCountries.map( ( countryCode ) => ( {
+					countryCode,
+					time: 1,
+					maxTime: 5,
+				} ) )
+			);
+		}
+	}, [ audienceCountries, actualCountryCount, onChange ] );
 
 	// Given the limitations of `<Form>` component we can communicate up only onChange.
 	// Therefore we loose the information whether it was add, change, delete.

--- a/js/src/components/free-listings/configure-product-listings/shipping-time-setup/shipping-countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time-setup/shipping-countries-form.js
@@ -59,7 +59,7 @@ export default function ShippingCountriesForm( {
 				} ) )
 			);
 		}
-	}, [ audienceCountries, actualCountryCount, onChange ] );
+	} );
 
 	// Given the limitations of `<Form>` component we can communicate up only onChange.
 	// Therefore we loose the information whether it was add, change, delete.

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
 			},
 			{
 				"path": "./js/build/commons.js",
-				"maxSize": "85.60 kB"
+				"maxSize": "85.70 kB"
 			},
 			{
 				"path": "./js/build/vendors.js",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-683/onboarding-continue-button-disabled-despite-shipping-time-fields

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Disconnect all accounts (if connected) to start fresh, or manually clear the `wp_gla_shipping_times` and `wp_gla_shipping_rates` tables to simulate a first-time setup without full re-onboarding.
2. Begin the onboarding flow and proceed to the second step (Set up listings), ensuring you are on the non-service-based merchant path.
3. Verify the shipping time row is pre-populated with default values (min: 1 day, max: 5 days) without any user interaction.
4. Verify the "Continue" button is enabled without needing to manually interact with the shipping time fields.
5. Complete the onboarding flow and verify it finishes without errors.
6. Post-onboarding, navigate to the Shipping tab and verify there are no regressions in the shipping rate and time configuration.
7. Repeat steps 2–5 on the service-based merchant path to confirm the flow is unaffected.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Onboarding "Continue" button incorrectly disabled when shipping time fields are pre-populated with default values.
