### PR TITLE
Fixed invalid tracking prop names for GenAI flow

### DIFF
--- a/js/src/components/paid-ads/asset-group/asset-group-editor/gen-ai-image-picker/index.js
+++ b/js/src/components/paid-ads/asset-group/asset-group-editor/gen-ai-image-picker/index.js
@@ -23,9 +23,9 @@ import './index.scss';
  * Triggered when the "Add selected images" button is clicked.
  *
  * @event gla_gen_ai_image_picker_add_selected_images_click
- * @property {string} finalUrl The final URL for which the images were generated.
- * @property {string} assetKey The asset key for which the images were generated.
- * @property {number} numberOfSelectedImages The number of images that were selected to be added.
+ * @property {string} final_url The final URL for which the images were generated.
+ * @property {string} asset_key The asset key for which the images were generated.
+ * @property {number} num_selected_images The number of images that were selected to be added.
  */
 
 /**
@@ -137,9 +137,9 @@ export default function GenAIImagePicker( { assetKey, onAddSelectedImages } ) {
 					disabled={ selectedImages.length === 0 }
 					eventName="gla_gen_ai_image_picker_add_selected_images_click"
 					eventProps={ {
-						finalUrl,
-						assetKey,
-						numberOfSelectedImages: selectedImages.length,
+						final_url: finalUrl,
+						asset_key: assetKey,
+						num_selected_images: selectedImages.length,
 					} }
 				/>
 			</FlexBlock>

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -643,9 +643,9 @@ Triggered when the "Add selected images" button is clicked.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
-`finalUrl` | `string` | The final URL for which the images were generated.
-`assetKey` | `string` | The asset key for which the images were generated.
-`numberOfSelectedImages` | `number` | The number of images that were selected to be added.
+`final_url` | `string` | The final URL for which the images were generated.
+`asset_key` | `string` | The asset key for which the images were generated.
+`num_selected_images` | `number` | The number of images that were selected to be added.
 #### Emitters
 - [`exports`](../../js/src/components/paid-ads/asset-group/asset-group-editor/gen-ai-image-picker/index.js#L41) when the "Add selected images" button is clicked.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `gla_gen_ai_image_picker_add_selected_images_click` event passed its properties in camelCase (`finalUrl`, `assetKey`, `numberOfSelectedImages`) instead of the expected snake_case property names, so these were rejected + produced console warnings locally.

Closes [GOOWOO-762: AI image selection event is not tracked](https://linear.app/a8c/issue/GOOWOO-762/ai-image-selection-event-is-not-tracked)

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to Marketing > Google for WooCommerce.
2. Click to create a new campaign.
3. Set a budget and click to proceed to the next step.
4. Wait for the GenAI assets generation to complete. 
5. Select 1 or more of the generated images and click the _Add selected images_ button.
6. Notice the console log errors. 
7. **Apply the fix**.
8. Repeat steps 1-4. 
9. Type the following in the console: 
```
 const _v = window.wcTracks.validateEvent;
  window.wcTracks.validateEvent = ( n, p ) => {
      console.log( '%cTRACK', 'color:#0a0', 'wcadmin_' + n, p );
      return _v.call( window.wcTracks, n, p );
  };
```
or use your favorite tool for logging events.
10. Select 1 or more of the generated images and click the _Add selected images_ button.
11. Ensure that events are tracked. 

### Changelog entry

> Fix - Resolved console log errors when selecting AI generated images in campaigns. 
