### PR TITLE
GOOWOO-758: Allow extensions to set MAPI customAttributes via the product attribute filter

### DIFF
--- a/src/Product/WCProductInputAdapter.php
+++ b/src/Product/WCProductInputAdapter.php
@@ -74,6 +74,9 @@ class WCProductInputAdapter {
 	/** @var array */
 	protected $attributes = [];
 
+	/** @var array Merchant API custom attributes to attach to the product input. */
+	protected $custom_attributes = [];
+
 	/** @var string[] Target countries to add shipping entries for. */
 	protected $shipping_countries = [];
 
@@ -139,8 +142,44 @@ class WCProductInputAdapter {
 			$this->offer_id,
 			$this->content_language,
 			$this->feed_label,
-			$this->attributes
+			$this->attributes,
+			$this->custom_attributes
 		);
+	}
+
+	/**
+	 * Get the Merchant API custom attributes that will be attached to the product input.
+	 *
+	 * @return array
+	 */
+	public function get_custom_attributes(): array {
+		return $this->custom_attributes;
+	}
+
+	/**
+	 * Replace the Merchant API custom attributes attached to the product input.
+	 *
+	 * Each entry is a plain array matching the Merchant API CustomAttribute shape, e.g.
+	 * `[ 'name' => 'foo', 'value' => 'bar' ]` or
+	 * `[ 'name' => 'foo', 'groupValues' => [ [ 'name' => 'k', 'value' => 'v' ] ] ]`.
+	 *
+	 * @param array $custom_attributes
+	 */
+	public function set_custom_attributes( array $custom_attributes ): void {
+		$this->custom_attributes = array_values( $custom_attributes );
+	}
+
+	/**
+	 * Append a single Merchant API custom attribute to the product input.
+	 *
+	 * Intended for use from the `woocommerce_gla_product_attribute_values` filter, where the
+	 * adapter is passed as the third argument, so extensions can attach custom attributes
+	 * without modifying core GLA code.
+	 *
+	 * @param array $custom_attribute A plain array matching the Merchant API CustomAttribute shape.
+	 */
+	public function add_custom_attribute( array $custom_attribute ): void {
+		$this->custom_attributes[] = $custom_attribute;
 	}
 
 	/**

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -702,6 +702,9 @@ class WCProductInputAdapterTest extends UnitTest {
 		$this->assertSame( 'Blue', $attrs['color'] );
 	}
 
+	/**
+	 * A product input has no custom attributes unless something adds them.
+	 */
 	public function test_no_custom_attributes_by_default() {
 		$product = WC_Helper_Product::create_simple_product();
 
@@ -710,6 +713,9 @@ class WCProductInputAdapterTest extends UnitTest {
 		$this->assertSame( [], $input->get_custom_attributes() );
 	}
 
+	/**
+	 * The adapter's get/add/set custom-attribute accessors behave as expected.
+	 */
 	public function test_adapter_custom_attribute_accessors() {
 		$product = WC_Helper_Product::create_simple_product();
 		$adapter = new WCProductInputAdapter( $product, 'US' );
@@ -752,6 +758,10 @@ class WCProductInputAdapterTest extends UnitTest {
 		);
 	}
 
+	/**
+	 * The attribute-values filter can attach custom attributes to the product input
+	 * without leaking them into the typed product attributes.
+	 */
 	public function test_filter_can_add_custom_attributes() {
 		$product = WC_Helper_Product::create_simple_product();
 
@@ -806,6 +816,9 @@ class WCProductInputAdapterTest extends UnitTest {
 		$this->assertArrayNotHasKey( 'native_commerce', $attrs );
 	}
 
+	/**
+	 * Custom attributes set on the adapter are serialized under customAttributes.
+	 */
 	public function test_set_custom_attributes_replaces_and_serializes() {
 		$product = WC_Helper_Product::create_simple_product();
 

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -710,6 +710,20 @@ class WCProductInputAdapterTest extends UnitTest {
 		$this->assertSame( [], $input->get_custom_attributes() );
 	}
 
+	public function test_adapter_custom_attribute_accessors() {
+		$product = WC_Helper_Product::create_simple_product();
+		$adapter = new WCProductInputAdapter( $product, 'US' );
+
+		$this->assertSame( [], $adapter->get_custom_attributes() );
+
+		$adapter->add_custom_attribute( [ 'name' => 'x', 'value' => '1' ] );
+		$this->assertSame( [ [ 'name' => 'x', 'value' => '1' ] ], $adapter->get_custom_attributes() );
+
+		// set_custom_attributes replaces (and reindexes) the existing list.
+		$adapter->set_custom_attributes( [ 2 => [ 'name' => 'y', 'value' => '2' ] ] );
+		$this->assertSame( [ [ 'name' => 'y', 'value' => '2' ] ], $adapter->get_custom_attributes() );
+	}
+
 	public function test_filter_can_add_custom_attributes() {
 		$product = WC_Helper_Product::create_simple_product();
 

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -716,12 +716,40 @@ class WCProductInputAdapterTest extends UnitTest {
 
 		$this->assertSame( [], $adapter->get_custom_attributes() );
 
-		$adapter->add_custom_attribute( [ 'name' => 'x', 'value' => '1' ] );
-		$this->assertSame( [ [ 'name' => 'x', 'value' => '1' ] ], $adapter->get_custom_attributes() );
+		$adapter->add_custom_attribute(
+			[
+				'name'  => 'x',
+				'value' => '1',
+			]
+		);
+		$this->assertSame(
+			[
+				[
+					'name'  => 'x',
+					'value' => '1',
+				],
+			],
+			$adapter->get_custom_attributes()
+		);
 
 		// set_custom_attributes replaces (and reindexes) the existing list.
-		$adapter->set_custom_attributes( [ 2 => [ 'name' => 'y', 'value' => '2' ] ] );
-		$this->assertSame( [ [ 'name' => 'y', 'value' => '2' ] ], $adapter->get_custom_attributes() );
+		$adapter->set_custom_attributes(
+			[
+				2 => [
+					'name'  => 'y',
+					'value' => '2',
+				],
+			]
+		);
+		$this->assertSame(
+			[
+				[
+					'name'  => 'y',
+					'value' => '2',
+				],
+			],
+			$adapter->get_custom_attributes()
+		);
 	}
 
 	public function test_filter_can_add_custom_attributes() {
@@ -733,7 +761,12 @@ class WCProductInputAdapterTest extends UnitTest {
 				$adapter->add_custom_attribute(
 					[
 						'name'        => 'native_commerce',
-						'groupValues' => [ [ 'name' => 'checkout_eligibility', 'value' => 'true' ] ],
+						'groupValues' => [
+							[
+								'name'  => 'checkout_eligibility',
+								'value' => 'true',
+							],
+						],
 					]
 				);
 				$adapter->add_custom_attribute(
@@ -756,7 +789,12 @@ class WCProductInputAdapterTest extends UnitTest {
 		$this->assertCount( 2, $custom_attributes );
 		$this->assertSame( 'native_commerce', $custom_attributes[0]['name'] );
 		$this->assertSame(
-			[ [ 'name' => 'checkout_eligibility', 'value' => 'true' ] ],
+			[
+				[
+					'name'  => 'checkout_eligibility',
+					'value' => 'true',
+				],
+			],
 			$custom_attributes[0]['groupValues']
 		);
 		$this->assertSame( 'merchant_item_id', $custom_attributes[1]['name'] );
@@ -774,8 +812,14 @@ class WCProductInputAdapterTest extends UnitTest {
 		$adapter = new WCProductInputAdapter( $product, 'US' );
 		$adapter->set_custom_attributes(
 			[
-				[ 'name' => 'a', 'value' => '1' ],
-				[ 'name' => 'b', 'value' => '2' ],
+				[
+					'name'  => 'a',
+					'value' => '1',
+				],
+				[
+					'name'  => 'b',
+					'value' => '2',
+				],
 			]
 		);
 
@@ -784,8 +828,14 @@ class WCProductInputAdapterTest extends UnitTest {
 		$this->assertArrayHasKey( 'customAttributes', $serialized );
 		$this->assertSame(
 			[
-				[ 'name' => 'a', 'value' => '1' ],
-				[ 'name' => 'b', 'value' => '2' ],
+				[
+					'name'  => 'a',
+					'value' => '1',
+				],
+				[
+					'name'  => 'b',
+					'value' => '2',
+				],
 			],
 			$serialized['customAttributes']
 		);

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -701,4 +701,79 @@ class WCProductInputAdapterTest extends UnitTest {
 		$this->assertSame( 'M', $attrs['size'] );
 		$this->assertSame( 'Blue', $attrs['color'] );
 	}
+
+	public function test_no_custom_attributes_by_default() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$input = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input();
+
+		$this->assertSame( [], $input->get_custom_attributes() );
+	}
+
+	public function test_filter_can_add_custom_attributes() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		add_filter(
+			'woocommerce_gla_product_attribute_values',
+			function ( $overrides, $wc_product, $adapter ) {
+				$adapter->add_custom_attribute(
+					[
+						'name'        => 'native_commerce',
+						'groupValues' => [ [ 'name' => 'checkout_eligibility', 'value' => 'true' ] ],
+					]
+				);
+				$adapter->add_custom_attribute(
+					[
+						'name'  => 'merchant_item_id',
+						'value' => '123',
+					]
+				);
+
+				return $overrides;
+			},
+			10,
+			3
+		);
+
+		$input = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input();
+		remove_all_filters( 'woocommerce_gla_product_attribute_values' );
+
+		$custom_attributes = $input->get_custom_attributes();
+		$this->assertCount( 2, $custom_attributes );
+		$this->assertSame( 'native_commerce', $custom_attributes[0]['name'] );
+		$this->assertSame(
+			[ [ 'name' => 'checkout_eligibility', 'value' => 'true' ] ],
+			$custom_attributes[0]['groupValues']
+		);
+		$this->assertSame( 'merchant_item_id', $custom_attributes[1]['name'] );
+		$this->assertSame( '123', $custom_attributes[1]['value'] );
+
+		// Custom attributes must not leak into the typed product attributes.
+		$attrs = $input->get_attributes();
+		$this->assertArrayNotHasKey( 'customAttributes', $attrs );
+		$this->assertArrayNotHasKey( 'native_commerce', $attrs );
+	}
+
+	public function test_set_custom_attributes_replaces_and_serializes() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$adapter = new WCProductInputAdapter( $product, 'US' );
+		$adapter->set_custom_attributes(
+			[
+				[ 'name' => 'a', 'value' => '1' ],
+				[ 'name' => 'b', 'value' => '2' ],
+			]
+		);
+
+		$serialized = $adapter->get_product_input()->to_array();
+
+		$this->assertArrayHasKey( 'customAttributes', $serialized );
+		$this->assertSame(
+			[
+				[ 'name' => 'a', 'value' => '1' ],
+				[ 'name' => 'b', 'value' => '2' ],
+			],
+			$serialized['customAttributes']
+		);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Addresses [GOOWOO-758](https://linear.app/a8c/issue/GOOWOO-758). Targets `feature/mapi-migration` (where `WCProductInputAdapter` / `ProductInput` live), not `develop`.

On `feature/mapi-migration`, `WCProductInputAdapter` re-fires the public `woocommerce_gla_product_attribute_values` filter, but `get_product_input()` only passed `$this->attributes` (→ `productAttributes`) and **never populated** `ProductInput`'s 5th `custom_attributes` arg. So an extension hooking that filter had **no way to set Merchant API `customAttributes`** — they were silently dropped. The Content API adapter previously exposed `setCustomAttributes()`; that surface was lost in the migration.

This restores a small, **generic** custom-attributes surface (no UCP-specific code):

- `WCProductInputAdapter`: new `protected $custom_attributes`, plus `get_custom_attributes()` / `set_custom_attributes()` / `add_custom_attribute()`.
- `get_product_input()` forwards `$this->custom_attributes` to `ProductInput`.

Extensions mutate the adapter from the existing filter (3rd arg), mirroring the old Content API pattern:

```php
add_filter( 'woocommerce_gla_product_attribute_values', function ( $overrides, $product, $adapter ) {
    $adapter->add_custom_attribute( [
        'name'        => 'native_commerce',
        'groupValues' => [ [ 'name' => 'checkout_eligibility', 'value' => 'true' ] ],
    ] );
    return $overrides;
}, 10, 3 );
```

First consumer is Google UCP eligibility ([WOOAI-634](https://linear.app/a8c/issue/WOOAI-634)), implemented in woocommerce-ai — but this PR ships no UCP logic.

### Detailed test instructions:

1. Check out the branch and run the adapter unit tests: `vendor/bin/phpunit --filter WCProductInputAdapterTest` — the three new tests pass (`test_no_custom_attributes_by_default`, `test_filter_can_add_custom_attributes`, `test_set_custom_attributes_replaces_and_serializes`).
2. From a snippet/extension, add a `woocommerce_gla_product_attribute_values` filter that calls `$adapter->add_custom_attribute( [ 'name' => 'native_commerce', 'groupValues' => [ [ 'name' => 'checkout_eligibility', 'value' => 'true' ] ] ] )`.
3. Sync a product and confirm the outbound `productInputs.insert` body contains the entry under `customAttributes` (not `productAttributes`).
4. Confirm products with no such filter sync unchanged (empty `customAttributes`).

### Changelog entry

> Dev - Allow extensions to attach Merchant API custom attributes to synced products via the `woocommerce_gla_product_attribute_values` filter.