### PR TITLE
GOOWOO-557: Fix card border-radius and double border on dashboard and settings

### DIFF
--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -43,6 +43,13 @@
 		&__header {
 			font-size: inherit;
 		}
+
+		// The card border-radius is applied by @wordpress/components via Emotion
+		// to the first/last card children (CardBody, CardFooter), not the card
+		// container. Without overflow: hidden, table content overflows those radii.
+		&__body:first-child {
+			overflow: hidden;
+		}
 	}
 
 	// Adjust InputControl suffix's empty right margin.

--- a/js/src/pages/dashboard/summary-section/summary-card.scss
+++ b/js/src/pages/dashboard/summary-section/summary-card.scss
@@ -1,4 +1,7 @@
 .gla-summary-card {
+	// Prevents child elements from overflowing the card's border-radius.
+	overflow: hidden;
+
 	> div:last-child {
 		// Make card contents within a row have the same height
 		flex: 1;
@@ -16,7 +19,6 @@
 		align-items: center;
 		height: 100%;
 		padding: var(--main-gap);
-		border: $border-width solid $gray-200;
 		background-color: #f8f9fa;
 		color: $gray-700;
 		text-align: center;


### PR DESCRIPTION
### Changes proposed in this Pull Request

Closes https://linear.app/a8c/issue/GOOWOO-557/dashboard-fix-card-borders

Fixes two visual issues with card components on the dashboard and settings pages in WordPress 6.9.4:

1. **Broken top corner border-radius** — The `@wordpress/components` Card applies its border-radius via Emotion CSS-in-JS to `CardBody` (the first child), not the card container. Without `overflow: hidden` on `CardBody`, table content renders over the rounded corners. Scoped to `.gla-admin-page` to avoid affecting other plugins.

2. **Double border on dashboard summary cards** — `.gla-summary-card__body` had an explicit `border: 1px solid` that created a second visible border on top of the card's existing `box-shadow` border. Removing it leaves a single clean border.

### Testing

Verified manually on WordPress 6.9.4 (Pressable staging):
- Attribute mapping table card: top-left corner now correctly rounded
- Dashboard summary card placeholder: single border, no duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)