### PR TITLE
Enforce feedLabel format constraint in MarketService validation

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/MarketsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/MarketsController.php
@@ -131,7 +131,7 @@ class MarketsController extends BaseController {
 		return function ( Request $request ) {
 			$config = [
 				'country'    => $request->get_param( 'country' ),
-				'feed_label' => $request->get_param( 'country' ),
+				'feed_label' => $request->get_param( 'feed_label' ) ?? $request->get_param( 'country' ),
 			];
 
 			if ( null !== $request->get_param( 'language' ) ) {
@@ -388,8 +388,7 @@ class MarketsController extends BaseController {
 			'feed_label'    => [
 				'type'              => 'string',
 				'description'       => __( 'Google feed label.', 'google-listings-and-ads' ),
-				'context'           => [ 'view' ],
-				'readonly'          => true,
+				'context'           => [ 'view', 'edit' ],
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 			'shipping_rate' => [

--- a/src/Exception/InvalidValue.php
+++ b/src/Exception/InvalidValue.php
@@ -85,6 +85,19 @@ class InvalidValue extends LogicException implements GoogleListingsAndAdsExcepti
 	}
 
 	/**
+	 * Create a new instance of the exception when a value does not match a required regex pattern.
+	 *
+	 * @param string $key     The name of the value.
+	 * @param string $pattern The regex pattern the value was checked against.
+	 * @param string $value   The offending value.
+	 *
+	 * @return static
+	 */
+	public static function does_not_match_pattern( string $key, string $pattern, string $value ): InvalidValue {
+		return new static( sprintf( 'The value of %s must match pattern %s; got "%s".', $key, $pattern, $value ) );
+	}
+
+	/**
 	 * Create a new instance of the exception when a value isn't a valid coupon ID.
 	 *
 	 * @param mixed $value The provided coupon ID that isn't valid.

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -34,6 +34,12 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	use OptionsAwareTrait;
 
 	/**
+	 * Google Content API constraint on `feedLabel`: up to 20 characters,
+	 * uppercase letters, digits and dashes only.
+	 */
+	private const FEED_LABEL_PATTERN = '/^[A-Z0-9-]{1,20}$/';
+
+	/**
 	 * @var TargetAudience
 	 */
 	protected TargetAudience $target_audience;
@@ -398,6 +404,10 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			if ( empty( $config[ $key ] ) || ! is_string( $config[ $key ] ) ) {
 				throw InvalidValue::is_empty( $key );
 			}
+		}
+
+		if ( ! preg_match( self::FEED_LABEL_PATTERN, $config['feed_label'] ) ) {
+			throw InvalidValue::does_not_match_pattern( 'feed_label', self::FEED_LABEL_PATTERN, $config['feed_label'] );
 		}
 
 		foreach ( [ 'language', 'currency' ] as $key ) {

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -656,7 +656,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 						return isset( $params['shipping_rate'] )
 							&& ! isset( $params['id'] )
 							&& ! isset( $params['label'] )
-							&& ! isset( $params['feed_label'] )
 							&& ! isset( $params['free_shipping'] );
 					}
 				)
@@ -758,5 +757,157 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->assertEquals( 201, $response->get_status() );
 		$this->assertEquals( [ 'CHF', 'EUR' ], $response->get_data()['currency'] );
+	}
+
+	public function test_post_market_uses_client_supplied_feed_label(): void {
+		$created_market = [
+			'country'       => 'GB',
+			'language'      => [ 'en' ],
+			'currency'      => [ 'GBP' ],
+			'feed_label'    => 'GB-EN',
+			'shipping_rate' => 'flat',
+			'shipping_time' => 'flat',
+			'free_shipping' => null,
+		];
+
+		$created = false;
+
+		$this->market_service->method( 'add_market' )
+			->with(
+				'gb-en',
+				$this->callback(
+					function ( $config ) {
+						return 'GB' === $config['country']
+							&& 'GB-EN' === $config['feed_label'];
+					}
+				)
+			)
+			->willReturnCallback(
+				function () use ( &$created ) {
+					$created = true;
+				}
+			);
+
+		$this->market_service->method( 'get_market' )
+			->willReturnCallback(
+				function ( string $id ) use ( &$created, $created_market ) {
+					if ( 'gb-en' === $id && $created ) {
+						return $created_market;
+					}
+					return null;
+				}
+			);
+
+		$response = $this->do_request(
+			self::ROUTE_MARKETS,
+			'POST',
+			[
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB-EN',
+			]
+		);
+
+		$this->assertEquals( 201, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'gb-en', $data['id'] );
+		$this->assertEquals( 'GB-EN', $data['feed_label'] );
+	}
+
+	public function test_post_market_falls_back_to_country_when_feed_label_absent(): void {
+		$created = false;
+
+		$this->market_service->method( 'add_market' )
+			->with(
+				'gb',
+				$this->callback(
+					function ( $config ) {
+						return 'GB' === $config['country']
+							&& 'GB' === $config['feed_label'];
+					}
+				)
+			)
+			->willReturnCallback(
+				function () use ( &$created ) {
+					$created = true;
+				}
+			);
+
+		$this->market_service->method( 'get_market' )
+			->willReturnCallback(
+				function ( string $id ) use ( &$created ) {
+					if ( 'gb' === $id && $created ) {
+						return [ 'country' => 'GB', 'feed_label' => 'GB' ];
+					}
+					return null;
+				}
+			);
+
+		$response = $this->do_request(
+			self::ROUTE_MARKETS,
+			'POST',
+			[
+				'country' => 'GB',
+			]
+		);
+
+		$this->assertEquals( 201, $response->get_status() );
+	}
+
+	public function test_post_market_returns_400_when_feed_label_pattern_invalid(): void {
+		$this->market_service->method( 'get_market' )
+			->willReturn( null );
+
+		$this->market_service->method( 'add_market' )
+			->willThrowException(
+				InvalidValue::does_not_match_pattern( 'feed_label', '/^[A-Z0-9-]{1,20}$/', 'gb-en' )
+			);
+
+		$response = $this->do_request(
+			self::ROUTE_MARKETS,
+			'POST',
+			[
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'gb-en',
+			]
+		);
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertStringContainsString( 'feed_label', $response->get_data()['message'] );
+		$this->assertStringContainsString( 'gb-en', $response->get_data()['message'] );
+	}
+
+	public function test_put_passes_feed_label_through(): void {
+		$this->market_service->method( 'get_market' )
+			->with( 'gb' )
+			->willReturn( self::SECONDARY_MARKET );
+
+		$this->market_service->expects( $this->once() )
+			->method( 'update_market' )
+			->with(
+				'gb',
+				$this->callback(
+					function ( $params ) {
+						return isset( $params['feed_label'] )
+							&& 'GB-EN' === $params['feed_label'];
+					}
+				)
+			)
+			->willReturn(
+				array_merge( self::SECONDARY_MARKET, [ 'feed_label' => 'GB-EN' ] )
+			);
+
+		$response = $this->do_request(
+			self::ROUTE_MARKET . 'gb',
+			'PUT',
+			[
+				'feed_label' => 'GB-EN',
+			]
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
 	}
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -838,7 +838,10 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnCallback(
 				function ( string $id ) use ( &$created ) {
 					if ( 'gb' === $id && $created ) {
-						return [ 'country' => 'GB', 'feed_label' => 'GB' ];
+						return [
+							'country'    => 'GB',
+							'feed_label' => 'GB',
+						];
 					}
 					return null;
 				}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -811,6 +811,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$created = false;
 
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb-en' );
+
 		$this->market_service->method( 'add_market' )
 			->with(
 				'gb-en',
@@ -856,6 +858,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 	public function test_post_market_falls_back_to_country_when_feed_label_absent(): void {
 		$created = false;
+
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
 
 		$this->market_service->method( 'add_market' )
 			->with(

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -882,6 +882,163 @@ class MarketServiceTest extends UnitTest {
 		);
 	}
 
+	/**
+	 * @dataProvider provide_valid_feed_labels
+	 *
+	 * @param string $feed_label
+	 */
+	public function test_add_market_accepts_valid_feed_label( string $feed_label ): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [],
+				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'GB' ] ],
+			]
+		);
+
+		$persisted = null;
+		$this->options->method( 'update' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$persisted ) {
+					if ( OptionsInterface::MARKETS === $key ) {
+						$persisted = $value;
+					}
+					return true;
+				}
+			);
+
+		$this->market_service->add_market(
+			'gb',
+			[
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => $feed_label,
+			]
+		);
+
+		$this->assertSame( $feed_label, $persisted['gb']['feed_label'] );
+	}
+
+	/**
+	 * @dataProvider provide_invalid_feed_labels
+	 *
+	 * @param string $feed_label
+	 */
+	public function test_add_market_rejects_invalid_feed_label( string $feed_label ): void {
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => [] ] );
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->add_market(
+			'gb',
+			[
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => $feed_label,
+			]
+		);
+	}
+
+	/**
+	 * @dataProvider provide_valid_feed_labels
+	 *
+	 * @param string $feed_label
+	 */
+	public function test_update_market_accepts_valid_feed_label( string $feed_label ): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$result = $this->market_service->update_market( 'gb', [ 'feed_label' => $feed_label ] );
+
+		$this->assertSame( $feed_label, $result['feed_label'] );
+	}
+
+	/**
+	 * @dataProvider provide_invalid_feed_labels
+	 *
+	 * @param string $feed_label
+	 */
+	public function test_update_market_rejects_invalid_feed_label( string $feed_label ): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => $existing ] );
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->update_market( 'gb', [ 'feed_label' => $feed_label ] );
+	}
+
+	public function test_feed_label_rejection_message_references_pattern_and_value(): void {
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => [] ] );
+
+		$this->expectException( InvalidValue::class );
+		$this->expectExceptionMessageMatches( '#feed_label.*\[A-Z0-9-\].*"us"#' );
+
+		$this->market_service->add_market(
+			'gb',
+			[
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'us',
+			]
+		);
+	}
+
+	public function test_empty_feed_label_still_throws_is_empty_not_pattern(): void {
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => [] ] );
+
+		$this->expectException( InvalidValue::class );
+		$this->expectExceptionMessage( 'The value of feed_label can not be empty.' );
+
+		$this->market_service->add_market(
+			'gb',
+			[
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => '',
+			]
+		);
+	}
+
+	public function provide_valid_feed_labels(): array {
+		return [
+			'two-letter uppercase'   => [ 'US' ],
+			'uppercase with dash'    => [ 'GB-EN' ],
+			'alphanumeric'           => [ 'A1' ],
+			'twenty char max length' => [ 'A1-B2-C3-D4-E5-F6-G7' ],
+		];
+	}
+
+	public function provide_invalid_feed_labels(): array {
+		return [
+			'lowercase'        => [ 'us' ],
+			'twenty-one chars' => [ 'A1-B2-C3-D4-E5-F6-G7-' ],
+			'underscore'       => [ 'GB_EN' ],
+			'period'           => [ 'GB.EN' ],
+			'space'            => [ 'GB EN' ],
+			'at sign'          => [ 'GB@EN' ],
+		];
+	}
+
 	public function test_add_market_persists_array_language_and_currency(): void {
 		$config = [
 			'country'    => 'CH',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-712/enforce-feedlabel-format-constraint-in-marketservice-validation

### Screenshots:

N/A

### Detailed test instructions:


1. Confirm an invalid feed_label throws with a message naming the field, pattern, and offending value:

Run:
```
wp eval '
$svc = woogle_get_container()->get( \Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService::class );
try {
  $svc->add_market( "xx", [
      "country"    => "GB",
      "language"   => [ "en" ],
      "currency"   => [ "GBP" ],
      "feed_label" => "gb-en",
  ] );
  echo "NO THROW\n";
} catch ( \Throwable $e ) {
  echo get_class($e) . ": " . $e->getMessage() . "\n";
}'
```

Expect: Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue: The value of feed_label must match pattern /^[A-Z0-9-]{1,20}$/; got "gb-en".

2. Confirm a valid feed_label works:

Run:
```
wp eval '
$svc = woogle_get_container()->get( \Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService::class );
try {
  $svc->add_market( "xx", [
      "country"    => "GB",
      "language"   => [ "en" ],
      "currency"   => [ "GBP" ],
      "feed_label" => "GB-EN",
  ] );
  echo "Passes, 'GB-EN' is valid.\n";
} catch ( \Throwable $e ) {
  echo get_class($e) . ": " . $e->getMessage() . "\n";
}'
```

Expect: "Passes, 'GB-EN' is valid."

3. Clean up the test market:

Run:
```
wp eval '
woogle_get_container()
  ->get( \Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService::class )
  ->delete_market( "xx" );'
```

Expect: No response or error.


**Admin Tests**

- Open WP Admin, then the Console for the following tests:

4. Confirm invalid feed label is rejected:

Run:

```
fetch( '/wp-json/wc/gla/mc/markets', {                                                                                                                                                                    
      method: 'POST',
      credentials: 'include',                                                                                                                                                                               
      headers: {                                            
          'Content-Type': 'application/json',                                                                                                                                                               
          'X-WP-Nonce': wpApiSettings.nonce,                
      },                                                                                                                                                                                                    
      body: JSON.stringify( {
          country:    'GB',                                                                                                                                                                                 
          language:   [ 'en' ],                             
          currency:   [ 'GBP' ],                                                                                                                                                                            
          feed_label: 'gb-en',
      } ),                                                                                                                                                                                                  
  } ).then( r => r.json().then( j => console.log( r.status, j ) ) );
```

Expect: `400` status with error: `{message: 'The value of feed_label must match pattern /^[A-Z0-9-]{1,20}$/; got "gb-en".'}`

5. Confirm valid feed label is accepted

Run:

```
  fetch( '/wp-json/wc/gla/mc/markets', {
      method: 'POST',                                                                                                                                                                                       
      credentials: 'include',                               
      headers: {                                                                                                                                                                                            
          'Content-Type': 'application/json',
          'X-WP-Nonce': wpApiSettings.nonce,                                                                                                                                                                
      },                                                    
      body: JSON.stringify( {
          country:  'GB',                                                                                                                                                                                   
          language: [ 'en' ],
          currency: [ 'GBP' ],                                                                                                                                                                              
      } ),                                                  
  } ).then( r => r.json().then( j => console.log( r.status, j ) ) );
```

Expect: `201` response with message: `{country: 'GB', feed_label: 'GB', language: Array(1), currency: Array(1), shipping_rate: 'automatic', …}`

6. Cleanup; remove the feed label successfully added in previous step:

Run:

```
  fetch( '/wp-json/wc/gla/mc/markets/gb', {                                                                                                                                                                 
      method: 'DELETE',                                     
      credentials: 'include',
      headers: { 'X-WP-Nonce': wpApiSettings.nonce },                                                                                                                                                       
  } ).then( r => r.json().then( j => console.log( r.status, j ) ) );
```

Expect: `200` response with message: `{deleted: true, id: 'gb'}`

### Additional details:

> Update - Enforce feedLabel format constraint in MarketService validation