### PR TITLE
Ensure incomplete connection states show as disconnected.

### DIFF
--- a/src/Ads/AccountService.php
+++ b/src/Ads/AccountService.php
@@ -85,7 +85,9 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		];
 
 		$incomplete = $this->state->last_incomplete_step();
-		if ( ! empty( $incomplete ) ) {
+
+		// Ensure that if there is an incomplete step, but we don't have an Ads ID yet, the status is 'disconnected' instead of 'incomplete'.
+		if ( ! empty( $incomplete ) && ( $id || 'set_id' !== $incomplete ) ) {
 			$status['status'] = 'incomplete';
 			$status['step']   = $incomplete;
 		}

--- a/tests/Unit/Ads/AccountServiceTest.php
+++ b/tests/Unit/Ads/AccountServiceTest.php
@@ -227,6 +227,32 @@ class AccountServiceTest extends UnitTest {
 		$this->assertEquals( self::TEST_DISCONNECTED_DATA, $this->account->get_connected_account() );
 	}
 
+	public function test_get_connected_account_with_failed_set_id_step_returns_disconnected() {
+		$this->options->expects( $this->once() )
+			->method( 'get_ads_id' )
+			->willReturn( 0 );
+
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::ADS_ACCOUNT_OCID ],
+				[ OptionsInterface::ADS_ACCOUNT_CURRENCY ],
+				[ OptionsInterface::ADS_ACCOUNT_CURRENCY ]
+			)
+			->willReturnOnConsecutiveCalls(
+				null,
+				null,
+				null
+			);
+
+		// Simulate state left behind after a failed account creation or link attempt:
+		// the set_id step is the first incomplete step but no Ads ID was stored.
+		$this->state->expects( $this->once() )
+			->method( 'last_incomplete_step' )
+			->willReturn( 'set_id' );
+
+		$this->assertEquals( self::TEST_DISCONNECTED_DATA, $this->account->get_connected_account() );
+	}
+
 	public function test_use_existing_account_already_connected() {
 		$this->options->expects( $this->once() )
 			->method( 'get_ads_id' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-761.

This fixes an issue is in `AccountService::get_connected_account()` at `src/Ads/AccountService.php:87-91`. After a failed POST to `/wc/gla/ads/accounts` (403), the ADS_ACCOUNT_STATE option gets written to the DB with `set_id` in a non-done status, making the account appear "incomplete" even though no ID was ever stored.

## Screenshot

<img width="1420" height="490" alt="image" src="https://github.com/user-attachments/assets/c6efebc0-4589-48ec-9890-b1f4364fd369" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Start on the develop branch (not this PR).

1. Disconnect all accounts
2. Filter the connect server: `define( 'WOOCOMMERCE_GLA_CONNECT_SERVER_URL', 'http://localhost' );`
3. Go to the first page of the onboarding screen and connect an existing Ads account (notice failure
4. Remove the filter and refresh the page
5. Notice the UI looks like an account with the ID `0` is connected.
6. Check out the branch with the fix
7. Refresh the onboarding page and see that the Ads account looks disconnected.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Ensure incomplete connection states show as disconnected.
