### PR TITLE
Style dropdown of AppSearchableSelectControl.

### DIFF
--- a/js/src/components/app-searchable-select-control/index.scss
+++ b/js/src/components/app-searchable-select-control/index.scss
@@ -8,10 +8,30 @@
 		text-transform: uppercase;
 	}
 
+	.gla-searchable-select-control__input {
+		position: relative;
+
+		&::after {
+			background-color: currentcolor;
+			content: "";
+			display: block;
+			height: 1.5rem;
+			mask-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyNCAyNCc+PHBhdGggZmlsbD0nd2hpdGUnIGQ9J00xNS45OSAxMC44OSAxMiAxNC4zbC0zLjk5LTMuNDJMOSA5Ljc1bDMgMi41OCAzLjAxLTIuNTh6Jy8+PC9zdmc+);
+			mask-position: center;
+			mask-repeat: no-repeat;
+			mask-size: contain;
+			position: absolute;
+			right: 8px;
+			top: 50%;
+			transform: translateY(-50%);
+			width: 1.5rem;
+		}
+	}
+
 	.woocommerce-select-control .components-base-control {
 		border-color: $gray-600;
 		border-radius: 2px;
-		padding: 2px 2px 2px 8px;
+		padding: 2px 44px 2px 8px; // 44px right padding for the chevron icon.
 	}
 
 	.woocommerce-select-control .woocommerce-select-control__listbox {

--- a/js/src/components/app-searchable-select-control/index.scss
+++ b/js/src/components/app-searchable-select-control/index.scss
@@ -31,7 +31,7 @@
 	.woocommerce-select-control .components-base-control {
 		border-color: $gray-600;
 		border-radius: 2px;
-		padding: 2px 44px 2px 8px; // 44px right padding for the chevron icon.
+		padding: 4px 44px 4px 8px; // 44px right padding for the chevron icon.
 	}
 
 	.woocommerce-select-control .woocommerce-select-control__listbox {
@@ -57,5 +57,9 @@
 
 	.woocommerce-select-control__control-icon {
 		display: none;
+	}
+
+	.woocommerce-select-control .components-base-control .woocommerce-select-control__control-input {
+		min-height: 26px;
 	}
 }

--- a/js/src/components/app-searchable-select-control/index.scss
+++ b/js/src/components/app-searchable-select-control/index.scss
@@ -14,8 +14,28 @@
 		padding: 2px 2px 2px 8px;
 	}
 
+	.woocommerce-select-control .woocommerce-select-control__listbox {
+		border: 1.5px solid var(--wp-admin-theme-color, #3858e9);
+		border-radius: 2px;
+		box-shadow: none;
+		top: calc(100% + 8px);
+	}
+
 	.gla-searchable-select-control__helper-text {
 		font-style: normal;
 		color: $gray-700;
+	}
+
+	.woocommerce-select-control__option {
+		font-size: $gla-font-base;
+		font-weight: 400;
+		height: unset;
+		line-height: $gla-line-height-medium;
+		min-height: unset;
+		padding: 6px 12px;
+	}
+
+	.woocommerce-select-control__control-icon {
+		display: none;
 	}
 }

--- a/js/src/meta-boxes/channel-visibility/google-ads-promo.scss
+++ b/js/src/meta-boxes/channel-visibility/google-ads-promo.scss
@@ -31,11 +31,11 @@
 
 .gla-channel-visibility__sync-notice .components-notice__content {
 
-	& > p:first-child {
+	> p:first-child {
 		margin-top: 0;
 	}
 
-	& > p:last-child {
+	> p:last-child {
 		margin-bottom: 0;
 	}
 }

--- a/js/src/pages/markets/market-fields/locale-section/currency-select-control.js
+++ b/js/src/pages/markets/market-fields/locale-section/currency-select-control.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/js/src/pages/markets/market-fields/locale-section/currency-select-control.js
+++ b/js/src/pages/markets/market-fields/locale-section/currency-select-control.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -62,6 +63,7 @@ const CurrencySelectControl = () => {
 				} }
 				inlineTags
 				multiple
+				isSearchable
 			/>
 			{ renderRequestedValidation( 'currency' ) }
 		</div>

--- a/js/src/pages/markets/market-fields/locale-section/language-select-control.js
+++ b/js/src/pages/markets/market-fields/locale-section/language-select-control.js
@@ -66,6 +66,7 @@ const LanguageSelectControl = () => {
 				) }
 				inlineTags
 				multiple
+				isSearchable
 			/>
 			{ renderRequestedValidation( 'language' ) }
 		</div>

--- a/js/src/pages/markets/markets-header/index.scss
+++ b/js/src/pages/markets/markets-header/index.scss
@@ -21,8 +21,6 @@
 		@include placeholder;
 		// The mixin's default `$gray-100` matches the WP admin page background,
 		// so bump it one shade darker to keep the skeleton visible here.
-		& {
-			background-color: $gray-200;
-		}
+		background-color: $gray-200;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes [GOOWOO-680](https://linear.app/a8c/issue/GOOWOO-680/style-searchableselectcontrol-dropdown-to-match-figma-designs)

Styles were added to the `AppSearchableSelectControl` wrapper component to improve the appearance of the dropdown listbox, list options, and the control icon.

**Notes:**

- `SearchableSelectControl` in `js/src/components/searchable-select-control/index.scss` carries two-year-old CSS hacks and overrides that could produce unexpected results if modified. To avoid interfering with those, all new style rules are scoped to `.gla-app-searchable-select-control`, which is only applied by `AppSearchableSelectControl `— currently used exclusively by `LanguageSelectControl `and `CurrencySelectControl `in the locale section of the market form.
- As part of this work, `CurrencySelectControl` was also updated with an expanded placeholder options list (10 currencies), `isSearchable` enabled, and a wired-up `onChange` handler in preparation for the real data integration.
- Some linting errors present in unrelated CSS files were also addressed as part of this work.

### Screenshots:

**Design**

<img width="504" height="403" alt="Screenshot 2026-05-22 at 13 09 02" src="https://github.com/user-attachments/assets/fa1d457d-57a1-4242-8c9f-dcf342f962d3" />

**Implementation**

<img width="822" height="363" alt="Screenshot 2026-05-22 at 13 21 22" src="https://github.com/user-attachments/assets/3664b91e-a9e9-4c5f-9212-3890b89b9920" />

**Notes on the implemented design:**
1. The `SearchControl` component from WooCommerce does not support displaying the search field above the options as in the design. I have discussed this with @asvinb and agreed that we will not attempt to move the search field to match the design.
2. The design of the labels has not been implemented as part of this ticket.


### Detailed test instructions:

1. Navigate to the "Shipping" tab and ensure your Shipping rates option is set to "Automatically sync my store’s shipping settings to Google." 
2. Open your browser console and type in `glaData.isMultiLingualStore = true` and hit Enter.
3. Navigate to the "Markets" tab.
4. Click the Edit symbol next to one of your markets in the list of markets.
5. You should now be able to see and test the dropdown under the "Currency" label.

Please note that the Languages dropdown won't be populated unless you're using an actual multi language plugin. We are simulating using the plugin by typing in the `glaData.isMultiLingualStore = true` command in the browser console. This causes the dropdown fields to be displayed but languages won't be populated because there is no plugin to fetch options from.