### PR TITLE
GOOWOO-709: Migrate product delete sync to MAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
 			},
 			{
 				"path": "./google-listings-and-ads.zip",
-				"maxSize": "8.43 mB",
+				"maxSize": "8.6 mB",
 				"compression": "none"
 			}
 		],

--- a/src/API/Google/Mapi/Services/MapiProductInputsService.php
+++ b/src/API/Google/Mapi/Services/MapiProductInputsService.php
@@ -209,6 +209,73 @@ class MapiProductInputsService implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Delete a single product. The target data source is resolved from the input's
+	 * contentLanguage + feedLabel.
+	 *
+	 * @param ProductInput $input Product to delete.
+	 *
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function delete( ProductInput $input ): void {
+		$data_source = $this->data_sources->ensure_data_source_for(
+			$input->get_content_language(),
+			$input->get_feed_label()
+		);
+
+		$this->client->delete( $this->build_delete_path( $input, $data_source ) );
+	}
+
+	/**
+	 * Delete multiple products in parallel. Each input is routed to the data source
+	 * matching its (contentLanguage, feedLabel).
+	 *
+	 * @param ProductInput[] $inputs
+	 * @param int            $concurrency
+	 *
+	 * @return array{successes: array<int, ProductInput>, failures: array<int, MerchantApiException>}
+	 * @throws MerchantApiException On a non-2xx MAPI response while resolving a data source.
+	 */
+	public function delete_many( array $inputs, int $concurrency = 10 ): array {
+		$paths_by_index = [];
+		foreach ( $inputs as $index => $input ) {
+			$data_source              = $this->data_sources->ensure_data_source_for(
+				$input->get_content_language(),
+				$input->get_feed_label()
+			);
+			$paths_by_index[ $index ] = $this->build_delete_path( $input, $data_source );
+		}
+
+		$client = $this->client;
+
+		$requests = function () use ( $inputs, $client, $paths_by_index ) {
+			foreach ( $inputs as $index => $input ) {
+				yield $index => $client->request_async( 'DELETE', $paths_by_index[ $index ] );
+			}
+		};
+
+		$successes = [];
+		$failures  = [];
+
+		( new EachPromise(
+			$requests(),
+			[
+				'concurrency' => $concurrency,
+				'fulfilled'   => function ( array $body, int $index ) use ( &$successes, $inputs ) {
+					$successes[ $index ] = $inputs[ $index ];
+				},
+				'rejected'    => function ( $reason, int $index ) use ( &$failures ) {
+					$failures[ $index ] = $reason;
+				},
+			]
+		) )->promise()->wait();
+
+		return [
+			'successes' => $successes,
+			'failures'  => $failures,
+		];
+	}
+
+	/**
 	 * Build the productInputs.insert path with the resolved data source.
 	 *
 	 * @param string $data_source Data source resource name.
@@ -243,6 +310,26 @@ class MapiProductInputsService implements OptionsAwareInterface {
 			rawurlencode( $input->get_offer_id() ),
 			rawurlencode( $data_source ),
 			rawurlencode( implode( ',', $update_mask ) )
+		);
+	}
+
+	/**
+	 * Build the productInputs.delete path with the resolved data source.
+	 *
+	 * @param ProductInput $input       Products to delete.
+	 * @param string       $data_source Data source resource name.
+	 *
+	 * @return string
+	 */
+	protected function build_delete_path( ProductInput $input, string $data_source ): string {
+		return sprintf(
+			'%s/accounts/%s/productInputs/%s~%s~%s?dataSource=%s',
+			MapiPaths::PRODUCTS,
+			$this->options->get_merchant_id(),
+			$input->get_content_language(),
+			$input->get_feed_label(),
+			rawurlencode( $input->get_offer_id() ),
+			rawurlencode( $data_source )
 		);
 	}
 }

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -1716,9 +1716,9 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 
 				try {
 					$products = $product_repository->find_synced_products();
-					$stale_entries = $batch_product_helper->generate_stale_products_request_entries( $products );
+					$stale_entries = $batch_product_helper->generate_stale_products_delete_entries( $products );
 
-					$result = $product_syncer->delete_by_batch_requests( $stale_entries );
+					$result = $product_syncer->delete_mapi_entries( $stale_entries );
 
 					$this->response .= sprintf( '%s products cleaned up.', count( $result->get_products() ) ) . "\n";
 					if ( ! empty( $result->get_errors() ) ) {

--- a/src/Jobs/CleanupProductsJob.php
+++ b/src/Jobs/CleanupProductsJob.php
@@ -48,7 +48,7 @@ class CleanupProductsJob extends AbstractProductSyncerBatchedJob {
 	 */
 	protected function process_items( array $items ) {
 		$products      = $this->product_repository->find_by_ids( $items );
-		$stale_entries = $this->batch_product_helper->generate_stale_products_request_entries( $products );
-		$this->product_syncer->delete_by_batch_requests( $stale_entries );
+		$stale_entries = $this->batch_product_helper->generate_stale_products_delete_entries( $products );
+		$this->product_syncer->delete_mapi_entries( $stale_entries );
 	}
 }

--- a/src/Jobs/DeleteAllProducts.php
+++ b/src/Jobs/DeleteAllProducts.php
@@ -46,9 +46,8 @@ class DeleteAllProducts extends AbstractProductSyncerBatchedJob {
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
 	protected function process_items( array $items ) {
-		$products        = $this->product_repository->find_by_ids( $items );
-		$product_entries = $this->batch_product_helper->generate_delete_request_entries( $products );
-		$this->product_syncer->delete_by_batch_requests( $product_entries );
+		$products = $this->product_repository->find_by_ids( $items );
+		$this->product_syncer->delete( $products );
 	}
 
 	/**

--- a/src/Jobs/DeleteProducts.php
+++ b/src/Jobs/DeleteProducts.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncerException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ProductIDMap;
 
@@ -37,8 +36,7 @@ class DeleteProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
 	public function process_items( array $product_id_map ) {
-		$product_entries = BatchProductIDRequestEntry::create_from_id_map( new ProductIDMap( $product_id_map ) );
-		$this->product_syncer->delete_by_batch_requests( $product_entries );
+		$this->product_syncer->delete_by_id_map( $product_id_map );
 	}
 
 	/**

--- a/src/Jobs/Update/CleanupProductTargetCountriesJob.php
+++ b/src/Jobs/Update/CleanupProductTargetCountriesJob.php
@@ -50,7 +50,7 @@ class CleanupProductTargetCountriesJob extends AbstractProductSyncerBatchedJob {
 	 */
 	protected function process_items( array $items ) {
 		$products      = $this->product_repository->find_by_ids( $items );
-		$stale_entries = $this->batch_product_helper->generate_stale_countries_request_entries( $products );
-		$this->product_syncer->delete_by_batch_requests( $stale_entries );
+		$stale_entries = $this->batch_product_helper->generate_stale_countries_delete_entries( $products );
+		$this->product_syncer->delete_mapi_entries( $stale_entries );
 	}
 }

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -309,6 +309,66 @@ class BatchProductHelper implements Service {
 	}
 
 	/**
+	 * Generate MAPI delete entries for the given products.
+	 *
+	 * @param WC_Product[] $products
+	 *
+	 * @return array<int, array{wc_product_id: int, country: string, google_id: string, input: ProductInput}>
+	 */
+	public function generate_mapi_delete_entries( array $products ): array {
+		$entries = [];
+
+		foreach ( $products as $product ) {
+			$this->validate_instanceof( $product, WC_Product::class );
+
+			if ( $product instanceof WC_Product_Variable ) {
+				$entries = array_merge( $entries, $this->generate_mapi_delete_entries( $product->get_available_variations( 'objects' ) ) );
+				continue;
+			}
+
+			$google_ids = $this->product_helper->get_synced_google_product_ids( $product );
+			if ( empty( $google_ids ) ) {
+				continue;
+			}
+
+			foreach ( $google_ids as $country => $google_id ) {
+				$identity = $this->parse_mapi_identity( (string) $google_id );
+				if ( null === $identity ) {
+					continue;
+				}
+
+				[ $language, $feed, $offer_id ] = $identity;
+
+				$entries[] = [
+					'wc_product_id' => $product->get_id(),
+					'country'       => (string) $country,
+					'google_id'     => (string) $google_id,
+					'input'         => new ProductInput( $offer_id, $language, $feed ),
+				];
+			}
+		}
+
+		return $entries;
+	}
+
+	/**
+	 * Parse a MAPI Google product id (e.g. `en~US~gla_29`) into its identity array
+	 * [language, feed, offerId].
+	 *
+	 * @param string $google_id
+	 *
+	 * @return array{0: string, 1: string, 2: string}|null
+	 */
+	public function parse_mapi_identity( string $google_id ): ?array {
+		$parts = explode( '~', $google_id, 3 );
+		if ( count( $parts ) !== 3 ) {
+			return null;
+		}
+
+		return [ $parts[0], $parts[1], $parts[2] ];
+	}
+
+	/**
 	 * @param WCProductAdapter $product
 	 *
 	 * @return BatchInvalidProductEntry|true
@@ -327,54 +387,66 @@ class BatchProductHelper implements Service {
 	}
 
 	/**
-	 * Filters and returns an array of request entries for Google products that should no longer be submitted for the selected target audience.
+	 * Generate MAPI delete entries for products whose stored google_ids include
+	 * countries that are no longer in the target audience.
 	 *
 	 * @param WC_Product[] $products
 	 *
-	 * @return BatchProductIDRequestEntry[]
+	 * @return array<int, array{wc_product_id: int, country: string, google_id: string, input: ProductInput}>
 	 */
-	public function generate_stale_products_request_entries( array $products ): array {
+	public function generate_stale_products_delete_entries( array $products ): array {
 		$target_audience = $this->target_audience->get_target_countries();
-		$request_entries = [];
-		foreach ( $products as $product ) {
-			$google_ids = $this->meta_handler->get_google_ids( $product ) ?: [];
-			$stale_ids  = array_diff_key( $google_ids, array_flip( $target_audience ) );
-			foreach ( $stale_ids as $stale_id ) {
-				$request_entries[ $stale_id ] = new BatchProductIDRequestEntry(
-					$product->get_id(),
-					$stale_id
-				);
-			}
-		}
 
-		return $request_entries;
+		return $this->build_stale_entries( $products, $target_audience );
 	}
 
 	/**
-	 * Returns an array of request entries for Google products that should no
-	 * longer be submitted for every target country.
+	 * Generate MAPI delete entries for products whose stored google_ids target
+	 * countries other than the main target country.
 	 *
 	 * @since 1.1.0
 	 *
 	 * @param WC_Product[] $products
 	 *
-	 * @return BatchProductIDRequestEntry[]
+	 * @return array<int, array{wc_product_id: int, country: string, google_id: string, input: ProductInput}>
 	 */
-	public function generate_stale_countries_request_entries( array $products ): array {
-		$main_target_country = $this->target_audience->get_main_target_country();
+	public function generate_stale_countries_delete_entries( array $products ): array {
+		return $this->build_stale_entries( $products, [ $this->target_audience->get_main_target_country() ] );
+	}
 
-		$request_entries = [];
+	/**
+	 * Build MAPI delete entries from products by keeping only the google_ids whose
+	 * country is NOT in $keep_countries. Malformed ids are skipped.
+	 *
+	 * @param WC_Product[] $products
+	 * @param string[]     $keep_countries
+	 *
+	 * @return array<int, array{wc_product_id: int, country: string, google_id: string, input: ProductInput}>
+	 */
+	protected function build_stale_entries( array $products, array $keep_countries ): array {
+		$entries = [];
+
 		foreach ( $products as $product ) {
 			$google_ids = $this->meta_handler->get_google_ids( $product ) ?: [];
-			$stale_ids  = array_diff_key( $google_ids, array_flip( [ $main_target_country ] ) );
-			foreach ( $stale_ids as $stale_id ) {
-				$request_entries[ $stale_id ] = new BatchProductIDRequestEntry(
-					$product->get_id(),
-					$stale_id
-				);
+			$stale_ids  = array_diff_key( $google_ids, array_flip( $keep_countries ) );
+
+			foreach ( $stale_ids as $country => $google_id ) {
+				$identity = $this->parse_mapi_identity( (string) $google_id );
+				if ( null === $identity ) {
+					continue;
+				}
+
+				[ $language, $feed, $offer_id ] = $identity;
+
+				$entries[] = [
+					'wc_product_id' => $product->get_id(),
+					'country'       => (string) $country,
+					'google_id'     => (string) $google_id,
+					'input'         => new ProductInput( $offer_id, $language, $feed ),
+				];
 			}
 		}
 
-		return $request_entries;
+		return $entries;
 	}
 }

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -313,7 +313,7 @@ class BatchProductHelper implements Service {
 	 *
 	 * @param WC_Product[] $products
 	 *
-	 * @return array<int, array{wc_product_id: int, country: string, google_id: string, input: ProductInput}>
+	 * @return array<int, array{wc_product_id: int, google_id: string, input: ProductInput}>
 	 */
 	public function generate_mapi_delete_entries( array $products ): array {
 		$entries = [];
@@ -331,7 +331,7 @@ class BatchProductHelper implements Service {
 				continue;
 			}
 
-			foreach ( $google_ids as $country => $google_id ) {
+			foreach ( $google_ids as $google_id ) {
 				$identity = $this->parse_mapi_identity( (string) $google_id );
 				if ( null === $identity ) {
 					continue;
@@ -341,7 +341,6 @@ class BatchProductHelper implements Service {
 
 				$entries[] = [
 					'wc_product_id' => $product->get_id(),
-					'country'       => (string) $country,
 					'google_id'     => (string) $google_id,
 					'input'         => new ProductInput( $offer_id, $language, $feed ),
 				];
@@ -392,7 +391,7 @@ class BatchProductHelper implements Service {
 	 *
 	 * @param WC_Product[] $products
 	 *
-	 * @return array<int, array{wc_product_id: int, country: string, google_id: string, input: ProductInput}>
+	 * @return array<int, array{wc_product_id: int, google_id: string, input: ProductInput}>
 	 */
 	public function generate_stale_products_delete_entries( array $products ): array {
 		$target_audience = $this->target_audience->get_target_countries();
@@ -408,7 +407,7 @@ class BatchProductHelper implements Service {
 	 *
 	 * @param WC_Product[] $products
 	 *
-	 * @return array<int, array{wc_product_id: int, country: string, google_id: string, input: ProductInput}>
+	 * @return array<int, array{wc_product_id: int, google_id: string, input: ProductInput}>
 	 */
 	public function generate_stale_countries_delete_entries( array $products ): array {
 		return $this->build_stale_entries( $products, [ $this->target_audience->get_main_target_country() ] );
@@ -421,7 +420,7 @@ class BatchProductHelper implements Service {
 	 * @param WC_Product[] $products
 	 * @param string[]     $keep_countries
 	 *
-	 * @return array<int, array{wc_product_id: int, country: string, google_id: string, input: ProductInput}>
+	 * @return array<int, array{wc_product_id: int, google_id: string, input: ProductInput}>
 	 */
 	protected function build_stale_entries( array $products, array $keep_countries ): array {
 		$entries = [];
@@ -430,7 +429,7 @@ class BatchProductHelper implements Service {
 			$google_ids = $this->meta_handler->get_google_ids( $product ) ?: [];
 			$stale_ids  = array_diff_key( $google_ids, array_flip( $keep_countries ) );
 
-			foreach ( $stale_ids as $country => $google_id ) {
+			foreach ( $stale_ids as $google_id ) {
 				$identity = $this->parse_mapi_identity( (string) $google_id );
 				if ( null === $identity ) {
 					continue;
@@ -440,7 +439,6 @@ class BatchProductHelper implements Service {
 
 				$entries[] = [
 					'wc_product_id' => $product->get_id(),
-					'country'       => (string) $country,
 					'google_id'     => (string) $google_id,
 					'input'         => new ProductInput( $offer_id, $language, $feed ),
 				];

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -290,8 +290,6 @@ class ProductSyncer implements Service {
 	 * @throws ProductSyncerException If there are any errors while deleting products from Google Merchant Center.
 	 */
 	public function delete( array $products ): BatchProductResponse {
-		$this->validate_merchant_center_setup();
-
 		$synced_products = $this->batch_helper->filter_synced_products( $products );
 		$entries         = $this->batch_helper->generate_mapi_delete_entries( $synced_products );
 
@@ -300,7 +298,7 @@ class ProductSyncer implements Service {
 
 	/**
 	 * Delete the products described by the given id map (`[ google_id => wc_product_id ]`),
-	 * the shape produced by ProductIDMap. Country is parsed from the google_id's feed segment.
+	 * the shape produced by ProductIDMap.
 	 *
 	 * @param array<string, int> $product_id_map
 	 *
@@ -309,8 +307,6 @@ class ProductSyncer implements Service {
 	 * @throws ProductSyncerException If there are any errors while deleting products from Google Merchant Center.
 	 */
 	public function delete_by_id_map( array $product_id_map ): BatchProductResponse {
-		$this->validate_merchant_center_setup();
-
 		$entries = [];
 		foreach ( $product_id_map as $google_id => $wc_product_id ) {
 			$identity = $this->batch_helper->parse_mapi_identity( (string) $google_id );
@@ -322,7 +318,6 @@ class ProductSyncer implements Service {
 
 			$entries[] = [
 				'wc_product_id' => (int) $wc_product_id,
-				'country'       => $feed,
 				'google_id'     => (string) $google_id,
 				'input'         => new ProductInput( $offer_id, $language, $feed ),
 			];
@@ -334,13 +329,15 @@ class ProductSyncer implements Service {
 	/**
 	 * Delete the given MAPI entries via productInputs.delete.
 	 *
-	 * @param array<int, array{wc_product_id: int, country: string, google_id: string, input: ProductInput}> $entries
+	 * @param array<int, array{wc_product_id: int, google_id: string, input: ProductInput}> $entries
 	 *
 	 * @return BatchProductResponse Containing both the deleted and invalid products.
 	 *
 	 * @throws ProductSyncerException If there are any errors while deleting products from Google Merchant Center.
 	 */
 	public function delete_mapi_entries( array $entries ): BatchProductResponse {
+		$this->validate_merchant_center_setup();
+
 		if ( empty( $entries ) ) {
 			return new BatchProductResponse( [], [] );
 		}

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -9,7 +9,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiPro
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
@@ -187,7 +186,7 @@ class ProductSyncer implements Service {
 	protected function build_synced_google_product( ProductInput $input, string $country ): GoogleProduct {
 		$google_product = new GoogleProduct();
 		$google_product->setId(
-			sprintf( 'online:%s:%s:%s', $input->get_content_language(), $input->get_feed_label(), $input->get_offer_id() )
+			sprintf( '%s~%s~%s', $input->get_content_language(), $input->get_feed_label(), $input->get_offer_id() )
 		);
 		$google_product->setTargetCountry( $country );
 
@@ -294,44 +293,89 @@ class ProductSyncer implements Service {
 		$this->validate_merchant_center_setup();
 
 		$synced_products = $this->batch_helper->filter_synced_products( $products );
-		$product_entries = $this->batch_helper->generate_delete_request_entries( $synced_products );
+		$entries         = $this->batch_helper->generate_mapi_delete_entries( $synced_products );
 
-		return $this->delete_by_batch_requests( $product_entries );
+		return $this->delete_mapi_entries( $entries );
 	}
 
 	/**
-	 * Deletes an array of WooCommerce products from Google Merchant Center.
+	 * Delete the products described by the given id map (`[ google_id => wc_product_id ]`),
+	 * the shape produced by ProductIDMap. Country is parsed from the google_id's feed segment.
 	 *
-	 * Note: This method does not automatically delete variations of a parent product. They each must be provided via the $product_entries argument.
+	 * @param array<string, int> $product_id_map
 	 *
-	 * @param BatchProductIDRequestEntry[] $product_entries
-	 *
-	 * @return BatchProductResponse Containing both the deleted and invalid products (including their variation).
+	 * @return BatchProductResponse Containing both the deleted and invalid products.
 	 *
 	 * @throws ProductSyncerException If there are any errors while deleting products from Google Merchant Center.
 	 */
-	public function delete_by_batch_requests( array $product_entries ): BatchProductResponse {
+	public function delete_by_id_map( array $product_id_map ): BatchProductResponse {
 		$this->validate_merchant_center_setup();
 
-		// return empty response if no synced product found
-		if ( empty( $product_entries ) ) {
+		$entries = [];
+		foreach ( $product_id_map as $google_id => $wc_product_id ) {
+			$identity = $this->batch_helper->parse_mapi_identity( (string) $google_id );
+			if ( null === $identity ) {
+				continue;
+			}
+
+			[ $language, $feed, $offer_id ] = $identity;
+
+			$entries[] = [
+				'wc_product_id' => (int) $wc_product_id,
+				'country'       => $feed,
+				'google_id'     => (string) $google_id,
+				'input'         => new ProductInput( $offer_id, $language, $feed ),
+			];
+		}
+
+		return $this->delete_mapi_entries( $entries );
+	}
+
+	/**
+	 * Delete the given MAPI entries via productInputs.delete.
+	 *
+	 * @param array<int, array{wc_product_id: int, country: string, google_id: string, input: ProductInput}> $entries
+	 *
+	 * @return BatchProductResponse Containing both the deleted and invalid products.
+	 *
+	 * @throws ProductSyncerException If there are any errors while deleting products from Google Merchant Center.
+	 */
+	public function delete_mapi_entries( array $entries ): BatchProductResponse {
+		if ( empty( $entries ) ) {
 			return new BatchProductResponse( [], [] );
 		}
 
 		$deleted_products = [];
 		$invalid_products = [];
-		foreach ( array_chunk( $product_entries, GoogleProductService::BATCH_SIZE ) as $batch_entries ) {
+
+		foreach ( array_chunk( $entries, GoogleProductService::BATCH_SIZE ) as $batch ) {
+			$inputs = array_map(
+				static function ( array $entry ): ProductInput {
+					return $entry['input'];
+				},
+				$batch
+			);
+
 			try {
-				$response = $this->google_service->delete_batch( $batch_entries );
-
-				$deleted_products = array_merge( $deleted_products, $response->get_products() );
-				$invalid_products = array_merge( $invalid_products, $response->get_errors() );
-
-				array_walk( $deleted_products, [ $this->batch_helper, 'mark_as_unsynced' ] );
+				$result = $this->mapi_inputs->delete_many( $inputs );
 			} catch ( Exception $exception ) {
 				do_action( 'woocommerce_gla_exception', $exception, __METHOD__ );
 
 				throw new ProductSyncerException( sprintf( 'Error deleting Google products: %s', $exception->getMessage() ), 0, $exception );
+			}
+
+			foreach ( $batch as $index => $entry ) {
+				if ( isset( $result['successes'][ $index ] ) ) {
+					$deleted_entry      = new BatchProductEntry( $entry['wc_product_id'], null );
+					$deleted_products[] = $deleted_entry;
+					$this->batch_helper->mark_as_unsynced( $deleted_entry );
+				} elseif ( isset( $result['failures'][ $index ] ) ) {
+					$invalid_products[] = $this->build_delete_invalid_entry(
+						$entry['wc_product_id'],
+						$entry['google_id'],
+						$result['failures'][ $index ]
+					);
+				}
 			}
 		}
 
@@ -343,29 +387,34 @@ class ProductSyncer implements Service {
 			$invalid_products
 		);
 
-		do_action(
-			'woocommerce_gla_debug_message',
-			sprintf(
-				"Deleted %s products:\n%s",
-				count( $deleted_products ),
-				wp_json_encode( $deleted_products ),
-			),
-			__METHOD__
-		);
-		if ( ! empty( $invalid_products ) ) {
-			do_action(
-				'woocommerce_gla_debug_message',
-				sprintf(
-					"Failed to delete %s products from Merchant Center:\n%s",
-					count( $invalid_products ),
-					wp_json_encode( $invalid_products )
-				),
-				__METHOD__
-			);
-		}
-
 		return new BatchProductResponse( $deleted_products, $invalid_products );
 	}
+
+	/**
+	 * Build an invalid entry from a failed MAPI delete. 404 is tagged with the
+	 * not-found reason so the existing handler removes the stale google_id;
+	 * server errors are tagged with the internal-error reason so they are retried.
+	 *
+	 * @param int       $wc_product_id
+	 * @param string    $google_id
+	 * @param Exception $reason
+	 *
+	 * @return BatchInvalidProductEntry
+	 */
+	protected function build_delete_invalid_entry( int $wc_product_id, string $google_id, Exception $reason ): BatchInvalidProductEntry {
+		$status = $reason instanceof MerchantApiException ? $reason->get_http_status() : 0;
+
+		if ( 404 === $status ) {
+			$errors = [ GoogleProductService::NOT_FOUND_ERROR_REASON => $reason->getMessage() ];
+		} elseif ( $status >= 500 ) {
+			$errors = [ GoogleProductService::INTERNAL_ERROR_REASON => $reason->getMessage() ];
+		} else {
+			$errors = [ 'invalid' => $reason->getMessage() ];
+		}
+
+		return new BatchInvalidProductEntry( $wc_product_id, $google_id, $errors );
+	}
+
 
 	/**
 	 * Return the list of supported product types.

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
@@ -79,6 +79,16 @@ class MapiProductInputsServiceTest extends UnitTest {
 		);
 	}
 
+	protected function expected_delete_path( ProductInput $input, string $data_source ): string {
+		return sprintf(
+			'products/v1/accounts/12345/productInputs/%s~%s~%s?dataSource=%s',
+			$input->get_content_language(),
+			$input->get_feed_label(),
+			rawurlencode( $input->get_offer_id() ),
+			rawurlencode( $data_source )
+		);
+	}
+
 	protected function make_input( string $offer_id = 'sku42', string $language = 'en', string $feed = 'US' ): ProductInput {
 		return new ProductInput( $offer_id, $language, $feed, [ 'title' => 'Test' ] );
 	}
@@ -314,5 +324,86 @@ class MapiProductInputsServiceTest extends UnitTest {
 				new ProductInputPatch( $this->make_input( 'bad' ), [] ),
 			]
 		);
+	}
+
+	public function test_delete_resolves_data_source_and_calls_expected_path() {
+		$input = $this->make_input();
+
+		$this->client->expects( $this->once() )
+			->method( 'delete' )
+			->with( $this->expected_delete_path( $input, self::DS_EN_US ) )
+			->willReturn( [] );
+
+		$this->service->delete( $input );
+	}
+
+	public function test_delete_routes_different_market_to_a_different_data_source() {
+		$input = $this->make_input( 'sku42', 'fr', 'CA' );
+
+		$this->client->expects( $this->once() )
+			->method( 'delete' )
+			->with( $this->expected_delete_path( $input, self::DS_FR_CA ) )
+			->willReturn( [] );
+
+		$this->service->delete( $input );
+	}
+
+	public function test_delete_propagates_merchant_api_exception() {
+		$this->client->method( 'delete' )
+			->willThrowException( new MerchantApiException( 404, [], __METHOD__ ) );
+
+		$this->expectException( MerchantApiException::class );
+
+		$this->service->delete( $this->make_input() );
+	}
+
+	public function test_delete_many_keys_successes_and_failures_by_index() {
+		$this->client->method( 'request_async' )
+			->willReturnCallback(
+				function ( string $method, string $path ) {
+					if ( false !== strpos( $path, 'bad' ) ) {
+						return Create::rejectionFor( new MerchantApiException( 404, [], __METHOD__ ) );
+					}
+
+					return Create::promiseFor( [] );
+				}
+			);
+
+		$inputs = [
+			$this->make_input( 'good1' ),
+			$this->make_input( 'bad' ),
+			$this->make_input( 'good2' ),
+		];
+
+		$result = $this->service->delete_many( $inputs );
+
+		$this->assertCount( 2, $result['successes'] );
+		$this->assertCount( 1, $result['failures'] );
+		$this->assertArrayHasKey( 0, $result['successes'] );
+		$this->assertArrayHasKey( 2, $result['successes'] );
+		$this->assertArrayHasKey( 1, $result['failures'] );
+		$this->assertInstanceOf( MerchantApiException::class, $result['failures'][1] );
+	}
+
+	public function test_delete_many_routes_each_input_to_its_own_data_source() {
+		$paths_seen = [];
+
+		$this->client->method( 'request_async' )
+			->willReturnCallback(
+				function ( string $method, string $path ) use ( &$paths_seen ) {
+					$paths_seen[] = [ $method, $path ];
+
+					return Create::promiseFor( [] );
+				}
+			);
+
+		$us_input = $this->make_input( 'us_sku', 'en', 'US' );
+		$ca_input = $this->make_input( 'ca_sku', 'fr', 'CA' );
+
+		$this->service->delete_many( [ $us_input, $ca_input ] );
+
+		$this->assertSame( 'DELETE', $paths_seen[0][0] );
+		$this->assertSame( $this->expected_delete_path( $us_input, self::DS_EN_US ), $paths_seen[0][1] );
+		$this->assertSame( $this->expected_delete_path( $ca_input, self::DS_FR_CA ), $paths_seen[1][1] );
 	}
 }

--- a/tests/Unit/Jobs/DeleteAllProductsTest.php
+++ b/tests/Unit/Jobs/DeleteAllProductsTest.php
@@ -16,7 +16,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\JobTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -127,12 +126,6 @@ class DeleteAllProductsTest extends UnitTest {
 
 	public function test_process_item() {
 		$filtered_product_list = new FilteredProductList( $this->generate_simple_product_mocks_set( 1 ), 1 );
-		$request_entries       = [
-			new BatchProductIDRequestEntry(
-				$filtered_product_list->get()[0]->get_id(),
-				'mc_id'
-			),
-		];
 
 		$this->product_repository
 			->expects( $this->once() )
@@ -140,21 +133,14 @@ class DeleteAllProductsTest extends UnitTest {
 			->with( $filtered_product_list->get_product_ids() )
 			->willReturn( $filtered_product_list->get() );
 
-		$this->product_helper->expects( $this->once() )
-			->method( 'generate_delete_request_entries' )
-			->with( $filtered_product_list->get() )
-			->willReturn(
-				$request_entries
-			);
-
 		$this->action_scheduler
 			->method( 'has_scheduled_action' )
 			->willReturn( false );
 
 		$this->product_syncer
 			->expects( $this->once() )
-			->method( 'delete_by_batch_requests' )
-			->with( $request_entries );
+			->method( 'delete' )
+			->with( $filtered_product_list->get() );
 
 		do_action( self::PROCESS_ITEM_HOOK, $filtered_product_list->get_product_ids() );
 	}

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -201,7 +201,6 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertCount( count( $products ), $results );
 		foreach ( $results as $entry ) {
 			$this->assertInstanceOf( ProductInput::class, $entry['input'] );
-			$this->assertSame( 'US', $entry['country'] );
 			$this->assertSame( "en~US~gla_{$entry['wc_product_id']}", $entry['google_id'] );
 			$this->assertSame( 'en', $entry['input']->get_content_language() );
 			$this->assertSame( 'US', $entry['input']->get_feed_label() );
@@ -403,17 +402,15 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 
 		$this->assertCount( 2, $results );
 
-		$entries_by_country = [];
 		foreach ( $results as $entry ) {
 			$this->assertInstanceOf( ProductInput::class, $entry['input'] );
 			$this->assertSame( $stale_product_id, $entry['wc_product_id'] );
-			$entries_by_country[ $entry['country'] ] = $entry;
 		}
 
-		$this->assertArrayHasKey( 'AU', $entries_by_country );
-		$this->assertArrayHasKey( 'DK', $entries_by_country );
-		$this->assertSame( $stale_google_ids['AU'], $entries_by_country['AU']['google_id'] );
-		$this->assertSame( $stale_google_ids['DK'], $entries_by_country['DK']['google_id'] );
+		$google_ids = array_column( $results, 'google_id' );
+		$this->assertContains( $stale_google_ids['AU'], $google_ids );
+		$this->assertContains( $stale_google_ids['DK'], $google_ids );
+		$this->assertNotContains( $stale_google_ids['US'], $google_ids );
 	}
 
 	public function test_generate_stale_countries_delete_entries() {
@@ -436,17 +433,15 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 
 		$this->assertCount( 2, $results );
 
-		$entries_by_country = [];
 		foreach ( $results as $entry ) {
 			$this->assertInstanceOf( ProductInput::class, $entry['input'] );
 			$this->assertSame( $stale_product_id, $entry['wc_product_id'] );
-			$entries_by_country[ $entry['country'] ] = $entry;
 		}
 
-		$this->assertArrayHasKey( 'AU', $entries_by_country );
-		$this->assertArrayHasKey( 'DK', $entries_by_country );
-		$this->assertSame( $stale_google_ids['AU'], $entries_by_country['AU']['google_id'] );
-		$this->assertSame( $stale_google_ids['DK'], $entries_by_country['DK']['google_id'] );
+		$google_ids = array_column( $results, 'google_id' );
+		$this->assertContains( $stale_google_ids['AU'], $google_ids );
+		$this->assertContains( $stale_google_ids['DK'], $google_ids );
+		$this->assertNotContains( $stale_google_ids['US'], $google_ids );
 	}
 
 	/**

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidClass;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
@@ -185,6 +186,78 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertArrayNotHasKey( 'online:en:US:gla_' . $skipped_product->get_id(), $results );
 	}
 
+	public function test_generate_mapi_delete_entries() {
+		$products = $this->create_and_return_supported_test_products();
+
+		foreach ( $products as $product ) {
+			$this->product_helper->mark_as_synced(
+				$product,
+				$this->generate_google_product_mock( "en~US~gla_{$product->get_id()}", 'US' )
+			);
+		}
+
+		$results = $this->batch_product_helper->generate_mapi_delete_entries( $products );
+
+		$this->assertCount( count( $products ), $results );
+		foreach ( $results as $entry ) {
+			$this->assertInstanceOf( ProductInput::class, $entry['input'] );
+			$this->assertSame( 'US', $entry['country'] );
+			$this->assertSame( "en~US~gla_{$entry['wc_product_id']}", $entry['google_id'] );
+			$this->assertSame( 'en', $entry['input']->get_content_language() );
+			$this->assertSame( 'US', $entry['input']->get_feed_label() );
+			$this->assertSame( "gla_{$entry['wc_product_id']}", $entry['input']->get_offer_id() );
+		}
+	}
+
+	public function test_generate_mapi_delete_entries_variable_product() {
+		$variable   = WC_Helper_Product::create_variation_product();
+		$variations = [];
+		foreach ( $variable->get_children() as $variation_id ) {
+			$variation = $this->wc->get_product( $variation_id );
+			$this->product_helper->mark_as_synced(
+				$variation,
+				$this->generate_google_product_mock( "en~US~gla_{$variation->get_id()}", 'US' )
+			);
+			$variations[] = $variation;
+		}
+
+		$results = $this->batch_product_helper->generate_mapi_delete_entries( [ $variable ] );
+
+		$this->assertCount( count( $variations ), $results );
+	}
+
+	public function test_generate_mapi_delete_entries_skips_products_without_google_id() {
+		$products = $this->create_and_return_supported_test_products();
+
+		foreach ( $products as $product ) {
+			$this->product_helper->mark_as_synced(
+				$product,
+				$this->generate_google_product_mock( "en~US~gla_{$product->get_id()}", 'US' )
+			);
+		}
+
+		$skipped_product = $products[0];
+		$this->product_meta->delete_google_ids( $skipped_product );
+
+		$results = $this->batch_product_helper->generate_mapi_delete_entries( $products );
+
+		$this->assertNotContains( $skipped_product->get_id(), array_column( $results, 'wc_product_id' ) );
+	}
+
+	public function test_generate_mapi_delete_entries_skips_malformed_id() {
+		$products = $this->create_and_return_supported_test_products();
+		$product  = $products[0];
+
+		$this->product_helper->mark_as_synced(
+			$product,
+			$this->generate_google_product_mock( 'malformed-id', 'US' )
+		);
+
+		$results = $this->batch_product_helper->generate_mapi_delete_entries( [ $product ] );
+
+		$this->assertEmpty( $results );
+	}
+
 	public function test_validate_and_generate_update_request_entries() {
 		$products = $this->create_and_return_supported_test_products();
 
@@ -310,7 +383,7 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->batch_product_helper->validate_and_generate_update_request_entries( $products );
 	}
 
-	public function test_generate_stale_products_request_entries() {
+	public function test_generate_stale_products_delete_entries() {
 		$products         = $this->create_and_return_supported_test_products();
 		$stale_product    = $products[0];
 		$stale_product_id = $stale_product->get_id();
@@ -318,30 +391,32 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->target_audience->expects( $this->once() )
 			->method( 'get_target_countries' )
 			->willReturn( [ 'US' ] );
-		$this->target_audience->expects( $this->any() )
-			->method( 'get_main_target_country' )
-			->willReturn( 'US' );
 
 		$stale_google_ids = [
-			'AU' => "online:en:AU:gla_{$stale_product_id}",
-			'DK' => "online:en:DK:gla_{$stale_product_id}",
-			'US' => "online:en:US:gla_{$stale_product_id}",
+			'AU' => "en~AU~gla_{$stale_product_id}",
+			'DK' => "en~DK~gla_{$stale_product_id}",
+			'US' => "en~US~gla_{$stale_product_id}",
 		];
 		$this->product_meta->update_google_ids( $stale_product, $stale_google_ids );
 
-		$results = $this->batch_product_helper->generate_stale_products_request_entries( $products );
+		$results = $this->batch_product_helper->generate_stale_products_delete_entries( $products );
 
 		$this->assertCount( 2, $results );
-		$this->assertContainsOnlyInstancesOf( BatchProductIDRequestEntry::class, $results );
-		$this->assertArrayHasKey( $stale_google_ids['AU'], $results );
-		$this->assertArrayHasKey( $stale_google_ids['DK'], $results );
 
-		foreach ( $results as $request_entry ) {
-			$this->assertEquals( $stale_product_id, $request_entry->get_wc_product_id() );
+		$entries_by_country = [];
+		foreach ( $results as $entry ) {
+			$this->assertInstanceOf( ProductInput::class, $entry['input'] );
+			$this->assertSame( $stale_product_id, $entry['wc_product_id'] );
+			$entries_by_country[ $entry['country'] ] = $entry;
 		}
+
+		$this->assertArrayHasKey( 'AU', $entries_by_country );
+		$this->assertArrayHasKey( 'DK', $entries_by_country );
+		$this->assertSame( $stale_google_ids['AU'], $entries_by_country['AU']['google_id'] );
+		$this->assertSame( $stale_google_ids['DK'], $entries_by_country['DK']['google_id'] );
 	}
 
-	public function test_generate_stale_countries_request_entries() {
+	public function test_generate_stale_countries_delete_entries() {
 		$products         = $this->create_and_return_supported_test_products();
 		$stale_product    = $products[0];
 		$stale_product_id = $stale_product->get_id();
@@ -351,22 +426,27 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			->willReturn( 'US' );
 
 		$stale_google_ids = [
-			'AU' => "online:en:AU:gla_{$stale_product_id}",
-			'DK' => "online:en:DK:gla_{$stale_product_id}",
-			'US' => "online:en:US:gla_{$stale_product_id}",
+			'AU' => "en~AU~gla_{$stale_product_id}",
+			'DK' => "en~DK~gla_{$stale_product_id}",
+			'US' => "en~US~gla_{$stale_product_id}",
 		];
 		$this->product_meta->update_google_ids( $stale_product, $stale_google_ids );
 
-		$results = $this->batch_product_helper->generate_stale_countries_request_entries( $products );
+		$results = $this->batch_product_helper->generate_stale_countries_delete_entries( $products );
 
 		$this->assertCount( 2, $results );
-		$this->assertContainsOnlyInstancesOf( BatchProductIDRequestEntry::class, $results );
-		$this->assertArrayHasKey( $stale_google_ids['AU'], $results );
-		$this->assertArrayHasKey( $stale_google_ids['DK'], $results );
 
-		foreach ( $results as $request_entry ) {
-			$this->assertEquals( $stale_product_id, $request_entry->get_wc_product_id() );
+		$entries_by_country = [];
+		foreach ( $results as $entry ) {
+			$this->assertInstanceOf( ProductInput::class, $entry['input'] );
+			$this->assertSame( $stale_product_id, $entry['wc_product_id'] );
+			$entries_by_country[ $entry['country'] ] = $entry;
 		}
+
+		$this->assertArrayHasKey( 'AU', $entries_by_country );
+		$this->assertArrayHasKey( 'DK', $entries_by_country );
+		$this->assertSame( $stale_google_ids['AU'], $entries_by_country['AU']['google_id'] );
+		$this->assertSame( $stale_google_ids['DK'], $entries_by_country['DK']['google_id'] );
 	}
 
 	/**

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -549,6 +549,23 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$this->product_syncer->delete_by_id_map( [] );
 	}
 
+	public function test_delete_mapi_entries_throws_exception_when_mc_is_blocked() {
+		$merchant_center = $this->createMock( MerchantCenterService::class );
+		$merchant_center->expects( $this->any() )
+			->method( 'should_push' )
+			->willReturn( true );
+		$this->merchant_center->expects( $this->any() )
+			->method( 'is_enabled_for_datatype' )
+			->with( 'products' )
+			->willReturn( false );
+		$this->product_syncer = $this->get_product_syncer( [ 'merchant_center' => $merchant_center ] );
+
+		$this->expectException( ProductSyncerException::class );
+
+		// The cleanup jobs call delete_mapi_entries() directly, so it must validate too.
+		$this->product_syncer->delete_mapi_entries( [] );
+	}
+
 	/**
 	 * Function to return an instance of ProductSyncer.
 	 *

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -9,7 +9,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiPro
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
@@ -195,49 +194,92 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		// $rejected_products: products that were synced but deleting them resulted in errors and were rejected by Google API
 		[ $deleted_products, $rejected_products ] = $this->create_multiple_simple_product_sets( 2, 2 );
 
-		$this->mock_google_service( $deleted_products, $rejected_products );
-
 		$products = array_merge( $deleted_products, $rejected_products );
 
-		// first we mark all products as synced
 		array_walk(
 			$products,
 			function ( WC_Product $product ) {
-				$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
+				$this->product_helper->mark_as_synced(
+					$product,
+					$this->generate_google_product_mock( "en~US~gla_{$product->get_id()}", 'US' )
+				);
 			}
 		);
+
+		$this->mock_mapi_delete( $deleted_products, $rejected_products, 500 );
 
 		$results = $this->product_syncer->delete( $products );
 		$this->assert_delete_results_are_valid( $results, $deleted_products, $rejected_products );
 	}
 
-	public function test_delete_by_batch_requests() {
+	/**
+	 * Mock MapiProductInputsService::delete_many to succeed for $synced products
+	 * and fail with the given HTTP status for $rejected products.
+	 *
+	 * @param array $synced_products   WC product IDs.
+	 * @param array $rejected_products WC product IDs.
+	 * @param int   $failure_status    HTTP status to use for failures (e.g. 500 to retry, 404 for not-found).
+	 */
+	protected function mock_mapi_delete( array $synced_products, array $rejected_products, int $failure_status ): void {
+		$this->mapi_inputs->expects( $this->any() )
+			->method( 'delete_many' )
+			->willReturnCallback(
+				function ( array $inputs ) use ( $synced_products, $rejected_products, $failure_status ) {
+					$successes = [];
+					$failures  = [];
+					foreach ( $inputs as $index => $input ) {
+						$product_id = (int) str_replace( 'gla_', '', $input->get_offer_id() );
+						if ( isset( $synced_products[ $product_id ] ) ) {
+							$successes[ $index ] = $input;
+						} elseif ( isset( $rejected_products[ $product_id ] ) ) {
+							$failures[ $index ] = new MerchantApiException( $failure_status, [], 'MAPI error' );
+						}
+					}
+
+					return [
+						'successes' => $successes,
+						'failures'  => $failures,
+					];
+				}
+			);
+	}
+
+	public function test_delete_by_id_map() {
 		// $deleted_products:  products that were successfully synced and then deleted from Merchant Center
 		// $rejected_products: products that were synced but deleting them resulted in errors and were rejected by Google API
 		[ $deleted_products, $rejected_products ] = $this->create_multiple_simple_product_sets( 2, 2 );
 
-		$this->mock_google_service( $deleted_products, $rejected_products );
-
 		$products = array_merge( $deleted_products, $rejected_products );
 
-		// first we mark all products as synced
 		array_walk(
 			$products,
 			function ( WC_Product $product ) {
-				$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
+				$this->product_helper->mark_as_synced(
+					$product,
+					$this->generate_google_product_mock( "en~US~gla_{$product->get_id()}", 'US' )
+				);
 			}
 		);
 
-		// generate delete request entries
-		$product_entries = array_map(
-			function ( WC_Product $product ) {
-				return new BatchProductIDRequestEntry( $product->get_id(), $this->generate_google_id( $product ) );
-			},
-			$products
-		);
+		$this->mock_mapi_delete( $deleted_products, $rejected_products, 500 );
 
-		$results = $this->product_syncer->delete_by_batch_requests( $product_entries );
+		$product_id_map = [];
+		foreach ( $products as $product ) {
+			$product_id_map[ "en~US~gla_{$product->get_id()}" ] = $product->get_id();
+		}
+
+		$results = $this->product_syncer->delete_by_id_map( $product_id_map );
 		$this->assert_delete_results_are_valid( $results, $deleted_products, $rejected_products );
+	}
+
+	public function test_delete_by_id_map_skips_malformed_ids() {
+		$this->mapi_inputs->expects( $this->never() )
+			->method( 'delete_many' );
+
+		$results = $this->product_syncer->delete_by_id_map( [ 'not-mapi-shape' => 99 ] );
+
+		$this->assertEmpty( $results->get_products() );
+		$this->assertEmpty( $results->get_errors() );
 	}
 
 	protected function assert_delete_results_are_valid( $results, $deleted_products, $rejected_products ) {
@@ -264,36 +306,22 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 
 	public function test_delete_removes_google_id_of_not_found_products() {
 		// $deleted_products:  products that were successfully synced and then deleted from Merchant Center
-		// $not_found_products: products that were synced but deleting them resulted in a not-found error and were rejected by Google API
+		// $not_found_products: products that were synced but deleting them returned 404 (already gone)
 		[ $deleted_products, $not_found_products ] = $this->create_multiple_simple_product_sets( 2, 2 );
-
-		$this->google_service->expects( $this->once() )
-			->method( 'delete_batch' )
-			->willReturnCallback(
-				function ( array $product_entries ) use ( $deleted_products, $not_found_products ) {
-					$errors  = [];
-					$entries = [];
-					foreach ( $product_entries as $product_entry ) {
-						if ( isset( $deleted_products[ $product_entry->get_wc_product_id() ] ) ) {
-							$entries[] = new BatchProductEntry( $product_entry->get_wc_product_id(), null );
-						} elseif ( isset( $not_found_products[ $product_entry->get_wc_product_id() ] ) ) {
-							$errors[] = new BatchInvalidProductEntry( $product_entry->get_wc_product_id(), $product_entry->get_product_id(), [ GoogleProductService::NOT_FOUND_ERROR_REASON => 'Not Found!' ] );
-						}
-					}
-
-					return new BatchProductResponse( $entries, $errors );
-				}
-			);
 
 		$products = array_merge( $deleted_products, $not_found_products );
 
-		// first we mark all products as synced
 		array_walk(
 			$products,
 			function ( WC_Product $product ) {
-				$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
+				$this->product_helper->mark_as_synced(
+					$product,
+					$this->generate_google_product_mock( "en~US~gla_{$product->get_id()}", 'US' )
+				);
 			}
 		);
+
+		$this->mock_mapi_delete( $deleted_products, $not_found_products, 404 );
 
 		$results = $this->product_syncer->delete( $products );
 
@@ -352,7 +380,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$this->product_syncer->delete( [ $product ] );
 	}
 
-	public function test_delete_by_batch_requests_fails_if_merchant_center_not_setup() {
+	public function test_delete_by_id_map_fails_if_merchant_center_not_setup() {
 		$product = WC_Helper_Product::create_simple_product();
 
 		$merchant_center = $this->createMock( MerchantCenterService::class );
@@ -362,7 +390,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$this->product_syncer = $this->get_product_syncer( [ 'merchant_center' => $merchant_center ] );
 
 		$this->expectException( ProductSyncerException::class );
-		$this->product_syncer->delete_by_batch_requests( [ new BatchProductIDRequestEntry( $product->get_id(), $this->generate_google_id( $product ) ) ] );
+		$this->product_syncer->delete_by_id_map( [ "en~US~gla_{$product->get_id()}" => $product->get_id() ] );
 	}
 
 	public function test_update_by_batch_requests_throws_exception_if_google_api_call_fails() {
@@ -376,33 +404,30 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$this->product_syncer->update_by_batch_requests( [ new BatchProductRequestEntry( $product->get_id(), $this->generate_adapted_product( $product ) ) ] );
 	}
 
-	public function test_delete_by_batch_requests_throws_exception_if_google_api_call_fails() {
+	public function test_delete_by_id_map_throws_exception_if_google_api_call_fails() {
 		$product = WC_Helper_Product::create_simple_product();
 
-		$this->google_service->expects( $this->any() )
-			->method( 'delete_batch' )
+		$this->mapi_inputs->expects( $this->any() )
+			->method( 'delete_many' )
 			->willThrowException( new GoogleException() );
 
 		$this->expectException( ProductSyncerException::class );
-		$this->product_syncer->delete_by_batch_requests( [ new BatchProductIDRequestEntry( $product->get_id(), $this->generate_google_id( $product ) ) ] );
+		$this->product_syncer->delete_by_id_map( [ "en~US~gla_{$product->get_id()}" => $product->get_id() ] );
 	}
 
-	public function test_delete_by_batch_requests_no_retry_if_product_is_unavailable_in_database() {
+	public function test_delete_by_id_map_no_retry_if_product_is_unavailable_in_database() {
 		// $deleted_products:  products that were successfully synced and then deleted from Merchant Center
 		// $rejected_products: products that were synced but deleting them resulted in errors and were rejected by Google API
 		[ $deleted_products, $rejected_products ] = $this->create_multiple_simple_product_sets( 2, 1 );
 
-		$this->mock_google_service( $deleted_products, $rejected_products );
+		$this->mock_mapi_delete( $deleted_products, $rejected_products, 500 );
 
 		$products = array_merge( $deleted_products, $rejected_products );
 
-		// generate delete request entries
-		$product_entries = array_map(
-			function ( WC_Product $product ) {
-				return new BatchProductIDRequestEntry( $product->get_id(), $this->generate_google_id( $product ) );
-			},
-			$products
-		);
+		$product_id_map = [];
+		foreach ( $products as $product ) {
+			$product_id_map[ "en~US~gla_{$product->get_id()}" ] = $product->get_id();
+		}
 
 		// force delete all products
 		array_walk(
@@ -413,7 +438,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 			}
 		);
 
-		$results = $this->product_syncer->delete_by_batch_requests( $product_entries );
+		$results = $this->product_syncer->delete_by_id_map( $product_id_map );
 		$this->assertEquals( 0, did_action( 'woocommerce_gla_batch_retry_delete_products' ) );
 
 		$result_product_ids = array_map(
@@ -426,135 +451,6 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$delete_ready_product_ids = array_keys( $deleted_products );
 
 		$this->assertEqualsCanonicalizing( $result_product_ids, $delete_ready_product_ids );
-	}
-
-	public function test_delete_by_batch_requests_should_delete_trashed_product() {
-		// $deleted_products:  products that were successfully synced and then deleted from Merchant Center
-		// $rejected_products: products that were synced but deleting them resulted in errors and were rejected by Google API
-		[ $deleted_products, $rejected_products ] = $this->create_multiple_simple_product_sets( 2, 1 );
-
-		$this->mock_google_service( $deleted_products, $rejected_products );
-
-		$products = array_merge( $deleted_products, $rejected_products );
-
-		// generate delete request entries
-		$product_entries = array_map(
-			function ( WC_Product $product ) {
-				return new BatchProductIDRequestEntry( $product->get_id(), $this->generate_google_id( $product ) );
-			},
-			$products
-		);
-
-		// first we mark all products as synced and
-		// set the product status to trash
-		array_walk(
-			$products,
-			function ( WC_Product $product ) {
-				$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
-				$product->set_status( 'trash' );
-				$product->save();
-			}
-		);
-
-		$results = $this->product_syncer->delete_by_batch_requests( $product_entries );
-
-		$result_product_ids = array_map(
-			function ( $product_entry ) {
-				return $product_entry->get_wc_product_id();
-			},
-			$results->get_products()
-		);
-
-		$delete_ready_product_ids = array_keys( $deleted_products );
-
-		$this->assertEqualsCanonicalizing( $result_product_ids, $delete_ready_product_ids );
-		$this->assert_delete_results_are_valid( $results, $deleted_products, $rejected_products );
-	}
-
-	public function test_delete_by_batch_requests_should_delete_catalog_visibility_hidden_product() {
-		// $deleted_products:  products that were successfully synced and then deleted from Merchant Center
-		// $rejected_products: products that were synced but deleting them resulted in errors and were rejected by Google API
-		[ $deleted_products, $rejected_products ] = $this->create_multiple_simple_product_sets( 2, 1 );
-
-		$this->mock_google_service( $deleted_products, $rejected_products );
-
-		$products = array_merge( $deleted_products, $rejected_products );
-
-		// generate delete request entries
-		$product_entries = array_map(
-			function ( WC_Product $product ) {
-				return new BatchProductIDRequestEntry( $product->get_id(), $this->generate_google_id( $product ) );
-			},
-			$products
-		);
-
-		// first we mark all products as synced and
-		// set the product's catalog visibility to hidden
-		array_walk(
-			$products,
-			function ( WC_Product $product ) {
-				$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
-				$product->set_catalog_visibility( 'hidden' );
-				$product->save();
-			}
-		);
-
-		$results = $this->product_syncer->delete_by_batch_requests( $product_entries );
-
-		$result_product_ids = array_map(
-			function ( $product_entry ) {
-				return $product_entry->get_wc_product_id();
-			},
-			$results->get_products()
-		);
-
-		$delete_ready_product_ids = array_keys( $deleted_products );
-
-		$this->assertEqualsCanonicalizing( $result_product_ids, $delete_ready_product_ids );
-		$this->assert_delete_results_are_valid( $results, $deleted_products, $rejected_products );
-	}
-
-	public function test_delete_by_batch_requests_should_delete_draft_product() {
-		// $deleted_products:  products that were successfully synced and then deleted from Merchant Center
-		// $rejected_products: products that were synced but deleting them resulted in errors and were rejected by Google API
-		[ $deleted_products, $rejected_products ] = $this->create_multiple_simple_product_sets( 2, 1 );
-
-		$this->mock_google_service( $deleted_products, $rejected_products );
-
-		$products = array_merge( $deleted_products, $rejected_products );
-
-		// generate delete request entries
-		$product_entries = array_map(
-			function ( WC_Product $product ) {
-				return new BatchProductIDRequestEntry( $product->get_id(), $this->generate_google_id( $product ) );
-			},
-			$products
-		);
-
-		// first we mark all products as synced and
-		// set the product status to draft
-		array_walk(
-			$products,
-			function ( WC_Product $product ) {
-				$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
-				$product->set_status( 'draft' );
-				$product->save();
-			}
-		);
-
-		$results = $this->product_syncer->delete_by_batch_requests( $product_entries );
-
-		$result_product_ids = array_map(
-			function ( $product_entry ) {
-				return $product_entry->get_wc_product_id();
-			},
-			$results->get_products()
-		);
-
-		$delete_ready_product_ids = array_keys( $deleted_products );
-
-		$this->assertEqualsCanonicalizing( $result_product_ids, $delete_ready_product_ids );
-		$this->assert_delete_results_are_valid( $results, $deleted_products, $rejected_products );
 	}
 
 	protected function mock_google_service( $successful_products, $failed_products ): void {
@@ -637,7 +533,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$this->product_syncer->delete( [] );
 	}
 
-	public function test_delete_by_batch_throws_exception_when_mc_is_blocked() {
+	public function test_delete_by_id_map_throws_exception_when_mc_is_blocked() {
 		$merchant_center = $this->createMock( MerchantCenterService::class );
 		$merchant_center->expects( $this->any() )
 			->method( 'should_push' )
@@ -650,7 +546,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 
 		$this->expectException( ProductSyncerException::class );
 
-		$this->product_syncer->delete_by_batch_requests( [] );
+		$this->product_syncer->delete_by_id_map( [] );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-709/migrate-product-delete-sync-to-mapi

This PR removes the Content API for deleting products, and it adds support for MAPI `productInputs.delete`


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Add a product, and confirm it shows in Merchant Center
2. Trash it or delete it
3. Confirm the product is gone from Merchant Center

You will have to wait for a few min for the sync to happen 

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
