### PR TITLE
GOOWOO-751: Migrate account issues to MAPI

### DIFF
--- a/src/API/Google/Mapi/MapiPaths.php
+++ b/src/API/Google/Mapi/MapiPaths.php
@@ -17,4 +17,5 @@ final class MapiPaths {
 	public const PRODUCTS    = 'products/v1';
 	public const DATASOURCES = 'datasources/v1';
 	public const REPORTS     = 'reports/v1';
+	public const ACCOUNTS    = 'accounts/v1';
 }

--- a/src/API/Google/Mapi/Services/MapiAccountIssuesService.php
+++ b/src/API/Google/Mapi/Services/MapiAccountIssuesService.php
@@ -1,0 +1,81 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MapiPaths;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountIssuesService
+ *
+ * Reads account-level Merchant Center issues from the Merchant API
+ * accounts.issues.list resource.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services
+ */
+class MapiAccountIssuesService implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/** @var MerchantApiClient */
+	protected $client;
+
+	/**
+	 * MapiAccountIssuesService constructor.
+	 *
+	 * @param MerchantApiClient $client
+	 */
+	public function __construct( MerchantApiClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * Return all account-level issues for the connected merchant account.
+	 *
+	 * @return array List of AccountIssue resources, each decoded as an array.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function get_account_issues(): array {
+		$issues     = [];
+		$page_token = '';
+
+		do {
+			$response = $this->client->get( $this->build_list_path( $page_token ) );
+
+			foreach ( $response['accountIssues'] ?? [] as $issue ) {
+				$issues[] = $issue;
+			}
+
+			$page_token = $response['nextPageToken'] ?? '';
+		} while ( '' !== $page_token );
+
+		return $issues;
+	}
+
+	/**
+	 * Build the resource path for listing account issues.
+	 *
+	 * @param string $page_token
+	 *
+	 * @return string
+	 */
+	protected function build_list_path( string $page_token ): string {
+		$path = sprintf(
+			'%s/accounts/%s/issues',
+			MapiPaths::ACCOUNTS,
+			$this->options->get_merchant_id()
+		);
+
+		if ( '' !== $page_token ) {
+			$path .= '?pageToken=' . rawurlencode( $page_token );
+		}
+
+		return $path;
+	}
+}

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -22,6 +22,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
@@ -111,6 +112,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		MapiProductsService::class       => true,
 		MapiDataSourcesService::class    => true,
 		MapiProductInputsService::class  => true,
+		MapiAccountIssuesService::class  => true,
 		SiteVerification::class          => true,
 		Settings::class                  => true,
 	];
@@ -222,6 +224,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( MapiProductsService::class, MerchantApiClient::class );
 		$this->share( MapiDataSourcesService::class, MerchantApiClient::class );
 		$this->share( MapiProductInputsService::class, MerchantApiClient::class, MapiDataSourcesService::class );
+		$this->share( MapiAccountIssuesService::class, MerchantApiClient::class );
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -3,8 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductMetaQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
@@ -489,29 +489,34 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * @throws Exception If the account state can't be retrieved from Google.
 	 */
 	protected function refresh_account_issues(): void {
-		/** @var Merchant $merchant */
-		$merchant       = $this->container->get( Merchant::class );
 		$account_issues = [];
 		$created_at     = $this->cache_created_time->format( 'Y-m-d H:i:s' );
-		$issues         = $merchant->get_accountstatus()->getAccountLevelIssues() ?? [];
-		foreach ( $issues as $issue ) {
-			$key = md5( $issue->getTitle() );
+
+		/** @var MapiAccountIssuesService $account_issues_service */
+		$account_issues_service = $this->container->get( MapiAccountIssuesService::class );
+		foreach ( $account_issues_service->get_account_issues() as $issue ) {
+			$title        = $issue['title'] ?? '';
+			$key          = md5( $title );
+			$region_codes = $this->account_issue_region_codes( $issue );
 
 			if ( isset( $account_issues[ $key ] ) ) {
-				$account_issues[ $key ]['applicable_countries'][] = $issue->getCountry();
+				$account_issues[ $key ]['applicable_countries'] = array_merge(
+					$account_issues[ $key ]['applicable_countries'],
+					$region_codes
+				);
 			} else {
 				$account_issues[ $key ] = [
 					'product_id'           => 0,
 					'product'              => __( 'All products', 'google-listings-and-ads' ),
-					'code'                 => $issue->getId(),
-					'issue'                => $issue->getTitle(),
-					'action'               => $issue->getDetail(),
-					'action_url'           => $issue->getDocumentation(),
+					'code'                 => $this->account_issue_code( $issue['name'] ?? '' ),
+					'issue'                => $title,
+					'action'               => $issue['detail'] ?? '',
+					'action_url'           => $issue['documentationUri'] ?? '',
 					'created_at'           => $created_at,
 					'type'                 => self::TYPE_ACCOUNT,
-					'severity'             => $issue->getSeverity(),
+					'severity'             => $this->account_issue_severity( $issue['severity'] ?? '' ),
 					'source'               => 'mc',
-					'applicable_countries' => [ $issue->getCountry() ],
+					'applicable_countries' => $region_codes,
 				];
 
 				$account_issues[ $key ] = $this->maybe_override_issue_values( $account_issues[ $key ] );
@@ -535,6 +540,65 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		/** @var MerchantIssueQuery $issue_query */
 		$issue_query = $this->container->get( MerchantIssueQuery::class );
 		$issue_query->update_or_insert( $account_issues );
+	}
+
+	/**
+	 * Extract the region codes a Merchant API account issue impacts.
+	 *
+	 * @param array $issue AccountIssue resource, decoded as an array.
+	 *
+	 * @return string[]
+	 */
+	protected function account_issue_region_codes( array $issue ): array {
+		$codes = [];
+		foreach ( $issue['impactedDestinations'] ?? [] as $destination ) {
+			foreach ( $destination['impacts'] ?? [] as $impact ) {
+				if ( ! empty( $impact['regionCode'] ) ) {
+					$codes[] = $impact['regionCode'];
+				}
+			}
+		}
+
+		return $codes;
+	}
+
+	/**
+	 * Derive the issue code from a Merchant API account issue resource name
+	 * (accounts/{account}/issues/{issue}).
+	 *
+	 * @param string $name
+	 *
+	 * @return string
+	 */
+	protected function account_issue_code( string $name ): string {
+		if ( '' === $name ) {
+			return '';
+		}
+
+		$parts = explode( '/', $name );
+
+		// The Merchant API uses kebab-case issue ids, while the Content API codes
+		// (and the maybe_override_issue_values matches) are snake_case. Normalize so
+		// the override matching and the stored code keep the pre-migration convention.
+		return str_replace( '-', '_', (string) end( $parts ) );
+	}
+
+	/**
+	 * Map a Merchant API account issue severity.
+	 *
+	 * CRITICAL, ERROR and SUGGESTION keep the pre-migration lower-case values.
+	 * SEVERITY_UNSPECIFIED (and any unrecognized value) folds into 'error' so the
+	 * issue stays in the error bucket for both get_issue_severity() and the
+	 * only-errors filter.
+	 *
+	 * @param string $severity
+	 *
+	 * @return string
+	 */
+	protected function account_issue_severity( string $severity ): string {
+		$severity = strtolower( $severity );
+
+		return in_array( $severity, [ 'critical', self::SEVERITY_ERROR, 'suggestion' ], true ) ? $severity : self::SEVERITY_ERROR;
 	}
 
 	/**

--- a/tests/Unit/API/Google/Mapi/Services/MapiAccountIssuesServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiAccountIssuesServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountIssuesServiceTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services
+ */
+class MapiAccountIssuesServiceTest extends UnitTest {
+
+	protected const MERCHANT_ID = 12345;
+	protected const LIST_PATH   = 'accounts/v1/accounts/12345/issues';
+
+	/** @var MockObject|MerchantApiClient */
+	protected $client;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var MapiAccountIssuesService */
+	protected $service;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->client  = $this->createMock( MerchantApiClient::class );
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_merchant_id' )->willReturn( self::MERCHANT_ID );
+
+		$this->service = new MapiAccountIssuesService( $this->client );
+		$this->service->set_options_object( $this->options );
+	}
+
+	public function test_returns_account_issues() {
+		$issues = [
+			[
+				'name'  => 'accounts/12345/issues/one',
+				'title' => 'Issue one',
+			],
+			[
+				'name'  => 'accounts/12345/issues/two',
+				'title' => 'Issue two',
+			],
+		];
+
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::LIST_PATH )
+			->willReturn( [ 'accountIssues' => $issues ] );
+
+		$this->assertSame( $issues, $this->service->get_account_issues() );
+	}
+
+	public function test_returns_empty_array_when_no_issues() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::LIST_PATH )
+			->willReturn( [] );
+
+		$this->assertSame( [], $this->service->get_account_issues() );
+	}
+
+	public function test_follows_pagination() {
+		$this->client->expects( $this->exactly( 2 ) )
+			->method( 'get' )
+			->withConsecutive(
+				[ self::LIST_PATH ],
+				[ self::LIST_PATH . '?pageToken=page-2' ]
+			)
+			->willReturnOnConsecutiveCalls(
+				[
+					'accountIssues' => [ [ 'name' => 'accounts/12345/issues/one' ] ],
+					'nextPageToken' => 'page-2',
+				],
+				[
+					'accountIssues' => [ [ 'name' => 'accounts/12345/issues/two' ] ],
+				]
+			);
+
+		$this->assertSame(
+			[
+				[ 'name' => 'accounts/12345/issues/one' ],
+				[ 'name' => 'accounts/12345/issues/two' ],
+			],
+			$this->service->get_account_issues()
+		);
+	}
+}

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -18,6 +18,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\Product;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
@@ -59,6 +60,7 @@ class MerchantStatusesTest extends UnitTest {
 
 	private $merchant;
 	private $mapi_products_service;
+	private $mapi_account_issues_service;
 	private $merchant_issue_query;
 	private $merchant_center_service;
 	private $account_status;
@@ -85,6 +87,7 @@ class MerchantStatusesTest extends UnitTest {
 		parent::setUp();
 		$this->merchant                             = $this->createMock( Merchant::class );
 		$this->mapi_products_service                = $this->createMock( MapiProductsService::class );
+		$this->mapi_account_issues_service          = $this->createMock( MapiAccountIssuesService::class );
 		$this->merchant_issue_query                 = $this->createMock( MerchantIssueQuery::class );
 		$this->merchant_center_service              = $this->createMock( MerchantCenterService::class );
 		$this->account_status                       = $this->createMock( ShoppingContent\AccountStatus::class );
@@ -102,6 +105,7 @@ class MerchantStatusesTest extends UnitTest {
 		$this->container = new Container();
 		$this->container->addShared( Merchant::class, $this->merchant );
 		$this->container->addShared( MapiProductsService::class, $this->mapi_products_service );
+		$this->container->addShared( MapiAccountIssuesService::class, $this->mapi_account_issues_service );
 		$this->container->addShared( MerchantIssueQuery::class, $this->merchant_issue_query );
 		$this->container->addShared( MerchantCenterService::class, $this->merchant_center_service );
 		$this->container->addShared( TransientsInterface::class, $this->transients );
@@ -141,53 +145,46 @@ class MerchantStatusesTest extends UnitTest {
 	public function test_refresh_account_issues() {
 		$this->product_meta_query_helper->expects( $this->any() )->method( 'get_all_values' )->willReturn( [] );
 
-		$this->account_status->expects( $this->any() )
-		->method( 'getAccountLevelIssues' )
+		$this->mapi_account_issues_service->expects( $this->once() )
+		->method( 'get_account_issues' )
 		->willReturn(
 			[
-				'one'   => new ShoppingContent\AccountStatusAccountLevelIssue(
-					[
-						'id'            => 'id',
-						'title'         => 'title',
-						'country'       => 'US',
-						'destination'   => 'destination',
-						'detail'        => 'detail',
-						'documentation' => 'https://example.com',
-						'severity'      => 'critical',
-					]
-				),
-				'two'   => new ShoppingContent\AccountStatusAccountLevelIssue(
-					[
-						'id'            => 'id2',
-						'title'         => 'title2',
-						'country'       => 'CA',
-						'destination'   => 'destination2',
-						'detail'        => 'detail2',
-						'documentation' => 'https://example.com/2',
-						'severity'      => 'error',
-					]
-				),
-				'three' => new ShoppingContent\AccountStatusAccountLevelIssue(
-					[
-						'id'            => 'id2',
-						'title'         => 'title2',
-						'country'       => 'US',
-						'destination'   => 'destination2',
-						'detail'        => 'detail2',
-						'documentation' => 'https://example.com/2',
-						'severity'      => 'error',
-					]
-				),
+				[
+					'name'                 => 'accounts/12345/issues/id',
+					'title'                => 'title',
+					'detail'               => 'detail',
+					'documentationUri'     => 'https://example.com',
+					'severity'             => 'CRITICAL',
+					'impactedDestinations' => [
+						[ 'impacts' => [ [ 'regionCode' => 'US' ] ] ],
+					],
+				],
+				[
+					'name'                 => 'accounts/12345/issues/id2',
+					'title'                => 'title2',
+					'detail'               => 'detail2',
+					'documentationUri'     => 'https://example.com/2',
+					'severity'             => 'ERROR',
+					'impactedDestinations' => [
+						[ 'impacts' => [ [ 'regionCode' => 'CA' ], [ 'regionCode' => 'US' ] ] ],
+					],
+				],
+				[
+					'name'                 => 'accounts/12345/issues/id3',
+					'title'                => 'title3',
+					'detail'               => 'detail3',
+					'documentationUri'     => 'https://example.com/3',
+					'severity'             => 'SEVERITY_UNSPECIFIED',
+					'impactedDestinations' => [
+						[ 'impacts' => [ [ 'regionCode' => 'GB' ] ] ],
+					],
+				],
 			]
 		);
 
 		$this->merchant_center_service->expects( $this->any() )
 		->method( 'is_connected' )
 		->willReturn( true );
-
-		$this->merchant->expects( $this->any() )
-		->method( 'get_accountstatus' )
-		->willReturn( $this->account_status );
 
 		$issues = [
 			md5( 'title' )  => [
@@ -216,11 +213,70 @@ class MerchantStatusesTest extends UnitTest {
 				'source'               => 'mc',
 				'applicable_countries' => '["CA","US"]',
 			],
+			md5( 'title3' ) => [
+				'product_id'           => 0,
+				'product'              => 'All products',
+				'code'                 => 'id3',
+				'issue'                => 'title3',
+				'action'               => 'detail3',
+				'action_url'           => 'https://example.com/3',
+				'created_at'           => $this->merchant_statuses->get_cache_created_time()->format( 'Y-m-d H:i:s' ),
+				'type'                 => 'account',
+				'severity'             => 'error',
+				'source'               => 'mc',
+				'applicable_countries' => '["GB"]',
+			],
 		];
 
 		$this->merchant_issue_query->expects( $this->exactly( 2 ) )
 		->method( 'update_or_insert' )
 		->withConsecutive( [ $issues ], [] );
+		$this->merchant_statuses->refresh_account_and_presync_issues();
+	}
+
+	public function test_refresh_account_issues_overrides_home_page_issue() {
+		$this->product_meta_query_helper->expects( $this->any() )->method( 'get_all_values' )->willReturn( [] );
+
+		$this->mapi_account_issues_service->expects( $this->once() )
+		->method( 'get_account_issues' )
+		->willReturn(
+			[
+				[
+					'name'                 => 'accounts/12345/issues/home-page-issue',
+					'title'                => 'Some original Google title',
+					'detail'               => 'detail',
+					'documentationUri'     => 'https://example.com',
+					'severity'             => 'ERROR',
+					'impactedDestinations' => [
+						[ 'impacts' => [ [ 'regionCode' => 'US' ] ] ],
+					],
+				],
+			]
+		);
+
+		$this->merchant_center_service->expects( $this->any() )
+		->method( 'is_connected' )
+		->willReturn( true );
+
+		$expected = [
+			md5( 'Some original Google title' ) => [
+				'product_id'           => 0,
+				'product'              => 'All products',
+				'code'                 => 'home_page_issue',
+				'issue'                => 'Website claim is lost, need to re verify and claim your website. Please reference the support link',
+				'action'               => 'detail',
+				'action_url'           => 'https://woocommerce.com/document/google-for-woocommerce/faq/#reverify-website',
+				'created_at'           => $this->merchant_statuses->get_cache_created_time()->format( 'Y-m-d H:i:s' ),
+				'type'                 => 'account',
+				'severity'             => 'error',
+				'source'               => 'mc',
+				'applicable_countries' => '["US"]',
+			],
+		];
+
+		$this->merchant_issue_query->expects( $this->exactly( 2 ) )
+		->method( 'update_or_insert' )
+		->withConsecutive( [ $expected ], [] );
 		$this->merchant_statuses->refresh_account_and_presync_issues();
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-751/migrate-account-issues-to-mapi

Moves Merchant Center account-level issues from the Content API to the MAPI (accounts.issues.list), continuing the MAPI migration.

Note, this work is based on https://github.com/woocommerce/google-listings-and-ads/pull/3508. After that PR gets merged, the base branch should be changed to `feature/mapi-migration`


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

- Connect to a Merchant Center account that has at least one account-level issue (unclaimed website, missing business info, account under review).
- Go to Marketing -> Google for WooCommerce -> Product Feed -> "Issues to resolve". Account issues sort first, shown against "All products".
- Confirm they match Merchant Center: title, action link, severity, and countries.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

Migrate Merchant Center account issues to the MAPI.
>
