### PR TITLE
GOOWOO-723: Migrate product attributes and custom attribute mapping rules to the MAPI

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -327,7 +327,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			ValidatorInterface::class,
 			ProductFactory::class,
 			TargetAudience::class,
-			AttributeMappingRulesQuery::class
+			AttributeMappingRulesQuery::class,
+			AttributeManager::class
 		);
 		$this->share_with_tags(
 			ProductSyncer::class,

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Product as GoogleProduct;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use WC_Product;
@@ -64,6 +65,11 @@ class BatchProductHelper implements Service {
 	protected $attribute_mapping_rules_query;
 
 	/**
+	 * @var AttributeManager
+	 */
+	protected $attribute_manager;
+
+	/**
 	 * BatchProductHelper constructor.
 	 *
 	 * @param ProductMetaHandler         $meta_handler
@@ -72,6 +78,7 @@ class BatchProductHelper implements Service {
 	 * @param ProductFactory             $product_factory
 	 * @param TargetAudience             $target_audience
 	 * @param AttributeMappingRulesQuery $attribute_mapping_rules_query
+	 * @param AttributeManager           $attribute_manager
 	 */
 	public function __construct(
 		ProductMetaHandler $meta_handler,
@@ -79,7 +86,8 @@ class BatchProductHelper implements Service {
 		ValidatorInterface $validator,
 		ProductFactory $product_factory,
 		TargetAudience $target_audience,
-		AttributeMappingRulesQuery $attribute_mapping_rules_query
+		AttributeMappingRulesQuery $attribute_mapping_rules_query,
+		AttributeManager $attribute_manager
 	) {
 		$this->meta_handler                  = $meta_handler;
 		$this->product_helper                = $product_helper;
@@ -87,6 +95,7 @@ class BatchProductHelper implements Service {
 		$this->product_factory               = $product_factory;
 		$this->target_audience               = $target_audience;
 		$this->attribute_mapping_rules_query = $attribute_mapping_rules_query;
+		$this->attribute_manager             = $attribute_manager;
 	}
 
 	/**
@@ -272,6 +281,7 @@ class BatchProductHelper implements Service {
 		$entries          = [];
 		$country          = $this->target_audience->get_main_target_country();
 		$target_countries = $this->target_audience->get_target_countries();
+		$mapping_rules    = $this->attribute_mapping_rules_query->get_results();
 
 		foreach ( $products as $product ) {
 			$this->validate_instanceof( $product, WC_Product::class );
@@ -290,10 +300,15 @@ class BatchProductHelper implements Service {
 					? $this->product_helper->get_wc_product( $product->get_parent_id() )
 					: null;
 
+				$attributes = $this->attribute_manager->get_all_values( $product );
+				if ( null !== $parent ) {
+					$attributes = array_merge( $this->attribute_manager->get_all_values( $parent ), $attributes );
+				}
+
 				$entries[] = [
 					'product' => $product,
 					'country' => $country,
-					'input'   => ( new WCProductInputAdapter( $product, $country, $parent, $target_countries ) )->get_product_input(),
+					'input'   => ( new WCProductInputAdapter( $product, $country, $parent, $target_countries, $attributes, $mapping_rules ) )->get_product_input(),
 				];
 			} catch ( GoogleListingsAndAdsException $exception ) {
 				do_action(

--- a/src/Product/WCProductInputAdapter.php
+++ b/src/Product/WCProductInputAdapter.php
@@ -4,8 +4,11 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMapping\AttributeMappingHelper;
 use WC_Product;
+use WC_Product_Variable;
 use WC_Product_Variation;
 
 defined( 'ABSPATH' ) || exit;
@@ -26,6 +29,29 @@ class WCProductInputAdapter {
 	public const AVAILABILITY_BACKORDER    = 'backorder';
 
 	public const IMAGE_SIZE_FULL = 'full';
+
+	/**
+	 * Supported per-product Google attribute ids (WooCommerce attribute keys).
+	 * Translated to their MAPI keys and types in set_attribute().
+	 */
+	protected const SUPPORTED_ATTRIBUTES = [
+		'gtin',
+		'mpn',
+		'brand',
+		'condition',
+		'gender',
+		'size',
+		'sizeSystem',
+		'sizeType',
+		'color',
+		'material',
+		'pattern',
+		'ageGroup',
+		'multipack',
+		'isBundle',
+		'availabilityDate',
+		'adult',
+	];
 
 	/** @var WC_Product */
 	protected $wc_product;
@@ -51,6 +77,15 @@ class WCProductInputAdapter {
 	/** @var string[] Target countries to add shipping entries for. */
 	protected $shipping_countries = [];
 
+	/** @var array Per-product Google attribute values keyed by attribute id. */
+	protected $gla_attributes = [];
+
+	/** @var array Attribute mapping rules to apply. */
+	protected $mapping_rules = [];
+
+	/** @var int[] Product (or parent) category term ids, used for rule conditions. */
+	protected $product_category_ids = [];
+
 	/**
 	 * WCProductInputAdapter constructor.
 	 *
@@ -58,13 +93,26 @@ class WCProductInputAdapter {
 	 * @param string          $target_country     Feed label.
 	 * @param WC_Product|null $parent_product     Parent product, required when $product is a variation.
 	 * @param string[]        $shipping_countries Additional target countries to add shipping entries for.
+	 * @param array           $gla_attributes     Per-product Google attribute values.
+	 * @param array           $mapping_rules      Attribute mapping rules to apply.
+	 *
+	 * @throws InvalidValue When $product is a variation and a valid parent product is not provided.
 	 */
-	public function __construct( WC_Product $product, string $target_country, ?WC_Product $parent_product = null, array $shipping_countries = [] ) {
+	public function __construct( WC_Product $product, string $target_country, ?WC_Product $parent_product = null, array $shipping_countries = [], array $gla_attributes = [], array $mapping_rules = [] ) {
 		$this->wc_product         = $product;
 		$this->parent_wc_product  = $parent_product;
 		$this->feed_label         = $target_country;
 		$this->shipping_countries = $shipping_countries;
+		$this->gla_attributes     = $gla_attributes;
+		$this->mapping_rules      = $mapping_rules;
 		$this->tax_excluded       = $this->resolve_tax_excluded();
+
+		if ( $this->is_variation() && ! $this->parent_wc_product instanceof WC_Product_Variable ) {
+			throw InvalidValue::not_instance_of( WC_Product_Variable::class, 'parent_product' );
+		}
+
+		$base_product_id            = $this->is_variation() ? $this->parent_wc_product->get_id() : $this->wc_product->get_id();
+		$this->product_category_ids = wc_get_product_term_ids( $base_product_id, 'product_cat' );
 
 		$this->map_identity();
 		$this->map_general_attributes();
@@ -72,6 +120,13 @@ class WCProductInputAdapter {
 		$this->map_availability();
 		$this->map_price();
 		$this->map_shipping();
+		$this->map_product_types();
+
+		// Order matters: per-product values override rules, gtin overrides those, the override filter wins.
+		$this->map_attribute_mapping_rules();
+		$this->map_gla_attributes();
+		$this->map_gtin();
+		$this->override_attributes();
 	}
 
 	/**
@@ -226,6 +281,50 @@ class WCProductInputAdapter {
 	}
 
 	/**
+	 * Map the product's categories to the productTypes attribute (capped at 10),
+	 * ported from WCProductAdapter::map_product_categories.
+	 */
+	protected function map_product_types(): void {
+		$product_types = [];
+		foreach ( array_unique( $this->product_category_ids ) as $category_id ) {
+			if ( ! is_int( $category_id ) ) {
+				continue;
+			}
+
+			$path = $this->category_path( $category_id );
+			if ( '' !== $path ) {
+				$product_types[] = $path;
+			}
+		}
+
+		if ( ! empty( $product_types ) ) {
+			$this->attributes['productTypes'] = array_slice( $product_types, 0, 10 );
+		}
+	}
+
+	/**
+	 * Build the "Parent > Child" category path for a category term id.
+	 *
+	 * @param int $category_id
+	 *
+	 * @return string
+	 */
+	protected function category_path( int $category_id ): string {
+		$names = [];
+		do {
+			$term = get_term_by( 'id', $category_id, 'product_cat', 'ARRAY_A' );
+			if ( ! $term ) {
+				break;
+			}
+
+			$names[]     = $term['name'];
+			$category_id = (int) $term['parent'];
+		} while ( ! empty( $term['parent'] ) );
+
+		return implode( ' > ', array_reverse( $names ) );
+	}
+
+	/**
 	 * Map the shipping attributes.
 	 */
 	protected function map_shipping(): void {
@@ -331,6 +430,258 @@ class WCProductInputAdapter {
 		$is_virtual = apply_filters( 'woocommerce_gla_product_property_value_is_virtual', $is_virtual, $this->wc_product );
 
 		return false !== $is_virtual;
+	}
+
+	/**
+	 * Map the per-product Google attribute values (brand, gtin, color, size, etc.).
+	 */
+	protected function map_gla_attributes(): void {
+		foreach ( $this->gla_attributes as $attribute_id => $value ) {
+			if ( ! in_array( $attribute_id, self::SUPPORTED_ATTRIBUTES, true ) ) {
+				continue;
+			}
+
+			/** This filter is documented in src/Product/WCProductAdapter.php */
+			$value = apply_filters( "woocommerce_gla_product_attribute_value_{$attribute_id}", $value, $this->wc_product );
+
+			if ( null === $value || '' === $value ) {
+				continue;
+			}
+
+			$this->set_attribute( $attribute_id, $value );
+		}
+	}
+
+	/**
+	 * Apply the custom attribute mapping rules, resolving each rule's source value
+	 * for products that match the rule's category conditions.
+	 */
+	protected function map_attribute_mapping_rules(): void {
+		foreach ( $this->mapping_rules as $rule ) {
+			$attribute_id = $rule['attribute'] ?? '';
+			if ( ! in_array( $attribute_id, self::SUPPORTED_ATTRIBUTES, true ) ) {
+				continue;
+			}
+
+			if ( ! $this->rule_match_conditions( $rule ) ) {
+				continue;
+			}
+
+			/** This filter is documented in src/Product/WCProductAdapter.php */
+			$value = apply_filters(
+				"woocommerce_gla_product_attribute_value_{$attribute_id}",
+				$this->get_source( (string) ( $rule['source'] ?? '' ) ),
+				$this->wc_product
+			);
+
+			if ( null === $value || '' === $value ) {
+				continue;
+			}
+
+			$this->set_attribute( $attribute_id, $value );
+		}
+	}
+
+	/**
+	 * Whether the product matches a mapping rule's category conditions.
+	 *
+	 * @param array $rule
+	 *
+	 * @return bool
+	 */
+	protected function rule_match_conditions( array $rule ): bool {
+		$condition_type = $rule['category_condition_type'] ?? '';
+
+		if ( AttributeMappingHelper::CATEGORY_CONDITION_TYPE_ALL === $condition_type ) {
+			return true;
+		}
+
+		$categories = explode( ',', (string) ( $rule['categories'] ?? '' ) );
+		$contains   = ! empty( array_intersect( $categories, $this->product_category_ids ) );
+
+		if ( AttributeMappingHelper::CATEGORY_CONDITION_TYPE_ONLY === $condition_type ) {
+			return $contains;
+		}
+
+		return ! $contains;
+	}
+
+	/**
+	 * Resolve a mapping rule source to its value: a product field, taxonomy term,
+	 * custom attribute, or a static value.
+	 *
+	 * @param string $source
+	 *
+	 * @return string
+	 */
+	protected function get_source( string $source ): string {
+		$separator = strpos( $source, ':' );
+		if ( ! $separator ) {
+			return $source;
+		}
+
+		$type  = substr( $source, 0, $separator );
+		$value = substr( $source, $separator + 1 );
+
+		switch ( $type ) {
+			case 'product':
+				return $this->get_product_field( $value );
+			case 'taxonomy':
+				return $this->get_product_taxonomy( $value );
+			case 'attribute':
+				return $this->get_custom_attribute( $value );
+			default:
+				return $source;
+		}
+	}
+
+	/**
+	 * Get a core product field value for a mapping rule source.
+	 *
+	 * @param string $field
+	 *
+	 * @return string
+	 */
+	protected function get_product_field( string $field ): string {
+		if ( 'weight_with_unit' === $field ) {
+			$weight = $this->wc_product->get_weight();
+			return $weight ? $weight . ' ' . get_option( 'woocommerce_weight_unit' ) : '';
+		}
+
+		$getter = 'get_' . $field;
+		if ( is_callable( [ $this->wc_product, $getter ] ) ) {
+			$value = $this->wc_product->$getter();
+			return is_scalar( $value ) ? (string) $value : '';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Get the first taxonomy term value for a mapping rule source.
+	 *
+	 * @param string $taxonomy
+	 *
+	 * @return string
+	 */
+	protected function get_product_taxonomy( string $taxonomy ): string {
+		if ( $this->is_variation() ) {
+			$values = $this->wc_product->get_attribute( $taxonomy );
+
+			if ( ! $values ) {
+				$values = $this->get_taxonomy_term_names( $this->wc_product->get_id(), $taxonomy );
+			}
+
+			if ( ! $values && $this->parent_wc_product instanceof WC_Product ) {
+				$values = $this->parent_wc_product->get_attribute( $taxonomy );
+				if ( ! $values ) {
+					$values = $this->get_taxonomy_term_names( $this->parent_wc_product->get_id(), $taxonomy );
+				}
+			}
+
+			if ( is_string( $values ) ) {
+				$values = explode( ', ', $values );
+			}
+		} else {
+			$values = $this->get_taxonomy_term_names( $this->wc_product->get_id(), $taxonomy );
+		}
+
+		if ( empty( $values ) || is_wp_error( $values ) ) {
+			return '';
+		}
+
+		return (string) $values[0];
+	}
+
+	/**
+	 * Get the term names for a product taxonomy.
+	 *
+	 * @param int    $product_id
+	 * @param string $taxonomy
+	 *
+	 * @return string[]
+	 */
+	protected function get_taxonomy_term_names( int $product_id, string $taxonomy ): array {
+		$terms = wc_get_product_terms( $product_id, $taxonomy );
+
+		return wp_list_pluck( $terms, 'name' );
+	}
+
+	/**
+	 * Get the first custom attribute or meta value for a mapping rule source.
+	 *
+	 * @param string $attribute_name
+	 *
+	 * @return string
+	 */
+	protected function get_custom_attribute( string $attribute_name ): string {
+		$value = $this->wc_product->get_attribute( $attribute_name );
+
+		if ( ! $value ) {
+			$value = $this->wc_product->get_meta( $attribute_name );
+		}
+
+		if ( ! is_scalar( $value ) ) {
+			return '';
+		}
+
+		$values = array_filter( array_map( 'trim', explode( WC_DELIMITER, (string) $value ) ) );
+
+		return empty( $values ) ? '' : (string) reset( $values );
+	}
+
+	/**
+	 * Apply the attribute-values override filter, which takes precedence over every
+	 * other attribute mapping.
+	 */
+	protected function override_attributes(): void {
+		/** This filter is documented in src/Product/WCProductAdapter.php */
+		$overrides = apply_filters( 'woocommerce_gla_product_attribute_values', [], $this->wc_product, $this );
+
+		if ( is_array( $overrides ) ) {
+			$this->attributes = array_merge( $this->attributes, $overrides );
+		}
+	}
+
+	/**
+	 * Set a single Google attribute, mapping it to its MAPI key and type.
+	 *
+	 * @param string $attribute_id
+	 * @param mixed  $value
+	 */
+	protected function set_attribute( string $attribute_id, $value ): void {
+		switch ( $attribute_id ) {
+			case 'gtin':
+				$this->attributes['gtins'] = [ (string) $value ];
+				break;
+			case 'sizeType':
+				$this->attributes['sizeTypes'] = [ (string) $value ];
+				break;
+			case 'multipack':
+				$this->attributes['multipack'] = (string) (int) $value;
+				break;
+			case 'isBundle':
+			case 'adult':
+				$this->attributes[ $attribute_id ] = wc_string_to_bool( $value );
+				break;
+			default:
+				$this->attributes[ $attribute_id ] = (string) $value;
+		}
+	}
+
+	/**
+	 * Map the WooCommerce core global unique id (GTIN) when available. Ported from WCProductAdapter.
+	 */
+	protected function map_gtin(): void {
+		// Core global unique ID field was added in WC 9.2.
+		if ( ! method_exists( $this->wc_product, 'get_global_unique_id' ) ) {
+			return;
+		}
+
+		$gtin = preg_replace( '/[^0-9]/', '', (string) $this->wc_product->get_global_unique_id() );
+		if ( ! empty( $gtin ) ) {
+			$this->attributes['gtins'] = [ $gtin ];
+		}
 	}
 
 	/**

--- a/src/Product/WCProductInputAdapter.php
+++ b/src/Product/WCProductInputAdapter.php
@@ -496,8 +496,9 @@ class WCProductInputAdapter {
 			return true;
 		}
 
-		$categories = explode( ',', (string) ( $rule['categories'] ?? '' ) );
-		$contains   = ! empty( array_intersect( $categories, $this->product_category_ids ) );
+		$categories   = explode( ',', (string) ( $rule['categories'] ?? '' ) );
+		$category_ids = array_map( 'strval', $this->product_category_ids );
+		$contains     = ! empty( array_intersect( $categories, $category_ids ) );
 
 		if ( AttributeMappingHelper::CATEGORY_CONDITION_TYPE_ONLY === $condition_type ) {
 			return $contains;
@@ -516,7 +517,7 @@ class WCProductInputAdapter {
 	 */
 	protected function get_source( string $source ): string {
 		$separator = strpos( $source, ':' );
-		if ( ! $separator ) {
+		if ( false === $separator ) {
 			return $source;
 		}
 
@@ -635,7 +636,18 @@ class WCProductInputAdapter {
 	 * other attribute mapping.
 	 */
 	protected function override_attributes(): void {
-		/** This filter is documented in src/Product/WCProductAdapter.php */
+		/**
+		 * Filters the attribute values to override on the Merchant API product input.
+		 *
+		 * Merchant API counterpart of the same filter in WCProductAdapter. Note: the
+		 * third parameter is now a WCProductInputAdapter (Merchant API) rather than a
+		 * WCProductAdapter (Content API), and overrides must use Merchant API attribute
+		 * keys and value shapes.
+		 *
+		 * @param array                 $overrides  Attribute values keyed by Merchant API attribute key.
+		 * @param WC_Product            $wc_product The WooCommerce product.
+		 * @param WCProductInputAdapter $adapter    The product input adapter.
+		 */
 		$overrides = apply_filters( 'woocommerce_gla_product_attribute_values', [], $this->wc_product, $this );
 
 		if ( is_array( $overrides ) ) {

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -11,6 +11,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntr
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Brand;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Color;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductFactory;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
@@ -369,6 +372,37 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		}
 	}
 
+	public function test_generate_mapi_update_entries_merges_parent_and_variation_attributes() {
+		$this->target_audience->expects( $this->any() )->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->expects( $this->any() )->method( 'get_target_countries' )->willReturn( [ 'US' ] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$attribute_manager = $this->container->get( AttributeManager::class );
+
+		$variable  = WC_Helper_Product::create_variation_product();
+		$variation = $this->wc->get_product( $variable->get_children()[0] );
+
+		// Parent-level attribute (inherited by the variation) plus a variation-level attribute.
+		$attribute_manager->update( $variable, new Brand( 'ParentBrand' ) );
+		$attribute_manager->update( $variation, new Color( 'VariationColor' ) );
+
+		$entries = $this->batch_product_helper->generate_mapi_update_entries( [ $variable ] );
+
+		$entry = null;
+		foreach ( $entries as $candidate ) {
+			if ( $candidate['product']->get_id() === $variation->get_id() ) {
+				$entry = $candidate;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $entry, 'No entry generated for the variation.' );
+
+		$attrs = $entry['input']->get_attributes();
+		$this->assertSame( 'ParentBrand', $attrs['brand'] );
+		$this->assertSame( 'VariationColor', $attrs['color'] );
+	}
+
 	/**
 	 * @return WC_Product[]
 	 */
@@ -392,6 +426,6 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->product_factory      = $this->container->get( ProductFactory::class );
 		$this->wc                   = $this->container->get( WC::class );
 		$this->product_helper       = new ProductHelper( $this->product_meta, $this->wc, $this->target_audience );
-		$this->batch_product_helper = new BatchProductHelper( $this->product_meta, $this->product_helper, $this->validator, $this->product_factory, $this->target_audience, $this->rules_query );
+		$this->batch_product_helper = new BatchProductHelper( $this->product_meta, $this->product_helper, $this->validator, $this->product_factory, $this->target_audience, $this->rules_query, $this->container->get( AttributeManager::class ) );
 	}
 }

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductFactory;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
@@ -92,6 +93,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 										$product_factory,
 										$this->target_audience,
 										$this->rules_query,
+										$this->container->get( AttributeManager::class ),
 									]
 								)
 								->getMock();

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductInputAdapter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
@@ -80,6 +81,15 @@ class WCProductInputAdapterTest extends UnitTest {
 		$attrs = ( new WCProductInputAdapter( $variation, 'US', $parent ) )->get_product_input()->get_attributes();
 
 		$this->assertSame( (string) $parent->get_id(), $attrs['itemGroupId'] );
+	}
+
+	public function test_variation_without_parent_throws() {
+		$parent     = WC_Helper_Product::create_variation_product();
+		$variations = $parent->get_children();
+		$variation  = wc_get_product( $variations[0] );
+
+		$this->expectException( InvalidValue::class );
+		new WCProductInputAdapter( $variation, 'US' );
 	}
 
 	public function test_maps_price_to_micros() {
@@ -325,5 +335,370 @@ class WCProductInputAdapterTest extends UnitTest {
 			],
 			$attrs['shippingWeight']
 		);
+	}
+
+	public function test_maps_string_attributes() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter(
+			$product,
+			'US',
+			null,
+			[],
+			[
+				'brand'     => 'Acme',
+				'color'     => 'Red',
+				'material'  => 'Cotton',
+				'pattern'   => 'Striped',
+				'mpn'       => 'MPN123',
+				'condition' => 'new',
+				'ageGroup'  => 'adult',
+				'gender'    => 'unisex',
+			]
+		) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'Acme', $attrs['brand'] );
+		$this->assertSame( 'Red', $attrs['color'] );
+		$this->assertSame( 'Cotton', $attrs['material'] );
+		$this->assertSame( 'Striped', $attrs['pattern'] );
+		$this->assertSame( 'MPN123', $attrs['mpn'] );
+		$this->assertSame( 'new', $attrs['condition'] );
+		$this->assertSame( 'adult', $attrs['ageGroup'] );
+		$this->assertSame( 'unisex', $attrs['gender'] );
+	}
+
+	public function test_maps_size_attribute() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [], [ 'size' => 'XL' ] ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'XL', $attrs['size'] );
+	}
+
+	public function test_maps_array_attributes() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter(
+			$product,
+			'US',
+			null,
+			[],
+			[
+				'gtin'     => '00012345678905',
+				'sizeType' => 'regular',
+			]
+		) )->get_product_input()->get_attributes();
+
+		$this->assertSame( [ '00012345678905' ], $attrs['gtins'] );
+		$this->assertSame( [ 'regular' ], $attrs['sizeTypes'] );
+		$this->assertArrayNotHasKey( 'gtin', $attrs );
+		$this->assertArrayNotHasKey( 'sizeType', $attrs );
+	}
+
+	public function test_coerces_boolean_and_multipack_attributes() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter(
+			$product,
+			'US',
+			null,
+			[],
+			[
+				'isBundle'  => 'yes',
+				'adult'     => 'no',
+				'multipack' => '6',
+			]
+		) )->get_product_input()->get_attributes();
+
+		$this->assertSame( true, $attrs['isBundle'] );
+		$this->assertSame( false, $attrs['adult'] );
+		$this->assertSame( '6', $attrs['multipack'] );
+	}
+
+	public function test_skips_unsupported_attribute() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter(
+			$product,
+			'US',
+			null,
+			[],
+			[
+				'notAReal' => 'x',
+				'brand'    => 'Acme',
+			]
+		) )->get_product_input()->get_attributes();
+
+		$this->assertArrayNotHasKey( 'notAReal', $attrs );
+		$this->assertSame( 'Acme', $attrs['brand'] );
+	}
+
+	public function test_applies_attribute_value_filter() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		add_filter(
+			'woocommerce_gla_product_attribute_value_brand',
+			function () {
+				return 'Filtered';
+			}
+		);
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [], [ 'brand' => 'Original' ] ) )->get_product_input()->get_attributes();
+		remove_all_filters( 'woocommerce_gla_product_attribute_value_brand' );
+
+		$this->assertSame( 'Filtered', $attrs['brand'] );
+	}
+
+	public function test_applies_attribute_values_override_filter() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		add_filter(
+			'woocommerce_gla_product_attribute_values',
+			function ( $values ) {
+				$values['color'] = 'Blue';
+				return $values;
+			}
+		);
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [], [ 'brand' => 'Acme' ] ) )->get_product_input()->get_attributes();
+		remove_all_filters( 'woocommerce_gla_product_attribute_values' );
+
+		$this->assertSame( 'Blue', $attrs['color'] );
+		$this->assertSame( 'Acme', $attrs['brand'] );
+	}
+
+	public function test_applies_mapping_rule_with_static_source() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$rules = [
+			[
+				'attribute'               => 'brand',
+				'source'                  => 'RuleBrand',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [], [], $rules ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'RuleBrand', $attrs['brand'] );
+	}
+
+	public function test_mapping_rule_resolves_product_field_source() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_sku( 'SKU-123' );
+		$product->save();
+
+		$rules = [
+			[
+				'attribute'               => 'mpn',
+				'source'                  => 'product:sku',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [], [], $rules ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'SKU-123', $attrs['mpn'] );
+	}
+
+	public function test_per_product_value_overrides_mapping_rule() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$rules = [
+			[
+				'attribute'               => 'brand',
+				'source'                  => 'RuleBrand',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [], [ 'brand' => 'ProductBrand' ], $rules ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'ProductBrand', $attrs['brand'] );
+	}
+
+	public function test_mapping_rule_only_condition_matches_category() {
+		$term    = wp_insert_term( 'RuleCat', 'product_cat' );
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_category_ids( [ $term['term_id'] ] );
+		$product->save();
+
+		$rules = [
+			[
+				'attribute'               => 'brand',
+				'source'                  => 'MatchedBrand',
+				'category_condition_type' => 'ONLY',
+				'categories'              => (string) $term['term_id'],
+			],
+			[
+				'attribute'               => 'color',
+				'source'                  => 'ShouldNotApply',
+				'category_condition_type' => 'ONLY',
+				'categories'              => '999999',
+			],
+		];
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [], [], $rules ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'MatchedBrand', $attrs['brand'] );
+		$this->assertArrayNotHasKey( 'color', $attrs );
+	}
+
+	public function test_mapping_rule_skips_unsupported_attribute() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$rules = [
+			[
+				'attribute'               => 'notAReal',
+				'source'                  => 'x',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [], [], $rules ) )->get_product_input()->get_attributes();
+
+		$this->assertArrayNotHasKey( 'notAReal', $attrs );
+	}
+
+	public function test_maps_product_types_from_categories() {
+		$parent = wp_insert_term( 'Clothing', 'product_cat' );
+		$child  = wp_insert_term( 'Shirts', 'product_cat', [ 'parent' => $parent['term_id'] ] );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_category_ids( [ $child['term_id'] ] );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( [ 'Clothing > Shirts' ], $attrs['productTypes'] );
+	}
+
+	public function test_product_types_capped_at_ten() {
+		$category_ids = [];
+		for ( $i = 1; $i <= 11; $i++ ) {
+			$term           = wp_insert_term( "CapCat{$i}", 'product_cat' );
+			$category_ids[] = $term['term_id'];
+		}
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_category_ids( $category_ids );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertCount( 10, $attrs['productTypes'] );
+	}
+
+	public function test_mapping_rule_resolves_taxonomy_source() {
+		$term    = wp_insert_term( 'TaxoCat', 'product_cat' );
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_category_ids( [ $term['term_id'] ] );
+		$product->save();
+
+		$rules = [
+			[
+				'attribute'               => 'material',
+				'source'                  => 'taxonomy:product_cat',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [], [], $rules ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'TaxoCat', $attrs['material'] );
+	}
+
+	public function test_mapping_rule_resolves_custom_attribute_source() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->update_meta_data( 'fabric', 'First | Second' );
+		$product->save();
+
+		$rules = [
+			[
+				'attribute'               => 'pattern',
+				'source'                  => 'attribute:fabric',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [], [], $rules ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'First', $attrs['pattern'] );
+	}
+
+	public function test_mapping_rule_except_condition_excludes_matching_category() {
+		$term    = wp_insert_term( 'ExceptCat', 'product_cat' );
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_category_ids( [ $term['term_id'] ] );
+		$product->save();
+
+		$rules = [
+			[
+				'attribute'               => 'brand',
+				'source'                  => 'ShouldNotApply',
+				'category_condition_type' => 'EXCEPT',
+				'categories'              => (string) $term['term_id'],
+			],
+			[
+				'attribute'               => 'color',
+				'source'                  => 'ShouldApply',
+				'category_condition_type' => 'EXCEPT',
+				'categories'              => '999999',
+			],
+		];
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [], [], $rules ) )->get_product_input()->get_attributes();
+
+		$this->assertArrayNotHasKey( 'brand', $attrs );
+		$this->assertSame( 'ShouldApply', $attrs['color'] );
+	}
+
+	public function test_core_gtin_overrides_per_product_gtin() {
+		$product = WC_Helper_Product::create_simple_product();
+		if ( ! method_exists( $product, 'set_global_unique_id' ) ) {
+			$this->markTestSkipped( 'Core global unique id requires WooCommerce 9.2+.' );
+		}
+		$product->set_global_unique_id( '12-345' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [], [ 'gtin' => '99999' ] ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( [ '12345' ], $attrs['gtins'] );
+	}
+
+	public function test_override_filter_accepts_mapi_keys() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		add_filter(
+			'woocommerce_gla_product_attribute_values',
+			function () {
+				return [
+					'gtins' => [ '999' ],
+					'size'  => 'M',
+					'color' => 'Blue',
+				];
+			}
+		);
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+		remove_all_filters( 'woocommerce_gla_product_attribute_values' );
+
+		$this->assertSame( [ '999' ], $attrs['gtins'] );
+		$this->assertSame( 'M', $attrs['size'] );
+		$this->assertSame( 'Blue', $attrs['color'] );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Extends `WCProductInputAdapter` to build the full product attribute layer for the MAPI, replacing the Content API attribute mapping that lived in `WCProductAdapter`.

Closes https://linear.app/a8c/issue/GOOWOO-723/migrate-product-attributes-and-custom-attribute-mapping-rules-to-the





### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
