### PR TITLE
GOOWOO-566: Clear free shipping threshold when flat rate is 0

### DIFF
--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -109,7 +109,7 @@ const SetupFreeListings = ( {
 			// Translate the single flat rate into the per-country array the API expects.
 			// Preserve any existing free_shipping_threshold per country, unless the
 			// new rate is free (0), in which case clear the threshold.
-			const isFree = ! ( change.value > 0 );
+			const isFree = change.value === 0;
 			const countries = resolveFinalCountries( values );
 			const existingByCountry = new Map(
 				values.shipping_country_rates.map( ( r ) => [ r.country, r ] )

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -107,16 +107,19 @@ const SetupFreeListings = ( {
 
 		if ( change.name === 'flat_shipping_rate' ) {
 			// Translate the single flat rate into the per-country array the API expects.
-			// Preserve any existing free_shipping_threshold per country.
+			// Preserve any existing free_shipping_threshold per country, unless the
+			// new rate is free (0), in which case clear the threshold.
+			const isFree = ! ( change.value > 0 );
 			const countries = resolveFinalCountries( values );
 			const existingByCountry = new Map(
 				values.shipping_country_rates.map( ( r ) => [ r.country, r ] )
 			);
 			const rates = countries.map( ( country ) => ( {
 				options: {
-					free_shipping_threshold:
-						existingByCountry.get( country )?.options
-							?.free_shipping_threshold,
+					free_shipping_threshold: isFree
+						? undefined
+						: existingByCountry.get( country )?.options
+								?.free_shipping_threshold,
 				},
 				country,
 				currency: currencyCode,

--- a/js/src/pages/markets/market-form.js
+++ b/js/src/pages/markets/market-form.js
@@ -37,23 +37,25 @@ function getCountryPredicate( isPrimaryMarket, values ) {
 }
 
 /**
- * Patches top-level fields on matching rate rows.
+ * Patches top-level fields and/or the `options` object on matching rate rows.
+ *
+ * @param {Array}    rates         Current rate rows.
+ * @param {Function} isTarget      Predicate — true for rows that should be patched.
+ * @param {Object}   [patch]       Top-level fields to merge onto matching rows.
+ * @param {Object}   [optionsPatch] Fields to merge into `row.options` on matching rows.
+ * @return {Array} New rate array with matching rows patched.
  */
-function updateRates( rates, isTarget, patch ) {
-	return rates.map( ( rate ) =>
-		isTarget( rate.country ) ? { ...rate, ...patch } : rate
-	);
-}
-
-/**
- * Patches the `options` object on matching rate rows (merges, does not replace).
- */
-function updateRateOptions( rates, isTarget, optionsPatch ) {
-	return rates.map( ( rate ) =>
-		isTarget( rate.country )
-			? { ...rate, options: { ...rate.options, ...optionsPatch } }
-			: rate
-	);
+function updateRateRows( rates, isTarget, patch, optionsPatch ) {
+	return rates.map( ( rate ) => {
+		if ( ! isTarget( rate.country ) ) return rate;
+		return {
+			...rate,
+			...patch,
+			...( optionsPatch !== undefined && {
+				options: { ...rate.options, ...optionsPatch },
+			} ),
+		};
+	} );
 }
 
 /**
@@ -179,20 +181,38 @@ const MarketForm = ( {
 		const times = values.shipping_country_times || [];
 
 		switch ( change.name ) {
-			case 'flat_shipping_rate':
+			case 'flat_shipping_rate': {
+				const isFree = ! ( change.value > 0 );
 				setValue(
 					'shipping_country_rates',
-					updateRates( rates, isTarget, { rate: change.value } )
+					updateRateRows(
+						rates,
+						isTarget,
+						{ rate: change.value },
+						isFree
+							? { free_shipping_threshold: undefined }
+							: undefined
+					)
 				);
+				if ( isFree ) {
+					setValue( 'free_shipping_threshold', undefined );
+					setValue( 'offer_free_shipping', false );
+				}
 				break;
+			}
 
 			case 'offer_free_shipping':
 				if ( change.value === false ) {
 					setValue(
 						'shipping_country_rates',
-						updateRateOptions( rates, isTarget, {
-							free_shipping_threshold: undefined,
-						} )
+						updateRateRows(
+							rates,
+							isTarget,
+							{},
+							{
+								free_shipping_threshold: undefined,
+							}
+						)
 					);
 				}
 				break;
@@ -214,9 +234,14 @@ const MarketForm = ( {
 			case 'free_shipping_threshold':
 				setValue(
 					'shipping_country_rates',
-					updateRateOptions( rates, isTarget, {
-						free_shipping_threshold: change.value,
-					} )
+					updateRateRows(
+						rates,
+						isTarget,
+						{},
+						{
+							free_shipping_threshold: change.value,
+						}
+					)
 				);
 				break;
 		}

--- a/js/src/pages/markets/market-form.js
+++ b/js/src/pages/markets/market-form.js
@@ -185,7 +185,7 @@ const MarketForm = ( {
 
 		switch ( change.name ) {
 			case 'flat_shipping_rate': {
-				const isFree = ! ( change.value > 0 );
+				const isFree = change.value === 0;
 				setValue(
 					'shipping_country_rates',
 					updateRateRows(

--- a/js/src/pages/markets/market-form.js
+++ b/js/src/pages/markets/market-form.js
@@ -47,7 +47,10 @@ function getCountryPredicate( isPrimaryMarket, values ) {
  */
 function updateRateRows( rates, isTarget, patch, optionsPatch ) {
 	return rates.map( ( rate ) => {
-		if ( ! isTarget( rate.country ) ) return rate;
+		if ( ! isTarget( rate.country ) ) {
+			return rate;
+		}
+
 		return {
 			...rate,
 			...patch,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-566/remove-country-selection-from-order-value-condition

_Replace this with a good description of your changes & reasoning._
QA feedback from: https://github.com/woocommerce/google-listings-and-ads/pull/3370#issuecomment-4486104463


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Repeat the steps as per the [following comment](https://github.com/woocommerce/google-listings-and-ads/pull/3370#issuecomment-4486104463).
2. Ensure the free shipping threshold is cleared correctly when free shipping applies.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
