### PR TITLE
Enhancements for useApiFetchCallback.

### DIFF
--- a/js/src/components/google-mc-account-card/reclaim-url-card/index.js
+++ b/js/src/components/google-mc-account-card/reclaim-url-card/index.js
@@ -46,6 +46,7 @@ const ReclaimUrlCard = ( { id, websiteUrl, onSwitchAccount = noop } ) => {
 			path: `/wc/gla/mc/accounts/claim-overwrite`,
 			method: 'POST',
 			data: { id },
+			parse: false,
 		} );
 	const homeUrl = getSetting( 'homeUrl' );
 	const { data: existingGoogleMCAccounts } = useExistingGoogleMCAccounts();
@@ -53,7 +54,7 @@ const ReclaimUrlCard = ( { id, websiteUrl, onSwitchAccount = noop } ) => {
 
 	const handleReclaimClick = async () => {
 		reset();
-		await fetchClaimOverwrite( { parse: false } );
+		await fetchClaimOverwrite();
 		invalidateResolution( 'getGoogleMCAccount', [] );
 	};
 

--- a/js/src/components/google-mc-account-card/switch-url-card/index.js
+++ b/js/src/components/google-mc-account-card/switch-url-card/index.js
@@ -50,12 +50,13 @@ const SwitchUrlCard = ( {
 			path: `/wc/gla/mc/accounts/switch-url`,
 			method: 'POST',
 			data: { id },
+			parse: false,
 		} );
 	const homeUrl = getSetting( 'homeUrl' );
 
 	const handleSwitch = async () => {
 		try {
-			await fetchMCAccountSwitchUrl( { parse: false } );
+			await fetchMCAccountSwitchUrl();
 			invalidateResolution( 'getGoogleMCAccount', [] );
 		} catch ( e ) {
 			if ( e.status !== 403 ) {

--- a/js/src/hooks/useApiFetchCallback.js
+++ b/js/src/hooks/useApiFetchCallback.js
@@ -85,7 +85,7 @@ const shouldReturnResponseBody = ( options ) => {
  * const handleSwitch = async () => {
  * 		// make the apiFetch call here.
  * 		// account is the response body.
- * 		// you can provide option in the function call and it will be merged with the original option.
+ * 		// you can provide `data` and `query` to override those options for this specific call.
  * 		const account = await fetchMCAccountSwitchUrl();
  *
  * 		receiveMCAccount( account );
@@ -112,7 +112,7 @@ const shouldReturnResponseBody = ( options ) => {
  * ```
  *
  * @param {import('@wordpress/api-fetch').APIFetchOptions} [options] options to be forwarded to `apiFetch`.
- * @param {defaultState} initialState overwrite default state.
+ * @param {Object} [initialState] initial state values merged with the default state `{ loading, error, data, response, options }`.
  * @return {Array} `[ apiFetchCallback, fetchResult ]`
  * 		- `apiFetchCallback` is the function to be called to trigger `apiFetch`.
  * 							You call apiFetchCallback in your event handler.
@@ -122,7 +122,7 @@ const shouldReturnResponseBody = ( options ) => {
  * 							You can optionally pass in a reset state and it will be merged with the initial state.
  * 		`apiFetchCallback` accepts an optional `overwriteOptions` argument with only `data` and `query` properties.
  * 		- `data` overrides the request body for the call.
- * 		- `query` appends or overrides URL query parameters for the call.
+ * 		- `query` overrides the URL query parameters for the call.
  */
 const useApiFetchCallback = ( options, initialState = defaultState ) => {
 	const optionsRefValue = useIsEqualRefValue( options );

--- a/js/src/hooks/useApiFetchCallback.js
+++ b/js/src/hooks/useApiFetchCallback.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useReducer } from '@wordpress/element';
+import { useCallback, useMemo, useReducer } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
@@ -120,21 +120,30 @@ const shouldReturnResponseBody = ( options ) => {
  * 							`{ loading, error, data, response, options, reset }`.
  * 							`reset` is a function to reset things to initial state (clearing error, data, response and options).
  * 							You can optionally pass in a reset state and it will be merged with the initial state.
+ * 		`apiFetchCallback` accepts an optional `overwriteOptions` argument with only `data` and `query` properties.
+ * 		- `data` overrides the request body for the call.
+ * 		- `query` appends or overrides URL query parameters for the call.
  */
 const useApiFetchCallback = ( options, initialState = defaultState ) => {
 	const optionsRefValue = useIsEqualRefValue( options );
-	const mergedState = {
-		...defaultState,
-		...initialState,
-	};
+	const initialStateRefValue = useIsEqualRefValue( initialState );
+	const mergedState = useMemo(
+		() => ( { ...defaultState, ...initialStateRefValue } ),
+		[ initialStateRefValue ]
+	);
 	const [ state, dispatch ] = useReducer( reducer, mergedState );
 
 	const enhancedApiFetch = useCallback(
 		async ( overwriteOptions ) => {
-			const mergedOptions = {
-				...optionsRefValue,
-				...overwriteOptions,
-			};
+			const mergedOptions = { ...optionsRefValue };
+			if ( overwriteOptions ) {
+				if ( 'data' in overwriteOptions ) {
+					mergedOptions.data = overwriteOptions.data;
+				}
+				if ( 'query' in overwriteOptions ) {
+					mergedOptions.query = overwriteOptions.query;
+				}
+			}
 
 			dispatch( { type: TYPES.START, options: mergedOptions } );
 
@@ -200,12 +209,15 @@ const useApiFetchCallback = ( options, initialState = defaultState ) => {
 		[ optionsRefValue ]
 	);
 
-	const reset = ( resetState ) => {
-		dispatch( {
-			type: TYPES.RESET,
-			state: { ...mergedState, ...resetState },
-		} );
-	};
+	const reset = useCallback(
+		( resetState ) => {
+			dispatch( {
+				type: TYPES.RESET,
+				state: { ...mergedState, ...resetState },
+			} );
+		},
+		[ mergedState ]
+	);
 
 	const fetchResult = {
 		...state,

--- a/js/src/hooks/useConnectMCAccount.js
+++ b/js/src/hooks/useConnectMCAccount.js
@@ -18,6 +18,7 @@ const useConnectMCAccount = ( value ) => {
 		path: `/wc/gla/mc/accounts`,
 		method: 'POST',
 		data: { id: value },
+		parse: false,
 	} );
 	const {
 		invalidateResolution,
@@ -34,7 +35,7 @@ const useConnectMCAccount = ( value ) => {
 			clearDetailedErrorBySlots( [
 				ERROR_SLOTS.GOOGLE_MC_CONNECTION_ERROR_SLOT,
 			] );
-			await fetchMCAccounts( { parse: false } );
+			await fetchMCAccounts();
 			invalidateResolution( 'getGoogleMCAccount', [] );
 		} catch ( e ) {
 			if ( e?.code === 'fetch_error' ) {

--- a/js/src/hooks/useCreateMCAccount.js
+++ b/js/src/hooks/useCreateMCAccount.js
@@ -18,13 +18,13 @@ const useCreateMCAccount = () => {
 	const [ fetchCreateMCAccount, result ] = useApiFetchCallback( {
 		path: `/wc/gla/mc/accounts`,
 		method: 'POST',
+		parse: false,
 	} );
 
 	const handleCreateAccount = async () => {
 		try {
 			await fetchCreateMCAccount( {
 				data: result.error?.id && { id: result.error.id },
-				parse: false,
 			} );
 			invalidateResolution( 'getGoogleMCAccount', [] );
 		} catch ( e ) {

--- a/js/src/hooks/useUpsertAdsAccount.js
+++ b/js/src/hooks/useUpsertAdsAccount.js
@@ -41,13 +41,14 @@ const useUpsertAdsAccount = () => {
 		data: {
 			id: googleAdsAccount?.id || undefined,
 		},
+		parse: false,
 	} );
 
 	const upsertAdsAccount = useCallback( async () => {
 		setCurrentAction( isCreation ? 'create' : 'update' );
 
 		try {
-			await fetchCreateAccount( { parse: false } );
+			await fetchCreateAccount();
 		} catch ( e ) {
 			// For status code 428, we want to allow users to continue and proceed,
 			// so we swallow the error for status code 428,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes [GOOWOO-8](https://linear.app/a8c/issue/GOOWOO-8/enhancement-for-useapifetchcallback)

Improves the `useApiFetchCallback` hook with two changes:

**Stabilize and memoize returned functions:** `mergedState` is now stabilized via `useIsEqualRefValue` + `useMemo`, and reset is wrapped in `useCallback`. This makes both `enhancedApiFetch` and reset maintain stable references across renders when their inputs haven't changed, preventing unnecessary re-renders for consumer components and avoiding spurious dependency changes in downstream hooks.

**Restrict `overwriteOptions` to `data` and `query` only:** The callback returned by `useApiFetchCallback` is stateful and bound to a specific API endpoint. Allowing arbitrary option overrides at call time (e.g. `path`, `method`) creates a misuse vector where the same hook instance could be used to call unrelated endpoints. Limiting `overwriteOptions` to `data` (request body) and `query` (URL parameters) covers the only legitimate dynamic-at-call-time use cases. As part of this change, the five callsites that were passing `{ parse: false }` as an overwrite have been updated to declare `parse: false` at hook instantiation instead.


### Screenshots:

N/A. Internal hook refactor with no UI changes.


### Detailed test instructions:

1. Go through the Merchant Center setup flow and connect a Google MC account. Verify that account connection, URL switching (`switch-url-card`), and URL reclaiming (`reclaim-url-card`) continue to work correctly, including the 403 reclaim flow.
2. Go through the Google Ads account setup flow. Verify that creating or connecting a Google Ads account (`useUpsertAdsAccount`, `useCreateMCAccount`, `useConnectMCAccount`) works without regressions.
3. Trigger an error state in any of the above flows and confirm that the `reset` function correctly clears the error, then re-triggering the action works as expected.


### Additional details:

A third enhancement was considered, accepting an optional `initialData` argument to pre-populate the `data` field of the hook's state. This was not implemented because this capability already exists via the existing `initialState` second parameter (e.g. `useApiFetchCallback( options, { data: someInitialValue } )`). Adding a dedicated `initialData` parameter would duplicate existing API surface without adding new capability, making the hook signature harder to reason about for no gain.


### Changelog entry

> Dev - Stabilize `reset` function reference in `useApiFetchCallback` by wrapping it in `useCallback` with a memoized `mergedState` dependency.
> Dev - Restrict `overwriteOptions` argument of `useApiFetchCallback` callback to `data` and `query` properties only.
> Dev - Migrate five callsites from passing `parse: false` via `overwriteOptions` to declaring it at hook instantiation.
