### PR TITLE
GOOWOO-692: Migrate product create + update sync to MAPI

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -18,6 +18,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AssetSuggestionsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection as GoogleConnection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
@@ -331,6 +332,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags(
 			ProductSyncer::class,
 			GoogleProductService::class,
+			MapiProductInputsService::class,
 			BatchProductHelper::class,
 			ProductHelper::class,
 			MerchantCenterService::class,

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\GoogleListingsAndAdsException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
@@ -17,6 +18,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingCo
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use WC_Product;
 use WC_Product_Variable;
+use WC_Product_Variation;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -255,6 +257,55 @@ class BatchProductHelper implements Service {
 		}
 
 		return $request_entries;
+	}
+
+	/**
+	 * Generate MAPI ProductInput entries for the given products. Expands variable
+	 * products into variations, skips products that are not sync-ready, and builds
+	 * a ProductInput per product targeting the main target country.
+	 *
+	 * @param WC_Product[] $products
+	 *
+	 * @return array<int, array{product: WC_Product, country: string, input: ProductInput}>
+	 */
+	public function generate_mapi_update_entries( array $products ): array {
+		$entries = [];
+		$country = $this->target_audience->get_main_target_country();
+
+		foreach ( $products as $product ) {
+			$this->validate_instanceof( $product, WC_Product::class );
+
+			try {
+				if ( ! $this->product_helper->is_sync_ready( $product ) ) {
+					continue;
+				}
+
+				if ( $product instanceof WC_Product_Variable ) {
+					$entries = array_merge( $entries, $this->generate_mapi_update_entries( $product->get_available_variations( 'objects' ) ) );
+					continue;
+				}
+
+				$parent = $product instanceof WC_Product_Variation
+					? $this->product_helper->get_wc_product( $product->get_parent_id() )
+					: null;
+
+				$entries[] = [
+					'product' => $product,
+					'country' => $country,
+					'input'   => ( new WCProductInputAdapter( $product, $country, $parent ) )->get_product_input(),
+				];
+			} catch ( GoogleListingsAndAdsException $exception ) {
+				do_action(
+					'woocommerce_gla_error',
+					sprintf( 'Skipping product (ID: %s) due to exception: %s', $product->get_id(), $exception->getMessage() ),
+					__METHOD__
+				);
+
+				continue;
+			}
+		}
+
+		return $entries;
 	}
 
 	/**

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -269,8 +269,9 @@ class BatchProductHelper implements Service {
 	 * @return array<int, array{product: WC_Product, country: string, input: ProductInput}>
 	 */
 	public function generate_mapi_update_entries( array $products ): array {
-		$entries = [];
-		$country = $this->target_audience->get_main_target_country();
+		$entries          = [];
+		$country          = $this->target_audience->get_main_target_country();
+		$target_countries = $this->target_audience->get_target_countries();
 
 		foreach ( $products as $product ) {
 			$this->validate_instanceof( $product, WC_Product::class );
@@ -292,7 +293,7 @@ class BatchProductHelper implements Service {
 				$entries[] = [
 					'product' => $product,
 					'country' => $country,
-					'input'   => ( new WCProductInputAdapter( $product, $country, $parent ) )->get_product_input(),
+					'input'   => ( new WCProductInputAdapter( $product, $country, $parent, $target_countries ) )->get_product_input(),
 				];
 			} catch ( GoogleListingsAndAdsException $exception ) {
 				do_action(

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -3,8 +3,12 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
@@ -12,6 +16,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Product as GoogleProduct;
 use Exception;
 use WC_Product;
 
@@ -31,6 +36,11 @@ class ProductSyncer implements Service {
 	 * @var GoogleProductService
 	 */
 	protected $google_service;
+
+	/**
+	 * @var MapiProductInputsService
+	 */
+	protected $mapi_inputs;
 
 	/**
 	 * @var BatchProductHelper
@@ -60,15 +70,17 @@ class ProductSyncer implements Service {
 	/**
 	 * ProductSyncer constructor.
 	 *
-	 * @param GoogleProductService  $google_service
-	 * @param BatchProductHelper    $batch_helper
-	 * @param ProductHelper         $product_helper
-	 * @param MerchantCenterService $merchant_center
-	 * @param WC                    $wc
-	 * @param ProductRepository     $product_repository
+	 * @param GoogleProductService     $google_service
+	 * @param MapiProductInputsService $mapi_inputs
+	 * @param BatchProductHelper       $batch_helper
+	 * @param ProductHelper            $product_helper
+	 * @param MerchantCenterService    $merchant_center
+	 * @param WC                       $wc
+	 * @param ProductRepository        $product_repository
 	 */
 	public function __construct(
 		GoogleProductService $google_service,
+		MapiProductInputsService $mapi_inputs,
 		BatchProductHelper $batch_helper,
 		ProductHelper $product_helper,
 		MerchantCenterService $merchant_center,
@@ -76,6 +88,7 @@ class ProductSyncer implements Service {
 		ProductRepository $product_repository
 	) {
 		$this->google_service     = $google_service;
+		$this->mapi_inputs        = $mapi_inputs;
 		$this->batch_helper       = $batch_helper;
 		$this->product_helper     = $product_helper;
 		$this->merchant_center    = $merchant_center;
@@ -95,10 +108,109 @@ class ProductSyncer implements Service {
 	public function update( array $products ): BatchProductResponse {
 		$this->validate_merchant_center_setup();
 
-		// prepare and validate products
-		$product_entries = $this->batch_helper->validate_and_generate_update_request_entries( $products );
+		$entries = $this->batch_helper->generate_mapi_update_entries( $products );
 
-		return $this->update_by_batch_requests( $product_entries );
+		return $this->update_mapi_entries( $entries );
+	}
+
+	/**
+	 * Submit MAPI ProductInput entries to Merchant Center via productInputs.insert.
+	 *
+	 * @param array<int, array{product: WC_Product, country: string, input: ProductInput}> $entries
+	 *
+	 * @return BatchProductResponse Containing both the synced and invalid products.
+	 *
+	 * @throws ProductSyncerException If there are any errors while syncing products with Google Merchant Center.
+	 */
+	protected function update_mapi_entries( array $entries ): BatchProductResponse {
+		if ( empty( $entries ) ) {
+			return new BatchProductResponse( [], [] );
+		}
+
+		$updated_products = [];
+		$invalid_products = [];
+
+		foreach ( array_chunk( $entries, GoogleProductService::BATCH_SIZE ) as $batch ) {
+			$inputs = array_map(
+				static function ( array $entry ): ProductInput {
+					return $entry['input'];
+				},
+				$batch
+			);
+
+			try {
+				$result = $this->mapi_inputs->insert_many( $inputs );
+			} catch ( Exception $exception ) {
+				do_action( 'woocommerce_gla_exception', $exception, __METHOD__ );
+
+				throw new ProductSyncerException( sprintf( 'Error updating Google products: %s', $exception->getMessage() ), 0, $exception );
+			}
+
+			foreach ( $batch as $index => $entry ) {
+				if ( isset( $result['successes'][ $index ] ) ) {
+					$synced_entry = new BatchProductEntry(
+						$entry['product']->get_id(),
+						$this->build_synced_google_product( $result['successes'][ $index ], $entry['country'] )
+					);
+
+					$updated_products[] = $synced_entry;
+					$this->batch_helper->mark_as_synced( $synced_entry );
+				} elseif ( isset( $result['failures'][ $index ] ) ) {
+					$invalid_entry = $this->build_invalid_entry( $entry['product']->get_id(), $result['failures'][ $index ] );
+
+					$invalid_products[] = $invalid_entry;
+					$this->batch_helper->mark_as_invalid( $invalid_entry );
+				}
+			}
+		}
+
+		$this->handle_update_errors( $invalid_products );
+
+		do_action(
+			'woocommerce_gla_batch_updated_products',
+			$updated_products,
+			$invalid_products
+		);
+
+		return new BatchProductResponse( $updated_products, $invalid_products );
+	}
+
+	/**
+	 * Build a Google product carrying the synced id and target country,
+	 * used to update the product's sync metadata.
+	 *
+	 * @param ProductInput $input
+	 * @param string       $country
+	 *
+	 * @return GoogleProduct
+	 */
+	protected function build_synced_google_product( ProductInput $input, string $country ): GoogleProduct {
+		$google_product = new GoogleProduct();
+		$google_product->setId(
+			sprintf( 'online:%s:%s:%s', $input->get_content_language(), $input->get_feed_label(), $input->get_offer_id() )
+		);
+		$google_product->setTargetCountry( $country );
+
+		return $google_product;
+	}
+
+	/**
+	 * Build an invalid product entry from a failed MAPI insert. Server errors are
+	 * tagged with the internal-error reason so they are retried.
+	 *
+	 * @param int       $wc_product_id
+	 * @param Exception $reason
+	 *
+	 * @return BatchInvalidProductEntry
+	 */
+	protected function build_invalid_entry( int $wc_product_id, Exception $reason ): BatchInvalidProductEntry {
+		if ( $reason instanceof MerchantApiException && $reason->get_http_status() >= 500 ) {
+			$errors = [ GoogleProductService::INTERNAL_ERROR_REASON => $reason->getMessage() ];
+		} else {
+			$errors = [ 'invalid' => $reason->getMessage() ];
+		}
+
+		return new BatchInvalidProductEntry( $wc_product_id, null, $errors );
 	}
 
 	/**

--- a/src/Product/WCProductInputAdapter.php
+++ b/src/Product/WCProductInputAdapter.php
@@ -1,0 +1,254 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use WC_Product;
+use WC_Product_Variation;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WCProductInputAdapter
+ *
+ * Builds a Merchant API ProductInput directly from a WooCommerce product.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product
+ */
+class WCProductInputAdapter {
+
+	use PluginHelper;
+
+	public const AVAILABILITY_IN_STOCK     = 'in_stock';
+	public const AVAILABILITY_OUT_OF_STOCK = 'out_of_stock';
+	public const AVAILABILITY_BACKORDER    = 'backorder';
+
+	public const IMAGE_SIZE_FULL = 'full';
+
+	/** @var WC_Product */
+	protected $wc_product;
+
+	/** @var WC_Product|null Parent product when $wc_product is a variation. */
+	protected $parent_wc_product;
+
+	/** @var string */
+	protected $offer_id;
+
+	/** @var string */
+	protected $content_language;
+
+	/** @var string */
+	protected $feed_label;
+
+	/** @var bool */
+	protected $tax_excluded = false;
+
+	/** @var array */
+	protected $attributes = [];
+
+	/**
+	 * WCProductInputAdapter constructor.
+	 *
+	 * @param WC_Product      $product        The WooCommerce product.
+	 * @param string          $target_country Feed label.
+	 * @param WC_Product|null $parent_product Parent product, required when $product is a variation.
+	 */
+	public function __construct( WC_Product $product, string $target_country, ?WC_Product $parent_product = null ) {
+		$this->wc_product        = $product;
+		$this->parent_wc_product = $parent_product;
+		$this->feed_label        = $target_country;
+		$this->tax_excluded      = $this->resolve_tax_excluded();
+
+		$this->map_identity();
+		$this->map_general_attributes();
+		$this->map_images();
+		$this->map_availability();
+		$this->map_price();
+	}
+
+	/**
+	 * Return the assembled ProductInput.
+	 *
+	 * @return ProductInput
+	 */
+	public function get_product_input(): ProductInput {
+		return new ProductInput(
+			$this->offer_id,
+			$this->content_language,
+			$this->feed_label,
+			$this->attributes
+		);
+	}
+
+	/**
+	 * Resolve the product identity (offer id and content language).
+	 */
+	protected function map_identity(): void {
+		$this->offer_id         = $this->get_offer_id( $this->wc_product->get_id() );
+		$this->content_language = empty( get_locale() ) ? 'en' : strtolower( substr( get_locale(), 0, 2 ) );
+	}
+
+	/**
+	 * Build the Merchant Center offer id for a WooCommerce product id.
+	 *
+	 * @param int $product_id
+	 *
+	 * @return string
+	 */
+	protected function get_offer_id( int $product_id ): string {
+		/** This filter is documented in src/Product/WCProductAdapter.php */
+		return apply_filters( 'woocommerce_gla_get_google_product_offer_id', "{$this->get_slug()}_{$product_id}", $product_id );
+	}
+
+	/**
+	 * Map the general product attributes (title, description, link, item group).
+	 */
+	protected function map_general_attributes(): void {
+		$this->attributes['title']       = $this->wc_product->get_title();
+		$this->attributes['description'] = $this->get_description();
+		$this->attributes['link']        = $this->wc_product->get_permalink();
+
+		if ( $this->is_variation() ) {
+			$this->attributes['itemGroupId'] = (string) $this->parent_wc_product->get_id();
+		}
+	}
+
+	/**
+	 * Build the product description. Ported from WCProductAdapter to preserve behavior.
+	 *
+	 * @return string
+	 */
+	protected function get_description(): string {
+		$use_short_description = apply_filters( 'woocommerce_gla_use_short_description', false );
+
+		$description = ! empty( $this->wc_product->get_description() ) && ! $use_short_description
+			? $this->wc_product->get_description()
+			: $this->wc_product->get_short_description();
+
+		if ( $this->is_variation() ) {
+			$parent_description = ! empty( $this->parent_wc_product->get_description() ) && ! $use_short_description
+				? $this->parent_wc_product->get_description()
+				: $this->parent_wc_product->get_short_description();
+			$new_line           = ! empty( $description ) && ! empty( $parent_description ) ? PHP_EOL : '';
+			$description        = $parent_description . $new_line . $description;
+		}
+
+		$apply_shortcodes = apply_filters( 'woocommerce_gla_product_description_apply_shortcodes', false, $this->wc_product );
+		$description      = $apply_shortcodes ? do_shortcode( $description ) : strip_shortcodes( $description );
+
+		$description = mb_convert_encoding( $description, 'UTF-8', 'UTF-8' );
+		$description = preg_replace( '/[\x00-\x08\x0B\x0C\x0E-\x1F\x80-\x9F]/u', '', $description );
+
+		$kses_allowed_tags = array_fill_keys( array_keys( wp_kses_allowed_html( 'post' ) ), [] );
+		$description       = wp_kses( $description, $kses_allowed_tags );
+		$description       = mb_substr( $description, 0, 5000, 'utf-8' );
+
+		return apply_filters( 'woocommerce_gla_product_attribute_value_description', $description, $this->wc_product );
+	}
+
+	/**
+	 * Map the product images.
+	 */
+	protected function map_images(): void {
+		$image_id          = $this->wc_product->get_image_id();
+		$gallery_image_ids = $this->wc_product->get_gallery_image_ids() ?: [];
+
+		if ( $this->is_variation() ) {
+			$image_id              = $image_id ?? $this->parent_wc_product->get_image_id();
+			$parent_gallery_images = $this->parent_wc_product->get_gallery_image_ids() ?: [];
+			$gallery_image_ids     = ! empty( $gallery_image_ids ) ? $gallery_image_ids : $parent_gallery_images;
+		}
+
+		// Promote the first gallery image to the main image when none is set.
+		if ( empty( $image_id ) && ! empty( $gallery_image_ids[0] ) ) {
+			$image_id = $gallery_image_ids[0];
+			unset( $gallery_image_ids[0] );
+		}
+
+		$image_link = wp_get_attachment_image_url( $image_id, self::IMAGE_SIZE_FULL, false );
+		if ( ! empty( $image_link ) ) {
+			$this->attributes['imageLink'] = $image_link;
+		}
+
+		$gallery_links = array_map(
+			function ( $gallery_image_id ) {
+				return wp_get_attachment_image_url( $gallery_image_id, self::IMAGE_SIZE_FULL, false );
+			},
+			$gallery_image_ids
+		);
+		$gallery_links = array_values( array_unique( array_filter( $gallery_links ), SORT_REGULAR ) );
+		$gallery_links = array_slice( $gallery_links, 0, 10 );
+
+		if ( ! empty( $gallery_links ) ) {
+			$this->attributes['additionalImageLinks'] = $gallery_links;
+		}
+	}
+
+	/**
+	 * Map the stock availability.
+	 */
+	protected function map_availability(): void {
+		if ( ! $this->wc_product->is_in_stock() ) {
+			$availability = self::AVAILABILITY_OUT_OF_STOCK;
+		} elseif ( $this->wc_product->is_on_backorder( 1 ) ) {
+			$availability = self::AVAILABILITY_BACKORDER;
+		} else {
+			$availability = self::AVAILABILITY_IN_STOCK;
+		}
+
+		$this->attributes['availability'] = $availability;
+	}
+
+	/**
+	 * Map the regular price, applying tax inclusion/exclusion rules.
+	 */
+	protected function map_price(): void {
+		$regular_price = $this->wc_product->get_regular_price();
+		if ( '' === $regular_price ) {
+			return;
+		}
+
+		$price = $this->tax_excluded
+			? wc_get_price_excluding_tax( $this->wc_product, [ 'price' => $regular_price ] )
+			: wc_get_price_including_tax( $this->wc_product, [ 'price' => $regular_price ] );
+
+		$price = apply_filters( 'woocommerce_gla_product_attribute_value_price', $price, $this->wc_product, $this->tax_excluded );
+
+		$this->attributes['price'] = $this->to_money( (float) $price, get_woocommerce_currency() );
+	}
+
+	/**
+	 * Whether tax should be excluded from the price for this product's market.
+	 *
+	 * @return bool
+	 */
+	protected function resolve_tax_excluded(): bool {
+		$tax_excluded = in_array( $this->feed_label, [ 'US', 'CA' ], true );
+
+		return boolval( apply_filters( 'woocommerce_gla_tax_excluded', $tax_excluded ) );
+	}
+
+	/**
+	 * Convert a decimal amount and currency into a MAPI money value.
+	 *
+	 * @param float  $value
+	 * @param string $currency
+	 *
+	 * @return array
+	 */
+	protected function to_money( float $value, string $currency ): array {
+		return [
+			'amountMicros' => (string) (int) round( $value * 1000000 ),
+			'currencyCode' => $currency,
+		];
+	}
+
+	/**
+	 * @return bool
+	 */
+	protected function is_variation(): bool {
+		return $this->wc_product instanceof WC_Product_Variation;
+	}
+}

--- a/src/Product/WCProductInputAdapter.php
+++ b/src/Product/WCProductInputAdapter.php
@@ -48,24 +48,30 @@ class WCProductInputAdapter {
 	/** @var array */
 	protected $attributes = [];
 
+	/** @var string[] Target countries to add shipping entries for. */
+	protected $shipping_countries = [];
+
 	/**
 	 * WCProductInputAdapter constructor.
 	 *
-	 * @param WC_Product      $product        The WooCommerce product.
-	 * @param string          $target_country Feed label.
-	 * @param WC_Product|null $parent_product Parent product, required when $product is a variation.
+	 * @param WC_Product      $product            The WooCommerce product.
+	 * @param string          $target_country     Feed label.
+	 * @param WC_Product|null $parent_product     Parent product, required when $product is a variation.
+	 * @param string[]        $shipping_countries Additional target countries to add shipping entries for.
 	 */
-	public function __construct( WC_Product $product, string $target_country, ?WC_Product $parent_product = null ) {
-		$this->wc_product        = $product;
-		$this->parent_wc_product = $parent_product;
-		$this->feed_label        = $target_country;
-		$this->tax_excluded      = $this->resolve_tax_excluded();
+	public function __construct( WC_Product $product, string $target_country, ?WC_Product $parent_product = null, array $shipping_countries = [] ) {
+		$this->wc_product         = $product;
+		$this->parent_wc_product  = $parent_product;
+		$this->feed_label         = $target_country;
+		$this->shipping_countries = $shipping_countries;
+		$this->tax_excluded       = $this->resolve_tax_excluded();
 
 		$this->map_identity();
 		$this->map_general_attributes();
 		$this->map_images();
 		$this->map_availability();
 		$this->map_price();
+		$this->map_shipping();
 	}
 
 	/**
@@ -217,6 +223,114 @@ class WCProductInputAdapter {
 		$price = apply_filters( 'woocommerce_gla_product_attribute_value_price', $price, $this->wc_product, $this->tax_excluded );
 
 		$this->attributes['price'] = $this->to_money( (float) $price, get_woocommerce_currency() );
+	}
+
+	/**
+	 * Map the shipping attributes.
+	 */
+	protected function map_shipping(): void {
+		$is_virtual = $this->is_virtual();
+
+		$countries = array_values( array_unique( array_filter( array_merge( [ $this->feed_label ], $this->shipping_countries ) ) ) );
+
+		$shipping = [];
+		foreach ( $countries as $country ) {
+			$entry = [ 'country' => $country ];
+
+			// Virtual products override any country shipping cost with zero.
+			if ( $is_virtual ) {
+				$entry['price'] = $this->to_money( 0.0, get_woocommerce_currency() );
+			}
+
+			$shipping[] = $entry;
+		}
+
+		if ( ! empty( $shipping ) ) {
+			$this->attributes['shipping'] = $shipping;
+		}
+
+		// Dimensions, weight and label only apply to physical products.
+		if ( $is_virtual ) {
+			return;
+		}
+
+		$this->map_shipping_dimensions();
+		$this->map_shipping_weight();
+
+		$shipping_class = $this->wc_product->get_shipping_class();
+		if ( ! empty( $shipping_class ) ) {
+			$this->attributes['shippingLabel'] = $shipping_class;
+		}
+	}
+
+	/**
+	 * Map the shipping dimensions when length, width and height are all set.
+	 */
+	protected function map_shipping_dimensions(): void {
+		$unit = apply_filters( 'woocommerce_gla_dimension_unit', get_option( 'woocommerce_dimension_unit' ) );
+		if ( ! in_array( $unit, [ 'in', 'cm' ], true ) ) {
+			$unit = 'cm';
+		}
+
+		$length = wc_get_dimension( (float) $this->wc_product->get_length(), $unit );
+		$width  = wc_get_dimension( (float) $this->wc_product->get_width(), $unit );
+		$height = wc_get_dimension( (float) $this->wc_product->get_height(), $unit );
+
+		if ( $length > 0 && $width > 0 && $height > 0 ) {
+			$this->attributes['shippingLength'] = [
+				'value' => $length,
+				'unit'  => $unit,
+			];
+			$this->attributes['shippingWidth']  = [
+				'value' => $width,
+				'unit'  => $unit,
+			];
+			$this->attributes['shippingHeight'] = [
+				'value' => $height,
+				'unit'  => $unit,
+			];
+		}
+	}
+
+	/**
+	 * Map the shipping weight.
+	 */
+	protected function map_shipping_weight(): void {
+		$weight = (float) $this->wc_product->get_weight();
+		if ( $weight <= 0 ) {
+			return;
+		}
+
+		$unit = apply_filters( 'woocommerce_gla_weight_unit', get_option( 'woocommerce_weight_unit' ) );
+		if ( ! in_array( $unit, [ 'g', 'lbs', 'oz' ], true ) ) {
+			$unit = 'g';
+		}
+
+		$weight = wc_get_weight( $weight, $unit );
+
+		// Google Merchant Center uses lb rather than lbs.
+		if ( 'lbs' === $unit ) {
+			$unit = 'lb';
+		}
+
+		$this->attributes['shippingWeight'] = [
+			'value' => $weight,
+			'unit'  => $unit,
+		];
+	}
+
+	/**
+	 * Whether the product is virtual.
+	 *
+	 * @return bool
+	 */
+	protected function is_virtual(): bool {
+		$is_virtual = $this->wc_product->is_virtual();
+
+		/** This filter is documented in src/Product/WCProductAdapter.php */
+		$is_virtual = apply_filters( 'woocommerce_gla_product_property_value_is_virtual', $is_virtual, $this->wc_product );
+
+		return false !== $is_virtual;
 	}
 
 	/**

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -947,10 +947,11 @@ class AccountServiceTest extends UnitTest {
 	}
 
 	public function test_disconnect() {
-		$this->options->expects( $this->exactly( 8 ) )
+		$this->options->expects( $this->exactly( 9 ) )
 			->method( 'delete' )
 			->withConsecutive(
 				[ OptionsInterface::CONTACT_INFO_SETUP ],
+				[ OptionsInterface::MAPI_DATA_SOURCES ],
 				[ OptionsInterface::MC_SETUP_COMPLETED_AT ],
 				[ OptionsInterface::MERCHANT_ACCOUNT_STATE ],
 				[ OptionsInterface::MERCHANT_CENTER ],

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -3,6 +3,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
@@ -42,6 +45,9 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 	/** @var MockObject|GoogleProductService $google_service */
 	protected $google_service;
 
+	/** @var MockObject|MapiProductInputsService $mapi_inputs */
+	protected $mapi_inputs;
+
 	/** @var MockObject|TargetAudience $target_audience */
 	protected $target_audience;
 
@@ -70,10 +76,14 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 	protected $wc;
 
 	public function test_update() {
+		// $synced_products:   products that were successfully synced to Merchant Center
+		// $rejected_products: products that have errors and were rejected by Google API
+		[ $synced_products, $rejected_products ] = $this->create_multiple_simple_product_sets( 2, 2 );
+
 		$validator       = $this->createMock( ValidatorInterface::class );
 		$product_factory = $this->container->get( ProductFactory::class );
 		$batch_helper    = $this->getMockBuilder( BatchProductHelper::class )
-								->setMethods( [ 'validate_and_generate_update_request_entries' ] )
+								->setMethods( [ 'generate_mapi_update_entries' ] )
 								->setConstructorArgs(
 									[
 										$this->product_meta,
@@ -86,28 +96,59 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 								)
 								->getMock();
 		$batch_helper->expects( $this->once() )
-			->method( 'validate_and_generate_update_request_entries' )
+			->method( 'generate_mapi_update_entries' )
 			->willReturnCallback(
 				function ( array $products ) {
 					return array_map(
 						function ( WC_Product $product ) {
-							return new BatchProductRequestEntry( $product->get_id(), $this->generate_adapted_product( $product ) );
+							return [
+								'product' => $product,
+								'country' => 'US',
+								'input'   => new ProductInput( "gla_{$product->get_id()}", 'en', 'US', [ 'title' => $product->get_title() ] ),
+							];
 						},
 						$products
 					);
 				}
 			);
 
-		// $synced_products:   products that were successfully synced to Merchant Center
-		// $rejected_products: products that have errors and were rejected by Google API
-		[ $synced_products, $rejected_products ] = $this->create_multiple_simple_product_sets( 2, 2 );
-
-		$this->mock_google_service( $synced_products, $rejected_products );
+		$this->mock_mapi_inputs( $synced_products, $rejected_products );
 		$product_syncer = $this->get_product_syncer( [ 'batch_helper' => $batch_helper ] );
 
 		$products = array_merge( $synced_products, $rejected_products );
 		$results  = $product_syncer->update( $products );
 		$this->assert_update_results_are_valid( $results, $synced_products, $rejected_products );
+	}
+
+	/**
+	 * Mock MapiProductInputsService::insert_many to succeed for synced products and
+	 * fail for rejected products.
+	 *
+	 * @param array $synced_products   WC product IDs.
+	 * @param array $rejected_products WC product IDs.
+	 */
+	protected function mock_mapi_inputs( array $synced_products, array $rejected_products ): void {
+		$this->mapi_inputs->expects( $this->any() )
+			->method( 'insert_many' )
+			->willReturnCallback(
+				function ( array $inputs ) use ( $synced_products, $rejected_products ) {
+					$successes = [];
+					$failures  = [];
+					foreach ( $inputs as $index => $input ) {
+						$product_id = (int) str_replace( 'gla_', '', $input->get_offer_id() );
+						if ( isset( $synced_products[ $product_id ] ) ) {
+							$successes[ $index ] = $input;
+						} elseif ( isset( $rejected_products[ $product_id ] ) ) {
+							$failures[ $index ] = new MerchantApiException( 500, [], 'Internal Error!' );
+						}
+					}
+
+					return [
+						'successes' => $successes,
+						'failures'  => $failures,
+					];
+				}
+			);
 	}
 
 	public function test_update_by_batch_requests() {
@@ -619,6 +660,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 	 */
 	private function get_product_syncer( $args = [] ): ProductSyncer {
 		$args['google_service']     = $args['google_service'] ?? $this->google_service;
+		$args['mapi_inputs']        = $args['mapi_inputs'] ?? $this->mapi_inputs;
 		$args['batch_helper']       = $args['batch_helper'] ?? $this->batch_helper;
 		$args['product_helper']     = $args['product_helper'] ?? $this->product_helper;
 		$args['merchant_center']    = $args['merchant_center'] ?? $this->merchant_center;
@@ -627,6 +669,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 
 		return new ProductSyncer(
 			$args['google_service'],
+			$args['mapi_inputs'],
 			$args['batch_helper'],
 			$args['product_helper'],
 			$args['merchant_center'],
@@ -656,6 +699,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 			->willReturn( true );
 
 		$this->google_service = $this->createMock( GoogleProductService::class );
+		$this->mapi_inputs    = $this->createMock( MapiProductInputsService::class );
 		$this->rules_query    = $this->createMock( AttributeMappingRulesQuery::class );
 
 		$this->product_meta       = $this->container->get( ProductMetaHandler::class );

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -140,4 +140,160 @@ class WCProductInputAdapterTest extends UnitTest {
 		$this->assertArrayNotHasKey( 'imageLink', $attrs );
 		$this->assertArrayNotHasKey( 'additionalImageLinks', $attrs );
 	}
+
+	public function test_adds_shipping_entry_for_feed_label_country() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( [ [ 'country' => 'US' ] ], $attrs['shipping'] );
+	}
+
+	public function test_adds_shipping_entry_per_target_country() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [ 'US', 'CA', 'GB' ] ) )->get_product_input()->get_attributes();
+
+		$this->assertEqualsCanonicalizing( [ 'US', 'CA', 'GB' ], array_column( $attrs['shipping'], 'country' ) );
+		$this->assertCount( 3, $attrs['shipping'] );
+	}
+
+	public function test_virtual_product_shipping_is_free_with_no_measurements() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_virtual( true );
+		$product->set_weight( '2' );
+		$product->set_length( '10' );
+		$product->set_width( '10' );
+		$product->set_height( '10' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame(
+			[
+				[
+					'country' => 'US',
+					'price'   => [
+						'amountMicros' => '0',
+						'currencyCode' => get_woocommerce_currency(),
+					],
+				],
+			],
+			$attrs['shipping']
+		);
+		$this->assertArrayNotHasKey( 'shippingWeight', $attrs );
+		$this->assertArrayNotHasKey( 'shippingLength', $attrs );
+		$this->assertArrayNotHasKey( 'shippingLabel', $attrs );
+	}
+
+	public function test_physical_product_maps_dimensions_and_weight() {
+		update_option( 'woocommerce_dimension_unit', 'cm' );
+		update_option( 'woocommerce_weight_unit', 'g' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_virtual( false );
+		$product->set_length( '10' );
+		$product->set_width( '20' );
+		$product->set_height( '30' );
+		$product->set_weight( '500' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertEqualsCanonicalizing( [ 'value' => 10.0, 'unit' => 'cm' ], $attrs['shippingLength'] );
+		$this->assertEqualsCanonicalizing( [ 'value' => 20.0, 'unit' => 'cm' ], $attrs['shippingWidth'] );
+		$this->assertEqualsCanonicalizing( [ 'value' => 30.0, 'unit' => 'cm' ], $attrs['shippingHeight'] );
+		$this->assertEqualsCanonicalizing( [ 'value' => 500.0, 'unit' => 'g' ], $attrs['shippingWeight'] );
+	}
+
+	public function test_maps_shipping_label_from_shipping_class() {
+		$term = wp_insert_term( 'Bulky', 'product_shipping_class' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_shipping_class_id( $term['term_id'] );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'bulky', $attrs['shippingLabel'] );
+	}
+
+	public function test_physical_product_without_weight_omits_shipping_weight() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_virtual( false );
+		$product->set_weight( '' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertArrayHasKey( 'shipping', $attrs );
+		$this->assertArrayNotHasKey( 'shippingWeight', $attrs );
+	}
+
+	public function test_omits_shipping_dimensions_when_not_all_set() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_virtual( false );
+		$product->set_length( '10' );
+		$product->set_width( '20' );
+		$product->set_height( '' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertArrayNotHasKey( 'shippingLength', $attrs );
+		$this->assertArrayNotHasKey( 'shippingWidth', $attrs );
+		$this->assertArrayNotHasKey( 'shippingHeight', $attrs );
+	}
+
+	public function test_maps_weight_unit_lbs_to_lb() {
+		update_option( 'woocommerce_weight_unit', 'lbs' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_virtual( false );
+		$product->set_weight( '3' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'lb', $attrs['shippingWeight']['unit'] );
+	}
+
+	public function test_honors_virtual_property_filter_for_shipping() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_virtual( false );
+		$product->set_weight( '2' );
+		$product->save();
+
+		add_filter( 'woocommerce_gla_product_property_value_is_virtual', '__return_true' );
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+		remove_filter( 'woocommerce_gla_product_property_value_is_virtual', '__return_true' );
+
+		// Forced virtual: free shipping and no weight mapped.
+		$this->assertSame(
+			[
+				'amountMicros' => '0',
+				'currencyCode' => get_woocommerce_currency(),
+			],
+			$attrs['shipping'][0]['price']
+		);
+		$this->assertArrayNotHasKey( 'shippingWeight', $attrs );
+	}
+
+	public function test_variation_maps_shipping() {
+		update_option( 'woocommerce_weight_unit', 'g' );
+
+		$parent     = WC_Helper_Product::create_variation_product();
+		$variations = $parent->get_children();
+		$variation  = wc_get_product( $variations[0] );
+		$variation->set_virtual( false );
+		$variation->set_weight( '4' );
+		$variation->save();
+
+		$attrs = ( new WCProductInputAdapter( $variation, 'US', $parent ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( [ [ 'country' => 'US' ] ], $attrs['shipping'] );
+		$this->assertEqualsCanonicalizing( [ 'value' => 4.0, 'unit' => 'g' ], $attrs['shippingWeight'] );
+	}
 }

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -202,10 +202,34 @@ class WCProductInputAdapterTest extends UnitTest {
 
 		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
 
-		$this->assertEqualsCanonicalizing( [ 'value' => 10.0, 'unit' => 'cm' ], $attrs['shippingLength'] );
-		$this->assertEqualsCanonicalizing( [ 'value' => 20.0, 'unit' => 'cm' ], $attrs['shippingWidth'] );
-		$this->assertEqualsCanonicalizing( [ 'value' => 30.0, 'unit' => 'cm' ], $attrs['shippingHeight'] );
-		$this->assertEqualsCanonicalizing( [ 'value' => 500.0, 'unit' => 'g' ], $attrs['shippingWeight'] );
+		$this->assertEqualsCanonicalizing(
+			[
+				'value' => 10.0,
+				'unit'  => 'cm',
+			],
+			$attrs['shippingLength']
+		);
+		$this->assertEqualsCanonicalizing(
+			[
+				'value' => 20.0,
+				'unit'  => 'cm',
+			],
+			$attrs['shippingWidth']
+		);
+		$this->assertEqualsCanonicalizing(
+			[
+				'value' => 30.0,
+				'unit'  => 'cm',
+			],
+			$attrs['shippingHeight']
+		);
+		$this->assertEqualsCanonicalizing(
+			[
+				'value' => 500.0,
+				'unit'  => 'g',
+			],
+			$attrs['shippingWeight']
+		);
 	}
 
 	public function test_maps_shipping_label_from_shipping_class() {
@@ -294,6 +318,12 @@ class WCProductInputAdapterTest extends UnitTest {
 		$attrs = ( new WCProductInputAdapter( $variation, 'US', $parent ) )->get_product_input()->get_attributes();
 
 		$this->assertSame( [ [ 'country' => 'US' ] ], $attrs['shipping'] );
-		$this->assertEqualsCanonicalizing( [ 'value' => 4.0, 'unit' => 'g' ], $attrs['shippingWeight'] );
+		$this->assertEqualsCanonicalizing(
+			[
+				'value' => 4.0,
+				'unit'  => 'g',
+			],
+			$attrs['shippingWeight']
+		);
 	}
 }

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -1,0 +1,144 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductInputAdapter;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
+use WC_Helper_Product;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WCProductInputAdapterTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product
+ */
+class WCProductInputAdapterTest extends UnitTest {
+
+	use ProductTrait;
+
+	public function test_returns_product_input_with_identity() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_name( 'Adapter title' );
+		$product->save();
+
+		$input = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input();
+
+		$this->assertInstanceOf( ProductInput::class, $input );
+		$this->assertSame( "gla_{$product->get_id()}", $input->get_offer_id() );
+		$this->assertSame( 'en', $input->get_content_language() );
+		$this->assertSame( 'US', $input->get_feed_label() );
+	}
+
+	public function test_maps_general_attributes() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_name( 'Adapter title' );
+		$product->set_description( 'A description' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'Adapter title', $attrs['title'] );
+		$this->assertSame( 'A description', $attrs['description'] );
+		$this->assertSame( $product->get_permalink(), $attrs['link'] );
+		$this->assertArrayNotHasKey( 'itemGroupId', $attrs );
+	}
+
+	public function test_falls_back_to_short_description() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_description( '' );
+		$product->set_short_description( 'Short only' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'Short only', $attrs['description'] );
+	}
+
+	public function test_strips_shortcodes_from_description() {
+		add_shortcode( 'gla_probe_sc', '__return_empty_string' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_description( 'Hello [gla_probe_sc]' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		remove_shortcode( 'gla_probe_sc' );
+
+		$this->assertStringNotContainsString( '[gla_probe_sc]', $attrs['description'] );
+	}
+
+	public function test_variation_sets_item_group_id_to_parent() {
+		$parent     = WC_Helper_Product::create_variation_product();
+		$variations = $parent->get_children();
+		$variation  = wc_get_product( $variations[0] );
+
+		$attrs = ( new WCProductInputAdapter( $variation, 'US', $parent ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( (string) $parent->get_id(), $attrs['itemGroupId'] );
+	}
+
+	public function test_maps_price_to_micros() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '19.99' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame(
+			[
+				'amountMicros' => '19990000',
+				'currencyCode' => get_woocommerce_currency(),
+			],
+			$attrs['price']
+		);
+	}
+
+	public function test_omits_price_when_no_regular_price() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '' );
+		$product->set_price( '' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertArrayNotHasKey( 'price', $attrs );
+	}
+
+	public function test_maps_availability_in_stock() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_stock_status( 'instock' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'in_stock', $attrs['availability'] );
+	}
+
+	public function test_maps_availability_out_of_stock() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_stock_status( 'outofstock' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'out_of_stock', $attrs['availability'] );
+	}
+
+	public function test_omits_images_when_product_has_none() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_image_id( '' );
+		$product->set_gallery_image_ids( [] );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertArrayNotHasKey( 'imageLink', $attrs );
+		$this->assertArrayNotHasKey( 'additionalImageLinks', $attrs );
+	}
+
+}

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -140,5 +140,4 @@ class WCProductInputAdapterTest extends UnitTest {
 		$this->assertArrayNotHasKey( 'imageLink', $attrs );
 		$this->assertArrayNotHasKey( 'additionalImageLinks', $attrs );
 	}
-
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

First step in moving product sync off the Content API. The existing `WCProductAdapter` extends `ShoppingContent\Product` and is tied to the Content API SDK model. Since the official MAPI PHP SDK requires PHP 8.1+ (the plugin floor is 7.4), we build a MAPI equivalent from scratch. Adds `WCProductInputAdapter` alongside the old one (built incrementally toward parity) and routes product create/edit sync through MAPI's `productInputs.insert`. Delete stays on the Content API for now. This phase covers the minimum required fields (title, description, link, images, availability, price), richer attributes follow in the next phase.

Closes https://linear.app/a8c/issue/GOOWOO-692/migrate-product-create-update-sync-to-mapi

Note: once https://github.com/woocommerce/google-listings-and-ads/pull/3445 gets merged, change the base branch to `feature/mapi-migration`
### Screenshots:

<!--- Optional --->


### Detailed test instructions:
- Add a new product in WooCommerce. After a moment, the product should appear in Google Merchant Center.
- Edit an existing synced product (e.g. change the title). The change should appear in Merchant Center.
- Add a variable product with variations. Each variation appears as a separate product in Merchant Center.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
