### PR TITLE
GOOWOO-703: Fix - convert saved flat shipping rate to manual for multilingual stores in onboarding stepper

### DIFF
--- a/js/src/components/free-listings/setup-free-listings/form-content.js
+++ b/js/src/components/free-listings/setup-free-listings/form-content.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import { SHIPPING_RATE_METHOD, SHIPPING_TIME_METHOD } from '~/constants';
 import ChooseAudienceSection from '~/components/free-listings/choose-audience-section';
 import ShippingRateSection from '~/components/shipping-rate-section';
 import ShippingTimeSection from '~/components/free-listings/configure-product-listings/shipping-time-section';
@@ -14,9 +15,10 @@ import isNonFreeShippingRate from '~/utils/isNonFreeShippingRate';
 const FormContent = () => {
 	const { values } = useAdaptiveFormContext();
 
-	const shouldDisplayShippingTime = values.shipping_time === 'flat';
+	const shouldDisplayShippingTime =
+		values.shipping_time === SHIPPING_TIME_METHOD.FLAT;
 	const shouldDisplayOrderValueCondition =
-		values.shipping_rate === 'flat' &&
+		values.shipping_rate === SHIPPING_RATE_METHOD.FLAT &&
 		values.shipping_country_rates.some( isNonFreeShippingRate );
 
 	return (

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -8,6 +8,10 @@ import { pick, noop } from 'lodash';
 /**
  * Internal dependencies
  */
+import {
+	DEFAULT_SHIPPING_MIN_TIME,
+	DEFAULT_SHIPPING_MAX_TIME,
+} from '~/constants';
 import AppSpinner from '~/components/app-spinner';
 import AppButton from '~/components/app-button';
 import AdaptiveForm from '~/components/adaptive-form';
@@ -312,9 +316,11 @@ const SetupFreeListings = ( {
 					// Derived from the first entry; the full per-country array is in shipping_country_rates.
 					flat_shipping_rate: shippingRates?.[ 0 ]?.rate,
 					// Simple flat time values for all countries (UI only, derived from shippingTimes).
-					flat_shipping_min_time: shippingTimes?.[ 0 ]?.time ?? null,
+					flat_shipping_min_time:
+						shippingTimes?.[ 0 ]?.time ?? DEFAULT_SHIPPING_MIN_TIME,
 					flat_shipping_max_time:
-						shippingTimes?.[ 0 ]?.maxTime ?? null,
+						shippingTimes?.[ 0 ]?.maxTime ??
+						DEFAULT_SHIPPING_MAX_TIME,
 					// Glue shipping rates and times together, as the Form does not support nested structures.
 					shipping_country_rates: shippingRates,
 					shipping_country_times: shippingTimes,

--- a/js/src/components/shipping-rate-section/shipping-rate-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-section.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { useAdaptiveFormContext } from '~/components/adaptive-form';
-import { glaData, SHIPPING_RATE_METHOD } from '~/constants';
+import { SHIPPING_RATE_METHOD } from '~/constants';
 import FlatShippingRatesInputCards from './flat-shipping-rates-input-cards';
 import ShippingRateMethodSection from './shipping-rate-method-section';
 
@@ -13,14 +13,12 @@ import ShippingRateMethodSection from './shipping-rate-method-section';
  */
 const ShippingRateSection = () => {
 	const { values } = useAdaptiveFormContext();
-	const { isMultiLingualStore } = glaData;
 
 	return (
 		<ShippingRateMethodSection>
-			{ ! isMultiLingualStore &&
-				values.shipping_rate === SHIPPING_RATE_METHOD.FLAT && (
-					<FlatShippingRatesInputCards />
-				) }
+			{ values.shipping_rate === SHIPPING_RATE_METHOD.FLAT && (
+				<FlatShippingRatesInputCards />
+			) }
 		</ShippingRateMethodSection>
 	);
 };

--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -49,6 +49,9 @@ export const SHIPPING_TIME_METHOD = {
 	MANUAL: 'manual',
 };
 
+export const DEFAULT_SHIPPING_MIN_TIME = 1;
+export const DEFAULT_SHIPPING_MAX_TIME = 5;
+
 // Stepper key related
 const campaignStepEntries = [
 	[ 'CAMPAIGN', 'campaign' ],

--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
@@ -51,8 +51,11 @@ const SavedSetupStepper = ( { savedStep } ) => {
 	const adminUrl = useAdminUrl();
 	const { settings, saveSettings } = useSettings();
 	const { data: suggestedAudience } = useTargetAudienceWithSuggestions();
-	const { targetAudience, getFinalCountries } =
-		useTargetAudienceFinalCountryCodes();
+	const {
+		targetAudience,
+		getFinalCountries,
+		loaded: hasResolvedTargetAudience,
+	} = useTargetAudienceFinalCountryCodes();
 	const {
 		hasFinishedResolution: hasResolvedShippingRates,
 		data: shippingRates,
@@ -101,19 +104,26 @@ const SavedSetupStepper = ( { savedStep } ) => {
 
 	// Auto-save default shipping times when no times have been saved yet.
 	useEffect( () => {
-		if ( hasResolvedShippingTimes && ! shippingTimes.length ) {
+		if (
+			hasResolvedTargetAudience &&
+			hasResolvedShippingTimes &&
+			! shippingTimes.length
+		) {
 			const countries = getFinalCountries( targetAudience );
-			if ( countries.length ) {
+
+			if ( countries?.length ) {
 				const defaultTimes = countries.map( ( countryCode ) => ( {
 					countryCode,
 					time: DEFAULT_SHIPPING_MIN_TIME,
 					maxTime: DEFAULT_SHIPPING_MAX_TIME,
 				} ) );
+
 				saveShippingTimes( defaultTimes );
 			}
 		}
 	}, [
 		hasResolvedShippingTimes,
+		hasResolvedTargetAudience,
 		shippingTimes,
 		getFinalCountries,
 		targetAudience,
@@ -171,17 +181,21 @@ const SavedSetupStepper = ( { savedStep } ) => {
 	const initShippingRates = hasResolvedShippingRates ? shippingRates : null;
 	const initShippingTimes = hasResolvedShippingTimes ? shippingTimes : null;
 	const initTargetAudience = targetAudience?.location ? targetAudience : null;
-	const initSettings = settings?.shipping_rate ? settings : null;
+	const baseSettings = settings?.shipping_rate ? { ...settings } : null;
 
-	// If the store is multilingual and the shipping rate is flat, we need to change it to manual
-	// because flat shipping rates are not supported for multilingual stores.
-	if (
-		initSettings?.shipping_rate === SHIPPING_RATE_METHOD.FLAT &&
-		glaData.isMultiLingualStore
-	) {
-		initSettings.shipping_rate = SHIPPING_RATE_METHOD.MANUAL;
-		initSettings.shipping_time = SHIPPING_TIME_METHOD.MANUAL;
-	}
+	// If the store is multilingual and the shipping rate method is set to flat,
+	// we need to override it to manual to allow for per-country shipping rates.
+	const needsManualOverride =
+		baseSettings?.shipping_rate === SHIPPING_RATE_METHOD.FLAT &&
+		glaData.isMultiLingualStore;
+
+	const initSettings = needsManualOverride
+		? {
+				...baseSettings,
+				shipping_rate: SHIPPING_RATE_METHOD.MANUAL,
+				shipping_time: SHIPPING_TIME_METHOD.MANUAL,
+		  }
+		: baseSettings;
 
 	return (
 		<Stepper

--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
@@ -143,6 +143,15 @@ const SavedSetupStepper = ( { savedStep } ) => {
 	const initTargetAudience = targetAudience?.location ? targetAudience : null;
 	const initSettings = settings?.shipping_rate ? settings : null;
 
+	// If the store is multilingual and the shipping rate is flat, we need to change it to manual
+	// because flat shipping rates are not supported for multilingual stores.
+	if (
+		initSettings?.shipping_rate === SHIPPING_RATE_METHOD.FLAT &&
+		glaData.isMultiLingualStore
+	) {
+		initSettings.shipping_rate = SHIPPING_RATE_METHOD.MANUAL;
+	}
+
 	return (
 		<Stepper
 			className="gla-setup-stepper"

--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
@@ -24,7 +24,12 @@ import SetupListings from './setup-listings';
 import SetupPaidAds from './setup-paid-ads';
 import EuPoliticalDeclarationProvider from '~/components/eu-political-declaration/eu-political-declaration-provider';
 import { STEP_NAME_KEY_MAP } from './constants';
-import { GUIDE_NAMES, SHIPPING_RATE_METHOD, glaData } from '~/constants';
+import {
+	GUIDE_NAMES,
+	SHIPPING_RATE_METHOD,
+	SHIPPING_TIME_METHOD,
+	glaData,
+} from '~/constants';
 import { getProductFeedUrl } from '~/utils/urls';
 import {
 	recordStepperChangeEvent,
@@ -85,7 +90,9 @@ const SavedSetupStepper = ( { savedStep } ) => {
 				shipping_rate: glaData.isMultiLingualStore
 					? SHIPPING_RATE_METHOD.MANUAL
 					: SHIPPING_RATE_METHOD.FLAT,
-				shipping_time: 'flat',
+				shipping_time: glaData.isMultiLingualStore
+					? SHIPPING_TIME_METHOD.MANUAL
+					: SHIPPING_TIME_METHOD.FLAT,
 			} );
 		}
 	}, [ settings, saveSettings ] );
@@ -150,6 +157,7 @@ const SavedSetupStepper = ( { savedStep } ) => {
 		glaData.isMultiLingualStore
 	) {
 		initSettings.shipping_rate = SHIPPING_RATE_METHOD.MANUAL;
+		initSettings.shipping_time = SHIPPING_TIME_METHOD.MANUAL;
 	}
 
 	return (

--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
@@ -28,6 +28,8 @@ import {
 	GUIDE_NAMES,
 	SHIPPING_RATE_METHOD,
 	SHIPPING_TIME_METHOD,
+	DEFAULT_SHIPPING_MIN_TIME,
+	DEFAULT_SHIPPING_MAX_TIME,
 	glaData,
 } from '~/constants';
 import { getProductFeedUrl } from '~/utils/urls';
@@ -96,6 +98,27 @@ const SavedSetupStepper = ( { savedStep } ) => {
 			} );
 		}
 	}, [ settings, saveSettings ] );
+
+	// Auto-save default shipping times when no times have been saved yet.
+	useEffect( () => {
+		if ( hasResolvedShippingTimes && ! shippingTimes.length ) {
+			const countries = getFinalCountries( targetAudience );
+			if ( countries.length ) {
+				const defaultTimes = countries.map( ( countryCode ) => ( {
+					countryCode,
+					time: DEFAULT_SHIPPING_MIN_TIME,
+					maxTime: DEFAULT_SHIPPING_MAX_TIME,
+				} ) );
+				saveShippingTimes( defaultTimes );
+			}
+		}
+	}, [
+		hasResolvedShippingTimes,
+		shippingTimes,
+		getFinalCountries,
+		targetAudience,
+		saveShippingTimes,
+	] );
 
 	/**
 	 * Handles "onContinue" callback to set the current step and record event tracking.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-703/show-flat-shipping-rate-option-when-it-is-the-currently-saved.

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Follow same test instruction from https://github.com/woocommerce/google-listings-and-ads/pull/3480 and https://github.com/woocommerce/google-listings-and-ads/pull/3455


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
