### PR TITLE
[GOOWOO-714] Reduce redundant DB queries in MarketService::get_markets()

### DIFF
--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -59,6 +59,11 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	protected WPML $wpml;
 
 	/**
+	 * @var ?array
+	 */
+	private ?array $cached_shipping_rates = null;
+
+	/**
 	 * MarketService constructor.
 	 *
 	 * @param TargetAudience    $target_audience
@@ -98,7 +103,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		$secondary = is_array( $stored ) ? $stored : [];
 		unset( $secondary['primary'] );
 
-		$all_rates     = $this->shipping_rate_query->get_all_shipping_rates();
+		$all_rates     = $this->get_cached_shipping_rates();
 		$all_countries = $this->wc->get_countries();
 
 		foreach ( $secondary as &$market ) {
@@ -421,13 +426,29 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 */
 	private function get_primary_free_shipping_threshold(): ?float {
 		$country = $this->target_audience->get_main_target_country();
-		$rates   = $this->shipping_rate_query->get_all_shipping_rates();
+		$rates   = $this->get_cached_shipping_rates();
 
 		if ( isset( $rates[ $country ]['free_shipping_threshold'] ) ) {
 			return (float) $rates[ $country ]['free_shipping_threshold'];
 		}
 
 		return null;
+	}
+
+	/**
+	 * Returns shipping rates, fetched lazily and cached on the service instance.
+	 *
+	 * The container shares MarketService across a request, so this cache lives for
+	 * the request and is discarded when the instance is destroyed.
+	 *
+	 * @return array
+	 */
+	private function get_cached_shipping_rates(): array {
+		if ( null === $this->cached_shipping_rates ) {
+			$this->cached_shipping_rates = $this->shipping_rate_query->get_all_shipping_rates();
+		}
+
+		return $this->cached_shipping_rates;
 	}
 
 	/**

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -1191,6 +1191,37 @@ class MarketServiceTest extends UnitTest {
 	}
 
 	/**
+	 * Verifies that shipping rates are fetched once per MarketService instance.
+	 *
+	 * The assertion is on the mock, not on a return value: `expects( $this->once() )`
+	 * tells PHPUnit to fail at teardown if `get_all_shipping_rates()` is invoked
+	 * 0 times or 2+ times across the three service calls below.
+	 *
+	 * The three calls mirror the controller's create-market flow — `get_market()`
+	 * for the existence check, `get_market()` for the read-back, plus a `get_markets()`
+	 * for good measure — so a working cache yields one query, a broken cache yields three.
+	 *
+	 * Does not use `set_up_primary_market_dependencies()` because that helper attaches
+	 * a `->method('get_all_shipping_rates')` matcher to the same mock method; stacking
+	 * that with `expects( $this->once() )->method(...)` creates two rules per call and
+	 * makes the count expectation unreliable.
+	 */
+	public function test_shipping_rates_fetched_once_across_multiple_get_markets_calls(): void {
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => [] ] );
+
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US' ] );
+
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'get_all_shipping_rates' )
+			->willReturn( [] );
+
+		$this->market_service->get_market( 'some-id' );
+		$this->market_service->get_market( 'some-id' );
+		$this->market_service->get_markets();
+	}
+
+	/**
 	 * Sets up the options mock to return specific values for different option keys.
 	 *
 	 * @param array $option_map Keyed by OptionsInterface constant, values are the return values.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-714/reduce-redundant-db-queries-in-marketserviceget-markets

### Screenshots:

N/A

### Detailed test instructions:

1. Verify unit tests pass (there are no changes here that can be tested in admin)

### Additional details:

> Update - Cache shipping rates to reduce DB queries