### PR TITLE
fix: Hide flat shipping rate option when onboarding for multi lingual store

### DIFF
--- a/js/src/components/shipping-rate-section/shipping-rate-method-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-method-section.js
@@ -33,14 +33,24 @@ const ShippingRateMethodSection = ( { children } ) => {
 	const isFlatShippingRate =
 		settings?.shipping_rate === SHIPPING_RATE_METHOD.FLAT;
 
-	// Defer the one-time snapshot until settings has resolved. Using a ref so
-	// mid-session auto-saves (which flip isFlatShippingRate to false) don't
-	// hide the option after it was already shown.
+	// Take a one-time snapshot once both settings and MC setup have resolved.
+	// Using a ref so mid-session auto-saves (which flip isFlatShippingRate to
+	// false) don't hide the option after it was already shown.
+	// During onboarding (status === 'incomplete'), ignore any previously stored
+	// flat rate: the auto-save in SavedSetupStepper always initialises
+	// shipping_rate to 'flat', so isFlatShippingRate would always be true here,
+	// which incorrectly shows the option for multilingual stores.
 	const showFlatOptionRef = useRef( null );
-	if ( showFlatOptionRef.current === null && settings !== undefined ) {
-		showFlatOptionRef.current = ! isMultiLingualStore || isFlatShippingRate;
+	if (
+		showFlatOptionRef.current === null &&
+		settings !== undefined &&
+		hasFinishedResolution
+	) {
+		const isOnboarding = mcSetup?.status === 'incomplete';
+		showFlatOptionRef.current =
+			! isMultiLingualStore || ( isFlatShippingRate && ! isOnboarding );
 	}
-	const showFlatOption = showFlatOptionRef.current;
+	const showFlatOption = showFlatOptionRef.current ?? ! isMultiLingualStore;
 
 	// Hide the automatic shipping rate option if there are no shipping rates and the merchant is onboarding.
 	const hideAutomaticShippingRate =

--- a/js/src/components/shipping-rate-section/shipping-rate-method-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-method-section.js
@@ -33,7 +33,7 @@ const ShippingRateMethodSection = ( { children } ) => {
 	const isFlatShippingRate =
 		settings?.shipping_rate === SHIPPING_RATE_METHOD.FLAT;
 
-	// Take a one-time snapshot once both settings and MC setup have resolved.
+	// Take a one-time snapshot once settings have resolved.
 	// Using a ref so mid-session auto-saves (which flip isFlatShippingRate to
 	// false) don't hide the option after it was already shown.
 	// For multilingual stores the flat option is shown only when the stored
@@ -42,11 +42,7 @@ const ShippingRateMethodSection = ( { children } ) => {
 	// 'manual', never 'flat', so isFlatShippingRate is false on a clean
 	// onboarding and the option is correctly hidden.
 	const showFlatOptionRef = useRef( null );
-	if (
-		showFlatOptionRef.current === null &&
-		settings !== undefined &&
-		hasFinishedResolution
-	) {
+	if ( showFlatOptionRef.current === null && settings !== undefined ) {
 		showFlatOptionRef.current = ! isMultiLingualStore || isFlatShippingRate;
 	}
 	const showFlatOption = showFlatOptionRef.current ?? ! isMultiLingualStore;

--- a/js/src/components/shipping-rate-section/shipping-rate-method-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-method-section.js
@@ -30,8 +30,6 @@ const ShippingRateMethodSection = ( { children } ) => {
 	const { hasFinishedResolution, data: mcSetup } = useMCSetup();
 	const inputProps = getInputProps( 'shipping_rate' );
 	const { isMultiLingualStore } = glaData;
-	const isFlatShippingRate =
-		settings?.shipping_rate === SHIPPING_RATE_METHOD.FLAT;
 
 	// Take a one-time snapshot once settings have resolved.
 	// Using a ref so mid-session auto-saves (which flip isFlatShippingRate to
@@ -43,6 +41,8 @@ const ShippingRateMethodSection = ( { children } ) => {
 	// onboarding and the option is correctly hidden.
 	const showFlatOptionRef = useRef( null );
 	if ( showFlatOptionRef.current === null && settings !== undefined ) {
+		const isFlatShippingRate =
+			settings?.shipping_rate === SHIPPING_RATE_METHOD.FLAT;
 		showFlatOptionRef.current = ! isMultiLingualStore || isFlatShippingRate;
 	}
 	const showFlatOption = showFlatOptionRef.current ?? ! isMultiLingualStore;

--- a/js/src/components/shipping-rate-section/shipping-rate-method-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-method-section.js
@@ -42,7 +42,7 @@ const ShippingRateMethodSection = ( { children } ) => {
 	const showFlatOptionRef = useRef( null );
 	if ( showFlatOptionRef.current === null && settings !== undefined ) {
 		const isFlatShippingRate =
-			settings?.shipping_rate === SHIPPING_RATE_METHOD.FLAT;
+			settings.shipping_rate === SHIPPING_RATE_METHOD.FLAT;
 		showFlatOptionRef.current = ! isMultiLingualStore || isFlatShippingRate;
 	}
 	const showFlatOption = showFlatOptionRef.current ?? ! isMultiLingualStore;

--- a/js/src/components/shipping-rate-section/shipping-rate-method-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-method-section.js
@@ -36,19 +36,18 @@ const ShippingRateMethodSection = ( { children } ) => {
 	// Take a one-time snapshot once both settings and MC setup have resolved.
 	// Using a ref so mid-session auto-saves (which flip isFlatShippingRate to
 	// false) don't hide the option after it was already shown.
-	// During onboarding (status === 'incomplete'), ignore any previously stored
-	// flat rate: the auto-save in SavedSetupStepper always initialises
-	// shipping_rate to 'flat', so isFlatShippingRate would always be true here,
-	// which incorrectly shows the option for multilingual stores.
+	// For multilingual stores the flat option is shown only when the stored
+	// value is already 'flat' (i.e. the merchant previously configured it).
+	// The SavedSetupStepper auto-save initialises multilingual stores to
+	// 'manual', never 'flat', so isFlatShippingRate is false on a clean
+	// onboarding and the option is correctly hidden.
 	const showFlatOptionRef = useRef( null );
 	if (
 		showFlatOptionRef.current === null &&
 		settings !== undefined &&
 		hasFinishedResolution
 	) {
-		const isOnboarding = mcSetup?.status === 'incomplete';
-		showFlatOptionRef.current =
-			! isMultiLingualStore || ( isFlatShippingRate && ! isOnboarding );
+		showFlatOptionRef.current = ! isMultiLingualStore || isFlatShippingRate;
 	}
 	const showFlatOption = showFlatOptionRef.current ?? ! isMultiLingualStore;
 

--- a/js/src/components/shipping-rate-section/shipping-rate-section.test.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.test.js
@@ -256,5 +256,49 @@ describe( 'ShippingRateSection', () => {
 				)
 			).toBeInTheDocument();
 		} );
+		it( 'should render the flat shipping rate option when the stored shipping_rate is flat', () => {
+			useSettings.mockImplementation( () => {
+				return {
+					settings: {
+						shipping_rates_count: 1,
+						shipping_rate: 'flat',
+					},
+				};
+			} );
+
+			const { getByText } = render( <ShippingRateSection /> );
+
+			expect(
+				getByText(
+					'My shipping settings are simple. I can manually estimate flat shipping rates.'
+				)
+			).toBeInTheDocument();
+		} );
+
+		it( 'should render the flat shipping rate option when onboarding and the stored shipping_rate is flat', () => {
+			useMCSetup.mockImplementation( () => {
+				return {
+					hasFinishedResolution: true,
+					data: { status: 'incomplete' },
+				};
+			} );
+
+			useSettings.mockImplementation( () => {
+				return {
+					settings: {
+						shipping_rates_count: 1,
+						shipping_rate: 'flat',
+					},
+				};
+			} );
+
+			const { getByText } = render( <ShippingRateSection /> );
+
+			expect(
+				getByText(
+					'My shipping settings are simple. I can manually estimate flat shipping rates.'
+				)
+			).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
@@ -24,7 +24,7 @@ import SetupListings from './setup-listings';
 import SetupPaidAds from './setup-paid-ads';
 import EuPoliticalDeclarationProvider from '~/components/eu-political-declaration/eu-political-declaration-provider';
 import { STEP_NAME_KEY_MAP } from './constants';
-import { GUIDE_NAMES, glaData } from '~/constants';
+import { GUIDE_NAMES, SHIPPING_RATE_METHOD, glaData } from '~/constants';
 import { getProductFeedUrl } from '~/utils/urls';
 import {
 	recordStepperChangeEvent,
@@ -82,7 +82,9 @@ const SavedSetupStepper = ( { savedStep } ) => {
 		if ( settings?.shipping_rate === null ) {
 			saveSettings( {
 				...settings,
-				shipping_rate: glaData.isMultiLingualStore ? 'manual' : 'flat',
+				shipping_rate: glaData.isMultiLingualStore
+					? SHIPPING_RATE_METHOD.MANUAL
+					: SHIPPING_RATE_METHOD.FLAT,
 				shipping_time: 'flat',
 			} );
 		}

--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
@@ -24,7 +24,7 @@ import SetupListings from './setup-listings';
 import SetupPaidAds from './setup-paid-ads';
 import EuPoliticalDeclarationProvider from '~/components/eu-political-declaration/eu-political-declaration-provider';
 import { STEP_NAME_KEY_MAP } from './constants';
-import { GUIDE_NAMES } from '~/constants';
+import { GUIDE_NAMES, glaData } from '~/constants';
 import { getProductFeedUrl } from '~/utils/urls';
 import {
 	recordStepperChangeEvent,
@@ -82,7 +82,7 @@ const SavedSetupStepper = ( { savedStep } ) => {
 		if ( settings?.shipping_rate === null ) {
 			saveSettings( {
 				...settings,
-				shipping_rate: 'flat',
+				shipping_rate: glaData.isMultiLingualStore ? 'manual' : 'flat',
 				shipping_time: 'flat',
 			} );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes [GOOWOO-703](https://linear.app/a8c/issue/GOOWOO-703/show-flat-shipping-rate-option-when-it-is-the-currently-saved#comment-5e104795).

During onboarding, the "flat rate" shipping option was incorrectly appearing for multilingual stores. The root cause was a combination of two behaviours:

1. `saved-setup-stepper.js` auto-saves `shipping_rate: 'flat'` as the default whenever it is `null` (a fallback from the original implementation).
2. The `initSettings` gate (`settings?.shipping_rate ? settings : null`) means `ShippingRateMethodSection` never renders until `shipping_rate` has a value — so the component always saw `'flat'` on its first render, making `isFlatShippingRate` always `true` for all stores, including multilingual ones.

**Fix 1 — default shipping rate (`saved-setup-stepper.js`):**
Changed the auto-save default from `'flat'` to `'manual'` when `glaData.isMultiLingualStore` is `true`. This ensures fresh onboarding for multilingual stores starts with the correct default and `isFlatShippingRate` is `false` on first render.

**Fix 2 — visibility snapshot guard (`shipping-rate-method-section.js`):**
The one-time `showFlatOption` ref snapshot is now also gated on `hasFinishedResolution` and checks `mcSetup?.status === 'incomplete'`. This covers the re-onboarding scenario where the database still holds a previous `'flat'` value (so the auto-save in Fix 1 never fires), ensuring the flat option is still suppressed for multilingual stores during onboarding even when stale data is present.

The mid-session freeze behaviour (preventing the flat option from disappearing after a user switches away from flat and triggers an auto-save) is preserved.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Install the plugin.
2. Complete the full onboarding flow and choose "flat rate" as the shipping method. Continue to completion.
3. Disconnect all accounts.
4. Activate the WPML plugin to setup a multilingual store (or mock a multilingual store by setting `isMultiLingualStore` to true in the code).
5. Navigate back to the onboarding wizard.
6. Proceed to the "Configure product listings" step and verify the **"My shipping settings are simple. I can manually estimate flat shipping rates."** option is **not visible**.
7. Repeat steps 3–4 several times (both with and without a full page reload between disconnect and re-onboarding) to confirm the option never appears intermittently.
8. On a **non-multilingual** store, verify all three shipping rate options (automatic, flat, manual) continue to appear as expected during onboarding.
9. On a multilingual store that has previously configured flat shipping and has **completed** onboarding, navigate to the shipping settings page and confirm the flat rate option **is** visible (to allow switching away).


### Additional details:

### Changelog entry

>
