### PR TITLE
GOOWOO-755: Migrate content.accounts.get to MAPI accounts.get

### DIFF
--- a/src/API/Google/Mapi/Services/MapiAccountBusinessInfoService.php
+++ b/src/API/Google/Mapi/Services/MapiAccountBusinessInfoService.php
@@ -46,6 +46,22 @@ class MapiAccountBusinessInfoService implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Update the business information for the connected merchant account.
+	 *
+	 * @param array  $business_info BusinessInfo fields to write.
+	 * @param string $update_mask   Comma-separated list of fields to update.
+	 *
+	 * @return array The updated BusinessInfo.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function update_business_info( array $business_info, string $update_mask ): array {
+		return $this->client->patch(
+			$this->build_path() . '?updateMask=' . rawurlencode( $update_mask ),
+			$business_info
+		);
+	}
+
+	/**
 	 * Build the businessInfo resource path for the connected merchant account.
 	 *
 	 * @return string

--- a/src/API/Google/Mapi/Services/MapiAccountBusinessInfoService.php
+++ b/src/API/Google/Mapi/Services/MapiAccountBusinessInfoService.php
@@ -55,8 +55,12 @@ class MapiAccountBusinessInfoService implements OptionsAwareInterface {
 	 * @throws MerchantApiException On a non-2xx MAPI response.
 	 */
 	public function update_business_info( array $business_info, string $update_mask ): array {
+		// Encode each field name individually so the commas separating a
+		// multi-field mask are preserved rather than percent-encoded.
+		$encoded_mask = implode( ',', array_map( 'rawurlencode', explode( ',', $update_mask ) ) );
+
 		return $this->client->patch(
-			$this->build_path() . '?updateMask=' . rawurlencode( $update_mask ),
+			$this->build_path() . '?updateMask=' . $encoded_mask,
 			$business_info
 		);
 	}

--- a/src/API/Google/Mapi/Services/MapiAccountBusinessInfoService.php
+++ b/src/API/Google/Mapi/Services/MapiAccountBusinessInfoService.php
@@ -1,0 +1,60 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MapiPaths;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountBusinessInfoService
+ *
+ * Reads the business information (address, phone, customer service) for the
+ * connected account from the Merchant API accounts.businessInfo resource.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services
+ */
+class MapiAccountBusinessInfoService implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/** @var MerchantApiClient */
+	protected $client;
+
+	/**
+	 * MapiAccountBusinessInfoService constructor.
+	 *
+	 * @param MerchantApiClient $client
+	 */
+	public function __construct( MerchantApiClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * Retrieve the business information for the connected merchant account.
+	 *
+	 * @return array BusinessInfo resource decoded as an array.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function get_business_info(): array {
+		return $this->client->get( $this->build_path() );
+	}
+
+	/**
+	 * Build the businessInfo resource path for the connected merchant account.
+	 *
+	 * @return string
+	 */
+	protected function build_path(): string {
+		return sprintf(
+			'%s/accounts/%s/businessInfo',
+			MapiPaths::ACCOUNTS,
+			$this->options->get_merchant_id()
+		);
+	}
+}

--- a/src/API/Google/Mapi/Services/MapiAccountHomepageService.php
+++ b/src/API/Google/Mapi/Services/MapiAccountHomepageService.php
@@ -1,0 +1,78 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MapiPaths;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountHomepageService
+ *
+ * Reads and claims the store homepage via the Merchant API accounts.homepage
+ * resource, which exposes the website uri and claimed status plus the claim action.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services
+ */
+class MapiAccountHomepageService implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/** @var MerchantApiClient */
+	protected $client;
+
+	/**
+	 * MapiAccountHomepageService constructor.
+	 *
+	 * @param MerchantApiClient $client
+	 */
+	public function __construct( MerchantApiClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * Retrieve the homepage resource for a merchant account.
+	 *
+	 * @param int $merchant_id Optional - the account to read. Defaults to the connected account.
+	 *
+	 * @return array Homepage resource decoded as an array (uri, claimed).
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function get_homepage( int $merchant_id = 0 ): array {
+		return $this->client->get( $this->build_path( $merchant_id ) );
+	}
+
+	/**
+	 * Claim the store homepage for the connected merchant account.
+	 *
+	 * @param bool $overwrite Whether to remove an existing claim from another account.
+	 *
+	 * @return array Homepage resource decoded as an array.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function claim( bool $overwrite = false ): array {
+		return $this->client->post( $this->build_path() . ':claim', [ 'overwrite' => $overwrite ] );
+	}
+
+	/**
+	 * Build the homepage resource path for a merchant account.
+	 *
+	 * @param int $merchant_id Optional - the account to target. Defaults to the connected account.
+	 *
+	 * @return string
+	 */
+	protected function build_path( int $merchant_id = 0 ): string {
+		$merchant_id = $merchant_id ?: $this->options->get_merchant_id();
+
+		return sprintf(
+			'%s/accounts/%s/homepage',
+			MapiPaths::ACCOUNTS,
+			$merchant_id
+		);
+	}
+}

--- a/src/API/Google/Mapi/Services/MapiAccountUsersService.php
+++ b/src/API/Google/Mapi/Services/MapiAccountUsersService.php
@@ -1,0 +1,60 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MapiPaths;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountUsersService
+ *
+ * Reads the authenticated user's access to the connected account from the
+ * Merchant API accounts.users resource (users/me).
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services
+ */
+class MapiAccountUsersService implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/** @var MerchantApiClient */
+	protected $client;
+
+	/**
+	 * MapiAccountUsersService constructor.
+	 *
+	 * @param MerchantApiClient $client
+	 */
+	public function __construct( MerchantApiClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * Retrieve the authenticated user's resource for the connected merchant account.
+	 *
+	 * @return array User resource decoded as an array (name, state, accessRights).
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function get_current_user(): array {
+		return $this->client->get( $this->build_path() );
+	}
+
+	/**
+	 * Build the users/me resource path for the connected merchant account.
+	 *
+	 * @return string
+	 */
+	protected function build_path(): string {
+		return sprintf(
+			'%s/accounts/%s/users/me',
+			MapiPaths::ACCOUNTS,
+			$this->options->get_merchant_id()
+		);
+	}
+}

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -342,6 +342,19 @@ class Merchant implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Update the business information for the connected Merchant Center account.
+	 *
+	 * @param array  $business_info BusinessInfo fields to write.
+	 * @param string $update_mask   Comma-separated list of fields to update.
+	 *
+	 * @return array The updated businessInfo.
+	 * @throws MerchantApiException If the business info can't be updated.
+	 */
+	public function update_business_info( array $business_info, string $update_mask ): array {
+		return $this->business_info_service->update_business_info( $business_info, $update_mask );
+	}
+
+	/**
 	 * Check if we have access to the merchant account.
 	 *
 	 * @param string $email Email address of the connected account.

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
@@ -40,12 +42,21 @@ class Merchant implements OptionsAwareInterface {
 	protected $service;
 
 	/**
+	 * The Merchant API homepage service.
+	 *
+	 * @var MapiAccountHomepageService
+	 */
+	protected $homepage_service;
+
+	/**
 	 * Merchant constructor.
 	 *
-	 * @param ShoppingContent $service
+	 * @param ShoppingContent            $service
+	 * @param MapiAccountHomepageService $homepage_service
 	 */
-	public function __construct( ShoppingContent $service ) {
-		$this->service = $service;
+	public function __construct( ShoppingContent $service, MapiAccountHomepageService $homepage_service ) {
+		$this->service          = $service;
+		$this->homepage_service = $homepage_service;
 	}
 
 	/**
@@ -56,11 +67,10 @@ class Merchant implements OptionsAwareInterface {
 	 */
 	public function claimwebsite(): bool {
 		try {
-			$id = $this->options->get_merchant_id();
-			$this->service->accounts->claimwebsite( $id, $id );
+			$this->homepage_service->claim();
 			do_action( 'woocommerce_gla_site_claim_success', [ 'details' => 'google_proxy' ] );
-		} catch ( GoogleException $e ) {
-			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
+		} catch ( MerchantApiException $e ) {
+			// The woocommerce_gla_mc_client_exception action is fired by MerchantApiException::__construct().
 			do_action( 'woocommerce_gla_site_claim_failure', [ 'details' => 'google_proxy' ] );
 
 			if ( $this->is_website_claim_conflict_error( $e ) ) {
@@ -82,51 +92,18 @@ class Merchant implements OptionsAwareInterface {
 	/**
 	 * Check if the exception indicates a website claim conflict error.
 	 *
-	 * This handles Content API error format by checking structured error data.
-	 * The API used to return 403, but now returns 400 with specific error details.
+	 * The Merchant API returns a FAILED_PRECONDITION status when the homepage is
+	 * already claimed by another account and overwrite was not requested.
 	 *
-	 * Content API error structure:
-	 * - code: 400
-	 * - errors[].domain: "content.ContentErrorDomain"
-	 * - errors[].message: contains "overwrite"
-	 *
-	 * TODO: When migrating to Merchant API, it may have a different error format.
-	 * Possible fields to check:
-	 * - code: 400
-	 * - status: "FAILED_PRECONDITION"
-	 * - details[].metadata.REASON: "INVALID_TRANSITION_CLAIMED_DESCENDANTS"
-	 *
-	 * @param GoogleException $e The exception to check.
+	 * @param MerchantApiException $e The exception to check.
 	 * @return bool True if the error indicates a claim conflict.
 	 */
-	private function is_website_claim_conflict_error( GoogleException $e ): bool {
-		$code = $e->getCode();
-
-		// The API used to return 403, kept here in case some undiscovered conditions still return it.
-		if ( $code === 403 ) {
+	private function is_website_claim_conflict_error( MerchantApiException $e ): bool {
+		if ( 403 === $e->get_http_status() ) {
 			return true;
 		}
 
-		if ( $code !== 400 ) {
-			return false;
-		}
-
-		// Check structured error data from Content API.
-		if ( $e instanceof GoogleServiceException ) {
-			$errors = $e->getErrors();
-			if ( is_array( $errors ) ) {
-				foreach ( $errors as $error ) {
-					$is_content_api_domain = isset( $error['domain'] ) && $error['domain'] === 'content.ContentErrorDomain';
-					$has_overwrite_message = isset( $error['message'] ) && stripos( $error['message'], 'overwrite' ) !== false;
-
-					if ( $is_content_api_domain && $has_overwrite_message ) {
-						return true;
-					}
-				}
-			}
-		}
-
-		return false;
+		return 'FAILED_PRECONDITION' === ( $e->get_response_body()['error']['status'] ?? '' );
 	}
 
 	/**
@@ -243,9 +220,10 @@ class Merchant implements OptionsAwareInterface {
 
 		if ( empty( $claimed_url_hash ) && $this->options->get_merchant_id() ) {
 			try {
-				$account_url = $this->get_account()->getWebsiteUrl();
+				$homepage    = $this->homepage_service->get_homepage();
+				$account_url = $homepage['uri'] ?? '';
 
-				if ( empty( $account_url ) || ! $this->get_accountstatus()->getWebsiteClaimed() ) {
+				if ( empty( $account_url ) || empty( $homepage['claimed'] ) ) {
 					return null;
 				}
 

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -4,7 +4,9 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountBusinessInfoService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountUsersService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
@@ -49,14 +51,32 @@ class Merchant implements OptionsAwareInterface {
 	protected $homepage_service;
 
 	/**
+	 * The Merchant API business info service.
+	 *
+	 * @var MapiAccountBusinessInfoService
+	 */
+	protected $business_info_service;
+
+	/**
+	 * The Merchant API users service.
+	 *
+	 * @var MapiAccountUsersService
+	 */
+	protected $users_service;
+
+	/**
 	 * Merchant constructor.
 	 *
-	 * @param ShoppingContent            $service
-	 * @param MapiAccountHomepageService $homepage_service
+	 * @param ShoppingContent                $service
+	 * @param MapiAccountHomepageService     $homepage_service
+	 * @param MapiAccountBusinessInfoService $business_info_service
+	 * @param MapiAccountUsersService        $users_service
 	 */
-	public function __construct( ShoppingContent $service, MapiAccountHomepageService $homepage_service ) {
-		$this->service          = $service;
-		$this->homepage_service = $homepage_service;
+	public function __construct( ShoppingContent $service, MapiAccountHomepageService $homepage_service, MapiAccountBusinessInfoService $business_info_service, MapiAccountUsersService $users_service ) {
+		$this->service               = $service;
+		$this->homepage_service      = $homepage_service;
+		$this->business_info_service = $business_info_service;
+		$this->users_service         = $users_service;
 	}
 
 	/**
@@ -312,6 +332,16 @@ class Merchant implements OptionsAwareInterface {
 	}
 
 	/**
+	 * Get the business information for the connected Merchant Center account.
+	 *
+	 * @return array The businessInfo resource decoded as an array.
+	 * @throws MerchantApiException If the business info can't be retrieved.
+	 */
+	public function get_business_info(): array {
+		return $this->business_info_service->get_business_info();
+	}
+
+	/**
 	 * Check if we have access to the merchant account.
 	 *
 	 * @param string $email Email address of the connected account.
@@ -319,21 +349,17 @@ class Merchant implements OptionsAwareInterface {
 	 * @return bool
 	 */
 	public function has_access( string $email ): bool {
-		$id = $this->options->get_merchant_id();
-
 		try {
-			$account = $this->service->accounts->get( $id, $id );
-
-			foreach ( $account->getUsers() as $user ) {
-				if ( $email === $user->getEmailAddress() && $user->getAdmin() ) {
-					return true;
-				}
-			}
-		} catch ( GoogleException $e ) {
-			do_action( 'woocommerce_gla_mc_client_exception', $e, __METHOD__ );
+			$user = $this->users_service->get_current_user();
+		} catch ( MerchantApiException $e ) {
+			// The woocommerce_gla_mc_client_exception action is fired by MerchantApiException::__construct().
+			return false;
 		}
 
-		return false;
+		$name_parts = explode( '/', $user['name'] ?? '' );
+		$user_email = (string) end( $name_parts );
+
+		return $email === $user_email && in_array( 'ADMIN', $user['accessRights'] ?? [], true );
 	}
 
 	/**

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -82,6 +82,10 @@ class Merchant implements OptionsAwareInterface {
 	/**
 	 * Claim a website for the user's Merchant Center account.
 	 *
+	 * A MerchantApiException from the claim request is caught and translated into
+	 * a plain Exception (code 403 for a claim conflict, otherwise the original
+	 * status) so callers receive a stable exception type.
+	 *
 	 * @return bool
 	 * @throws Exception If the website claim fails.
 	 */
@@ -113,7 +117,10 @@ class Merchant implements OptionsAwareInterface {
 	 * Check if the exception indicates a website claim conflict error.
 	 *
 	 * The Merchant API returns a FAILED_PRECONDITION status when the homepage is
-	 * already claimed by another account and overwrite was not requested.
+	 * already claimed by another account and overwrite was not requested. A 403 is
+	 * also treated as a conflict for parity with the Content API, which surfaced
+	 * claim conflicts that way; AccountService keys off the resulting 403 code to
+	 * offer the overwrite flow.
 	 *
 	 * @param MerchantApiException $e The exception to check.
 	 * @return bool True if the error indicates a claim conflict.
@@ -356,6 +363,10 @@ class Merchant implements OptionsAwareInterface {
 
 	/**
 	 * Check if we have access to the merchant account.
+	 *
+	 * A MerchantApiException from the users lookup is caught and reported as no
+	 * access (returns false) rather than propagated; it is logged through the
+	 * woocommerce_gla_mc_client_exception action fired by the exception.
 	 *
 	 * @param string $email Email address of the connected account.
 	 *

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -388,16 +388,16 @@ class Settings implements ContainerAwareInterface {
 	 *
 	 * @since 1.4.0
 	 */
-	protected function maybe_get_state_name( string $state_code, string $country ): string {
+	public function maybe_get_state_name( string $state_code, string $country ): string {
 		/** @var WC $wc */
 		$wc = $this->container->get( WC::class );
 
 		$states = $country ? array_filter( (array) $wc->get_wc_countries()->get_states( $country ) ) : [];
 
 		if ( ! empty( $states ) ) {
-			$state_code = wc_strtoupper( $state_code );
-			if ( isset( $states[ $state_code ] ) ) {
-				return $states[ $state_code ];
+			$upper_code = wc_strtoupper( $state_code );
+			if ( isset( $states[ $upper_code ] ) ) {
+				return $states[ $upper_code ];
 			}
 		}
 

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -22,6 +22,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
@@ -82,39 +83,40 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * @var array
 	 */
 	protected $provides = [
-		Client::class                    => true,
-		ShoppingContent::class           => true,
-		GoogleAdsClient::class           => true,
-		GuzzleClient::class              => true,
-		Middleware::class                => true,
-		Merchant::class                  => true,
-		MerchantMetrics::class           => true,
-		Ads::class                       => true,
-		AdsIncentives::class             => true,
-		AdsAssetGroup::class             => true,
-		AdsCampaign::class               => true,
-		AdsCampaignAsset::class          => true,
-		AdsCampaignBudget::class         => true,
-		AdsCampaignLabel::class          => true,
-		AdsConversionAction::class       => true,
-		AdsReport::class                 => true,
-		AdsRecommendationsService::class => true,
-		AdsAssetGenerationService::class => true,
-		AdsAssetGroupAsset::class        => true,
-		AdsAsset::class                  => true,
-		BudgetMetrics::class             => true,
-		BudgetRecommendations::class     => true,
-		'connect_server_root'            => true,
-		Connection::class                => true,
-		GoogleProductService::class      => true,
-		GooglePromotionService::class    => true,
-		MerchantApiClient::class         => true,
-		MapiProductsService::class       => true,
-		MapiDataSourcesService::class    => true,
-		MapiProductInputsService::class  => true,
-		MapiAccountIssuesService::class  => true,
-		SiteVerification::class          => true,
-		Settings::class                  => true,
+		Client::class                     => true,
+		ShoppingContent::class            => true,
+		GoogleAdsClient::class            => true,
+		GuzzleClient::class               => true,
+		Middleware::class                 => true,
+		Merchant::class                   => true,
+		MerchantMetrics::class            => true,
+		Ads::class                        => true,
+		AdsIncentives::class              => true,
+		AdsAssetGroup::class              => true,
+		AdsCampaign::class                => true,
+		AdsCampaignAsset::class           => true,
+		AdsCampaignBudget::class          => true,
+		AdsCampaignLabel::class           => true,
+		AdsConversionAction::class        => true,
+		AdsReport::class                  => true,
+		AdsRecommendationsService::class  => true,
+		AdsAssetGenerationService::class  => true,
+		AdsAssetGroupAsset::class         => true,
+		AdsAsset::class                   => true,
+		BudgetMetrics::class              => true,
+		BudgetRecommendations::class      => true,
+		'connect_server_root'             => true,
+		Connection::class                 => true,
+		GoogleProductService::class       => true,
+		GooglePromotionService::class     => true,
+		MerchantApiClient::class          => true,
+		MapiProductsService::class        => true,
+		MapiDataSourcesService::class     => true,
+		MapiProductInputsService::class   => true,
+		MapiAccountIssuesService::class   => true,
+		MapiAccountHomepageService::class => true,
+		SiteVerification::class           => true,
+		Settings::class                   => true,
 	];
 
 	/**
@@ -149,7 +151,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( BudgetMetrics::class, GoogleAdsClient::class );
 		$this->share( BudgetRecommendations::class, GoogleAdsClient::class );
 
-		$this->share( Merchant::class, ShoppingContent::class );
+		$this->share( Merchant::class, ShoppingContent::class, MapiAccountHomepageService::class );
 		$this->share( MerchantMetrics::class, MerchantApiClient::class, GoogleAdsClient::class, WP::class, TransientsInterface::class );
 		$this->share( MerchantReport::class, ProductHelper::class, MerchantApiClient::class );
 
@@ -225,6 +227,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( MapiDataSourcesService::class, MerchantApiClient::class );
 		$this->share( MapiProductInputsService::class, MerchantApiClient::class, MapiDataSourcesService::class );
 		$this->share( MapiAccountIssuesService::class, MerchantApiClient::class );
+		$this->share( MapiAccountHomepageService::class, MerchantApiClient::class );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -22,8 +22,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountBusinessInfoService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountUsersService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
@@ -83,40 +85,42 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * @var array
 	 */
 	protected $provides = [
-		Client::class                     => true,
-		ShoppingContent::class            => true,
-		GoogleAdsClient::class            => true,
-		GuzzleClient::class               => true,
-		Middleware::class                 => true,
-		Merchant::class                   => true,
-		MerchantMetrics::class            => true,
-		Ads::class                        => true,
-		AdsIncentives::class              => true,
-		AdsAssetGroup::class              => true,
-		AdsCampaign::class                => true,
-		AdsCampaignAsset::class           => true,
-		AdsCampaignBudget::class          => true,
-		AdsCampaignLabel::class           => true,
-		AdsConversionAction::class        => true,
-		AdsReport::class                  => true,
-		AdsRecommendationsService::class  => true,
-		AdsAssetGenerationService::class  => true,
-		AdsAssetGroupAsset::class         => true,
-		AdsAsset::class                   => true,
-		BudgetMetrics::class              => true,
-		BudgetRecommendations::class      => true,
-		'connect_server_root'             => true,
-		Connection::class                 => true,
-		GoogleProductService::class       => true,
-		GooglePromotionService::class     => true,
-		MerchantApiClient::class          => true,
-		MapiProductsService::class        => true,
-		MapiDataSourcesService::class     => true,
-		MapiProductInputsService::class   => true,
-		MapiAccountIssuesService::class   => true,
-		MapiAccountHomepageService::class => true,
-		SiteVerification::class           => true,
-		Settings::class                   => true,
+		Client::class                         => true,
+		ShoppingContent::class                => true,
+		GoogleAdsClient::class                => true,
+		GuzzleClient::class                   => true,
+		Middleware::class                     => true,
+		Merchant::class                       => true,
+		MerchantMetrics::class                => true,
+		Ads::class                            => true,
+		AdsIncentives::class                  => true,
+		AdsAssetGroup::class                  => true,
+		AdsCampaign::class                    => true,
+		AdsCampaignAsset::class               => true,
+		AdsCampaignBudget::class              => true,
+		AdsCampaignLabel::class               => true,
+		AdsConversionAction::class            => true,
+		AdsReport::class                      => true,
+		AdsRecommendationsService::class      => true,
+		AdsAssetGenerationService::class      => true,
+		AdsAssetGroupAsset::class             => true,
+		AdsAsset::class                       => true,
+		BudgetMetrics::class                  => true,
+		BudgetRecommendations::class          => true,
+		'connect_server_root'                 => true,
+		Connection::class                     => true,
+		GoogleProductService::class           => true,
+		GooglePromotionService::class         => true,
+		MerchantApiClient::class              => true,
+		MapiProductsService::class            => true,
+		MapiDataSourcesService::class         => true,
+		MapiProductInputsService::class       => true,
+		MapiAccountIssuesService::class       => true,
+		MapiAccountHomepageService::class     => true,
+		MapiAccountBusinessInfoService::class => true,
+		MapiAccountUsersService::class        => true,
+		SiteVerification::class               => true,
+		Settings::class                       => true,
 	];
 
 	/**
@@ -151,7 +155,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( BudgetMetrics::class, GoogleAdsClient::class );
 		$this->share( BudgetRecommendations::class, GoogleAdsClient::class );
 
-		$this->share( Merchant::class, ShoppingContent::class, MapiAccountHomepageService::class );
+		$this->share( Merchant::class, ShoppingContent::class, MapiAccountHomepageService::class, MapiAccountBusinessInfoService::class, MapiAccountUsersService::class );
 		$this->share( MerchantMetrics::class, MerchantApiClient::class, GoogleAdsClient::class, WP::class, TransientsInterface::class );
 		$this->share( MerchantReport::class, ProductHelper::class, MerchantApiClient::class );
 
@@ -228,6 +232,8 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( MapiProductInputsService::class, MerchantApiClient::class, MapiDataSourcesService::class );
 		$this->share( MapiAccountIssuesService::class, MerchantApiClient::class );
 		$this->share( MapiAccountHomepageService::class, MerchantApiClient::class );
+		$this->share( MapiAccountBusinessInfoService::class, MerchantApiClient::class );
+		$this->share( MapiAccountUsersService::class, MerchantApiClient::class );
 	}
 
 	/**

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
 use Automattic\Jetpack\Connection\Client;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
@@ -350,7 +351,8 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 					case 'claim':
 						// At this step, the website URL is assumed to be correct.
 						// If the URL is already claimed, no claim should be attempted.
-						if ( $merchant->get_accountstatus( $merchant_id )->getWebsiteClaimed() ) {
+						$homepage = $this->container->get( MapiAccountHomepageService::class )->get_homepage( $merchant_id );
+						if ( ! empty( $homepage['claimed'] ) ) {
 							break;
 						}
 
@@ -474,7 +476,8 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 
 		if ( untrailingslashit( $site_url ) !== untrailingslashit( $account_url ) ) {
 
-			$is_website_claimed = $merchant->get_accountstatus( $merchant_id )->getWebsiteClaimed();
+			$homepage           = $this->container->get( MapiAccountHomepageService::class )->get_homepage( $merchant_id );
+			$is_website_claimed = ! empty( $homepage['claimed'] );
 
 			if ( ! empty( $account_url ) && $is_website_claimed && ! $this->allow_switch_url ) {
 				$state                              = $this->state->get();

--- a/src/MerchantCenter/ContactInformation.php
+++ b/src/MerchantCenter/ContactInformation.php
@@ -3,10 +3,12 @@
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountAddress;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountBusinessInformation;
 
 /**
@@ -48,9 +50,73 @@ class ContactInformation implements Service {
 	 * @throws ExceptionWithResponseData If the Merchant Center account can't be retrieved.
 	 */
 	public function get_contact_information(): ?AccountBusinessInformation {
-		$business_information = $this->merchant->get_account()->getBusinessInformation();
+		try {
+			$business_info = $this->merchant->get_business_info();
+		} catch ( MerchantApiException $e ) {
+			throw new ExceptionWithResponseData( $e->getMessage(), $e->getCode(), $e );
+		}
 
-		return $business_information ?: null;
+		if ( empty( $business_info ) ) {
+			return null;
+		}
+
+		return $this->map_business_info( $business_info );
+	}
+
+	/**
+	 * Map a Merchant API businessInfo resource onto an AccountBusinessInformation.
+	 *
+	 * @param array $business_info BusinessInfo resource decoded as an array.
+	 *
+	 * @return AccountBusinessInformation
+	 */
+	protected function map_business_info( array $business_info ): AccountBusinessInformation {
+		$contact_information = new AccountBusinessInformation();
+
+		if ( ! empty( $business_info['address'] ) ) {
+			$contact_information->setAddress( $this->map_address( $business_info['address'] ) );
+		}
+
+		if ( ! empty( $business_info['phone']['e164Number'] ) ) {
+			$contact_information->setPhoneNumber( $business_info['phone']['e164Number'] );
+		}
+
+		if ( ! empty( $business_info['phoneVerificationState'] ) ) {
+			// The frontend only understands verified/unverified; fold UNSPECIFIED and
+			// any other non-verified state into UNVERIFIED.
+			$contact_information->setPhoneVerificationStatus(
+				'PHONE_VERIFICATION_STATE_VERIFIED' === $business_info['phoneVerificationState'] ? 'VERIFIED' : 'UNVERIFIED'
+			);
+		}
+
+		return $contact_information;
+	}
+
+	/**
+	 * Map a Merchant API PostalAddress onto an AccountAddress.
+	 *
+	 * @param array $address PostalAddress decoded as an array.
+	 *
+	 * @return AccountAddress
+	 */
+	protected function map_address( array $address ): AccountAddress {
+		$region  = $address['administrativeArea'] ?? '';
+		$country = $address['regionCode'] ?? '';
+
+		// Normalize the region to the state name so it matches the store address,
+		// which is built with state names. maybe_get_state_name leaves a name unchanged.
+		if ( '' !== $region && '' !== $country ) {
+			$region = $this->settings->maybe_get_state_name( $region, $country );
+		}
+
+		$account_address = new AccountAddress();
+		$account_address->setCountry( $country );
+		$account_address->setPostalCode( $address['postalCode'] ?? '' );
+		$account_address->setLocality( $address['locality'] ?? '' );
+		$account_address->setRegion( $region );
+		$account_address->setStreetAddress( implode( "\n", $address['addressLines'] ?? [] ) );
+
+		return $account_address;
 	}
 
 	/**
@@ -62,26 +128,16 @@ class ContactInformation implements Service {
 	 * @throws ExceptionWithResponseData If the Merchant Center account can't be retrieved or updated.
 	 */
 	public function update_address_based_on_store_settings(): AccountBusinessInformation {
-		$business_information = $this->get_contact_information() ?: new AccountBusinessInformation();
+		// Read the current business information from the account so the address update
+		// preserves the other fields (phone, customer service) instead of the reduced
+		// view returned by get_contact_information().
+		$account              = $this->merchant->get_account();
+		$business_information = $account->getBusinessInformation() ?: new AccountBusinessInformation();
+		$business_information->setAddress( $this->settings->get_store_address() );
 
-		$store_address = $this->settings->get_store_address();
-		$business_information->setAddress( $store_address );
-
-		$this->update_contact_information( $business_information );
-
-		return $business_information;
-	}
-
-	/**
-	 * Update the contact information for the connected Merchant Center account.
-	 *
-	 * @param AccountBusinessInformation $business_information
-	 *
-	 * @throws ExceptionWithResponseData If the Merchant Center account can't be retrieved or updated.
-	 */
-	protected function update_contact_information( AccountBusinessInformation $business_information ): void {
-		$account = $this->merchant->get_account();
 		$account->setBusinessInformation( $business_information );
 		$this->merchant->update_account( $account );
+
+		return $business_information;
 	}
 }

--- a/src/MerchantCenter/ContactInformation.php
+++ b/src/MerchantCenter/ContactInformation.php
@@ -109,14 +109,39 @@ class ContactInformation implements Service {
 			$region = $this->settings->maybe_get_state_name( $region, $country );
 		}
 
+		$street = implode( "\n", $address['addressLines'] ?? [] );
+
 		$account_address = new AccountAddress();
-		$account_address->setCountry( $country );
-		$account_address->setPostalCode( $address['postalCode'] ?? '' );
-		$account_address->setLocality( $address['locality'] ?? '' );
-		$account_address->setRegion( $region );
-		$account_address->setStreetAddress( implode( "\n", $address['addressLines'] ?? [] ) );
+		$account_address->setCountry( ! empty( $country ) ? $country : null );
+		$account_address->setPostalCode( ! empty( $address['postalCode'] ) ? $address['postalCode'] : null );
+		$account_address->setLocality( ! empty( $address['locality'] ) ? $address['locality'] : null );
+		$account_address->setRegion( ! empty( $region ) ? $region : null );
+		$account_address->setStreetAddress( ! empty( $street ) ? $street : null );
 
 		return $account_address;
+	}
+
+	/**
+	 * Map an AccountAddress onto a Merchant API PostalAddress.
+	 *
+	 * @param AccountAddress $address
+	 *
+	 * @return array PostalAddress fields for the businessInfo resource.
+	 */
+	protected function map_to_postal_address( AccountAddress $address ): array {
+		$postal_address = [
+			'regionCode'         => (string) $address->getCountry(),
+			'administrativeArea' => (string) $address->getRegion(),
+			'locality'           => (string) $address->getLocality(),
+			'postalCode'         => (string) $address->getPostalCode(),
+		];
+
+		$street = (string) $address->getStreetAddress();
+		if ( '' !== $street ) {
+			$postal_address['addressLines'] = explode( "\n", $street );
+		}
+
+		return $postal_address;
 	}
 
 	/**
@@ -128,16 +153,14 @@ class ContactInformation implements Service {
 	 * @throws ExceptionWithResponseData If the Merchant Center account can't be retrieved or updated.
 	 */
 	public function update_address_based_on_store_settings(): AccountBusinessInformation {
-		// Read the current business information from the account so the address update
-		// preserves the other fields (phone, customer service) instead of the reduced
-		// view returned by get_contact_information().
-		$account              = $this->merchant->get_account();
-		$business_information = $account->getBusinessInformation() ?: new AccountBusinessInformation();
-		$business_information->setAddress( $this->settings->get_store_address() );
+		$address = $this->map_to_postal_address( $this->settings->get_store_address() );
 
-		$account->setBusinessInformation( $business_information );
-		$this->merchant->update_account( $account );
+		try {
+			$business_info = $this->merchant->update_business_info( [ 'address' => $address ], 'address' );
+		} catch ( MerchantApiException $e ) {
+			throw new ExceptionWithResponseData( $e->getMessage(), $e->getCode(), $e );
+		}
 
-		return $business_information;
+		return $this->map_business_info( $business_info );
 	}
 }

--- a/src/MerchantCenter/ContactInformation.php
+++ b/src/MerchantCenter/ContactInformation.php
@@ -129,12 +129,19 @@ class ContactInformation implements Service {
 	 * @return array PostalAddress fields for the businessInfo resource.
 	 */
 	protected function map_to_postal_address( AccountAddress $address ): array {
-		$postal_address = [
-			'regionCode'         => (string) $address->getCountry(),
-			'administrativeArea' => (string) $address->getRegion(),
-			'locality'           => (string) $address->getLocality(),
-			'postalCode'         => (string) $address->getPostalCode(),
-		];
+		// Omit empty fields so a partial store address does not overwrite
+		// previously-set sub-fields on the businessInfo resource with blanks.
+		$postal_address = array_filter(
+			[
+				'regionCode'         => (string) $address->getCountry(),
+				'administrativeArea' => (string) $address->getRegion(),
+				'locality'           => (string) $address->getLocality(),
+				'postalCode'         => (string) $address->getPostalCode(),
+			],
+			static function ( string $value ): bool {
+				return '' !== $value;
+			}
+		);
 
 		$street = (string) $address->getStreetAddress();
 		if ( '' !== $street ) {

--- a/tests/Unit/API/Google/Mapi/Services/MapiAccountBusinessInfoServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiAccountBusinessInfoServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountBusinessInfoService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountBusinessInfoServiceTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services
+ */
+class MapiAccountBusinessInfoServiceTest extends UnitTest {
+
+	protected const MERCHANT_ID = 12345;
+	protected const PATH        = 'accounts/v1/accounts/12345/businessInfo';
+
+	/** @var MockObject|MerchantApiClient */
+	protected $client;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var MapiAccountBusinessInfoService */
+	protected $service;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->client  = $this->createMock( MerchantApiClient::class );
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_merchant_id' )->willReturn( self::MERCHANT_ID );
+
+		$this->service = new MapiAccountBusinessInfoService( $this->client );
+		$this->service->set_options_object( $this->options );
+	}
+
+	public function test_get_business_info() {
+		$business_info = [
+			'name'    => 'accounts/12345/businessInfo',
+			'address' => [
+				'regionCode' => 'US',
+				'postalCode' => '22211',
+			],
+		];
+
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::PATH )
+			->willReturn( $business_info );
+
+		$this->assertSame( $business_info, $this->service->get_business_info() );
+	}
+}

--- a/tests/Unit/API/Google/Mapi/Services/MapiAccountBusinessInfoServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiAccountBusinessInfoServiceTest.php
@@ -57,4 +57,19 @@ class MapiAccountBusinessInfoServiceTest extends UnitTest {
 
 		$this->assertSame( $business_info, $this->service->get_business_info() );
 	}
+
+	public function test_update_business_info() {
+		$business_info = [ 'address' => [ 'regionCode' => 'US' ] ];
+		$response      = [
+			'name'    => 'accounts/12345/businessInfo',
+			'address' => [ 'regionCode' => 'US' ],
+		];
+
+		$this->client->expects( $this->once() )
+			->method( 'patch' )
+			->with( self::PATH . '?updateMask=address', $business_info )
+			->willReturn( $response );
+
+		$this->assertSame( $response, $this->service->update_business_info( $business_info, 'address' ) );
+	}
 }

--- a/tests/Unit/API/Google/Mapi/Services/MapiAccountHomepageServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiAccountHomepageServiceTest.php
@@ -1,0 +1,87 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountHomepageServiceTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services
+ */
+class MapiAccountHomepageServiceTest extends UnitTest {
+
+	protected const MERCHANT_ID   = 12345;
+	protected const HOMEPAGE_PATH = 'accounts/v1/accounts/12345/homepage';
+
+	/** @var MockObject|MerchantApiClient */
+	protected $client;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var MapiAccountHomepageService */
+	protected $service;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->client  = $this->createMock( MerchantApiClient::class );
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_merchant_id' )->willReturn( self::MERCHANT_ID );
+
+		$this->service = new MapiAccountHomepageService( $this->client );
+		$this->service->set_options_object( $this->options );
+	}
+
+	public function test_get_homepage() {
+		$homepage = [
+			'name'    => 'accounts/12345/homepage',
+			'uri'     => 'https://store.example',
+			'claimed' => true,
+		];
+
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::HOMEPAGE_PATH )
+			->willReturn( $homepage );
+
+		$this->assertSame( $homepage, $this->service->get_homepage() );
+	}
+
+	public function test_get_homepage_with_explicit_merchant_id() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( 'accounts/v1/accounts/999/homepage' )
+			->willReturn( [ 'claimed' => false ] );
+
+		$this->assertSame( [ 'claimed' => false ], $this->service->get_homepage( 999 ) );
+	}
+
+	public function test_claim() {
+		$homepage = [ 'claimed' => true ];
+
+		$this->client->expects( $this->once() )
+			->method( 'post' )
+			->with( self::HOMEPAGE_PATH . ':claim', [ 'overwrite' => false ] )
+			->willReturn( $homepage );
+
+		$this->assertSame( $homepage, $this->service->claim() );
+	}
+
+	public function test_claim_with_overwrite() {
+		$this->client->expects( $this->once() )
+			->method( 'post' )
+			->with( self::HOMEPAGE_PATH . ':claim', [ 'overwrite' => true ] )
+			->willReturn( [ 'claimed' => true ] );
+
+		$this->assertSame( [ 'claimed' => true ], $this->service->claim( true ) );
+	}
+}

--- a/tests/Unit/API/Google/Mapi/Services/MapiAccountUsersServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiAccountUsersServiceTest.php
@@ -55,4 +55,19 @@ class MapiAccountUsersServiceTest extends UnitTest {
 
 		$this->assertSame( $user, $this->service->get_current_user() );
 	}
+
+	public function test_get_current_user_builds_path_from_merchant_id() {
+		$options = $this->createMock( OptionsInterface::class );
+		$options->method( 'get_merchant_id' )->willReturn( 67890 );
+
+		$service = new MapiAccountUsersService( $this->client );
+		$service->set_options_object( $options );
+
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( 'accounts/v1/accounts/67890/users/me' )
+			->willReturn( [] );
+
+		$service->get_current_user();
+	}
 }

--- a/tests/Unit/API/Google/Mapi/Services/MapiAccountUsersServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiAccountUsersServiceTest.php
@@ -1,0 +1,58 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountUsersService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountUsersServiceTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services
+ */
+class MapiAccountUsersServiceTest extends UnitTest {
+
+	protected const MERCHANT_ID = 12345;
+	protected const PATH        = 'accounts/v1/accounts/12345/users/me';
+
+	/** @var MockObject|MerchantApiClient */
+	protected $client;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var MapiAccountUsersService */
+	protected $service;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->client  = $this->createMock( MerchantApiClient::class );
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_merchant_id' )->willReturn( self::MERCHANT_ID );
+
+		$this->service = new MapiAccountUsersService( $this->client );
+		$this->service->set_options_object( $this->options );
+	}
+
+	public function test_get_current_user() {
+		$user = [
+			'name'         => 'accounts/12345/users/me@example.com',
+			'state'        => 'VERIFIED',
+			'accessRights' => [ 'ADMIN', 'STANDARD' ],
+		];
+
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::PATH )
+			->willReturn( $user );
+
+		$this->assertSame( $user, $this->service->get_current_user() );
+	}
+}

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -94,6 +94,7 @@ class MerchantTest extends UnitTest {
 			->willThrowException( $this->merchant_api_exception( 500 ) );
 
 		$this->expectException( Exception::class );
+		$this->expectExceptionCode( 500 );
 		$this->merchant->claimwebsite();
 	}
 

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -4,7 +4,9 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountBusinessInfoService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountUsersService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -42,6 +44,12 @@ class MerchantTest extends UnitTest {
 	/** @var MockObject|MapiAccountHomepageService $homepage_service */
 	protected $homepage_service;
 
+	/** @var MockObject|MapiAccountBusinessInfoService $business_info_service */
+	protected $business_info_service;
+
+	/** @var MockObject|MapiAccountUsersService $users_service */
+	protected $users_service;
+
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
@@ -62,9 +70,11 @@ class MerchantTest extends UnitTest {
 		$this->service->freelistingsprogram = $this->createMock( ShoppingContent\Resource\Freelistingsprogram::class );
 		$this->service->shoppingadsprogram  = $this->createMock( ShoppingContent\Resource\Shoppingadsprogram::class );
 
-		$this->homepage_service = $this->createMock( MapiAccountHomepageService::class );
-		$this->options          = $this->createMock( OptionsInterface::class );
-		$this->merchant         = new Merchant( $this->service, $this->homepage_service );
+		$this->homepage_service      = $this->createMock( MapiAccountHomepageService::class );
+		$this->business_info_service = $this->createMock( MapiAccountBusinessInfoService::class );
+		$this->users_service         = $this->createMock( MapiAccountUsersService::class );
+		$this->options               = $this->createMock( OptionsInterface::class );
+		$this->merchant              = new Merchant( $this->service, $this->homepage_service, $this->business_info_service, $this->users_service );
 		$this->merchant->set_options_object( $this->options );
 
 		$this->merchant_id = 12345;
@@ -424,38 +434,68 @@ class MerchantTest extends UnitTest {
 		);
 	}
 
+	public function test_get_business_info() {
+		$business_info = [
+			'name'    => 'accounts/12345/businessInfo',
+			'address' => [ 'regionCode' => 'US' ],
+		];
+
+		$this->business_info_service->expects( $this->once() )
+			->method( 'get_business_info' )
+			->willReturn( $business_info );
+
+		$this->assertSame( $business_info, $this->merchant->get_business_info() );
+	}
+
 	public function test_has_access_to_account() {
-		$account = $this->createMock( Account::class );
-		$user    = $this->createMock( AccountUser::class );
-		$email   = 'john@doe.email';
+		$email = 'john@doe.email';
 
-		$user->expects( $this->once() )
-			->method( 'getEmailAddress' )
-			->willReturn( $email );
+		$this->users_service->expects( $this->once() )
+			->method( 'get_current_user' )
+			->willReturn(
+				[
+					'name'         => 'accounts/12345/users/' . $email,
+					'accessRights' => [ 'ADMIN', 'STANDARD' ],
+				]
+			);
 
-		$user->expects( $this->once() )
-			->method( 'getAdmin' )
-			->willReturn( true );
+		$this->assertTrue( $this->merchant->has_access( $email ) );
+	}
 
-		$account->expects( $this->once() )
-			->method( 'getUsers' )
-			->willReturn( [ $user ] );
+	public function test_no_access_when_not_admin() {
+		$email = 'john@doe.email';
 
-		$this->mock_get_account( $account );
+		$this->users_service->expects( $this->once() )
+			->method( 'get_current_user' )
+			->willReturn(
+				[
+					'name'         => 'accounts/12345/users/' . $email,
+					'accessRights' => [ 'STANDARD' ],
+				]
+			);
 
-		$this->assertTrue(
-			$this->merchant->has_access( $email )
-		);
+		$this->assertFalse( $this->merchant->has_access( $email ) );
+	}
+
+	public function test_no_access_when_email_mismatch() {
+		$this->users_service->expects( $this->once() )
+			->method( 'get_current_user' )
+			->willReturn(
+				[
+					'name'         => 'accounts/12345/users/someone@else.email',
+					'accessRights' => [ 'ADMIN' ],
+				]
+			);
+
+		$this->assertFalse( $this->merchant->has_access( 'john@doe.email' ) );
 	}
 
 	public function test_no_access_to_account() {
-		$email = 'john@doe.email';
+		$this->users_service->expects( $this->once() )
+			->method( 'get_current_user' )
+			->willThrowException( $this->merchant_api_exception( 500 ) );
 
-		$this->mock_get_account_exception( $this->get_google_exception( 'No access' ) );
-
-		$this->assertFalse(
-			$this->merchant->has_access( $email )
-		);
+		$this->assertFalse( $this->merchant->has_access( 'john@doe.email' ) );
 	}
 
 	public function test_update_merchant_id() {

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -3,6 +3,8 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -37,6 +39,9 @@ class MerchantTest extends UnitTest {
 	/** @var MockObject|ShoppingContent $service */
 	protected $service;
 
+	/** @var MockObject|MapiAccountHomepageService $homepage_service */
+	protected $homepage_service;
+
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
@@ -57,8 +62,9 @@ class MerchantTest extends UnitTest {
 		$this->service->freelistingsprogram = $this->createMock( ShoppingContent\Resource\Freelistingsprogram::class );
 		$this->service->shoppingadsprogram  = $this->createMock( ShoppingContent\Resource\Shoppingadsprogram::class );
 
-		$this->options  = $this->createMock( OptionsInterface::class );
-		$this->merchant = new Merchant( $this->service );
+		$this->homepage_service = $this->createMock( MapiAccountHomepageService::class );
+		$this->options          = $this->createMock( OptionsInterface::class );
+		$this->merchant         = new Merchant( $this->service, $this->homepage_service );
 		$this->merchant->set_options_object( $this->options );
 
 		$this->merchant_id = 12345;
@@ -66,57 +72,43 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_claim_website() {
-		$this->service->accounts->expects( $this->once() )
-			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id );
+		$this->homepage_service->expects( $this->once() )
+			->method( 'claim' )
+			->willReturn( [ 'claimed' => true ] );
 		$this->assertTrue( $this->merchant->claimwebsite() );
 	}
 
 	public function test_claimwebsite_error() {
-		$this->service->accounts->expects( $this->once() )
-			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->will(
-				$this->throwException(
-					new GoogleException()
-				)
-			);
+		$this->homepage_service->expects( $this->once() )
+			->method( 'claim' )
+			->willThrowException( $this->merchant_api_exception( 500 ) );
 
 		$this->expectException( Exception::class );
 		$this->merchant->claimwebsite();
 	}
 
 	public function test_website_already_claimed() {
-		$this->service->accounts->expects( $this->once() )
-			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->will(
-				$this->throwException(
-					new GoogleException( 'claimed', 403 )
-				)
-			);
+		$this->homepage_service->expects( $this->once() )
+			->method( 'claim' )
+			->willThrowException( $this->merchant_api_exception( 403 ) );
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionCode( 403 );
 		$this->merchant->claimwebsite();
 	}
 
-	public function test_website_claim_conflict_content_api() {
-		$message = "There exist other accounts with homepage that conflicts with the homepage of account 1234567890. Set the parameter 'overwrite' to true if you want to take the claim and remove it from these accounts: user@example.com";
-		$error   = [
-			'domain'  => 'content.ContentErrorDomain',
-			'reason'  => 'invalid_parameter',
-			'message' => $message,
+	public function test_website_claim_conflict() {
+		$body = [
+			'error' => [
+				'code'    => 400,
+				'status'  => 'FAILED_PRECONDITION',
+				'message' => 'The homepage is already claimed by another account.',
+			],
 		];
 
-		$this->service->accounts->expects( $this->once() )
-			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->will(
-				$this->throwException(
-					new GoogleServiceException( $message, 400, null, [ $error ] )
-				)
-			);
+		$this->homepage_service->expects( $this->once() )
+			->method( 'claim' )
+			->willThrowException( $this->merchant_api_exception( 400, $body ) );
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionCode( 403 );
@@ -125,44 +117,17 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_claimwebsite_non_conflict_400_error() {
-		$message = 'Request contains an invalid argument.';
-		$error   = [
-			'domain'  => 'content.ContentErrorDomain',
-			'reason'  => 'invalid',
-			'message' => $message,
+		$body = [
+			'error' => [
+				'code'    => 400,
+				'status'  => 'INVALID_ARGUMENT',
+				'message' => 'Request contains an invalid argument.',
+			],
 		];
 
-		$this->service->accounts->expects( $this->once() )
-			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->will(
-				$this->throwException(
-					new GoogleServiceException( $message, 400, null, [ $error ] )
-				)
-			);
-
-		$this->expectException( Exception::class );
-		$this->expectExceptionCode( 400 );
-		$this->expectExceptionMessage( 'Unable to claim website.' );
-		$this->merchant->claimwebsite();
-	}
-
-	public function test_claimwebsite_non_content_api_domain_error() {
-		$message = "There exist other accounts with homepage that conflicts. Set the parameter 'overwrite' to true.";
-		$error   = [
-			'domain'  => 'global',
-			'reason'  => 'forbidden',
-			'message' => $message,
-		];
-
-		$this->service->accounts->expects( $this->once() )
-			->method( 'claimwebsite' )
-			->with( $this->merchant_id, $this->merchant_id )
-			->will(
-				$this->throwException(
-					new GoogleServiceException( $message, 400, null, [ $error ] )
-				)
-			);
+		$this->homepage_service->expects( $this->once() )
+			->method( 'claim' )
+			->willThrowException( $this->merchant_api_exception( 400, $body ) );
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionCode( 400 );
@@ -279,30 +244,31 @@ class MerchantTest extends UnitTest {
 
 	public function test_get_claimed_url_hash_not_claimed() {
 		$url = 'https://site.test';
-		$this->mock_get_account( $this->get_account_with_url( $url ) );
-		$this->mock_get_account_status( $this->get_status_website_claimed( false ) );
+		$this->homepage_service->method( 'get_homepage' )
+			->willReturn( [ 'uri' => $url, 'claimed' => false ] );
 
 		$this->assertNull( $this->merchant->get_claimed_url_hash() );
 	}
 
 	public function test_get_claimed_url_hash_from_account() {
 		$url = 'https://site.test';
-		$this->mock_get_account( $this->get_account_with_url( $url ) );
-		$this->mock_get_account_status( $this->get_status_website_claimed() );
+		$this->homepage_service->method( 'get_homepage' )
+			->willReturn( [ 'uri' => $url, 'claimed' => true ] );
 
 		$this->assertEquals( md5( $url ), $this->merchant->get_claimed_url_hash() );
 	}
 
 	public function test_get_claimed_url_hash_with_trailing_slash() {
 		$url = 'https://site.test';
-		$this->mock_get_account( $this->get_account_with_url( trailingslashit( $url ) ) );
-		$this->mock_get_account_status( $this->get_status_website_claimed() );
+		$this->homepage_service->method( 'get_homepage' )
+			->willReturn( [ 'uri' => trailingslashit( $url ), 'claimed' => true ] );
 
 		$this->assertEquals( md5( $url ), $this->merchant->get_claimed_url_hash() );
 	}
 
 	public function test_get_claimed_url_hash_from_account_failure() {
-		$this->mock_get_account_exception( $this->get_google_service_exception() );
+		$this->homepage_service->method( 'get_homepage' )
+			->willThrowException( $this->merchant_api_exception( 500 ) );
 
 		$this->assertNull( $this->merchant->get_claimed_url_hash() );
 	}
@@ -605,5 +571,9 @@ class MerchantTest extends UnitTest {
 			->method( 'get' )
 			->with( $this->merchant_id, $this->merchant_id )
 			->will( $this->throwException( $exception ) );
+	}
+
+	private function merchant_api_exception( int $http_status, array $response_body = [] ): MerchantApiException {
+		return new MerchantApiException( $http_status, $response_body, __METHOD__ );
 	}
 }

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -245,7 +245,12 @@ class MerchantTest extends UnitTest {
 	public function test_get_claimed_url_hash_not_claimed() {
 		$url = 'https://site.test';
 		$this->homepage_service->method( 'get_homepage' )
-			->willReturn( [ 'uri' => $url, 'claimed' => false ] );
+			->willReturn(
+				[
+					'uri'     => $url,
+					'claimed' => false,
+				]
+			);
 
 		$this->assertNull( $this->merchant->get_claimed_url_hash() );
 	}
@@ -253,7 +258,12 @@ class MerchantTest extends UnitTest {
 	public function test_get_claimed_url_hash_from_account() {
 		$url = 'https://site.test';
 		$this->homepage_service->method( 'get_homepage' )
-			->willReturn( [ 'uri' => $url, 'claimed' => true ] );
+			->willReturn(
+				[
+					'uri'     => $url,
+					'claimed' => true,
+				]
+			);
 
 		$this->assertEquals( md5( $url ), $this->merchant->get_claimed_url_hash() );
 	}
@@ -261,7 +271,12 @@ class MerchantTest extends UnitTest {
 	public function test_get_claimed_url_hash_with_trailing_slash() {
 		$url = 'https://site.test';
 		$this->homepage_service->method( 'get_homepage' )
-			->willReturn( [ 'uri' => trailingslashit( $url ), 'claimed' => true ] );
+			->willReturn(
+				[
+					'uri'     => trailingslashit( $url ),
+					'claimed' => true,
+				]
+			);
 
 		$this->assertEquals( md5( $url ), $this->merchant->get_claimed_url_hash() );
 	}

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -447,6 +447,18 @@ class MerchantTest extends UnitTest {
 		$this->assertSame( $business_info, $this->merchant->get_business_info() );
 	}
 
+	public function test_update_business_info() {
+		$business_info = [ 'address' => [ 'regionCode' => 'US' ] ];
+		$response      = [ 'name' => 'accounts/12345/businessInfo' ];
+
+		$this->business_info_service->expects( $this->once() )
+			->method( 'update_business_info' )
+			->with( $business_info, 'address' )
+			->willReturn( $response );
+
+		$this->assertSame( $response, $this->merchant->update_business_info( $business_info, 'address' ) );
+	}
+
 	public function test_has_access_to_account() {
 		$email = 'john@doe.email';
 

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
@@ -52,6 +53,9 @@ class AccountServiceTest extends UnitTest {
 
 	/** @var MockObject|Merchant $merchant */
 	protected $merchant;
+
+	/** @var MockObject|MapiAccountHomepageService $homepage_service */
+	protected $homepage_service;
 
 	/** @var MockObject|MerchantCenterService $mc_service */
 	protected $mc_service;
@@ -132,6 +136,7 @@ class AccountServiceTest extends UnitTest {
 		$this->ads                          = $this->createMock( Ads::class );
 		$this->cleanup_synced               = $this->createMock( CleanupSyncedProducts::class );
 		$this->merchant                     = $this->createMock( Merchant::class );
+		$this->homepage_service             = $this->createMock( MapiAccountHomepageService::class );
 		$this->mc_service                   = $this->createMock( MerchantCenterService::class );
 		$this->issue_table                  = $this->createMock( MerchantIssueTable::class );
 		$this->merchant_statuses            = $this->createMock( MerchantStatuses::class );
@@ -151,6 +156,7 @@ class AccountServiceTest extends UnitTest {
 		$this->container->addShared( AdsAccountState::class, $this->ads_state );
 		$this->container->addShared( CleanupSyncedProducts::class, $this->cleanup_synced );
 		$this->container->addShared( Merchant::class, $this->merchant );
+		$this->container->addShared( MapiAccountHomepageService::class, $this->homepage_service );
 		$this->container->addShared( MerchantCenterService::class, $this->mc_service );
 		$this->container->addShared( MerchantIssueTable::class, $this->issue_table );
 		$this->container->addShared( MerchantStatuses::class, $this->merchant_statuses );
@@ -322,9 +328,10 @@ class AccountServiceTest extends UnitTest {
 			->method( 'get_account' )
 			->willReturn( $this->get_account_with_url( self::TEST_OLD_URL ) );
 
-		$this->merchant->expects( $this->any() )
-			->method( 'get_accountstatus' )
-			->willReturn( $this->get_status_website_claimed() );
+		$this->homepage_service->expects( $this->any() )
+			->method( 'get_homepage' )
+			->with( self::TEST_ACCOUNT_ID )
+			->willReturn( [ 'claimed' => true ] );
 
 		try {
 			$this->account->use_existing_account_id( self::TEST_ACCOUNT_ID );
@@ -507,9 +514,10 @@ class AccountServiceTest extends UnitTest {
 				]
 			);
 
-		$this->merchant->expects( $this->any() )
-			->method( 'get_accountstatus' )
-			->willReturn( $this->get_status_website_claimed() );
+		$this->homepage_service->expects( $this->any() )
+			->method( 'get_homepage' )
+			->with( self::TEST_ACCOUNT_ID )
+			->willReturn( [ 'claimed' => true ] );
 
 		$this->merchant->expects( $this->never() )
 			->method( 'claimwebsite' );

--- a/tests/Unit/MerchantCenter/ContactInformationTest.php
+++ b/tests/Unit/MerchantCenter/ContactInformationTest.php
@@ -80,6 +80,28 @@ class ContactInformationTest extends ContainerAwareUnitTest {
 		$this->assertEquals( 'US', $address->getCountry() );
 	}
 
+	public function test_empty_address_fields_map_to_null() {
+		$this->merchant->expects( $this->any() )
+			->method( 'get_business_info' )
+			->willReturn(
+				[
+					'name'    => 'accounts/12345/businessInfo',
+					'address' => [
+						'regionCode'   => 'US',
+						'addressLines' => [ '' ],
+					],
+				]
+			);
+
+		$address = $this->contact_information->get_contact_information()->getAddress();
+
+		$this->assertSame( 'US', $address->getCountry() );
+		$this->assertNull( $address->getRegion() );
+		$this->assertNull( $address->getLocality() );
+		$this->assertNull( $address->getPostalCode() );
+		$this->assertNull( $address->getStreetAddress() );
+	}
+
 	public function test_region_code_maps_to_state_name() {
 		// Use the real Settings so the actual code->name conversion (and WC state data) runs.
 		$contact = new ContactInformation( $this->merchant, $this->container->get( Settings::class ) );
@@ -100,28 +122,38 @@ class ContactInformationTest extends ContainerAwareUnitTest {
 	}
 
 	public function test_update_address() {
-		$this->merchant->expects( $this->any() )
-			->method( 'get_account' )
-			->willReturn( $this->get_empty_account() );
-
 		$this->google_settings->expects( $this->any() )
 			->method( 'get_store_address' )
 			->willReturn( $this->get_sample_address() );
 
+		$this->google_settings->expects( $this->any() )
+			->method( 'maybe_get_state_name' )
+			->willReturnArgument( 0 );
+
+		$expected_address = [
+			'regionCode'         => 'US',
+			'administrativeArea' => 'California',
+			'locality'           => 'San Francisco',
+			'postalCode'         => '12345',
+			'addressLines'       => [ '123 Main St.' ],
+		];
+
+		$this->merchant->expects( $this->once() )
+			->method( 'update_business_info' )
+			->with( [ 'address' => $expected_address ], 'address' )
+			->willReturn(
+				[
+					'name'    => 'accounts/12345/businessInfo',
+					'address' => $expected_address,
+				]
+			);
+
 		$results = $this->contact_information->update_address_based_on_store_settings();
 
-		$this->assertEquals(
-			$this->get_sample_address()->getPostalCode(),
-			$results->getAddress()->getPostalCode()
-		);
-		$this->assertEquals(
-			$this->get_sample_address()->getStreetAddress(),
-			$results->getAddress()->getStreetAddress()
-		);
-		$this->assertEquals(
-			$this->get_sample_address()->getCountry(),
-			$results->getAddress()->getCountry()
-		);
+		$this->assertEquals( '12345', $results->getAddress()->getPostalCode() );
+		$this->assertEquals( '123 Main St.', $results->getAddress()->getStreetAddress() );
+		$this->assertEquals( 'California', $results->getAddress()->getRegion() );
+		$this->assertEquals( 'US', $results->getAddress()->getCountry() );
 	}
 
 	public function test_maps_phone_and_verification_state() {

--- a/tests/Unit/MerchantCenter/ContactInformationTest.php
+++ b/tests/Unit/MerchantCenter/ContactInformationTest.php
@@ -198,4 +198,17 @@ class ContactInformationTest extends ContainerAwareUnitTest {
 		$this->expectException( ExceptionWithResponseData::class );
 		$this->contact_information->get_contact_information();
 	}
+
+	public function test_update_address_exception() {
+		$this->google_settings->expects( $this->any() )
+			->method( 'get_store_address' )
+			->willReturn( $this->get_sample_address() );
+
+		$this->merchant->expects( $this->any() )
+			->method( 'update_business_info' )
+			->willThrowException( new MerchantApiException( 500, [], __METHOD__ ) );
+
+		$this->expectException( ExceptionWithResponseData::class );
+		$this->contact_information->update_address_based_on_store_settings();
+	}
 }

--- a/tests/Unit/MerchantCenter/ContactInformationTest.php
+++ b/tests/Unit/MerchantCenter/ContactInformationTest.php
@@ -3,7 +3,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\ContactInformation;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\ContainerAwareUnitTest;
@@ -42,45 +44,65 @@ class ContactInformationTest extends ContainerAwareUnitTest {
 
 	public function test_get_empty_contact_information() {
 		$this->merchant->expects( $this->any() )
-			->method( 'get_account' )
-			->willReturn( $this->get_empty_account() );
+			->method( 'get_business_info' )
+			->willReturn( [] );
 
 		$this->assertNull( $this->contact_information->get_contact_information() );
 	}
 
 	public function test_get_valid_contact_information() {
 		$this->merchant->expects( $this->any() )
-			->method( 'get_account' )
-			->willReturn( $this->get_valid_account() );
+			->method( 'get_business_info' )
+			->willReturn(
+				[
+					'name'    => 'accounts/12345/businessInfo',
+					'address' => [
+						'regionCode'         => 'US',
+						'administrativeArea' => 'CA',
+						'locality'           => 'San Francisco',
+						'addressLines'       => [ '123 Main St.' ],
+						'postalCode'         => '12345',
+					],
+				]
+			);
 
-		$contact_information = $this->contact_information->get_contact_information();
+		$this->google_settings->expects( $this->any() )
+			->method( 'maybe_get_state_name' )
+			->with( 'CA', 'US' )
+			->willReturn( 'California' );
 
-		$this->assertEquals(
-			$this->get_sample_address()->getPostalCode(),
-			$contact_information->getAddress()->getPostalCode()
-		);
-		$this->assertEquals(
-			$this->get_sample_address()->getStreetAddress(),
-			$contact_information->getAddress()->getStreetAddress()
-		);
-		$this->assertEquals(
-			$this->get_sample_address()->getLocality(),
-			$contact_information->getAddress()->getLocality()
-		);
-		$this->assertEquals(
-			$this->get_sample_address()->getRegion(),
-			$contact_information->getAddress()->getRegion()
-		);
-		$this->assertEquals(
-			$this->get_sample_address()->getCountry(),
-			$contact_information->getAddress()->getCountry()
-		);
+		$address = $this->contact_information->get_contact_information()->getAddress();
+
+		$this->assertEquals( '12345', $address->getPostalCode() );
+		$this->assertEquals( '123 Main St.', $address->getStreetAddress() );
+		$this->assertEquals( 'San Francisco', $address->getLocality() );
+		$this->assertEquals( 'California', $address->getRegion() );
+		$this->assertEquals( 'US', $address->getCountry() );
+	}
+
+	public function test_region_code_maps_to_state_name() {
+		// Use the real Settings so the actual code->name conversion (and WC state data) runs.
+		$contact = new ContactInformation( $this->merchant, $this->container->get( Settings::class ) );
+
+		$this->merchant->expects( $this->any() )
+			->method( 'get_business_info' )
+			->willReturn(
+				[
+					'name'    => 'accounts/12345/businessInfo',
+					'address' => [
+						'regionCode'         => 'US',
+						'administrativeArea' => 'CA',
+					],
+				]
+			);
+
+		$this->assertEquals( 'California', $contact->get_contact_information()->getAddress()->getRegion() );
 	}
 
 	public function test_update_address() {
 		$this->merchant->expects( $this->any() )
 			->method( 'get_account' )
-			->willReturn( $this->get_valid_account() );
+			->willReturn( $this->get_empty_account() );
 
 		$this->google_settings->expects( $this->any() )
 			->method( 'get_store_address' )
@@ -97,25 +119,51 @@ class ContactInformationTest extends ContainerAwareUnitTest {
 			$results->getAddress()->getStreetAddress()
 		);
 		$this->assertEquals(
-			$this->get_sample_address()->getLocality(),
-			$results->getAddress()->getLocality()
-		);
-		$this->assertEquals(
-			$this->get_sample_address()->getRegion(),
-			$results->getAddress()->getRegion()
-		);
-		$this->assertEquals(
 			$this->get_sample_address()->getCountry(),
 			$results->getAddress()->getCountry()
 		);
 	}
 
-	public function test_get_account_exception() {
+	public function test_maps_phone_and_verification_state() {
 		$this->merchant->expects( $this->any() )
-			->method( 'get_account' )
-			->willThrowException( $this->get_google_exception() );
+			->method( 'get_business_info' )
+			->willReturn(
+				[
+					'name'                   => 'accounts/12345/businessInfo',
+					'phone'                  => [ 'e164Number' => '+15551234567' ],
+					'phoneVerificationState' => 'PHONE_VERIFICATION_STATE_VERIFIED',
+				]
+			);
 
-		$this->expectExceptionObject( $this->get_google_exception() );
+		$contact_information = $this->contact_information->get_contact_information();
+
+		$this->assertEquals( '+15551234567', $contact_information->getPhoneNumber() );
+		$this->assertEquals( 'VERIFIED', $contact_information->getPhoneVerificationStatus() );
+	}
+
+	public function test_maps_unspecified_verification_state_to_unverified() {
+		$this->merchant->expects( $this->any() )
+			->method( 'get_business_info' )
+			->willReturn(
+				[
+					'name'                   => 'accounts/12345/businessInfo',
+					'phone'                  => [ 'e164Number' => '+15551234567' ],
+					'phoneVerificationState' => 'PHONE_VERIFICATION_STATE_UNSPECIFIED',
+				]
+			);
+
+		$this->assertEquals(
+			'UNVERIFIED',
+			$this->contact_information->get_contact_information()->getPhoneVerificationStatus()
+		);
+	}
+
+	public function test_get_business_info_exception() {
+		$this->merchant->expects( $this->any() )
+			->method( 'get_business_info' )
+			->willThrowException( new MerchantApiException( 500, [], __METHOD__ ) );
+
+		$this->expectException( ExceptionWithResponseData::class );
 		$this->contact_information->get_contact_information();
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-755/migrate-contentaccountsget-to-mapi-accountsget

Migrates the Merchant Center account reads not covered by the website-claim ticket from the Content API accounts.get to the MAPI


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

- Connect Google for WooCommerce and open the contact-information / store-requirements screen. Confirm the Merchant Center address, phone, and verification status display as before.
- Confirm the "MC address differs from store address" indicator is correct when they match (including the state/region), and that updating the address still works.
- Check the connection status , merchant access still resolves (yes/no) for the connected account.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry
Migrate Merchant Center business info and account access reads to the MAPI.
>
