### PR TITLE
GOOWOO-651 Signal Detection for Skipped Campaigns

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -331,7 +331,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 
 		// Notifications.
 		$this->share_with_tags( NotificationService::class, WP::class );
-		$this->share_with_tags( SkippedCampaignEvaluator::class );
+		$this->share_with_tags( SkippedCampaignEvaluator::class, AdsCampaign::class );
 		$this->share_with_tags( AbandonedOnboardingEvaluator::class, MerchantAccountState::class );
 		$this->share_with_tags( NotOnboarded90DaysEvaluator::class, OnboardingCompleted::class );
 		$this->share_with_tags( EnhancedConversionsOffEvaluator::class );

--- a/src/Notification/Evaluators/SkippedCampaignEvaluator.php
+++ b/src/Notification/Evaluators/SkippedCampaignEvaluator.php
@@ -5,9 +5,12 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignType;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\CachedNotificationEvaluatorTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
 
@@ -16,14 +19,26 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class SkippedCampaignEvaluator
  *
- * Fires when MC setup is complete and Ads setup is not complete.
+ * Fires when Ads setup is complete and the merchant has no enabled Performance Max campaigns.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
  */
-class SkippedCampaignEvaluator implements NotificationEvaluatorInterface, MerchantCenterAwareInterface, AdsAwareInterface, Service {
+class SkippedCampaignEvaluator implements NotificationEvaluatorInterface, AdsAwareInterface, Service {
 
 	use AdsAwareTrait;
-	use MerchantCenterAwareTrait;
+	use CachedNotificationEvaluatorTrait;
+
+	/** @var AdsCampaign */
+	protected $ads_campaign;
+
+	/**
+	 * SkippedCampaignEvaluator constructor.
+	 *
+	 * @param AdsCampaign $ads_campaign
+	 */
+	public function __construct( AdsCampaign $ads_campaign ) {
+		$this->ads_campaign = $ads_campaign;
+	}
 
 	/**
 	 * Get the notification's unique ID.
@@ -35,12 +50,29 @@ class SkippedCampaignEvaluator implements NotificationEvaluatorInterface, Mercha
 	}
 
 	/**
-	 * Whether the notification's condition is currently met.
+	 * Evaluate whether the notification condition is met.
 	 *
 	 * @return bool
 	 */
-	public function should_show(): bool {
-		return $this->merchant_center->is_setup_complete() && ! $this->ads_service->is_setup_complete();
+	protected function evaluate_condition(): bool {
+		if ( ! $this->ads_service->is_setup_complete() ) {
+			return false;
+		}
+
+		try {
+			foreach ( $this->ads_campaign->get_campaigns( true, false ) as $campaign ) {
+				if (
+					CampaignType::PERFORMANCE_MAX === $campaign['type']
+					&& CampaignStatus::ENABLED === $campaign['status']
+				) {
+					return false;
+				}
+			}
+		} catch ( ExceptionWithResponseData $e ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/Unit/Notification/Evaluators/SkippedCampaignEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/SkippedCampaignEvaluatorTest.php
@@ -4,7 +4,9 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignType;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
@@ -22,8 +24,8 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 	/** @var MockObject|AdsService $ads_service */
 	protected $ads_service;
 
-	/** @var MockObject|MerchantCenterService $merchant_center */
-	protected $merchant_center;
+	/** @var MockObject|AdsCampaign $ads_campaign */
+	protected $ads_campaign;
 
 	/** @var SkippedCampaignEvaluator $evaluator */
 	protected $evaluator;
@@ -34,11 +36,10 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->ads_service     = $this->createMock( AdsService::class );
-		$this->merchant_center = $this->createMock( MerchantCenterService::class );
-		$this->evaluator       = new SkippedCampaignEvaluator();
+		$this->ads_service  = $this->createMock( AdsService::class );
+		$this->ads_campaign = $this->createMock( AdsCampaign::class );
+		$this->evaluator    = new SkippedCampaignEvaluator( $this->ads_campaign );
 		$this->evaluator->set_ads_object( $this->ads_service );
-		$this->evaluator->set_merchant_center_object( $this->merchant_center );
 	}
 
 	public function test_get_id() {
@@ -53,23 +54,101 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 		$this->assertNull( $this->evaluator->get_snooze_duration() );
 	}
 
-	public function test_should_show_when_mc_complete_and_ads_incomplete() {
-		$this->merchant_center->method( 'is_setup_complete' )->willReturn( true );
+	public function test_should_not_show_when_ads_incomplete() {
 		$this->ads_service->method( 'is_setup_complete' )->willReturn( false );
-
-		$this->assertTrue( $this->evaluator->should_show() );
-	}
-
-	public function test_should_not_show_when_mc_incomplete() {
-		$this->merchant_center->method( 'is_setup_complete' )->willReturn( false );
-		$this->ads_service->method( 'is_setup_complete' )->willReturn( false );
+		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
 
 		$this->assertFalse( $this->evaluator->should_show() );
 	}
 
-	public function test_should_not_show_when_ads_complete() {
-		$this->merchant_center->method( 'is_setup_complete' )->willReturn( true );
+	public function test_should_show_when_ads_complete_and_no_campaigns() {
 		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_campaign->method( 'get_campaigns' )
+			->with( true, false )
+			->willReturn( [] );
+
+		$this->assertTrue( $this->evaluator->should_show() );
+	}
+
+	public function test_should_show_when_ads_complete_and_only_paused_pmax_campaign() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_campaign->method( 'get_campaigns' )
+			->with( true, false )
+			->willReturn(
+				[
+					[
+						'id'     => 1,
+						'type'   => CampaignType::PERFORMANCE_MAX,
+						'status' => CampaignStatus::PAUSED,
+					],
+				]
+			);
+
+		$this->assertTrue( $this->evaluator->should_show() );
+	}
+
+	public function test_should_show_when_ads_complete_and_only_non_pmax_enabled_campaign() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_campaign->method( 'get_campaigns' )
+			->with( true, false )
+			->willReturn(
+				[
+					[
+						'id'     => 1,
+						'type'   => CampaignType::SHOPPING,
+						'status' => CampaignStatus::ENABLED,
+					],
+				]
+			);
+
+		$this->assertTrue( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_enabled_pmax_campaign_present() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_campaign->method( 'get_campaigns' )
+			->with( true, false )
+			->willReturn(
+				[
+					[
+						'id'     => 1,
+						'type'   => CampaignType::PERFORMANCE_MAX,
+						'status' => CampaignStatus::ENABLED,
+					],
+				]
+			);
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_enabled_pmax_campaign_created_outside_onboarding() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_campaign->method( 'get_campaigns' )
+			->with( true, false )
+			->willReturn(
+				[
+					[
+						'id'     => 1,
+						'type'   => CampaignType::SHOPPING,
+						'status' => CampaignStatus::ENABLED,
+					],
+					[
+						'id'     => 2,
+						'type'   => CampaignType::PERFORMANCE_MAX,
+						'status' => CampaignStatus::ENABLED,
+					],
+				]
+			);
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_cache_hit_skips_api_call() {
+		$user_id = $this->login_as_administrator();
+
+		set_transient( 'gla_notif_skipped-campaign-creation_' . $user_id, 0, HOUR_IN_SECONDS );
+
+		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
 
 		$this->assertFalse( $this->evaluator->should_show() );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates the Skipped Campaign notification signal so it fires for merchants who completed G4W ads onboarding but have no enabled Performance Max campaigns in their Google Ads account.

- Replaces the previous MC-complete / ads-incomplete check with `AdsService::is_setup_complete()` (aligned with `glaData.adsSetupComplete`) plus a scan of current campaigns via `AdsCampaign::get_campaigns()`.

- Treats only enabled Performance Max campaigns as blocking the notification; paused or non-PMax campaigns do not suppress it.

- Adds evaluator result caching via `CachedNotificationEvaluatorTrait`, consistent with other campaign-based notifications.

- Registers `AdsCampaign` as a container dependency and expands unit test coverage.

Closes https://linear.app/a8c/issue/GOOWOO-651/be-signal-detection-case-1-skipped-campaign-creation

### Screenshots:
N/A


### Detailed test instructions:

Use a store with Google for WooCommerce connected and ads onboarding completed (`glaData.adsSetupComplete` is true). Test as an admin user who can manage GLA.

Verify the signal via the REST API:

`GET /wp-json/wc/gla/notifications`

Look for an entry with `"id": "skipped-campaign-creation"`.

**Scenario 1 — Notification should show**
State: Ads onboarding complete, no enabled Performance Max campaigns.

Complete onboarding without creating a campaign, or
Have only paused PMax campaigns, or
Have only non-PMax enabled campaigns (e.g. Shopping).
Expected: API returns skipped-campaign-creation in notifications.

**Scenario 2 — Notification should not show**
State: Ads onboarding complete, at least one enabled Performance Max campaign exists.

Create a PMax campaign during onboarding, or
Create one later from the GLA dashboard (outside onboarding).
Expected: `skipped-campaign-creation` is not in the response.

**Scenario 3 — Dismissal is permanent**
Trigger the notification (Scenario 1).
Dismiss it: `DELETE /wp-json/wc/gla/notifications/skipped-campaign-creation`
Reload and call GET again.
Expected: Notification does not return, even if the merchant still has no enabled PMax campaigns.

**Notes**
Clear the evaluator cache between scenario switches if results look stale: `delete transient gla_notif_skipped-campaign-creation_{user_id}`.

The REST API response is the source of truth for this signal until the notification UI is wired.