### PR TITLE
GOOWOO-717 + GOOWOO-741: Migrate product status + listing to the Merchant API

### DIFF
--- a/src/API/Google/Mapi/Services/MapiDataSourcesService.php
+++ b/src/API/Google/Mapi/Services/MapiDataSourcesService.php
@@ -93,25 +93,50 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 	 * @throws MerchantApiException On a non-2xx MAPI response.
 	 */
 	protected function find_existing_data_source( string $content_language, string $feed_label ): ?string {
-		$response = $this->client->get(
-			sprintf( '%s/accounts/%s/dataSources', MapiPaths::DATASOURCES, $this->options->get_merchant_id() )
-		);
+		$page_token = '';
 
-		foreach ( $response['dataSources'] ?? [] as $source ) {
-			$primary = $source['primaryProductDataSource'] ?? null;
-			if ( ! is_array( $primary ) || ! isset( $source['name'] ) ) {
-				continue;
+		do {
+			$response = $this->client->get( $this->build_list_path( $page_token ) );
+
+			foreach ( $response['dataSources'] ?? [] as $source ) {
+				$primary = $source['primaryProductDataSource'] ?? null;
+				if ( ! is_array( $primary ) || ! isset( $source['name'] ) ) {
+					continue;
+				}
+
+				if (
+					$content_language === ( $primary['contentLanguage'] ?? '' )
+					&& $feed_label === ( $primary['feedLabel'] ?? '' )
+				) {
+					return $source['name'];
+				}
 			}
 
-			if (
-				$content_language === ( $primary['contentLanguage'] ?? '' )
-				&& $feed_label === ( $primary['feedLabel'] ?? '' )
-			) {
-				return $source['name'];
-			}
-		}
+			$page_token = $response['nextPageToken'] ?? '';
+		} while ( '' !== $page_token );
 
 		return null;
+	}
+
+	/**
+	 * Build the resource path for listing data sources.
+	 *
+	 * @param string $page_token
+	 *
+	 * @return string
+	 */
+	protected function build_list_path( string $page_token ): string {
+		$path = sprintf(
+			'%s/accounts/%s/dataSources',
+			MapiPaths::DATASOURCES,
+			$this->options->get_merchant_id()
+		);
+
+		if ( '' !== $page_token ) {
+			$path .= '?pageToken=' . rawurlencode( $page_token );
+		}
+
+		return $path;
 	}
 
 	/**

--- a/src/API/Google/Mapi/Services/MapiProductsService.php
+++ b/src/API/Google/Mapi/Services/MapiProductsService.php
@@ -91,28 +91,28 @@ class MapiProductsService implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Fetch all products for the account, following pagination.
+	 * Yield all products for the account, following pagination.
+	 *
+	 * Returns a generator so callers can stream the catalog without holding every
+	 * product in memory at once.
 	 *
 	 * @param int $page_size Maximum products to request per page.
 	 *
-	 * @return Product[]
+	 * @return iterable<Product>
 	 * @throws MerchantApiException On non-2xx response.
 	 */
-	public function list( int $page_size = 250 ): array {
-		$products   = [];
+	public function list( int $page_size = 250 ): iterable {
 		$page_token = '';
 
 		do {
 			$body = $this->client->get( $this->build_list_path( $page_size, $page_token ) );
 
 			foreach ( $body['products'] ?? [] as $product ) {
-				$products[] = Product::from_array( $product );
+				yield Product::from_array( $product );
 			}
 
 			$page_token = $body['nextPageToken'] ?? '';
 		} while ( '' !== $page_token );
-
-		return $products;
 	}
 
 	/**

--- a/src/API/Google/Mapi/Services/MapiProductsService.php
+++ b/src/API/Google/Mapi/Services/MapiProductsService.php
@@ -91,6 +91,31 @@ class MapiProductsService implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Fetch all products for the account, following pagination.
+	 *
+	 * @param int $page_size Maximum products to request per page.
+	 *
+	 * @return Product[]
+	 * @throws MerchantApiException On non-2xx response.
+	 */
+	public function list( int $page_size = 250 ): array {
+		$products   = [];
+		$page_token = '';
+
+		do {
+			$body = $this->client->get( $this->build_list_path( $page_size, $page_token ) );
+
+			foreach ( $body['products'] ?? [] as $product ) {
+				$products[] = Product::from_array( $product );
+			}
+
+			$page_token = $body['nextPageToken'] ?? '';
+		} while ( '' !== $page_token );
+
+		return $products;
+	}
+
+	/**
 	 * Build the resource path for a product.
 	 *
 	 * @param string $google_product_id
@@ -104,5 +129,28 @@ class MapiProductsService implements OptionsAwareInterface {
 			$this->options->get_merchant_id(),
 			$google_product_id
 		);
+	}
+
+	/**
+	 * Build the resource path for listing products.
+	 *
+	 * @param int    $page_size
+	 * @param string $page_token
+	 *
+	 * @return string
+	 */
+	protected function build_list_path( int $page_size, string $page_token ): string {
+		$path = sprintf(
+			'%s/accounts/%s/products?pageSize=%d',
+			MapiPaths::PRODUCTS,
+			$this->options->get_merchant_id(),
+			$page_size
+		);
+
+		if ( '' !== $page_token ) {
+			$path .= '&pageToken=' . rawurlencode( $page_token );
+		}
+
+		return $path;
 	}
 }

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -13,9 +13,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingCo
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Account;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountAdsLink;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountStatus;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ProductstatusesCustomBatchResponse;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ProductstatusesCustomBatchRequest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\RequestPhoneVerificationRequest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\RequestReviewFreeListingsRequest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\RequestReviewShoppingAdsRequest;
@@ -50,33 +47,6 @@ class Merchant implements OptionsAwareInterface {
 	public function __construct( ShoppingContent $service ) {
 		$this->service = $service;
 	}
-
-	/**
-	 * @return Product[]
-	 */
-	public function get_products(): array {
-		$products = $this->service->products->listProducts( $this->options->get_merchant_id() );
-		$return   = [];
-
-		while ( ! empty( $products->getResources() ) ) {
-
-			foreach ( $products->getResources() as $product ) {
-				$return[] = $product;
-			}
-
-			if ( empty( $products->getNextPageToken() ) ) {
-				break;
-			}
-
-			$products = $this->service->products->listProducts(
-				$this->options->get_merchant_id(),
-				[ 'pageToken' => $products->getNextPageToken() ]
-			);
-		}
-
-		return $return;
-	}
-
 
 	/**
 	 * Claim a website for the user's Merchant Center account.
@@ -306,33 +276,6 @@ class Merchant implements OptionsAwareInterface {
 			throw new Exception( __( 'Unable to retrieve Merchant Center account status.', 'google-listings-and-ads' ), $e->getCode() );
 		}
 		return $mc_account_status;
-	}
-
-	/**
-	 * Retrieve a batch of Merchant Center Product Statuses using the provided Merchant Center product IDs.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param string[] $mc_product_ids
-	 *
-	 * @return ProductstatusesCustomBatchResponse;
-	 */
-	public function get_productstatuses_batch( array $mc_product_ids ): ProductstatusesCustomBatchResponse {
-		$merchant_id = $this->options->get_merchant_id();
-		$entries     = [];
-		foreach ( $mc_product_ids as $index => $id ) {
-			$entries[] = [
-				'batchId'    => $index + 1,
-				'productId'  => $id,
-				'method'     => 'GET',
-				'merchantId' => $merchant_id,
-			];
-		}
-
-		// Retrieve batch.
-		$request = new ProductstatusesCustomBatchRequest();
-		$request->setEntries( $entries );
-		return $this->service->productstatuses->custombatch( $request );
 	}
 
 	/**

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -1291,8 +1291,8 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 		}
 
 		if ( 'wcs-google-mc-proxy' === $_GET['action'] && check_admin_referer( 'wcs-google-mc-proxy' ) ) {
-			/** @var Merchant $merchant */
-			$merchant = $this->container->get( Merchant::class );
+			/** @var MapiProductsService $service */
+			$service = $this->container->get( MapiProductsService::class );
 			/** @var OptionsInterface $options */
 			$options = $this->container->get( OptionsInterface::class );
 
@@ -1303,13 +1303,18 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 
 			$this->response = "Proxied request > get products for merchant {$options->get_merchant_id()}\n";
 
-			$products = $merchant->get_products();
-			if ( empty( $products ) ) {
-				$this->response .= 'No products found';
-			}
+			try {
+				$products = $service->list();
+				if ( empty( $products ) ) {
+					$this->response .= 'No products found';
+				}
 
-			foreach ( $products as $product ) {
-				$this->response .= "{$product->getId()} {$product->getTitle()}\n";
+				foreach ( $products as $product ) {
+					$this->response .= "{$product->get_id()} {$product->get_title()}\n";
+				}
+			} catch ( MerchantApiException $e ) {
+				$this->response .= sprintf( "HTTP %d\n", $e->get_http_status() );
+				$this->response .= print_r( $e->get_response_body(), true );
 			}
 		}
 

--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -1304,13 +1304,14 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 			$this->response = "Proxied request > get products for merchant {$options->get_merchant_id()}\n";
 
 			try {
-				$products = $service->list();
-				if ( empty( $products ) ) {
-					$this->response .= 'No products found';
+				$count = 0;
+				foreach ( $service->list() as $product ) {
+					$this->response .= "{$product->get_id()} {$product->get_title()}\n";
+					++$count;
 				}
 
-				foreach ( $products as $product ) {
-					$this->response .= "{$product->get_id()} {$product->get_title()}\n";
+				if ( 0 === $count ) {
+					$this->response .= 'No products found';
 				}
 			} catch ( MerchantApiException $e ) {
 				$this->response .= sprintf( "HTTP %d\n", $e->get_http_status() );

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductMetaQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
@@ -19,7 +20,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\ChannelVisibility;
 use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ProductStatus as GoogleProductStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
@@ -390,30 +390,19 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * @return array The list of product issues.
 	 */
 	protected function get_product_issues( array $statuses ): array {
-		/** @var Merchant $merchant */
-		$merchant = $this->container->get( Merchant::class );
 		/** @var ProductHelper $product_helper */
-		$product_helper      = $this->container->get( ProductHelper::class );
+		$product_helper = $this->container->get( ProductHelper::class );
+		/** @var MapiProductsService $mapi_products */
+		$mapi_products       = $this->container->get( MapiProductsService::class );
 		$visibility_meta_key = $this->prefix_meta_key( ProductMetaHandler::KEY_VISIBILITY );
 
-		$google_ids     = array_column( $statuses, 'mc_id' );
-		$product_issues = [];
-		$created_at     = $this->cache_created_time->format( 'Y-m-d H:i:s' );
-		$entries        = $merchant->get_productstatuses_batch( $google_ids )->getEntries() ?? [];
-		foreach ( $entries as $response_entry ) {
-			/** @var GoogleProductStatus $mc_product_status */
-			$mc_product_status = $response_entry->getProductStatus();
-			$mc_product_id     = $mc_product_status->getProductId();
-			$wc_product_id     = $product_helper->get_wc_product_id( $mc_product_id );
-			$wc_product        = $this->product_data_lookup[ $wc_product_id ] ?? null;
+		// Map each synced Merchant API product ID back to its WooCommerce product.
+		$google_id_to_wc_id = [];
+		foreach ( $statuses as $status ) {
+			$wc_product_id = $status['product_id'];
+			$wc_product    = $this->product_data_lookup[ $wc_product_id ] ?? null;
 
-			// Skip products not synced by this extension.
 			if ( ! $wc_product ) {
-				do_action(
-					'woocommerce_gla_debug_message',
-					sprintf( 'Merchant Center product %s not found in this WooCommerce store.', $mc_product_id ),
-					__METHOD__ . ' in remove_invalid_statuses()',
-				);
 				continue;
 			}
 			// Unsynced issues shouldn't be shown.
@@ -421,10 +410,29 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 				continue;
 			}
 
+			foreach ( $product_helper->get_synced_google_product_ids( $wc_product ) ?? [] as $google_id ) {
+				$google_id_to_wc_id[ $google_id ] = $wc_product_id;
+			}
+		}
+
+		if ( empty( $google_id_to_wc_id ) ) {
+			return [];
+		}
+
+		$created_at     = $this->cache_created_time->format( 'Y-m-d H:i:s' );
+		$products       = $mapi_products->get_many( array_keys( $google_id_to_wc_id ) );
+		$product_issues = [];
+
+		foreach ( $products as $google_id => $product ) {
+			$product_status = $product->get_product_status();
+
 			// Confirm there are issues for this product.
-			if ( empty( $mc_product_status->getItemLevelIssues() ) ) {
+			if ( ! $product_status || empty( $product_status->get_item_level_issues() ) ) {
 				continue;
 			}
+
+			$wc_product_id = $google_id_to_wc_id[ $google_id ];
+			$wc_product    = $this->product_data_lookup[ $wc_product_id ];
 
 			$product_issue_template = [
 				'product'              => html_entity_decode( $wc_product->get_name(), ENT_QUOTES ),
@@ -433,23 +441,23 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 				'applicable_countries' => [],
 				'source'               => 'mc',
 			];
-			foreach ( $mc_product_status->getItemLevelIssues() as $item_level_issue ) {
-				if ( 'merchant_action' !== $item_level_issue->getResolution() ) {
+			foreach ( $product_status->get_item_level_issues() as $item_level_issue ) {
+				if ( 'merchant_action' !== $item_level_issue->get_resolution() ) {
 					continue;
 				}
-				$hash_key = $wc_product_id . '__' . md5( $item_level_issue->getDescription() );
+				$hash_key = $wc_product_id . '__' . md5( $item_level_issue->get_description() );
 
 				$this->product_issue_countries[ $hash_key ] = array_merge(
 					$this->product_issue_countries[ $hash_key ] ?? [],
-					$item_level_issue->getApplicableCountries()
+					$item_level_issue->get_applicable_countries()
 				);
 
 				$product_issues[ $hash_key ] = $product_issue_template + [
-					'code'       => $item_level_issue->getCode(),
-					'issue'      => $item_level_issue->getDescription(),
-					'action'     => $item_level_issue->getDetail(),
-					'action_url' => $item_level_issue->getDocumentation(),
-					'severity'   => $item_level_issue->getServability(),
+					'code'       => $item_level_issue->get_code(),
+					'issue'      => $item_level_issue->get_description(),
+					'action'     => $item_level_issue->get_detail(),
+					'action_url' => $item_level_issue->get_documentation(),
+					'severity'   => $item_level_issue->get_severity(),
 				];
 			}
 		}
@@ -1001,8 +1009,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			[
 				'warning',
 				'suggestion',
-				'demoted',
-				'unaffected',
+				'DEMOTED',
+				'NOT_IMPACTED',
 			],
 			true
 		);

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -403,6 +403,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			$wc_product    = $this->product_data_lookup[ $wc_product_id ] ?? null;
 
 			if ( ! $wc_product ) {
+				do_action(
+					'woocommerce_gla_debug_message',
+					sprintf( 'Merchant Center product %s not found in this WooCommerce store.', $status['mc_id'] ?? $wc_product_id ),
+					__METHOD__
+				);
 				continue;
 			}
 			// Unsynced issues shouldn't be shown.

--- a/tests/Unit/API/Google/Mapi/Services/MapiDataSourcesServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiDataSourcesServiceTest.php
@@ -172,4 +172,48 @@ class MapiDataSourcesServiceTest extends UnitTest {
 			$this->service->ensure_data_source_for( 'fr', 'CA' )
 		);
 	}
+
+	public function test_finds_matching_data_source_on_a_later_page() {
+		$this->options->method( 'get' )->willReturn( [] );
+
+		$this->client->expects( $this->exactly( 2 ) )
+			->method( 'get' )
+			->withConsecutive(
+				[ self::LIST_PATH ],
+				[ self::LIST_PATH . '?pageToken=page-2' ]
+			)
+			->willReturnOnConsecutiveCalls(
+				[
+					'dataSources'   => [
+						[
+							'name'                     => 'accounts/12345/dataSources/100',
+							'primaryProductDataSource' => [
+								'contentLanguage' => 'fr',
+								'feedLabel'       => 'CA',
+							],
+						],
+					],
+					'nextPageToken' => 'page-2',
+				],
+				[
+					'dataSources' => [
+						[
+							'name'                     => 'accounts/12345/dataSources/200',
+							'primaryProductDataSource' => [
+								'contentLanguage' => 'en',
+								'feedLabel'       => 'US',
+							],
+						],
+					],
+				]
+			);
+
+		// A match on a later page must be reused, never duplicated.
+		$this->client->expects( $this->never() )->method( 'post' );
+
+		$this->assertSame(
+			'accounts/12345/dataSources/200',
+			$this->service->ensure_data_source_for( 'en', 'US' )
+		);
+	}
 }

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
@@ -156,4 +156,52 @@ class MapiProductsServiceTest extends UnitTest {
 		$this->assertCount( 1, $captured );
 		$this->assertSame( $boom, $captured[0][0] );
 	}
+
+	public function test_list_follows_pagination_and_returns_products() {
+		$this->client->expects( $this->exactly( 2 ) )
+			->method( 'get' )
+			->withConsecutive(
+				[ 'products/v1/accounts/12345/products?pageSize=250' ],
+				[ 'products/v1/accounts/12345/products?pageSize=250&pageToken=a%2Fb%3Dc' ]
+			)
+			->willReturnOnConsecutiveCalls(
+				[
+					'products'      => [
+						[
+							'name'    => 'accounts/12345/products/a',
+							'offerId' => 'a',
+						],
+						[
+							'name'    => 'accounts/12345/products/b',
+							'offerId' => 'b',
+						],
+					],
+					'nextPageToken' => 'a/b=c',
+				],
+				[
+					'products' => [
+						[
+							'name'    => 'accounts/12345/products/c',
+							'offerId' => 'c',
+						],
+					],
+				]
+			);
+
+		$products = $this->service->list();
+
+		$this->assertCount( 3, $products );
+		$this->assertContainsOnlyInstancesOf( Product::class, $products );
+		$this->assertSame( 'a', $products[0]->get_offer_id() );
+		$this->assertSame( 'c', $products[2]->get_offer_id() );
+	}
+
+	public function test_list_returns_empty_array_when_no_products() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( 'products/v1/accounts/12345/products?pageSize=250' )
+			->willReturn( [ 'products' => [] ] );
+
+		$this->assertSame( [], $this->service->list() );
+	}
 }

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
@@ -188,7 +188,7 @@ class MapiProductsServiceTest extends UnitTest {
 				]
 			);
 
-		$products = $this->service->list();
+		$products = iterator_to_array( $this->service->list() );
 
 		$this->assertCount( 3, $products );
 		$this->assertContainsOnlyInstancesOf( Product::class, $products );
@@ -196,12 +196,21 @@ class MapiProductsServiceTest extends UnitTest {
 		$this->assertSame( 'c', $products[2]->get_offer_id() );
 	}
 
-	public function test_list_returns_empty_array_when_no_products() {
+	public function test_list_yields_nothing_when_no_products() {
 		$this->client->expects( $this->once() )
 			->method( 'get' )
 			->with( 'products/v1/accounts/12345/products?pageSize=250' )
 			->willReturn( [ 'products' => [] ] );
 
-		$this->assertSame( [], $this->service->list() );
+		$this->assertSame( [], iterator_to_array( $this->service->list() ) );
+	}
+
+	public function test_list_request_uses_custom_page_size() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( 'products/v1/accounts/12345/products?pageSize=100' )
+			->willReturn( [ 'products' => [] ] );
+
+		iterator_to_array( $this->service->list( 100 ) );
 	}
 }

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -15,15 +15,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingCo
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountAdsLink;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountUser;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Product;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ProductsListResponse;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ProductstatusesCustomBatchRequest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ProductstatusesCustomBatchResponse;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\RequestPhoneVerificationResponse;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Resource\Accounts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Resource\Accountstatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Resource\Products;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Resource\Productstatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\VerifyPhoneNumberResponse;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -68,79 +63,6 @@ class MerchantTest extends UnitTest {
 
 		$this->merchant_id = 12345;
 		$this->options->method( 'get_merchant_id' )->willReturn( $this->merchant_id );
-	}
-
-	public function test_get_products_empty_list() {
-		$list_response = $this->createMock( ProductsListResponse::class );
-
-		$this->service->products->expects( $this->once() )
-			->method( 'listProducts' )
-			->with( $this->merchant_id )
-			->willReturn( $list_response );
-
-		$products = $this->merchant->get_products();
-		$this->assertEquals( $products, [] );
-	}
-
-	public function test_get_products() {
-		$list_response = $this->createMock( ProductsListResponse::class );
-
-		$product_list = [
-			$this->createMock( Product::class ),
-			$this->createMock( Product::class ),
-		];
-
-		$list_response->expects( $this->any() )
-			->method( 'getResources' )
-			->willReturn( $product_list );
-
-		$this->service->products->expects( $this->once() )
-			->method( 'listProducts' )
-			->with( $this->merchant_id )
-			->willReturn( $list_response );
-
-		$this->assertEquals(
-			$product_list,
-			$this->merchant->get_products()
-		);
-	}
-
-	public function test_get_products_multiple_pages() {
-		$list_response = $this->createMock( ProductsListResponse::class );
-
-		$token        = uniqid();
-		$product_list = [
-			$this->createMock( Product::class ),
-			$this->createMock( Product::class ),
-		];
-
-		$list_response->expects( $this->any() )
-			->method( 'getResources' )
-			->willReturn( $product_list );
-
-		$list_response->expects( $this->any() )
-			->method( 'getNextPageToken' )
-			->will(
-				$this->onConsecutiveCalls(
-					$token,
-					$token,
-					null
-				)
-			);
-
-		$this->service->products->expects( $this->exactly( 2 ) )
-			->method( 'listProducts' )
-			->withConsecutive(
-				[ $this->merchant_id ],
-				[ $this->merchant_id, [ 'pageToken' => $token ] ]
-			)
-			->willReturnOnConsecutiveCalls(
-				$list_response,
-				$list_response
-			);
-
-		$products = $this->merchant->get_products();
-		$this->assertCount( count( $product_list ) * 2, $products );
 	}
 
 	public function test_claim_website() {
@@ -398,36 +320,6 @@ class MerchantTest extends UnitTest {
 		$this->expectException( Exception::class );
 		$this->expectExceptionCode( 400 );
 		$this->merchant->get_accountstatus();
-	}
-
-	public function test_get_productstatuses_batch() {
-		$this->service->productstatuses = $this->createMock( Productstatuses::class );
-
-		$this->service->productstatuses->expects( $this->once() )
-			->method( 'custombatch' )
-			->with(
-				$this->callback(
-					function ( ProductstatusesCustomBatchRequest $request ) {
-						$this->assertEquals(
-							[
-								'batchId'    => 3,
-								'productId'  => 3,
-								'method'     => 'GET',
-								'merchantId' => $this->merchant_id,
-							],
-							$request->getEntries()[2]
-						);
-
-						return true;
-					}
-				)
-			)
-			->willReturn( $this->createMock( ProductstatusesCustomBatchResponse::class ) );
-
-		$this->assertInstanceOf(
-			ProductstatusesCustomBatchResponse::class,
-			$this->merchant->get_productstatuses_batch( [ 1, 2, 3 ] )
-		);
 	}
 
 	public function test_update_account() {

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -17,10 +17,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ProductstatusesCustomBatchResponse;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ProductstatusesCustomBatchResponseEntry;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ProductStatusItemLevelIssue;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ProductStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\Product;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
@@ -60,6 +58,7 @@ class MerchantStatusesTest extends UnitTest {
 	protected const MC_STATUS_LIFETIME = 60;
 
 	private $merchant;
+	private $mapi_products_service;
 	private $merchant_issue_query;
 	private $merchant_center_service;
 	private $account_status;
@@ -85,6 +84,7 @@ class MerchantStatusesTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 		$this->merchant                             = $this->createMock( Merchant::class );
+		$this->mapi_products_service                = $this->createMock( MapiProductsService::class );
 		$this->merchant_issue_query                 = $this->createMock( MerchantIssueQuery::class );
 		$this->merchant_center_service              = $this->createMock( MerchantCenterService::class );
 		$this->account_status                       = $this->createMock( ShoppingContent\AccountStatus::class );
@@ -101,6 +101,7 @@ class MerchantStatusesTest extends UnitTest {
 
 		$this->container = new Container();
 		$this->container->addShared( Merchant::class, $this->merchant );
+		$this->container->addShared( MapiProductsService::class, $this->mapi_products_service );
 		$this->container->addShared( MerchantIssueQuery::class, $this->merchant_issue_query );
 		$this->container->addShared( MerchantCenterService::class, $this->merchant_center_service );
 		$this->container->addShared( TransientsInterface::class, $this->transients );
@@ -500,7 +501,7 @@ class MerchantStatusesTest extends UnitTest {
 		$variation_id_1 = $variations[0]['variation_id'];
 		$variation_id_2 = $variations[1]['variation_id'];
 
-		// We should fetch issues for Products with channel visibility set to DONT_SYNC_AND_SHOW.
+		// Products set to DONT_SYNC_AND_SHOW should be skipped (their issues are not fetched).
 		$product_4->update_meta_data( $this->prefix_meta_key( ProductMetaHandler::KEY_VISIBILITY ), ChannelVisibility::DONT_SYNC_AND_SHOW );
 		$product_4->save_meta_data();
 
@@ -597,28 +598,31 @@ class MerchantStatusesTest extends UnitTest {
 
 		];
 
-		$product_status = $this->get_product_status_item( $product_1->get_id() );
+		$this->product_helper->method( 'get_synced_google_product_ids' )
+		->willReturnCallback(
+			function ( $product ) {
+				return [ 'ES' => $this->get_mapi_id( $product->get_id() ) ];
+			}
+		);
 
-		$entry = new ProductstatusesCustomBatchResponseEntry();
-		$entry->setProductStatus( $product_status );
-
-		$product_status_2 = $this->get_product_status_item( $product_4->get_id() );
-		$entry_2          = new ProductstatusesCustomBatchResponseEntry();
-		$entry_2->setProductStatus( $product_status_2 );
-
-		$response = new ProductstatusesCustomBatchResponse();
-		$response->setEntries( [ $entry, $entry_2 ] );
-
-		$this->merchant->expects( $this->once() )
-		->method( 'get_productstatuses_batch' )
-		->with( [ $this->get_mc_id( $product_1->get_id() ), $this->get_mc_id( $product_2->get_id() ), $this->get_mc_id( $product_3->get_id() ), $this->get_mc_id( $variation_id_1 ), $this->get_mc_id( $variation_id_2 ),  $this->get_mc_id( $product_4->get_id() ) ] )
-		->willReturn( $response );
-
-		$this->product_helper->expects( $this->exactly( count( $response->getEntries() ) ) )
-		->method( 'get_wc_product_id' )
-		->willReturnOnConsecutiveCalls(
-			$product_1->get_id(),
-			$product_4->get_id(),
+		// product_4 (DONT_SYNC_AND_SHOW) must be excluded from the fetch; product_2's issue
+		// is pending_processing and must be filtered out of the resulting product issues.
+		$this->mapi_products_service->expects( $this->once() )
+		->method( 'get_many' )
+		->with(
+			[
+				$this->get_mapi_id( $product_1->get_id() ),
+				$this->get_mapi_id( $product_2->get_id() ),
+				$this->get_mapi_id( $product_3->get_id() ),
+				$this->get_mapi_id( $variation_id_1 ),
+				$this->get_mapi_id( $variation_id_2 ),
+			]
+		)
+		->willReturn(
+			[
+				$this->get_mapi_id( $product_1->get_id() ) => $this->get_mapi_product( $product_1->get_id() ),
+				$this->get_mapi_id( $product_2->get_id() ) => $this->get_mapi_product( $product_2->get_id(), 'pending_processing' ),
+			]
 		);
 
 		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
@@ -629,11 +633,11 @@ class MerchantStatusesTest extends UnitTest {
 					'created_at'           => $this->merchant_statuses->get_cache_created_time()->format( 'Y-m-d H:i:s' ),
 					'applicable_countries' => wp_json_encode( [ 'ES' ] ),
 					'source'               => 'mc',
-					'code'                 => $product_status->getItemLevelIssues()[0]->getCode(),
-					'issue'                => $product_status->getItemLevelIssues()[0]->getDescription(),
-					'action'               => $product_status->getItemLevelIssues()[0]->getDetail(),
-					'action_url'           => $product_status->getItemLevelIssues()[0]->getDocumentation(),
-					'severity'             => $product_status->getItemLevelIssues()[0]->getServability(),
+					'code'                 => 'issue_code',
+					'issue'                => 'issue_description',
+					'action'               => 'issue_detail',
+					'action_url'           => 'https://example.com',
+					'severity'             => 'DISAPPROVED',
 				],
 			]
 		);
@@ -753,13 +757,6 @@ class MerchantStatusesTest extends UnitTest {
 
 		];
 
-		$response = new ProductstatusesCustomBatchResponse();
-		$response->setEntries( [] );
-
-		$this->merchant->expects( $this->exactly( 1 ) )
-		->method( 'get_productstatuses_batch' )
-		->willReturn( $response );
-
 		$this->product_repository->expects( $this->exactly( 2 ) )->method( 'find_by_ids_as_associative_array' )->willReturn( [ $product_id => $product_1 ] );
 
 		$this->merchant_issue_table->expects( $this->once() )->method( 'delete_specific_product_issues' )->with( [ $product_id ] );
@@ -833,13 +830,6 @@ class MerchantStatusesTest extends UnitTest {
 			]
 		);
 
-		$response = new ProductstatusesCustomBatchResponse();
-		$response->setEntries( [] );
-
-		$this->merchant->expects( $this->exactly( 2 ) )
-		->method( 'get_productstatuses_batch' )
-		->willReturn( $response );
-
 		$this->merchant_statuses->process_product_statuses(
 			$product_statuses_1
 		);
@@ -890,13 +880,6 @@ class MerchantStatusesTest extends UnitTest {
 			]
 		);
 
-		$response = new ProductstatusesCustomBatchResponse();
-		$response->setEntries( [] );
-
-		$this->merchant->expects( $this->exactly( 2 ) )
-		->method( 'get_productstatuses_batch' )
-		->willReturn( $response );
-
 		$this->merchant_statuses->process_product_statuses(
 			$product_statuses_1
 		);
@@ -946,13 +929,6 @@ class MerchantStatusesTest extends UnitTest {
 				'parents'             => [ $variable_product->get_id() => MCStatus::DISAPPROVED ],
 			]
 		);
-
-		$response = new ProductstatusesCustomBatchResponse();
-		$response->setEntries( [] );
-
-		$this->merchant->expects( $this->exactly( 2 ) )
-		->method( 'get_productstatuses_batch' )
-		->willReturn( $response );
 
 		$this->merchant_statuses->process_product_statuses(
 			$product_statuses_1
@@ -1039,22 +1015,29 @@ class MerchantStatusesTest extends UnitTest {
 		$this->merchant_statuses->clear_product_statuses_cache_and_issues();
 	}
 
-	protected function get_product_status_item( $wc_product_id ): ProductStatus {
-		$product_status = new ProductStatus();
-		$product_status->setProductId( $this->get_mc_id( $wc_product_id ) );
+	protected function get_mapi_product( $wc_product_id, string $resolution = 'merchant_action' ): Product {
+		return Product::from_array(
+			[
+				'name'          => 'accounts/123/products/' . $this->get_mapi_id( $wc_product_id ),
+				'productStatus' => [
+					'itemLevelIssues' => [
+						[
+							'code'                => 'issue_code',
+							'description'         => 'issue_description',
+							'detail'              => 'issue_detail',
+							'documentation'       => 'https://example.com',
+							'resolution'          => $resolution,
+							'severity'            => 'DISAPPROVED',
+							'applicableCountries' => [ 'ES' ],
+						],
+					],
+				],
+			]
+		);
+	}
 
-		$issue = new ProductStatusItemLevelIssue();
-		$issue->setResolution( 'merchant_action' );
-		$issue->setApplicableCountries( [ 'ES' ] );
-		$issue->setCode( 'issue_code' );
-		$issue->setDescription( 'issue_description' );
-		$issue->setDetail( 'issue_detail' );
-		$issue->setDocumentation( 'https://example.com' );
-		$issue->setServability( 'critical' );
-
-		$product_status->setItemLevelIssues( [ $issue ] );
-
-		return $product_status;
+	protected function get_mapi_id( $wc_product_id ): string {
+		return 'en~ES~gla_' . $wc_product_id;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Migrate product status + listing to the MAPI

`MerchantStatuses` reads product status + item-level issues via `MapiProductsService` (accounts.products) instead of `get_productstatuses_batch`. The old `productstatuses.custombatch` path is removed.
New paginated `MapiProductsService::list() `(accounts.products.list) replaces the Content API `Merchant::get_products()`
Data-source fix: `MapiDataSourcesService::find_existing_data_source()` now paginates, so it can't create a duplicate when a match sits on a later page.

How to test:
Connection Test -> "Send proxied request to Google Merchant Center" lists products
`composer test-unit -- --filter "MapiProductsServiceTest|MapiDataSourcesServiceTest|MerchantStatusesTest|MerchantTest"`

Closes https://linear.app/a8c/issue/GOOWOO-717/migrate-product-status-fetching-to-the-mapi and https://linear.app/a8c/issue/GOOWOO-741/migrate-product-listing-to-the-mapi


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
