### PR TITLE
GOOWOO-239: Fix flaky notification-badge, step-3, price-benchmark, and settings tests

### DIFF
--- a/tests/e2e/specs/dashboard/notification-badge.test.js
+++ b/tests/e2e/specs/dashboard/notification-badge.test.js
@@ -57,16 +57,16 @@ test.describe( 'Notification Badge', () => {
 				.locator( 'span.update-plugins' )
 				.filter( { hasText: '1' } );
 
-			expect( badge ).toBeVisible();
+			await expect( badge ).toBeVisible();
 		} );
 
-		test( 'In Google for WooCommerce sub-menu when Marketing menu is expanded', () => {
+		test( 'In Google for WooCommerce sub-menu when Marketing menu is expanded', async () => {
 			const badge = dashboardPage.page
 				.getByRole( 'link', { name: 'Google for WooCommerce' } )
 				.locator( 'span.update-plugins' )
 				.filter( { hasText: '1' } );
 
-			expect( badge ).toBeVisible();
+			await expect( badge ).toBeVisible();
 		} );
 
 		test( 'On Marketing menu when switched to Analytics menu', async () => {
@@ -75,7 +75,7 @@ test.describe( 'Notification Badge', () => {
 				.locator( 'span.update-plugins' )
 				.filter( { hasText: '1' } );
 
-			expect( badge ).toBeVisible();
+			await expect( badge ).toBeVisible();
 
 			await dashboardPage.page
 				.getByRole( 'link', { name: 'Analytics' } )
@@ -86,7 +86,7 @@ test.describe( 'Notification Badge', () => {
 				.locator( 'span.update-plugins' )
 				.filter( { hasText: '1' } );
 
-			expect( badgeMoved ).toBeVisible();
+			await expect( badgeMoved ).toBeVisible();
 		} );
 	} );
 

--- a/tests/e2e/specs/dashboard/notification-badge.test.js
+++ b/tests/e2e/specs/dashboard/notification-badge.test.js
@@ -105,7 +105,7 @@ test.describe( 'Notification Badge', () => {
 				.locator( 'span.update-plugins' )
 				.filter( { hasText: '1' } );
 
-			expect( badge ).not.toBeVisible();
+			await expect( badge ).not.toBeVisible();
 		} );
 	} );
 } );

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -83,7 +83,7 @@ test.describe( 'GTag events', () => {
 
 		// Go to block shop page
 		await page.goto( pageSlug );
-		await blockProductAddToCart( page );
+		await blockProductAddToCart( page, simpleProductID );
 
 		await event.then( ( request ) => {
 			const data = getEventData( request );

--- a/tests/e2e/specs/gtag-events/gtag-events.test.js
+++ b/tests/e2e/specs/gtag-events/gtag-events.test.js
@@ -83,7 +83,7 @@ test.describe( 'GTag events', () => {
 
 		// Go to block shop page
 		await page.goto( pageSlug );
-		await blockProductAddToCart( page, simpleProductID );
+		await blockProductAddToCart( page );
 
 		await event.then( ( request ) => {
 			const data = getEventData( request );

--- a/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
+++ b/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
@@ -448,6 +448,9 @@ test.describe( 'Complete your campaign', () => {
 				} );
 
 				test( 'Suggest a higher budget for getting back free credits', async () => {
+					await expect(
+						page.getByLabel( 'recommended' )
+					).toBeChecked();
 					await setupBudgetPage.fillBudget( '8' );
 					await completeCampaign.clickCompleteSetupButton();
 

--- a/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
+++ b/tests/e2e/specs/onboarding/step-3-complete-campaign.test.js
@@ -16,7 +16,11 @@ import {
 	getFAQPanelRow,
 	checkBillingAdsPopup,
 } from '../../utils/page';
-import { clearServiceBasedMerchant } from '../../utils/api';
+import {
+	clearServiceBasedMerchant,
+	setCompletedAdsSetup,
+	clearCompletedAdsSetup,
+} from '../../utils/api';
 
 test.use( { storageState: process.env.ADMINSTATE } );
 
@@ -492,6 +496,9 @@ test.describe( 'Complete your campaign', () => {
 					await setupAdsAccountPage.mockAdsAccountIncomplete();
 					await completeCampaign.goto();
 					await completeCampaign.clickSkipPaidAdsCreationButton();
+					await completeCampaign
+						.getSkipPaidAdsCreationModal()
+						.waitFor( { state: 'visible' } );
 				} );
 
 				test( 'should see the modal', async () => {
@@ -690,15 +697,17 @@ test.describe( 'Complete your campaign', () => {
 
 		test.describe( 'Ads setup is complete', async () => {
 			test.beforeAll( async () => {
+				await setCompletedAdsSetup();
 				await completeCampaign.goto();
 				await completeCampaign.clickSkipPaidAdsCreationButton();
 				await completeCampaign.clickCompleteSetupModalButton();
 				await page.waitForURL( /path=%2Fgoogle%2Fproduct-feed/, {
 					waitUntil: 'domcontentloaded',
 				} );
-				await page.evaluate( () => {
-					window.glaData.adsSetupComplete = true;
-				} );
+			} );
+
+			test.afterAll( async () => {
+				await clearCompletedAdsSetup();
 			} );
 
 			test( 'should have two prompts in the setup success modal', async () => {

--- a/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
+++ b/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
@@ -89,10 +89,7 @@ test.describe( 'Price Benchmark Page', () => {
 		} );
 
 		test( 'Displays error message when data view fails to load', async () => {
-			await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions( [] );
-			await priceBenchmarkPage.goto();
-
-			// Mock 500 response for the data view script only once.
+			// Mock must be registered before goto() so it intercepts the script request during page load.
 			const once = priceBenchmarkPage.withFulfillTimes( 1 );
 			await once.fulfillRequest(
 				/\/js\/build\/wp-dataviews-shim.js(\/.*)?\b/,
@@ -100,6 +97,9 @@ test.describe( 'Price Benchmark Page', () => {
 				500,
 				[ 'GET' ]
 			);
+
+			await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions( [] );
+			await priceBenchmarkPage.goto();
 
 			const errorMessage = page.locator(
 				'.gla-price-benchmark__error-message'
@@ -203,6 +203,8 @@ test.describe( 'Price Benchmark Page', () => {
 				},
 				404
 			);
+			// Reload after mocks are registered so the component fetches with the 404 summary response.
+			await priceBenchmarkPage.goto();
 
 			const errorMessage = page.locator(
 				'.components-snackbar__content'

--- a/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
+++ b/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
@@ -89,7 +89,8 @@ test.describe( 'Price Benchmark Page', () => {
 		} );
 
 		test( 'Displays error message when data view fails to load', async () => {
-			// Mock must be registered before goto() so it intercepts the script request during page load.
+			// wp-dataviews-shim.js is loaded as a blocking script during HTML parsing,
+			// not lazily — the route must be registered before goto() or the request is already gone.
 			const once = priceBenchmarkPage.withFulfillTimes( 1 );
 			await once.fulfillRequest(
 				/\/js\/build\/wp-dataviews-shim.js(\/.*)?\b/,

--- a/tests/e2e/specs/settings/settings.test.js
+++ b/tests/e2e/specs/settings/settings.test.js
@@ -6,7 +6,12 @@ import { expect, test } from '@playwright/test';
 /**
  * Internal dependencies
  */
-import { clearOnboardedMerchant, setOnboardedMerchant } from '../../utils/api';
+import {
+	clearOnboardedMerchant,
+	clearServiceBasedMerchant,
+	setOnboardedMerchant,
+	setServiceBasedMerchant,
+} from '../../utils/api';
 import SettingsPage from '../../utils/pages/settings';
 
 test.use( { storageState: process.env.ADMINSTATE } );
@@ -298,12 +303,17 @@ test.describe( 'Settings', () => {
 
 	test.describe( 'No connected Google Merchant Center account', () => {
 		test.beforeAll( async () => {
+			await setServiceBasedMerchant();
 			await settingsPage.mockJetpackConnected();
 			await settingsPage.mockGoogleConnected();
 			await settingsPage.mockAdsAccountConnected();
 			await settingsPage.mockMCNotConnected();
 			await settingsPage.mockTargetAudienceCountries();
 			await settingsPage.goto();
+		} );
+
+		test.afterAll( async () => {
+			await clearServiceBasedMerchant();
 		} );
 
 		test( 'should not show Google Merchant Center account card', async () => {

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -50,10 +50,10 @@ add_filter(
 add_filter(
 	'google_for_woocommerce_admin_menu_notification_count',
 	function( int $current_count ) {
-		if ( isset( $_GET['no_notifications'] ) && $_GET['no_notifications'] === true ) {
+		if ( isset( $_GET['no_notifications'] ) && $_GET['no_notifications'] === 'true' ) {
 			return 0;
 		}
 
-		return $current_count++;
+		return ++$current_count;
 	}
 );

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -57,7 +57,8 @@ export async function relatedProductAddToCart( page ) {
  * @param {Page} page
  */
 export async function blockProductAddToCart( page ) {
-	const addToCart = '.wp-block-button__link.add_to_cart_button:not([disabled])';
+	const addToCart =
+		'.wp-block-button__link.add_to_cart_button:not([disabled])';
 
 	const button = page.locator( addToCart ).first();
 	await button.click();

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -56,12 +56,14 @@ export async function relatedProductAddToCart( page ) {
  *
  * @param {Page} page
  */
-export async function blockProductAddToCart( page ) {
-	const addToCart =
-		'.wp-block-button__link.add_to_cart_button:not([disabled])';
+export async function blockProductAddToCart( page, productId = null ) {
+	const addToCart = productId
+		? `[data-product_id="${ productId }"].add_to_cart_button:not([disabled])`
+		: '.wp-block-button__link.add_to_cart_button:not([disabled])';
 
-	await page.locator( addToCart ).first().click();
-	await expect( page.locator( addToCart ).first() ).toHaveClass( /added/ );
+	const button = page.locator( addToCart ).first();
+	await button.click();
+	await expect( button ).toHaveClass( /added/ );
 }
 
 /**

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -56,10 +56,8 @@ export async function relatedProductAddToCart( page ) {
  *
  * @param {Page} page
  */
-export async function blockProductAddToCart( page, productId = null ) {
-	const addToCart = productId
-		? `[data-product_id="${ productId }"].add_to_cart_button:not([disabled])`
-		: '.wp-block-button__link.add_to_cart_button:not([disabled])';
+export async function blockProductAddToCart( page ) {
+	const addToCart = '.wp-block-button__link.add_to_cart_button:not([disabled])';
 
 	const button = page.locator( addToCart ).first();
 	await button.click();

--- a/tests/e2e/utils/track-event.js
+++ b/tests/e2e/utils/track-event.js
@@ -17,19 +17,21 @@ export function trackGtagEvent( page, eventName, urlPath = null ) {
 	const eventPath = '/pagead/';
 	return page.waitForRequest( ( request ) => {
 		const url = request.url();
-		const match = 'event=' + eventName;
-		const origin = new URL( page.url() ).origin;
 		const params = new URL( url ).searchParams;
 
-		return (
-			url.includes( eventPath ) &&
-			params.get( 'data' )?.includes( match ) &&
-			( urlPath
-				? params
-						.get( 'url' )
-						.includes( `${ `${ origin }/${ urlPath }` }` )
-				: true )
-		);
+		if (
+			! url.includes( eventPath ) ||
+			! params.get( 'data' )?.includes( 'event=' + eventName )
+		) {
+			return false;
+		}
+
+		if ( ! urlPath ) {
+			return true;
+		}
+
+		const origin = new URL( page.url() ).origin;
+		return params.get( 'url' )?.includes( `${ origin }/${ urlPath }` );
 	} );
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-239/flaky-e2e-tests-identified-in-enhanced-conversions-functionality.

_Replace this with a good description of your changes & reasoning._
- Replace `window.glaData` mutation with `setCompletedAdsSetup`/`clearCompletedAdsSetup` API calls for proper test isolation; add `afterAll` cleanup to prevent cross-test pollution
- Add `waitFor` on skip modal visibility before assertions to eliminate race condition
- Simplify `trackGtagEvent` to early-return pattern; guard null `url` param to prevent crashes

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. E2E actions tests pass
2. No regressions in other onboarding E2E specs

[Passing tests](https://github.com/woocommerce/google-listings-and-ads/actions/runs/28251898271)


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev -  Fix flaky E2E tests for onboarding step-3 campaign flow.
