### PR TITLE
GOOWOO-633 Fix Settings tab page error when missing Google or Jetpack data

### DIFF
--- a/js/src/components/google-account-card/connected-google-account-card.js
+++ b/js/src/components/google-account-card/connected-google-account-card.js
@@ -23,7 +23,7 @@ const ConnectedGoogleAccountCard = ( {
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE }
-			description={ googleAccount.email }
+			description={ googleAccount?.email }
 			helper={ helper }
 			indicator={ <ConnectedIconLabel /> }
 		>

--- a/js/src/components/google-account-card/connected-google-account-card.js
+++ b/js/src/components/google-account-card/connected-google-account-card.js
@@ -23,7 +23,7 @@ const ConnectedGoogleAccountCard = ( {
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE }
-			description={ googleAccount?.email }
+			description={ googleAccount.email }
 			helper={ helper }
 			indicator={ <ConnectedIconLabel /> }
 		>

--- a/js/src/pages/settings/index.js
+++ b/js/src/pages/settings/index.js
@@ -46,7 +46,8 @@ const Settings = () => {
 
 	useUpdateRestAPIAuthorizeStatusByUrlQuery();
 
-	const { google } = useGoogleAccount();
+	const { google, hasFinishedResolution: hasFinishedResolutionGoogle } =
+		useGoogleAccount();
 	const isReconnectGooglePage = subpath === subpaths.reconnectGoogleAccount;
 	const { hasFinishedResolution, hasGoogleMCConnection } =
 		useGoogleMCAccount();
@@ -74,12 +75,16 @@ const Settings = () => {
 	// This page wouldn't get any 401 response when losing Google account access,
 	// so we still need to detect it here.
 	useEffect( () => {
-		if ( ! isReconnectGooglePage && google?.active === 'no' ) {
+		if (
+			! isReconnectGooglePage &&
+			hasFinishedResolutionGoogle &&
+			( ! google || google?.active === 'no' )
+		) {
 			getHistory().replace(
 				getReconnectAccountUrl( API_RESPONSE_CODES.GOOGLE_DISCONNECTED )
 			);
 		}
-	}, [ isReconnectGooglePage, google ] );
+	}, [ isReconnectGooglePage, google, hasFinishedResolutionGoogle ] );
 
 	// Navigate to subpath if any.
 	switch ( subpath ) {

--- a/js/src/pages/settings/linked-accounts.js
+++ b/js/src/pages/settings/linked-accounts.js
@@ -100,10 +100,12 @@ export default function LinkedAccounts() {
 			) : (
 				<>
 					<ConnectedWPComAccountCard jetpack={ jetpack } />
-					<ConnectedGoogleAccountCard
-						googleAccount={ google }
-						hideAccountSwitch
-					/>
+					{ google && (
+						<ConnectedGoogleAccountCard
+							googleAccount={ google }
+							hideAccountSwitch
+						/>
+					) }
 
 					{ hasGoogleMCConnection && (
 						<MerchantCenterAccountInfoCard

--- a/js/src/utils/getConnectedJetpackInfo.js
+++ b/js/src/utils/getConnectedJetpackInfo.js
@@ -16,7 +16,7 @@ import { __ } from '@wordpress/i18n';
  */
 export default function getConnectedJetpackInfo( jetpack ) {
 	// Error-proofing for calling with not yet connect jetpack.
-	if ( jetpack.active !== 'yes' ) {
+	if ( ! jetpack || jetpack.active !== 'yes' ) {
 		return '';
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-633/gfw-v362-settings-page-crashes-with-typeerror-cannot-read-properties

Add guards to ensure settings page is rendered when google or jetpack is not defined.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the plugin dashboard.
2. Open devtools and go to the `Network` tab.
3. Search for: `/wp-json/wc/gla/google/connected` and `/wp-json/wc/gla/jetpack/connected`, right click on them and then `Block Requests > Block Request URL`
5. Refresh the page and ensure the page loads showing a toast message error but there's no error in the console and no generic error on the page saying "Oops, something went wrong"


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Load settings tab when either Jetpack or Google data is not fully available
