### PR TITLE
[GOOWOO-711] Create MC shipping services in Merchant Center when a new market is created

### DIFF
--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -83,26 +83,13 @@ class Settings implements ContainerAwareInterface {
 	/**
 	 * Whether we should synchronize settings with the Merchant Center.
 	 *
-	 * Returns true when at least one configured market has a non-manual
-	 * shipping_rate combined with shipping_time === 'flat'. A non-manual
-	 * secondary market is enough to require a sync even when the primary
-	 * is configured as 'manual'.
-	 *
 	 * @return bool
 	 */
 	protected function should_sync_shipping(): bool {
 		/** @var MarketService $market_service */
 		$market_service = $this->container->get( MarketService::class );
 
-		foreach ( $market_service->get_markets() as $market ) {
-			$rate = $market['shipping_rate'] ?? null;
-			$time = $market['shipping_time'] ?? null;
-			if ( 'manual' !== $rate && 'flat' === $time ) {
-				return true;
-			}
-		}
-
-		return false;
+		return $market_service->has_syncable_markets();
 	}
 
 	/**

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -26,6 +27,7 @@ defined( 'ABSPATH' ) || exit;
  * Class Settings
  *
  * Container used for:
+ * - MarketService
  * - OptionsInterface
  * - ShippingRateQuery
  * - ShippingTimeQuery
@@ -79,14 +81,28 @@ class Settings implements ContainerAwareInterface {
 	}
 
 	/**
-	 * Whether we should synchronize settings with the Merchant Center
+	 * Whether we should synchronize settings with the Merchant Center.
+	 *
+	 * Returns true when at least one configured market has a non-manual
+	 * shipping_rate combined with shipping_time === 'flat'. A non-manual
+	 * secondary market is enough to require a sync even when the primary
+	 * is configured as 'manual'.
 	 *
 	 * @return bool
 	 */
 	protected function should_sync_shipping(): bool {
-		$shipping_rate = $this->get_settings()['shipping_rate'] ?? '';
-		$shipping_time = $this->get_settings()['shipping_time'] ?? '';
-		return in_array( $shipping_rate, [ 'flat', 'automatic' ], true ) && 'flat' === $shipping_time;
+		/** @var MarketService $market_service */
+		$market_service = $this->container->get( MarketService::class );
+
+		foreach ( $market_service->get_markets() as $market ) {
+			$rate = $market['shipping_rate'] ?? null;
+			$time = $market['shipping_time'] ?? null;
+			if ( 'manual' !== $rate && 'flat' === $time ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -103,6 +119,13 @@ class Settings implements ContainerAwareInterface {
 	/**
 	 * Generate a ShippingSettings object for syncing the store shipping settings to Merchant Center.
 	 *
+	 * Builds a `[ country => currency ]` map from every non-manual market and
+	 * passes it into the chosen adapter so that each per-country shipping service
+	 * gets that market's own currency rather than a single store-wide value.
+	 *
+	 * The adapter choice still follows the primary's rate mode (`automatic`
+	 * → WC adapter; otherwise → DB adapter), matching pre-multi-market behaviour.
+	 *
 	 * @return ShippingSettings
 	 *
 	 * @since 2.1.0
@@ -114,25 +137,76 @@ class Settings implements ContainerAwareInterface {
 		$wc_proxy = $this->container->get( WC::class );
 		$currency = $wc_proxy->get_woocommerce_currency();
 
+		$country_currency_map = $this->build_country_currency_map();
+
 		if ( $this->should_get_shipping_rates_from_woocommerce() ) {
 			return new WCShippingSettingsAdapter(
 				[
-					'currency'          => $currency,
-					'rates_collections' => $this->get_shipping_rates_collections_from_woocommerce(),
-					'delivery_times'    => $times,
-					'accountId'         => $this->get_account_id(),
+					'currency'             => $currency,
+					'country_currency_map' => $country_currency_map,
+					'rates_collections'    => $this->get_shipping_rates_collections_from_woocommerce(),
+					'delivery_times'       => $times,
+					'accountId'            => $this->get_account_id(),
 				]
 			);
 		}
 
 		return new DBShippingSettingsAdapter(
 			[
-				'currency'       => $currency,
-				'db_rates'       => $this->get_shipping_rates_from_database(),
-				'delivery_times' => $times,
-				'accountId'      => $this->get_account_id(),
+				'currency'             => $currency,
+				'country_currency_map' => $country_currency_map,
+				'db_rates'             => $this->get_shipping_rates_from_database(),
+				'delivery_times'       => $times,
+				'accountId'            => $this->get_account_id(),
 			]
 		);
+	}
+
+	/**
+	 * Returns a `[ country => currency ]` map for every non-manual market.
+	 *
+	 * Each market contributes its country and the first entry of its `currency[]`
+	 * array. Manual markets are skipped — they don't get an MC shipping service.
+	 *
+	 * @return array<string, string>
+	 */
+	protected function build_country_currency_map(): array {
+		/** @var MarketService $market_service */
+		$market_service = $this->container->get( MarketService::class );
+
+		$map = [];
+		foreach ( $market_service->get_markets() as $market ) {
+			if ( 'manual' === ( $market['shipping_rate'] ?? null ) ) {
+				continue;
+			}
+			$country = $market['country'] ?? null;
+			if ( ! $country ) {
+				continue;
+			}
+			$map[ $country ] = $this->resolve_market_currency( $market );
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Resolves a market's currency, taking the first element of its `currency[]`
+	 * array and falling back to the store currency.
+	 *
+	 * @param array $market
+	 * @return string
+	 */
+	private function resolve_market_currency( array $market ): string {
+		if ( ! empty( $market['currency'] ) && is_array( $market['currency'] ) ) {
+			$first = reset( $market['currency'] );
+			if ( is_string( $first ) && '' !== $first ) {
+				return $first;
+			}
+		}
+
+		/** @var WC $wc_proxy */
+		$wc_proxy = $this->container->get( WC::class );
+		return $wc_proxy->get_woocommerce_currency();
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -43,6 +43,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateShippingSettings;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateSyncableProductsCount;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateMerchantProductStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateMerchantPriceBenchmarks;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Coupon\CouponSyncer;
@@ -162,7 +163,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( PluginUpdate::class, JobRepository::class );
 
 		// Share shipping settings syncer job and hooks.
-		$this->share_action_scheduler_job( UpdateShippingSettings::class, MerchantCenterService::class, GoogleSettings::class );
+		$this->share_action_scheduler_job( UpdateShippingSettings::class, MerchantCenterService::class, GoogleSettings::class, MarketService::class );
 		$this->share_with_tags( Shipping\SyncerHooks::class, MerchantCenterService::class, GoogleSettings::class, JobRepository::class );
 
 		// Share plugin update jobs

--- a/src/Jobs/UpdateShippingSettings.php
+++ b/src/Jobs/UpdateShippingSettings.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 
 defined( 'ABSPATH' ) || exit;
@@ -33,17 +34,30 @@ class UpdateShippingSettings extends AbstractActionSchedulerJob {
 	protected $google_settings;
 
 	/**
+	 * @var MarketService
+	 */
+	protected $market_service;
+
+	/**
 	 * UpdateShippingSettings constructor.
 	 *
 	 * @param ActionSchedulerInterface  $action_scheduler
 	 * @param ActionSchedulerJobMonitor $monitor
 	 * @param MerchantCenterService     $merchant_center
 	 * @param GoogleSettings            $google_settings
+	 * @param MarketService             $market_service
 	 */
-	public function __construct( ActionSchedulerInterface $action_scheduler, ActionSchedulerJobMonitor $monitor, MerchantCenterService $merchant_center, GoogleSettings $google_settings ) {
+	public function __construct(
+		ActionSchedulerInterface $action_scheduler,
+		ActionSchedulerJobMonitor $monitor,
+		MerchantCenterService $merchant_center,
+		GoogleSettings $google_settings,
+		MarketService $market_service
+	) {
 		parent::__construct( $action_scheduler, $monitor );
 		$this->merchant_center = $merchant_center;
 		$this->google_settings = $google_settings;
+		$this->market_service  = $market_service;
 	}
 
 	/**
@@ -95,9 +109,26 @@ class UpdateShippingSettings extends AbstractActionSchedulerJob {
 	/**
 	 * Can the WooCommerce shipping settings be synced to Google Merchant Center.
 	 *
+	 * Returns true when MC is connected and at least one configured market has a
+	 * non-manual shipping_rate with shipping_time === 'flat'. With multi-market
+	 * support a non-manual secondary can require a sync even when the primary
+	 * itself is set to 'manual'.
+	 *
 	 * @return bool
 	 */
 	protected function can_sync_shipping(): bool {
-		return $this->merchant_center->is_connected() && $this->google_settings->should_get_shipping_rates_from_woocommerce();
+		if ( ! $this->merchant_center->is_connected() ) {
+			return false;
+		}
+
+		foreach ( $this->market_service->get_markets() as $market ) {
+			$rate = $market['shipping_rate'] ?? null;
+			$time = $market['shipping_time'] ?? null;
+			if ( 'manual' !== $rate && 'flat' === $time ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/src/Jobs/UpdateShippingSettings.php
+++ b/src/Jobs/UpdateShippingSettings.php
@@ -109,11 +109,6 @@ class UpdateShippingSettings extends AbstractActionSchedulerJob {
 	/**
 	 * Can the WooCommerce shipping settings be synced to Google Merchant Center.
 	 *
-	 * Returns true when MC is connected and at least one configured market has a
-	 * non-manual shipping_rate with shipping_time === 'flat'. With multi-market
-	 * support a non-manual secondary can require a sync even when the primary
-	 * itself is set to 'manual'.
-	 *
 	 * @return bool
 	 */
 	protected function can_sync_shipping(): bool {
@@ -121,14 +116,6 @@ class UpdateShippingSettings extends AbstractActionSchedulerJob {
 			return false;
 		}
 
-		foreach ( $this->market_service->get_markets() as $market ) {
-			$rate = $market['shipping_rate'] ?? null;
-			$time = $market['shipping_time'] ?? null;
-			if ( 'manual' !== $rate && 'flat' === $time ) {
-				return true;
-			}
-		}
-
-		return false;
+		return $this->market_service->has_syncable_markets();
 	}
 }

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -405,6 +405,27 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	}
 
 	/**
+	 * Whether any configured market needs its shipping settings synced to Merchant Center.
+	 *
+	 * Returns true when at least one market has a non-`manual` `shipping_rate`
+	 * combined with `shipping_time === 'flat'`. A non-`manual` secondary market
+	 * is enough to require a sync even when the primary itself is `manual`.
+	 *
+	 * @return bool
+	 */
+	public function has_syncable_markets(): bool {
+		foreach ( $this->get_markets() as $market ) {
+			$rate = $market['shipping_rate'] ?? null;
+			$time = $market['shipping_time'] ?? null;
+			if ( 'manual' !== $rate && 'flat' === $time ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Returns true if a supported multilingual integration is active.
 	 *
 	 * @return bool

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedMarketProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateShippingSettings;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -236,6 +237,10 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		if ( ! empty( $config['country'] ) ) {
 			$this->remove_country_from_target_audience( $config['country'] );
 		}
+
+		if ( 'manual' !== ( $config['shipping_rate'] ?? null ) ) {
+			$this->schedule_shipping_sync();
+		}
 	}
 
 	/**
@@ -276,6 +281,14 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 				->schedule( [ 'feed_label' => $old_feed_label ] );
 		}
 
+		$shipping_keys = [ 'country', 'currency', 'shipping_rate', 'shipping_time' ];
+		foreach ( $shipping_keys as $key ) {
+			if ( ( $existing[ $key ] ?? null ) !== ( $merged[ $key ] ?? null ) ) {
+				$this->schedule_shipping_sync();
+				break;
+			}
+		}
+
 		return $this->get_market( $id );
 	}
 
@@ -296,9 +309,10 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			);
 		}
 
-		$markets    = $this->get_stored_secondary_markets();
-		$country    = $markets[ $id ]['country'] ?? null;
-		$feed_label = $markets[ $id ]['feed_label'] ?? null;
+		$markets       = $this->get_stored_secondary_markets();
+		$country       = $markets[ $id ]['country'] ?? null;
+		$feed_label    = $markets[ $id ]['feed_label'] ?? null;
+		$shipping_rate = $markets[ $id ]['shipping_rate'] ?? null;
 
 		unset( $markets[ $id ] );
 		$this->options->update( OptionsInterface::MARKETS, $markets );
@@ -310,6 +324,10 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		if ( $feed_label ) {
 			$this->job_repository->get( CleanupOrphanedMarketProductsJob::class )
 				->schedule( [ 'feed_label' => $feed_label ] );
+		}
+
+		if ( 'manual' !== $shipping_rate ) {
+			$this->schedule_shipping_sync();
 		}
 	}
 
@@ -382,6 +400,14 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 */
 	public function get_currencies(): array {
 		return $this->wpml->get_currencies();
+	}
+
+	/**
+	 * Schedules the shipping-settings sync job so MC shipping services are
+	 * regenerated for every non-manual market.
+	 */
+	private function schedule_shipping_sync(): void {
+		$this->job_repository->get( UpdateShippingSettings::class )->schedule();
 	}
 
 	/**

--- a/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
@@ -28,6 +28,14 @@ abstract class AbstractShippingSettingsAdapter extends GoogleShippingSettings {
 	protected $delivery_times;
 
 	/**
+	 * Optional map of country code => ISO 4217 currency code used to override
+	 * `$currency` on a per-country basis. Populated from configured markets.
+	 *
+	 * @var array<string, string>
+	 */
+	protected $country_currency_map = [];
+
+	/**
 	 * Initialize this object's properties from an array.
 	 *
 	 * @param array $properties Used to seed this object's properties.
@@ -39,14 +47,29 @@ abstract class AbstractShippingSettingsAdapter extends GoogleShippingSettings {
 	public function mapTypes( $properties ) {
 		$this->validate_gla_data( $properties );
 
-		$this->currency       = $properties['currency'];
-		$this->delivery_times = $properties['delivery_times'];
+		$this->currency             = $properties['currency'];
+		$this->delivery_times       = $properties['delivery_times'];
+		$this->country_currency_map = isset( $properties['country_currency_map'] ) && is_array( $properties['country_currency_map'] )
+			? $properties['country_currency_map']
+			: [];
 
 		$this->map_gla_data( $properties );
 
 		$this->unset_gla_data( $properties );
 
 		parent::mapTypes( $properties );
+	}
+
+	/**
+	 * Returns the currency to use for a given country's shipping service,
+	 * preferring the per-country mapping when supplied and falling back to the
+	 * adapter's default `$currency` otherwise.
+	 *
+	 * @param string $country
+	 * @return string
+	 */
+	protected function get_currency_for_country( string $country ): string {
+		return $this->country_currency_map[ $country ] ?? $this->currency;
 	}
 
 	/**
@@ -98,6 +121,7 @@ abstract class AbstractShippingSettingsAdapter extends GoogleShippingSettings {
 	protected function unset_gla_data( array &$data ): void {
 		unset( $data['currency'] );
 		unset( $data['delivery_times'] );
+		unset( $data['country_currency_map'] );
 	}
 
 	/**

--- a/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
@@ -70,21 +70,22 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 				continue;
 			}
 
-			$service = $this->create_shipping_service( $country, $this->currency, (float) $rate );
+			$currency = $this->get_currency_for_country( $country );
+			$service  = $this->create_shipping_service( $country, $currency, (float) $rate );
 
 			if ( isset( $options['free_shipping_threshold'] ) ) {
 				$minimum_order_value = (float) $options['free_shipping_threshold'];
 
 				if ( $rate > 0 ) {
 					// Add a conditional free-shipping service if the current rate is not free.
-					$services[] = $this->create_conditional_free_shipping_service( $country, $this->currency, $minimum_order_value );
+					$services[] = $this->create_conditional_free_shipping_service( $country, $currency, $minimum_order_value );
 				} else {
 					// Set the minimum order value if the current rate is free.
 					$service->setMinimumOrderValue(
 						new Price(
 							[
 								'value'    => $minimum_order_value,
-								'currency' => $this->currency,
+								'currency' => $currency,
 							]
 						)
 					);

--- a/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
@@ -143,8 +143,9 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 			$rate_groups[ $class ] = $this->create_rate_group( $location_rates, $shipping_area, $applicable_classes );
 		}
 
-		$country = $service_collection->get_country();
-		$name    = sprintf(
+		$country  = $service_collection->get_country();
+		$currency = $this->get_currency_for_country( $country );
+		$name     = sprintf(
 		/* translators: %1 is a random 4-digit string, %2 is the country code  */
 			__( '[%1$s] Google for WooCommerce generated service - %2$s', 'google-listings-and-ads' ),
 			sprintf( '%04x', wp_rand( 0, 0xffff ) ),
@@ -155,7 +156,7 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 			[
 				'active'          => true,
 				'deliveryCountry' => $country,
-				'currency'        => $this->currency,
+				'currency'        => $currency,
 				'name'            => $name,
 				'deliveryTime'    => $this->get_delivery_time( $country ),
 				'rateGroups'      => array_values( $rate_groups ),
@@ -166,7 +167,7 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 		if ( $min_order_amount ) {
 			$min_order_value = new Price(
 				[
-					'currency' => $this->currency,
+					'currency' => $currency,
 					'value'    => $min_order_amount,
 				]
 			);

--- a/tests/Unit/API/Google/SettingsTest.php
+++ b/tests/Unit/API/Google/SettingsTest.php
@@ -1,0 +1,236 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\DBShippingSettingsAdapter;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\WCShippingSettingsAdapter;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionClass;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class SettingsTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ */
+class SettingsTest extends UnitTest {
+
+	/** @var MockObject|MarketService */
+	protected $market_service;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var MockObject|WC */
+	protected $wc_proxy;
+
+	/** @var MockObject|TargetAudience */
+	protected $target_audience;
+
+	/** @var MockObject|ShippingTimeQuery */
+	protected $shipping_time_query;
+
+	/** @var MockObject|ShippingRateQuery */
+	protected $shipping_rate_query;
+
+	/** @var MockObject|ShippingZone */
+	protected $shipping_zone;
+
+	/** @var Container */
+	protected $container;
+
+	/** @var Settings */
+	protected $settings;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->market_service      = $this->createMock( MarketService::class );
+		$this->options             = $this->createMock( OptionsInterface::class );
+		$this->wc_proxy            = $this->createMock( WC::class );
+		$this->target_audience     = $this->createMock( TargetAudience::class );
+		$this->shipping_time_query = $this->createMock( ShippingTimeQuery::class );
+		$this->shipping_rate_query = $this->createMock( ShippingRateQuery::class );
+		$this->shipping_zone       = $this->createMock( ShippingZone::class );
+
+		$this->container = new Container();
+		$this->container->addShared( MarketService::class, $this->market_service );
+		$this->container->addShared( OptionsInterface::class, $this->options );
+		$this->container->addShared( WC::class, $this->wc_proxy );
+		$this->container->addShared( TargetAudience::class, $this->target_audience );
+		$this->container->addShared( ShippingTimeQuery::class, $this->shipping_time_query );
+		$this->container->addShared( ShippingRateQuery::class, $this->shipping_rate_query );
+		$this->container->addShared( ShippingZone::class, $this->shipping_zone );
+
+		$this->settings = new Settings();
+		$this->settings->set_container( $this->container );
+	}
+
+	public function test_should_sync_shipping_true_when_only_secondary_is_non_manual(): void {
+		$this->market_service->method( 'get_markets' )->willReturn(
+			[
+				'primary' => [
+					'shipping_rate' => 'manual',
+					'shipping_time' => 'flat',
+				],
+				'fr'      => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+			]
+		);
+
+		$this->assertTrue( $this->invoke( 'should_sync_shipping' ) );
+	}
+
+	public function test_should_sync_shipping_false_when_every_market_is_manual(): void {
+		$this->market_service->method( 'get_markets' )->willReturn(
+			[
+				'primary' => [
+					'shipping_rate' => 'manual',
+					'shipping_time' => 'flat',
+				],
+				'fr'      => [
+					'shipping_rate' => 'manual',
+					'shipping_time' => 'flat',
+				],
+			]
+		);
+
+		$this->assertFalse( $this->invoke( 'should_sync_shipping' ) );
+	}
+
+	public function test_should_sync_shipping_false_when_shipping_time_not_flat(): void {
+		$this->market_service->method( 'get_markets' )->willReturn(
+			[
+				'primary' => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'manual',
+				],
+			]
+		);
+
+		$this->assertFalse( $this->invoke( 'should_sync_shipping' ) );
+	}
+
+	public function test_generate_shipping_settings_produces_db_adapter_with_per_country_currency(): void {
+		$this->market_service->method( 'get_markets' )->willReturn(
+			[
+				'primary' => [
+					'country'       => 'US',
+					'currency'      => [ 'USD' ],
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				'fr'      => [
+					'country'       => 'FR',
+					'currency'      => [ 'EUR' ],
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+			]
+		);
+
+		$this->options->method( 'get' )->willReturnCallback(
+			function ( $key, $fallback = null ) {
+				switch ( $key ) {
+					case OptionsInterface::MERCHANT_CENTER:
+						return [ 'shipping_rate' => 'flat' ];
+					case OptionsInterface::MERCHANT_ID:
+						return 1234567890;
+					default:
+						return $fallback;
+				}
+			}
+		);
+		$this->wc_proxy->method( 'get_woocommerce_currency' )->willReturn( 'USD' );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn(
+			[
+				'US' => [
+					'time'     => 1,
+					'max_time' => 2,
+				],
+				'FR' => [
+					'time'     => 2,
+					'max_time' => 4,
+				],
+			]
+		);
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'country' => 'US',
+					'rate'    => 10,
+					'options' => [],
+				],
+				[
+					'country' => 'FR',
+					'rate'    => 5,
+					'options' => [],
+				],
+			]
+		);
+
+		$adapter = $this->invoke( 'generate_shipping_settings' );
+
+		$this->assertInstanceOf( DBShippingSettingsAdapter::class, $adapter );
+
+		$by_country = [];
+		foreach ( $adapter->getServices() as $service ) {
+			$by_country[ $service->getDeliveryCountry() ] = $service;
+		}
+
+		$this->assertSame( 'USD', $by_country['US']->getCurrency() );
+		$this->assertSame( 'EUR', $by_country['FR']->getCurrency() );
+	}
+
+	public function test_generate_shipping_settings_skips_manual_markets_from_currency_map(): void {
+		$this->market_service->method( 'get_markets' )->willReturn(
+			[
+				'primary' => [
+					'country'       => 'US',
+					'currency'      => [ 'USD' ],
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				'fr'      => [
+					'country'       => 'FR',
+					'currency'      => [ 'EUR' ],
+					'shipping_rate' => 'manual',
+					'shipping_time' => 'flat',
+				],
+			]
+		);
+
+		$this->wc_proxy->method( 'get_woocommerce_currency' )->willReturn( 'USD' );
+
+		$map = $this->invoke( 'build_country_currency_map' );
+
+		$this->assertSame( [ 'US' => 'USD' ], $map );
+	}
+
+	/**
+	 * Invokes a protected method on the Settings instance via reflection so we
+	 * can test the multi-market gates without exposing internals.
+	 *
+	 * @param string $method
+	 * @return mixed
+	 */
+	private function invoke( string $method ) {
+		$ref = ( new ReflectionClass( Settings::class ) )->getMethod( $method );
+		$ref->setAccessible( true );
+		return $ref->invoke( $this->settings );
+	}
+}

--- a/tests/Unit/API/Google/SettingsTest.php
+++ b/tests/Unit/API/Google/SettingsTest.php
@@ -78,49 +78,14 @@ class SettingsTest extends UnitTest {
 		$this->settings->set_container( $this->container );
 	}
 
-	public function test_should_sync_shipping_true_when_only_secondary_is_non_manual(): void {
-		$this->market_service->method( 'get_markets' )->willReturn(
-			[
-				'primary' => [
-					'shipping_rate' => 'manual',
-					'shipping_time' => 'flat',
-				],
-				'fr'      => [
-					'shipping_rate' => 'flat',
-					'shipping_time' => 'flat',
-				],
-			]
-		);
+	public function test_should_sync_shipping_returns_true_when_market_service_has_syncable_markets(): void {
+		$this->market_service->method( 'has_syncable_markets' )->willReturn( true );
 
 		$this->assertTrue( $this->invoke( 'should_sync_shipping' ) );
 	}
 
-	public function test_should_sync_shipping_false_when_every_market_is_manual(): void {
-		$this->market_service->method( 'get_markets' )->willReturn(
-			[
-				'primary' => [
-					'shipping_rate' => 'manual',
-					'shipping_time' => 'flat',
-				],
-				'fr'      => [
-					'shipping_rate' => 'manual',
-					'shipping_time' => 'flat',
-				],
-			]
-		);
-
-		$this->assertFalse( $this->invoke( 'should_sync_shipping' ) );
-	}
-
-	public function test_should_sync_shipping_false_when_shipping_time_not_flat(): void {
-		$this->market_service->method( 'get_markets' )->willReturn(
-			[
-				'primary' => [
-					'shipping_rate' => 'flat',
-					'shipping_time' => 'manual',
-				],
-			]
-		);
+	public function test_should_sync_shipping_returns_false_when_market_service_has_no_syncable_markets(): void {
+		$this->market_service->method( 'has_syncable_markets' )->willReturn( false );
 
 		$this->assertFalse( $this->invoke( 'should_sync_shipping' ) );
 	}

--- a/tests/Unit/Jobs/UpdateShippingSettingsTest.php
+++ b/tests/Unit/Jobs/UpdateShippingSettingsTest.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSet
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateShippingSettings;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -31,17 +32,29 @@ class UpdateShippingSettingsTest extends UnitTest {
 	/** @var MockObject|GoogleSettings $google_settings */
 	protected $google_settings;
 
+	/** @var MockObject|MarketService $market_service */
+	protected $market_service;
+
 	/** @var UpdateShippingSettings $job */
 	protected $job;
 
-	public function test_job_is_scheduled() {
-		$this->merchant_center->expects( $this->any() )
-			->method( 'is_connected' )
-			->willReturn( true );
+	private const MARKET_NON_MANUAL_FLAT = [
+		'shipping_rate' => 'flat',
+		'shipping_time' => 'flat',
+	];
 
-		$this->google_settings->expects( $this->any() )
-			->method( 'should_get_shipping_rates_from_woocommerce' )
-			->willReturn( true );
+	private const MARKET_MANUAL = [
+		'shipping_rate' => 'manual',
+		'shipping_time' => 'flat',
+	];
+
+	public function test_job_is_scheduled_when_any_market_is_non_manual_flat() {
+		$this->merchant_center->method( 'is_connected' )->willReturn( true );
+		$this->market_service->method( 'get_markets' )->willReturn(
+			[
+				'primary' => self::MARKET_NON_MANUAL_FLAT,
+			]
+		);
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )
@@ -50,86 +63,94 @@ class UpdateShippingSettingsTest extends UnitTest {
 		$this->job->schedule();
 	}
 
-	public function test_job_is_not_scheduled_if_shipping_not_set_to_automatic_sync() {
-		$this->merchant_center->expects( $this->any() )
-			->method( 'is_connected' )
-			->willReturn( true );
-		$this->google_settings->expects( $this->any() )
-			->method( 'should_get_shipping_rates_from_woocommerce' )
-			->willReturn( false );
+	public function test_job_is_scheduled_when_only_secondary_is_non_manual_and_primary_is_manual() {
+		$this->merchant_center->method( 'is_connected' )->willReturn( true );
+		$this->market_service->method( 'get_markets' )->willReturn(
+			[
+				'primary' => self::MARKET_MANUAL,
+				'fr'      => self::MARKET_NON_MANUAL_FLAT,
+			]
+		);
 
-		$this->action_scheduler->expects( $this->never() )
+		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )
 			->with( $this->job->get_process_item_hook() );
+
+		$this->job->schedule();
+	}
+
+	public function test_job_is_not_scheduled_when_every_market_is_manual() {
+		$this->merchant_center->method( 'is_connected' )->willReturn( true );
+		$this->market_service->method( 'get_markets' )->willReturn(
+			[
+				'primary' => self::MARKET_MANUAL,
+				'fr'      => self::MARKET_MANUAL,
+			]
+		);
+
+		$this->action_scheduler->expects( $this->never() )
+			->method( 'schedule_immediate' );
 
 		$this->job->schedule();
 	}
 
 	public function test_job_is_not_scheduled_if_mc_not_connected() {
-		$this->merchant_center->expects( $this->any() )
-			->method( 'is_connected' )
-			->willReturn( false );
-		$this->google_settings->expects( $this->any() )
-			->method( 'should_get_shipping_rates_from_woocommerce' )
-			->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( false );
+		$this->market_service->method( 'get_markets' )->willReturn(
+			[
+				'primary' => self::MARKET_NON_MANUAL_FLAT,
+			]
+		);
 
 		$this->action_scheduler->expects( $this->never() )
-			->method( 'schedule_immediate' )
-			->with( $this->job->get_process_item_hook() );
+			->method( 'schedule_immediate' );
 
 		$this->job->schedule();
 	}
 
 	public function test_process_items() {
-		$this->merchant_center->expects( $this->any() )
-			->method( 'is_connected' )
-			->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( true );
+		$this->market_service->method( 'get_markets' )->willReturn(
+			[
+				'primary' => self::MARKET_NON_MANUAL_FLAT,
+			]
+		);
 
-		$this->google_settings->expects( $this->any() )
-			->method( 'should_get_shipping_rates_from_woocommerce' )
-			->willReturn( true );
-
-		$this->google_settings->expects( $this->once() )
-			->method( 'sync_shipping' );
+		$this->google_settings->expects( $this->once() )->method( 'sync_shipping' );
 
 		do_action( $this->job->get_process_item_hook(), [] );
 	}
 
 	public function test_process_items_fails_if_mc_not_connected() {
-		$this->merchant_center->expects( $this->any() )
-			->method( 'is_connected' )
-			->willReturn( false );
-		$this->google_settings->expects( $this->any() )
-			->method( 'should_get_shipping_rates_from_woocommerce' )
-			->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( false );
+		$this->market_service->method( 'get_markets' )->willReturn(
+			[
+				'primary' => self::MARKET_NON_MANUAL_FLAT,
+			]
+		);
 
-		$this->google_settings->expects( $this->never() )
-			->method( 'sync_shipping' );
-
-		$this->expectException( JobException::class );
-
-		do_action( $this->job->get_process_item_hook(), [] );
-	}
-
-	public function test_process_items_fails_if_shipping_not_set_to_automatic_sync() {
-		$this->merchant_center->expects( $this->any() )
-			->method( 'is_connected' )
-			->willReturn( true );
-		$this->google_settings->expects( $this->any() )
-			->method( 'should_get_shipping_rates_from_woocommerce' )
-			->willReturn( false );
-
-		$this->google_settings->expects( $this->never() )
-			->method( 'sync_shipping' );
+		$this->google_settings->expects( $this->never() )->method( 'sync_shipping' );
 
 		$this->expectException( JobException::class );
 
 		do_action( $this->job->get_process_item_hook(), [] );
 	}
 
-	/**
-	 * Runs before each test is executed.
-	 */
+	public function test_process_items_fails_when_every_market_is_manual() {
+		$this->merchant_center->method( 'is_connected' )->willReturn( true );
+		$this->market_service->method( 'get_markets' )->willReturn(
+			[
+				'primary' => self::MARKET_MANUAL,
+			]
+		);
+
+		$this->google_settings->expects( $this->never() )->method( 'sync_shipping' );
+
+		$this->expectException( JobException::class );
+
+		do_action( $this->job->get_process_item_hook(), [] );
+	}
+
 	public function setUp(): void {
 		parent::setUp();
 
@@ -137,8 +158,15 @@ class UpdateShippingSettingsTest extends UnitTest {
 		$this->monitor          = $this->createMock( ActionSchedulerJobMonitor::class );
 		$this->merchant_center  = $this->createMock( MerchantCenterService::class );
 		$this->google_settings  = $this->createMock( GoogleSettings::class );
+		$this->market_service   = $this->createMock( MarketService::class );
 
-		$this->job = new UpdateShippingSettings( $this->action_scheduler, $this->monitor, $this->merchant_center, $this->google_settings );
+		$this->job = new UpdateShippingSettings(
+			$this->action_scheduler,
+			$this->monitor,
+			$this->merchant_center,
+			$this->google_settings,
+			$this->market_service
+		);
 
 		$this->job->init();
 	}

--- a/tests/Unit/Jobs/UpdateShippingSettingsTest.php
+++ b/tests/Unit/Jobs/UpdateShippingSettingsTest.php
@@ -38,23 +38,9 @@ class UpdateShippingSettingsTest extends UnitTest {
 	/** @var UpdateShippingSettings $job */
 	protected $job;
 
-	private const MARKET_NON_MANUAL_FLAT = [
-		'shipping_rate' => 'flat',
-		'shipping_time' => 'flat',
-	];
-
-	private const MARKET_MANUAL = [
-		'shipping_rate' => 'manual',
-		'shipping_time' => 'flat',
-	];
-
-	public function test_job_is_scheduled_when_any_market_is_non_manual_flat() {
+	public function test_job_is_scheduled_when_market_service_has_syncable_markets() {
 		$this->merchant_center->method( 'is_connected' )->willReturn( true );
-		$this->market_service->method( 'get_markets' )->willReturn(
-			[
-				'primary' => self::MARKET_NON_MANUAL_FLAT,
-			]
-		);
+		$this->market_service->method( 'has_syncable_markets' )->willReturn( true );
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )
@@ -63,30 +49,9 @@ class UpdateShippingSettingsTest extends UnitTest {
 		$this->job->schedule();
 	}
 
-	public function test_job_is_scheduled_when_only_secondary_is_non_manual_and_primary_is_manual() {
+	public function test_job_is_not_scheduled_when_market_service_has_no_syncable_markets() {
 		$this->merchant_center->method( 'is_connected' )->willReturn( true );
-		$this->market_service->method( 'get_markets' )->willReturn(
-			[
-				'primary' => self::MARKET_MANUAL,
-				'fr'      => self::MARKET_NON_MANUAL_FLAT,
-			]
-		);
-
-		$this->action_scheduler->expects( $this->once() )
-			->method( 'schedule_immediate' )
-			->with( $this->job->get_process_item_hook() );
-
-		$this->job->schedule();
-	}
-
-	public function test_job_is_not_scheduled_when_every_market_is_manual() {
-		$this->merchant_center->method( 'is_connected' )->willReturn( true );
-		$this->market_service->method( 'get_markets' )->willReturn(
-			[
-				'primary' => self::MARKET_MANUAL,
-				'fr'      => self::MARKET_MANUAL,
-			]
-		);
+		$this->market_service->method( 'has_syncable_markets' )->willReturn( false );
 
 		$this->action_scheduler->expects( $this->never() )
 			->method( 'schedule_immediate' );
@@ -96,11 +61,7 @@ class UpdateShippingSettingsTest extends UnitTest {
 
 	public function test_job_is_not_scheduled_if_mc_not_connected() {
 		$this->merchant_center->method( 'is_connected' )->willReturn( false );
-		$this->market_service->method( 'get_markets' )->willReturn(
-			[
-				'primary' => self::MARKET_NON_MANUAL_FLAT,
-			]
-		);
+		$this->market_service->method( 'has_syncable_markets' )->willReturn( true );
 
 		$this->action_scheduler->expects( $this->never() )
 			->method( 'schedule_immediate' );
@@ -110,11 +71,7 @@ class UpdateShippingSettingsTest extends UnitTest {
 
 	public function test_process_items() {
 		$this->merchant_center->method( 'is_connected' )->willReturn( true );
-		$this->market_service->method( 'get_markets' )->willReturn(
-			[
-				'primary' => self::MARKET_NON_MANUAL_FLAT,
-			]
-		);
+		$this->market_service->method( 'has_syncable_markets' )->willReturn( true );
 
 		$this->google_settings->expects( $this->once() )->method( 'sync_shipping' );
 
@@ -123,11 +80,7 @@ class UpdateShippingSettingsTest extends UnitTest {
 
 	public function test_process_items_fails_if_mc_not_connected() {
 		$this->merchant_center->method( 'is_connected' )->willReturn( false );
-		$this->market_service->method( 'get_markets' )->willReturn(
-			[
-				'primary' => self::MARKET_NON_MANUAL_FLAT,
-			]
-		);
+		$this->market_service->method( 'has_syncable_markets' )->willReturn( true );
 
 		$this->google_settings->expects( $this->never() )->method( 'sync_shipping' );
 
@@ -136,13 +89,9 @@ class UpdateShippingSettingsTest extends UnitTest {
 		do_action( $this->job->get_process_item_hook(), [] );
 	}
 
-	public function test_process_items_fails_when_every_market_is_manual() {
+	public function test_process_items_fails_when_market_service_has_no_syncable_markets() {
 		$this->merchant_center->method( 'is_connected' )->willReturn( true );
-		$this->market_service->method( 'get_markets' )->willReturn(
-			[
-				'primary' => self::MARKET_MANUAL,
-			]
-		);
+		$this->market_service->method( 'has_syncable_markets' )->willReturn( false );
 
 		$this->google_settings->expects( $this->never() )->method( 'sync_shipping' );
 

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -1432,6 +1432,69 @@ class MarketServiceTest extends UnitTest {
 		$this->market_service->get_markets();
 	}
 
+	public function test_has_syncable_markets_true_when_only_secondary_is_non_manual(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'manual',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'fr' => [
+						'country'       => 'FR',
+						'feed_label'    => 'FR',
+						'language'      => [ 'fr' ],
+						'currency'      => [ 'EUR' ],
+						'shipping_rate' => 'flat',
+						'shipping_time' => 'flat',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->assertTrue( $this->market_service->has_syncable_markets() );
+	}
+
+	public function test_has_syncable_markets_false_when_every_market_is_manual(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'manual',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'fr' => [
+						'country'       => 'FR',
+						'feed_label'    => 'FR',
+						'language'      => [ 'fr' ],
+						'currency'      => [ 'EUR' ],
+						'shipping_rate' => 'manual',
+						'shipping_time' => 'flat',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->assertFalse( $this->market_service->has_syncable_markets() );
+	}
+
+	public function test_has_syncable_markets_false_when_shipping_time_not_flat(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'manual',
+				],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->assertFalse( $this->market_service->has_syncable_markets() );
+	}
+
 	/**
 	 * Sets up the options mock to return specific values for different option keys.
 	 *

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedMarketProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateShippingSettings;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -49,24 +50,38 @@ class MarketServiceTest extends UnitTest {
 	/** @var MockObject|CleanupOrphanedMarketProductsJob */
 	protected $cleanup_job;
 
+	/** @var MockObject|UpdateShippingSettings */
+	protected $shipping_settings_job;
+
 	/** @var MarketService */
 	protected $market_service;
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->target_audience     = $this->createMock( TargetAudience::class );
-		$this->options             = $this->createMock( OptionsInterface::class );
-		$this->shipping_rate_query = $this->createMock( ShippingRateQuery::class );
-		$this->shipping_time_query = $this->createMock( ShippingTimeQuery::class );
-		$this->wc                  = $this->createMock( WC::class );
-		$this->wpml                = $this->createMock( WPML::class );
-		$this->job_repository      = $this->createMock( JobRepository::class );
-		$this->cleanup_job         = $this->createMock( CleanupOrphanedMarketProductsJob::class );
+		$this->target_audience       = $this->createMock( TargetAudience::class );
+		$this->options               = $this->createMock( OptionsInterface::class );
+		$this->shipping_rate_query   = $this->createMock( ShippingRateQuery::class );
+		$this->shipping_time_query   = $this->createMock( ShippingTimeQuery::class );
+		$this->wc                    = $this->createMock( WC::class );
+		$this->wpml                  = $this->createMock( WPML::class );
+		$this->job_repository        = $this->createMock( JobRepository::class );
+		$this->cleanup_job           = $this->createMock( CleanupOrphanedMarketProductsJob::class );
+		$this->shipping_settings_job = $this->createMock( UpdateShippingSettings::class );
 
 		$this->job_repository->method( 'get' )
-			->with( CleanupOrphanedMarketProductsJob::class )
-			->willReturn( $this->cleanup_job );
+			->willReturnCallback(
+				function ( $classname ) {
+					switch ( $classname ) {
+						case CleanupOrphanedMarketProductsJob::class:
+							return $this->cleanup_job;
+						case UpdateShippingSettings::class:
+							return $this->shipping_settings_job;
+						default:
+							return null;
+					}
+				}
+			);
 
 		$this->market_service = new MarketService(
 			$this->target_audience,
@@ -595,6 +610,10 @@ class MarketServiceTest extends UnitTest {
 			->method( 'schedule' )
 			->with( [ 'feed_label' => 'GB' ] );
 
+		// feed_label rename alone does not touch country/currency/shipping_rate/shipping_time.
+		$this->shipping_settings_job->expects( $this->never() )
+			->method( 'schedule' );
+
 		$this->market_service->update_market( 'gb', [ 'feed_label' => 'GB-PROMO' ] );
 	}
 
@@ -616,6 +635,10 @@ class MarketServiceTest extends UnitTest {
 		$this->cleanup_job->expects( $this->never() )
 			->method( 'schedule' );
 
+		// Shipping-relevant fields (country, currency, shipping_rate, shipping_time) DID change.
+		$this->shipping_settings_job->expects( $this->once() )
+			->method( 'schedule' );
+
 		$this->market_service->update_market(
 			'gb',
 			[
@@ -626,6 +649,71 @@ class MarketServiceTest extends UnitTest {
 				'shipping_time' => 'automatic',
 			]
 		);
+	}
+
+	public function test_add_market_with_manual_shipping_rate_does_not_schedule_shipping_sync(): void {
+		$config = [
+			'country'       => 'DE',
+			'language'      => [ 'de' ],
+			'currency'      => [ 'EUR' ],
+			'feed_label'    => 'DE',
+			'shipping_rate' => 'manual',
+		];
+
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [],
+				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'US' ] ],
+			]
+		);
+		$this->options->method( 'update' )->willReturn( true );
+
+		$this->shipping_settings_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->market_service->add_market( 'de', $config );
+	}
+
+	public function test_update_market_does_not_schedule_shipping_sync_when_only_language_changes(): void {
+		$existing = [
+			'gb' => [
+				'country'       => 'GB',
+				'language'      => [ 'en' ],
+				'currency'      => [ 'GBP' ],
+				'feed_label'    => 'GB',
+				'shipping_rate' => 'flat',
+				'shipping_time' => 'flat',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->shipping_settings_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'language' => [ 'en', 'cy' ] ] );
+	}
+
+	public function test_delete_market_with_manual_shipping_rate_does_not_schedule_shipping_sync(): void {
+		$existing = [
+			'gb' => [
+				'country'       => 'GB',
+				'language'      => [ 'en' ],
+				'currency'      => [ 'GBP' ],
+				'feed_label'    => 'GB',
+				'shipping_rate' => 'manual',
+				'shipping_time' => 'flat',
+			],
+		];
+
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => $existing ] );
+		$this->options->method( 'update' )->willReturn( true );
+
+		$this->shipping_settings_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->market_service->delete_market( 'gb' );
 	}
 
 	public function test_add_market_does_not_schedule_cleanup(): void {
@@ -645,6 +733,10 @@ class MarketServiceTest extends UnitTest {
 		$this->options->method( 'update' )->willReturn( true );
 
 		$this->cleanup_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		// shipping_rate defaults to 'flat' (non-manual) → shipping sync IS scheduled.
+		$this->shipping_settings_job->expects( $this->once() )
 			->method( 'schedule' );
 
 		$this->market_service->add_market( 'de', $config );
@@ -707,10 +799,12 @@ class MarketServiceTest extends UnitTest {
 	public function test_delete_market_schedules_cleanup_with_feed_label(): void {
 		$existing = [
 			'gb' => [
-				'country'    => 'GB',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => 'GB',
+				'country'       => 'GB',
+				'language'      => [ 'en' ],
+				'currency'      => [ 'GBP' ],
+				'feed_label'    => 'GB',
+				'shipping_rate' => 'flat',
+				'shipping_time' => 'flat',
 			],
 		];
 
@@ -721,11 +815,18 @@ class MarketServiceTest extends UnitTest {
 			->method( 'schedule' )
 			->with( [ 'feed_label' => 'GB' ] );
 
+		// Non-manual shipping_rate → shipping sync also scheduled.
+		$this->shipping_settings_job->expects( $this->once() )
+			->method( 'schedule' );
+
 		$this->market_service->delete_market( 'gb' );
 	}
 
 	public function test_delete_market_primary_throws_and_does_not_schedule_cleanup(): void {
 		$this->cleanup_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->shipping_settings_job->expects( $this->never() )
 			->method( 'schedule' );
 
 		$this->expectException( InvalidValue::class );

--- a/tests/Unit/Shipping/GoogleAdapter/DBShippingSettingsAdapterTest.php
+++ b/tests/Unit/Shipping/GoogleAdapter/DBShippingSettingsAdapterTest.php
@@ -246,4 +246,52 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 			]
 		);
 	}
+
+	public function test_country_currency_map_overrides_per_service_currency() {
+		$db_rates = [
+			[
+				'country' => 'US',
+				'rate'    => 10,
+				'options' => [],
+			],
+			[
+				'country' => 'FR',
+				'rate'    => 5,
+				'options' => [],
+			],
+		];
+
+		$settings = new DBShippingSettingsAdapter(
+			[
+				'currency'             => 'USD',
+				'country_currency_map' => [
+					'FR' => 'EUR',
+				],
+				'delivery_times'       => [
+					'US' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+					'FR' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
+				'db_rates'             => $db_rates,
+			]
+		);
+
+		$services = $settings->getServices();
+
+		$this->assertCount( 2, $services );
+		foreach ( $services as $service ) {
+			if ( 'US' === $service->getDeliveryCountry() ) {
+				$this->assertEquals( 'USD', $service->getCurrency() );
+				$this->assertEquals( 'USD', $service->getRateGroups()[0]->getSingleValue()->getFlatRate()->getCurrency() );
+			} elseif ( 'FR' === $service->getDeliveryCountry() ) {
+				$this->assertEquals( 'EUR', $service->getCurrency() );
+				$this->assertEquals( 'EUR', $service->getRateGroups()[0]->getSingleValue()->getFlatRate()->getCurrency() );
+			}
+		}
+	}
 }

--- a/tests/Unit/Shipping/GoogleAdapter/WCShippingSettingsAdapterTest.php
+++ b/tests/Unit/Shipping/GoogleAdapter/WCShippingSettingsAdapterTest.php
@@ -380,4 +380,59 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 			]
 		);
 	}
+
+	public function test_country_currency_map_overrides_per_service_currency() {
+		$min_order_rate = new ShippingRate( 0 );
+		$min_order_rate->set_min_order_amount( 1000 );
+
+		$us_rate = new LocationRate( new ShippingLocation( 1, 'US' ), new ShippingRate( 100 ) );
+		$fr_rate = new LocationRate( new ShippingLocation( 2, 'FR' ), new ShippingRate( 50 ) );
+		$fr_min  = new LocationRate( new ShippingLocation( 2, 'FR' ), $min_order_rate );
+
+		$settings = new WCShippingSettingsAdapter(
+			[
+				'currency'             => 'USD',
+				'country_currency_map' => [
+					'FR' => 'EUR',
+				],
+				'rates_collections'    => [
+					new CountryRatesCollection( 'US', [ $us_rate ] ),
+					new CountryRatesCollection( 'FR', [ $fr_rate, $fr_min ] ),
+				],
+				'delivery_times'       => [
+					'US' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+					'FR' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
+			]
+		);
+
+		$services   = $settings->getServices();
+		$by_country = [];
+		foreach ( $services as $service ) {
+			$by_country[ $service->getDeliveryCountry() ][] = $service;
+		}
+
+		$this->assertNotEmpty( $by_country['US'] );
+		$this->assertNotEmpty( $by_country['FR'] );
+
+		foreach ( $by_country['US'] as $service ) {
+			$this->assertEquals( 'USD', $service->getCurrency() );
+			if ( $service->getMinimumOrderValue() ) {
+				$this->assertEquals( 'USD', $service->getMinimumOrderValue()->getCurrency() );
+			}
+		}
+
+		foreach ( $by_country['FR'] as $service ) {
+			$this->assertEquals( 'EUR', $service->getCurrency() );
+			if ( $service->getMinimumOrderValue() ) {
+				$this->assertEquals( 'EUR', $service->getMinimumOrderValue()->getCurrency() );
+			}
+		}
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Note: This started from `feature/GOOWOO-710-apply-market-feedlabel-to-products-when-syncing-to-merchant-center`  / https://github.com/woocommerce/google-listings-and-ads/pull/3503 (which started from `feature/GOOWOO-591-map-products-to-markets-when-syncing-to-mc` / https://github.com/woocommerce/google-listings-and-ads/pull/3403).

Closes https://linear.app/a8c/issue/GOOWOO-711/create-mc-shipping-services-in-merchant-center-when-a-new-market-is


### Screenshots:

N/A

### Detailed test instructions:

Reset shipping-job history and seed three markets (one manual), run:

```
wp eval '
$store = ActionScheduler::store();
foreach ( as_get_scheduled_actions( [ "hook" => "gla/jobs/update_shipping_settings/process_item", "per_page" => 100 ] ) as $id => $a ) {
  $store->delete_action( $id );
}
update_option( "gla_markets", [
  "fr" => [ "country" => "FR", "feed_label" => "FR", "language" => [ "fr" ], "currency" => [ "EUR" ], "shipping_rate" => "flat",   "shipping_time" => "flat" ],
  "es" => [ "country" => "ES", "feed_label" => "ES", "language" => [ "es" ], "currency" => [ "EUR" ], "shipping_rate" => "manual", "shipping_time" => "flat" ],
] );
' 
```

1. Per-market currency map omits manual markets

Run:
```
wp eval '
$c   = woogle_get_container();
$ref = ( new ReflectionClass( \Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings::class ) )->getMethod( "build_country_currency_map" );
$ref->setAccessible( true );
echo wp_json_encode( $ref->invoke( $c->get( \Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings::class ) ) ) . "\n";
'
```

Expected: map contains FR and the primary's country, no ES key.

2. add_market non-manual schedules; manual does not

Trigger the writes, run:

```
wp eval '
$ms = woogle_get_container()->get( \Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService::class );
$ms->add_market( "nl", [ "country" => "NL", "feed_label" => "NL", "language" => [ "nl" ], "currency" => [ "EUR" ], "shipping_rate" => "flat",   "shipping_time" => "flat" ] );
$ms->add_market( "it", [ "country" => "IT", "feed_label" => "IT", "language" => [ "it" ], "currency" => [ "EUR" ], "shipping_rate" => "manual", "shipping_time" => "flat" ] );
'
```

Inspect shipping-job actions, run:

```
wp eval '
foreach ( as_get_scheduled_actions( [
  "hook"     => "gla/jobs/update_shipping_settings/process_item",
  "per_page" => 5,
  "orderby"  => "date",
  "order"    => "DESC",
] ) as $id => $a ) {
  printf( "action_id=%d  args=%s\n", $id, wp_json_encode( $a->get_args() ) );
}
'
```

Expected: exactly one action from adding  NL (adding IT add added nothing).

Make note of the highest action ID.

3. update_market: shipping-relevant change schedules; language-only does not

Trigger the writes, run:

```
wp eval '
$ms = woogle_get_container()->get( \Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService::class );
$ms->update_market( "fr", [ "shipping_rate" => "automatic" ] );
$ms->update_market( "fr", [ "language" => [ "fr", "ca" ] ] );
'
```

Inspect shipping-job actions, run:

```
wp eval '
foreach ( as_get_scheduled_actions( [
  "hook"     => "gla/jobs/update_shipping_settings/process_item",
  "per_page" => 5,
  "orderby"  => "date",
  "order"    => "DESC",
] ) as $id => $a ) {
  printf( "action_id=%d  args=%s\n", $id, wp_json_encode( $a->get_args() ) );
}
'
```

Expected: exactly one new action higher than the action ID noted from the previous step (from the shipping_rate change). The language-only change added nothing.

Make note of the new highest action ID.

4. delete_market: non-manual schedules; manual does not

Trigger the deletes, run:

```
wp eval '
$ms = woogle_get_container()->get( \Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService::class );
$ms->delete_market( "fr" );
$ms->delete_market( "es" );
'
```

Inspect shipping-job actions, run:

```
wp eval '
foreach ( as_get_scheduled_actions( [
  "hook"     => "gla/jobs/update_shipping_settings/process_item",
  "per_page" => 5,
  "orderby"  => "date",
  "order"    => "DESC",
] ) as $id => $a ) {
  printf( "action_id=%d  args=%s\n", $id, wp_json_encode( $a->get_args() ) );
}
'
```

Expected: exactly one new action from the FR delete, higher than the action ID noted from the previous step. [The ES delete (manual) added nothing.]

5. Live MC verification (per-market currencies land)

Run any pending actions, run:

```
wp action-scheduler run --force
```

Trigger an immediate shipping sync, run:

```
wp eval '
woogle_get_container()->get( \Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository::class )
 ->get( \Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateShippingSettings::class )
 ->schedule();
'
```

Run the new action, run:

```
wp action-scheduler run --force
```

6. Verify in Merchant Centre

In the MC dashboard: Tools → Shipping and Returns → Shipping services. Confirm one service per remaining non-manual market with the correct country and currency.

### Additional details:

> Update - Create MC shipping services in Merchant Center when a new market is created