### PR TITLE
Ensure dropdown icon does not have its own pointer event.

### DIFF
--- a/js/src/components/app-searchable-select-control/index.scss
+++ b/js/src/components/app-searchable-select-control/index.scss
@@ -20,6 +20,7 @@
 			mask-position: center;
 			mask-repeat: no-repeat;
 			mask-size: contain;
+			pointer-events: none;
 			position: absolute;
 			right: 8px;
 			top: 50%;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Fix the dropdown chevron icon in AppSearchableSelectControl not responding to clicks. The ::after pseudo-element used to render the chevron was positioned absolutely over the input field and intercepting pointer events, preventing the dropdown from opening when clicking on the icon area.

Adding pointer-events: none to the pseudo-element allows clicks to pass through to the underlying input element.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Navigate to the "Shipping" tab and ensure your Shipping rates option is set to "Automatically sync my store’s shipping settings to Google."
2. Open your browser console and type in glaData.isMultiLingualStore = true and hit Enter.
3. Navigate to the "Markets" tab.
4. Click the Edit symbol next to one of your markets in the list of markets. You should now be able to see and test the dropdown under the "Currency" label.


### Changelog entry

>
