### PR TITLE
[GOOWOO-713] Move market ID generation into MarketService::generate_market_id()

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/MarketsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/MarketsController.php
@@ -142,10 +142,9 @@ class MarketsController extends BaseController {
 				$config['currency'] = $request->get_param( 'currency' );
 			}
 
-			// TODO: Move ID generation into MarketService::generate_market_id().
-			$id = sanitize_title( $config['feed_label'] );
-
-			if ( 'primary' === $id ) {
+			try {
+				$id = $this->market_service->generate_market_id( $config['feed_label'] );
+			} catch ( InvalidValue $e ) {
 				return new Response(
 					[ 'message' => __( 'Cannot create a market with a reserved ID.', 'google-listings-and-ads' ) ],
 					400

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -188,6 +188,30 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	}
 
 	/**
+	 * Generates a market ID from a feed label.
+	 *
+	 * Centralises the ID-generation rule so any code path that creates a market
+	 * (REST controller, batch import, migration, CLI) produces consistent IDs.
+	 *
+	 * @param string $feed_label The market's feed label.
+	 *
+	 * @return string The sanitised market ID.
+	 *
+	 * @throws InvalidValue When the generated ID equals the reserved 'primary' key.
+	 */
+	public function generate_market_id( string $feed_label ): string {
+		$id = sanitize_title( $feed_label );
+
+		if ( 'primary' === $id ) {
+			throw new InvalidValue(
+				sprintf( 'The feed label "%s" generates the reserved market ID "primary".', $feed_label )
+			);
+		}
+
+		return $id;
+	}
+
+	/**
 	 * Adds a new market config to the store.
 	 *
 	 * Primary cannot be added — it is always synthesised from site settings.

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -196,6 +196,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$created = false;
 
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'de' );
+
 		$this->market_service->method( 'add_market' )
 			->willReturnCallback(
 				function () use ( &$created ) {
@@ -258,6 +260,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$created = false;
 
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
+
 		$this->market_service->method( 'add_market' )
 			->with(
 				'gb',
@@ -298,6 +302,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 	public function test_post_market_with_empty_language_currency_arrays_passes_empty_arrays(): void {
 		$created = false;
+
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
 
 		$this->market_service->method( 'add_market' )
 			->with(
@@ -340,6 +346,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_post_market_returns_400_when_add_market_throws_invalid_value(): void {
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'de' );
+
 		$this->market_service->method( 'get_market' )
 			->willReturn( null );
 
@@ -359,7 +367,30 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 400, $response->get_status() );
 	}
 
+	public function test_post_market_returns_400_when_generate_market_id_rejects_reserved_id(): void {
+		$this->market_service->method( 'generate_market_id' )
+			->willThrowException( new InvalidValue( 'reserved-id rejection' ) );
+
+		$response = $this->do_request(
+			self::ROUTE_MARKETS,
+			'POST',
+			[
+				'country'  => 'XX',
+				'language' => [ 'en' ],
+				'currency' => [ 'USD' ],
+			]
+		);
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertSame(
+			'Cannot create a market with a reserved ID.',
+			$response->get_data()['message']
+		);
+	}
+
 	public function test_post_market_returns_409_when_id_already_exists(): void {
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
+
 		$this->market_service->method( 'get_market' )
 			->with( 'gb' )
 			->willReturn( self::SECONDARY_MARKET );
@@ -585,6 +616,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$created = false;
 
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'jp' );
+
 		$this->market_service->method( 'add_market' )
 			->willReturnCallback(
 				function () use ( &$created ) {
@@ -616,6 +649,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_post_market_free_shipping_cannot_be_set_in_payload(): void {
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'jp' );
+
 		$this->market_service->method( 'get_market' )
 			->willReturnOnConsecutiveCalls( null, [] );
 
@@ -685,6 +720,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$created = false;
 
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'ch' );
+
 		$this->market_service->method( 'add_market' )
 			->willReturnCallback(
 				function () use ( &$created ) {
@@ -728,6 +765,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		];
 
 		$created = false;
+
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'ch' );
 
 		$this->market_service->method( 'add_market' )
 			->willReturnCallback(

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -1190,6 +1190,28 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( [], $this->market_service->get_currencies() );
 	}
 
+	public function test_generate_market_id_sanitises_uppercase_feed_label(): void {
+		$this->assertSame( 'gb', $this->market_service->generate_market_id( 'GB' ) );
+	}
+
+	public function test_generate_market_id_converts_multi_word_label_to_slug(): void {
+		$this->assertSame( 'united-kingdom', $this->market_service->generate_market_id( 'United Kingdom' ) );
+	}
+
+	public function test_generate_market_id_throws_when_label_sanitises_to_reserved_primary(): void {
+		$this->expectException( InvalidValue::class );
+		$this->expectExceptionMessageMatches( '/reserved/' );
+
+		$this->market_service->generate_market_id( 'Primary' );
+	}
+
+	public function test_generate_market_id_throws_when_label_is_already_lowercase_primary(): void {
+		$this->expectException( InvalidValue::class );
+		$this->expectExceptionMessageMatches( '/reserved/' );
+
+		$this->market_service->generate_market_id( 'primary' );
+	}
+
 	/**
 	 * Sets up the options mock to return specific values for different option keys.
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-713/move-market-id-generation-into-marketservicegenerate-market-id

### Screenshots:

N/A


### Detailed test instructions:

1. The REST API rejects a feed label that would generate the reserved "primary" ID

In WP Admin, open the Inspector -> Console; enter:

```
wp.apiFetch( {
  path: '/wc/gla/mc/markets',
  method: 'POST',
  data: { country: 'Primary', language: [ 'en' ], currency: [ 'USD' ] },
} ).then(
  r => console.log( 'unexpected 2xx', r ),
  e => console.log( 'rejected', e )
);
```

Expect: rejected { message: "Cannot create a market with a reserved ID." } with 400 (Bad Request) on the Network tab line.

2. A valid country code still creates a market and returns its slug

In WP Admin, open the Inspector -> Console; enter:
```
wp.apiFetch( {
  path: '/wc/gla/mc/markets',
  method: 'POST',
  data: { country: 'DE', language: [ 'de' ], currency: [ 'EUR' ] },
} ).then( r => console.log( 'created', r.id, r ), console.error );
```

Expect: created de { id: "de", country: "DE", ... }.

3. Adding a market using an ID already in use fails

In WP Admin, open the Inspector -> Console; enter:
```
wp.apiFetch( {
  path: '/wc/gla/mc/markets',
  method: 'POST',
  data: { country: 'DE', language: [ 'de' ], currency: [ 'EUR' ] },
} ).then(
  r => console.log( 'unexpected 2xx', r ),
  e => console.log( 'rejected', e )
);
```

Expect: rejected { message: "A market with this ID already exists.", id: "de" } with 409 (Conflict) on the Network tab line.

4. Clean up the test market added in this testing

In WP Admin, open the Inspector -> Console; enter:
```
wp.apiFetch( {
  path: '/wc/gla/mc/markets/de',
  method: 'DELETE',
} ).then( console.log );
```

Expect: a 200 / deletion confirmation body: `{deleted: true, id: 'de'}`


### Additional details:

> Update - Move market ID generation into MarketService::generate_market_id()
