### PR TITLE
GOOWOO-753: Migrate website claim (status + action) to MAPI

### DIFF
--- a/src/API/Google/Mapi/Services/MapiAccountHomepageService.php
+++ b/src/API/Google/Mapi/Services/MapiAccountHomepageService.php
@@ -1,0 +1,78 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MapiPaths;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountHomepageService
+ *
+ * Reads and claims the store homepage via the Merchant API accounts.homepage
+ * resource, which exposes the website uri and claimed status plus the claim action.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services
+ */
+class MapiAccountHomepageService implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/** @var MerchantApiClient */
+	protected $client;
+
+	/**
+	 * MapiAccountHomepageService constructor.
+	 *
+	 * @param MerchantApiClient $client
+	 */
+	public function __construct( MerchantApiClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * Retrieve the homepage resource for a merchant account.
+	 *
+	 * @param int $merchant_id Optional - the account to read. Defaults to the connected account.
+	 *
+	 * @return array Homepage resource decoded as an array (uri, claimed).
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function get_homepage( int $merchant_id = 0 ): array {
+		return $this->client->get( $this->build_path( $merchant_id ) );
+	}
+
+	/**
+	 * Claim the store homepage for the connected merchant account.
+	 *
+	 * @param bool $overwrite Whether to remove an existing claim from another account.
+	 *
+	 * @return array Homepage resource decoded as an array.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function claim( bool $overwrite = false ): array {
+		return $this->client->post( $this->build_path() . ':claim', [ 'overwrite' => $overwrite ] );
+	}
+
+	/**
+	 * Build the homepage resource path for a merchant account.
+	 *
+	 * @param int $merchant_id Optional - the account to target. Defaults to the connected account.
+	 *
+	 * @return string
+	 */
+	protected function build_path( int $merchant_id = 0 ): string {
+		$merchant_id = $merchant_id ?: $this->options->get_merchant_id();
+
+		return sprintf(
+			'%s/accounts/%s/homepage',
+			MapiPaths::ACCOUNTS,
+			$merchant_id
+		);
+	}
+}

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
@@ -40,12 +42,21 @@ class Merchant implements OptionsAwareInterface {
 	protected $service;
 
 	/**
+	 * The Merchant API homepage service.
+	 *
+	 * @var MapiAccountHomepageService
+	 */
+	protected $homepage_service;
+
+	/**
 	 * Merchant constructor.
 	 *
-	 * @param ShoppingContent $service
+	 * @param ShoppingContent            $service
+	 * @param MapiAccountHomepageService $homepage_service
 	 */
-	public function __construct( ShoppingContent $service ) {
-		$this->service = $service;
+	public function __construct( ShoppingContent $service, MapiAccountHomepageService $homepage_service ) {
+		$this->service          = $service;
+		$this->homepage_service = $homepage_service;
 	}
 
 	/**
@@ -56,11 +67,10 @@ class Merchant implements OptionsAwareInterface {
 	 */
 	public function claimwebsite(): bool {
 		try {
-			$id = $this->options->get_merchant_id();
-			$this->service->accounts->claimwebsite( $id, $id );
+			$this->homepage_service->claim();
 			do_action( 'woocommerce_gla_site_claim_success', [ 'details' => 'google_proxy' ] );
-		} catch ( GoogleException $e ) {
-			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
+		} catch ( MerchantApiException $e ) {
+			// The woocommerce_gla_mc_client_exception action is fired by MerchantApiException::__construct().
 			do_action( 'woocommerce_gla_site_claim_failure', [ 'details' => 'google_proxy' ] );
 
 			if ( $this->is_website_claim_conflict_error( $e ) ) {
@@ -82,51 +92,18 @@ class Merchant implements OptionsAwareInterface {
 	/**
 	 * Check if the exception indicates a website claim conflict error.
 	 *
-	 * This handles Content API error format by checking structured error data.
-	 * The API used to return 403, but now returns 400 with specific error details.
+	 * The Merchant API returns a FAILED_PRECONDITION status when the homepage is
+	 * already claimed by another account and overwrite was not requested.
 	 *
-	 * Content API error structure:
-	 * - code: 400
-	 * - errors[].domain: "content.ContentErrorDomain"
-	 * - errors[].message: contains "overwrite"
-	 *
-	 * TODO: When migrating to Merchant API, it may have a different error format.
-	 * Possible fields to check:
-	 * - code: 400
-	 * - status: "FAILED_PRECONDITION"
-	 * - details[].metadata.REASON: "INVALID_TRANSITION_CLAIMED_DESCENDANTS"
-	 *
-	 * @param GoogleException $e The exception to check.
+	 * @param MerchantApiException $e The exception to check.
 	 * @return bool True if the error indicates a claim conflict.
 	 */
-	private function is_website_claim_conflict_error( GoogleException $e ): bool {
-		$code = $e->getCode();
-
-		// The API used to return 403, kept here in case some undiscovered conditions still return it.
-		if ( $code === 403 ) {
+	private function is_website_claim_conflict_error( MerchantApiException $e ): bool {
+		if ( 403 === $e->get_http_status() ) {
 			return true;
 		}
 
-		if ( $code !== 400 ) {
-			return false;
-		}
-
-		// Check structured error data from Content API.
-		if ( $e instanceof GoogleServiceException ) {
-			$errors = $e->getErrors();
-			if ( is_array( $errors ) ) {
-				foreach ( $errors as $error ) {
-					$is_content_api_domain = isset( $error['domain'] ) && $error['domain'] === 'content.ContentErrorDomain';
-					$has_overwrite_message = isset( $error['message'] ) && stripos( $error['message'], 'overwrite' ) !== false;
-
-					if ( $is_content_api_domain && $has_overwrite_message ) {
-						return true;
-					}
-				}
-			}
-		}
-
-		return false;
+		return 'FAILED_PRECONDITION' === ( $e->get_response_body()['error']['status'] ?? '' );
 	}
 
 	/**
@@ -243,9 +220,10 @@ class Merchant implements OptionsAwareInterface {
 
 		if ( empty( $claimed_url_hash ) && $this->options->get_merchant_id() ) {
 			try {
-				$account_url = $this->get_account()->getWebsiteUrl();
+				$homepage    = $this->homepage_service->get_homepage();
+				$account_url = $homepage['uri'] ?? '';
 
-				if ( empty( $account_url ) || ! $this->get_accountstatus()->getWebsiteClaimed() ) {
+				if ( empty( $account_url ) || empty( $homepage['claimed'] ) ) {
 					return null;
 				}
 

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -22,6 +22,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
@@ -82,39 +83,40 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * @var array
 	 */
 	protected $provides = [
-		Client::class                    => true,
-		ShoppingContent::class           => true,
-		GoogleAdsClient::class           => true,
-		GuzzleClient::class              => true,
-		Middleware::class                => true,
-		Merchant::class                  => true,
-		MerchantMetrics::class           => true,
-		Ads::class                       => true,
-		AdsIncentives::class             => true,
-		AdsAssetGroup::class             => true,
-		AdsCampaign::class               => true,
-		AdsCampaignAsset::class          => true,
-		AdsCampaignBudget::class         => true,
-		AdsCampaignLabel::class          => true,
-		AdsConversionAction::class       => true,
-		AdsReport::class                 => true,
-		AdsRecommendationsService::class => true,
-		AdsAssetGenerationService::class => true,
-		AdsAssetGroupAsset::class        => true,
-		AdsAsset::class                  => true,
-		BudgetMetrics::class             => true,
-		BudgetRecommendations::class     => true,
-		'connect_server_root'            => true,
-		Connection::class                => true,
-		GoogleProductService::class      => true,
-		GooglePromotionService::class    => true,
-		MerchantApiClient::class         => true,
-		MapiProductsService::class       => true,
-		MapiDataSourcesService::class    => true,
-		MapiProductInputsService::class  => true,
-		MapiAccountIssuesService::class  => true,
-		SiteVerification::class          => true,
-		Settings::class                  => true,
+		Client::class                     => true,
+		ShoppingContent::class            => true,
+		GoogleAdsClient::class            => true,
+		GuzzleClient::class               => true,
+		Middleware::class                 => true,
+		Merchant::class                   => true,
+		MerchantMetrics::class            => true,
+		Ads::class                        => true,
+		AdsIncentives::class              => true,
+		AdsAssetGroup::class              => true,
+		AdsCampaign::class                => true,
+		AdsCampaignAsset::class           => true,
+		AdsCampaignBudget::class          => true,
+		AdsCampaignLabel::class           => true,
+		AdsConversionAction::class        => true,
+		AdsReport::class                  => true,
+		AdsRecommendationsService::class  => true,
+		AdsAssetGenerationService::class  => true,
+		AdsAssetGroupAsset::class         => true,
+		AdsAsset::class                   => true,
+		BudgetMetrics::class              => true,
+		BudgetRecommendations::class      => true,
+		'connect_server_root'             => true,
+		Connection::class                 => true,
+		GoogleProductService::class       => true,
+		GooglePromotionService::class     => true,
+		MerchantApiClient::class          => true,
+		MapiProductsService::class        => true,
+		MapiDataSourcesService::class     => true,
+		MapiProductInputsService::class   => true,
+		MapiAccountIssuesService::class   => true,
+		MapiAccountHomepageService::class => true,
+		SiteVerification::class           => true,
+		Settings::class                   => true,
 	];
 
 	/**
@@ -149,7 +151,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( BudgetMetrics::class, GoogleAdsClient::class );
 		$this->share( BudgetRecommendations::class, GoogleAdsClient::class );
 
-		$this->share( Merchant::class, ShoppingContent::class );
+		$this->share( Merchant::class, ShoppingContent::class, MapiAccountHomepageService::class );
 		$this->share( MerchantMetrics::class, MerchantApiClient::class, GoogleAdsClient::class, WP::class, TransientsInterface::class );
 		$this->share( MerchantReport::class, ProductHelper::class, MerchantApiClient::class );
 
@@ -225,6 +227,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( MapiDataSourcesService::class, MerchantApiClient::class );
 		$this->share( MapiProductInputsService::class, MerchantApiClient::class, MapiDataSourcesService::class );
 		$this->share( MapiAccountIssuesService::class, MerchantApiClient::class );
+		$this->share( MapiAccountHomepageService::class, MerchantApiClient::class );
 	}
 
 	/**

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
@@ -350,7 +351,8 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 					case 'claim':
 						// At this step, the website URL is assumed to be correct.
 						// If the URL is already claimed, no claim should be attempted.
-						if ( $merchant->get_accountstatus( $merchant_id )->getWebsiteClaimed() ) {
+						$homepage = $this->container->get( MapiAccountHomepageService::class )->get_homepage( $merchant_id );
+						if ( ! empty( $homepage['claimed'] ) ) {
 							break;
 						}
 
@@ -474,7 +476,8 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 
 		if ( untrailingslashit( $site_url ) !== untrailingslashit( $account_url ) ) {
 
-			$is_website_claimed = $merchant->get_accountstatus( $merchant_id )->getWebsiteClaimed();
+			$homepage           = $this->container->get( MapiAccountHomepageService::class )->get_homepage( $merchant_id );
+			$is_website_claimed = ! empty( $homepage['claimed'] );
 
 			if ( ! empty( $account_url ) && $is_website_claimed && ! $this->allow_switch_url ) {
 				$state                              = $this->state->get();

--- a/tests/Unit/API/Google/Mapi/Services/MapiAccountHomepageServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiAccountHomepageServiceTest.php
@@ -1,0 +1,87 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountHomepageServiceTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services
+ */
+class MapiAccountHomepageServiceTest extends UnitTest {
+
+	protected const MERCHANT_ID   = 12345;
+	protected const HOMEPAGE_PATH = 'accounts/v1/accounts/12345/homepage';
+
+	/** @var MockObject|MerchantApiClient */
+	protected $client;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var MapiAccountHomepageService */
+	protected $service;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->client  = $this->createMock( MerchantApiClient::class );
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_merchant_id' )->willReturn( self::MERCHANT_ID );
+
+		$this->service = new MapiAccountHomepageService( $this->client );
+		$this->service->set_options_object( $this->options );
+	}
+
+	public function test_get_homepage() {
+		$homepage = [
+			'name'    => 'accounts/12345/homepage',
+			'uri'     => 'https://store.example',
+			'claimed' => true,
+		];
+
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::HOMEPAGE_PATH )
+			->willReturn( $homepage );
+
+		$this->assertSame( $homepage, $this->service->get_homepage() );
+	}
+
+	public function test_get_homepage_with_explicit_merchant_id() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( 'accounts/v1/accounts/999/homepage' )
+			->willReturn( [ 'claimed' => false ] );
+
+		$this->assertSame( [ 'claimed' => false ], $this->service->get_homepage( 999 ) );
+	}
+
+	public function test_claim() {
+		$homepage = [ 'claimed' => true ];
+
+		$this->client->expects( $this->once() )
+			->method( 'post' )
+			->with( self::HOMEPAGE_PATH . ':claim', [ 'overwrite' => false ] )
+			->willReturn( $homepage );
+
+		$this->assertSame( $homepage, $this->service->claim() );
+	}
+
+	public function test_claim_with_overwrite() {
+		$this->client->expects( $this->once() )
+			->method( 'post' )
+			->with( self::HOMEPAGE_PATH . ':claim', [ 'overwrite' => true ] )
+			->willReturn( [ 'claimed' => true ] );
+
+		$this->assertSame( [ 'claimed' => true ], $this->service->claim( true ) );
+	}
+}

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -37,6 +39,9 @@ class MerchantTest extends UnitTest {
 	/** @var MockObject|ShoppingContent $service */
 	protected $service;
 
+	/** @var MockObject|MapiAccountHomepageService $homepage_service */
+	protected $homepage_service;
+
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
@@ -57,8 +62,9 @@ class MerchantTest extends UnitTest {
 		$this->service->freelistingsprogram = $this->createMock( ShoppingContent\Resource\Freelistingsprogram::class );
 		$this->service->shoppingadsprogram  = $this->createMock( ShoppingContent\Resource\Shoppingadsprogram::class );
 
-		$this->options  = $this->createMock( OptionsInterface::class );
-		$this->merchant = new Merchant( $this->service );
+		$this->homepage_service = $this->createMock( MapiAccountHomepageService::class );
+		$this->options          = $this->createMock( OptionsInterface::class );
+		$this->merchant         = new Merchant( $this->service, $this->homepage_service );
 		$this->merchant->set_options_object( $this->options );
 
 		$this->merchant_id = 12345;
@@ -66,57 +72,43 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_claim_website() {
-		$this->service->accounts->expects( $this->once() )
-			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id );
+		$this->homepage_service->expects( $this->once() )
+			->method( 'claim' )
+			->willReturn( [ 'claimed' => true ] );
 		$this->assertTrue( $this->merchant->claimwebsite() );
 	}
 
 	public function test_claimwebsite_error() {
-		$this->service->accounts->expects( $this->once() )
-			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->will(
-				$this->throwException(
-					new GoogleException()
-				)
-			);
+		$this->homepage_service->expects( $this->once() )
+			->method( 'claim' )
+			->willThrowException( $this->merchant_api_exception( 500 ) );
 
 		$this->expectException( Exception::class );
 		$this->merchant->claimwebsite();
 	}
 
 	public function test_website_already_claimed() {
-		$this->service->accounts->expects( $this->once() )
-			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->will(
-				$this->throwException(
-					new GoogleException( 'claimed', 403 )
-				)
-			);
+		$this->homepage_service->expects( $this->once() )
+			->method( 'claim' )
+			->willThrowException( $this->merchant_api_exception( 403 ) );
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionCode( 403 );
 		$this->merchant->claimwebsite();
 	}
 
-	public function test_website_claim_conflict_content_api() {
-		$message = "There exist other accounts with homepage that conflicts with the homepage of account 1234567890. Set the parameter 'overwrite' to true if you want to take the claim and remove it from these accounts: user@example.com";
-		$error   = [
-			'domain'  => 'content.ContentErrorDomain',
-			'reason'  => 'invalid_parameter',
-			'message' => $message,
+	public function test_website_claim_conflict() {
+		$body = [
+			'error' => [
+				'code'    => 400,
+				'status'  => 'FAILED_PRECONDITION',
+				'message' => 'The homepage is already claimed by another account.',
+			],
 		];
 
-		$this->service->accounts->expects( $this->once() )
-			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->will(
-				$this->throwException(
-					new GoogleServiceException( $message, 400, null, [ $error ] )
-				)
-			);
+		$this->homepage_service->expects( $this->once() )
+			->method( 'claim' )
+			->willThrowException( $this->merchant_api_exception( 400, $body ) );
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionCode( 403 );
@@ -125,44 +117,17 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_claimwebsite_non_conflict_400_error() {
-		$message = 'Request contains an invalid argument.';
-		$error   = [
-			'domain'  => 'content.ContentErrorDomain',
-			'reason'  => 'invalid',
-			'message' => $message,
+		$body = [
+			'error' => [
+				'code'    => 400,
+				'status'  => 'INVALID_ARGUMENT',
+				'message' => 'Request contains an invalid argument.',
+			],
 		];
 
-		$this->service->accounts->expects( $this->once() )
-			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->will(
-				$this->throwException(
-					new GoogleServiceException( $message, 400, null, [ $error ] )
-				)
-			);
-
-		$this->expectException( Exception::class );
-		$this->expectExceptionCode( 400 );
-		$this->expectExceptionMessage( 'Unable to claim website.' );
-		$this->merchant->claimwebsite();
-	}
-
-	public function test_claimwebsite_non_content_api_domain_error() {
-		$message = "There exist other accounts with homepage that conflicts. Set the parameter 'overwrite' to true.";
-		$error   = [
-			'domain'  => 'global',
-			'reason'  => 'forbidden',
-			'message' => $message,
-		];
-
-		$this->service->accounts->expects( $this->once() )
-			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->will(
-				$this->throwException(
-					new GoogleServiceException( $message, 400, null, [ $error ] )
-				)
-			);
+		$this->homepage_service->expects( $this->once() )
+			->method( 'claim' )
+			->willThrowException( $this->merchant_api_exception( 400, $body ) );
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionCode( 400 );
@@ -279,30 +244,31 @@ class MerchantTest extends UnitTest {
 
 	public function test_get_claimed_url_hash_not_claimed() {
 		$url = 'https://site.test';
-		$this->mock_get_account( $this->get_account_with_url( $url ) );
-		$this->mock_get_account_status( $this->get_status_website_claimed( false ) );
+		$this->homepage_service->method( 'get_homepage' )
+			->willReturn( [ 'uri' => $url, 'claimed' => false ] );
 
 		$this->assertNull( $this->merchant->get_claimed_url_hash() );
 	}
 
 	public function test_get_claimed_url_hash_from_account() {
 		$url = 'https://site.test';
-		$this->mock_get_account( $this->get_account_with_url( $url ) );
-		$this->mock_get_account_status( $this->get_status_website_claimed() );
+		$this->homepage_service->method( 'get_homepage' )
+			->willReturn( [ 'uri' => $url, 'claimed' => true ] );
 
 		$this->assertEquals( md5( $url ), $this->merchant->get_claimed_url_hash() );
 	}
 
 	public function test_get_claimed_url_hash_with_trailing_slash() {
 		$url = 'https://site.test';
-		$this->mock_get_account( $this->get_account_with_url( trailingslashit( $url ) ) );
-		$this->mock_get_account_status( $this->get_status_website_claimed() );
+		$this->homepage_service->method( 'get_homepage' )
+			->willReturn( [ 'uri' => trailingslashit( $url ), 'claimed' => true ] );
 
 		$this->assertEquals( md5( $url ), $this->merchant->get_claimed_url_hash() );
 	}
 
 	public function test_get_claimed_url_hash_from_account_failure() {
-		$this->mock_get_account_exception( $this->get_google_service_exception() );
+		$this->homepage_service->method( 'get_homepage' )
+			->willThrowException( $this->merchant_api_exception( 500 ) );
 
 		$this->assertNull( $this->merchant->get_claimed_url_hash() );
 	}
@@ -605,5 +571,9 @@ class MerchantTest extends UnitTest {
 			->method( 'get' )
 			->with( $this->merchant_id, $this->merchant_id )
 			->will( $this->throwException( $exception ) );
+	}
+
+	private function merchant_api_exception( int $http_status, array $response_body = [] ): MerchantApiException {
+		return new MerchantApiException( $http_status, $response_body, __METHOD__ );
 	}
 }

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -245,7 +245,12 @@ class MerchantTest extends UnitTest {
 	public function test_get_claimed_url_hash_not_claimed() {
 		$url = 'https://site.test';
 		$this->homepage_service->method( 'get_homepage' )
-			->willReturn( [ 'uri' => $url, 'claimed' => false ] );
+			->willReturn(
+				[
+					'uri'     => $url,
+					'claimed' => false,
+				]
+			);
 
 		$this->assertNull( $this->merchant->get_claimed_url_hash() );
 	}
@@ -253,7 +258,12 @@ class MerchantTest extends UnitTest {
 	public function test_get_claimed_url_hash_from_account() {
 		$url = 'https://site.test';
 		$this->homepage_service->method( 'get_homepage' )
-			->willReturn( [ 'uri' => $url, 'claimed' => true ] );
+			->willReturn(
+				[
+					'uri'     => $url,
+					'claimed' => true,
+				]
+			);
 
 		$this->assertEquals( md5( $url ), $this->merchant->get_claimed_url_hash() );
 	}
@@ -261,7 +271,12 @@ class MerchantTest extends UnitTest {
 	public function test_get_claimed_url_hash_with_trailing_slash() {
 		$url = 'https://site.test';
 		$this->homepage_service->method( 'get_homepage' )
-			->willReturn( [ 'uri' => trailingslashit( $url ), 'claimed' => true ] );
+			->willReturn(
+				[
+					'uri'     => trailingslashit( $url ),
+					'claimed' => true,
+				]
+			);
 
 		$this->assertEquals( md5( $url ), $this->merchant->get_claimed_url_hash() );
 	}

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
@@ -52,6 +53,9 @@ class AccountServiceTest extends UnitTest {
 
 	/** @var MockObject|Merchant $merchant */
 	protected $merchant;
+
+	/** @var MockObject|MapiAccountHomepageService $homepage_service */
+	protected $homepage_service;
 
 	/** @var MockObject|MerchantCenterService $mc_service */
 	protected $mc_service;
@@ -132,6 +136,7 @@ class AccountServiceTest extends UnitTest {
 		$this->ads                          = $this->createMock( Ads::class );
 		$this->cleanup_synced               = $this->createMock( CleanupSyncedProducts::class );
 		$this->merchant                     = $this->createMock( Merchant::class );
+		$this->homepage_service             = $this->createMock( MapiAccountHomepageService::class );
 		$this->mc_service                   = $this->createMock( MerchantCenterService::class );
 		$this->issue_table                  = $this->createMock( MerchantIssueTable::class );
 		$this->merchant_statuses            = $this->createMock( MerchantStatuses::class );
@@ -151,6 +156,7 @@ class AccountServiceTest extends UnitTest {
 		$this->container->addShared( AdsAccountState::class, $this->ads_state );
 		$this->container->addShared( CleanupSyncedProducts::class, $this->cleanup_synced );
 		$this->container->addShared( Merchant::class, $this->merchant );
+		$this->container->addShared( MapiAccountHomepageService::class, $this->homepage_service );
 		$this->container->addShared( MerchantCenterService::class, $this->mc_service );
 		$this->container->addShared( MerchantIssueTable::class, $this->issue_table );
 		$this->container->addShared( MerchantStatuses::class, $this->merchant_statuses );
@@ -322,9 +328,10 @@ class AccountServiceTest extends UnitTest {
 			->method( 'get_account' )
 			->willReturn( $this->get_account_with_url( self::TEST_OLD_URL ) );
 
-		$this->merchant->expects( $this->any() )
-			->method( 'get_accountstatus' )
-			->willReturn( $this->get_status_website_claimed() );
+		$this->homepage_service->expects( $this->any() )
+			->method( 'get_homepage' )
+			->with( self::TEST_ACCOUNT_ID )
+			->willReturn( [ 'claimed' => true ] );
 
 		try {
 			$this->account->use_existing_account_id( self::TEST_ACCOUNT_ID );
@@ -507,9 +514,10 @@ class AccountServiceTest extends UnitTest {
 				]
 			);
 
-		$this->merchant->expects( $this->any() )
-			->method( 'get_accountstatus' )
-			->willReturn( $this->get_status_website_claimed() );
+		$this->homepage_service->expects( $this->any() )
+			->method( 'get_homepage' )
+			->with( self::TEST_ACCOUNT_ID )
+			->willReturn( [ 'claimed' => true ] );
 
 		$this->merchant->expects( $this->never() )
 			->method( 'claimwebsite' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-753/migrate-website-claim-status-action-to-mapi

Migrates the Merchant Center website claim (status reads and the claim action) from the Content API to the Merchant API homepage resource

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

- Connect Google for WooCommerce to a Merchant Center account and complete onboarding. Confirm the site ends up claimed in Google Merchant Center.
- Reconnect an account whose URL is already claimed under a different account , the "use overwrite" prompt should still appear.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
Migrate the Merchant Center website claim status and action to the Merchant API.
>
