### PR TITLE
Add/goowoo 598 goowoo 602 update use market data views config

### DIFF
--- a/js/src/hooks/useMarketDataViewsConfig.js
+++ b/js/src/hooks/useMarketDataViewsConfig.js
@@ -64,7 +64,7 @@ const isPrimaryMarket = ( market ) => market.id === PRIMARY_MARKET_ID;
  * - Manual non-multilingual: Market, Country (count), Shipping (static "Managed in Google"). Only primary market shown.
  * - Manual multilingual: Market (label + country count for primary, country name for secondaries), Language, Currency. All markets shown.
  * - Flat (multilingual or not): Market (label + country count for primary), Shipping Rate, Shipping Time, Free shipping. All markets shown. Both store types render identically per Figma; the multilingual variant of this scenario is GOOWOO-602.
- * - Automatic multilingual: Market, Language, Currency, Shipping time. All markets shown.
+ * - Automatic multilingual: Market (label + country count for primary), Language, Currency, Shipping time. All markets shown.
  * - Automatic non-multilingual: Market (label + country count), Shipping time. Only primary market shown.
  * - Default/fall-through: Market + Shipping time for all markets, with primary market showing country count in label.
  */
@@ -358,7 +358,7 @@ const buildFlatConfig = ( { markets, ratesByCountry, timesByCountry } ) => {
  * Automatic shipping scenario. The column set differs based on whether the store
  * has multilingual support:
  *
- * - Multilingual: Market, Language, Currency, Shipping time — all markets as rows.
+ * - Multilingual: Market (label + country count for primary, country name for secondaries), Language, Currency, Shipping time — all markets as rows.
  * - Non-multilingual: Market (label + country count), Shipping time — primary market only.
  *
  * @param {Object}                  options
@@ -382,12 +382,31 @@ const buildAutomaticConfig = ( {
 			ALL_FIELDS.shippingTime,
 		];
 
-		const data = markets.map( ( market ) => ( {
-			...market,
-			shippingTime: formatShippingTime(
-				timesByCountry[ market.country ]
-			),
-		} ) );
+		const data = markets.map( ( market ) => {
+			const row = {
+				...market,
+				shippingTime: formatShippingTime(
+					timesByCountry[ market.country ]
+				),
+			};
+
+			if ( isPrimaryMarket( market ) ) {
+				const countryCount = market.countries?.length ?? 0;
+				row.label = sprintf(
+					// translators: 1: market label, 2: number of countries.
+					_n(
+						'%1$s (%2$d country)',
+						'%1$s (%2$d countries)',
+						countryCount,
+						'google-listings-and-ads'
+					),
+					market.label,
+					countryCount
+				);
+			}
+
+			return row;
+		} );
 
 		return { fields, data };
 	}

--- a/js/src/hooks/useMarketDataViewsConfig.js
+++ b/js/src/hooks/useMarketDataViewsConfig.js
@@ -63,7 +63,7 @@ const isPrimaryMarket = ( market ) => market.id === PRIMARY_MARKET_ID;
  * Scenarios:
  * - Manual non-multilingual: Market, Country (count), Shipping (static "Managed in Google"). Only primary market shown.
  * - Manual multilingual: Market (label + country count for primary, country name for secondaries), Language, Currency. All markets shown.
- * - Flat: Market, Shipping Rate, Shipping Time, Free shipping. All markets shown.
+ * - Flat (multilingual or not): Market, Shipping Rate, Shipping Time, Free shipping. All markets shown. Both store types render identically per Figma; the multilingual variant of this scenario is GOOWOO-602.
  * - Automatic multilingual: Market, Language, Currency, Shipping time. All markets shown.
  * - Automatic non-multilingual: Market (label + country count), Shipping time. Only primary market shown.
  * - Default/fall-through: Market + Shipping time for all markets, with primary market showing country count in label.
@@ -297,6 +297,10 @@ const buildManualConfig = ( {
  * Flat shipping scenario: Market, Shipping Rate, Shipping Time, Free shipping.
  * All markets (primary and additional) appear as rows.
  *
+ * Covers both non-multilingual and multilingual stores — Figma renders both
+ * frames identically, so the builder is shared rather than branched on
+ * `isMultiLingualStore`. The multilingual variant is tracked as GOOWOO-602.
+ *
  * @param {Object}                  options
  * @param {Market[]}               options.markets        All markets from useMarkets.
  * @param {Object.<string,RateRow>} options.ratesByCountry Country-keyed map of shipping rate rows.
@@ -401,10 +405,9 @@ const buildAutomaticConfig = ( {
 
 /**
  * Fall-through default — preserves the legacy Market + Shipping times shape for
- * any scenario that doesn't yet have a dedicated builder.
- *
- * TODO: Remove once all scenarios have explicit branches:
- *   - GOOWOO-602: flat + multilingual variant.
+ * any scenario that doesn't yet have a dedicated builder. With every documented
+ * scenario now branched, this only catches unexpected `shipping_rate` values
+ * and serves as a safety net.
  *
  * @param {Object}              options
  * @param {Market[]}           options.markets      All markets from useMarkets.

--- a/js/src/hooks/useMarketDataViewsConfig.js
+++ b/js/src/hooks/useMarketDataViewsConfig.js
@@ -63,7 +63,7 @@ const isPrimaryMarket = ( market ) => market.id === PRIMARY_MARKET_ID;
  * Scenarios:
  * - Manual non-multilingual: Market, Country (count), Shipping (static "Managed in Google"). Only primary market shown.
  * - Manual multilingual: Market (label + country count for primary, country name for secondaries), Language, Currency. All markets shown.
- * - Flat (multilingual or not): Market, Shipping Rate, Shipping Time, Free shipping. All markets shown. Both store types render identically per Figma; the multilingual variant of this scenario is GOOWOO-602.
+ * - Flat (multilingual or not): Market (label + country count for primary), Shipping Rate, Shipping Time, Free shipping. All markets shown. Both store types render identically per Figma; the multilingual variant of this scenario is GOOWOO-602.
  * - Automatic multilingual: Market, Language, Currency, Shipping time. All markets shown.
  * - Automatic non-multilingual: Market (label + country count), Shipping time. Only primary market shown.
  * - Default/fall-through: Market + Shipping time for all markets, with primary market showing country count in label.
@@ -325,12 +325,30 @@ const buildFlatConfig = ( { markets, ratesByCountry, timesByCountry } ) => {
 
 		const rateRow = ratesByCountry[ country ];
 		const timeRow = timesByCountry[ country ];
-		return {
+
+		const row = {
 			...market,
 			shippingRate: formatShippingRate( rateRow ),
 			shippingTime: formatShippingTime( timeRow ),
 			freeShipping: formatFreeShipping( rateRow ),
 		};
+
+		if ( isPrimaryMarket( market ) ) {
+			const countryCount = market.countries?.length ?? 0;
+			row.label = sprintf(
+				// translators: 1: market label, 2: number of countries.
+				_n(
+					'%1$s (%2$d country)',
+					'%1$s (%2$d countries)',
+					countryCount,
+					'google-listings-and-ads'
+				),
+				market.label,
+				countryCount
+			);
+		}
+
+		return row;
 	} );
 
 	return { fields, data };

--- a/js/src/hooks/useMarketDataViewsConfig.js
+++ b/js/src/hooks/useMarketDataViewsConfig.js
@@ -61,7 +61,8 @@ const isPrimaryMarket = ( market ) => market.id === PRIMARY_MARKET_ID;
  * Each scenario builder returns an object with `fields` (DataViews column definitions) and `data` (pre-formatted rows).
  *
  * Scenarios:
- * - Manual: Market, Country (count), Shipping (static "Managed in Google"). Only primary market shown.
+ * - Manual non-multilingual: Market, Country (count), Shipping (static "Managed in Google"). Only primary market shown.
+ * - Manual multilingual: Market (label + country count for primary, country name for secondaries), Language, Currency. All markets shown.
  * - Flat: Market, Shipping Rate, Shipping Time, Free shipping. All markets shown.
  * - Automatic multilingual: Market, Language, Currency, Shipping time. All markets shown.
  * - Automatic non-multilingual: Market (label + country count), Shipping time. Only primary market shown.
@@ -208,14 +209,57 @@ const formatFreeShipping = ( rateRow ) => {
 };
 
 /**
- * Manual shipping scenario: Market, Country (count), Shipping (static "Managed in Google").
- * Only the primary market row is shown.
+ * Manual shipping scenario. The column set differs based on whether the store
+ * has multilingual support:
  *
- * @param {Object}         options
- * @param {Market}         options.primaryMarket Primary market data from usePrimaryMarketDetails.
+ * - Multilingual: Market (label + country count for primary, country name for
+ *   secondaries), Language, Currency — all markets as rows.
+ * - Non-multilingual: Market, Country (count), Shipping (static "Managed in
+ *   Google") — primary market only.
+ *
+ * @param {Object}     options
+ * @param {Market}     options.primaryMarket       Primary market data from usePrimaryMarketDetails.
+ * @param {Market[]}   options.markets             All markets from useMarkets.
+ * @param {boolean}    options.isMultiLingualStore Whether the store has a multilingual plugin.
  * @return {DataViewsConfig} DataViews fields and pre-formatted rows.
  */
-const buildManualConfig = ( { primaryMarket } ) => {
+const buildManualConfig = ( {
+	primaryMarket,
+	markets,
+	isMultiLingualStore,
+} ) => {
+	if ( isMultiLingualStore ) {
+		const fields = [
+			ALL_FIELDS.market,
+			ALL_FIELDS.language,
+			ALL_FIELDS.currency,
+		];
+
+		const data = markets.map( ( market ) => {
+			if ( ! isPrimaryMarket( market ) ) {
+				return market;
+			}
+
+			const countryCount = market.countries?.length ?? 0;
+			return {
+				...market,
+				label: sprintf(
+					// translators: 1: market label, 2: number of countries.
+					_n(
+						'%1$s (%2$d country)',
+						'%1$s (%2$d countries)',
+						countryCount,
+						'google-listings-and-ads'
+					),
+					market.label,
+					countryCount
+				),
+			};
+		} );
+
+		return { fields, data };
+	}
+
 	const countryCount = primaryMarket?.countries?.length ?? 0;
 
 	const fields = [
@@ -360,7 +404,7 @@ const buildAutomaticConfig = ( {
  * any scenario that doesn't yet have a dedicated builder.
  *
  * TODO: Remove once all scenarios have explicit branches:
- *   - GOOWOO-598 / -602: remaining multilingual variants.
+ *   - GOOWOO-602: flat + multilingual variant.
  *
  * @param {Object}              options
  * @param {Market[]}           options.markets      All markets from useMarkets.
@@ -431,7 +475,11 @@ const useMarketDataViewsConfig = () => {
 
 	if ( shippingRate === SHIPPING_RATE_METHOD.MANUAL ) {
 		return {
-			...buildManualConfig( { primaryMarket } ),
+			...buildManualConfig( {
+				primaryMarket,
+				markets,
+				isMultiLingualStore,
+			} ),
 			hasFinishedResolution,
 		};
 	}

--- a/js/src/hooks/useMarketDataViewsConfig.test.js
+++ b/js/src/hooks/useMarketDataViewsConfig.test.js
@@ -345,6 +345,33 @@ describe( 'useMarketDataViewsConfig', () => {
 			);
 			expect( result.current.data[ 1 ].freeShipping ).toMatch( /50/ );
 		} );
+
+		test( 'formats the primary market label with the country count', () => {
+			setMocks( {
+				primary: PRIMARY_MARKET_FLAT,
+				markets: [ PRIMARY_MARKET_FLAT, SECONDARY_MARKET_FLAT ],
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+
+			expect( result.current.data[ 0 ].label ).toBe(
+				'Primary Market (3 countries)'
+			);
+		} );
+
+		test( 'leaves the secondary market label as the country name', () => {
+			setMocks( {
+				primary: PRIMARY_MARKET_FLAT,
+				markets: [
+					PRIMARY_MARKET_FLAT,
+					{ ...SECONDARY_MARKET_FLAT, label: 'France' },
+				],
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+
+			expect( result.current.data[ 1 ].label ).toBe( 'France' );
+		} );
 	} );
 
 	describe( 'automatic shipping, no multilingual store', () => {
@@ -635,6 +662,20 @@ describe( 'useMarketDataViewsConfig', () => {
 			expect( secondary.shippingRate ).toMatch( /8/ );
 			expect( secondary.shippingTime ).toBe( '5 - 7 days' );
 			expect( secondary.freeShipping ).toMatch( /Free over/ );
+		} );
+
+		test( 'formats the primary market label with the country count', () => {
+			setMocks( {
+				primary: PRIMARY_MARKET_FLAT,
+				markets: [ PRIMARY_MARKET_FLAT, SECONDARY_MARKET_FLAT ],
+				multiLingualStore: true,
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+
+			expect( result.current.data[ 0 ].label ).toBe(
+				'Primary Market (3 countries)'
+			);
 		} );
 	} );
 

--- a/js/src/hooks/useMarketDataViewsConfig.test.js
+++ b/js/src/hooks/useMarketDataViewsConfig.test.js
@@ -90,6 +90,22 @@ const SECONDARY_MARKET_MULTILINGUAL_AUTOMATIC = {
 	currency: 'EUR',
 };
 
+const PRIMARY_MARKET_MULTILINGUAL_MANUAL = {
+	...PRIMARY_MARKET,
+	shipping_rate: 'manual',
+	language: 'English',
+	currency: 'USD',
+};
+
+const SECONDARY_MARKET_MULTILINGUAL_MANUAL = {
+	id: 'fr',
+	country: 'FR',
+	label: 'France',
+	shipping_rate: 'manual',
+	language: 'French',
+	currency: 'EUR',
+};
+
 const setMocks = ( {
 	primary = PRIMARY_MARKET,
 	markets = [ PRIMARY_MARKET ],
@@ -457,6 +473,111 @@ describe( 'useMarketDataViewsConfig', () => {
 			expect( secondary.language ).toBe( 'French' );
 			expect( secondary.currency ).toBe( 'EUR' );
 			expect( secondary.shippingTime ).toBe( '5 - 7 days' );
+		} );
+	} );
+
+	describe( 'multilingual store, manual shipping', () => {
+		test( 'returns exactly three fields: Market, Language, Currency', () => {
+			setMocks( {
+				primary: PRIMARY_MARKET_MULTILINGUAL_MANUAL,
+				markets: [ PRIMARY_MARKET_MULTILINGUAL_MANUAL ],
+				multiLingualStore: true,
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+
+			expect( result.current.fields.map( ( f ) => f.id ) ).toEqual( [
+				'market',
+				'language',
+				'currency',
+			] );
+		} );
+
+		test( 'includes both primary and additional markets as rows', () => {
+			setMocks( {
+				primary: PRIMARY_MARKET_MULTILINGUAL_MANUAL,
+				markets: [
+					PRIMARY_MARKET_MULTILINGUAL_MANUAL,
+					SECONDARY_MARKET_MULTILINGUAL_MANUAL,
+				],
+				multiLingualStore: true,
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+
+			expect( result.current.data ).toHaveLength( 2 );
+			expect( result.current.data[ 0 ].id ).toBe( 'primary' );
+			expect( result.current.data[ 1 ].id ).toBe( 'fr' );
+		} );
+
+		test( 'formats the primary market label with the country count', () => {
+			setMocks( {
+				primary: PRIMARY_MARKET_MULTILINGUAL_MANUAL,
+				markets: [ PRIMARY_MARKET_MULTILINGUAL_MANUAL ],
+				multiLingualStore: true,
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+
+			expect( result.current.data[ 0 ].label ).toBe(
+				'Primary Market (3 countries)'
+			);
+		} );
+
+		test( 'pluralizes singular country count', () => {
+			setMocks( {
+				primary: {
+					...PRIMARY_MARKET_MULTILINGUAL_MANUAL,
+					countries: [ 'US' ],
+				},
+				markets: [
+					{
+						...PRIMARY_MARKET_MULTILINGUAL_MANUAL,
+						countries: [ 'US' ],
+					},
+				],
+				multiLingualStore: true,
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+
+			expect( result.current.data[ 0 ].label ).toBe(
+				'Primary Market (1 country)'
+			);
+		} );
+
+		test( 'leaves the secondary market label as the country name', () => {
+			setMocks( {
+				primary: PRIMARY_MARKET_MULTILINGUAL_MANUAL,
+				markets: [
+					PRIMARY_MARKET_MULTILINGUAL_MANUAL,
+					SECONDARY_MARKET_MULTILINGUAL_MANUAL,
+				],
+				multiLingualStore: true,
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+
+			expect( result.current.data[ 1 ].label ).toBe( 'France' );
+		} );
+
+		test( 'each row retains market language and currency', () => {
+			setMocks( {
+				primary: PRIMARY_MARKET_MULTILINGUAL_MANUAL,
+				markets: [
+					PRIMARY_MARKET_MULTILINGUAL_MANUAL,
+					SECONDARY_MARKET_MULTILINGUAL_MANUAL,
+				],
+				multiLingualStore: true,
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+			const [ primary, secondary ] = result.current.data;
+
+			expect( primary.language ).toBe( 'English' );
+			expect( primary.currency ).toBe( 'USD' );
+			expect( secondary.language ).toBe( 'French' );
+			expect( secondary.currency ).toBe( 'EUR' );
 		} );
 	} );
 

--- a/js/src/hooks/useMarketDataViewsConfig.test.js
+++ b/js/src/hooks/useMarketDataViewsConfig.test.js
@@ -581,6 +581,63 @@ describe( 'useMarketDataViewsConfig', () => {
 		} );
 	} );
 
+	describe( 'multilingual store, flat shipping', () => {
+		// Per Figma, the multilingual flat table renders identically to the
+		// non-multilingual flat table — no Language/Currency columns, same
+		// rendering. These tests lock in that decision so future changes that
+		// diverge the two are caught.
+
+		test( 'returns the same four fields as the non-multilingual flat scenario', () => {
+			setMocks( {
+				primary: PRIMARY_MARKET_FLAT,
+				markets: [ PRIMARY_MARKET_FLAT, SECONDARY_MARKET_FLAT ],
+				multiLingualStore: true,
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+
+			expect( result.current.fields.map( ( f ) => f.id ) ).toEqual( [
+				'market',
+				'shippingRate',
+				'shippingTime',
+				'freeShipping',
+			] );
+		} );
+
+		test( 'includes both primary and additional markets as rows', () => {
+			setMocks( {
+				primary: PRIMARY_MARKET_FLAT,
+				markets: [ PRIMARY_MARKET_FLAT, SECONDARY_MARKET_FLAT ],
+				multiLingualStore: true,
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+
+			expect( result.current.data ).toHaveLength( 2 );
+			expect( result.current.data[ 0 ].id ).toBe( 'primary' );
+			expect( result.current.data[ 1 ].id ).toBe( 'fr' );
+		} );
+
+		test( 'formats shipping cells the same way as the non-multilingual flat scenario', () => {
+			setMocks( {
+				primary: PRIMARY_MARKET_FLAT,
+				markets: [ PRIMARY_MARKET_FLAT, SECONDARY_MARKET_FLAT ],
+				multiLingualStore: true,
+				shippingRates: SHIPPING_RATES,
+				shippingTimes: SHIPPING_TIMES,
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+			const [ primary, secondary ] = result.current.data;
+
+			expect( primary.shippingRate ).toMatch( /10/ );
+			expect( primary.shippingTime ).toBe( '3 - 5 days' );
+			expect( secondary.shippingRate ).toMatch( /8/ );
+			expect( secondary.shippingTime ).toBe( '5 - 7 days' );
+			expect( secondary.freeShipping ).toMatch( /Free over/ );
+		} );
+	} );
+
 	describe( 'loading state', () => {
 		test( 'returns empty fields and data while markets have not resolved', () => {
 			useMarkets.mockReturnValue( {

--- a/js/src/hooks/useMarketDataViewsConfig.test.js
+++ b/js/src/hooks/useMarketDataViewsConfig.test.js
@@ -501,6 +501,23 @@ describe( 'useMarketDataViewsConfig', () => {
 			expect( secondary.currency ).toBe( 'EUR' );
 			expect( secondary.shippingTime ).toBe( '5 - 7 days' );
 		} );
+
+		test( 'formats the primary market label with the country count', () => {
+			setMocks( {
+				primary: PRIMARY_MARKET_MULTILINGUAL_AUTOMATIC,
+				markets: [
+					PRIMARY_MARKET_MULTILINGUAL_AUTOMATIC,
+					SECONDARY_MARKET_MULTILINGUAL_AUTOMATIC,
+				],
+				multiLingualStore: true,
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+
+			expect( result.current.data[ 0 ].label ).toBe(
+				'Primary Market (3 countries)'
+			);
+		} );
 	} );
 
 	describe( 'multilingual store, manual shipping', () => {

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
 			},
 			{
 				"path": "./js/build/commons.js",
-				"maxSize": "86.90 kB"
+				"maxSize": "87.10 kB"
 			},
 			{
 				"path": "./js/build/vendors.js",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes GOOWOO-598 and GOOWOO-602, aligns with #3420

Adds the multilingual variants of the Markets table to `useMarketDataViewsConfig`, and aligns two existing scenarios with Figma:

- GOOWOO-598 — When the store has a multilingual plugin active and shipping is set to Manual, the table now renders Market / Language / Currency with both the primary and all secondary markets as rows. The primary row's Market cell includes the country count ("Primary Market (3 countries)"); secondary rows use the country name.
- GOOWOO-602 — When the store has a multilingual plugin active and shipping is set to Flat, the table renders the same four columns as the non-multilingual flat variant (Market / Shipping rate / Shipping time / Free shipping) per Figma. No new branch was needed — both store types share the existing `buildFlatConfig`. Locked in via a regression test block so future divergence is caught.
- Figma alignment — `buildFlatConfig` and the multilingual branch of `buildAutomaticConfig` were missing the (N countries) suffix on the primary row's Market cell. Two small commits add it, mirroring how `buildAutomaticConfig` non-multi and `buildDefaultConfig` already format the primary's label.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

These cover the four hook scenarios this PR touches. The hook always sees `isMultiLingualStore = false` in a real install today (the backend currently hard-codes `MarketService::has_multilingual_support()` to `false`), so the multilingual paths are exercised by unit tests + a small browser-console override for manual verification.

**Prerequisites**

- GLA onboarded with a primary market of 3 countries (e.g. US, CA, MX) plus at least one secondary market (e.g. FR) with shipping rate + time saved.
- Be able to switch shipping rate between Manual / Flat / Automatic via Marketing → Google for WooCommerce → Settings.

**1. Non-multilingual scenarios**

- Settings → Shipping rate = Flat. Open the Markets tab.
  - Primary row's Market cell should now read "Primary Market (3 countries)"
  - Secondary row's Market cell is the country name (e.g. "France").
  - Columns: Market / Shipping rate / Shipping time / Free shipping — values populated for both rows.
- Settings → Shipping rate = Manual. Open the Markets tab.
  - Primary-only row with Market / Country / Shipping = "Managed in Google". Unchanged by this PR — included as a sanity check.
- Settings → Shipping rate = Automatic. Open the Markets tab.
  - Primary-only row with "Primary Market (3 countries)" and Shipping times populated. Unchanged by this PR.

**2. Multilingual scenarios (console override required)**

In the browser console on the Markets page, run:
```
window.glaData.isMultiLingualStore = true;
```
Then reload the page (without clearing the override — JS reads it on render).

- With Settings → Shipping rate = Manual (GOOWOO-598):
  - Columns should be Market / Language / Currency only — no Country, no Shipping.
  - Primary row: "Primary Market (3 countries)" / <primary.language> / <primary.currency>.
  - Secondary row(s): country name / <secondary.language> / <secondary.currency>.
- With Settings → Shipping rate = Flat (GOOWOO-602):
  - Columns should be the same four as the non-multilingual flat case (no Language/Currency).
  - Primary row's Market cell still reads "Primary Market (3 countries)".
- With Settings → Shipping rate = Automatic (alignment verification):
  - Columns: Market / Language / Currency / Shipping times.
  - Primary row's Market cell now reads "Primary Market (3 countries)" (previously was just "Primary Market").

**3. Unit tests**

```
npx jest js/src/hooks/useMarketDataViewsConfig.test.js js/src/pages/markets/ --testPathIgnorePatterns="/.claude/"
```

Expect 144 tests passing across 16 suites.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
