### PR TITLE
GOOWOO-706: Move default times prefill to `SavedSetupStepper`

### DIFF
--- a/js/src/components/free-listings/configure-product-listings/shipping-time-setup/shipping-countries-form.js
+++ b/js/src/components/free-listings/configure-product-listings/shipping-time-setup/shipping-countries-form.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { useEffect, useRef } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import VerticalGapLayout from '~/components/vertical-gap-layout';
@@ -30,7 +25,6 @@ export default function ShippingCountriesForm( {
 	audienceCountries,
 	onChange,
 } ) {
-	const mountedRef = useRef( false );
 	const actualCountryCount = shippingTimes.length;
 	const actualCountries = new Map(
 		shippingTimes.map( ( time ) => [ time.countryCode, time ] )
@@ -42,24 +36,6 @@ export default function ShippingCountriesForm( {
 
 	// Group countries with the same time.
 	const countriesTimeArray = getShippingTimesGroups( shippingTimes );
-
-	useEffect( () => {
-		if ( mountedRef.current ) {
-			return;
-		}
-		mountedRef.current = true;
-
-		// Prefill to-be-added time if there are selected audience countries, but no times provided yet.
-		if ( actualCountryCount === 0 && audienceCountries.length > 0 ) {
-			onChange(
-				audienceCountries.map( ( countryCode ) => ( {
-					countryCode,
-					time: 1,
-					maxTime: 5,
-				} ) )
-			);
-		}
-	} );
 
 	// Given the limitations of `<Form>` component we can communicate up only onChange.
 	// Therefore we loose the information whether it was add, change, delete.

--- a/js/src/components/free-listings/setup-free-listings/form-content.js
+++ b/js/src/components/free-listings/setup-free-listings/form-content.js
@@ -14,7 +14,11 @@ import isNonFreeShippingRate from '~/utils/isNonFreeShippingRate';
 const FormContent = () => {
 	const { values } = useAdaptiveFormContext();
 
-	const shouldDisplayShippingTime = values.shipping_time === 'flat';
+	const hasCountries =
+		values.location === 'all' || values.countries.length > 0;
+	const shouldDisplayShippingTime =
+		values.shipping_time === 'flat' && hasCountries;
+	const shouldDisplayShippingRate = hasCountries;
 	const shouldDisplayOrderValueCondition =
 		values.shipping_rate === 'flat' &&
 		values.shipping_country_rates.some( isNonFreeShippingRate );
@@ -22,7 +26,7 @@ const FormContent = () => {
 	return (
 		<>
 			<ChooseAudienceSection />
-			<ShippingRateSection />
+			{ shouldDisplayShippingRate && <ShippingRateSection /> }
 			{ shouldDisplayOrderValueCondition && (
 				<OrderValueConditionSection />
 			) }

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { createSlotFill } from '@wordpress/components';
 import { Form } from '@woocommerce/components';
 import { pick, noop } from 'lodash';
@@ -92,6 +92,29 @@ const SetupFreeListings = ( {
 } ) => {
 	const formRef = useRef();
 
+	// AdaptiveForm ignores `initialValues` changes after mount. When SavedSetupStepper
+	// auto-saves default shipping times (e.g. after the wp_gla_shipping_times table is
+	// cleared), the store updates and `shippingTimes` arrives as a new prop, but the
+	// form's internal `shipping_country_times` stays stale. This effect detects the
+	// empty → non-empty transition and pushes the new value into the live form state.
+	// skipNextTimesChangeRef prevents the resulting handleChange from firing a redundant
+	// saveShippingTimes — the data was just saved by SavedSetupStepper moments before.
+	const prevShippingTimesRef = useRef( shippingTimes );
+	const skipNextTimesChangeRef = useRef( false );
+	useEffect( () => {
+		const prev = prevShippingTimesRef.current;
+		prevShippingTimesRef.current = shippingTimes;
+
+		if ( ! formRef.current || ! shippingTimes ) {
+			return;
+		}
+
+		if ( prev?.length === 0 && shippingTimes.length > 0 ) {
+			skipNextTimesChangeRef.current = true;
+			formRef.current.setValue( 'shipping_country_times', shippingTimes );
+		}
+	}, [ shippingTimes ] );
+
 	if ( ! ( targetAudience && settings && shippingRates && shippingTimes ) ) {
 		return <AppSpinner />;
 	}
@@ -133,6 +156,13 @@ const SetupFreeListings = ( {
 				setValue( 'shipping_country_rates', nextValue );
 			}
 		} else if ( change.name === 'shipping_country_times' ) {
+			// Skip the save when the change was triggered by syncing times from the store
+			// (see skipNextTimesChangeRef above) — the data is already persisted.
+			if ( skipNextTimesChangeRef.current ) {
+				skipNextTimesChangeRef.current = false;
+				return;
+			}
+
 			// Skip the call of `onShippingTimesChange` if any shipping times are invalid.
 			const error = handleValidate( values );
 			const isValid = ! error.hasOwnProperty( change.name );

--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -42,6 +42,9 @@ export const SHIPPING_RATE_METHOD = {
 	FLAT_RATE: 'flat_rate',
 };
 
+export const DEFAULT_SHIPPING_MIN_TIME = 1;
+export const DEFAULT_SHIPPING_MAX_TIME = 5;
+
 // Stepper key related
 const campaignStepEntries = [
 	[ 'CAMPAIGN', 'campaign' ],

--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
@@ -3,7 +3,7 @@
  */
 import { Stepper } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -24,7 +24,11 @@ import SetupListings from './setup-listings';
 import SetupPaidAds from './setup-paid-ads';
 import EuPoliticalDeclarationProvider from '~/components/eu-political-declaration/eu-political-declaration-provider';
 import { STEP_NAME_KEY_MAP } from './constants';
-import { GUIDE_NAMES } from '~/constants';
+import {
+	GUIDE_NAMES,
+	DEFAULT_SHIPPING_MIN_TIME,
+	DEFAULT_SHIPPING_MAX_TIME,
+} from '~/constants';
 import { getProductFeedUrl } from '~/utils/urls';
 import {
 	recordStepperChangeEvent,
@@ -87,6 +91,35 @@ const SavedSetupStepper = ( { savedStep } ) => {
 			} );
 		}
 	}, [ settings, saveSettings ] );
+
+	// getFinalCountries is redefined inside mapSelect on every store update, giving it an
+	// unstable reference. A ref keeps the latest version without putting it in effect deps.
+	const getFinalCountriesRef = useRef( getFinalCountries );
+	getFinalCountriesRef.current = getFinalCountries;
+
+	// Auto-save default shipping times when no times have been saved yet.
+	useEffect( () => {
+		if (
+			hasResolvedShippingTimes &&
+			! shippingTimes.length &&
+			targetAudience?.location
+		) {
+			const countries = getFinalCountriesRef.current( targetAudience );
+			if ( countries.length ) {
+				const defaultTimes = countries.map( ( countryCode ) => ( {
+					countryCode,
+					time: DEFAULT_SHIPPING_MIN_TIME,
+					maxTime: DEFAULT_SHIPPING_MAX_TIME,
+				} ) );
+				saveShippingTimes( defaultTimes );
+			}
+		}
+	}, [
+		hasResolvedShippingTimes,
+		shippingTimes,
+		targetAudience,
+		saveShippingTimes,
+	] );
 
 	/**
 	 * Handles "onContinue" callback to set the current step and record event tracking.

--- a/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-setup-stepper.js
@@ -111,7 +111,16 @@ const SavedSetupStepper = ( { savedStep } ) => {
 					time: DEFAULT_SHIPPING_MIN_TIME,
 					maxTime: DEFAULT_SHIPPING_MAX_TIME,
 				} ) );
-				saveShippingTimes( defaultTimes );
+
+				saveShippingTimes( defaultTimes ).catch( () =>
+					createNotice(
+						'error',
+						__(
+							'There was an error saving shipping times.',
+							'google-listings-and-ads'
+						)
+					)
+				);
 			}
 		}
 	}, [
@@ -119,6 +128,7 @@ const SavedSetupStepper = ( { savedStep } ) => {
 		shippingTimes,
 		targetAudience,
 		saveShippingTimes,
+		createNotice,
 	] );
 
 	/**


### PR DESCRIPTION


### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-706/estimated-shipping-times-are-blank

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the onboarding
2. In the second step, without changing the default shipping times, click on continue
3. There should not be any validation error on the estimate shipping times as they are prefilled with data
4. If no countries are selected, the shipping rates and times section should not show up.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Estimated shipping times no longer show validation errors when continuing onboarding without changing the prefilled defaults.