### PR TITLE
Display singular form for shipping label when necessary.

### DIFF
--- a/js/src/pages/markets/components/market-data-views/shipping-times-cell.js
+++ b/js/src/pages/markets/components/market-data-views/shipping-times-cell.js
@@ -46,10 +46,11 @@ const ShippingTimesCell = ( { market } ) => {
 	}
 
 	return sprintf(
-		// translators: 1: minimum shipping days, 2: maximum shipping days.
-		__( '%1$d - %2$d days', 'google-listings-and-ads' ),
+		// translators: 1: minimum shipping days, 2: maximum shipping days, 3: number of shipping days.
+		__( '%1$d - %2$d %3$s', 'google-listings-and-ads' ),
 		time,
-		maxTime
+		maxTime,
+		_n( 'day', 'days', maxTime, 'google-listings-and-ads' )
 	);
 };
 

--- a/js/src/pages/markets/components/market-data-views/shipping-times-cell.js
+++ b/js/src/pages/markets/components/market-data-views/shipping-times-cell.js
@@ -46,7 +46,7 @@ const ShippingTimesCell = ( { market } ) => {
 	}
 
 	return sprintf(
-		// translators: 1: minimum shipping days, 2: maximum shipping days, 3: number of shipping days.
+		// translators: 1: minimum shipping days, 2: maximum shipping days, 3: shipping days unit (day or days).
 		__( '%1$d - %2$d %3$s', 'google-listings-and-ads' ),
 		time,
 		maxTime,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes [GOOWOO-721](https://linear.app/a8c/issue/GOOWOO-721/use-singular-form-for-shipping-times-range-labels-ending-in-1-eg-0-1)

Use singular labels for shipping times when shipping times is a range and the highest value in the range is singular, e.g. "0-1 day".


### Detailed test instructions:

1. Ensure the shipping rate method is set to "auto".
2. Add a new market, or edit an existing market and set its estimated shipping time to 0 to 1 day.
3. Then check the shipping times cell for the newly created market, and ensure that the label uses singular form "day" rather than plural "days".


### Changelog entry

>
