### PR TITLE
[GOOWOO-726] Fire WP action hooks after secondary market create, update, and delete.

### DIFF
--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -276,6 +276,14 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		if ( 'manual' !== ( $config['shipping_rate'] ?? null ) ) {
 			$this->schedule_shipping_sync();
 		}
+
+		/**
+		 * Fires after a secondary market is successfully added.
+		 *
+		 * @param string $id     The market ID.
+		 * @param array  $config The market configuration as persisted, including shipping_rate and shipping_time defaults.
+		 */
+		do_action( 'woocommerce_gla_market_added', $id, $config );
 	}
 
 	/**
@@ -296,8 +304,17 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	public function update_market( string $id, array $config ): array {
 		if ( 'primary' === $id ) {
 			$this->update_primary_market_fanout( $config );
+			$updated_market = $this->get_market( $id );
 
-			return $this->get_market( $id );
+			/**
+			 * Fires after a market is successfully updated.
+			 *
+			 * @param string $id             The market ID.
+			 * @param array  $updated_market The updated market.
+			 */
+			do_action( 'woocommerce_gla_market_updated', $id, $updated_market );
+
+			return $updated_market;
 		}
 
 		$markets  = $this->get_stored_secondary_markets();
@@ -324,7 +341,17 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			}
 		}
 
-		return $this->get_market( $id );
+		$updated_market = $this->get_market( $id );
+
+		/**
+		 * Fires after a market is successfully updated.
+		 *
+		 * @param string $id             The market ID.
+		 * @param array  $updated_market The updated market.
+		 */
+		do_action( 'woocommerce_gla_market_updated', $id, $updated_market );
+
+		return $updated_market;
 	}
 
 	/**
@@ -344,10 +371,15 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			);
 		}
 
-		$markets       = $this->get_stored_secondary_markets();
-		$country       = $markets[ $id ]['country'] ?? null;
-		$feed_label    = $markets[ $id ]['feed_label'] ?? null;
-		$shipping_rate = $markets[ $id ]['shipping_rate'] ?? null;
+		$markets = $this->get_stored_secondary_markets();
+		if ( ! isset( $markets[ $id ] ) ) {
+			return;
+		}
+
+		$deleted_config = $markets[ $id ];
+		$country        = $deleted_config['country'] ?? null;
+		$feed_label     = $deleted_config['feed_label'] ?? null;
+		$shipping_rate  = $deleted_config['shipping_rate'] ?? null;
 
 		unset( $markets[ $id ] );
 		$this->options->update( OptionsInterface::MARKETS, $markets );
@@ -364,6 +396,14 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		if ( 'manual' !== $shipping_rate ) {
 			$this->schedule_shipping_sync();
 		}
+
+		/**
+		 * Fires after a secondary market is successfully deleted.
+		 *
+		 * @param string $id             The market ID.
+		 * @param array  $deleted_config The market configuration as it existed at the time of deletion.
+		 */
+		do_action( 'woocommerce_gla_market_deleted', $id, $deleted_config );
 	}
 
 	/**

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -281,9 +281,9 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		 * Fires after a secondary market is successfully added.
 		 *
 		 * @param string $id     The market ID.
-		 * @param array  $market The newly added market, fully resolved (same shape as get_market()).
+		 * @param array  $config The market configuration as persisted, including shipping_rate and shipping_time defaults.
 		 */
-		do_action( 'woocommerce_gla_market_added', $id, $this->get_market( $id ) );
+		do_action( 'woocommerce_gla_market_added', $id, $config );
 	}
 
 	/**

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -281,9 +281,9 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		 * Fires after a secondary market is successfully added.
 		 *
 		 * @param string $id     The market ID.
-		 * @param array  $config The market configuration as persisted, including shipping_rate and shipping_time defaults.
+		 * @param array  $market The newly added market, fully resolved (same shape as get_market()).
 		 */
-		do_action( 'woocommerce_gla_market_added', $id, $config );
+		do_action( 'woocommerce_gla_market_added', $id, $this->get_market( $id ) );
 	}
 
 	/**
@@ -304,17 +304,8 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	public function update_market( string $id, array $config ): array {
 		if ( 'primary' === $id ) {
 			$this->update_primary_market_fanout( $config );
-			$updated_market = $this->get_market( $id );
 
-			/**
-			 * Fires after a market is successfully updated.
-			 *
-			 * @param string $id             The market ID.
-			 * @param array  $updated_market The updated market.
-			 */
-			do_action( 'woocommerce_gla_market_updated', $id, $updated_market );
-
-			return $updated_market;
+			return $this->fire_market_updated_action( $id );
 		}
 
 		$markets  = $this->get_stored_secondary_markets();
@@ -341,13 +332,24 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			}
 		}
 
+		return $this->fire_market_updated_action( $id );
+	}
+
+	/**
+	 * Fires the woocommerce_gla_market_updated action and returns the resolved market.
+	 *
+	 * @param string $id The market ID.
+	 *
+	 * @return array The updated market, fully resolved (same shape as get_market()).
+	 */
+	private function fire_market_updated_action( string $id ): array {
 		$updated_market = $this->get_market( $id );
 
 		/**
 		 * Fires after a market is successfully updated.
 		 *
 		 * @param string $id             The market ID.
-		 * @param array  $updated_market The updated market.
+		 * @param array  $updated_market The updated market, fully resolved (same shape as get_market()).
 		 */
 		do_action( 'woocommerce_gla_market_updated', $id, $updated_market );
 
@@ -373,7 +375,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 		$markets = $this->get_stored_secondary_markets();
 		if ( ! isset( $markets[ $id ] ) ) {
-			return;
+			return; // Avoid spurious options write and shipping sync for a non-existent market.
 		}
 
 		$deleted_config = $markets[ $id ];

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -1929,8 +1929,8 @@ class MarketServiceTest extends UnitTest {
 				}
 			);
 
-		$fired_count    = 0;
-		$captured_id    = null;
+		$fired_count     = 0;
+		$captured_id     = null;
 		$captured_config = null;
 		add_action(
 			'woocommerce_gla_market_added',
@@ -2125,8 +2125,8 @@ class MarketServiceTest extends UnitTest {
 		);
 		$this->options->method( 'update' )->willReturn( true );
 
-		$fired_count    = 0;
-		$captured_id    = null;
+		$fired_count     = 0;
+		$captured_id     = null;
 		$captured_config = null;
 		add_action(
 			'woocommerce_gla_market_deleted',

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -1907,7 +1907,7 @@ class MarketServiceTest extends UnitTest {
 			'feed_label' => 'GB',
 		];
 
-		$this->set_up_options_get(
+		$this->set_up_options_get_with_tracking(
 			[
 				OptionsInterface::MERCHANT_CENTER => [
 					'shipping_rate' => 'automatic',
@@ -1917,27 +1917,17 @@ class MarketServiceTest extends UnitTest {
 				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'US' ] ],
 			]
 		);
-
-		$persisted_markets = null;
-		$this->options->method( 'update' )
-			->willReturnCallback(
-				function ( $key, $value ) use ( &$persisted_markets ) {
-					if ( OptionsInterface::MARKETS === $key ) {
-						$persisted_markets = $value;
-					}
-					return true;
-				}
-			);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
 
 		$fired_count     = 0;
 		$captured_id     = null;
-		$captured_config = null;
+		$captured_market = null;
 		add_action(
 			'woocommerce_gla_market_added',
-			function ( $id, $hook_config ) use ( &$fired_count, &$captured_id, &$captured_config ) {
+			function ( $id, $hook_market ) use ( &$fired_count, &$captured_id, &$captured_market ) {
 				++$fired_count;
 				$captured_id     = $id;
-				$captured_config = $hook_config;
+				$captured_market = $hook_market;
 			},
 			10,
 			2
@@ -1947,11 +1937,13 @@ class MarketServiceTest extends UnitTest {
 
 		$this->assertSame( 1, $fired_count );
 		$this->assertSame( 'gb', $captured_id );
-		$this->assertSame( $persisted_markets['gb'], $captured_config );
-		$this->assertSame( 'automatic', $captured_config['shipping_rate'] );
-		$this->assertSame( 'automatic', $captured_config['shipping_time'] );
-		$this->assertSame( [ 'en' ], $captured_config['language'] );
-		$this->assertSame( [ 'GBP' ], $captured_config['currency'] );
+		$this->assertSame( 'automatic', $captured_market['shipping_rate'] );
+		$this->assertSame( 'automatic', $captured_market['shipping_time'] );
+		$this->assertSame( [ 'en' ], $captured_market['language'] );
+		$this->assertSame( [ 'GBP' ], $captured_market['currency'] );
+		foreach ( [ 'countries', 'label', 'free_shipping' ] as $key ) {
+			$this->assertArrayHasKey( $key, $captured_market );
+		}
 	}
 
 	public function test_add_market_does_not_fire_market_added_hook_when_id_is_primary(): void {

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -83,6 +83,13 @@ class MarketServiceTest extends UnitTest {
 				}
 			);
 
+		// Safe defaults so get_market() can be called without per-test setup.
+		// Tests that need specific values override these via set_up_primary_market_dependencies().
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn( [] );
+		$this->wc->method( 'get_countries' )->willReturn( [] );
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( '' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [] );
+
 		$this->market_service = new MarketService(
 			$this->target_audience,
 			$this->shipping_rate_query,

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -1899,6 +1899,288 @@ class MarketServiceTest extends UnitTest {
 		$this->assertFalse( $this->market_service->has_syncable_markets() );
 	}
 
+	public function test_add_market_fires_market_added_hook_on_success(): void {
+		$config = [
+			'country'    => 'GB',
+			'language'   => [ 'en' ],
+			'currency'   => [ 'GBP' ],
+			'feed_label' => 'GB',
+		];
+
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'automatic',
+				],
+				OptionsInterface::MARKETS         => [],
+				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'US' ] ],
+			]
+		);
+
+		$persisted_markets = null;
+		$this->options->method( 'update' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$persisted_markets ) {
+					if ( OptionsInterface::MARKETS === $key ) {
+						$persisted_markets = $value;
+					}
+					return true;
+				}
+			);
+
+		$fired_count    = 0;
+		$captured_id    = null;
+		$captured_config = null;
+		add_action(
+			'woocommerce_gla_market_added',
+			function ( $id, $hook_config ) use ( &$fired_count, &$captured_id, &$captured_config ) {
+				++$fired_count;
+				$captured_id     = $id;
+				$captured_config = $hook_config;
+			},
+			10,
+			2
+		);
+
+		$this->market_service->add_market( 'gb', $config );
+
+		$this->assertSame( 1, $fired_count );
+		$this->assertSame( 'gb', $captured_id );
+		$this->assertSame( $persisted_markets['gb'], $captured_config );
+		$this->assertSame( 'automatic', $captured_config['shipping_rate'] );
+		$this->assertSame( 'automatic', $captured_config['shipping_time'] );
+		$this->assertSame( [ 'en' ], $captured_config['language'] );
+		$this->assertSame( [ 'GBP' ], $captured_config['currency'] );
+	}
+
+	public function test_add_market_does_not_fire_market_added_hook_when_id_is_primary(): void {
+		$fired = false;
+		add_action(
+			'woocommerce_gla_market_added',
+			function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		$this->expectException( InvalidValue::class );
+
+		try {
+			$this->market_service->add_market( 'primary', [] );
+		} finally {
+			$this->assertFalse( $fired );
+		}
+	}
+
+	public function test_add_market_does_not_fire_market_added_hook_when_validation_fails(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+
+		$fired = false;
+		add_action(
+			'woocommerce_gla_market_added',
+			function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		$this->expectException( InvalidValue::class );
+
+		try {
+			$this->market_service->add_market(
+				'gb',
+				[
+					'country'    => 'GB',
+					'feed_label' => '',
+					'language'   => [ 'en' ],
+					'currency'   => [ 'GBP' ],
+				]
+			);
+		} finally {
+			$this->assertFalse( $fired );
+		}
+	}
+
+	public function test_update_market_fires_market_updated_hook_on_primary_success(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [],
+				OptionsInterface::MARKETS         => [],
+				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'US' ] ],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$fired_count     = 0;
+		$captured_id     = null;
+		$captured_market = null;
+		add_action(
+			'woocommerce_gla_market_updated',
+			function ( $id, $updated_market ) use ( &$fired_count, &$captured_id, &$captured_market ) {
+				++$fired_count;
+				$captured_id     = $id;
+				$captured_market = $updated_market;
+			},
+			10,
+			2
+		);
+
+		$result = $this->market_service->update_market( 'primary', [ 'shipping_rate' => 'flat' ] );
+
+		$this->assertSame( 1, $fired_count );
+		$this->assertSame( 'primary', $captured_id );
+		$this->assertSame( $result, $captured_market );
+		foreach ( [ 'id', 'label', 'countries', 'country', 'language', 'currency', 'feed_label', 'shipping_rate', 'shipping_time', 'free_shipping' ] as $key ) {
+			$this->assertArrayHasKey( $key, $captured_market );
+		}
+	}
+
+	public function test_update_market_fires_market_updated_hook_on_secondary_success(): void {
+		$existing = [
+			'gb' => [
+				'country'       => 'GB',
+				'language'      => [ 'en' ],
+				'currency'      => [ 'GBP' ],
+				'feed_label'    => 'GB',
+				'shipping_rate' => 'flat',
+				'shipping_time' => 'flat',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$fired_count     = 0;
+		$captured_id     = null;
+		$captured_market = null;
+		add_action(
+			'woocommerce_gla_market_updated',
+			function ( $id, $updated_market ) use ( &$fired_count, &$captured_id, &$captured_market ) {
+				++$fired_count;
+				$captured_id     = $id;
+				$captured_market = $updated_market;
+			},
+			10,
+			2
+		);
+
+		$result = $this->market_service->update_market( 'gb', [ 'currency' => [ 'EUR' ] ] );
+
+		$this->assertSame( 1, $fired_count );
+		$this->assertSame( 'gb', $captured_id );
+		$this->assertSame( $result, $captured_market );
+		foreach ( [ 'countries', 'label', 'free_shipping' ] as $key ) {
+			$this->assertArrayHasKey( $key, $captured_market );
+		}
+	}
+
+	public function test_update_market_does_not_fire_market_updated_hook_when_validation_fails(): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => $existing ] );
+
+		$fired = false;
+		add_action(
+			'woocommerce_gla_market_updated',
+			function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		$this->expectException( InvalidValue::class );
+
+		try {
+			$this->market_service->update_market( 'gb', [ 'feed_label' => '' ] );
+		} finally {
+			$this->assertFalse( $fired );
+		}
+	}
+
+	public function test_delete_market_fires_market_deleted_hook_on_success(): void {
+		$existing_entry = [
+			'country'       => 'GB',
+			'language'      => [ 'en' ],
+			'currency'      => [ 'GBP' ],
+			'feed_label'    => 'GB',
+			'shipping_rate' => 'flat',
+			'shipping_time' => 'flat',
+		];
+
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [ 'gb' => $existing_entry ],
+				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'US' ] ],
+			]
+		);
+		$this->options->method( 'update' )->willReturn( true );
+
+		$fired_count    = 0;
+		$captured_id    = null;
+		$captured_config = null;
+		add_action(
+			'woocommerce_gla_market_deleted',
+			function ( $id, $deleted_config ) use ( &$fired_count, &$captured_id, &$captured_config ) {
+				++$fired_count;
+				$captured_id     = $id;
+				$captured_config = $deleted_config;
+			},
+			10,
+			2
+		);
+
+		$this->market_service->delete_market( 'gb' );
+
+		$this->assertSame( 1, $fired_count );
+		$this->assertSame( 'gb', $captured_id );
+		$this->assertSame( $existing_entry, $captured_config );
+	}
+
+	public function test_delete_market_does_not_fire_market_deleted_hook_when_id_is_primary(): void {
+		$fired = false;
+		add_action(
+			'woocommerce_gla_market_deleted',
+			function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		$this->expectException( InvalidValue::class );
+
+		try {
+			$this->market_service->delete_market( 'primary' );
+		} finally {
+			$this->assertFalse( $fired );
+		}
+	}
+
+	public function test_delete_market_does_not_fire_market_deleted_hook_when_id_not_in_stored_markets(): void {
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => [] ] );
+		$this->options->expects( $this->never() )->method( 'update' );
+
+		$fired = false;
+		add_action(
+			'woocommerce_gla_market_deleted',
+			function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		$this->market_service->delete_market( 'unknown' );
+
+		$this->assertFalse( $fired );
+	}
+
 	/**
 	 * Sets up the options mock to return specific values for different option keys.
 	 *

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -83,13 +83,6 @@ class MarketServiceTest extends UnitTest {
 				}
 			);
 
-		// Safe defaults so get_market() can be called without per-test setup.
-		// Tests that need specific values override these via set_up_primary_market_dependencies().
-		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn( [] );
-		$this->wc->method( 'get_countries' )->willReturn( [] );
-		$this->target_audience->method( 'get_main_target_country' )->willReturn( '' );
-		$this->target_audience->method( 'get_target_countries' )->willReturn( [] );
-
 		$this->market_service = new MarketService(
 			$this->target_audience,
 			$this->shipping_rate_query,
@@ -1914,7 +1907,7 @@ class MarketServiceTest extends UnitTest {
 			'feed_label' => 'GB',
 		];
 
-		$this->set_up_options_get_with_tracking(
+		$this->set_up_options_get(
 			[
 				OptionsInterface::MERCHANT_CENTER => [
 					'shipping_rate' => 'automatic',
@@ -1924,17 +1917,27 @@ class MarketServiceTest extends UnitTest {
 				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'US' ] ],
 			]
 		);
-		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$persisted_markets = null;
+		$this->options->method( 'update' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$persisted_markets ) {
+					if ( OptionsInterface::MARKETS === $key ) {
+						$persisted_markets = $value;
+					}
+					return true;
+				}
+			);
 
 		$fired_count     = 0;
 		$captured_id     = null;
-		$captured_market = null;
+		$captured_config = null;
 		add_action(
 			'woocommerce_gla_market_added',
-			function ( $id, $hook_market ) use ( &$fired_count, &$captured_id, &$captured_market ) {
+			function ( $id, $hook_config ) use ( &$fired_count, &$captured_id, &$captured_config ) {
 				++$fired_count;
 				$captured_id     = $id;
-				$captured_market = $hook_market;
+				$captured_config = $hook_config;
 			},
 			10,
 			2
@@ -1944,13 +1947,11 @@ class MarketServiceTest extends UnitTest {
 
 		$this->assertSame( 1, $fired_count );
 		$this->assertSame( 'gb', $captured_id );
-		$this->assertSame( 'automatic', $captured_market['shipping_rate'] );
-		$this->assertSame( 'automatic', $captured_market['shipping_time'] );
-		$this->assertSame( [ 'en' ], $captured_market['language'] );
-		$this->assertSame( [ 'GBP' ], $captured_market['currency'] );
-		foreach ( [ 'countries', 'label', 'free_shipping' ] as $key ) {
-			$this->assertArrayHasKey( $key, $captured_market );
-		}
+		$this->assertSame( $persisted_markets['gb'], $captured_config );
+		$this->assertSame( 'automatic', $captured_config['shipping_rate'] );
+		$this->assertSame( 'automatic', $captured_config['shipping_time'] );
+		$this->assertSame( [ 'en' ], $captured_config['language'] );
+		$this->assertSame( [ 'GBP' ], $captured_config['currency'] );
 	}
 
 	public function test_add_market_does_not_fire_market_added_hook_when_id_is_primary(): void {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-726/fire-wp-action-hooks-after-secondary-market-create-update-and-delete

### Screenshots:

N/A


### Detailed test instructions:

1. Verify unit tests pass
2. Confirm a secondary market can be added and removed (no errors / change to functionality)


### Additional details: