### PR TITLE
GOOWOO-578: Use Icon component to render icons

### DIFF
--- a/js/src/pages/markets/market-data-views/index.js
+++ b/js/src/pages/markets/market-data-views/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
-import { edit, trash } from '@wordpress/icons';
+import { Icon, edit, trash } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -54,7 +54,11 @@ const MarketDataViews = () => {
 			{
 				id: 'edit',
 				label: __( 'Edit', 'google-listings-and-ads' ),
-				icon: loaded ? edit : <Spinner />,
+				icon: loaded ? (
+					<Icon icon={ edit } width={ 24 } height={ 24 } />
+				) : (
+					<Spinner />
+				),
 				isPrimary: true,
 				callback: loaded
 					? ( [ market ] ) => setEditingMarket( market )
@@ -63,7 +67,7 @@ const MarketDataViews = () => {
 			{
 				id: 'delete',
 				label: __( 'Delete', 'google-listings-and-ads' ),
-				icon: trash,
+				icon: <Icon icon={ trash } width={ 24 } height={ 24 } />,
 				isDestructive: true,
 				isEligible: ( market ) => ! isPrimaryMarket( market ),
 				callback: ( [ market ] ) => setDeletingMarket( market ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-578/update-editmarketmodal-to-edit-appropriate-fields-for-the-primary-feed

_Replace this with a good description of your changes & reasoning._
This is a follow up PR for the [following QA ](https://github.com/woocommerce/google-listings-and-ads/pull/3404#issuecomment-4488786987)observation.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the markets tab in Safari browser
2. Ensure the icons within the data views component render as expected.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
