### PR TITLE
GOOWOO-545: Update EU declaration modal title

### DIFF
--- a/js/src/components/eu-political-declaration/modal.js
+++ b/js/src/components/eu-political-declaration/modal.js
@@ -47,31 +47,22 @@ const Modal = ( { onRequestClose, eventContext } ) => {
 	const isEditOrDashboard =
 		eventContext === 'edit-ads' || eventContext === 'dashboard';
 
-	const { title, description } = isEditOrDashboard
-		? {
-				title: __(
-					'Campaign changes are paused for this Google Ads account',
-					'google-listings-and-ads'
-				),
-				description: __(
-					'To comply with EU political ads rules, you can’t create or edit campaigns in this account until the required declarations are added.',
-					'google-listings-and-ads'
-				),
-		  }
-		: {
-				title: __(
-					'Missing EU ads declaration',
-					'google-listings-and-ads'
-				),
-				description: __(
-					"You can't edit your campaigns until you complete the EU political ads declaration in Google Ads.",
-					'google-listings-and-ads'
-				),
-		  };
+	const description = isEditOrDashboard
+		? __(
+				'To comply with EU political ads rules, you can’t create or edit campaigns in this account until the required declarations are added.',
+				'google-listings-and-ads'
+		  )
+		: __(
+				"You can't edit your campaigns until you complete the EU political ads declaration in Google Ads.",
+				'google-listings-and-ads'
+		  );
 
 	return (
 		<AppModal
-			title={ title }
+			title={ __(
+				'Missing EU ads declaration',
+				'google-listings-and-ads'
+			) }
 			buttons={ [
 				<AppButton
 					key="go-to-google-ads"

--- a/js/src/components/eu-political-declaration/modal.js
+++ b/js/src/components/eu-political-declaration/modal.js
@@ -60,11 +60,11 @@ const Modal = ( { onRequestClose, eventContext } ) => {
 		  }
 		: {
 				title: __(
-					'Some campaigns are missing European Union (EU) ads status',
+					'Missing EU ads declaration',
 					'google-listings-and-ads'
 				),
 				description: __(
-					'Changes to any campaigns in this account are not allowed because EU political ads declarations are missing.',
+					"You can't edit your campaigns until you complete the EU political ads declaration in Google Ads.",
 					'google-listings-and-ads'
 				),
 		  };
@@ -89,6 +89,7 @@ const Modal = ( { onRequestClose, eventContext } ) => {
 			] }
 			onRequestClose={ onRequestClose }
 			className="gla-eu-political-declaration-modal"
+			size="small"
 		>
 			<p>{ description }</p>
 		</AppModal>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-545/eu-ad-declaration-modal-spacing-issue-with-wp-70-new-admin-screen

Update EU ads declaration modal title and description, use the small modal version

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the plugin dashboard
2. Edit a campaign that lacks the setting of the EU declaration
3. Modal should be triggered and title match the ACs

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Update EU declaration modal title
