### PR TITLE
GOOWOO-705 Shipping tab empty settings

### DIFF
--- a/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
+++ b/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
@@ -8,10 +8,9 @@ import { __ } from '@wordpress/i18n';
  */
 import { useAdaptiveFormContext } from '~/components/adaptive-form';
 import AppRadioContentControl from '~/components/app-radio-content-control';
-import RadioHelperText from '~/components/radio-helper-text';
 import Section from '~/components/section';
-import SpinnerCard from '~/components/spinner-card';
 import Subsection from '~/components/subsection';
+import RadioHelperText from '~/components/radio-helper-text';
 import SupportedCountrySelect from '~/components/supported-country-select';
 import VerticalGapLayout from '~/components/vertical-gap-layout';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
@@ -24,8 +23,7 @@ import './choose-audience-section.scss';
  * Does not provide any save strategy, this is to be bound externally.
  */
 const ChooseAudienceSection = () => {
-	const { hasGoogleMCConnection, hasFinishedResolution } =
-		useGoogleMCAccount();
+	const { hasGoogleMCConnection } = useGoogleMCAccount();
 	const {
 		getInputProps,
 		adapter: { renderRequestedValidation },
@@ -70,60 +68,51 @@ const ChooseAudienceSection = () => {
 				title={ __( 'Audience', 'google-listings-and-ads' ) }
 				description={ <p>{ description }</p> }
 			>
-				{ ! hasFinishedResolution ? (
-					<SpinnerCard />
-				) : (
-					<Section.Card>
-						<Section.Card.Body>
-							<Subsection>
-								<Subsection.Title>
-									{ __(
-										'Location',
+				<Section.Card>
+					<Section.Card.Body>
+						<Subsection>
+							<Subsection.Title>
+								{ __( 'Location', 'google-listings-and-ads' ) }
+							</Subsection.Title>
+							<Subsection.HelperText>
+								{ titleHelper }
+							</Subsection.HelperText>
+							<VerticalGapLayout size="medium">
+								<AppRadioContentControl
+									{ ...getInputProps( 'location' ) }
+									collapsible={ true }
+									label={ __(
+										'Selected countries only',
 										'google-listings-and-ads'
 									) }
-								</Subsection.Title>
-								<Subsection.HelperText>
-									{ titleHelper }
-								</Subsection.HelperText>
-								<VerticalGapLayout size="medium">
-									<AppRadioContentControl
-										{ ...getInputProps( 'location' ) }
-										collapsible={ true }
-										label={ __(
-											'Selected countries only',
+									value="selected"
+								>
+									<SupportedCountrySelect
+										multiple
+										{ ...getInputProps( 'countries' ) }
+										help={ __(
+											'Can’t find a country? Only supported countries can be selected.',
 											'google-listings-and-ads'
 										) }
-										value="selected"
-									>
-										<SupportedCountrySelect
-											multiple
-											{ ...getInputProps( 'countries' ) }
-											help={ __(
-												'Can’t find a country? Only supported countries can be selected.',
-												'google-listings-and-ads'
-											) }
-										/>
-										{ renderRequestedValidation(
-											'countries'
-										) }
-									</AppRadioContentControl>
-									<AppRadioContentControl
-										{ ...getInputProps( 'location' ) }
-										label={ __(
-											'All countries',
-											'google-listings-and-ads'
-										) }
-										value="all"
-									>
-										<RadioHelperText>
-											{ radioHelper }
-										</RadioHelperText>
-									</AppRadioContentControl>
-								</VerticalGapLayout>
-							</Subsection>
-						</Section.Card.Body>
-					</Section.Card>
-				) }
+									/>
+									{ renderRequestedValidation( 'countries' ) }
+								</AppRadioContentControl>
+								<AppRadioContentControl
+									{ ...getInputProps( 'location' ) }
+									label={ __(
+										'All countries',
+										'google-listings-and-ads'
+									) }
+									value="all"
+								>
+									<RadioHelperText>
+										{ radioHelper }
+									</RadioHelperText>
+								</AppRadioContentControl>
+							</VerticalGapLayout>
+						</Subsection>
+					</Section.Card.Body>
+				</Section.Card>
 			</Section>
 		</>
 	);

--- a/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
+++ b/js/src/components/free-listings/choose-audience-section/choose-audience-section.js
@@ -8,9 +8,10 @@ import { __ } from '@wordpress/i18n';
  */
 import { useAdaptiveFormContext } from '~/components/adaptive-form';
 import AppRadioContentControl from '~/components/app-radio-content-control';
-import Section from '~/components/section';
-import Subsection from '~/components/subsection';
 import RadioHelperText from '~/components/radio-helper-text';
+import Section from '~/components/section';
+import SpinnerCard from '~/components/spinner-card';
+import Subsection from '~/components/subsection';
 import SupportedCountrySelect from '~/components/supported-country-select';
 import VerticalGapLayout from '~/components/vertical-gap-layout';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
@@ -23,7 +24,8 @@ import './choose-audience-section.scss';
  * Does not provide any save strategy, this is to be bound externally.
  */
 const ChooseAudienceSection = () => {
-	const { hasGoogleMCConnection } = useGoogleMCAccount();
+	const { hasGoogleMCConnection, hasFinishedResolution } =
+		useGoogleMCAccount();
 	const {
 		getInputProps,
 		adapter: { renderRequestedValidation },
@@ -68,51 +70,60 @@ const ChooseAudienceSection = () => {
 				title={ __( 'Audience', 'google-listings-and-ads' ) }
 				description={ <p>{ description }</p> }
 			>
-				<Section.Card>
-					<Section.Card.Body>
-						<Subsection>
-							<Subsection.Title>
-								{ __( 'Location', 'google-listings-and-ads' ) }
-							</Subsection.Title>
-							<Subsection.HelperText>
-								{ titleHelper }
-							</Subsection.HelperText>
-							<VerticalGapLayout size="medium">
-								<AppRadioContentControl
-									{ ...getInputProps( 'location' ) }
-									collapsible={ true }
-									label={ __(
-										'Selected countries only',
+				{ ! hasFinishedResolution ? (
+					<SpinnerCard />
+				) : (
+					<Section.Card>
+						<Section.Card.Body>
+							<Subsection>
+								<Subsection.Title>
+									{ __(
+										'Location',
 										'google-listings-and-ads'
 									) }
-									value="selected"
-								>
-									<SupportedCountrySelect
-										multiple
-										{ ...getInputProps( 'countries' ) }
-										help={ __(
-											'Can’t find a country? Only supported countries can be selected.',
+								</Subsection.Title>
+								<Subsection.HelperText>
+									{ titleHelper }
+								</Subsection.HelperText>
+								<VerticalGapLayout size="medium">
+									<AppRadioContentControl
+										{ ...getInputProps( 'location' ) }
+										collapsible={ true }
+										label={ __(
+											'Selected countries only',
 											'google-listings-and-ads'
 										) }
-									/>
-									{ renderRequestedValidation( 'countries' ) }
-								</AppRadioContentControl>
-								<AppRadioContentControl
-									{ ...getInputProps( 'location' ) }
-									label={ __(
-										'All countries',
-										'google-listings-and-ads'
-									) }
-									value="all"
-								>
-									<RadioHelperText>
-										{ radioHelper }
-									</RadioHelperText>
-								</AppRadioContentControl>
-							</VerticalGapLayout>
-						</Subsection>
-					</Section.Card.Body>
-				</Section.Card>
+										value="selected"
+									>
+										<SupportedCountrySelect
+											multiple
+											{ ...getInputProps( 'countries' ) }
+											help={ __(
+												'Can’t find a country? Only supported countries can be selected.',
+												'google-listings-and-ads'
+											) }
+										/>
+										{ renderRequestedValidation(
+											'countries'
+										) }
+									</AppRadioContentControl>
+									<AppRadioContentControl
+										{ ...getInputProps( 'location' ) }
+										label={ __(
+											'All countries',
+											'google-listings-and-ads'
+										) }
+										value="all"
+									>
+										<RadioHelperText>
+											{ radioHelper }
+										</RadioHelperText>
+									</AppRadioContentControl>
+								</VerticalGapLayout>
+							</Subsection>
+						</Section.Card.Body>
+					</Section.Card>
+				) }
 			</Section>
 		</>
 	);

--- a/js/src/pages/shipping/index.js
+++ b/js/src/pages/shipping/index.js
@@ -189,8 +189,8 @@ export default function Shipping() {
 		}
 	};
 
-	const initialAudience = targetAudience?.countries ? targetAudience : {};
-	const initialSettings = settings?.shipping_rate ? settings : {};
+	const initialAudience = targetAudience?.location ? targetAudience : null;
+	const initialSettings = settings?.shipping_rate ? settings : null;
 	const initialRates = hasResolvedShippingRates ? savedShippingRates : {};
 	const initialTimes = hasResolvedShippingTimes ? savedShippingTimes : {};
 

--- a/js/src/pages/shipping/index.js
+++ b/js/src/pages/shipping/index.js
@@ -189,7 +189,7 @@ export default function Shipping() {
 		}
 	};
 
-	const initialAudience = targetAudience?.location ? targetAudience : null;
+	const initialAudience = targetAudience?.countries ? targetAudience : null;
 	const initialSettings = settings?.shipping_rate ? settings : null;
 	const initialRates = hasResolvedShippingRates ? savedShippingRates : {};
 	const initialTimes = hasResolvedShippingTimes ? savedShippingTimes : {};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-705/regression-in-shipping-tab

Fixes empty settings rendering in the shipping settings tab and adds card spinner while shipping settings are loading.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Reproduce the issue from `develop`:
1. Go to the Shipping tab in the plugin dashboard
2. Open devtools and in the Networks tab find the request to `/wc/gla/mc/settings` and throttle it (set it to 3G): <img width="581" height="757" alt="Screenshot 2026-05-28 at 18 15 06" src="https://github.com/user-attachments/assets/3d94ef40-d4a1-4e32-9611-e5313bd33780" />
3. Reload the page a few times until you see the some of the settings rendering as empty
4. Now switch to this featured branch and do the same, refresh a couple of times while throttling and confirm that the settings are not rendering empty anymore.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Shipping settings tab empty settings
