### PR TITLE
chore: pin third-party GitHub Actions to SHAs + enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,3 @@ updates:
           - "major"
     cooldown:
       default-days: 7
-      semver-major-days: 14

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm run test:js
 
       - name: Upload JS unit coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/clover.xml

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -112,7 +112,7 @@ jobs:
 
       - if: env.generate_coverage == 'true'
         name: Upload PHP unit coverage report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: tests/php-coverage/report.xml


### PR DESCRIPTION
Pins third-party GitHub Actions to commit SHAs and adds Dependabot coverage for the `github-actions` ecosystem.

Tracking: DEVPROD-1073

Verification commands:

```bash
# codecov/codecov-action # v4.6.0
gh api repos/codecov/codecov-action/commits/v4.6.0 --jq '{ref:"v4.6.0",resolved_sha:.sha,expected_sha:"b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238",matches:(.sha=="b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238")}'
```

Dependabot: created .github/dependabot.yml.
