### PR TITLE
Draft: Add Google UCP feed eligibility attributes (WOOAI-634)

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -90,6 +90,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Ucp\UcpProductAttributes;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\GoogleGtagJs;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\Tracks as TracksProxy;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -166,6 +167,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		SiteVerificationMeta::class      => true,
 		BatchProductHelper::class        => true,
 		ProductFilter::class             => true,
+		UcpProductAttributes::class      => true,
 		ProductRepository::class         => true,
 		ViewFactory::class               => true,
 		DebugLogger::class               => true,
@@ -312,6 +314,10 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( ProductMetaHandler::class );
 		$this->share( ProductHelper::class, ProductMetaHandler::class, WC::class, TargetAudience::class );
 		$this->share_with_tags( ProductFilter::class, ProductHelper::class );
+
+		// Google UCP (Universal Commerce Protocol) feed eligibility (draft / WOOAI-634).
+		$this->share_with_tags( UcpProductAttributes::class );
+
 		$this->share_with_tags( ProductRepository::class, ProductMetaHandler::class, ProductFilter::class );
 		$this->share_with_tags( ProductFactory::class, AttributeManager::class, WC::class );
 		$this->share_with_tags(

--- a/src/Product/Ucp/UcpEnablement.php
+++ b/src/Product/Ucp/UcpEnablement.php
@@ -62,14 +62,28 @@ class UcpEnablement {
 		}
 
 		// Fallback: detect the woocommerce-ai plugin and read its option directly.
-		if ( ! defined( 'WCAI_VERSION' ) ) {
+		$version = static::detected_wcai_version();
+		if ( null === $version ) {
 			return false;
 		}
 
-		if ( version_compare( (string) constant( 'WCAI_VERSION' ), self::MIN_WCAI_VERSION, '<' ) ) {
+		if ( version_compare( $version, self::MIN_WCAI_VERSION, '<' ) ) {
 			return false;
 		}
 
 		return 'yes' === get_option( self::FEATURE_OPTION );
+	}
+
+	/**
+	 * The detected woocommerce-ai plugin version, or null when the plugin is not present.
+	 *
+	 * Reads the `WCAI_VERSION` constant defined by woocommerce-ai. Isolated into its own method
+	 * (and called via late static binding) so the plugin-detection branches can be exercised in
+	 * tests without defining a process-global constant.
+	 *
+	 * @return string|null
+	 */
+	protected static function detected_wcai_version(): ?string {
+		return defined( 'WCAI_VERSION' ) ? (string) constant( 'WCAI_VERSION' ) : null;
 	}
 }

--- a/src/Product/Ucp/UcpEnablement.php
+++ b/src/Product/Ucp/UcpEnablement.php
@@ -1,0 +1,75 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Ucp;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class UcpEnablement
+ *
+ * Resolves whether Google UCP (Universal Commerce Protocol) eligibility data should be added to the
+ * Merchant Center product feed.
+ *
+ * The full UCP flow depends on the external `woocommerce-ai` plugin, which owns the agentic-commerce
+ * feature flag and the checkout/cart/profile surfaces. UCP support here is gated on that plugin being
+ * present, recent enough, and enabled.
+ *
+ * NOTE (draft / WOOAI-634): This reads `woocommerce-ai` internals directly as a fallback. Once
+ * `woocommerce-ai` exposes the stable enablement contract (WOOAI-637), the
+ * `woocommerce_agentic_commerce_enabled` filter becomes the single source of truth and the fallback
+ * below can be removed.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Ucp
+ */
+class UcpEnablement {
+
+	/**
+	 * The woocommerce-ai option that toggles agentic commerce.
+	 *
+	 * @var string
+	 */
+	public const FEATURE_OPTION = 'wcai_agentic_enabled';
+
+	/**
+	 * The minimum woocommerce-ai version that ships the AgenticModule / UCP surface.
+	 *
+	 * TODO: pin once the UCP-capable woocommerce-ai version is released.
+	 *
+	 * @var string
+	 */
+	public const MIN_WCAI_VERSION = '0.3.0';
+
+	/**
+	 * Whether UCP eligibility data should be emitted for this site.
+	 *
+	 * Evaluated at runtime (during feed building) rather than at plugin boot, because both plugins
+	 * load on `plugins_loaded` and load order is not guaranteed.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled(): bool {
+		// Preferred path: the woocommerce-ai public enablement contract (WOOAI-637), if available.
+		if ( has_filter( 'woocommerce_agentic_commerce_enabled' ) ) {
+			/**
+			 * Filters whether agentic commerce / UCP is enabled for this site.
+			 *
+			 * Owned and answered authoritatively by the woocommerce-ai plugin.
+			 *
+			 * @param bool $enabled Defaults to false when no authoritative listener is attached.
+			 */
+			return (bool) apply_filters( 'woocommerce_agentic_commerce_enabled', false );
+		}
+
+		// Fallback: detect the woocommerce-ai plugin and read its option directly.
+		if ( ! defined( 'WCAI_VERSION' ) ) {
+			return false;
+		}
+
+		if ( version_compare( (string) constant( 'WCAI_VERSION' ), self::MIN_WCAI_VERSION, '<' ) ) {
+			return false;
+		}
+
+		return 'yes' === get_option( self::FEATURE_OPTION );
+	}
+}

--- a/src/Product/Ucp/UcpProductAttributes.php
+++ b/src/Product/Ucp/UcpProductAttributes.php
@@ -1,0 +1,118 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Product\Ucp;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductAdapter;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\CustomAttribute;
+use WC_Product;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class UcpProductAttributes
+ *
+ * Adds Google UCP (Universal Commerce Protocol) eligibility attributes to products as they are
+ * adapted for the Merchant Center feed.
+ *
+ * Google UCP reads the existing Merchant Center feed; products opt in to agentic checkout via feed
+ * attributes (`native_commerce`, `merchant_item_id`, and — for regulated items — `consumer_notice`).
+ * These are not typed fields on the Content API product resource, so they are attached as
+ * `customAttributes`.
+ *
+ * DRAFT / WOOAI-634 — open questions captured in the PR description:
+ *  - Content API custom attributes vs. Merchant API supplemental data source for UCP eligibility.
+ *  - `consumer_notice` (nested groupValues) is not yet emitted — needs a data source for the notice.
+ *  - The per-product `woocommerce_agentic_commerce_should_sync_product` filter's canonical home is
+ *    still being decided (WOOAI-636); it is consulted here with a default of true.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Product\Ucp
+ */
+class UcpProductAttributes implements Service, Registerable {
+
+	/**
+	 * Register the feed hook.
+	 *
+	 * The service always registers; enablement is checked at runtime in the callback so load order
+	 * between this plugin and woocommerce-ai does not matter.
+	 */
+	public function register(): void {
+		add_filter(
+			'woocommerce_gla_product_attribute_values',
+			[ $this, 'add_ucp_attributes' ],
+			20,
+			3
+		);
+	}
+
+	/**
+	 * Attach UCP eligibility custom attributes to the adapted Google product.
+	 *
+	 * Hooked on `woocommerce_gla_product_attribute_values`. The adapter is mutated directly (it is the
+	 * Google product object); the `$attributes` override array is returned unchanged.
+	 *
+	 * @param array            $attributes Attribute overrides for the product (passed through untouched).
+	 * @param WC_Product       $product    The WooCommerce product being adapted.
+	 * @param WCProductAdapter $adapter    The Google product adapter.
+	 *
+	 * @return array
+	 */
+	public function add_ucp_attributes( array $attributes, WC_Product $product, WCProductAdapter $adapter ): array {
+		if ( ! UcpEnablement::is_enabled() ) {
+			return $attributes;
+		}
+
+		if ( ! $this->is_product_ucp_eligible( $product ) ) {
+			// Not eligible: emit nothing. The product is re-submitted in full each sync, so a product
+			// that becomes ineligible simply loses `native_commerce` on the next sync.
+			return $attributes;
+		}
+
+		$this->set_custom_attribute( $adapter, 'native_commerce', 'true' );
+		$this->set_custom_attribute( $adapter, 'merchant_item_id', (string) $product->get_id() );
+
+		// TODO (WOOAI-634): emit `consumer_notice` for regulated items once a notice data source exists.
+
+		return $attributes;
+	}
+
+	/**
+	 * Whether a given product should be exposed to agentic commerce / UCP.
+	 *
+	 * @param WC_Product $product The WooCommerce product.
+	 *
+	 * @return bool
+	 */
+	protected function is_product_ucp_eligible( WC_Product $product ): bool {
+		/**
+		 * Filters whether a product opts in to agentic commerce / UCP eligibility.
+		 *
+		 * Canonical definition/home is being decided in WOOAI-636. Defaults to true once agentic
+		 * commerce is enabled site-wide.
+		 *
+		 * @param bool       $should_sync Whether the product should be UCP-eligible.
+		 * @param WC_Product $product     The WooCommerce product.
+		 */
+		return (bool) apply_filters( 'woocommerce_agentic_commerce_should_sync_product', true, $product );
+	}
+
+	/**
+	 * Append a single custom attribute to the adapted product, preserving any existing ones.
+	 *
+	 * @param WCProductAdapter $adapter The Google product adapter.
+	 * @param string           $name    Attribute name.
+	 * @param string           $value   Attribute value.
+	 */
+	protected function set_custom_attribute( WCProductAdapter $adapter, string $name, string $value ): void {
+		$custom_attributes = $adapter->getCustomAttributes() ?? [];
+
+		$attribute = new CustomAttribute();
+		$attribute->setName( $name );
+		$attribute->setValue( $value );
+
+		$custom_attributes[] = $attribute;
+		$adapter->setCustomAttributes( $custom_attributes );
+	}
+}

--- a/tests/Unit/Product/Ucp/UcpEnablementTest.php
+++ b/tests/Unit/Product/Ucp/UcpEnablementTest.php
@@ -1,0 +1,94 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\Ucp;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Ucp\UcpEnablement;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+
+/**
+ * Test subclass that overrides woocommerce-ai version detection so the plugin-detection
+ * fallback can be exercised without defining a process-global `WCAI_VERSION` constant.
+ */
+class StubUcpEnablement extends UcpEnablement {
+
+	/** @var string|null */
+	public static $stub_version = null;
+
+	protected static function detected_wcai_version(): ?string {
+		return static::$stub_version;
+	}
+}
+
+/**
+ * Class UcpEnablementTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\Ucp
+ */
+class UcpEnablementTest extends UnitTest {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		remove_all_filters( 'woocommerce_agentic_commerce_enabled' );
+		StubUcpEnablement::$stub_version = null;
+		delete_option( UcpEnablement::FEATURE_OPTION );
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'woocommerce_agentic_commerce_enabled' );
+		StubUcpEnablement::$stub_version = null;
+		delete_option( UcpEnablement::FEATURE_OPTION );
+
+		parent::tearDown();
+	}
+
+	public function test_enabled_when_contract_filter_returns_true() {
+		add_filter( 'woocommerce_agentic_commerce_enabled', '__return_true' );
+
+		$this->assertTrue( UcpEnablement::is_enabled() );
+	}
+
+	public function test_disabled_when_contract_filter_returns_false() {
+		add_filter( 'woocommerce_agentic_commerce_enabled', '__return_false' );
+
+		$this->assertFalse( UcpEnablement::is_enabled() );
+	}
+
+	public function test_contract_filter_takes_precedence_over_plugin_detection() {
+		// Filter says no even though the plugin is present, recent, and the option is on.
+		StubUcpEnablement::$stub_version = UcpEnablement::MIN_WCAI_VERSION;
+		update_option( UcpEnablement::FEATURE_OPTION, 'yes' );
+		add_filter( 'woocommerce_agentic_commerce_enabled', '__return_false' );
+
+		$this->assertFalse( StubUcpEnablement::is_enabled() );
+	}
+
+	public function test_disabled_when_plugin_absent() {
+		StubUcpEnablement::$stub_version = null;
+		update_option( UcpEnablement::FEATURE_OPTION, 'yes' );
+
+		$this->assertFalse( StubUcpEnablement::is_enabled() );
+	}
+
+	public function test_disabled_when_plugin_too_old() {
+		StubUcpEnablement::$stub_version = '0.0.1';
+		update_option( UcpEnablement::FEATURE_OPTION, 'yes' );
+
+		$this->assertFalse( StubUcpEnablement::is_enabled() );
+	}
+
+	public function test_disabled_when_plugin_present_but_option_off() {
+		StubUcpEnablement::$stub_version = UcpEnablement::MIN_WCAI_VERSION;
+		update_option( UcpEnablement::FEATURE_OPTION, 'no' );
+
+		$this->assertFalse( StubUcpEnablement::is_enabled() );
+	}
+
+	public function test_enabled_when_plugin_present_and_option_on() {
+		StubUcpEnablement::$stub_version = UcpEnablement::MIN_WCAI_VERSION;
+		update_option( UcpEnablement::FEATURE_OPTION, 'yes' );
+
+		$this->assertTrue( StubUcpEnablement::is_enabled() );
+	}
+}

--- a/tests/Unit/Product/Ucp/UcpProductAttributesTest.php
+++ b/tests/Unit/Product/Ucp/UcpProductAttributesTest.php
@@ -1,0 +1,90 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\Ucp;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Ucp\UcpProductAttributes;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductAdapter;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use WC_Helper_Product;
+
+/**
+ * Class UcpProductAttributesTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product\Ucp
+ */
+class UcpProductAttributesTest extends UnitTest {
+
+	/** @var UcpProductAttributes */
+	private $ucp_attributes;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		remove_all_filters( 'woocommerce_gla_product_attribute_values' );
+		remove_all_filters( 'woocommerce_agentic_commerce_enabled' );
+		remove_all_filters( 'woocommerce_agentic_commerce_should_sync_product' );
+
+		$this->ucp_attributes = new UcpProductAttributes();
+		$this->ucp_attributes->register();
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'woocommerce_gla_product_attribute_values' );
+		remove_all_filters( 'woocommerce_agentic_commerce_enabled' );
+		remove_all_filters( 'woocommerce_agentic_commerce_should_sync_product' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Build an adapter for a simple product and return its custom attributes as a name => value map.
+	 *
+	 * @return array
+	 */
+	private function adapt_simple_product(): array {
+		$product = WC_Helper_Product::create_simple_product();
+		$adapter = new WCProductAdapter(
+			[
+				'wc_product'    => $product,
+				'targetCountry' => 'US',
+			]
+		);
+
+		$map = [];
+		foreach ( (array) $adapter->getCustomAttributes() as $attribute ) {
+			$map[ $attribute->getName() ] = $attribute->getValue();
+		}
+
+		return [ $product, $map ];
+	}
+
+	public function test_no_attributes_when_disabled() {
+		// No `woocommerce_agentic_commerce_enabled` listener and no WCAI plugin => disabled.
+		[ , $map ] = $this->adapt_simple_product();
+
+		$this->assertArrayNotHasKey( 'native_commerce', $map );
+		$this->assertArrayNotHasKey( 'merchant_item_id', $map );
+	}
+
+	public function test_attributes_added_when_enabled() {
+		add_filter( 'woocommerce_agentic_commerce_enabled', '__return_true' );
+
+		[ $product, $map ] = $this->adapt_simple_product();
+
+		$this->assertArrayHasKey( 'native_commerce', $map );
+		$this->assertSame( 'true', $map['native_commerce'] );
+		$this->assertArrayHasKey( 'merchant_item_id', $map );
+		$this->assertSame( (string) $product->get_id(), $map['merchant_item_id'] );
+	}
+
+	public function test_no_attributes_when_product_excluded_by_filter() {
+		add_filter( 'woocommerce_agentic_commerce_enabled', '__return_true' );
+		add_filter( 'woocommerce_agentic_commerce_should_sync_product', '__return_false' );
+
+		[ , $map ] = $this->adapt_simple_product();
+
+		$this->assertArrayNotHasKey( 'native_commerce', $map );
+		$this->assertArrayNotHasKey( 'merchant_item_id', $map );
+	}
+}


### PR DESCRIPTION
## Summary

Draft / RFC for **WOOAI-634** — make Woo products eligible for **Google UCP (Universal Commerce Protocol)** checkout on Google's AI surfaces.

Google UCP does **not** use a separate catalog — it reads the existing **Merchant Center product feed** ([docs](https://developers.google.com/merchant/ucp/guides/merchant-center)). Products opt in via feed attributes, so this PR stamps them onto the product GLA already syncs:

- **`native_commerce` = `true`** — opts the product into Google checkout
- **`merchant_item_id`** — the WC product id

Because these aren't typed fields on the Content API `Product` resource, they're attached as `customAttributes` on the adapted Google product.

## What's here

- **`Product\Ucp\UcpEnablement`** — runtime gate. Prefers the woocommerce-ai public contract `woocommerce_agentic_commerce_enabled` (WOOAI-637); falls back to detecting the plugin (`WCAI_VERSION` + min version) and reading `wcai_agentic_enabled`. Evaluated during feed build, not at boot, so plugin load order doesn't matter.
- **`Product\Ucp\UcpProductAttributes`** — `Service` hooked on `woocommerce_gla_product_attribute_values`; consults the per-product `woocommerce_agentic_commerce_should_sync_product` filter (WOOAI-636) before emitting attributes. No-op when disabled or when a product is excluded.
- Wired into `CoreServiceProvider`.
- Unit tests: enabled / disabled / per-product-excluded.

## Gating

woocommerce-ai installed + min version → `wcai_agentic_enabled` (or the WOOAI-637 contract) → per-product filter → attributes emitted. With everything off it's a complete no-op; standard Shopping sync is unchanged.

## ⚠️ Open questions (why this is a draft)

1. **Delivery path — Content API vs Merchant API.** GLA writes via the **Content API for Shopping** (`ShoppingContent`), which Google's UCP docs flag as **deprecated** for this, recommending the **Merchant API** + a **supplemental data source**. This PR takes the pragmatic Content-API `customAttributes` route; **needs validation that UCP eligibility is actually honored this way.** If not, this becomes a larger Merchant-API/supplemental-feed effort.
2. **`consumer_notice`** (regulated items) is **not** emitted yet — it needs nested `groupValues` and a data source for the notice. Marked TODO.
3. **Per-product filter home.** `woocommerce_agentic_commerce_should_sync_product` doesn't exist in either repo yet (WOOAI-636); consumed here with a default of `true`. Name/signature/default to be pinned with the agentic-commerce owners.
4. **Dependency on WOOAI-637** for a stable enablement contract — until then the fallback reads woocommerce-ai internals.
5. **Scope check:** woocommerce-ai also serves on-demand `catalog.search`/`catalog.lookup`. Confirm the MC-feed eligibility path is wanted *in addition*.

## Test plan

- [ ] CI (phpcs + phpunit) — not run locally (no vendor/).
- [ ] Manual: enable agentic commerce, sync, confirm `native_commerce`/`merchant_item_id` appear on the product in Merchant Center.
- [ ] Confirm open question #1 before merge.

Refs: WOOAI-634 (this), WOOAI-636 (filter), WOOAI-637 (contract), PAY-528 (Google Pay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)