### PR TITLE
GOOWOO-657 Signal Detection Payment and Shipping Set But No Sales

### DIFF
--- a/js/src/notifications-system/useNotificationsSystemMap.js
+++ b/js/src/notifications-system/useNotificationsSystemMap.js
@@ -72,7 +72,7 @@ const STATIC_MAP = {
 			},
 		],
 	},
-	'payments-shipping-no-sales': {
+	'ready-but-no-sales': {
 		title: __(
 			'Get more sales with Google Ads',
 			'google-listings-and-ads'

--- a/src/Notification/Evaluators/ReadyButNoSalesEvaluator.php
+++ b/src/Notification/Evaluators/ReadyButNoSalesEvaluator.php
@@ -47,7 +47,7 @@ class ReadyButNoSalesEvaluator implements NotificationEvaluatorInterface, Servic
 	 * @return string
 	 */
 	public function get_id(): string {
-		return 'payments-shipping-no-sales';
+		return 'ready-but-no-sales';
 	}
 
 	/**

--- a/src/Notification/Evaluators/ReadyButNoSalesEvaluator.php
+++ b/src/Notification/Evaluators/ReadyButNoSalesEvaluator.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class ReadyButNoSalesEvaluator
  *
- * Fires when payment gateways are active, shipping methods are configured, and the order count is zero.
+ * Fires when at least one payment method and one shipping method are configured and the store has zero sales.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
  */
@@ -47,7 +47,7 @@ class ReadyButNoSalesEvaluator implements NotificationEvaluatorInterface, Servic
 	 * @return string
 	 */
 	public function get_id(): string {
-		return 'ready-but-no-sales';
+		return 'payments-shipping-no-sales';
 	}
 
 	/**

--- a/tests/Unit/Notification/Evaluators/ReadyButNoSalesEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/ReadyButNoSalesEvaluatorTest.php
@@ -43,7 +43,7 @@ class ReadyButNoSalesEvaluatorTest extends UnitTest {
 	}
 
 	public function test_get_id() {
-		$this->assertEquals( 'ready-but-no-sales', $this->evaluator->get_id() );
+		$this->assertEquals( 'payments-shipping-no-sales', $this->evaluator->get_id() );
 	}
 
 	public function test_get_priority() {
@@ -106,7 +106,7 @@ class ReadyButNoSalesEvaluatorTest extends UnitTest {
 		$evaluator = $this->create_evaluator_with_order_count( 0 );
 		$user_id   = $this->login_as_administrator();
 
-		set_transient( 'gla_notif_ready-but-no-sales_' . $user_id, 1, HOUR_IN_SECONDS );
+		set_transient( 'gla_notif_payments-shipping-no-sales_' . $user_id, 1, HOUR_IN_SECONDS );
 
 		$this->policy_compliance_check->expects( $this->never() )->method( 'has_payment_gateways' );
 		$evaluator->expects( $this->never() )->method( 'store_has_any_enabled_shipping_method' );

--- a/tests/Unit/Notification/Evaluators/ReadyButNoSalesEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/ReadyButNoSalesEvaluatorTest.php
@@ -43,7 +43,7 @@ class ReadyButNoSalesEvaluatorTest extends UnitTest {
 	}
 
 	public function test_get_id() {
-		$this->assertEquals( 'payments-shipping-no-sales', $this->evaluator->get_id() );
+		$this->assertEquals( 'ready-but-no-sales', $this->evaluator->get_id() );
 	}
 
 	public function test_get_priority() {
@@ -106,7 +106,7 @@ class ReadyButNoSalesEvaluatorTest extends UnitTest {
 		$evaluator = $this->create_evaluator_with_order_count( 0 );
 		$user_id   = $this->login_as_administrator();
 
-		set_transient( 'gla_notif_payments-shipping-no-sales_' . $user_id, 1, HOUR_IN_SECONDS );
+		set_transient( 'gla_notif_ready-but-no-sales_' . $user_id, 1, HOUR_IN_SECONDS );
 
 		$this->policy_compliance_check->expects( $this->never() )->method( 'has_payment_gateways' );
 		$evaluator->expects( $this->never() )->method( 'store_has_any_enabled_shipping_method' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds the Payments and Shipping Set But No Sales growth signal via `ReadyButNoSalesEvaluator`, which fires when the merchant has at least one enabled payment gateway, at least one enabled shipping method (including the default zone), and zero completed WooCommerce orders.

Aligns the evaluator notification ID with the frontend map (`ready-but-no-sales`) so the growth notification renders correctly in the notifications panel.

Closes https://linear.app/a8c/issue/GOOWOO-657/be-signal-detection-case-23-payments-and-shipping-set-but-no-sales

### Screenshots:
N/A

### Detailed test instructions:

**Should show the notification**

- Enable at least one payment gateway (e.g. Cash on delivery or Stripe).

- Add at least one enabled shipping method to any zone (including “Locations not covered by your other zones”).

- Open Marketing → Google for WooCommerce (or any GLA admin page that loads the notifications panel).

- Confirm an “Action required” card appears with “Get more sales with Google Ads” and a Get started CTA.

**Should not show notification**

- All payment gateways disabled: No notification

- No shipping methods in any zone: No notification

- At least one completed order exists: No notification

**Dismissal**
Dismiss the notification from the panel.
Reload the page — it should not reappear (for that user), as long as the store still has zero completed orders.

**API check**
As an admin, call GET `/wp-json/wc/gla/notifications` and confirm the response includes an entry with "`id`": "`ready-but-no-sales`" and a `triggered_at` timestamp when conditions are met.