### PR TITLE
GOOWOO-687: Phase 2: Product patch

### DIFF
--- a/src/API/Google/Mapi/Models/ProductInputPatch.php
+++ b/src/API/Google/Mapi/Models/ProductInputPatch.php
@@ -1,0 +1,48 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ProductInputPatch
+ *
+ * Pairs a ProductInput with the update mask describing which fields to
+ * write.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models
+ */
+class ProductInputPatch {
+
+	/** @var ProductInput */
+	protected $input;
+
+	/** @var string[] */
+	protected $update_mask;
+
+	/**
+	 * ProductInputPatch constructor.
+	 *
+	 * @param ProductInput $input       The product and the changed attributes.
+	 * @param string[]     $update_mask Field names to update (e.g. productAttributes.title).
+	 */
+	public function __construct( ProductInput $input, array $update_mask ) {
+		$this->input       = $input;
+		$this->update_mask = $update_mask;
+	}
+
+	/**
+	 * @return ProductInput
+	 */
+	public function get_input(): ProductInput {
+		return $this->input;
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function get_update_mask(): array {
+		return $this->update_mask;
+	}
+}

--- a/src/API/Google/Mapi/Services/MapiProductInputsService.php
+++ b/src/API/Google/Mapi/Services/MapiProductInputsService.php
@@ -7,17 +7,19 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MapiPaths;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInputPatch;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Promise\EachPromise;
+use InvalidArgumentException;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Class MapiProductInputsService
  *
- * Writes products to the Merchant API via `accounts.productInputs.insert`. Each
- * write targets the data source matching the input's contentLanguage + feedLabel.
+ * Manages products on the Merchant API through the `accounts.productInputs.*`
+ * endpoints.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services
  */
@@ -118,6 +120,95 @@ class MapiProductInputsService implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Patch a single product.
+	 *
+	 * @param ProductInputPatch $patch
+	 *
+	 * @return ProductInput The hydrated response.
+	 * @throws InvalidArgumentException When the update mask is empty.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function patch( ProductInputPatch $patch ): ProductInput {
+		$input = $patch->get_input();
+		$mask  = $patch->get_update_mask();
+
+		if ( empty( $mask ) ) {
+			throw new InvalidArgumentException( 'A product patch requires a non-empty update mask.' );
+		}
+
+		$data_source = $this->data_sources->ensure_data_source_for(
+			$input->get_content_language(),
+			$input->get_feed_label()
+		);
+
+		$body = $this->client->patch(
+			$this->build_patch_path( $input, $mask, $data_source ),
+			$input->to_array()
+		);
+
+		return ProductInput::from_array( $body );
+	}
+
+	/**
+	 * Patch multiple products in parallel.
+	 *
+	 * @param ProductInputPatch[] $patches
+	 * @param int                 $concurrency
+	 *
+	 * @return array{successes: array<int, ProductInput>, failures: array<int, MerchantApiException>}
+	 * @throws InvalidArgumentException When any update mask is empty.
+	 * @throws MerchantApiException On a non-2xx MAPI response while resolving a data source.
+	 */
+	public function patch_many( array $patches, int $concurrency = 10 ): array {
+		// Resolve all data sources upfront so the async batch
+		// starts with every data source known and cached.
+		$paths_by_index = [];
+		foreach ( $patches as $index => $patch ) {
+			$input = $patch->get_input();
+			$mask  = $patch->get_update_mask();
+
+			if ( empty( $mask ) ) {
+				throw new InvalidArgumentException( 'A product patch requires a non-empty update mask.' );
+			}
+
+			$data_source              = $this->data_sources->ensure_data_source_for(
+				$input->get_content_language(),
+				$input->get_feed_label()
+			);
+			$paths_by_index[ $index ] = $this->build_patch_path( $input, $mask, $data_source );
+		}
+
+		$client = $this->client;
+
+		$requests = function () use ( $patches, $client, $paths_by_index ) {
+			foreach ( $patches as $index => $patch ) {
+				yield $index => $client->request_async( 'PATCH', $paths_by_index[ $index ], $patch->get_input()->to_array() );
+			}
+		};
+
+		$successes = [];
+		$failures  = [];
+
+		( new EachPromise(
+			$requests(),
+			[
+				'concurrency' => $concurrency,
+				'fulfilled'   => function ( array $body, int $index ) use ( &$successes ) {
+					$successes[ $index ] = ProductInput::from_array( $body );
+				},
+				'rejected'    => function ( $reason, int $index ) use ( &$failures ) {
+					$failures[ $index ] = $reason;
+				},
+			]
+		) )->promise()->wait();
+
+		return [
+			'successes' => $successes,
+			'failures'  => $failures,
+		];
+	}
+
+	/**
 	 * Build the productInputs.insert path with the resolved data source.
 	 *
 	 * @param string $data_source Data source resource name.
@@ -130,6 +221,28 @@ class MapiProductInputsService implements OptionsAwareInterface {
 			MapiPaths::PRODUCTS,
 			$this->options->get_merchant_id(),
 			rawurlencode( $data_source )
+		);
+	}
+
+	/**
+	 * Build the productInputs.patch path with the resolved data source and mask.
+	 *
+	 * @param ProductInput $input       The product resource name.
+	 * @param string[]     $update_mask Field names to update.
+	 * @param string       $data_source Data source resource name.
+	 *
+	 * @return string
+	 */
+	protected function build_patch_path( ProductInput $input, array $update_mask, string $data_source ): string {
+		return sprintf(
+			'%s/accounts/%s/productInputs/%s~%s~%s?dataSource=%s&updateMask=%s',
+			MapiPaths::PRODUCTS,
+			$this->options->get_merchant_id(),
+			$input->get_content_language(),
+			$input->get_feed_label(),
+			rawurlencode( $input->get_offer_id() ),
+			rawurlencode( $data_source ),
+			rawurlencode( implode( ',', $update_mask ) )
 		);
 	}
 }

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -17,6 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInputPatch;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
@@ -396,6 +397,41 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 					<?php wp_nonce_field( 'mapi-product-insert-many' ); ?>
 					<input name="page" value="connection-test-admin-page" type="hidden" />
 					<input name="action" value="mapi-product-insert-many" type="hidden" />
+				</form>
+				<form action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" method="GET">
+					<table class="form-table" role="presentation">
+						<tr>
+							<th>MAPI Patch Product:</th>
+							<td>
+								<p>
+									<input name="mapi_patch_offer_id" type="text" style="width:14em" placeholder="offer id" value="<?php echo isset( $_GET['mapi_patch_offer_id'] ) ? esc_attr( $_GET['mapi_patch_offer_id'] ) : ''; ?>" />
+									<input name="mapi_patch_attribute" type="text" style="width:10em" placeholder="title" value="<?php echo isset( $_GET['mapi_patch_attribute'] ) ? esc_attr( $_GET['mapi_patch_attribute'] ) : 'title'; ?>" />
+									<input name="mapi_patch_value" type="text" style="width:18em" placeholder="new value" value="<?php echo isset( $_GET['mapi_patch_value'] ) ? esc_attr( $_GET['mapi_patch_value'] ) : ''; ?>" />
+									<button class="button">Patch product via MAPI</button>
+								</p>
+							</td>
+						</tr>
+					</table>
+					<?php wp_nonce_field( 'mapi-product-patch' ); ?>
+					<input name="page" value="connection-test-admin-page" type="hidden" />
+					<input name="action" value="mapi-product-patch" type="hidden" />
+				</form>
+				<form action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" method="GET">
+					<table class="form-table" role="presentation">
+						<tr>
+							<th>MAPI Parallel Patch:</th>
+							<td>
+								<p>
+									<input name="mapi_patch_offer_ids" type="text" style="width:28em" placeholder="offer1, offer2, offer3" value="<?php echo isset( $_GET['mapi_patch_offer_ids'] ) ? esc_attr( $_GET['mapi_patch_offer_ids'] ) : ''; ?>" />
+									<input name="mapi_patch_title" type="text" style="width:18em" placeholder="new title for all" value="<?php echo isset( $_GET['mapi_patch_title'] ) ? esc_attr( $_GET['mapi_patch_title'] ) : ''; ?>" />
+									<button class="button">Patch products in parallel via MAPI</button>
+								</p>
+							</td>
+						</tr>
+					</table>
+					<?php wp_nonce_field( 'mapi-product-patch-many' ); ?>
+					<input name="page" value="connection-test-admin-page" type="hidden" />
+					<input name="action" value="mapi-product-patch-many" type="hidden" />
 				</form>
 				<form action="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>" method="GET">
 
@@ -1422,6 +1458,78 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 			$this->response = sprintf( "MAPI parallel productInputs.insert for %d product(s)\n\n", count( $inputs ) );
 
 			$result = $service->insert_many( $inputs );
+
+			foreach ( $offer_ids as $index => $offer_id ) {
+				$this->response .= "--- {$offer_id} ---\n";
+				if ( isset( $result['successes'][ $index ] ) ) {
+					$this->response .= $result['successes'][ $index ]->get_name() . "\n";
+				} elseif ( isset( $result['failures'][ $index ] ) ) {
+					$e               = $result['failures'][ $index ];
+					$this->response .= $e instanceof MerchantApiException
+						? sprintf( "HTTP %d\n%s", $e->get_http_status(), print_r( $e->get_response_body(), true ) )
+						: get_class( $e ) . ': ' . $e->getMessage() . "\n";
+				} else {
+					$this->response .= "(no result)\n";
+				}
+			}
+		}
+
+		if ( 'mapi-product-patch' === $_GET['action'] && check_admin_referer( 'mapi-product-patch' ) ) {
+			$offer_id  = isset( $_GET['mapi_patch_offer_id'] ) ? sanitize_text_field( wp_unslash( $_GET['mapi_patch_offer_id'] ) ) : '';
+			$attribute = isset( $_GET['mapi_patch_attribute'] ) ? sanitize_text_field( wp_unslash( $_GET['mapi_patch_attribute'] ) ) : '';
+			$value     = isset( $_GET['mapi_patch_value'] ) ? sanitize_text_field( wp_unslash( $_GET['mapi_patch_value'] ) ) : '';
+
+			if ( '' === $offer_id || '' === $attribute ) {
+				$this->response .= 'Please enter an offer ID and an attribute.';
+				return;
+			}
+
+			$input = new ProductInput( $offer_id, 'en', 'US', [ $attribute => $value ] );
+			$patch = new ProductInputPatch( $input, [ "productAttributes.{$attribute}" ] );
+
+			/** @var MapiProductInputsService $service */
+			$service        = $this->container->get( MapiProductInputsService::class );
+			$this->response = "MAPI productInputs.patch for {$offer_id} ({$attribute})\n\n";
+
+			try {
+				$result          = $service->patch( $patch );
+				$this->response .= print_r(
+					[
+						'name'       => $result->get_name(),
+						'offer_id'   => $result->get_offer_id(),
+						'attributes' => $result->get_attributes(),
+					],
+					true
+				);
+			} catch ( MerchantApiException $e ) {
+				$this->response .= sprintf( "HTTP %d\n", $e->get_http_status() );
+				$this->response .= print_r( $e->get_response_body(), true );
+			}
+		}
+
+		if ( 'mapi-product-patch-many' === $_GET['action'] && check_admin_referer( 'mapi-product-patch-many' ) ) {
+			$raw       = isset( $_GET['mapi_patch_offer_ids'] ) ? sanitize_text_field( wp_unslash( $_GET['mapi_patch_offer_ids'] ) ) : '';
+			$title     = isset( $_GET['mapi_patch_title'] ) ? sanitize_text_field( wp_unslash( $_GET['mapi_patch_title'] ) ) : '';
+			$offer_ids = array_filter( array_map( 'trim', explode( ',', $raw ) ) );
+
+			if ( empty( $offer_ids ) || '' === $title ) {
+				$this->response .= 'Please enter one or more offer IDs (comma-separated) and a title.';
+				return;
+			}
+
+			$patches = [];
+			foreach ( $offer_ids as $offer_id ) {
+				$patches[] = new ProductInputPatch(
+					new ProductInput( $offer_id, 'en', 'US', [ 'title' => $title ] ),
+					[ 'productAttributes.title' ]
+				);
+			}
+
+			/** @var MapiProductInputsService $service */
+			$service        = $this->container->get( MapiProductInputsService::class );
+			$this->response = sprintf( "MAPI parallel productInputs.patch for %d product(s)\n\n", count( $patches ) );
+
+			$result = $service->patch_many( $patches );
 
 			foreach ( $offer_ids as $index => $offer_id ) {
 				$this->response .= "--- {$offer_id} ---\n";

--- a/tests/Unit/API/Google/Mapi/Models/ProductInputPatchTest.php
+++ b/tests/Unit/API/Google/Mapi/Models/ProductInputPatchTest.php
@@ -1,0 +1,34 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Models;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInputPatch;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ProductInputPatchTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Models
+ */
+class ProductInputPatchTest extends UnitTest {
+
+	public function test_exposes_input_and_update_mask() {
+		$input = new ProductInput( 'sku42', 'en', 'US', [ 'title' => 'New title' ] );
+		$mask  = [ 'productAttributes.title', 'productAttributes.price' ];
+
+		$patch = new ProductInputPatch( $input, $mask );
+
+		$this->assertSame( $input, $patch->get_input() );
+		$this->assertSame( $mask, $patch->get_update_mask() );
+	}
+
+	public function test_accepts_empty_update_mask() {
+		$patch = new ProductInputPatch( new ProductInput( 'sku42', 'en', 'US' ), [] );
+
+		$this->assertSame( [], $patch->get_update_mask() );
+	}
+}

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInputPatch;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -65,6 +66,17 @@ class MapiProductInputsServiceTest extends UnitTest {
 
 	protected function expected_path( string $data_source ): string {
 		return 'products/v1/accounts/12345/productInputs:insert?dataSource=' . rawurlencode( $data_source );
+	}
+
+	protected function expected_patch_path( ProductInput $input, array $mask, string $data_source ): string {
+		return sprintf(
+			'products/v1/accounts/12345/productInputs/%s~%s~%s?dataSource=%s&updateMask=%s',
+			$input->get_content_language(),
+			$input->get_feed_label(),
+			rawurlencode( $input->get_offer_id() ),
+			rawurlencode( $data_source ),
+			rawurlencode( implode( ',', $mask ) )
+		);
 	}
 
 	protected function make_input( string $offer_id = 'sku42', string $language = 'en', string $feed = 'US' ): ProductInput {
@@ -177,5 +189,130 @@ class MapiProductInputsServiceTest extends UnitTest {
 
 		$this->assertSame( $this->expected_path( self::DS_EN_US ), $paths_seen['us_sku'] );
 		$this->assertSame( $this->expected_path( self::DS_FR_CA ), $paths_seen['ca_sku'] );
+	}
+
+	public function test_patch_resolves_data_source_and_builds_correct_path() {
+		$input = $this->make_input();
+		$mask  = [ 'productAttributes.title' ];
+
+		$this->client->expects( $this->once() )
+			->method( 'patch' )
+			->with( $this->expected_patch_path( $input, $mask, self::DS_EN_US ), $input->to_array() )
+			->willReturn(
+				[
+					'name'    => 'accounts/12345/productInputs/en~US~sku42',
+					'offerId' => 'sku42',
+				]
+			);
+
+		$result = $this->service->patch( new ProductInputPatch( $input, $mask ) );
+
+		$this->assertInstanceOf( ProductInput::class, $result );
+		$this->assertSame( 'sku42', $result->get_offer_id() );
+	}
+
+	public function test_patch_routes_different_market_to_a_different_data_source() {
+		$input = $this->make_input( 'sku42', 'fr', 'CA' );
+		$mask  = [ 'productAttributes.title' ];
+
+		$this->client->expects( $this->once() )
+			->method( 'patch' )
+			->with( $this->expected_patch_path( $input, $mask, self::DS_FR_CA ), $input->to_array() )
+			->willReturn( [ 'offerId' => 'sku42' ] );
+
+		$this->service->patch( new ProductInputPatch( $input, $mask ) );
+	}
+
+	public function test_patch_throws_on_empty_update_mask_without_http_call() {
+		$this->client->expects( $this->never() )->method( 'patch' );
+		$this->data_sources->expects( $this->never() )->method( 'ensure_data_source_for' );
+
+		$this->expectException( \InvalidArgumentException::class );
+
+		$this->service->patch( new ProductInputPatch( $this->make_input(), [] ) );
+	}
+
+	public function test_patch_propagates_merchant_api_exception() {
+		$this->client->method( 'patch' )
+			->willThrowException( new MerchantApiException( 404, [], __METHOD__ ) );
+
+		$this->expectException( MerchantApiException::class );
+
+		$this->service->patch( new ProductInputPatch( $this->make_input(), [ 'productAttributes.title' ] ) );
+	}
+
+	public function test_patch_many_keys_successes_and_failures_by_index() {
+		$this->client->method( 'request_async' )
+			->willReturnCallback(
+				function ( string $method, string $path, array $body ) {
+					if ( 'bad' === $body['offerId'] ) {
+						return Create::rejectionFor( new MerchantApiException( 500, [], __METHOD__ ) );
+					}
+
+					return Create::promiseFor(
+						[
+							'name'    => 'accounts/12345/productInputs/' . $body['offerId'],
+							'offerId' => $body['offerId'],
+						]
+					);
+				}
+			);
+
+		$mask   = [ 'productAttributes.title' ];
+		$result = $this->service->patch_many(
+			[
+				new ProductInputPatch( $this->make_input( 'good1' ), $mask ),
+				new ProductInputPatch( $this->make_input( 'bad' ), $mask ),
+				new ProductInputPatch( $this->make_input( 'good2' ), $mask ),
+			]
+		);
+
+		$this->assertCount( 2, $result['successes'] );
+		$this->assertCount( 1, $result['failures'] );
+		$this->assertArrayHasKey( 0, $result['successes'] );
+		$this->assertArrayHasKey( 2, $result['successes'] );
+		$this->assertArrayHasKey( 1, $result['failures'] );
+		$this->assertInstanceOf( MerchantApiException::class, $result['failures'][1] );
+	}
+
+	public function test_patch_many_routes_each_input_to_its_own_data_source() {
+		$paths_seen = [];
+
+		$this->client->method( 'request_async' )
+			->willReturnCallback(
+				function ( string $method, string $path, array $body ) use ( &$paths_seen ) {
+					$paths_seen[ $body['offerId'] ] = [ $method, $path ];
+
+					return Create::promiseFor( [ 'offerId' => $body['offerId'] ] );
+				}
+			);
+
+		$mask     = [ 'productAttributes.title' ];
+		$us_input = $this->make_input( 'us_sku', 'en', 'US' );
+		$ca_input = $this->make_input( 'ca_sku', 'fr', 'CA' );
+
+		$this->service->patch_many(
+			[
+				new ProductInputPatch( $us_input, $mask ),
+				new ProductInputPatch( $ca_input, $mask ),
+			]
+		);
+
+		$this->assertSame( 'PATCH', $paths_seen['us_sku'][0] );
+		$this->assertSame( $this->expected_patch_path( $us_input, $mask, self::DS_EN_US ), $paths_seen['us_sku'][1] );
+		$this->assertSame( $this->expected_patch_path( $ca_input, $mask, self::DS_FR_CA ), $paths_seen['ca_sku'][1] );
+	}
+
+	public function test_patch_many_throws_on_empty_update_mask_without_http_call() {
+		$this->client->expects( $this->never() )->method( 'request_async' );
+
+		$this->expectException( \InvalidArgumentException::class );
+
+		$this->service->patch_many(
+			[
+				new ProductInputPatch( $this->make_input( 'good' ), [ 'productAttributes.title' ] ),
+				new ProductInputPatch( $this->make_input( 'bad' ), [] ),
+			]
+		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds the MAPI update path. New `ProductInputPatch` value object and two methods on the existing write service: `patch` and `patch_many`. Each patch resolves its data source from the input's contentLanguage + feedLabel, same as insert, and only the masked fields are written.

Closes https://linear.app/a8c/issue/GOOWOO-687/phase-2-product-patch

Note: once https://github.com/woocommerce/google-listings-and-ads/pull/3432 gets merged, change the base branch to `feature/mapi-migration`

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
1. Open `wp-admin/admin.php?page=connection-test-admin-page`.
2. In "MAPI Patch Product", enter an existing offer ID, an attribute (`title`), and a new value, then submit. Expect the updated product details in the response.
3. In "MAPI Parallel Patch", enter comma-separated offer IDs and a new title, then submit. Expect one result block per ID.
4. Open Merchant Center > Products and confirm the change. MAPI processing is async, so allow it a minute or two.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
