### PR TITLE
GOOWOO-740 update GH actions to node24

### DIFF
--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@actions-v2
+        uses: woocommerce/grow/branch-label@actions-v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,12 +23,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@actions-v3
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@actions-v3
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
@@ -69,7 +69,7 @@ jobs:
 
       - name: Publish dev build to GitHub
         if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
-        uses: woocommerce/grow/publish-extension-dev-build@actions-v2
+        uses: woocommerce/grow/publish-extension-dev-build@actions-v3
         with:
           extension-asset-path: google-listings-and-ads.zip
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,12 +29,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@actions-v3
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@actions-v3
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -31,12 +31,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@actions-v3
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@actions-v2
+        uses: woocommerce/grow/eslint-annotation@actions-v3
 
       - name: Lint JavaScript and annotate linting errors
         run: npm run lint:js -- --quiet --format ./eslintFormatter.cjs
@@ -49,12 +49,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@actions-v3
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/stylelint-annotation@actions-v2
+        uses: woocommerce/grow/stylelint-annotation@actions-v3
 
       - name: Lint CSS and annotate linting errors
         run: npm run lint:css -- --custom-formatter ./stylelintFormatter.cjs

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -40,7 +40,7 @@ jobs:
         run: npm run test:js
 
       - name: Upload JS unit coverage report
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/clover.xml

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@actions-v3
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@actions-v3
         with:
           tools: cs2pr
 

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -26,7 +26,7 @@ jobs:
         # This generates the documentation string. The `id` property is used to reference the output in the next step.
       - name: Generate hook documentation
         id: generate-hook-docs
-        uses: woocommerce/grow/hook-documentation@actions-v2
+        uses: woocommerce/grow/hook-documentation@actions-v3
         with:
           source-directories: src/,views/,google-listings-and-ads.php,uninstall.php
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -112,7 +112,7 @@ jobs:
 
       - if: env.generate_coverage == 'true'
         name: Upload PHP unit coverage report
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: tests/php-coverage/report.xml

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -44,12 +44,12 @@ jobs:
     steps:
       - name: Get Release versions from WordPress
         id: wp
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@actions-v3
         with:
           slug: wordpress
       - name: Get Release versions from WooCommerce
         id: wc
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@actions-v3
         with:
           source: github
           slug: woocommerce/woocommerce
@@ -88,13 +88,13 @@ jobs:
         run: echo "generate_coverage=true" >> $GITHUB_ENV
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@actions-v3
         with:
           php-version: "${{ matrix.php }}"
           coverage: "${{ env.generate_coverage == 'true' && 'xdebug' || 'none' }}"
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v2
+        uses: woocommerce/grow/prepare-mysql@actions-v3
 
       - name: Install svn (used for installing WP versions)
         run: sudo apt-get -y install subversion
@@ -132,12 +132,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@actions-v3
         with:
           php-version: "${{ inputs.php-version }}"
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v2
+        uses: woocommerce/grow/prepare-mysql@actions-v3
 
       - name: Install svn (used for installing WP versions)
         run: sudo apt-get -y install subversion

--- a/.github/workflows/post-release-merge.yml
+++ b/.github/workflows/post-release-merge.yml
@@ -18,7 +18,7 @@ jobs:
   MergeTrunkDevelopPR:
     runs-on: ubuntu-latest
     steps:
-      - uses: woocommerce/grow/merge-trunk-develop-pr@actions-v2
+      - uses: woocommerce/grow/merge-trunk-develop-pr@actions-v3
 
   delete-simulate-release-branch:
     name: Delete simulate release branch

--- a/.github/workflows/prepare-release--deprecated.yml
+++ b/.github/workflows/prepare-release--deprecated.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create branch & PR
-        uses: woocommerce/grow/prepare-extension-release@actions-v2
+        uses: woocommerce/grow/prepare-extension-release@actions-v3
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -62,7 +62,10 @@ jobs:
         with:
           name: google-listings-and-ads.zip
       - name: Run QIT Tests
-        # Update it with more stable path once merged.
+        # TODO: woocommerce/grow/run-qit-extension was removed in actions-v3 (broken and unused upstream).
+        # This step needs to be migrated to invoke the QIT CLI directly.
+        # Tracked separately; leaving on actions-v2 until that migration is done.
+        # See: https://github.com/woocommerce/grow/pull/239
         uses: woocommerce/grow/run-qit-extension@actions-v2
         with:
           qit-partner-user: ${{ secrets.QIT_PARTNER_USER }}

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -21,7 +21,7 @@ jobs:
           ref: develop
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@actions-v3
         with:
           node-version-file: ".nvmrc"
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes [GOOWOO-740](https://linear.app/a8c/issue/GOOWOO-740/update-github-actions-to-node-24-google-for-woocommerce).

**Description:**
GitHub runners began defaulting to Node 24 on June 16, 2026, deprecating Node 20 actions. This PR updates all workflows in this repo to be Node 24-compatible.

**Changes:**
- `codecov/codecov-action`: bumped SHA pin from v4.6.0 to v5.5.4. v4 is a JS action declaring `runs: using: node20`; v5 switched to a composite/shell implementation, eliminating the node runtime dependency entirely.
- `woocommerce/grow` actions: bumped all usages from `@actions-v2` to `@actions-v3` across 11 workflow files. The `actions-v3` tag was released June 12, 2026 specifically for node24 compatibility — notably `get-plugin-releases` now declares `runs: using: node24`, and `prepare-node` now calls `actions/setup-node@v6` (previously `@v4`).

**Known limitations not addressed in this PR:**
- `update-browserslist-db.yml` still uses `c2corg/browserslist-update-action@v2.5.0`, which declares `runs: using: node20`. v2.5.0 is the latest release and the main branch has no node24 update.
- `run-qit.yml` still uses `woocommerce/grow/run-qit-extension@actions-v2` — this action was intentionally removed from actions-v3 as broken and unused ([grow#239](https://github.com/woocommerce/grow/pull/239)). A TODO comment has been added. Migration to the QIT CLI directly is tracked separately.
- `deploy.yml` has `node_version: '20'` — this controls the Node.js version used to build the plugin, not the runner runtime. It's tied to `.nvmrc` and is a separate concern.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. **No node20 deprecation warnings** in any workflow run after merging. Previously these appeared as yellow annotations on every run; they should be gone for all updated workflows.
2. `js-unit-tests` — verify the codecov upload step completes without errors.
3. `php-unit-tests` — same for the codecov upload step.
4. `branch-labels`, `js-css-linting`, `php-coding-standards`, `php-hook-documentation`, `post-release-merge` — these run on PR/push events; open a test PR to trigger them and confirm they pass.
5. `update-browserslist-db.yml` will still show a node20 warning — that's expected and documented.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
