### PR TITLE
GOOWOO-690 Get Currencies from Language/Currencies Endpoint

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/MarketsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/MarketsController.php
@@ -116,7 +116,7 @@ class MarketsController extends BaseController {
 			return new Response(
 				[
 					'languages'  => $this->market_service->get_languages(),
-					'currencies' => [],
+					'currencies' => $this->market_service->get_currencies(),
 				]
 			);
 		};

--- a/src/Integration/WPML.php
+++ b/src/Integration/WPML.php
@@ -77,11 +77,12 @@ class WPML implements IntegrationInterface {
 			return [];
 		}
 
-		return $this->format_currencies( $this->get_active_currency_codes() );
+		return $this->get_formatted_currencies( $this->get_active_currency_codes() );
 	}
 
 	/**
-	 * Returns currency codes configured for the store.
+	 * Returns WCML currency codes when multi-currency is enabled, or the single WooCommerce
+	 * store currency as a fallback when WCML multi-currency is off or unavailable.
 	 *
 	 * @return string[]
 	 */
@@ -90,9 +91,13 @@ class WPML implements IntegrationInterface {
 			global $woocommerce_wpml;
 
 			if ( isset( $woocommerce_wpml ) && is_object( $woocommerce_wpml ) && method_exists( $woocommerce_wpml, 'get_multi_currency' ) ) {
-				$codes = $woocommerce_wpml->get_multi_currency()->get_currency_codes();
+				$multi_currency = $woocommerce_wpml->get_multi_currency();
 
-				return is_array( $codes ) ? array_values( $codes ) : [];
+				if ( is_object( $multi_currency ) && method_exists( $multi_currency, 'get_currency_codes' ) ) {
+					$codes = $multi_currency->get_currency_codes();
+
+					return is_array( $codes ) ? array_values( $codes ) : [];
+				}
 			}
 		}
 
@@ -106,7 +111,7 @@ class WPML implements IntegrationInterface {
 	 *
 	 * @return array<int, array{code: string, symbol: string}>
 	 */
-	private function format_currencies( array $codes ): array {
+	private function get_formatted_currencies( array $codes ): array {
 		if ( ! function_exists( 'get_woocommerce_currency_symbol' ) ) {
 			return [];
 		}

--- a/src/Integration/WPML.php
+++ b/src/Integration/WPML.php
@@ -67,6 +67,73 @@ class WPML implements IntegrationInterface {
 	}
 
 	/**
+	 * Returns the store's active currencies from WCML when multi-currency is enabled,
+	 * or the WooCommerce store currency as a single entry otherwise.
+	 *
+	 * @return array<int, array{code: string, symbol: string}>
+	 */
+	public function get_currencies(): array {
+		if ( ! $this->is_active() ) {
+			return [];
+		}
+
+		return $this->format_currencies( $this->get_active_currency_codes() );
+	}
+
+	/**
+	 * Returns currency codes configured for the store.
+	 *
+	 * @return string[]
+	 */
+	protected function get_active_currency_codes(): array {
+		if ( function_exists( 'wcml_is_multi_currency_on' ) && wcml_is_multi_currency_on() ) {
+			global $woocommerce_wpml;
+
+			if ( isset( $woocommerce_wpml ) && is_object( $woocommerce_wpml ) && method_exists( $woocommerce_wpml, 'get_multi_currency' ) ) {
+				$codes = $woocommerce_wpml->get_multi_currency()->get_currency_codes();
+
+				return is_array( $codes ) ? array_values( $codes ) : [];
+			}
+		}
+
+		$currency = function_exists( 'get_woocommerce_currency' ) ? get_woocommerce_currency() : '';
+
+		return is_string( $currency ) && '' !== $currency ? [ $currency ] : [];
+	}
+
+	/**
+	 * @param string[] $codes
+	 *
+	 * @return array<int, array{code: string, symbol: string}>
+	 */
+	private function format_currencies( array $codes ): array {
+		if ( ! function_exists( 'get_woocommerce_currency_symbol' ) ) {
+			return [];
+		}
+
+		$result = [];
+
+		foreach ( $codes as $code ) {
+			if ( ! is_string( $code ) || '' === $code ) {
+				continue;
+			}
+
+			$symbol = get_woocommerce_currency_symbol( $code );
+
+			if ( ! is_string( $symbol ) || '' === $symbol ) {
+				continue;
+			}
+
+			$result[] = [
+				'code'   => $code,
+				'symbol' => html_entity_decode( $symbol, ENT_QUOTES, 'UTF-8' ),
+			];
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Resolves the display label for a WPML language entry.
 	 *
 	 * @param array<string, mixed> $language

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -311,6 +311,15 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	}
 
 	/**
+	 * Returns the store's active currencies from the multilingual integration.
+	 *
+	 * @return array<int, array{code: string, symbol: string}>
+	 */
+	public function get_currencies(): array {
+		return $this->wpml->get_currencies();
+	}
+
+	/**
 	 * Returns the stored secondary markets from the Markets option.
 	 *
 	 * @return array[]

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -110,6 +110,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 	public function test_get_languages_currencies_returns_200(): void {
 		$this->market_service->method( 'get_languages' )->willReturn( [] );
+		$this->market_service->method( 'get_currencies' )->willReturn( [] );
 
 		$response = $this->do_request( self::ROUTE_LANGUAGES_CURRENCIES );
 
@@ -131,12 +132,35 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		];
 
 		$this->market_service->method( 'get_languages' )->willReturn( $languages );
+		$this->market_service->method( 'get_currencies' )->willReturn( [] );
 
 		$response = $this->do_request( self::ROUTE_LANGUAGES_CURRENCIES );
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( $languages, $response->get_data()['languages'] );
 		$this->assertEquals( [], $response->get_data()['currencies'] );
+	}
+
+	public function test_get_languages_currencies_returns_currencies_from_market_service(): void {
+		$currencies = [
+			[
+				'code'   => 'USD',
+				'symbol' => '$',
+			],
+			[
+				'code'   => 'EUR',
+				'symbol' => '€',
+			],
+		];
+
+		$this->market_service->method( 'get_languages' )->willReturn( [] );
+		$this->market_service->method( 'get_currencies' )->willReturn( $currencies );
+
+		$response = $this->do_request( self::ROUTE_LANGUAGES_CURRENCIES );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( [], $response->get_data()['languages'] );
+		$this->assertEquals( $currencies, $response->get_data()['currencies'] );
 	}
 
 	public function test_languages_currencies_schema_shape(): void {

--- a/tests/Unit/Integration/WPMLTest.php
+++ b/tests/Unit/Integration/WPMLTest.php
@@ -132,14 +132,80 @@ class WPMLTest extends UnitTest {
 		$this->assertSame( [], $integration->get_languages() );
 	}
 
+	public function test_get_currencies_returns_empty_when_not_active(): void {
+		$integration = $this->create_integration( false );
+
+		$this->assertSame( [], $integration->get_currencies() );
+	}
+
+	public function test_get_currencies_returns_formatted_currencies(): void {
+		$integration = $this->create_integration( true, [ 'USD', 'EUR' ] );
+
+		$this->assertEquals(
+			[
+				[
+					'code'   => 'USD',
+					'symbol' => '$',
+				],
+				[
+					'code'   => 'EUR',
+					'symbol' => '€',
+				],
+			],
+			$integration->get_currencies()
+		);
+	}
+
+	public function test_get_currencies_returns_store_currency_when_no_wcml_codes(): void {
+		$integration = $this->create_integration( true, [ get_woocommerce_currency() ] );
+
+		$currency = get_woocommerce_currency();
+		$symbol   = html_entity_decode( get_woocommerce_currency_symbol( $currency ), ENT_QUOTES, 'UTF-8' );
+
+		$this->assertSame(
+			[
+				[
+					'code'   => $currency,
+					'symbol' => $symbol,
+				],
+			],
+			$integration->get_currencies()
+		);
+	}
+
+	public function test_get_currencies_skips_codes_without_symbol(): void {
+		$integration = $this->create_integration( true, [ 'USD', 'INVALID' ] );
+
+		$this->assertSame(
+			[
+				[
+					'code'   => 'USD',
+					'symbol' => '$',
+				],
+			],
+			$integration->get_currencies()
+		);
+	}
+
 	/**
-	 * @param bool $is_active
+	 * @param bool     $is_active
+	 * @param string[] $currency_codes
 	 *
 	 * @return WPML&MockObject
 	 */
-	private function create_integration( bool $is_active ): WPML {
-		$integration = $this->createPartialMock( WPML::class, [ 'is_active' ] );
+	private function create_integration( bool $is_active, array $currency_codes = [] ): WPML {
+		$methods = [ 'is_active' ];
+
+		if ( ! empty( $currency_codes ) ) {
+			$methods[] = 'get_active_currency_codes';
+		}
+
+		$integration = $this->createPartialMock( WPML::class, $methods );
 		$integration->method( 'is_active' )->willReturn( $is_active );
+
+		if ( ! empty( $currency_codes ) ) {
+			$integration->method( 'get_active_currency_codes' )->willReturn( $currency_codes );
+		}
 
 		return $integration;
 	}

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -818,6 +818,29 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( [], $this->market_service->get_languages() );
 	}
 
+	public function test_get_currencies_delegates_to_wpml(): void {
+		$currencies = [
+			[
+				'code'   => 'USD',
+				'symbol' => '$',
+			],
+			[
+				'code'   => 'EUR',
+				'symbol' => '€',
+			],
+		];
+
+		$this->wpml->method( 'get_currencies' )->willReturn( $currencies );
+
+		$this->assertSame( $currencies, $this->market_service->get_currencies() );
+	}
+
+	public function test_get_currencies_returns_empty_when_wpml_not_active(): void {
+		$this->wpml->method( 'get_currencies' )->willReturn( [] );
+
+		$this->assertSame( [], $this->market_service->get_currencies() );
+	}
+
 	/**
 	 * Sets up the options mock to return specific values for different option keys.
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Currencies are now wired through the same path as languages. Here’s what changed:

`WPML::get_currencies() `returns [] when WPML is not active
WCML multi-currency on (`wcml_is_multi_currency_on(`)): reads codes from `$woocommerce_wpml->get_multi_currency()->get_currency_codes()`

WPML only (no WCML multi-currency): falls back to the WooCommerce store currency as a single entry
Each item is `{ code, symbol }`, with symbols from `get_woocommerce_currency_symbol()`

Delegation
`MarketService::get_currencies() → WPML::get_currencies()`
`GET /wc/gla/mc/markets/languages-currencies` returns both arrays from MarketService

Closes https://linear.app/a8c/issue/GOOWOO-690/get-currencies-from-languages-currencies-endpoint

### Screenshots:
N/A

### Detailed test instructions:
#### Manual — without WPML
Deactivate WPML (and WCML if installed).
As admin, call GET /wp-json/wc/gla/mc/markets/languages-currencies

Expected: languages: [], currencies: [], glaData.isMultiLingualStore === false.

#### Manual — WPML only (multi-currency off)
Activate WPML Multilingual CMS with 2+ languages.
WCML can be installed, but multi-currency disabled (WooCommerce → Multi-Currency).
Hit the languages-currencies endpoint.

Expected:
languages: active WPML languages (code, label)
currencies: single entry — store currency + symbol (e.g. USD, $)
isMultiLingualStore: true

#### Manual — WPML + WCML multi-currency
Activate WPML and WooCommerce Multilingual.
Enable multi-currency and add currencies (e.g. USD, EUR, GBP).
Hit the languages-currencies endpoint.

Expected:
languages: all active WPML languages
currencies: all WCML currency codes with symbols (matches WCML settings)

Open Marketing → Google for WooCommerce → Markets → Add/Edit market.
Expected: language and currency drop-downs populated from the API

### Additional details:
Get Currencies from Language/Currencies Endpoint