### PR TITLE
GOOWOO-672 change coupon URL in case of coupons not synced

### DIFF
--- a/js/src/notifications-system/useNotificationsSystemMap.js
+++ b/js/src/notifications-system/useNotificationsSystemMap.js
@@ -32,7 +32,7 @@ const dashboardUrl = getDashboardUrl();
 const settingsUrl = getSettingsUrl();
 const wcAdvancedSettingsUrl = getWCAdvancedSettingsUrl();
 const onboardingUrl = getOnboardingUrl();
-const couponsUrl = getWCCouponsUrl();
+const wcCouponsUrl = getWCCouponsUrl();
 
 /**
  * Static notification configs — created once at module level, never re-created on render.
@@ -342,7 +342,7 @@ const useNotificationsSystemMap = () => {
 				actions: [
 					{
 						id: 'review-coupon-settings',
-						href: couponsUrl,
+						href: wcCouponsUrl,
 						children: __(
 							'Review coupon settings',
 							'google-listings-and-ads'

--- a/js/src/notifications-system/useNotificationsSystemMap.js
+++ b/js/src/notifications-system/useNotificationsSystemMap.js
@@ -16,6 +16,7 @@ import {
 	getSetupAdsUrl,
 	getWCAdvancedSettingsUrl,
 	getOnboardingUrl,
+	getCouponsUrl,
 } from '~/utils/urls';
 
 /**
@@ -31,6 +32,7 @@ const dashboardUrl = getDashboardUrl();
 const settingsUrl = getSettingsUrl();
 const wcAdvancedSettingsUrl = getWCAdvancedSettingsUrl();
 const onboardingUrl = getOnboardingUrl();
+const couponsUrl = getCouponsUrl();
 
 /**
  * Static notification configs — created once at module level, never re-created on render.
@@ -340,7 +342,7 @@ const useNotificationsSystemMap = () => {
 				actions: [
 					{
 						id: 'review-coupon-settings',
-						href: settingsUrl,
+						href: couponsUrl,
 						children: __(
 							'Review coupon settings',
 							'google-listings-and-ads'

--- a/js/src/notifications-system/useNotificationsSystemMap.js
+++ b/js/src/notifications-system/useNotificationsSystemMap.js
@@ -16,7 +16,7 @@ import {
 	getSetupAdsUrl,
 	getWCAdvancedSettingsUrl,
 	getOnboardingUrl,
-	getCouponsUrl,
+	getWCCouponsUrl,
 } from '~/utils/urls';
 
 /**
@@ -32,7 +32,7 @@ const dashboardUrl = getDashboardUrl();
 const settingsUrl = getSettingsUrl();
 const wcAdvancedSettingsUrl = getWCAdvancedSettingsUrl();
 const onboardingUrl = getOnboardingUrl();
-const couponsUrl = getCouponsUrl();
+const couponsUrl = getWCCouponsUrl();
 
 /**
  * Static notification configs — created once at module level, never re-created on render.

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -141,7 +141,7 @@ export const getReconnectAccountUrl = ( code ) => {
  *
  * @return {string} The URL of the coupons index page.
  */
-export const getCouponsUrl = () => {
+export const getWCCouponsUrl = () => {
 	return addQueryArgs( 'edit.php', {
 		post_type: 'shop_coupon',
 	} );

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -135,3 +135,14 @@ export const getReconnectAccountUrl = ( code ) => {
 
 	return getNewPath( { subpath }, settingsPath, null );
 };
+
+/**
+ * Returns the URL of the WooCommerce coupons index page.
+ *
+ * @return {string} The URL of the coupons index page.
+ */
+export const getCouponsUrl = () => {
+	return addQueryArgs( 'edit.php', {
+		post_type: 'shop_coupon',
+	} );
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes [GOOWOO-672](https://linear.app/a8c/issue/GOOWOO-672/fe-notification-case-8-coupons-not-synced).

Updates the CTA URL for the `coupons-not-synced` notification to redirect users to the WooCommerce coupons index page (`edit.php?post_type=shop_coupon`) instead of the GLA settings tab.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Trigger the coupons-not-synced notification by mocking the `wp-json/wc/gla/notifications` endpoint with the following sample response:
```
{
    "notifications": [
        {
            "id": "coupons-not-synced",
            "triggered_at":1778684311
        }
    ]
}
```

3. Click the "Review coupon settings" CTA in the notification.
4. Verify it redirects to the WooCommerce coupons list page (`wp-admin/edit.php?post_type=shop_coupon`) rather than the GLA settings tab.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
