### PR TITLE
GOOWOO-644 Google Ads API Evaluators

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -17,6 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AssetSuggestionsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsReport;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection as GoogleConnection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
@@ -72,11 +73,14 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Notes\SetupCampaign as SetupCamp
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\SetupCampaignTwoWeeks as SetupCampaign2Note;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\SetupCouponSharing as SetupCouponSharingNote;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\AbandonedOnboardingEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CampaignNoSalesEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CouponsNotSyncedEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\EnhancedConversionsOffEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\NotOnboarded90DaysEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\PausedCampaignEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ProductIssuesEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ReadyButNoSalesEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\RecommendationsAvailableEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SalesNotGrowingEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\Sold10ItemsEvaluator;
@@ -146,83 +150,86 @@ class CoreServiceProvider extends AbstractServiceProvider {
 	 * @var array
 	 */
 	protected $provides = [
-		Installer::class                       => true,
-		AddressUtility::class                  => true,
-		AssetsHandlerInterface::class          => true,
-		ContactInformationNote::class          => true,
-		CompleteSetupTask::class               => true,
-		CompleteSetupNote::class               => true,
-		CouponHelper::class                    => true,
-		CouponMetaHandler::class               => true,
-		CouponSyncer::class                    => true,
-		DateTimeUtility::class                 => true,
-		EventTracking::class                   => true,
-		GlobalSiteTag::class                   => true,
-		ISOUtility::class                      => true,
-		SiteVerificationEvents::class          => true,
-		OptionsInterface::class                => true,
-		TransientsInterface::class             => true,
-		ReconnectWordPressNote::class          => true,
-		ReviewAfterClicksNote::class           => true,
-		RESTControllers::class                 => true,
-		Service::class                         => true,
-		SetupCampaignNote::class               => true,
-		SetupCampaign2Note::class              => true,
-		SetupCouponSharingNote::class          => true,
-		NotificationService::class             => true,
-		AbandonedOnboardingEvaluator::class    => true,
-		EnhancedConversionsOffEvaluator::class => true,
-		NotOnboarded90DaysEvaluator::class     => true,
-		ProductIssuesEvaluator::class          => true,
-		SkippedCampaignEvaluator::class        => true,
-		Sold10ItemsEvaluator::class            => true,
-		ReadyButNoSalesEvaluator::class        => true,
-		CouponsNotSyncedEvaluator::class       => true,
-		SalesNotGrowingEvaluator::class        => true,
-		TrackingOffEvaluator::class            => true,
-		WcInstallTimestamp::class              => true,
-		TableManager::class                    => true,
-		TrackerSnapshot::class                 => true,
-		Tracks::class                          => true,
-		TracksInterface::class                 => true,
-		ProductSyncer::class                   => true,
-		ProductHelper::class                   => true,
-		ProductMetaHandler::class              => true,
-		SiteVerificationMeta::class            => true,
-		BatchProductHelper::class              => true,
-		ProductFilter::class                   => true,
-		ProductRepository::class               => true,
-		ViewFactory::class                     => true,
-		DebugLogger::class                     => true,
-		MerchantStatuses::class                => true,
-		PriceBenchmarks::class                 => true,
-		PhoneVerification::class               => true,
-		PolicyComplianceCheck::class           => true,
-		ContactInformation::class              => true,
-		MerchantCenterService::class           => true,
-		NotificationsService::class            => true,
-		TargetAudience::class                  => true,
-		MerchantAccountState::class            => true,
-		AdsAccountState::class                 => true,
-		DBInstaller::class                     => true,
-		AttributeManager::class                => true,
-		ProductFactory::class                  => true,
-		AttributesTab::class                   => true,
-		VariationsAttributes::class            => true,
-		DeprecatedFilters::class               => true,
-		ZoneLocationsParser::class             => true,
-		ZoneMethodsParser::class               => true,
-		LocationRatesProcessor::class          => true,
-		ShippingZone::class                    => true,
-		AdsRecommendationsService::class       => true,
-		AdsAccountService::class               => true,
-		MerchantAccountService::class          => true,
-		MarketingChannelRegistrar::class       => true,
-		OAuthService::class                    => true,
-		SyncStatus::class                      => true,
-		WPCLIMigrationGTIN::class              => true,
-		OnboardingCompleted::class             => true,
-		ServiceBasedMerchantState::class       => true,
+		Installer::class                         => true,
+		AddressUtility::class                    => true,
+		AssetsHandlerInterface::class            => true,
+		ContactInformationNote::class            => true,
+		CompleteSetupTask::class                 => true,
+		CompleteSetupNote::class                 => true,
+		CouponHelper::class                      => true,
+		CouponMetaHandler::class                 => true,
+		CouponSyncer::class                      => true,
+		DateTimeUtility::class                   => true,
+		EventTracking::class                     => true,
+		GlobalSiteTag::class                     => true,
+		ISOUtility::class                        => true,
+		SiteVerificationEvents::class            => true,
+		OptionsInterface::class                  => true,
+		TransientsInterface::class               => true,
+		ReconnectWordPressNote::class            => true,
+		ReviewAfterClicksNote::class             => true,
+		RESTControllers::class                   => true,
+		Service::class                           => true,
+		SetupCampaignNote::class                 => true,
+		SetupCampaign2Note::class                => true,
+		SetupCouponSharingNote::class            => true,
+		NotificationService::class               => true,
+		AbandonedOnboardingEvaluator::class      => true,
+		EnhancedConversionsOffEvaluator::class   => true,
+		NotOnboarded90DaysEvaluator::class       => true,
+		ProductIssuesEvaluator::class            => true,
+		SkippedCampaignEvaluator::class          => true,
+		Sold10ItemsEvaluator::class              => true,
+		ReadyButNoSalesEvaluator::class          => true,
+		CouponsNotSyncedEvaluator::class         => true,
+		SalesNotGrowingEvaluator::class          => true,
+		PausedCampaignEvaluator::class           => true,
+		CampaignNoSalesEvaluator::class          => true,
+		RecommendationsAvailableEvaluator::class => true,
+		TrackingOffEvaluator::class              => true,
+		WcInstallTimestamp::class                => true,
+		TableManager::class                      => true,
+		TrackerSnapshot::class                   => true,
+		Tracks::class                            => true,
+		TracksInterface::class                   => true,
+		ProductSyncer::class                     => true,
+		ProductHelper::class                     => true,
+		ProductMetaHandler::class                => true,
+		SiteVerificationMeta::class              => true,
+		BatchProductHelper::class                => true,
+		ProductFilter::class                     => true,
+		ProductRepository::class                 => true,
+		ViewFactory::class                       => true,
+		DebugLogger::class                       => true,
+		MerchantStatuses::class                  => true,
+		PriceBenchmarks::class                   => true,
+		PhoneVerification::class                 => true,
+		PolicyComplianceCheck::class             => true,
+		ContactInformation::class                => true,
+		MerchantCenterService::class             => true,
+		NotificationsService::class              => true,
+		TargetAudience::class                    => true,
+		MerchantAccountState::class              => true,
+		AdsAccountState::class                   => true,
+		DBInstaller::class                       => true,
+		AttributeManager::class                  => true,
+		ProductFactory::class                    => true,
+		AttributesTab::class                     => true,
+		VariationsAttributes::class              => true,
+		DeprecatedFilters::class                 => true,
+		ZoneLocationsParser::class               => true,
+		ZoneMethodsParser::class                 => true,
+		LocationRatesProcessor::class            => true,
+		ShippingZone::class                      => true,
+		AdsRecommendationsService::class         => true,
+		AdsAccountService::class                 => true,
+		MerchantAccountService::class            => true,
+		MarketingChannelRegistrar::class         => true,
+		OAuthService::class                      => true,
+		SyncStatus::class                        => true,
+		WPCLIMigrationGTIN::class                => true,
+		OnboardingCompleted::class               => true,
+		ServiceBasedMerchantState::class         => true,
 	];
 
 	/**
@@ -334,6 +341,9 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( ReadyButNoSalesEvaluator::class, PolicyComplianceCheck::class, WC::class );
 		$this->share_with_tags( CouponsNotSyncedEvaluator::class, CouponHelper::class );
 		$this->share_with_tags( SalesNotGrowingEvaluator::class );
+		$this->share_with_tags( PausedCampaignEvaluator::class, AdsCampaign::class );
+		$this->share_with_tags( CampaignNoSalesEvaluator::class, AdsCampaign::class, AdsReport::class );
+		$this->share_with_tags( RecommendationsAvailableEvaluator::class, AdsRecommendationsService::class, AdsCampaign::class );
 		$this->share_with_tags( WcInstallTimestamp::class );
 
 		// Product attributes

--- a/src/Notification/Evaluators/CampaignNoSalesEvaluator.php
+++ b/src/Notification/Evaluators/CampaignNoSalesEvaluator.php
@@ -1,0 +1,131 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsReport;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\CachedNotificationEvaluatorTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use DateTime;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CampaignNoSalesEvaluator
+ *
+ * Fires when at least one enabled campaign has recorded zero conversions over the last 90 days.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
+ */
+class CampaignNoSalesEvaluator implements NotificationEvaluatorInterface, AdsAwareInterface, Service {
+
+	use AdsAwareTrait;
+	use CachedNotificationEvaluatorTrait;
+
+	/** @var AdsCampaign */
+	protected $ads_campaign;
+
+	/** @var AdsReport */
+	protected $ads_report;
+
+	/**
+	 * CampaignNoSalesEvaluator constructor.
+	 *
+	 * @param AdsCampaign $ads_campaign
+	 * @param AdsReport   $ads_report
+	 */
+	public function __construct( AdsCampaign $ads_campaign, AdsReport $ads_report ) {
+		$this->ads_campaign = $ads_campaign;
+		$this->ads_report   = $ads_report;
+	}
+
+	/**
+	 * Get the notification's unique ID.
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return 'campaign-no-sales';
+	}
+
+	/**
+	 * Evaluate whether the notification condition is met.
+	 *
+	 * @return bool
+	 */
+	protected function evaluate_condition(): bool {
+		if ( ! $this->ads_service->is_setup_complete() ) {
+			return false;
+		}
+
+		try {
+			$enabled_campaigns = array_filter(
+				$this->ads_campaign->get_campaigns( true, false ),
+				static function ( array $campaign ): bool {
+					return CampaignStatus::ENABLED === $campaign['status'];
+				}
+			);
+		} catch ( ExceptionWithResponseData $e ) {
+			return false;
+		}
+
+		if ( empty( $enabled_campaigns ) ) {
+			return false;
+		}
+
+		try {
+			$report_data = $this->ads_report->get_report_data(
+				'campaigns',
+				[
+					'after'  => new DateTime( '-90 days' ),
+					'before' => new DateTime(),
+					'fields' => [ 'conversions' ],
+				]
+			);
+		} catch ( ExceptionWithResponseData $e ) {
+			return false;
+		}
+
+		$campaign_conversions = [];
+
+		foreach ( $report_data['campaigns'] ?? [] as $campaign_report ) {
+			$campaign_conversions[ $campaign_report['id'] ] = $campaign_report['subtotals']['conversions'] ?? 0;
+		}
+
+		foreach ( $enabled_campaigns as $campaign ) {
+			$conversions = $campaign_conversions[ $campaign['id'] ] ?? 0;
+
+			if ( 0.0 === (float) $conversions ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the notification's priority.
+	 *
+	 * @return int
+	 */
+	public function get_priority(): int {
+		return NotificationPriorities::CAMPAIGN_NO_SALES;
+	}
+
+	/**
+	 * Get the snooze duration in seconds for temporary dismissals.
+	 *
+	 * @return int|null
+	 */
+	public function get_snooze_duration(): ?int {
+		return NotificationSnoozeDurations::CAMPAIGN_NO_SALES;
+	}
+}

--- a/src/Notification/Evaluators/PausedCampaignEvaluator.php
+++ b/src/Notification/Evaluators/PausedCampaignEvaluator.php
@@ -1,0 +1,92 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\CachedNotificationEvaluatorTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class PausedCampaignEvaluator
+ *
+ * Fires when at least one campaign is paused.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
+ */
+class PausedCampaignEvaluator implements NotificationEvaluatorInterface, AdsAwareInterface, Service {
+
+	use AdsAwareTrait;
+	use CachedNotificationEvaluatorTrait;
+
+	/** @var AdsCampaign */
+	protected $ads_campaign;
+
+	/**
+	 * PausedCampaignEvaluator constructor.
+	 *
+	 * @param AdsCampaign $ads_campaign
+	 */
+	public function __construct( AdsCampaign $ads_campaign ) {
+		$this->ads_campaign = $ads_campaign;
+	}
+
+	/**
+	 * Get the notification's unique ID.
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return 'paused-campaign';
+	}
+
+	/**
+	 * Evaluate whether the notification condition is met.
+	 *
+	 * @return bool
+	 */
+	protected function evaluate_condition(): bool {
+		if ( ! $this->ads_service->is_setup_complete() ) {
+			return false;
+		}
+
+		try {
+			foreach ( $this->ads_campaign->get_campaigns( true, false ) as $campaign ) {
+				if ( CampaignStatus::PAUSED === $campaign['status'] ) {
+					return true;
+				}
+			}
+		} catch ( ExceptionWithResponseData $e ) {
+			return false;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the notification's priority.
+	 *
+	 * @return int
+	 */
+	public function get_priority(): int {
+		return NotificationPriorities::PAUSED_CAMPAIGN;
+	}
+
+	/**
+	 * Get the snooze duration in seconds for temporary dismissals.
+	 *
+	 * @return int|null
+	 */
+	public function get_snooze_duration(): ?int {
+		return NotificationSnoozeDurations::PAUSED_CAMPAIGN;
+	}
+}

--- a/src/Notification/Evaluators/RecommendationsAvailableEvaluator.php
+++ b/src/Notification/Evaluators/RecommendationsAvailableEvaluator.php
@@ -1,0 +1,113 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsRecommendationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\CachedNotificationEvaluatorTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class RecommendationsAvailableEvaluator
+ *
+ * Fires when the recommendations endpoint returns at least one entry.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
+ */
+class RecommendationsAvailableEvaluator implements NotificationEvaluatorInterface, AdsAwareInterface, Service {
+
+	use AdsAwareTrait;
+	use CachedNotificationEvaluatorTrait;
+
+	/** @var AdsRecommendationsService */
+	protected $ads_recommendations;
+
+	/** @var AdsCampaign */
+	protected $ads_campaign;
+
+	/**
+	 * RecommendationsAvailableEvaluator constructor.
+	 *
+	 * @param AdsRecommendationsService $ads_recommendations
+	 * @param AdsCampaign               $ads_campaign
+	 */
+	public function __construct( AdsRecommendationsService $ads_recommendations, AdsCampaign $ads_campaign ) {
+		$this->ads_recommendations = $ads_recommendations;
+		$this->ads_campaign        = $ads_campaign;
+	}
+
+	/**
+	 * Get the notification's unique ID.
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return 'recommendations-available';
+	}
+
+	/**
+	 * Evaluate whether the notification condition is met.
+	 *
+	 * @return bool
+	 */
+	protected function evaluate_condition(): bool {
+		if ( ! $this->ads_service->is_setup_complete() ) {
+			return false;
+		}
+
+		$budget_recommendations = $this->ads_recommendations->get_recommendations(
+			[
+				'types'       => [
+					'CAMPAIGN_BUDGET',
+					'MARGINAL_ROI_CAMPAIGN_BUDGET',
+				],
+				'campaign_id' => 0,
+			]
+		);
+
+		if ( ! empty( $budget_recommendations ) ) {
+			return true;
+		}
+
+		$campaign = $this->ads_campaign->get_highest_spend_campaign();
+
+		if ( empty( $campaign['id'] ) ) {
+			return false;
+		}
+
+		$pmax_recommendations = $this->ads_recommendations->get_recommendations(
+			[
+				'types'       => [ 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH' ],
+				'campaign_id' => $campaign['id'],
+			]
+		);
+
+		return ! empty( $pmax_recommendations );
+	}
+
+	/**
+	 * Get the notification's priority.
+	 *
+	 * @return int
+	 */
+	public function get_priority(): int {
+		return NotificationPriorities::RECOMMENDATIONS_AVAILABLE;
+	}
+
+	/**
+	 * Get the snooze duration in seconds for temporary dismissals.
+	 *
+	 * @return int|null
+	 */
+	public function get_snooze_duration(): ?int {
+		return NotificationSnoozeDurations::RECOMMENDATIONS_AVAILABLE;
+	}
+}

--- a/src/Notification/NotificationPriorities.php
+++ b/src/Notification/NotificationPriorities.php
@@ -24,4 +24,7 @@ class NotificationPriorities {
 	public const READY_BUT_NO_SALES        = 80;
 	public const COUPONS_NOT_SYNCED        = 90;
 	public const SALES_NOT_GROWING         = 100;
+	public const PAUSED_CAMPAIGN           = 110;
+	public const CAMPAIGN_NO_SALES         = 120;
+	public const RECOMMENDATIONS_AVAILABLE = 130;
 }

--- a/src/Notification/NotificationSnoozeDurations.php
+++ b/src/Notification/NotificationSnoozeDurations.php
@@ -14,12 +14,15 @@ defined( 'ABSPATH' ) || exit;
  */
 class NotificationSnoozeDurations {
 
-	public const ABANDONED_ONBOARDING     = 30 * DAY_IN_SECONDS;
-	public const NOT_ONBOARDED_90_DAYS    = 30 * DAY_IN_SECONDS;
-	public const ENHANCED_CONVERSIONS_OFF = 7 * DAY_IN_SECONDS;
-	public const TRACKING_OFF             = 7 * DAY_IN_SECONDS;
-	public const SOLD_10_ITEMS            = 7 * DAY_IN_SECONDS;
-	public const READY_BUT_NO_SALES       = 7 * DAY_IN_SECONDS;
-	public const COUPONS_NOT_SYNCED       = 7 * DAY_IN_SECONDS;
-	public const SALES_NOT_GROWING        = 7 * DAY_IN_SECONDS;
+	public const ABANDONED_ONBOARDING      = 30 * DAY_IN_SECONDS;
+	public const NOT_ONBOARDED_90_DAYS     = 30 * DAY_IN_SECONDS;
+	public const ENHANCED_CONVERSIONS_OFF  = 7 * DAY_IN_SECONDS;
+	public const TRACKING_OFF              = 7 * DAY_IN_SECONDS;
+	public const SOLD_10_ITEMS             = 7 * DAY_IN_SECONDS;
+	public const READY_BUT_NO_SALES        = 7 * DAY_IN_SECONDS;
+	public const COUPONS_NOT_SYNCED        = 7 * DAY_IN_SECONDS;
+	public const SALES_NOT_GROWING         = 7 * DAY_IN_SECONDS;
+	public const PAUSED_CAMPAIGN           = 7 * DAY_IN_SECONDS;
+	public const CAMPAIGN_NO_SALES         = 7 * DAY_IN_SECONDS;
+	public const RECOMMENDATIONS_AVAILABLE = 7 * DAY_IN_SECONDS;
 }

--- a/tests/Unit/Notification/Evaluators/CampaignNoSalesEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/CampaignNoSalesEvaluatorTest.php
@@ -1,0 +1,171 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsReport;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CampaignNoSalesEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use DateTime;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CampaignNoSalesEvaluatorTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators
+ */
+class CampaignNoSalesEvaluatorTest extends UnitTest {
+
+	/** @var MockObject|AdsService $ads_service */
+	protected $ads_service;
+
+	/** @var MockObject|AdsCampaign $ads_campaign */
+	protected $ads_campaign;
+
+	/** @var MockObject|AdsReport $ads_report */
+	protected $ads_report;
+
+	/** @var CampaignNoSalesEvaluator $evaluator */
+	protected $evaluator;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->ads_service  = $this->createMock( AdsService::class );
+		$this->ads_campaign = $this->createMock( AdsCampaign::class );
+		$this->ads_report   = $this->createMock( AdsReport::class );
+		$this->evaluator    = new CampaignNoSalesEvaluator( $this->ads_campaign, $this->ads_report );
+		$this->evaluator->set_ads_object( $this->ads_service );
+	}
+
+	public function test_get_id() {
+		$this->assertEquals( 'campaign-no-sales', $this->evaluator->get_id() );
+	}
+
+	public function test_get_priority() {
+		$this->assertEquals( NotificationPriorities::CAMPAIGN_NO_SALES, $this->evaluator->get_priority() );
+	}
+
+	public function test_get_snooze_duration() {
+		$this->assertEquals( NotificationSnoozeDurations::CAMPAIGN_NO_SALES, $this->evaluator->get_snooze_duration() );
+	}
+
+	public function test_should_not_show_when_ads_incomplete() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( false );
+		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
+		$this->ads_report->expects( $this->never() )->method( 'get_report_data' );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_show_when_enabled_campaign_has_zero_conversions() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_campaign->method( 'get_campaigns' )
+			->with( true, false )
+			->willReturn(
+				[
+					[
+						'id'     => 1,
+						'status' => CampaignStatus::ENABLED,
+					],
+					[
+						'id'     => 2,
+						'status' => CampaignStatus::PAUSED,
+					],
+				]
+			);
+		$this->ads_report->method( 'get_report_data' )
+			->with(
+				'campaigns',
+				$this->callback(
+					function ( array $args ): bool {
+						return isset( $args['after'], $args['before'], $args['fields'] )
+							&& $args['after'] instanceof DateTime
+							&& $args['before'] instanceof DateTime
+							&& [ 'conversions' ] === $args['fields'];
+					}
+				)
+			)
+			->willReturn(
+				[
+					'campaigns' => [
+						[
+							'id'        => 1,
+							'subtotals' => [
+								'conversions' => 0,
+							],
+						],
+					],
+				]
+			);
+
+		$this->assertTrue( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_enabled_campaigns_have_conversions() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_campaign->method( 'get_campaigns' )
+			->with( true, false )
+			->willReturn(
+				[
+					[
+						'id'     => 1,
+						'status' => CampaignStatus::ENABLED,
+					],
+				]
+			);
+		$this->ads_report->method( 'get_report_data' )
+			->willReturn(
+				[
+					'campaigns' => [
+						[
+							'id'        => 1,
+							'subtotals' => [
+								'conversions' => 3,
+							],
+						],
+					],
+				]
+			);
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_show_when_enabled_campaign_missing_from_report() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_campaign->method( 'get_campaigns' )
+			->with( true, false )
+			->willReturn(
+				[
+					[
+						'id'     => 1,
+						'status' => CampaignStatus::ENABLED,
+					],
+				]
+			);
+		$this->ads_report->method( 'get_report_data' )->willReturn( [ 'campaigns' => [] ] );
+
+		$this->assertTrue( $this->evaluator->should_show() );
+	}
+
+	public function test_cache_hit_skips_api_call() {
+		$user_id = $this->login_as_administrator();
+
+		set_transient( 'gla_notif_campaign-no-sales_' . $user_id, 0, HOUR_IN_SECONDS );
+
+		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
+		$this->ads_report->expects( $this->never() )->method( 'get_report_data' );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+}

--- a/tests/Unit/Notification/Evaluators/PausedCampaignEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/PausedCampaignEvaluatorTest.php
@@ -1,0 +1,109 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\PausedCampaignEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class PausedCampaignEvaluatorTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators
+ */
+class PausedCampaignEvaluatorTest extends UnitTest {
+
+	/** @var MockObject|AdsService $ads_service */
+	protected $ads_service;
+
+	/** @var MockObject|AdsCampaign $ads_campaign */
+	protected $ads_campaign;
+
+	/** @var PausedCampaignEvaluator $evaluator */
+	protected $evaluator;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->ads_service  = $this->createMock( AdsService::class );
+		$this->ads_campaign = $this->createMock( AdsCampaign::class );
+		$this->evaluator    = new PausedCampaignEvaluator( $this->ads_campaign );
+		$this->evaluator->set_ads_object( $this->ads_service );
+	}
+
+	public function test_get_id() {
+		$this->assertEquals( 'paused-campaign', $this->evaluator->get_id() );
+	}
+
+	public function test_get_priority() {
+		$this->assertEquals( NotificationPriorities::PAUSED_CAMPAIGN, $this->evaluator->get_priority() );
+	}
+
+	public function test_get_snooze_duration() {
+		$this->assertEquals( NotificationSnoozeDurations::PAUSED_CAMPAIGN, $this->evaluator->get_snooze_duration() );
+	}
+
+	public function test_should_not_show_when_ads_incomplete() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( false );
+		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_show_when_paused_campaign_present() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_campaign->method( 'get_campaigns' )
+			->with( true, false )
+			->willReturn(
+				[
+					[
+						'id'     => 1,
+						'status' => CampaignStatus::ENABLED,
+					],
+					[
+						'id'     => 2,
+						'status' => CampaignStatus::PAUSED,
+					],
+				]
+			);
+
+		$this->assertTrue( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_no_paused_campaigns() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_campaign->method( 'get_campaigns' )
+			->with( true, false )
+			->willReturn(
+				[
+					[
+						'id'     => 1,
+						'status' => CampaignStatus::ENABLED,
+					],
+				]
+			);
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_cache_hit_skips_api_call() {
+		$user_id = $this->login_as_administrator();
+
+		set_transient( 'gla_notif_paused-campaign_' . $user_id, 0, HOUR_IN_SECONDS );
+
+		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+}

--- a/tests/Unit/Notification/Evaluators/RecommendationsAvailableEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/RecommendationsAvailableEvaluatorTest.php
@@ -1,0 +1,139 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsRecommendationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\RecommendationsAvailableEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class RecommendationsAvailableEvaluatorTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators
+ */
+class RecommendationsAvailableEvaluatorTest extends UnitTest {
+
+	/** @var MockObject|AdsService $ads_service */
+	protected $ads_service;
+
+	/** @var MockObject|AdsRecommendationsService $ads_recommendations */
+	protected $ads_recommendations;
+
+	/** @var MockObject|AdsCampaign $ads_campaign */
+	protected $ads_campaign;
+
+	/** @var RecommendationsAvailableEvaluator $evaluator */
+	protected $evaluator;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->ads_service         = $this->createMock( AdsService::class );
+		$this->ads_recommendations = $this->createMock( AdsRecommendationsService::class );
+		$this->ads_campaign        = $this->createMock( AdsCampaign::class );
+		$this->evaluator           = new RecommendationsAvailableEvaluator( $this->ads_recommendations, $this->ads_campaign );
+		$this->evaluator->set_ads_object( $this->ads_service );
+	}
+
+	public function test_get_id() {
+		$this->assertEquals( 'recommendations-available', $this->evaluator->get_id() );
+	}
+
+	public function test_get_priority() {
+		$this->assertEquals( NotificationPriorities::RECOMMENDATIONS_AVAILABLE, $this->evaluator->get_priority() );
+	}
+
+	public function test_get_snooze_duration() {
+		$this->assertEquals( NotificationSnoozeDurations::RECOMMENDATIONS_AVAILABLE, $this->evaluator->get_snooze_duration() );
+	}
+
+	public function test_should_not_show_when_ads_incomplete() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( false );
+		$this->ads_recommendations->expects( $this->never() )->method( 'get_recommendations' );
+		$this->ads_campaign->expects( $this->never() )->method( 'get_highest_spend_campaign' );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_show_when_budget_recommendations_present() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_recommendations->method( 'get_recommendations' )
+			->with(
+				[
+					'types'       => [
+						'CAMPAIGN_BUDGET',
+						'MARGINAL_ROI_CAMPAIGN_BUDGET',
+					],
+					'campaign_id' => 0,
+				]
+			)
+			->willReturn(
+				[
+					[
+						'id'   => 1,
+						'type' => 'CAMPAIGN_BUDGET',
+					],
+				]
+			);
+		$this->ads_campaign->expects( $this->never() )->method( 'get_highest_spend_campaign' );
+
+		$this->assertTrue( $this->evaluator->should_show() );
+	}
+
+	public function test_should_show_when_pmax_recommendations_present() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_recommendations->method( 'get_recommendations' )
+			->willReturnCallback(
+				function ( array $args ) {
+					if ( 0 === $args['campaign_id'] ) {
+						return [];
+					}
+
+					return [
+						[
+							'id'   => 2,
+							'type' => 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH',
+						],
+					];
+				}
+			);
+		$this->ads_campaign->method( 'get_highest_spend_campaign' )
+			->willReturn(
+				[
+					'id' => 1234567890,
+				]
+			);
+
+		$this->assertTrue( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_no_recommendations() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_recommendations->method( 'get_recommendations' )->willReturn( [] );
+		$this->ads_campaign->method( 'get_highest_spend_campaign' )->willReturn( [] );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_cache_hit_skips_api_call() {
+		$user_id = $this->login_as_administrator();
+
+		set_transient( 'gla_notif_recommendations-available_' . $user_id, 0, HOUR_IN_SECONDS );
+
+		$this->ads_recommendations->expects( $this->never() )->method( 'get_recommendations' );
+		$this->ads_campaign->expects( $this->never() )->method( 'get_highest_spend_campaign' );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds three Google Ads notification evaluators that call the Ads API to detect paused campaigns, zero-conversion campaigns, and available recommendations. Each evaluator returns false immediately when Ads setup is incomplete, caches results for 1 hour per user, and is registered in CoreServiceProvider.

`PausedCampaignEvaluator`: ID => `paused-campaign`. At least one campaign is paused

`CampaignNoSalesEvaluator`: ID => `campaign-no-sales`. At least one enabled campaign has 0 conversions in the last 90 days

`RecommendationsAvailableEvaluator`: ID => `recommendations-available`. Budget or PMax ad-strength recommendations exist (same types as `NotificationManager`)

Also adds matching priority/snooze constants and unit test coverage for all three evaluators.

Closes: https://linear.app/a8c/issue/GOOWOO-644/google-ads-api-evaluators-3

### Screenshots:
N/A

### Detailed test instructions:

#### Verify notifications via REST API
1. Open WooCommerce → Marketing → Google for WooCommerce (or any GLA admin page).
2. In DevTools → Network, find requests to `/wp-json/wc/gla/notifications`
3. Confirm the response includes notification objects with `id` and `triggered_at`:

`paused-campaign`. At least one campaign is paused

`campaign-no-sales`. At least one enabled campaign has 0 conversions in the last 90 days

`recommendations-available`. Budget or PMax ad-strength recommendations exist

#### Each evaluator test

**Paused campaign**
1. Pause a campaign in Google Ads.
2. Clear evaluator cache (see below), reload the GLA page, and check the API response for paused-campaign.
3. Re-enable the campaign, clear cache, and confirm it disappears after ~1 hour or immediately after cache clear.

**Campaign no sales**
1. Use an enabled campaign with no conversions in the last 90 days (or a new campaign).
2. Clear cache and confirm campaign-no-sales appears.
3. With a campaign that has conversions, confirm it does not appear.

**Recommendations available**
1. Use an account where Google Ads shows budget or PMax asset-strength recommendations.
2. Clear cache and confirm recommendations-available appears.
3. With no recommendations, confirm it does not appear.

**Ads not set up**
1. Disconnect Ads or use a store where Ads setup is incomplete.
2. Confirm none of the three IDs appear in the API response (no Google Ads API calls should be made).

**Admin menu badge**
1. With at least one notification active, check the Marketing menu for a badge count.
2. The count should include active notifications from NotificationService (in addition to existing recommendation badges).

**Dismissal**
1. Dismiss a notification via `DELETE /wp-json/wc/gla/notifications/{id}`.
2. Confirm it no longer appears in subsequent GET responses.

#### Clear cache between tests
Evaluator results are cached for 1 hour per user. To force re-evaluation:

// WP-CLI — replace USER_ID
```
delete_transient( 'gla_notif_paused-campaign_USER_ID' );
delete_transient( 'gla_notif_campaign-no-sales_USER_ID' );
delete_transient( 'gla_notif_recommendations-available_USER_ID' );
```

### Additional details:
This PR is based off of [GOOWOO-643](https://github.com/woocommerce/google-listings-and-ads/pull/3497)
