### PR TITLE
GOOWO-725: Preserve secondary market shipping times and rates when saving primary market

### DIFF
--- a/js/src/hooks/useSaveShippingRates.js
+++ b/js/src/hooks/useSaveShippingRates.js
@@ -35,22 +35,36 @@ const useSaveShippingRates = () => {
 		 * This is done by removing the old shipping rates first,
 		 * and then upserting the new shipping rates.
 		 *
-		 * @param {Array<ShippingRate>} newShippingRates
+		 * @param {Array<ShippingRate>} shippingRatesToSave
+		 * @param {Array<string>} [excludedCountryCodes=[]] Country codes to
+		 *   skip entirely — no deletes or upserts will be applied to them.
+		 *   Use this when the caller only manages a subset of markets (e.g. the
+		 *   primary market) so that rates belonging to other markets are never
+		 *   accidentally deleted.
 		 * @throws Will throw an error if any request failed.
 		 */
-		async ( newShippingRates ) => {
-			const deleteIds = getDeleteIds(
-				newShippingRates,
-				oldShippingRates
+		async ( shippingRatesToSave, excludedCountryCodes = [] ) => {
+			const excluded = new Set( excludedCountryCodes );
+
+			// Restrict both sides to the countries this call manages.
+			// Countries in `excludedCountryCodes` belong to other markets
+			// and must not be deleted or upserted.
+			const managedNewRates = shippingRatesToSave.filter(
+				( shippingRate ) => ! excluded.has( shippingRate.country )
 			);
+			const managedOldRates = oldShippingRates.filter(
+				( shippingRate ) => ! excluded.has( shippingRate.country )
+			);
+
+			const deleteIds = getDeleteIds( managedNewRates, managedOldRates );
 
 			if ( deleteIds.length ) {
 				await deleteShippingRates( deleteIds );
 			}
 
 			const diffShippingRates = getDifferentShippingRates(
-				newShippingRates,
-				oldShippingRates
+				managedNewRates,
+				managedOldRates
 			);
 			if ( diffShippingRates.length ) {
 				await upsertShippingRates( diffShippingRates );

--- a/js/src/hooks/useSaveShippingRates.test.js
+++ b/js/src/hooks/useSaveShippingRates.test.js
@@ -1,0 +1,145 @@
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useSaveShippingRates from './useSaveShippingRates';
+import useShippingRates from './useShippingRates';
+import { useAppDispatch } from '~/data';
+
+jest.mock( './useShippingRates' );
+jest.mock( '~/data', () => ( {
+	useAppDispatch: jest.fn(),
+} ) );
+
+const primaryRates = [
+	{ id: 1, country: 'US', rate: 10 },
+	{ id: 2, country: 'CA', rate: 10 },
+];
+
+const secondaryRate = { id: 3, country: 'DE', rate: 15 };
+
+describe( 'useSaveShippingRates', () => {
+	let deleteShippingRates;
+	let upsertShippingRates;
+
+	beforeEach( () => {
+		deleteShippingRates = jest.fn( () => Promise.resolve() );
+		upsertShippingRates = jest.fn( () => Promise.resolve() );
+
+		useShippingRates.mockReturnValue( {
+			data: [ ...primaryRates, secondaryRate ],
+		} );
+
+		useAppDispatch.mockReturnValue( {
+			deleteShippingRates,
+			upsertShippingRates,
+		} );
+	} );
+
+	describe( 'excludedCountryCodes (default empty)', () => {
+		it( 'deletes rates that exist in old rates but not in new rates', async () => {
+			const { result } = renderHook( () => useSaveShippingRates() );
+
+			// Save only US — CA and DE are missing and should be deleted.
+			await act( async () => {
+				await result.current.saveShippingRates( [
+					{ id: 1, country: 'US', rate: 10 },
+				] );
+			} );
+
+			expect( deleteShippingRates ).toHaveBeenCalledWith(
+				expect.arrayContaining( [ 2, 3 ] )
+			);
+		} );
+
+		it( 'does not call delete when no countries are removed', async () => {
+			const { result } = renderHook( () => useSaveShippingRates() );
+
+			await act( async () => {
+				await result.current.saveShippingRates( [
+					...primaryRates,
+					secondaryRate,
+				] );
+			} );
+
+			expect( deleteShippingRates ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'excludedCountryCodes provided', () => {
+		it( 'does not delete secondary market country even when absent from shippingRatesToSave', async () => {
+			const { result } = renderHook( () => useSaveShippingRates() );
+
+			// Simulate primary market save: only primary rates passed,
+			// DE excluded so it must not be deleted.
+			await act( async () => {
+				await result.current.saveShippingRates( primaryRates, [
+					'DE',
+				] );
+			} );
+
+			expect( deleteShippingRates ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not upsert secondary market country even when present in shippingRatesToSave with changed values', async () => {
+			const { result } = renderHook( () => useSaveShippingRates() );
+
+			// Include DE with a changed rate, but it is excluded so no upsert.
+			await act( async () => {
+				await result.current.saveShippingRates(
+					[ ...primaryRates, { id: 3, country: 'DE', rate: 99 } ],
+					[ 'DE' ]
+				);
+			} );
+
+			expect( upsertShippingRates ).not.toHaveBeenCalledWith(
+				expect.arrayContaining( [
+					expect.objectContaining( { country: 'DE' } ),
+				] )
+			);
+		} );
+
+		it( 'still deletes primary market countries that were removed', async () => {
+			const { result } = renderHook( () => useSaveShippingRates() );
+
+			// US removed from primary, CA kept, DE excluded.
+			await act( async () => {
+				await result.current.saveShippingRates(
+					[ { id: 2, country: 'CA', rate: 10 } ],
+					[ 'DE' ]
+				);
+			} );
+
+			expect( deleteShippingRates ).toHaveBeenCalledWith( [ 1 ] );
+			expect( deleteShippingRates ).not.toHaveBeenCalledWith(
+				expect.arrayContaining( [ 3 ] )
+			);
+		} );
+
+		it( 'still upserts changed primary market rates', async () => {
+			const { result } = renderHook( () => useSaveShippingRates() );
+
+			const updatedPrimaryRates = [
+				{ id: 1, country: 'US', rate: 20 },
+				{ id: 2, country: 'CA', rate: 20 },
+			];
+
+			await act( async () => {
+				await result.current.saveShippingRates( updatedPrimaryRates, [
+					'DE',
+				] );
+			} );
+
+			expect( upsertShippingRates ).toHaveBeenCalledWith(
+				expect.arrayContaining( [
+					expect.objectContaining( { country: 'US', rate: 20 } ),
+					expect.objectContaining( { country: 'CA', rate: 20 } ),
+				] )
+			);
+		} );
+	} );
+} );

--- a/js/src/hooks/useSaveShippingTimes.js
+++ b/js/src/hooks/useSaveShippingTimes.js
@@ -47,13 +47,30 @@ const useSaveShippingTimes = () => {
 		 * This is done by removing the old shipping times first,
 		 * and then upserting the new shipping times.
 		 *
-		 * @param {Array<ShippingTime>} newShippingTimes
+		 * @param {Array<ShippingTime>} shippingTimesToSave
+		 * @param {Array<string>} [excludedCountryCodes=[]] Country codes to
+		 *   skip entirely — no deletes or upserts will be applied to them.
+		 *   Use this when the caller only manages a subset of markets (e.g. the
+		 *   primary market) so that times belonging to other markets are never
+		 *   accidentally deleted.
 		 * @throws Will throw an error if any request failed.
 		 */
-		async ( newShippingTimes ) => {
+		async ( shippingTimesToSave, excludedCountryCodes = [] ) => {
+			const excluded = new Set( excludedCountryCodes );
+
+			// Restrict both sides to the countries this call manages.
+			// Countries in `excludedCountryCodes` belong to other markets
+			// and must not be deleted or upserted.
+			const managedNewTimes = shippingTimesToSave.filter(
+				( shippingTime ) => ! excluded.has( shippingTime.countryCode )
+			);
+			const managedOldTimes = oldShippingTimes.filter(
+				( shippingTime ) => ! excluded.has( shippingTime.countryCode )
+			);
+
 			const deletedCountryCodes = getDeletedCountryCodes(
-				newShippingTimes,
-				oldShippingTimes
+				managedNewTimes,
+				managedOldTimes
 			);
 
 			if ( deletedCountryCodes.length ) {
@@ -61,8 +78,8 @@ const useSaveShippingTimes = () => {
 			}
 
 			const diffShippingTimes = getDifferentShippingTimes(
-				newShippingTimes,
-				oldShippingTimes
+				managedNewTimes,
+				managedOldTimes
 			);
 			if ( diffShippingTimes.length ) {
 				const promises = getShippingTimesGroups(

--- a/js/src/hooks/useSaveShippingTimes.test.js
+++ b/js/src/hooks/useSaveShippingTimes.test.js
@@ -1,0 +1,149 @@
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useSaveShippingTimes from './useSaveShippingTimes';
+import useShippingTimes from './useShippingTimes';
+import { useAppDispatch } from '~/data';
+
+jest.mock( './useShippingTimes' );
+jest.mock( '~/data', () => ( {
+	useAppDispatch: jest.fn(),
+} ) );
+
+const primaryTimes = [
+	{ countryCode: 'US', time: 3, maxTime: 7 },
+	{ countryCode: 'CA', time: 3, maxTime: 7 },
+];
+
+const secondaryTime = { countryCode: 'DE', time: 5, maxTime: 10 };
+
+describe( 'useSaveShippingTimes', () => {
+	let deleteShippingTimes;
+	let upsertShippingTimes;
+
+	beforeEach( () => {
+		deleteShippingTimes = jest.fn( () => Promise.resolve() );
+		upsertShippingTimes = jest.fn( () => Promise.resolve() );
+
+		useShippingTimes.mockReturnValue( {
+			data: [ ...primaryTimes, secondaryTime ],
+		} );
+
+		useAppDispatch.mockReturnValue( {
+			deleteShippingTimes,
+			upsertShippingTimes,
+		} );
+	} );
+
+	describe( 'excludedCountryCodes (default empty)', () => {
+		it( 'deletes countries that exist in old times but not in new times', async () => {
+			const { result } = renderHook( () => useSaveShippingTimes() );
+
+			// Save only US — CA and DE are missing and should be deleted.
+			await act( async () => {
+				await result.current.saveShippingTimes( [
+					{ countryCode: 'US', time: 3, maxTime: 7 },
+				] );
+			} );
+
+			expect( deleteShippingTimes ).toHaveBeenCalledWith(
+				expect.arrayContaining( [ 'CA', 'DE' ] )
+			);
+		} );
+
+		it( 'does not call delete when no countries are removed', async () => {
+			const { result } = renderHook( () => useSaveShippingTimes() );
+
+			await act( async () => {
+				await result.current.saveShippingTimes( [
+					...primaryTimes,
+					secondaryTime,
+				] );
+			} );
+
+			expect( deleteShippingTimes ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'excludedCountryCodes provided', () => {
+		it( 'does not delete secondary market country even when absent from shippingTimesToSave', async () => {
+			const { result } = renderHook( () => useSaveShippingTimes() );
+
+			// Simulate the primary market save: only primary times passed,
+			// DE excluded so it must not be deleted.
+			await act( async () => {
+				await result.current.saveShippingTimes( primaryTimes, [
+					'DE',
+				] );
+			} );
+
+			expect( deleteShippingTimes ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not upsert secondary market country even when present in shippingTimesToSave with changed values', async () => {
+			const { result } = renderHook( () => useSaveShippingTimes() );
+
+			// Include DE with a changed time, but it is excluded so no upsert.
+			await act( async () => {
+				await result.current.saveShippingTimes(
+					[
+						...primaryTimes,
+						{ countryCode: 'DE', time: 99, maxTime: 99 },
+					],
+					[ 'DE' ]
+				);
+			} );
+
+			expect( upsertShippingTimes ).not.toHaveBeenCalledWith(
+				expect.objectContaining( {
+					countries: expect.arrayContaining( [ 'DE' ] ),
+				} )
+			);
+		} );
+
+		it( 'still deletes primary market countries that were removed', async () => {
+			const { result } = renderHook( () => useSaveShippingTimes() );
+
+			// US removed from primary, CA kept, DE excluded.
+			await act( async () => {
+				await result.current.saveShippingTimes(
+					[ { countryCode: 'CA', time: 3, maxTime: 7 } ],
+					[ 'DE' ]
+				);
+			} );
+
+			expect( deleteShippingTimes ).toHaveBeenCalledWith( [ 'US' ] );
+			expect( deleteShippingTimes ).not.toHaveBeenCalledWith(
+				expect.arrayContaining( [ 'DE' ] )
+			);
+		} );
+
+		it( 'still upserts changed primary market times', async () => {
+			const { result } = renderHook( () => useSaveShippingTimes() );
+
+			const updatedPrimaryTimes = [
+				{ countryCode: 'US', time: 4, maxTime: 8 },
+				{ countryCode: 'CA', time: 4, maxTime: 8 },
+			];
+
+			await act( async () => {
+				await result.current.saveShippingTimes( updatedPrimaryTimes, [
+					'DE',
+				] );
+			} );
+
+			expect( upsertShippingTimes ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					countries: expect.arrayContaining( [ 'US', 'CA' ] ),
+					time: 4,
+					maxTime: 8,
+				} )
+			);
+		} );
+	} );
+} );

--- a/js/src/pages/markets/components/market-form.js
+++ b/js/src/pages/markets/components/market-form.js
@@ -87,8 +87,8 @@ const MarketForm = ( {
 
 	const handleSubmit = async ( values ) => {
 		const {
-			shipping_country_rates,
-			shipping_country_times,
+			shipping_country_rates: shippingCountryRates,
+			shipping_country_times: shippingCountryTimes,
 			countries, // omit countries from the data sent to the API since it's already included in the shipping_country_rates and shipping_country_times, and including it in both places causes confusion; to be removed once the API is updated to accept countries only in the shipping rates and times.
 			...data
 		} = values;
@@ -109,14 +109,30 @@ const MarketForm = ( {
 			// rates + times, AUTOMATIC includes times only, MANUAL includes neither.
 			const { shipping_rate: shippingRateMethod } = settings;
 			const saves = [];
+			// Countries in the store that are outside the primary target
+			// audience belong to secondary markets — exclude them so they
+			// are never deleted when saving the primary market.
+			const excludedCountryCodes = isPrimaryMarket
+				? shippingRates
+						.filter(
+							( shippingRate ) =>
+								! countries.includes( shippingRate.country )
+						)
+						.map( ( shippingRate ) => shippingRate.country )
+				: [];
+
 			if ( shippingRateMethod === SHIPPING_RATE_METHOD.FLAT ) {
-				saves.push( saveShippingRates( shipping_country_rates ) );
+				saves.push(
+					saveShippingRates(
+						shippingCountryRates,
+						excludedCountryCodes
+					)
+				);
 			}
 			if ( shippingRateMethod !== SHIPPING_RATE_METHOD.MANUAL ) {
-				// Countries in the store that are outside the primary target
-				// audience belong to secondary markets — exclude them so they
-				// are never deleted when saving the primary market.
-				const excludedCountryCodes = isPrimaryMarket
+				// Times use `countryCode`; re-derive from the times store for
+				// correctness (rates and times may cover different country sets).
+				const excludedTimeCountryCodes = isPrimaryMarket
 					? shippingTimes
 							.filter(
 								( shippingTime ) =>
@@ -128,8 +144,8 @@ const MarketForm = ( {
 					: [];
 				saves.push(
 					saveShippingTimes(
-						shipping_country_times,
-						excludedCountryCodes
+						shippingCountryTimes,
+						excludedTimeCountryCodes
 					)
 				);
 			}

--- a/js/src/pages/markets/components/market-form.js
+++ b/js/src/pages/markets/components/market-form.js
@@ -113,7 +113,25 @@ const MarketForm = ( {
 				saves.push( saveShippingRates( shipping_country_rates ) );
 			}
 			if ( shippingRateMethod !== SHIPPING_RATE_METHOD.MANUAL ) {
-				saves.push( saveShippingTimes( shipping_country_times ) );
+				// Countries in the store that are outside the primary target
+				// audience belong to secondary markets — exclude them so they
+				// are never deleted when saving the primary market.
+				const excludedCountryCodes = isPrimaryMarket
+					? shippingTimes
+							.filter(
+								( shippingTime ) =>
+									! countries.includes(
+										shippingTime.countryCode
+									)
+							)
+							.map( ( shippingTime ) => shippingTime.countryCode )
+					: [];
+				saves.push(
+					saveShippingTimes(
+						shipping_country_times,
+						excludedCountryCodes
+					)
+				);
 			}
 			await Promise.all( saves );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-725/secondary-market-shipping-times-deleted-when-editing-primary-market

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. Switch to the feature branch
2. Open the primary market edit modal
3. Change the shipping min/max times
4. Save
5. Open the secondary market. Its times and rates must be unchanged
6. Open the secondary market edit modal
7. Change its shipping time
8. Save
9. Open the primary market. Its times and rates must be unchanged

Repeat with shipping rate method set to Automatic (rates section is hidden, only times are saved. Secondary market times must still survive a primary market save).


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
