### PR TITLE
[GOOWOO-701] Unable to add multiple languages and currencies to the primary market

### DIFF
--- a/src/Exception/InvalidValue.php
+++ b/src/Exception/InvalidValue.php
@@ -48,6 +48,17 @@ class InvalidValue extends LogicException implements GoogleListingsAndAdsExcepti
 	}
 
 	/**
+	 * Create a new instance of the exception when a value is not an array.
+	 *
+	 * @param string $key The name of the value.
+	 *
+	 * @return static
+	 */
+	public static function not_array( string $key ): InvalidValue {
+		return new static( sprintf( 'The value of %s must be of type array.', $key ) );
+	}
+
+	/**
 	 * Create a new instance of the exception when a value is not an instance of a given class.
 	 *
 	 * @param string $class_name The name of the class that the value must be an instance of.

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -410,7 +410,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 				continue;
 			}
 			if ( ! is_array( $config[ $key ] ) ) {
-				throw InvalidValue::is_empty( $key );
+				throw InvalidValue::not_array( $key );
 			}
 			$mc_settings[ $key ] = array_values( array_unique( $config[ $key ] ) );
 			$mc_updated          = true;
@@ -458,8 +458,11 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		}
 
 		foreach ( [ 'language', 'currency' ] as $key ) {
-			if ( ! isset( $config[ $key ] ) || ! is_array( $config[ $key ] ) ) {
+			if ( ! isset( $config[ $key ] ) ) {
 				throw InvalidValue::is_empty( $key );
+			}
+			if ( ! is_array( $config[ $key ] ) ) {
+				throw InvalidValue::not_array( $key );
 			}
 		}
 	}
@@ -485,7 +488,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	): array {
 		if ( $merge_language ) {
 			if ( array_key_exists( 'language', $config ) && ! is_array( $config['language'] ) ) {
-				throw InvalidValue::is_empty( 'language' );
+				throw InvalidValue::not_array( 'language' );
 			}
 
 			$language_extras    = isset( $config['language'] ) && is_array( $config['language'] ) ? $config['language'] : [];
@@ -498,7 +501,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 		if ( $merge_currency ) {
 			if ( array_key_exists( 'currency', $config ) && ! is_array( $config['currency'] ) ) {
-				throw InvalidValue::is_empty( 'currency' );
+				throw InvalidValue::not_array( 'currency' );
 			}
 
 			$currency_extras    = isset( $config['currency'] ) && is_array( $config['currency'] ) ? $config['currency'] : [];

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -165,8 +165,8 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			'label'         => __( 'Primary Market', 'google-listings-and-ads' ),
 			'countries'     => $this->target_audience->get_target_countries(),
 			'country'       => $defaults['country'],
-			'language'      => $defaults['language'],
-			'currency'      => $defaults['currency'],
+			'language'      => is_array( $mc_settings['language'] ?? null ) ? $mc_settings['language'] : $defaults['language'],
+			'currency'      => is_array( $mc_settings['currency'] ?? null ) ? $mc_settings['currency'] : $defaults['currency'],
 			'feed_label'    => $defaults['feed_label'],
 			'shipping_rate' => $mc_settings['shipping_rate'] ?? null,
 			'shipping_time' => $mc_settings['shipping_time'] ?? null,
@@ -357,6 +357,17 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		if ( array_key_exists( 'shipping_time', $config ) ) {
 			$mc_settings['shipping_time'] = $config['shipping_time'];
 			$mc_updated                   = true;
+		}
+
+		foreach ( [ 'language', 'currency' ] as $key ) {
+			if ( ! array_key_exists( $key, $config ) ) {
+				continue;
+			}
+			if ( ! is_array( $config[ $key ] ) ) {
+				throw InvalidValue::is_empty( $key );
+			}
+			$mc_settings[ $key ] = array_values( array_unique( $config[ $key ] ) );
+			$mc_updated          = true;
 		}
 
 		if ( $mc_updated ) {

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -344,6 +344,8 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * Fans out a primary market update to the underlying settings stores.
 	 *
 	 * @param array $config Partial config — only supplied keys are written.
+	 *
+	 * @throws InvalidValue When `language` or `currency` is present but not an array.
 	 */
 	private function update_primary_market_fanout( array $config ): void {
 		$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -598,6 +598,7 @@ class MarketServiceTest extends UnitTest {
 		);
 
 		$this->expectException( InvalidValue::class );
+		$this->expectExceptionMessage( 'The value of language must be of type array.' );
 
 		$this->market_service->update_market(
 			'primary',
@@ -614,6 +615,7 @@ class MarketServiceTest extends UnitTest {
 		);
 
 		$this->expectException( InvalidValue::class );
+		$this->expectExceptionMessage( 'The value of currency must be of type array.' );
 
 		$this->market_service->update_market(
 			'primary',

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -426,6 +426,7 @@ class MarketServiceTest extends UnitTest {
 				OptionsInterface::MARKETS         => [],
 			]
 		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
 
 		$update_calls = [];
 		$this->options->method( 'update' )
@@ -456,6 +457,7 @@ class MarketServiceTest extends UnitTest {
 				OptionsInterface::MARKETS         => [],
 			]
 		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
 
 		$update_calls = [];
 		$this->options->method( 'update' )
@@ -492,6 +494,7 @@ class MarketServiceTest extends UnitTest {
 				OptionsInterface::MARKETS         => [],
 			]
 		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
 
 		$update_calls = [];
 		$this->options->method( 'update' )
@@ -527,6 +530,7 @@ class MarketServiceTest extends UnitTest {
 				OptionsInterface::MARKETS         => [],
 			]
 		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
 
 		$update_calls = [];
 		$this->options->method( 'update' )
@@ -565,6 +569,7 @@ class MarketServiceTest extends UnitTest {
 				OptionsInterface::MARKETS         => [],
 			]
 		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
 
 		$update_calls = [];
 		$this->options->method( 'update' )

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -419,6 +419,246 @@ class MarketServiceTest extends UnitTest {
 		$this->assertArrayHasKey( 'countries', $result );
 	}
 
+	public function test_update_market_primary_persists_multiple_languages_and_currencies(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+
+		$update_calls = [];
+		$this->options->method( 'update' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$update_calls ) {
+					$update_calls[ $key ] = $value;
+					return true;
+				}
+			);
+
+		$this->market_service->update_market(
+			'primary',
+			[
+				'language' => [ 'en', 'fr' ],
+				'currency' => [ 'USD', 'EUR' ],
+			]
+		);
+
+		$this->assertArrayHasKey( OptionsInterface::MERCHANT_CENTER, $update_calls );
+		$this->assertSame( [ 'en', 'fr' ], $update_calls[ OptionsInterface::MERCHANT_CENTER ]['language'] );
+		$this->assertSame( [ 'USD', 'EUR' ], $update_calls[ OptionsInterface::MERCHANT_CENTER ]['currency'] );
+	}
+
+	public function test_update_market_primary_deduplicates_languages_and_currencies(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+
+		$update_calls = [];
+		$this->options->method( 'update' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$update_calls ) {
+					$update_calls[ $key ] = $value;
+					return true;
+				}
+			);
+
+		$this->market_service->update_market(
+			'primary',
+			[
+				'language' => [ 'en', 'fr', 'en' ],
+				'currency' => [ 'USD', 'USD', 'EUR' ],
+			]
+		);
+
+		$this->assertSame( [ 'en', 'fr' ], $update_calls[ OptionsInterface::MERCHANT_CENTER ]['language'] );
+		$this->assertSame( [ 'USD', 'EUR' ], $update_calls[ OptionsInterface::MERCHANT_CENTER ]['currency'] );
+	}
+
+	public function test_update_market_primary_partial_update_preserves_other_keys(): void {
+		$existing_mc = [
+			'shipping_rate' => 'flat',
+			'shipping_time' => 'flat',
+			'language'      => [ 'en', 'fr' ],
+			'currency'      => [ 'USD', 'EUR' ],
+		];
+
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => $existing_mc,
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+
+		$update_calls = [];
+		$this->options->method( 'update' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$update_calls ) {
+					$update_calls[ $key ] = $value;
+					return true;
+				}
+			);
+
+		$this->market_service->update_market(
+			'primary',
+			[ 'shipping_rate' => 'automatic' ]
+		);
+
+		$persisted = $update_calls[ OptionsInterface::MERCHANT_CENTER ];
+		$this->assertSame( 'automatic', $persisted['shipping_rate'] );
+		$this->assertSame( [ 'en', 'fr' ], $persisted['language'] );
+		$this->assertSame( [ 'USD', 'EUR' ], $persisted['currency'] );
+	}
+
+	public function test_update_market_primary_language_currency_update_preserves_shipping(): void {
+		$existing_mc = [
+			'shipping_rate' => 'automatic',
+			'shipping_time' => 'flat',
+			'language'      => [ 'en' ],
+			'currency'      => [ 'USD' ],
+		];
+
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => $existing_mc,
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+
+		$update_calls = [];
+		$this->options->method( 'update' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$update_calls ) {
+					$update_calls[ $key ] = $value;
+					return true;
+				}
+			);
+
+		$this->market_service->update_market(
+			'primary',
+			[
+				'language' => [ 'en', 'fr' ],
+				'currency' => [ 'USD', 'EUR' ],
+			]
+		);
+
+		$persisted = $update_calls[ OptionsInterface::MERCHANT_CENTER ];
+		$this->assertSame( [ 'en', 'fr' ], $persisted['language'] );
+		$this->assertSame( [ 'USD', 'EUR' ], $persisted['currency'] );
+		$this->assertSame( 'automatic', $persisted['shipping_rate'] );
+		$this->assertSame( 'flat', $persisted['shipping_time'] );
+	}
+
+	public function test_update_market_primary_persists_empty_language_and_currency_arrays(): void {
+		$existing_mc = [
+			'shipping_rate' => 'flat',
+			'language'      => [ 'en', 'fr' ],
+			'currency'      => [ 'USD', 'EUR' ],
+		];
+
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => $existing_mc,
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+
+		$update_calls = [];
+		$this->options->method( 'update' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$update_calls ) {
+					$update_calls[ $key ] = $value;
+					return true;
+				}
+			);
+
+		$this->market_service->update_market(
+			'primary',
+			[
+				'language' => [],
+				'currency' => [],
+			]
+		);
+
+		$persisted = $update_calls[ OptionsInterface::MERCHANT_CENTER ];
+		$this->assertSame( [], $persisted['language'] );
+		$this->assertSame( [], $persisted['currency'] );
+		$this->assertSame( 'flat', $persisted['shipping_rate'] );
+	}
+
+	public function test_update_market_primary_rejects_non_array_language(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->update_market(
+			'primary',
+			[ 'language' => 'en' ]
+		);
+	}
+
+	public function test_update_market_primary_rejects_non_array_currency(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->update_market(
+			'primary',
+			[ 'currency' => 'USD' ]
+		);
+	}
+
+	public function test_get_primary_market_returns_stored_language_and_currency_when_set(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'language' => [ 'en', 'fr' ],
+					'currency' => [ 'USD', 'EUR' ],
+				],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$result = $this->market_service->get_primary_market();
+
+		$this->assertSame( [ 'en', 'fr' ], $result['language'] );
+		$this->assertSame( [ 'USD', 'EUR' ], $result['currency'] );
+	}
+
+	public function test_get_primary_market_falls_back_to_defaults_when_stored_value_invalid(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'language' => 'en',
+					'currency' => 'USD',
+				],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$result = $this->market_service->get_primary_market();
+
+		$this->assertIsArray( $result['language'] );
+		$this->assertIsArray( $result['currency'] );
+		$this->assertNotSame( 'en', $result['language'] );
+		$this->assertNotSame( 'USD', $result['currency'] );
+	}
+
 	public function test_update_market_secondary_merges_and_persists(): void {
 		$existing = [
 			'gb' => [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-701/unable-to-add-multiple-languages-and-currencies-to-the-primary-market

### Screenshots:

N/A


### Detailed test instructions:

Prerequisites
- WPML and WCML installed and activated.
- WCML multi-currency mode enabled, with at least 2 currencies configured (e.g. USD, EUR).
- At least 2 WPML languages configured (e.g. English, French).
- Google for WooCommerce plugin connected to a Merchant Center account.

1. Two languages and two currencies can be saved for the primary

- In the WordPress admin sidebar, click Marketing → Google for WooCommerce.
- Click the Markets tab.
- Open Developer Tools, select the Network tab, add `market` to the filter
- Edit the primary market:
a. In the table row labelled Primary Market, click the Edit button.
b. In the Languages field, tick exactly two WPML languages (e.g. English and French).
c. In the Currencies field, tick exactly two WCML currencies (e.g. USD and EUR).
- Save and inspect the response

Expected:
- Response status is 200.
- The JSON contains "language": ["en","fr"] (codes matching your selections).
- The JSON contains "currency": ["USD","EUR"] (codes matching your selections).
- The Markets table on the page now shows both languages and both currencies on the Primary row.

2. Selections persist after a hard refresh

- Refresh the Markets page

Expected: the Primary Market row still shows both languages and both currencies selected in Step 1.

3. Partial updates preserve the other keys (both directions)

3a. Save shipping rate only:
- Edit the Primary Market
- Change only the Shipping rate field (e.g. flip between flat and automatic)
- Do not change Languages or Currencies
- Click Save
- Refresh the page

Expected: the Primary row still shows the selected values; i.e. they saved correctly and persist

3b. Save languages only:
- Edit the Primary Market
- In the Languages field, make a change to add or remove a language
- Do not change Currencies or Shipping.
- Click Save.
- Refresh the page

Expected: the Primary row still shows the selected values; i.e. they saved correctly and persist

3c. Save currency only:
- Edit the Primary Market
- In the Currency field, make a change to add or remove a currency
- Do not change Languages or Shipping.
- Click Save.
- Refresh the page

Expected: the Primary row still shows the selected values; i.e. they saved correctly and persist


4. Bad input is rejected with a clear error

- On the Markets page (Marketing → Google for WooCommerce → Markets), open Developer Tools (F12 or Cmd + Option + I).
- Click the Console tab.
- Paste this snippet and press Enter:

```
fetch('/wp-json/wc/gla/mc/markets/primary', {
  method: 'PUT',
  headers: {
      'Content-Type': 'application/json',
      'X-WP-Nonce': wpApiSettings.nonce
  },
  body: JSON.stringify({ language: { not: 'an array' } })
}).then(async (r) => {
  console.log('Status:', r.status);
  console.log('Body:', await r.json());
});
```

Expected:
- Status: 400.
- The error message states: `Invalid parameter(s): language`

- Refresh the Mar

Expected: the Primary row still shows the previous saved values; i.e. the failed API request does not make changes.

5. Duplicate codes are deduplicated

- On the Markets page, in the console enter:

```
fetch('/wp-json/wc/gla/mc/markets/primary', {
  method: 'PUT',
  headers: {
      'Content-Type': 'application/json',
      'X-WP-Nonce': wpApiSettings.nonce
  },
  body: JSON.stringify({ language: ['en', 'fr', 'en'], currency: ['USD', 'USD', 'EUR'] })
}).then(async (r) => {
  console.log('Status:', r.status);
  console.log('Body:', await r.json());
});
```

Expected:
- Status: 200.
- The logged body's language array contains each code exactly once: example: `["en","fr"]`
- The logged body's currency array contains each code exactly once: example: `["USD","EUR"]`


6. Secondary markets are unaffected

- Add a secondary market
- Refresh the page (this just confirms persistence, the checks below can be done before and after the page refresh)

Expected:
- The Primary market still shows the languages and currencies previously selected
- The Secondary market shows the languages and currencies selected

### Additional details:

> Update: Allow multiple languages and currencies on the primary market