### PR TITLE
GOOWOO-716: Cleanup: Migrate product create/update sync to the MAPI entirely

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -38,7 +38,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Event\ClearProductStatsCache;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GlobalSiteTag;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelperAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GooglePromotionService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\YouTube\Connection as YouTubeConnection;
@@ -324,14 +323,10 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			BatchProductHelper::class,
 			ProductMetaHandler::class,
 			ProductHelper::class,
-			ValidatorInterface::class,
-			ProductFactory::class,
-			TargetAudience::class,
-			AttributeMappingRulesQuery::class
+			TargetAudience::class
 		);
 		$this->share_with_tags(
 			ProductSyncer::class,
-			GoogleProductService::class,
 			MapiProductInputsService::class,
 			BatchProductHelper::class,
 			ProductHelper::class,

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -4,18 +4,15 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
-use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\GoogleListingsAndAdsException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Product as GoogleProduct;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 use WC_Product;
 use WC_Product_Variable;
 use WC_Product_Variation;
@@ -44,49 +41,25 @@ class BatchProductHelper implements Service {
 	protected $product_helper;
 
 	/**
-	 * @var ValidatorInterface
-	 */
-	protected $validator;
-
-	/**
-	 * @var ProductFactory
-	 */
-	protected $product_factory;
-
-	/**
 	 * @var TargetAudience
 	 */
 	protected $target_audience;
 
 	/**
-	 * @var AttributeMappingRulesQuery
-	 */
-	protected $attribute_mapping_rules_query;
-
-	/**
 	 * BatchProductHelper constructor.
 	 *
-	 * @param ProductMetaHandler         $meta_handler
-	 * @param ProductHelper              $product_helper
-	 * @param ValidatorInterface         $validator
-	 * @param ProductFactory             $product_factory
-	 * @param TargetAudience             $target_audience
-	 * @param AttributeMappingRulesQuery $attribute_mapping_rules_query
+	 * @param ProductMetaHandler $meta_handler
+	 * @param ProductHelper      $product_helper
+	 * @param TargetAudience     $target_audience
 	 */
 	public function __construct(
 		ProductMetaHandler $meta_handler,
 		ProductHelper $product_helper,
-		ValidatorInterface $validator,
-		ProductFactory $product_factory,
-		TargetAudience $target_audience,
-		AttributeMappingRulesQuery $attribute_mapping_rules_query
+		TargetAudience $target_audience
 	) {
-		$this->meta_handler                  = $meta_handler;
-		$this->product_helper                = $product_helper;
-		$this->validator                     = $validator;
-		$this->product_factory               = $product_factory;
-		$this->target_audience               = $target_audience;
-		$this->attribute_mapping_rules_query = $attribute_mapping_rules_query;
+		$this->meta_handler    = $meta_handler;
+		$this->product_helper  = $product_helper;
+		$this->target_audience = $target_audience;
 	}
 
 	/**
@@ -186,73 +159,6 @@ class BatchProductHelper implements Service {
 					$product->get_id(),
 					$google_id
 				);
-			}
-		}
-
-		return $request_entries;
-	}
-
-	/**
-	 * @param WC_Product[] $products
-	 *
-	 * @return BatchProductRequestEntry[]
-	 */
-	public function validate_and_generate_update_request_entries( array $products ): array {
-		$request_entries = [];
-		$mapping_rules   = $this->attribute_mapping_rules_query->get_results();
-
-		foreach ( $products as $product ) {
-			$this->validate_instanceof( $product, WC_Product::class );
-
-			try {
-				if ( ! $this->product_helper->is_sync_ready( $product ) ) {
-					do_action(
-						'woocommerce_gla_debug_message',
-						sprintf( 'Skipping product (ID: %s) because it is not ready to be synced.', $product->get_id() ),
-						__METHOD__
-					);
-
-					continue;
-				}
-
-				if ( $product instanceof WC_Product_Variable ) {
-					$request_entries = array_merge( $request_entries, $this->validate_and_generate_update_request_entries( $product->get_available_variations( 'objects' ) ) );
-					continue;
-				}
-
-				$target_countries    = $this->target_audience->get_target_countries();
-				$main_target_country = $this->target_audience->get_main_target_country();
-
-				// validate the product
-				$adapted_product   = $this->product_factory->create( $product, $main_target_country, $mapping_rules );
-				$validation_result = $this->validate_product( $adapted_product );
-				if ( $validation_result instanceof BatchInvalidProductEntry ) {
-					$this->mark_as_invalid( $validation_result );
-
-					do_action(
-						'woocommerce_gla_debug_message',
-						sprintf( 'Skipping product (ID: %s) because it does not pass validation: %s', $product->get_id(), wp_json_encode( $validation_result ) ),
-						__METHOD__
-					);
-
-					continue;
-				}
-
-				// add shipping for all selected target countries
-				array_walk( $target_countries, [ $adapted_product, 'add_shipping_country' ] );
-
-				$request_entries[] = new BatchProductRequestEntry(
-					$product->get_id(),
-					$adapted_product
-				);
-			} catch ( GoogleListingsAndAdsException $exception ) {
-				do_action(
-					'woocommerce_gla_error',
-					sprintf( 'Skipping product (ID: %s) due to exception: %s', $product->get_id(), $exception->getMessage() ),
-					__METHOD__
-				);
-
-				continue;
 			}
 		}
 
@@ -366,24 +272,6 @@ class BatchProductHelper implements Service {
 		}
 
 		return [ $parts[0], $parts[1], $parts[2] ];
-	}
-
-	/**
-	 * @param WCProductAdapter $product
-	 *
-	 * @return BatchInvalidProductEntry|true
-	 */
-	protected function validate_product( WCProductAdapter $product ) {
-		$violations = $this->validator->validate( $product );
-
-		if ( 0 !== count( $violations ) ) {
-			$invalid_product = new BatchInvalidProductEntry( $product->get_wc_product()->get_id() );
-			$invalid_product->map_validation_violations( $violations );
-
-			return $invalid_product;
-		}
-
-		return true;
 	}
 
 	/**

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -9,7 +9,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiPro
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
@@ -30,11 +29,6 @@ class ProductSyncer implements Service {
 
 	public const FAILURE_THRESHOLD        = 5;         // Number of failed attempts allowed per FAILURE_THRESHOLD_WINDOW
 	public const FAILURE_THRESHOLD_WINDOW = '3 hours'; // PHP supported Date and Time format: https://www.php.net/manual/en/datetime.formats.php
-
-	/**
-	 * @var GoogleProductService
-	 */
-	protected $google_service;
 
 	/**
 	 * @var MapiProductInputsService
@@ -69,7 +63,6 @@ class ProductSyncer implements Service {
 	/**
 	 * ProductSyncer constructor.
 	 *
-	 * @param GoogleProductService     $google_service
 	 * @param MapiProductInputsService $mapi_inputs
 	 * @param BatchProductHelper       $batch_helper
 	 * @param ProductHelper            $product_helper
@@ -78,7 +71,6 @@ class ProductSyncer implements Service {
 	 * @param ProductRepository        $product_repository
 	 */
 	public function __construct(
-		GoogleProductService $google_service,
 		MapiProductInputsService $mapi_inputs,
 		BatchProductHelper $batch_helper,
 		ProductHelper $product_helper,
@@ -86,7 +78,6 @@ class ProductSyncer implements Service {
 		WC $wc,
 		ProductRepository $product_repository
 	) {
-		$this->google_service     = $google_service;
 		$this->mapi_inputs        = $mapi_inputs;
 		$this->batch_helper       = $batch_helper;
 		$this->product_helper     = $product_helper;
@@ -210,74 +201,6 @@ class ProductSyncer implements Service {
 		}
 
 		return new BatchInvalidProductEntry( $wc_product_id, null, $errors );
-	}
-
-	/**
-	 * Submits an array of WooCommerce products to Google Merchant Center.
-	 *
-	 * @param BatchProductRequestEntry[] $product_entries
-	 *
-	 * @return BatchProductResponse Containing both the synced and invalid products.
-	 *
-	 * @throws ProductSyncerException If there are any errors while syncing products with Google Merchant Center.
-	 */
-	public function update_by_batch_requests( array $product_entries ): BatchProductResponse {
-		$this->validate_merchant_center_setup();
-
-		// bail if no valid products provided
-		if ( empty( $product_entries ) ) {
-			return new BatchProductResponse( [], [] );
-		}
-
-		$updated_products = [];
-		$invalid_products = [];
-		foreach ( array_chunk( $product_entries, GoogleProductService::BATCH_SIZE ) as $batch_entries ) {
-			try {
-				$response = $this->google_service->insert_batch( $batch_entries );
-
-				$updated_products = array_merge( $updated_products, $response->get_products() );
-				$invalid_products = array_merge( $invalid_products, $response->get_errors() );
-
-				// update the meta data for the synced and invalid products
-				array_walk( $updated_products, [ $this->batch_helper, 'mark_as_synced' ] );
-				array_walk( $invalid_products, [ $this->batch_helper, 'mark_as_invalid' ] );
-			} catch ( Exception $exception ) {
-				do_action( 'woocommerce_gla_exception', $exception, __METHOD__ );
-
-				throw new ProductSyncerException( sprintf( 'Error updating Google products: %s', $exception->getMessage() ), 0, $exception );
-			}
-		}
-
-		$this->handle_update_errors( $invalid_products );
-
-		do_action(
-			'woocommerce_gla_batch_updated_products',
-			$updated_products,
-			$invalid_products
-		);
-
-		do_action(
-			'woocommerce_gla_debug_message',
-			sprintf(
-				"Submitted %s products:\n%s",
-				count( $updated_products ),
-				wp_json_encode( $updated_products )
-			),
-			__METHOD__
-		);
-		if ( ! empty( $invalid_products ) ) {
-			do_action(
-				'woocommerce_gla_debug_message',
-				sprintf(
-					"%s products failed to sync with Merchant Center:\n%s",
-					count( $invalid_products ),
-					wp_json_encode( $invalid_products )
-				),
-				__METHOD__
-			);
-		}
-
-		return new BatchProductResponse( $updated_products, $invalid_products );
 	}
 
 	/**

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -4,31 +4,21 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
-use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidClass;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductFactory;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductAdapter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductMetaTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\Validator\ConstraintViolation;
-use Symfony\Component\Validator\ConstraintViolationList;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 use WC_Helper_Product;
 use WC_Product;
-use WC_Product_Variable;
-use WC_Product_Variation;
 
 /**
  * Class BatchProductHelperTest
@@ -46,20 +36,11 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 	/** @var ProductHelper $product_helper */
 	protected $product_helper;
 
-	/** @var MockObject|ValidatorInterface $validator */
-	protected $validator;
-
-	/** @var ProductFactory $product_factory */
-	protected $product_factory;
-
 	/** @var MockObject|TargetAudience $target_audience */
 	protected $target_audience;
 
 	/** @var BatchProductHelper $batch_product_helper */
 	protected $batch_product_helper;
-
-	/** @var AttributeMappingRulesQuery $rules_query */
-	protected $rules_query;
 
 	/** @var WC $wc */
 	protected $wc;
@@ -258,131 +239,6 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertEmpty( $results );
 	}
 
-	public function test_validate_and_generate_update_request_entries() {
-		$products = $this->create_and_return_supported_test_products();
-
-		$this->target_audience->expects( $this->any() )
-			->method( 'get_main_target_country' )
-			->willReturn( 'US' );
-		$this->validator->expects( $this->any() )
-			->method( 'validate' )
-			->willReturn( [] );
-
-		$this->rules_query->expects( $this->any() )
-			->method( 'get_results' )
-			->willReturn( [] );
-
-		$results = $this->batch_product_helper->validate_and_generate_update_request_entries( $products );
-
-		// the number of results can be bigger because of variable products
-		$this->assertGreaterThanOrEqual( \count( $products ), \count( $results ) );
-
-		$this->assertContainsOnlyInstancesOf( BatchProductRequestEntry::class, $results );
-
-		// the products (including variations if a variable product) sent to the method should ALL be returned as results
-		$results_product_ids = array_map(
-			function ( BatchProductRequestEntry $request_entry ) {
-				return $request_entry->get_wc_product_id();
-			},
-			$results
-		);
-		$param_product_ids   = [];
-		foreach ( $products as $product ) {
-			if ( $product instanceof WC_Product_Variable ) {
-				foreach ( $product->get_children() as $child ) {
-					$param_product_ids[] = $child->get_id();
-				}
-			} else {
-				$param_product_ids[] = $product->get_id();
-			}
-		}
-		$this->assertEqualSets( $param_product_ids, $results_product_ids );
-	}
-
-	public function test_validate_and_generate_update_request_entries_skips_invalid_product() {
-		$products = $this->create_and_return_supported_test_products();
-
-		// skip one product from the list
-		$invalid_product = $products[0];
-
-		$this->validator->expects( $this->any() )
-			->method( 'validate' )
-			->willReturnCallback(
-				function ( WCProductAdapter $product ) use ( $invalid_product ) {
-					if ( $product->get_wc_product()->get_id() === $invalid_product->get_id() ) {
-						$violation_example = $this->createMock( ConstraintViolation::class );
-						$violations        = new ConstraintViolationList();
-						$violations->add( $violation_example );
-
-						return $violations;
-					}
-
-					return [];
-				}
-			);
-
-		$this->rules_query->expects( $this->any() )
-			->method( 'get_results' )
-			->willReturn( [] );
-
-		$this->target_audience->expects( $this->any() )
-			->method( 'get_main_target_country' )
-			->willReturn( 'US' );
-
-		$results = $this->batch_product_helper->validate_and_generate_update_request_entries( $products );
-
-		$results_product_ids = array_map(
-			function ( BatchProductRequestEntry $request_entry ) {
-				return $request_entry->get_wc_product_id();
-			},
-			$results
-		);
-
-		$this->assertNotContains( $invalid_product->get_id(), $results_product_ids );
-	}
-
-	public function test_validate_and_generate_update_request_entries_skips_not_sync_ready() {
-		$products = $this->create_and_return_supported_test_products();
-
-		// skip one product from the list
-		$skipped_product = $products[0];
-		if ( $skipped_product instanceof WC_Product_Variation ) {
-			$this->product_meta->update_visibility( wc_get_product( $skipped_product->get_parent_id() ), ChannelVisibility::DONT_SYNC_AND_SHOW );
-		} else {
-			$this->product_meta->update_visibility( $skipped_product, ChannelVisibility::DONT_SYNC_AND_SHOW );
-		}
-
-		$this->target_audience->expects( $this->any() )
-			->method( 'get_main_target_country' )
-			->willReturn( 'US' );
-		$this->validator->expects( $this->any() )
-			->method( 'validate' )
-			->willReturn( [] );
-		$this->rules_query->expects( $this->any() )
-			->method( 'get_results' )
-			->willReturn( [] );
-
-		$results = $this->batch_product_helper->validate_and_generate_update_request_entries( $products );
-
-		$results_product_ids = array_map(
-			function ( BatchProductRequestEntry $request_entry ) {
-				return $request_entry->get_wc_product_id();
-			},
-			$results
-		);
-
-		$this->assertNotContains( $skipped_product->get_id(), $results_product_ids );
-	}
-
-	public function test_validate_and_generate_update_request_entries_including_invalid_product() {
-		$products = [
-			$this->generate_simple_product_mock(),
-			new BatchProductEntry( 0, null ),
-		];
-		$this->expectException( InvalidClass::class );
-		$this->batch_product_helper->validate_and_generate_update_request_entries( $products );
-	}
-
 	public function test_generate_stale_products_delete_entries() {
 		$products         = $this->create_and_return_supported_test_products();
 		$stale_product    = $products[0];
@@ -466,12 +322,9 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 		$this->target_audience      = $this->createMock( TargetAudience::class );
-		$this->validator            = $this->createMock( ValidatorInterface::class );
-		$this->rules_query          = $this->createMock( AttributeMappingRulesQuery::class );
 		$this->product_meta         = $this->container->get( ProductMetaHandler::class );
-		$this->product_factory      = $this->container->get( ProductFactory::class );
 		$this->wc                   = $this->container->get( WC::class );
 		$this->product_helper       = new ProductHelper( $this->product_meta, $this->wc, $this->target_audience );
-		$this->batch_product_helper = new BatchProductHelper( $this->product_meta, $this->product_helper, $this->validator, $this->product_factory, $this->target_audience, $this->rules_query );
+		$this->batch_product_helper = new BatchProductHelper( $this->product_meta, $this->product_helper, $this->target_audience );
 	}
 }

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -21,7 +21,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Value\SyncStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Exception as GoogleException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Product as GoogleProduct;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 use WC_Helper_Product;
 use WC_Product;
 

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -6,16 +6,9 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
-use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductFactory;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
@@ -41,9 +34,6 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 
 	use ProductTrait;
 
-	/** @var MockObject|GoogleProductService $google_service */
-	protected $google_service;
-
 	/** @var MockObject|MapiProductInputsService $mapi_inputs */
 	protected $mapi_inputs;
 
@@ -68,9 +58,6 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 	/** @var ProductRepository $product_repository */
 	protected $product_repository;
 
-	/** @var AttributeMappingRulesQuery $rules_query */
-	protected $rules_query;
-
 	/** @var WC $wc */
 	protected $wc;
 
@@ -79,18 +66,13 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		// $rejected_products: products that have errors and were rejected by Google API
 		[ $synced_products, $rejected_products ] = $this->create_multiple_simple_product_sets( 2, 2 );
 
-		$validator       = $this->createMock( ValidatorInterface::class );
-		$product_factory = $this->container->get( ProductFactory::class );
-		$batch_helper    = $this->getMockBuilder( BatchProductHelper::class )
+		$batch_helper = $this->getMockBuilder( BatchProductHelper::class )
 								->setMethods( [ 'generate_mapi_update_entries' ] )
 								->setConstructorArgs(
 									[
 										$this->product_meta,
 										$this->product_helper,
-										$validator,
-										$product_factory,
 										$this->target_audience,
-										$this->rules_query,
 									]
 								)
 								->getMock();
@@ -148,24 +130,6 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 					];
 				}
 			);
-	}
-
-	public function test_update_by_batch_requests() {
-		// $synced_products:   products that were successfully synced to Merchant Center
-		// $rejected_products: products that have errors and were rejected by Google API
-		[ $synced_products, $rejected_products ] = $this->create_multiple_simple_product_sets( 2, 2 );
-
-		$this->mock_google_service( $synced_products, $rejected_products );
-
-		$product_entries = array_map(
-			function ( WC_Product $product ) {
-				return new BatchProductRequestEntry( $product->get_id(), $this->generate_adapted_product( $product ) );
-			},
-			array_merge( $synced_products, $rejected_products )
-		);
-
-		$results = $this->product_syncer->update_by_batch_requests( $product_entries );
-		$this->assert_update_results_are_valid( $results, $synced_products, $rejected_products );
 	}
 
 	protected function assert_update_results_are_valid( $results, $synced_products, $rejected_products ) {
@@ -354,19 +318,6 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$this->product_syncer->update( [ $product ] );
 	}
 
-	public function test_update_by_batch_requests_fails_if_merchant_center_not_setup() {
-		$product = WC_Helper_Product::create_simple_product();
-
-		$merchant_center = $this->createMock( MerchantCenterService::class );
-		$merchant_center->expects( $this->any() )
-						->method( 'is_connected' )
-						->willReturn( false );
-		$this->product_syncer = $this->get_product_syncer( [ 'merchant_center' => $merchant_center ] );
-
-		$this->expectException( ProductSyncerException::class );
-		$this->product_syncer->update_by_batch_requests( [ new BatchProductRequestEntry( $product->get_id(), $this->generate_adapted_product( $product ) ) ] );
-	}
-
 	public function test_delete_fails_if_merchant_center_not_setup() {
 		$product = WC_Helper_Product::create_simple_product();
 
@@ -391,17 +342,6 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 
 		$this->expectException( ProductSyncerException::class );
 		$this->product_syncer->delete_by_id_map( [ "en~US~gla_{$product->get_id()}" => $product->get_id() ] );
-	}
-
-	public function test_update_by_batch_requests_throws_exception_if_google_api_call_fails() {
-		$product = WC_Helper_Product::create_simple_product();
-
-		$this->google_service->expects( $this->any() )
-			->method( 'insert_batch' )
-			->willThrowException( new GoogleException() );
-
-		$this->expectException( ProductSyncerException::class );
-		$this->product_syncer->update_by_batch_requests( [ new BatchProductRequestEntry( $product->get_id(), $this->generate_adapted_product( $product ) ) ] );
 	}
 
 	public function test_delete_by_id_map_throws_exception_if_google_api_call_fails() {
@@ -453,38 +393,6 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$this->assertEqualsCanonicalizing( $result_product_ids, $delete_ready_product_ids );
 	}
 
-	protected function mock_google_service( $successful_products, $failed_products ): void {
-		$callback = function ( array $product_entries ) use ( $successful_products, $failed_products ) {
-			$errors  = [];
-			$entries = [];
-			foreach ( $product_entries as $product_entry ) {
-				$google_product = $this->generate_google_product_mock();
-				if ( isset( $successful_products[ $product_entry->get_wc_product_id() ] ) ) {
-					$entries[] = new BatchProductEntry( $product_entry->get_wc_product_id(), $google_product );
-				} elseif ( isset( $failed_products[ $product_entry->get_wc_product_id() ] ) ) {
-					$errors[] = new BatchInvalidProductEntry(
-						$product_entry->get_wc_product_id(),
-						$google_product->getId(),
-						[
-							'Error',
-							GoogleProductService::INTERNAL_ERROR_REASON => 'Internal Error!',
-						]
-					);
-				}
-			}
-
-			return new BatchProductResponse( $entries, $errors );
-		};
-
-		$this->google_service->expects( $this->any() )
-			->method( 'insert_batch' )
-			->willReturnCallback( $callback );
-
-		$this->google_service->expects( $this->any() )
-			->method( 'delete_batch' )
-			->willReturnCallback( $callback );
-	}
-
 	public function test_update_throws_exception_when_mc_is_blocked() {
 		$merchant_center = $this->createMock( MerchantCenterService::class );
 		$merchant_center->expects( $this->any() )
@@ -499,22 +407,6 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$this->expectException( ProductSyncerException::class );
 
 		$this->product_syncer->update( [] );
-	}
-
-	public function test_update_by_batch_throws_exception_when_mc_is_blocked() {
-		$merchant_center = $this->createMock( MerchantCenterService::class );
-		$merchant_center->expects( $this->any() )
-			->method( 'should_push' )
-			->willReturn( true );
-		$this->merchant_center->expects( $this->any() )
-			->method( 'is_enabled_for_datatype' )
-			->with( 'products' )
-			->willReturn( false );
-		$this->product_syncer = $this->get_product_syncer( [ 'merchant_center' => $merchant_center ] );
-
-		$this->expectException( ProductSyncerException::class );
-
-		$this->product_syncer->update_by_batch_requests( [] );
 	}
 
 	public function test_delete_throws_exception_when_mc_is_blocked() {
@@ -555,7 +447,6 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 	 * @param object[] $args
 	 */
 	private function get_product_syncer( $args = [] ): ProductSyncer {
-		$args['google_service']     = $args['google_service'] ?? $this->google_service;
 		$args['mapi_inputs']        = $args['mapi_inputs'] ?? $this->mapi_inputs;
 		$args['batch_helper']       = $args['batch_helper'] ?? $this->batch_helper;
 		$args['product_helper']     = $args['product_helper'] ?? $this->product_helper;
@@ -564,7 +455,6 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$args['product_repository'] = $args['product_repository'] ?? $this->product_repository;
 
 		return new ProductSyncer(
-			$args['google_service'],
 			$args['mapi_inputs'],
 			$args['batch_helper'],
 			$args['product_helper'],
@@ -594,9 +484,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 			->with( 'products' )
 			->willReturn( true );
 
-		$this->google_service = $this->createMock( GoogleProductService::class );
-		$this->mapi_inputs    = $this->createMock( MapiProductInputsService::class );
-		$this->rules_query    = $this->createMock( AttributeMappingRulesQuery::class );
+		$this->mapi_inputs = $this->createMock( MapiProductInputsService::class );
 
 		$this->product_meta       = $this->container->get( ProductMetaHandler::class );
 		$this->batch_helper       = $this->container->get( BatchProductHelper::class );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is a follow-up PR for https://github.com/woocommerce/google-listings-and-ads/pull/3458, and it removes the Content API entirely from create/update path.



Closes https://linear.app/a8c/issue/GOOWOO-716/cleanup-migrate-product-createupdate-sync-to-the-mapi-entirely




### Screenshots:

<!--- Optional --->




### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
