### PR TITLE
[GOOWOO-727] Add WCML price conversion to WPML integration and wire into product adapter

### DIFF
--- a/src/Integration/WPML.php
+++ b/src/Integration/WPML.php
@@ -3,6 +3,10 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Integration;
 
+use DateTime;
+use WC_DateTime;
+use WC_Product;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -96,13 +100,113 @@ class WPML implements IntegrationInterface {
 	}
 
 	/**
+	 * Returns the regular price for a product converted into the given currency via WCML.
+	 *
+	 * @param WC_Product $product
+	 * @param string     $currency ISO 4217 currency code.
+	 *
+	 * @return float|null Converted regular price, or null when WPML is inactive, WCML multi-currency
+	 *                    is off, or the product has no regular price.
+	 */
+	public function get_product_price_in_currency( WC_Product $product, string $currency ): ?float {
+		if ( ! $this->is_active() || ! $this->is_wcml_multi_currency_on() ) {
+			return null;
+		}
+
+		$custom_prices = $this->get_wcml_custom_prices( (int) $product->get_id(), $currency );
+		if ( false !== $custom_prices ) {
+			return isset( $custom_prices['_regular_price'] ) && '' !== $custom_prices['_regular_price']
+				? (float) $custom_prices['_regular_price']
+				: null;
+		}
+
+		$regular_price = $product->get_regular_price();
+		if ( '' === $regular_price ) {
+			return null;
+		}
+
+		return (float) apply_filters( 'wcml_raw_price_amount', (float) $regular_price, $currency );
+	}
+
+	/**
+	 * Returns the sale price for a product converted into the given currency via WCML.
+	 *
+	 * @param WC_Product $product
+	 * @param string     $currency ISO 4217 currency code.
+	 *
+	 * @return float|null Converted sale price, or null when WPML is inactive, WCML multi-currency
+	 *                    is off, or the product has no sale price.
+	 */
+	public function get_product_sale_price_in_currency( WC_Product $product, string $currency ): ?float {
+		if ( ! $this->is_active() || ! $this->is_wcml_multi_currency_on() ) {
+			return null;
+		}
+
+		$custom_prices = $this->get_wcml_custom_prices( (int) $product->get_id(), $currency );
+		if ( false !== $custom_prices ) {
+			// Manual mode: WCML's get_product_custom_prices has already applied any
+			// per-currency or base sale-date range. An empty _sale_price means the sale
+			// is not currently active for this currency.
+			return isset( $custom_prices['_sale_price'] ) && '' !== $custom_prices['_sale_price']
+				? (float) $custom_prices['_sale_price']
+				: null;
+		}
+
+		$sale_price = $product->get_sale_price();
+		if ( '' === $sale_price ) {
+			return null;
+		}
+
+		// Auto mode: WCML's filter only performs exchange-rate conversion; it does not
+		// apply the base WC sale-end date. Honour that date here so an expired base sale
+		// is not auto-converted and emitted in the override currency.
+		$sale_end_date = $product->get_date_on_sale_to();
+		if ( ! empty( $sale_end_date ) && $sale_end_date < new WC_DateTime() ) {
+			return null;
+		}
+
+		return (float) apply_filters( 'wcml_raw_price_amount', (float) $sale_price, $currency );
+	}
+
+	/**
+	 * Returns the sale effective-date string for a product in a given currency, or null
+	 * when no per-currency dates are configured (the caller should fall back to base
+	 * WC sale dates in that case).
+	 *
+	 * WCML stores per-currency sale dates as Unix timestamps under post meta keys
+	 * `_sale_price_dates_from_{currency}` and `_sale_price_dates_to_{currency}`.
+	 *
+	 * @param WC_Product $product
+	 * @param string     $currency ISO 4217 currency code.
+	 *
+	 * @return string|null
+	 */
+	public function get_product_sale_dates_in_currency( WC_Product $product, string $currency ): ?string {
+		if ( ! $this->is_active() || ! $this->is_wcml_multi_currency_on() ) {
+			return null;
+		}
+
+		$from_meta = get_post_meta( $product->get_id(), '_sale_price_dates_from_' . $currency, true );
+		$to_meta   = get_post_meta( $product->get_id(), '_sale_price_dates_to_' . $currency, true );
+
+		if ( ! $from_meta && ! $to_meta ) {
+			return null;
+		}
+
+		$from = $from_meta ? gmdate( DateTime::ATOM, (int) $from_meta ) : '';
+		$to   = $to_meta ? gmdate( DateTime::ATOM, (int) $to_meta ) : '';
+
+		return sprintf( '%s/%s', $from, $to );
+	}
+
+	/**
 	 * Returns WCML currency codes when multi-currency is enabled, or the single WooCommerce
 	 * store currency as a fallback when WCML multi-currency is off or unavailable.
 	 *
 	 * @return string[]
 	 */
 	protected function get_active_currency_codes(): array {
-		if ( function_exists( 'wcml_is_multi_currency_on' ) && wcml_is_multi_currency_on() ) {
+		if ( $this->is_wcml_multi_currency_on() ) {
 			global $woocommerce_wpml;
 
 			if ( isset( $woocommerce_wpml ) && is_object( $woocommerce_wpml ) && method_exists( $woocommerce_wpml, 'get_multi_currency' ) ) {
@@ -119,6 +223,47 @@ class WPML implements IntegrationInterface {
 		$currency = function_exists( 'get_woocommerce_currency' ) ? get_woocommerce_currency() : '';
 
 		return is_string( $currency ) && '' !== $currency ? [ $currency ] : [];
+	}
+
+	/**
+	 * Returns whether WCML multi-currency is enabled.
+	 *
+	 * @return bool
+	 */
+	protected function is_wcml_multi_currency_on(): bool {
+		return function_exists( 'wcml_is_multi_currency_on' ) && wcml_is_multi_currency_on();
+	}
+
+	/**
+	 * Returns WCML's manual per-currency prices for a product, or false when manual prices
+	 * are not configured for that product+currency.
+	 *
+	 * Wraps WCML's own custom-prices lookup so callers can prefer manual values when set,
+	 * and fall back to the wcml_raw_price_amount auto-conversion filter otherwise.
+	 *
+	 * @param int    $product_id
+	 * @param string $currency
+	 *
+	 * @return array<string, string>|false
+	 */
+	protected function get_wcml_custom_prices( int $product_id, string $currency ) {
+		global $woocommerce_wpml;
+
+		if ( ! isset( $woocommerce_wpml ) || ! is_object( $woocommerce_wpml ) ) {
+			return false;
+		}
+
+		if ( ! isset( $woocommerce_wpml->multi_currency ) || ! isset( $woocommerce_wpml->multi_currency->custom_prices ) ) {
+			return false;
+		}
+
+		$custom_prices = $woocommerce_wpml->multi_currency->custom_prices;
+
+		if ( ! is_object( $custom_prices ) || ! method_exists( $custom_prices, 'get_product_custom_prices' ) ) {
+			return false;
+		}
+
+		return $custom_prices->get_product_custom_prices( $product_id, $currency );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -322,7 +322,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share( ProductHelper::class, ProductMetaHandler::class, WC::class, MarketService::class );
 		$this->share_with_tags( ProductFilter::class, ProductHelper::class );
 		$this->share_with_tags( ProductRepository::class, ProductMetaHandler::class, ProductFilter::class );
-		$this->share_with_tags( ProductFactory::class, AttributeManager::class, WC::class );
+		$this->share_with_tags( ProductFactory::class, AttributeManager::class, WC::class, WPML::class );
 		$this->share_with_tags(
 			BatchProductHelper::class,
 			ProductMetaHandler::class,

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -265,7 +265,8 @@ class BatchProductHelper implements Service {
 						$market['country'],
 						$mapping_rules,
 						$market['feed_label'],
-						$this->extract_language( $market )
+						$this->extract_language( $market ),
+						$this->extract_currency( $market )
 					);
 
 					$secondary_validation = $this->validate_product( $secondary_adapter );
@@ -318,6 +319,22 @@ class BatchProductHelper implements Service {
 		return is_array( $market['language'] ?? null )
 			? (string) ( $market['language'][0] ?? '' )
 			: (string) ( $market['language'] ?? '' );
+	}
+
+	/**
+	 * Extracts a single currency code from a market config.
+	 *
+	 * Each MC product carries exactly one price.currency. Markets store currency
+	 * as an array of codes; the first entry is used.
+	 *
+	 * @param array $market A market config array as returned by MarketService.
+	 *
+	 * @return string The single currency code, or empty string when none is set.
+	 */
+	protected function extract_currency( array $market ): string {
+		return is_array( $market['currency'] ?? null )
+			? (string) ( $market['currency'][0] ?? '' )
+			: (string) ( $market['currency'] ?? '' );
 	}
 
 	/**

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -331,7 +331,7 @@ class BatchProductHelper implements Service {
 	 *
 	 * @return string The single currency code, or empty string when none is set.
 	 */
-	protected function extract_currency( array $market ): string {
+	private static function extract_currency( array $market ): string {
 		return is_array( $market['currency'] ?? null )
 			? (string) ( $market['currency'][0] ?? '' )
 			: (string) ( $market['currency'] ?? '' );

--- a/src/Product/ProductFactory.php
+++ b/src/Product/ProductFactory.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use WC_Product;
@@ -33,22 +34,32 @@ class ProductFactory {
 	protected $wc;
 
 	/**
+	 * @var WPML|null
+	 */
+	protected ?WPML $wpml = null;
+
+	/**
 	 * ProductFactory constructor.
 	 *
 	 * @param AttributeManager $attribute_manager
 	 * @param WC               $wc
+	 * @param WPML|null        $wpml Optional WPML integration used for currency conversion when
+	 *                               a currency_override is supplied to create(). Null is allowed
+	 *                               so existing callers that pre-date the WPML dependency keep working.
 	 */
-	public function __construct( AttributeManager $attribute_manager, WC $wc ) {
+	public function __construct( AttributeManager $attribute_manager, WC $wc, ?WPML $wpml = null ) {
 		$this->attribute_manager = $attribute_manager;
 		$this->wc                = $wc;
+		$this->wpml              = $wpml;
 	}
 
 	/**
-	 * @param WC_Product $product
-	 * @param string     $target_country
-	 * @param array      $mapping_rules  The mapping rules setup by the user
-	 * @param string     $feed_label     Optional feed label.
-	 * @param string     $language       Optional ISO 639-1 language code.
+	 * @param WC_Product  $product
+	 * @param string      $target_country
+	 * @param array       $mapping_rules     The mapping rules setup by the user
+	 * @param string      $feed_label        Optional feed label.
+	 * @param string      $language          Optional ISO 639-1 language code.
+	 * @param string|null $currency_override Optional ISO 4217 currency code to override the store currency.
 	 *
 	 * @return WCProductAdapter
 	 *
@@ -59,7 +70,8 @@ class ProductFactory {
 		string $target_country,
 		array $mapping_rules,
 		string $feed_label = '',
-		string $language = ''
+		string $language = '',
+		?string $currency_override = null
 	): WCProductAdapter {
 		// We do not support syncing the parent variable product. Each variation is synced individually instead.
 		$this->validate_not_instanceof( $product, WC_Product_Variable::class );
@@ -81,6 +93,8 @@ class ProductFactory {
 				'targetCountry'     => $target_country,
 				'gla_attributes'    => $attributes,
 				'mapping_rules'     => $mapping_rules,
+				'wpml'              => $this->wpml,
+				'currency_override' => $currency_override ?? '',
 			]
 		);
 

--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMapping\AttributeMappingHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Condition;
@@ -69,6 +70,17 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	protected $product_category_ids;
 
 	/**
+	 * @var WPML|null WPML integration for currency conversion; null when not injected.
+	 */
+	protected ?WPML $wpml = null;
+
+	/**
+	 * @var string ISO 4217 currency code that overrides the store currency for price emission.
+	 *             Empty string when no override is active.
+	 */
+	protected string $currency_override = '';
+
+	/**
 	 * Initialize this object's properties from an array.
 	 *
 	 * @param array $properties Used to seed this object's properties.
@@ -95,6 +107,8 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 
 		$this->wc_product        = $properties['wc_product'];
 		$this->parent_wc_product = $properties['parent_wc_product'] ?? null;
+		$this->wpml              = $properties['wpml'] ?? null;
+		$this->currency_override = $properties['currency_override'] ?? '';
 
 		$mapping_rules  = $properties['mapping_rules'] ?? [];
 		$gla_attributes = $properties['gla_attributes'] ?? [];
@@ -104,6 +118,8 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		unset( $properties['parent_wc_product'] );
 		unset( $properties['gla_attributes'] );
 		unset( $properties['mapping_rules'] );
+		unset( $properties['wpml'] );
+		unset( $properties['currency_override'] );
 
 		parent::mapTypes( $properties );
 		$this->map_woocommerce_product();
@@ -624,6 +640,31 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	 * @return $this
 	 */
 	protected function map_wc_product_price( WC_Product $product ): WCProductAdapter {
+		if ( '' !== $this->currency_override && null !== $this->wpml ) {
+			$converted = $this->wpml->get_product_price_in_currency( $product, $this->currency_override );
+
+			if ( null !== $converted ) {
+				$price = $this->tax_excluded ?
+					wc_get_price_excluding_tax( $product, [ 'price' => $converted ] ) :
+					wc_get_price_including_tax( $product, [ 'price' => $converted ] );
+
+				/** This filter is documented in src/Product/WCProductAdapter.php */
+				$price = apply_filters( 'woocommerce_gla_product_attribute_value_price', $price, $product, $this->tax_excluded );
+
+				$this->setPrice(
+					new GooglePrice(
+						[
+							'currency' => strtoupper( $this->currency_override ),
+							'value'    => $price,
+						]
+					)
+				);
+
+				$this->map_wc_product_sale_price( $product );
+				return $this;
+			}
+		}
+
 		// set regular price
 		$regular_price = $product->get_regular_price();
 		if ( '' !== $regular_price ) {
@@ -663,6 +704,42 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	 * @return $this
 	 */
 	protected function map_wc_product_sale_price( WC_Product $product ): WCProductAdapter {
+		if ( '' !== $this->currency_override && null !== $this->wpml ) {
+			$converted_regular = $this->wpml->get_product_price_in_currency( $product, $this->currency_override );
+
+			if ( null !== $converted_regular ) {
+				$converted_sale = $this->wpml->get_product_sale_price_in_currency( $product, $this->currency_override );
+
+				if ( null === $converted_sale ) {
+					return $this;
+				}
+
+				$sale_price = $this->tax_excluded ?
+					wc_get_price_excluding_tax( $product, [ 'price' => $converted_sale ] ) :
+					wc_get_price_including_tax( $product, [ 'price' => $converted_sale ] );
+
+				/** This filter is documented in src/Product/WCProductAdapter.php */
+				$sale_price = apply_filters( 'woocommerce_gla_product_attribute_value_sale_price', $sale_price, $product, $this->tax_excluded );
+
+				$this->setSalePrice(
+					new GooglePrice(
+						[
+							'currency' => strtoupper( $this->currency_override ),
+							'value'    => $sale_price,
+						]
+					)
+				);
+
+				$effective_date = $this->wpml->get_product_sale_dates_in_currency( $product, $this->currency_override );
+				if ( null === $effective_date ) {
+					$effective_date = $this->get_wc_product_sale_price_effective_date( $product );
+				}
+				$this->setSalePriceEffectiveDate( $effective_date );
+
+				return $this;
+			}
+		}
+
 		// Grab the sale price of the base product. Some plugins (Dynamic
 		// pricing as an example) filter the active price, but not the sale
 		// price. If the active price < the regular price treat it as a sale

--- a/tests/Unit/Integration/WPMLTest.php
+++ b/tests/Unit/Integration/WPMLTest.php
@@ -6,6 +6,9 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Integration;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
+use WC_DateTime;
+use WC_Helper_Product;
+use WC_Product;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -18,6 +21,7 @@ class WPMLTest extends UnitTest {
 
 	public function tearDown(): void {
 		remove_all_filters( 'wpml_active_languages' );
+		remove_all_filters( 'wcml_raw_price_amount' );
 
 		parent::tearDown();
 	}
@@ -206,24 +210,370 @@ class WPMLTest extends UnitTest {
 		);
 	}
 
+	public function test_get_product_price_in_currency_returns_null_when_not_active(): void {
+		$integration = $this->create_integration( false );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->expects( $this->never() )->method( 'get_regular_price' );
+
+		$this->assertNull( $integration->get_product_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_price_in_currency_returns_null_when_wcml_multi_currency_off(): void {
+		$integration = $this->create_integration( true, [], false );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->expects( $this->never() )->method( 'get_regular_price' );
+
+		$this->assertNull( $integration->get_product_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_price_in_currency_returns_null_when_regular_price_empty(): void {
+		$integration = $this->create_integration( true, [], true );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->method( 'get_regular_price' )->willReturn( '' );
+
+		$this->assertNull( $integration->get_product_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_price_in_currency_returns_zero_for_free_product(): void {
+		$integration = $this->create_integration( true, [], true );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->method( 'get_regular_price' )->willReturn( '0' );
+
+		add_filter(
+			'wcml_raw_price_amount',
+			function ( $price ) {
+				return (float) $price;
+			}
+		);
+
+		$this->assertSame( 0.0, $integration->get_product_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_price_in_currency_returns_converted_price(): void {
+		$integration = $this->create_integration( true, [], true );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->method( 'get_regular_price' )->willReturn( '10' );
+
+		add_filter(
+			'wcml_raw_price_amount',
+			function ( $price ) {
+				return (float) $price * 0.8;
+			}
+		);
+
+		$this->assertSame( 8.0, $integration->get_product_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_price_in_currency_returns_null_when_not_active(): void {
+		$integration = $this->create_integration( false );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->expects( $this->never() )->method( 'get_sale_price' );
+
+		$this->assertNull( $integration->get_product_sale_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_price_in_currency_returns_null_when_wcml_multi_currency_off(): void {
+		$integration = $this->create_integration( true, [], false );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->expects( $this->never() )->method( 'get_sale_price' );
+
+		$this->assertNull( $integration->get_product_sale_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_price_in_currency_returns_null_when_sale_price_empty(): void {
+		$integration = $this->create_integration( true, [], true );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->method( 'get_sale_price' )->willReturn( '' );
+
+		$this->assertNull( $integration->get_product_sale_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_price_in_currency_returns_null_when_sale_empty_but_regular_set(): void {
+		$integration = $this->create_integration( true, [], true );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->method( 'get_regular_price' )->willReturn( '10' );
+		$product->method( 'get_sale_price' )->willReturn( '' );
+
+		$this->assertNull( $integration->get_product_sale_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_price_in_currency_returns_zero_for_free_sale(): void {
+		$integration = $this->create_integration( true, [], true );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->method( 'get_sale_price' )->willReturn( '0' );
+
+		add_filter(
+			'wcml_raw_price_amount',
+			function ( $price ) {
+				return (float) $price;
+			}
+		);
+
+		$this->assertSame( 0.0, $integration->get_product_sale_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_price_in_currency_returns_converted_sale(): void {
+		$integration = $this->create_integration( true, [], true );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->method( 'get_sale_price' )->willReturn( '8' );
+
+		add_filter(
+			'wcml_raw_price_amount',
+			function ( $price ) {
+				return (float) $price * 0.8;
+			}
+		);
+
+		$this->assertSame( 6.4, $integration->get_product_sale_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_price_in_currency_returns_null_when_manual_regular_empty(): void {
+		$integration = $this->create_integration(
+			true,
+			[],
+			true,
+			[
+				'_regular_price' => '',
+				'_price'         => '',
+			]
+		);
+
+		$product = $this->createMock( WC_Product::class );
+
+		$this->assertNull( $integration->get_product_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_price_in_currency_returns_null_when_manual_regular_missing(): void {
+		$integration = $this->create_integration(
+			true,
+			[],
+			true,
+			[
+				'_price' => '90',
+			]
+		);
+
+		$product = $this->createMock( WC_Product::class );
+
+		$this->assertNull( $integration->get_product_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_price_in_currency_returns_manual_regular_price(): void {
+		$integration = $this->create_integration(
+			true,
+			[],
+			true,
+			[
+				'_regular_price' => '90',
+				'_sale_price'    => '70',
+				'_price'         => '70',
+			]
+		);
+
+		$product = $this->createMock( WC_Product::class );
+		// Base regular price should NOT be consulted when manual prices are set.
+		$product->expects( $this->never() )->method( 'get_regular_price' );
+
+		add_filter(
+			'wcml_raw_price_amount',
+			function ( $price ) {
+				// Filter should NOT run when manual prices are present.
+				return (float) $price * 0.5;
+			}
+		);
+
+		$this->assertSame( 90.0, $integration->get_product_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_price_in_currency_returns_manual_sale_price(): void {
+		$integration = $this->create_integration(
+			true,
+			[],
+			true,
+			[
+				'_regular_price' => '90',
+				'_sale_price'    => '70',
+				'_price'         => '70',
+			]
+		);
+
+		$product = $this->createMock( WC_Product::class );
+		$product->expects( $this->never() )->method( 'get_sale_price' );
+
+		add_filter(
+			'wcml_raw_price_amount',
+			function ( $price ) {
+				return (float) $price * 0.5;
+			}
+		);
+
+		$this->assertSame( 70.0, $integration->get_product_sale_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_price_in_currency_returns_null_when_manual_sale_empty(): void {
+		// Merchant set a manual EUR regular price but left the EUR sale price empty:
+		// EUR market should carry no sale.
+		$integration = $this->create_integration(
+			true,
+			[],
+			true,
+			[
+				'_regular_price' => '90',
+				'_sale_price'    => '',
+				'_price'         => '90',
+			]
+		);
+
+		$product = $this->createMock( WC_Product::class );
+
+		$this->assertNull( $integration->get_product_sale_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_price_in_currency_auto_mode_returns_null_when_base_sale_end_in_past(): void {
+		// Auto mode (no manual prices). Base sale set with an end date already in the past.
+		$integration = $this->create_integration( true, [], true );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->method( 'get_sale_price' )->willReturn( '8' );
+		$product->method( 'get_date_on_sale_to' )->willReturn( new WC_DateTime( '2020-01-01' ) );
+
+		$this->assertNull( $integration->get_product_sale_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_price_in_currency_auto_mode_returns_value_when_base_sale_end_in_future(): void {
+		// Auto mode with a future end date: filter runs and converted value is returned.
+		$integration = $this->create_integration( true, [], true );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->method( 'get_sale_price' )->willReturn( '8' );
+		$product->method( 'get_date_on_sale_to' )->willReturn( new WC_DateTime( '2099-01-01' ) );
+
+		add_filter(
+			'wcml_raw_price_amount',
+			function ( $price ) {
+				return (float) $price * 0.8;
+			}
+		);
+
+		$this->assertSame( 6.4, $integration->get_product_sale_price_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_dates_in_currency_returns_null_when_not_active(): void {
+		$integration = $this->create_integration( false );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->assertNull( $integration->get_product_sale_dates_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_dates_in_currency_returns_null_when_wcml_off(): void {
+		$integration = $this->create_integration( true, [], false );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->assertNull( $integration->get_product_sale_dates_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_dates_in_currency_returns_null_when_no_per_currency_dates(): void {
+		$integration = $this->create_integration( true, [], true );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->assertNull( $integration->get_product_sale_dates_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_dates_in_currency_returns_formatted_range_when_both_dates_set(): void {
+		$integration = $this->create_integration( true, [], true );
+
+		$product = WC_Helper_Product::create_simple_product();
+		// 2026-06-01T00:00:00Z and 2027-06-01T00:00:00Z as Unix timestamps.
+		update_post_meta( $product->get_id(), '_sale_price_dates_from_EUR', 1748736000 );
+		update_post_meta( $product->get_id(), '_sale_price_dates_to_EUR', 1780272000 );
+
+		$expected = sprintf( '%s/%s', gmdate( 'Y-m-d\TH:i:sP', 1748736000 ), gmdate( 'Y-m-d\TH:i:sP', 1780272000 ) );
+
+		$this->assertSame( $expected, $integration->get_product_sale_dates_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_dates_in_currency_returns_formatted_range_when_only_from_set(): void {
+		$integration = $this->create_integration( true, [], true );
+
+		$product = WC_Helper_Product::create_simple_product();
+		update_post_meta( $product->get_id(), '_sale_price_dates_from_EUR', 1748736000 );
+
+		$expected = sprintf( '%s/', gmdate( 'Y-m-d\TH:i:sP', 1748736000 ) );
+
+		$this->assertSame( $expected, $integration->get_product_sale_dates_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_dates_in_currency_returns_formatted_range_when_only_to_set(): void {
+		$integration = $this->create_integration( true, [], true );
+
+		$product = WC_Helper_Product::create_simple_product();
+		update_post_meta( $product->get_id(), '_sale_price_dates_to_EUR', 1780272000 );
+
+		$expected = sprintf( '/%s', gmdate( 'Y-m-d\TH:i:sP', 1780272000 ) );
+
+		$this->assertSame( $expected, $integration->get_product_sale_dates_in_currency( $product, 'EUR' ) );
+	}
+
+	public function test_get_product_sale_price_in_currency_returns_null_when_manual_sale_missing(): void {
+		// Manual mode with no _sale_price key at all: also no sale.
+		$integration = $this->create_integration(
+			true,
+			[],
+			true,
+			[
+				'_regular_price' => '90',
+				'_price'         => '90',
+			]
+		);
+
+		$product = $this->createMock( WC_Product::class );
+
+		$this->assertNull( $integration->get_product_sale_price_in_currency( $product, 'EUR' ) );
+	}
+
 	/**
-	 * @param bool     $is_active
-	 * @param string[] $currency_codes
+	 * @param bool                          $is_active
+	 * @param string[]                      $currency_codes
+	 * @param bool|null                     $wcml_multi_currency_on When non-null, stubs is_wcml_multi_currency_on() to this value.
+	 * @param array<string, string>|false   $custom_prices          Return value for get_wcml_custom_prices() (default false = auto mode).
 	 *
 	 * @return WPML&MockObject
 	 */
-	private function create_integration( bool $is_active, array $currency_codes = [] ): WPML {
-		$methods = [ 'is_active' ];
+	private function create_integration( bool $is_active, array $currency_codes = [], ?bool $wcml_multi_currency_on = null, $custom_prices = false ): WPML {
+		$methods = [ 'is_active', 'get_wcml_custom_prices' ];
 
 		if ( ! empty( $currency_codes ) ) {
 			$methods[] = 'get_active_currency_codes';
 		}
 
+		if ( null !== $wcml_multi_currency_on ) {
+			$methods[] = 'is_wcml_multi_currency_on';
+		}
+
 		$integration = $this->createPartialMock( WPML::class, $methods );
 		$integration->method( 'is_active' )->willReturn( $is_active );
+		$integration->method( 'get_wcml_custom_prices' )->willReturn( $custom_prices );
 
 		if ( ! empty( $currency_codes ) ) {
 			$integration->method( 'get_active_currency_codes' )->willReturn( $currency_codes );
+		}
+
+		if ( null !== $wcml_multi_currency_on ) {
+			$integration->method( 'is_wcml_multi_currency_on' )->willReturn( $wcml_multi_currency_on );
 		}
 
 		return $integration;

--- a/tests/Unit/Integration/WPMLTest.php
+++ b/tests/Unit/Integration/WPMLTest.php
@@ -546,10 +546,10 @@ class WPMLTest extends UnitTest {
 	}
 
 	/**
-	 * @param bool                          $is_active
-	 * @param string[]                      $currency_codes
-	 * @param bool|null                     $wcml_multi_currency_on When non-null, stubs is_wcml_multi_currency_on() to this value.
-	 * @param array<string, string>|false   $custom_prices          Return value for get_wcml_custom_prices() (default false = auto mode).
+	 * @param bool                        $is_active
+	 * @param string[]                    $currency_codes
+	 * @param bool|null                   $wcml_multi_currency_on When non-null, stubs is_wcml_multi_currency_on() to this value.
+	 * @param array<string, string>|false $custom_prices          Return value for get_wcml_custom_prices() (default false = auto mode).
 	 *
 	 * @return WPML&MockObject
 	 */

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -656,6 +656,254 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		}
 	}
 
+	public function test_secondary_market_currency_passed_to_factory() {
+		$product         = WC_Helper_Product::create_simple_product();
+		$real_factory    = $this->container->get( ProductFactory::class );
+		$primary_adapter = $real_factory->create( $product, 'US', [], 'US', 'en' );
+
+		$captured_secondary_args = null;
+
+		$factory_mock = $this->createMock( ProductFactory::class );
+		$factory_mock->method( 'create' )
+			->willReturnCallback(
+				function ( WC_Product $p, string $country, array $rules, string $feed_label, string $language, ?string $currency_override = null ) use ( $primary_adapter, $real_factory, $product, &$captured_secondary_args ) {
+					if ( 'US' === $country ) {
+						return $primary_adapter;
+					}
+					$captured_secondary_args = [
+						'country'           => $country,
+						'feed_label'        => $feed_label,
+						'language'          => $language,
+						'currency_override' => $currency_override,
+					];
+					return $real_factory->create( $product, $country, $rules, $feed_label, $language, $currency_override );
+				}
+			);
+
+		$helper = new BatchProductHelper(
+			$this->product_meta,
+			$this->product_helper,
+			$this->validator,
+			$factory_mock,
+			$this->rules_query,
+			$this->market_service
+		);
+
+		$this->set_up_market_service_stubs(
+			[ 'US', 'DE' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => 'en',
+				],
+				'de'      => [
+					'country'    => 'DE',
+					'feed_label' => 'DE',
+					'language'   => [ 'de' ],
+					'currency'   => [ 'EUR' ],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$helper->validate_and_generate_update_request_entries( [ $product ] );
+
+		$this->assertSame( 'EUR', $captured_secondary_args['currency_override'] );
+	}
+
+	public function test_secondary_market_empty_currency_array_passes_empty_string() {
+		$product         = WC_Helper_Product::create_simple_product();
+		$real_factory    = $this->container->get( ProductFactory::class );
+		$primary_adapter = $real_factory->create( $product, 'US', [], 'US', 'en' );
+
+		$captured_currency_override = null;
+
+		$factory_mock = $this->createMock( ProductFactory::class );
+		$factory_mock->method( 'create' )
+			->willReturnCallback(
+				function ( WC_Product $p, string $country, array $rules, string $feed_label, string $language, ?string $currency_override = null ) use ( $primary_adapter, $real_factory, $product, &$captured_currency_override ) {
+					if ( 'US' === $country ) {
+						return $primary_adapter;
+					}
+					$captured_currency_override = $currency_override;
+					return $real_factory->create( $product, $country, $rules, $feed_label, $language, $currency_override );
+				}
+			);
+
+		$helper = new BatchProductHelper(
+			$this->product_meta,
+			$this->product_helper,
+			$this->validator,
+			$factory_mock,
+			$this->rules_query,
+			$this->market_service
+		);
+
+		$this->set_up_market_service_stubs(
+			[ 'US', 'DE' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => 'en',
+				],
+				'de'      => [
+					'country'    => 'DE',
+					'feed_label' => 'DE',
+					'language'   => [ 'de' ],
+					'currency'   => [],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$helper->validate_and_generate_update_request_entries( [ $product ] );
+
+		$this->assertSame( '', $captured_currency_override );
+	}
+
+	public function test_secondary_market_multiple_currencies_uses_first() {
+		$product         = WC_Helper_Product::create_simple_product();
+		$real_factory    = $this->container->get( ProductFactory::class );
+		$primary_adapter = $real_factory->create( $product, 'US', [], 'US', 'en' );
+
+		$captured_currency_override = null;
+
+		$factory_mock = $this->createMock( ProductFactory::class );
+		$factory_mock->method( 'create' )
+			->willReturnCallback(
+				function ( WC_Product $p, string $country, array $rules, string $feed_label, string $language, ?string $currency_override = null ) use ( $primary_adapter, $real_factory, $product, &$captured_currency_override ) {
+					if ( 'US' === $country ) {
+						return $primary_adapter;
+					}
+					$captured_currency_override = $currency_override;
+					return $real_factory->create( $product, $country, $rules, $feed_label, $language, $currency_override );
+				}
+			);
+
+		$helper = new BatchProductHelper(
+			$this->product_meta,
+			$this->product_helper,
+			$this->validator,
+			$factory_mock,
+			$this->rules_query,
+			$this->market_service
+		);
+
+		$this->set_up_market_service_stubs(
+			[ 'US', 'DE' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => 'en',
+				],
+				'de'      => [
+					'country'    => 'DE',
+					'feed_label' => 'DE',
+					'language'   => [ 'de' ],
+					'currency'   => [ 'EUR', 'CHF' ],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$helper->validate_and_generate_update_request_entries( [ $product ] );
+
+		$this->assertSame( 'EUR', $captured_currency_override );
+	}
+
+	public function test_two_secondary_markets_each_receive_their_own_currency() {
+		$product         = WC_Helper_Product::create_simple_product();
+		$real_factory    = $this->container->get( ProductFactory::class );
+		$primary_adapter = $real_factory->create( $product, 'US', [], 'US', 'en' );
+
+		$captured_currencies_by_country = [];
+
+		$factory_mock = $this->createMock( ProductFactory::class );
+		$factory_mock->method( 'create' )
+			->willReturnCallback(
+				function ( WC_Product $p, string $country, array $rules, string $feed_label, string $language, ?string $currency_override = null ) use ( $primary_adapter, $real_factory, $product, &$captured_currencies_by_country ) {
+					if ( 'US' === $country ) {
+						return $primary_adapter;
+					}
+					$captured_currencies_by_country[ $country ] = $currency_override;
+					return $real_factory->create( $product, $country, $rules, $feed_label, $language, $currency_override );
+				}
+			);
+
+		$helper = new BatchProductHelper(
+			$this->product_meta,
+			$this->product_helper,
+			$this->validator,
+			$factory_mock,
+			$this->rules_query,
+			$this->market_service
+		);
+
+		$this->set_up_market_service_stubs(
+			[ 'US', 'DE', 'AU' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => 'en',
+				],
+				'de'      => [
+					'country'    => 'DE',
+					'feed_label' => 'DE',
+					'language'   => [ 'de' ],
+					'currency'   => [ 'EUR' ],
+				],
+				'au'      => [
+					'country'    => 'AU',
+					'feed_label' => 'AU',
+					'language'   => [ 'en' ],
+					'currency'   => [ 'AUD' ],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$helper->validate_and_generate_update_request_entries( [ $product ] );
+
+		$this->assertSame( 'EUR', $captured_currencies_by_country['DE'] );
+		$this->assertSame( 'AUD', $captured_currencies_by_country['AU'] );
+	}
+
+	public function test_primary_entry_uses_store_currency_regardless_of_market_currency_array() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->set_up_market_service_stubs(
+			[ 'US' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => 'en',
+					'currency'   => [ 'EUR' ],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$results = $this->batch_product_helper->validate_and_generate_update_request_entries( [ $product ] );
+
+		$this->assertCount( 1, $results );
+		$this->assertSame( get_woocommerce_currency(), $results[0]->get_product()->getPrice()->getCurrency() );
+	}
+
 	/**
 	 * @return WC_Product[]
 	 */

--- a/tests/Unit/Product/ProductFactoryTest.php
+++ b/tests/Unit/Product/ProductFactoryTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidClass;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductFactory;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductAdapter;
@@ -35,6 +36,9 @@ class ProductFactoryTest extends ContainerAwareUnitTest {
 
 	/** @var WC $wc */
 	protected $wc;
+
+	/** @var MockObject|WPML $wpml */
+	protected $wpml;
 
 	public function test_create() {
 		$product = WC_Helper_Product::create_simple_product();
@@ -157,6 +161,76 @@ class ProductFactoryTest extends ContainerAwareUnitTest {
 		$this->product_factory->create( $variable, 'US', [] );
 	}
 
+	public function test_create_without_currency_override_uses_store_currency() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 10,
+				'regular_price' => 10,
+			]
+		);
+
+		$this->attribute_manager->method( 'get_all_values' )->willReturn( [] );
+
+		$adapted = $this->product_factory->create( $product, 'US', [] );
+
+		$this->assertEquals( get_woocommerce_currency(), $adapted->getPrice()->getCurrency() );
+	}
+
+	public function test_create_with_currency_override_passes_it_to_adapter() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 10,
+				'regular_price' => 10,
+			]
+		);
+
+		$this->attribute_manager->method( 'get_all_values' )->willReturn( [] );
+		$this->wpml->method( 'get_product_price_in_currency' )->willReturn( 8.0 );
+		$this->wpml->method( 'get_product_sale_price_in_currency' )->willReturn( null );
+
+		$adapted = $this->product_factory->create( $product, 'FR', [], 'FR-fr', 'fr', 'EUR' );
+
+		$this->assertEquals( 'EUR', $adapted->getPrice()->getCurrency() );
+		$this->assertEquals( 8.0, $adapted->getPrice()->getValue() );
+	}
+
+	public function test_factory_constructs_without_wpml_for_backward_compatibility() {
+		$factory = new ProductFactory( $this->attribute_manager, $this->wc );
+
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 10,
+				'regular_price' => 10,
+			]
+		);
+
+		$this->attribute_manager->method( 'get_all_values' )->willReturn( [] );
+
+		$adapted = $factory->create( $product, 'FR', [], 'FR-fr', 'fr', 'EUR' );
+
+		// No WPML injected, so currency_override has no effect; falls back to store currency.
+		$this->assertEquals( get_woocommerce_currency(), $adapted->getPrice()->getCurrency() );
+	}
+
+	public function test_create_with_null_currency_override_uses_store_currency() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 10,
+				'regular_price' => 10,
+			]
+		);
+
+		$this->attribute_manager->method( 'get_all_values' )->willReturn( [] );
+
+		$adapted = $this->product_factory->create( $product, 'FR', [], 'FR-fr', 'fr' );
+
+		$this->assertEquals( get_woocommerce_currency(), $adapted->getPrice()->getCurrency() );
+	}
+
 	/**
 	 * Runs before each test is executed.
 	 */
@@ -165,6 +239,7 @@ class ProductFactoryTest extends ContainerAwareUnitTest {
 		$this->attribute_manager = $this->createMock( AttributeManager::class );
 		$this->rules_query       = $this->createMock( AttributeMappingRulesQuery::class );
 		$this->wc                = $this->container->get( WC::class );
-		$this->product_factory   = new ProductFactory( $this->attribute_manager, $this->wc );
+		$this->wpml              = $this->createMock( WPML::class );
+		$this->product_factory   = new ProductFactory( $this->attribute_manager, $this->wc, $this->wpml );
 	}
 }

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\Brand;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\GTIN;
@@ -1768,6 +1769,309 @@ class WCProductAdapterTest extends UnitTest {
 		];
 	}
 
+	public function test_currency_override_applies_to_variation_product() {
+		$variable  = WC_Helper_Product::create_variation_product();
+		$variation = wc_get_product( $variable->get_children()[0] );
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_product_price_in_currency' )->willReturn( 8.0 );
+		$wpml->method( 'get_product_sale_price_in_currency' )->willReturn( 6.4 );
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $variation,
+				'parent_wc_product' => $variable,
+				'targetCountry'     => 'FR',
+				'wpml'              => $wpml,
+				'currency_override' => 'EUR',
+			]
+		);
+
+		$this->assertEquals( 'EUR', $adapted_product->getPrice()->getCurrency() );
+		$this->assertEquals( 8.0, $adapted_product->getPrice()->getValue() );
+		$this->assertEquals( 'EUR', $adapted_product->getSalePrice()->getCurrency() );
+		$this->assertEquals( 6.4, $adapted_product->getSalePrice()->getValue() );
+	}
+
+	public function test_currency_override_emits_zero_price_for_free_product_not_omitted() {
+		// Free product (regular price 0) with an active EUR override should still emit
+		// the price in EUR with value 0, not be omitted from the feed entirely.
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 0,
+				'regular_price' => 0,
+			]
+		);
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_product_price_in_currency' )->willReturn( 0.0 );
+		$wpml->method( 'get_product_sale_price_in_currency' )->willReturn( null );
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $product,
+				'targetCountry'     => 'FR',
+				'wpml'              => $wpml,
+				'currency_override' => 'EUR',
+			]
+		);
+
+		$this->assertNotNull( $adapted_product->getPrice() );
+		$this->assertEquals( 'EUR', $adapted_product->getPrice()->getCurrency() );
+		$this->assertEquals( 0, $adapted_product->getPrice()->getValue() );
+	}
+
+	public function test_currency_override_with_wpml_converts_regular_price() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 10,
+				'regular_price' => 10,
+			]
+		);
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_product_price_in_currency' )->willReturn( 8.0 );
+		$wpml->method( 'get_product_sale_price_in_currency' )->willReturn( null );
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $product,
+				'targetCountry'     => 'FR',
+				'wpml'              => $wpml,
+				'currency_override' => 'EUR',
+			]
+		);
+
+		$this->assertEquals( 'EUR', $adapted_product->getPrice()->getCurrency() );
+		$this->assertEquals( 8.0, $adapted_product->getPrice()->getValue() );
+		$this->assertNull( $adapted_product->getSalePrice() );
+	}
+
+	public function test_currency_override_with_wpml_converts_sale_price() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 8,
+				'regular_price' => 10,
+				'sale_price'    => 8,
+			]
+		);
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_product_price_in_currency' )->willReturn( 8.0 );
+		$wpml->method( 'get_product_sale_price_in_currency' )->willReturn( 6.4 );
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $product,
+				'targetCountry'     => 'FR',
+				'wpml'              => $wpml,
+				'currency_override' => 'EUR',
+			]
+		);
+
+		$this->assertEquals( 'EUR', $adapted_product->getPrice()->getCurrency() );
+		$this->assertEquals( 8.0, $adapted_product->getPrice()->getValue() );
+		$this->assertEquals( 'EUR', $adapted_product->getSalePrice()->getCurrency() );
+		$this->assertEquals( 6.4, $adapted_product->getSalePrice()->getValue() );
+	}
+
+	public function test_currency_override_falls_back_to_store_currency_when_wpml_returns_null() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 10,
+				'regular_price' => 10,
+				'sale_price'    => 8,
+			]
+		);
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_product_price_in_currency' )->willReturn( null );
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $product,
+				'targetCountry'     => 'FR',
+				'wpml'              => $wpml,
+				'currency_override' => 'EUR',
+			]
+		);
+
+		$this->assertEquals( get_woocommerce_currency(), $adapted_product->getPrice()->getCurrency() );
+		$this->assertEquals( 10, $adapted_product->getPrice()->getValue() );
+		$this->assertEquals( get_woocommerce_currency(), $adapted_product->getSalePrice()->getCurrency() );
+		$this->assertEquals( 8, $adapted_product->getSalePrice()->getValue() );
+	}
+
+	public function test_currency_override_without_wpml_instance_falls_back_to_store_currency() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 10,
+				'regular_price' => 10,
+			]
+		);
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $product,
+				'targetCountry'     => 'FR',
+				'currency_override' => 'EUR',
+			]
+		);
+
+		$this->assertEquals( get_woocommerce_currency(), $adapted_product->getPrice()->getCurrency() );
+		$this->assertEquals( 10, $adapted_product->getPrice()->getValue() );
+	}
+
+	public function test_no_currency_override_uses_store_currency() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 10,
+				'regular_price' => 10,
+			]
+		);
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'    => $product,
+				'targetCountry' => 'US',
+			]
+		);
+
+		$this->assertEquals( get_woocommerce_currency(), $adapted_product->getPrice()->getCurrency() );
+		$this->assertEquals( 10, $adapted_product->getPrice()->getValue() );
+	}
+
+	public function test_currency_override_skips_sale_when_sale_price_empty() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 10,
+				'regular_price' => 10,
+			]
+		);
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_product_price_in_currency' )->willReturn( 8.0 );
+		$wpml->method( 'get_product_sale_price_in_currency' )->willReturn( null );
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $product,
+				'targetCountry'     => 'FR',
+				'wpml'              => $wpml,
+				'currency_override' => 'EUR',
+			]
+		);
+
+		$this->assertNull( $adapted_product->getSalePrice() );
+		$this->assertNull( $adapted_product->getSalePriceEffectiveDate() );
+	}
+
+	public function test_currency_override_does_not_promote_active_price_to_sale() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 10,
+				'regular_price' => 10,
+			]
+		);
+
+		// Simulate a dynamic-pricing plugin filtering the active price below the regular,
+		// with no sale price set on the product.
+		add_filter(
+			'woocommerce_product_get_price',
+			function () {
+				return 8;
+			}
+		);
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_product_price_in_currency' )->willReturn( 8.0 );
+		$wpml->method( 'get_product_sale_price_in_currency' )->willReturn( null );
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $product,
+				'targetCountry'     => 'FR',
+				'wpml'              => $wpml,
+				'currency_override' => 'EUR',
+			]
+		);
+
+		$this->assertNull( $adapted_product->getSalePrice() );
+	}
+
+	public function test_currency_override_uses_per_currency_sale_dates_when_wpml_returns_them() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 8,
+				'regular_price' => 10,
+				'sale_price'    => 8,
+			]
+		);
+
+		$per_currency_dates = '2026-01-01T00:00:00+00:00/2027-01-01T00:00:00+00:00';
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_product_price_in_currency' )->willReturn( 8.0 );
+		$wpml->method( 'get_product_sale_price_in_currency' )->willReturn( 6.4 );
+		$wpml->method( 'get_product_sale_dates_in_currency' )->willReturn( $per_currency_dates );
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $product,
+				'targetCountry'     => 'FR',
+				'wpml'              => $wpml,
+				'currency_override' => 'EUR',
+			]
+		);
+
+		$this->assertEquals( $per_currency_dates, $adapted_product->getSalePriceEffectiveDate() );
+	}
+
+	public function test_currency_override_falls_back_to_base_sale_dates_when_no_per_currency_dates() {
+		$start = new WC_DateTime( '2026-01-01' );
+		$end   = new WC_DateTime( '2027-01-01' );
+
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 8,
+				'regular_price' => 10,
+				'sale_price'    => 8,
+			]
+		);
+		$product->set_date_on_sale_from( $start );
+		$product->set_date_on_sale_to( $end );
+		$product->save();
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_product_price_in_currency' )->willReturn( 8.0 );
+		$wpml->method( 'get_product_sale_price_in_currency' )->willReturn( 6.4 );
+		$wpml->method( 'get_product_sale_dates_in_currency' )->willReturn( null );
+
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'        => $product,
+				'targetCountry'     => 'FR',
+				'wpml'              => $wpml,
+				'currency_override' => 'EUR',
+			]
+		);
+
+		$this->assertEquals(
+			sprintf( '%s/%s', (string) $start, (string) $end ),
+			$adapted_product->getSalePriceEffectiveDate()
+		);
+	}
+
 	public function setUp(): void {
 		parent::setUp();
 
@@ -1780,6 +2084,7 @@ class WCProductAdapterTest extends UnitTest {
 		parent::tearDown();
 
 		// remove any added filter
+		remove_all_filters( 'woocommerce_product_get_price' );
 		remove_all_filters( 'woocommerce_gla_dimension_unit' );
 		remove_all_filters( 'woocommerce_gla_weight_unit' );
 		remove_all_filters( 'woocommerce_gla_product_attribute_value_price' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-727/add-wcml-price-conversion-to-wpml-integration-and-wire-into-product

### Screenshots:

N/A

### Detailed test instructions:

Prerequisites:
1. Ensure you have [WCML](https://wordpress.org/plugins/woocommerce-multilingual/) installed
2. Ensure you have at least 2 currencies enabled (`A` and `B`)
3. Ensure you have a primary market with currency `A` / secondary market with currency `B`. It does not matter which ones. 

Test steps

1. Update a product to have `A` and `B` currencies enabled, with a sale price. Tip: if price is `100` / sale price is `80`, for the other currency make these `101` and `81` - this minor difference makes comparison easier
2. Wait 30 seconds, this is needed for the sync to Merchant Centre to complete in the background
3. Open the Merchant Centre - double check you are viewing the same account the Google plugin is configured to use
4. Open the product and confirm you are seeing the primary market - swap to the secondary market. Note the URL contains `feedLabel`, this should match the country slug for the primary market.
5. Confirm the pricing shows the price and sale price correctly
6. Swap to the secondary market - you can simply update the `feedLabel` param in the URL
7. Confirm the secondary market shows the price and sale price correctly and in the correct currency


### Additional details:

> Add - Add WCML price conversion to WPML integration and wire into product adapter