### PR TITLE
Adjusting input spacing for RTL.

### DIFF
--- a/js/src/components/countries-time-input/time-stepper/index.scss
+++ b/js/src/components/countries-time-input/time-stepper/index.scss
@@ -1,11 +1,7 @@
 .gla-countries-time-stepper {
 	width: $gla-width-smaller;
 
-	:dir(ltr) .gla-countries-time-suffix {
-		margin-right: $grid-unit-05;
-	}
-
-	:dir(rtl) .gla-countries-time-suffix {
-		margin-left: $grid-unit-05;
+	.gla-countries-time-suffix {
+		margin-inline-end: $grid-unit-05;
 	}
 }

--- a/js/src/components/countries-time-input/time-stepper/index.scss
+++ b/js/src/components/countries-time-input/time-stepper/index.scss
@@ -1,6 +1,11 @@
 .gla-countries-time-stepper {
 	width: $gla-width-smaller;
-	.gla-countries-time-suffix {
+
+	:dir(ltr) .gla-countries-time-suffix {
 		margin-right: $grid-unit-05;
+	}
+
+	:dir(rtl) .gla-countries-time-suffix {
+		margin-left: $grid-unit-05;
 	}
 }

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -52,12 +52,8 @@
 		}
 	}
 
-	// Adjust InputControl suffix's empty right margin.
-	:dir(ltr) .components-input-control__suffix {
-		margin-right: $grid-unit;
-	}
-
-	:dir(rtl) .components-input-control__suffix {
-		margin-left: $grid-unit;
+	// Adjust InputControl suffix's empty inline-end margin.
+	.components-input-control__suffix {
+		margin-inline-end: $grid-unit;
 	}
 }

--- a/js/src/css/shared/_gutenberg-components.scss
+++ b/js/src/css/shared/_gutenberg-components.scss
@@ -53,7 +53,11 @@
 	}
 
 	// Adjust InputControl suffix's empty right margin.
-	.components-input-control__suffix {
+	:dir(ltr) .components-input-control__suffix {
 		margin-right: $grid-unit;
+	}
+
+	:dir(rtl) .components-input-control__suffix {
+		margin-left: $grid-unit;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes [GOOWOO-700](https://linear.app/a8c/issue/GOOWOO-700/rtl-issues-for-multi-lingual-screen)

This PR adjusts some CSS styles to apply margin only for LTR or RTL sites. 

Background: [UI issues reported by QA in a separate PR.](https://github.com/woocommerce/google-listings-and-ads/pull/3404#issuecomment-4488676095)


### Screenshots:

<img width="777" height="268" alt="Screenshot 2026-06-15 at 17 22 04" src="https://github.com/user-attachments/assets/5847b182-f590-424f-aa87-9ae514357525" />
<img width="850" height="292" alt="Screenshot 2026-06-15 at 17 21 41" src="https://github.com/user-attachments/assets/568f6b98-3cae-4c3b-a75d-2912f3ab1278" />
<img width="935" height="277" alt="Screenshot 2026-06-15 at 17 21 15" src="https://github.com/user-attachments/assets/ae8ca5f1-d868-40b0-8742-e0b1169f9d98" />



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Navigate to `/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fshipping`
2. Ensure your viewing the site as a RTL (right-to-left) site. You can do this in the browser's inspector tools by adding an attribute to the `<html>` element called `dir` with a value of `rtl`. E.g. `<html dir="rtl">`
3. You should now be able to see the margins that are indicated in the screenshots above. 
4. Switch back to `ltr` viewing and ensure that the margins are now on the opposite side of the affected elements.


### Changelog entry

>
