### PR TITLE
Add Google Ads API compat shim

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -39,6 +39,8 @@ class Autoloader {
 			return false;
 		}
 
+		require_once dirname( __DIR__ ) . '/src/Compatibility/GoogleAdsApiCompatibility.php';
+
 		return $autoloader_result;
 	}
 

--- a/src/Compatibility/GoogleAdsApiCompatibility.php
+++ b/src/Compatibility/GoogleAdsApiCompatibility.php
@@ -1,0 +1,58 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Compatibility;
+
+/**
+ * Provide lightweight aliases for removed Google Ads API classes.
+ *
+ * This keeps older deployed plugin code working during a rolling update without
+ * shipping the entire previous API version in the bundle.
+ */
+final class GoogleAdsApiCompatibility {
+
+	/**
+	 * Alias removed V22 service client classes to the V23 implementations.
+	 */
+	public static function register(): void {
+		self::alias_service_client( 'AccountLinkServiceClient' );
+		self::alias_service_client( 'AdGroupAdLabelServiceClient' );
+		self::alias_service_client( 'AdGroupAdServiceClient' );
+		self::alias_service_client( 'AdGroupCriterionServiceClient' );
+		self::alias_service_client( 'AdGroupServiceClient' );
+		self::alias_service_client( 'AdServiceClient' );
+		self::alias_service_client( 'AssetGenerationServiceClient' );
+		self::alias_service_client( 'AssetGroupListingGroupFilterServiceClient' );
+		self::alias_service_client( 'AssetGroupServiceClient' );
+		self::alias_service_client( 'BillingSetupServiceClient' );
+		self::alias_service_client( 'CampaignBudgetServiceClient' );
+		self::alias_service_client( 'CampaignCriterionServiceClient' );
+		self::alias_service_client( 'CampaignServiceClient' );
+		self::alias_service_client( 'ConversionActionServiceClient' );
+		self::alias_service_client( 'CustomerServiceClient' );
+		self::alias_service_client( 'CustomerUserAccessServiceClient' );
+		self::alias_service_client( 'GeoTargetConstantServiceClient' );
+		self::alias_service_client( 'GoogleAdsServiceClient' );
+		self::alias_service_client( 'IncentiveServiceClient' );
+		self::alias_service_client( 'ProductLinkInvitationServiceClient' );
+		self::alias_service_client( 'RecommendationServiceClient' );
+	}
+
+	/**
+	 * Alias a V22 service client to its V23 counterpart if needed.
+	 *
+	 * @param string $class_name Class short name without version namespace.
+	 */
+	private static function alias_service_client( string $class_name ): void {
+		$legacy_class = "Google\\Ads\\GoogleAds\\V22\\Services\\Client\\{$class_name}";
+		$new_class    = "Google\\Ads\\GoogleAds\\V23\\Services\\Client\\{$class_name}";
+
+		if ( class_exists( $legacy_class, false ) || ! class_exists( $new_class ) ) {
+			return;
+		}
+
+		class_alias( $new_class, $legacy_class );
+	}
+}
+
+GoogleAdsApiCompatibility::register();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-693.

This PR proposes a compatibility shim as part of the autoloader that maps classes from legacy API versions to the newer version in order to help avoid temporary fatal errors that can happen after a plugin upgrade is installed and previous code paths are still called from OPCache.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Add Google Ads API version compatibility shim to the autoloader.
