### PR TITLE
GOOWOO-689: Add Shipping rate method selector to `Settings` page

### DIFF
--- a/js/src/components/shipping-rate-section/shipping-rate-method-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-method-section.js
@@ -1,0 +1,132 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import { glaData, SHIPPING_RATE_METHOD } from '~/constants';
+import Section from '~/components/section';
+import AppRadioContentControl from '~/components/app-radio-content-control';
+import RadioHelperText from '~/components/radio-helper-text';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import VerticalGapLayout from '~/components/vertical-gap-layout';
+import useSettings from '~/hooks/useSettings';
+import useMCSetup from '~/hooks/useMCSetup';
+
+/**
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
+ * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
+ *
+ * @param {Object} props
+ * @param {JSX.Element} props.children Optional children to render below the shipping rate method options.
+ */
+const ShippingRateMethodSection = ( { children } ) => {
+	const { getInputProps } = useAdaptiveFormContext();
+	const { settings } = useSettings();
+	const { hasFinishedResolution, data: mcSetup } = useMCSetup();
+	const inputProps = getInputProps( 'shipping_rate' );
+	const { isMultiLingualStore } = glaData;
+
+	// Hide the automatic shipping rate option if there are no shipping rates and the merchant is onboarding.
+	const hideAutomatticShippingRate =
+		! settings?.shipping_rates_count &&
+		hasFinishedResolution &&
+		mcSetup?.status === 'incomplete';
+
+	return (
+		<Section
+			title={ __( 'Shipping rates', 'google-listings-and-ads' ) }
+			description={
+				<div>
+					<p>
+						{ __(
+							'Your estimated shipping rates and times will be shown to potential customers on Google.',
+							'google-listings-and-ads'
+						) }
+					</p>
+					<p>
+						<AppDocumentationLink
+							context="setup-mc-shipping"
+							linkId="shipping-read-more"
+							href="https://support.google.com/merchants/answer/7050921"
+						>
+							{ __( 'Read more', 'google-listings-and-ads' ) }
+						</AppDocumentationLink>
+					</p>
+				</div>
+			}
+		>
+			<Section.Card>
+				<Section.Card.Body>
+					<VerticalGapLayout size="large">
+						{ ! hideAutomatticShippingRate && (
+							<AppRadioContentControl
+								{ ...inputProps }
+								label={ __(
+									'Automatically sync my store’s shipping settings to Google.',
+									'google-listings-and-ads'
+								) }
+								value={ SHIPPING_RATE_METHOD.AUTOMATIC }
+								collapsible
+							>
+								<RadioHelperText>
+									{ __(
+										'My current settings and any future changes to my store’s shipping rates and classes will be automatically synced to Google Merchant Center.',
+										'google-listings-and-ads'
+									) }
+								</RadioHelperText>
+							</AppRadioContentControl>
+						) }
+
+						{ ! isMultiLingualStore && (
+							<AppRadioContentControl
+								{ ...inputProps }
+								label={ __(
+									'My shipping settings are simple. I can manually estimate flat shipping rates.',
+									'google-listings-and-ads'
+								) }
+								value={ SHIPPING_RATE_METHOD.FLAT }
+								collapsible
+							/>
+						) }
+
+						<AppRadioContentControl
+							{ ...inputProps }
+							label={ __(
+								'My shipping settings are complex. I will enter my shipping rates and times manually in Google Merchant Center.',
+								'google-listings-and-ads'
+							) }
+							value={ SHIPPING_RATE_METHOD.MANUAL }
+							collapsible
+						>
+							<RadioHelperText>
+								{ createInterpolateElement(
+									__(
+										'I understand that if I don’t set this up manually in <link>Google Merchant Center</link>, my products will be disapproved by Google.',
+										'google-listings-and-ads'
+									),
+									{
+										link: (
+											<AppDocumentationLink
+												context="setup-mc-shipping"
+												linkId="shipping-manual"
+												href="https://www.google.com/retail/solutions/merchant-center/"
+											/>
+										),
+									}
+								) }
+							</RadioHelperText>
+						</AppRadioContentControl>
+					</VerticalGapLayout>
+				</Section.Card.Body>
+			</Section.Card>
+			{ children }
+		</Section>
+	);
+};
+
+export default ShippingRateMethodSection;

--- a/js/src/components/shipping-rate-section/shipping-rate-method-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-method-section.js
@@ -32,7 +32,7 @@ const ShippingRateMethodSection = ( { children } ) => {
 	const { isMultiLingualStore } = glaData;
 
 	// Hide the automatic shipping rate option if there are no shipping rates and the merchant is onboarding.
-	const hideAutomatticShippingRate =
+	const hideAutomaticShippingRate =
 		! settings?.shipping_rates_count &&
 		hasFinishedResolution &&
 		mcSetup?.status === 'incomplete';
@@ -63,7 +63,7 @@ const ShippingRateMethodSection = ( { children } ) => {
 			<Section.Card>
 				<Section.Card.Body>
 					<VerticalGapLayout size="large">
-						{ ! hideAutomatticShippingRate && (
+						{ ! hideAutomaticShippingRate && (
 							<AppRadioContentControl
 								{ ...inputProps }
 								label={ __(

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -6,6 +6,11 @@ import { glaData, SHIPPING_RATE_METHOD } from '~/constants';
 import FlatShippingRatesInputCards from './flat-shipping-rates-input-cards';
 import ShippingRateMethodSection from './shipping-rate-method-section';
 
+/**
+ * Renders the shipping rate method section on the Settings page, including the
+ * flat shipping rates input cards if the store is not multilingual and the
+ * selected shipping rate method is flat.
+ */
 const ShippingRateSection = () => {
 	const { values } = useAdaptiveFormContext();
 	const { isMultiLingualStore } = glaData;

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -1,133 +1,22 @@
 /**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import { useAdaptiveFormContext } from '~/components/adaptive-form';
 import { glaData, SHIPPING_RATE_METHOD } from '~/constants';
-import Section from '~/components/section';
-import AppRadioContentControl from '~/components/app-radio-content-control';
-import RadioHelperText from '~/components/radio-helper-text';
-import AppDocumentationLink from '~/components/app-documentation-link';
-import VerticalGapLayout from '~/components/vertical-gap-layout';
 import FlatShippingRatesInputCards from './flat-shipping-rates-input-cards';
-import useSettings from '~/hooks/useSettings';
-import useMCSetup from '~/hooks/useMCSetup';
-
-/**
- * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
- * @fires gla_documentation_link_click with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
- */
+import ShippingRateMethodSection from './shipping-rate-method-section';
 
 const ShippingRateSection = () => {
-	const { getInputProps, values } = useAdaptiveFormContext();
-	const { settings } = useSettings();
-	const { hasFinishedResolution, data: mcSetup } = useMCSetup();
-	const inputProps = getInputProps( 'shipping_rate' );
+	const { values } = useAdaptiveFormContext();
 	const { isMultiLingualStore } = glaData;
 
-	// Hide the automatic shipping rate option if there are no shipping rates and the merchant is onboarding.
-	const hideAutomatticShippingRate =
-		! settings?.shipping_rates_count &&
-		hasFinishedResolution &&
-		mcSetup?.status === 'incomplete';
-
 	return (
-		<Section
-			title={ __( 'Shipping rates', 'google-listings-and-ads' ) }
-			description={
-				<div>
-					<p>
-						{ __(
-							'Your estimated shipping rates and times will be shown to potential customers on Google.',
-							'google-listings-and-ads'
-						) }
-					</p>
-					<p>
-						<AppDocumentationLink
-							context="setup-mc-shipping"
-							linkId="shipping-read-more"
-							href="https://support.google.com/merchants/answer/7050921"
-						>
-							{ __( 'Read more', 'google-listings-and-ads' ) }
-						</AppDocumentationLink>
-					</p>
-				</div>
-			}
-		>
-			<Section.Card>
-				<Section.Card.Body>
-					<VerticalGapLayout size="large">
-						{ ! hideAutomatticShippingRate && (
-							<AppRadioContentControl
-								{ ...inputProps }
-								label={ __(
-									'Automatically sync my store’s shipping settings to Google.',
-									'google-listings-and-ads'
-								) }
-								value={ SHIPPING_RATE_METHOD.AUTOMATIC }
-								collapsible
-							>
-								<RadioHelperText>
-									{ __(
-										'My current settings and any future changes to my store’s shipping rates and classes will be automatically synced to Google Merchant Center.',
-										'google-listings-and-ads'
-									) }
-								</RadioHelperText>
-							</AppRadioContentControl>
-						) }
-
-						{ ! isMultiLingualStore && (
-							<AppRadioContentControl
-								{ ...inputProps }
-								label={ __(
-									'My shipping settings are simple. I can manually estimate flat shipping rates.',
-									'google-listings-and-ads'
-								) }
-								value={ SHIPPING_RATE_METHOD.FLAT }
-								collapsible
-							/>
-						) }
-
-						<AppRadioContentControl
-							{ ...inputProps }
-							label={ __(
-								'My shipping settings are complex. I will enter my shipping rates and times manually in Google Merchant Center.',
-								'google-listings-and-ads'
-							) }
-							value={ SHIPPING_RATE_METHOD.MANUAL }
-							collapsible
-						>
-							<RadioHelperText>
-								{ createInterpolateElement(
-									__(
-										'I understand that if I don’t set this up manually in <link>Google Merchant Center</link>, my products will be disapproved by Google.',
-										'google-listings-and-ads'
-									),
-									{
-										link: (
-											<AppDocumentationLink
-												context="setup-mc-shipping"
-												linkId="shipping-manual"
-												href="https://www.google.com/retail/solutions/merchant-center/"
-											/>
-										),
-									}
-								) }
-							</RadioHelperText>
-						</AppRadioContentControl>
-					</VerticalGapLayout>
-				</Section.Card.Body>
-			</Section.Card>
+		<ShippingRateMethodSection>
 			{ ! isMultiLingualStore &&
 				values.shipping_rate === SHIPPING_RATE_METHOD.FLAT && (
 					<FlatShippingRatesInputCards />
 				) }
-		</Section>
+		</ShippingRateMethodSection>
 	);
 };
 

--- a/js/src/pages/settings/index.js
+++ b/js/src/pages/settings/index.js
@@ -15,6 +15,7 @@ import { subpaths, getReconnectAccountUrl } from '~/utils/urls';
 import { ContactInformationPreview } from '~/components/contact-information';
 import TargetAudienceSection from '~/components/target-audience-section';
 import SetupTaxRate from './setup-tax-rate';
+import ShippingRateSettings from './shipping-rate-settings';
 import LinkedAccounts from './linked-accounts';
 import ReconnectWPComAccount from './reconnect-wpcom-account';
 import ReconnectGoogleAccount from './reconnect-google-account';
@@ -115,6 +116,7 @@ const Settings = () => {
 			{ hasGoogleMCConnection && (
 				<>
 					<ContactInformationPreview />
+					<ShippingRateSettings />
 					<SetupTaxRate />
 				</>
 			) }

--- a/js/src/pages/settings/shipping-rate-settings.js
+++ b/js/src/pages/settings/shipping-rate-settings.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useCallback } from '@wordpress/element';
-import { noop } from 'lodash';
 
 /**
  * Internal dependencies

--- a/js/src/pages/settings/shipping-rate-settings.js
+++ b/js/src/pages/settings/shipping-rate-settings.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useCallback } from '@wordpress/element';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import AdaptiveForm from '~/components/adaptive-form';
+import AppSpinner from '~/components/app-spinner';
+import Section from '~/components/section';
+import ShippingRateMethodSection from '~/components/shipping-rate-section/shipping-rate-method-section';
+import { SHIPPING_RATE_METHOD, SHIPPING_TIME_METHOD } from '~/constants';
+import useSettings from '~/hooks/useSettings';
+import { handleApiError } from '~/utils/handleError';
+
+/**
+ * Renders the shipping rate method selector on the Settings page with auto-save.
+ *
+ * Changing the shipping rate method immediately triggers a save and sync to
+ * Google Merchant Center — no submit button is required.
+ *
+ * @return {JSX.Element|null} The shipping rate settings component.
+ */
+const ShippingRateSettings = () => {
+	const { settings, saveSettings, syncSettings } = useSettings();
+
+	const handleChange = useCallback(
+		async ( change ) => {
+			if ( change.name !== 'shipping_rate' ) {
+				return;
+			}
+
+			const newShippingRate = change.value;
+			const coupledShippingTime =
+				newShippingRate === SHIPPING_RATE_METHOD.MANUAL
+					? SHIPPING_TIME_METHOD.MANUAL
+					: SHIPPING_TIME_METHOD.FLAT;
+
+			try {
+				await saveSettings( {
+					...settings,
+					shipping_rate: newShippingRate,
+					shipping_time: coupledShippingTime,
+				} );
+			} catch ( error ) {
+				handleApiError(
+					error,
+					__(
+						'There was an error saving the shipping rate method.',
+						'google-listings-and-ads'
+					)
+				);
+				return;
+			}
+
+			try {
+				await syncSettings();
+			} catch ( error ) {
+				handleApiError(
+					error,
+					__(
+						'There was an error synchronizing the shipping rate method to Google Merchant Center.',
+						'google-listings-and-ads'
+					)
+				);
+			}
+		},
+		[ settings, saveSettings, syncSettings ]
+	);
+
+	if ( settings === undefined ) {
+		return (
+			<Section>
+				<AppSpinner />
+			</Section>
+		);
+	}
+
+	if ( ! settings?.hasOwnProperty( 'shipping_rate' ) ) {
+		return null;
+	}
+
+	return (
+		<AdaptiveForm
+			initialValues={ { shipping_rate: settings.shipping_rate } }
+			onChange={ handleChange }
+		>
+			<ShippingRateMethodSection />
+		</AdaptiveForm>
+	);
+};
+
+export default ShippingRateSettings;

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -532,7 +532,7 @@ When a documentation link is clicked.
 - [`ReclaimUrlCard`](../../js/src/components/google-mc-account-card/reclaim-url-card/index.js#L42) with `{ context: 'setup-mc', link_id: 'claim-url', href: 'https://support.google.com/merchants/answer/176793' }`
 - [`RequestFullAccessGoogleAccountCard`](../../js/src/components/google-account-card/request-full-access-google-account-card.js#L26) with `{ context: 'setup-mc-accounts', link_id: 'required-google-permissions', href: 'https://woocommerce.com/document/google-for-woocommerce/get-started/setup-and-configuration/#required-google-permissions' }`
 - [`SetupEnhancedConversions`](../../js/src/pages/settings/enhanced-conversions/setup-enhanced-conversions.js#L24) with `{ context: 'setup-enhanced-conversions', link_id: 'enhanced-conversions-read-more', href: 'https://support.google.com/google-ads/answer/9888656' }`
-- [`ShippingRateSection`](../../js/src/components/shipping-rate-section/shipping-rate-section.js#L26)
+- [`ShippingRateMethodSection`](../../js/src/components/shipping-rate-section/shipping-rate-method-section.js#L27)
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
 	- with `{ context: 'setup-mc-shipping', link_id: 'shipping-manual', href: 'https://www.google.com/retail/solutions/merchant-center/' }`
 - [`ShippingTimeSection`](../../js/src/components/free-listings/configure-product-listings/shipping-time-section.js#L17) with `{ context: 'setup-mc-shipping', link_id: 'shipping-read-more', href: 'https://support.google.com/merchants/answer/7050921' }`
@@ -708,7 +708,7 @@ Clicking on the "connect to a different Google account" button.
 #### Emitters
 - [`SwitchAccountButton`](../../js/src/components/google-account-card/switch-account-button.js#L25)
 
-### [`gla_google_ads_promo_create_campaign_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L35)
+### [`gla_google_ads_promo_create_campaign_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L37)
 Google Ads Promo "Create campaign" button is clicked.
 #### Properties
 | name | type | description |
@@ -716,7 +716,7 @@ Google Ads Promo "Create campaign" button is clicked.
 `context` | `string` | Context of the Google Ads Promo.
 `href` | `string` | URL of the "Create campaign" button.
 #### Emitters
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L52) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&subpath=%2Fcampaigns%2Fcreate&path=%2Fgoogle%2Fdashboard' }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L54) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&subpath=%2Fcampaigns%2Fcreate&path=%2Fgoogle%2Fdashboard' }`.
 
 ### [`gla_google_ads_promo_dismiss_click`](../../js/src/meta-boxes/channel-visibility/promo-cta.js#L14)
 Google Ads Promo "Dismiss" button is clicked.
@@ -736,9 +736,9 @@ Google Ads Promo "Get started" button is clicked.
 `href` | `string` | URL of the "Get started" button.
 #### Emitters
 - [`GetStartedCTA`](../../js/src/meta-boxes/channel-visibility/get-started-cta.js#L28) with `{ context: channel-visibility-meta-box, href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc' }`.
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L52) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc' }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L54) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc' }`.
 
-### [`gla_google_ads_promo_get_started_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L27)
+### [`gla_google_ads_promo_get_started_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L29)
 Google Ads Promo "Get started" button is clicked.
 #### Properties
 | name | type | description |
@@ -747,27 +747,27 @@ Google Ads Promo "Get started" button is clicked.
 `href` | `string` | URL of the "Get started" button.
 #### Emitters
 - [`GetStartedCTA`](../../js/src/meta-boxes/channel-visibility/get-started-cta.js#L28) with `{ context: channel-visibility-meta-box, href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc' }`.
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L52) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc' }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L54) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc' }`.
 
-### [`gla_google_ads_promo_shown`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L27)
+### [`gla_google_ads_promo_shown`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L28)
 Google Ads Promo banner is shown.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | Context of the Google Ads Promo.
 #### Emitters
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L41) with `{ context: channel-visibility-meta-box }`.
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L52) with `{ context: 'order-attribution-meta-box' }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L42) with `{ context: channel-visibility-meta-box }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L54) with `{ context: 'order-attribution-meta-box' }`.
 
-### [`gla_google_ads_promo_shown`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L20)
+### [`gla_google_ads_promo_shown`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L22)
 Google Ads Promo component is shown.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | Context of the Google Ads Promo.
 #### Emitters
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L41) with `{ context: channel-visibility-meta-box }`.
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L52) with `{ context: 'order-attribution-meta-box' }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L42) with `{ context: channel-visibility-meta-box }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L54) with `{ context: 'order-attribution-meta-box' }`.
 
 ### [`gla_google_mc_link_click`](../../js/src/utils/tracks.js#L195)
 Clicking on a Google Merchant Center link.
@@ -986,7 +986,7 @@ Triggered when moving to another step during creating/editing a campaign.
 - [`CreatePaidAdsCampaign`](../../js/src/pages/create-paid-ads-campaign/index.js#L50)
 	- with `{ context: 'create-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
 	- with `{ context: 'create-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
-- [`EditPaidAdsCampaign`](../../js/src/pages/edit-paid-ads-campaign/index.js#L70)
+- [`EditPaidAdsCampaign`](../../js/src/pages/edit-paid-ads-campaign/index.js#L71)
 	- with `{ context: 'edit-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
 	- with `{ context: 'edit-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
 
@@ -1181,19 +1181,19 @@ Setup Merchant Center
 	- with `{ triggered_by: 'stepper-step1-button' | 'stepper-step2-button', action: 'go-to-step1' | 'go-to-step2' }`.
 - [`SetupTopBar`](../../js/src/pages/onboarding/setup-top-bar.js#L17) with `{ triggered_by: 'back-button', action: 'leave' }`.
 
-### [`gla_shipping_notice_merchant_center_link_click`](../../js/src/pages/markets/market-fields/shipping-section/shipping-notice/index.js#L20)
+### [`gla_shipping_notice_merchant_center_link_click`](../../js/src/pages/markets/market-fields/shipping-section/shipping-notice/index.js#L19)
 
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `url` | `string` | The URL of the link that was clicked.
 #### Emitters
-- [`ShippingNotice`](../../js/src/pages/markets/market-fields/shipping-section/shipping-notice/index.js#L30) when the Merchant Center link in the notice is clicked.
+- [`ShippingNotice`](../../js/src/pages/markets/market-fields/shipping-section/shipping-notice/index.js#L29) when the Merchant Center link in the notice is clicked.
 
-### [`gla_shipping_rate_notice_shipping_settings_link_click`](../../js/src/pages/markets/market-fields/shipping-section/shipping-rate-controls/shipping-rate-notice/index.js#L14)
+### [`gla_shipping_rate_notice_shipping_settings_link_click`](../../js/src/pages/markets/market-fields/shipping-section/shipping-rate-controls/shipping-rate-notice/index.js#L13)
 
 #### Emitters
-- [`ShippingRateNotice`](../../js/src/pages/markets/market-fields/shipping-section/shipping-rate-controls/shipping-rate-notice/index.js#L23) When the shipping settings link in the notice is clicked.
+- [`ShippingRateNotice`](../../js/src/pages/markets/market-fields/shipping-section/shipping-rate-controls/shipping-rate-notice/index.js#L22) When the shipping settings link in the notice is clicked.
 
 ### [`gla_skip_campaign_creation_survey`](../../js/src/pages/onboarding/setup-stepper/skip-paid-ads-confirmation-modal/survey-modal.js#L22)
 Send survey responses when the user skips the paid ads setup.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-689/add-shipping-rate-method-selector-to-settings-page-with-auto-save

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the Settings page.
2. There should be a new "Shipping rates" section.
3. The shipping rate method should automatically be saved upon change in the background.
4. Refresh the page and see if the change is persistent.
5. The "Shipping rates" section in the "Shipping" tab should have the same value as on the "Settings" tab.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
