### PR TITLE
[GOOWOO-742] Push existing products to Google Merchant Center when a market is added, updated, or deleted

### DIFF
--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedMarketProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateShippingSettings;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
@@ -258,6 +259,8 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			$this->schedule_shipping_sync();
 		}
 
+		$this->job_repository->get( UpdateAllProducts::class )->schedule();
+
 		/**
 		 * Fires after a secondary market is successfully added.
 		 *
@@ -284,7 +287,30 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 */
 	public function update_market( string $id, array $config ): array {
 		if ( 'primary' === $id ) {
+			$existing_target = $this->options->get( OptionsInterface::TARGET_AUDIENCE, [] );
+			$existing_mc     = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
 			$this->update_primary_market_fanout( $config );
+
+			$merged_target = $this->options->get( OptionsInterface::TARGET_AUDIENCE, [] );
+			$merged_mc     = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
+			$existing_countries = $existing_target['countries'] ?? [];
+			$merged_countries   = $merged_target['countries'] ?? [];
+			$existing_language  = $existing_mc['language'] ?? [];
+			$merged_language    = $merged_mc['language'] ?? [];
+			$existing_currency  = $existing_mc['currency'] ?? [];
+			$merged_currency    = $merged_mc['currency'] ?? [];
+
+			$resync_needed = $existing_countries !== $merged_countries
+				|| array_diff( $existing_language, $merged_language ) !== []
+				|| array_diff( $merged_language, $existing_language ) !== []
+				|| array_diff( $existing_currency, $merged_currency ) !== []
+				|| array_diff( $merged_currency, $existing_currency ) !== [];
+
+			if ( $resync_needed ) {
+				$this->job_repository->get( UpdateAllProducts::class )->schedule();
+			}
 
 			return $this->fire_market_updated_action( $id );
 		}
@@ -311,6 +337,22 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 				$this->schedule_shipping_sync();
 				break;
 			}
+		}
+
+		$existing_language = $existing['language'] ?? [];
+		$merged_language   = $merged['language'] ?? [];
+		$existing_currency = $existing['currency'] ?? [];
+		$merged_currency   = $merged['currency'] ?? [];
+
+		$resync_needed = ( $existing['country'] ?? null ) !== ( $merged['country'] ?? null )
+			|| ( $existing['feed_label'] ?? null ) !== ( $merged['feed_label'] ?? null )
+			|| array_diff( $existing_language, $merged_language ) !== []
+			|| array_diff( $merged_language, $existing_language ) !== []
+			|| array_diff( $existing_currency, $merged_currency ) !== []
+			|| array_diff( $merged_currency, $existing_currency ) !== [];
+
+		if ( $resync_needed ) {
+			$this->job_repository->get( UpdateAllProducts::class )->schedule();
 		}
 
 		return $this->fire_market_updated_action( $id );
@@ -379,6 +421,8 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		if ( 'manual' !== $shipping_rate ) {
 			$this->schedule_shipping_sync();
 		}
+
+		$this->job_repository->get( UpdateAllProducts::class )->schedule();
 
 		/**
 		 * Fires after a secondary market is successfully deleted.

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedMarketProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateShippingSettings;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
@@ -53,21 +54,25 @@ class MarketServiceTest extends UnitTest {
 	/** @var MockObject|UpdateShippingSettings */
 	protected $shipping_settings_job;
 
+	/** @var MockObject|UpdateAllProducts */
+	protected $update_all_products_job;
+
 	/** @var MarketService */
 	protected $market_service;
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->target_audience       = $this->createMock( TargetAudience::class );
-		$this->options               = $this->createMock( OptionsInterface::class );
-		$this->shipping_rate_query   = $this->createMock( ShippingRateQuery::class );
-		$this->shipping_time_query   = $this->createMock( ShippingTimeQuery::class );
-		$this->wc                    = $this->createMock( WC::class );
-		$this->wpml                  = $this->createMock( WPML::class );
-		$this->job_repository        = $this->createMock( JobRepository::class );
-		$this->cleanup_job           = $this->createMock( CleanupOrphanedMarketProductsJob::class );
-		$this->shipping_settings_job = $this->createMock( UpdateShippingSettings::class );
+		$this->target_audience         = $this->createMock( TargetAudience::class );
+		$this->options                 = $this->createMock( OptionsInterface::class );
+		$this->shipping_rate_query     = $this->createMock( ShippingRateQuery::class );
+		$this->shipping_time_query     = $this->createMock( ShippingTimeQuery::class );
+		$this->wc                      = $this->createMock( WC::class );
+		$this->wpml                    = $this->createMock( WPML::class );
+		$this->job_repository          = $this->createMock( JobRepository::class );
+		$this->cleanup_job             = $this->createMock( CleanupOrphanedMarketProductsJob::class );
+		$this->shipping_settings_job   = $this->createMock( UpdateShippingSettings::class );
+		$this->update_all_products_job = $this->createMock( UpdateAllProducts::class );
 
 		$this->job_repository->method( 'get' )
 			->willReturnCallback(
@@ -77,6 +82,8 @@ class MarketServiceTest extends UnitTest {
 							return $this->cleanup_job;
 						case UpdateShippingSettings::class:
 							return $this->shipping_settings_job;
+						case UpdateAllProducts::class:
+							return $this->update_all_products_job;
 						default:
 							return null;
 					}
@@ -1000,6 +1007,313 @@ class MarketServiceTest extends UnitTest {
 			->method( 'schedule' );
 
 		$this->market_service->delete_market( 'gb' );
+	}
+
+	public function test_add_market_secondary_schedules_update_all_products(): void {
+		$config = [
+			'country'    => 'GB',
+			'language'   => [ 'en' ],
+			'currency'   => [ 'GBP' ],
+			'feed_label' => 'GB',
+		];
+
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [],
+				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'US' ] ],
+			]
+		);
+		$this->options->method( 'update' )->willReturn( true );
+
+		$this->update_all_products_job->expects( $this->once() )
+			->method( 'schedule' );
+
+		$this->market_service->add_market( 'gb', $config );
+	}
+
+	public function test_add_market_primary_does_not_schedule_update_all_products(): void {
+		$this->update_all_products_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->add_market( 'primary', [] );
+	}
+
+	public function test_add_market_invalid_config_does_not_schedule_update_all_products(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+
+		$this->update_all_products_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->add_market(
+			'gb',
+			[
+				'country'    => 'GB',
+				'feed_label' => '',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+			]
+		);
+	}
+
+	public function test_update_market_secondary_schedules_update_all_products_when_country_differs(): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->update_all_products_job->expects( $this->once() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'country' => 'IE' ] );
+	}
+
+	public function test_update_market_primary_schedules_update_all_products_when_target_audience_countries_change(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [],
+				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'US' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->update_all_products_job->expects( $this->once() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market(
+			'primary',
+			[ 'countries' => [ 'US', 'CA' ] ]
+		);
+	}
+
+	public function test_update_market_primary_schedules_update_all_products_when_target_audience_countries_reordered(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [],
+				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'US', 'GB' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US', 'GB' ] );
+
+		$this->update_all_products_job->expects( $this->once() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market(
+			'primary',
+			[ 'countries' => [ 'GB', 'US' ] ]
+		);
+	}
+
+	public function test_update_market_secondary_schedules_update_all_products_when_feed_label_differs(): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->update_all_products_job->expects( $this->once() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'feed_label' => 'GB-PROMO' ] );
+	}
+
+	public function test_update_market_secondary_schedules_update_all_products_when_language_differs(): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->update_all_products_job->expects( $this->once() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'language' => [ 'en', 'cy' ] ] );
+	}
+
+	public function test_update_market_secondary_schedules_update_all_products_when_currency_differs(): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->update_all_products_job->expects( $this->once() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'currency' => [ 'EUR' ] ] );
+	}
+
+	public function test_update_market_does_not_schedule_update_all_products_when_only_shipping_rate_differs(): void {
+		$existing = [
+			'gb' => [
+				'country'       => 'GB',
+				'language'      => [ 'en' ],
+				'currency'      => [ 'GBP' ],
+				'feed_label'    => 'GB',
+				'shipping_rate' => 'flat',
+				'shipping_time' => 'flat',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->update_all_products_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'shipping_rate' => 'automatic' ] );
+	}
+
+	public function test_update_market_does_not_schedule_update_all_products_when_only_shipping_time_differs(): void {
+		$existing = [
+			'gb' => [
+				'country'       => 'GB',
+				'language'      => [ 'en' ],
+				'currency'      => [ 'GBP' ],
+				'feed_label'    => 'GB',
+				'shipping_rate' => 'flat',
+				'shipping_time' => 'flat',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->update_all_products_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'shipping_time' => 'automatic' ] );
+	}
+
+	public function test_update_market_does_not_schedule_update_all_products_when_no_fields_differ(): void {
+		$existing = [
+			'gb' => [
+				'country'       => 'GB',
+				'language'      => [ 'en' ],
+				'currency'      => [ 'GBP' ],
+				'feed_label'    => 'GB',
+				'shipping_rate' => 'flat',
+				'shipping_time' => 'flat',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->update_all_products_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [] );
+	}
+
+	public function test_update_market_does_not_schedule_update_all_products_when_language_reordered(): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en', 'cy' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->update_all_products_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'language' => [ 'cy', 'en' ] ] );
+	}
+
+	public function test_update_market_does_not_schedule_update_all_products_when_currency_reordered(): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP', 'EUR' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->update_all_products_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'currency' => [ 'EUR', 'GBP' ] ] );
+	}
+
+	public function test_delete_market_secondary_schedules_update_all_products(): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => $existing ] );
+		$this->options->method( 'update' )->willReturn( true );
+
+		$this->update_all_products_job->expects( $this->once() )
+			->method( 'schedule' );
+
+		$this->market_service->delete_market( 'gb' );
+	}
+
+	public function test_delete_market_primary_does_not_schedule_update_all_products(): void {
+		$this->update_all_products_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->delete_market( 'primary' );
+	}
+
+	public function test_delete_market_unknown_id_does_not_schedule_update_all_products(): void {
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => [] ] );
+
+		$this->update_all_products_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->market_service->delete_market( 'unknown' );
 	}
 
 	public function test_add_market_does_not_schedule_cleanup(): void {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-742/push-existing-products-to-google-merchant-center-when-a-market-is

### Screenshots:

N/A

### Detailed test instructions:

Setup
1. Local install with Google for WooCommerce connected to a real Merchant Center account.
2. Have several products already synced under the primary feed. Confirm they appear in the primary sub-feed in Merchant Center.

Test 1: Add secondary market schedules a resync
1. Add a secondary market: country = FR, feed_label = FR, language = ['fr'], currency = ['EUR'].
2. Trigger Action Scheduler (or wait for the next run).
4. Expect: the FR sub-feed in Merchant Center fills with all synced products, without touching any product manually.

Test 2: Updating only shipping_rate does NOT schedule a resync
1. Update only the secondary market's shipping_rate.
2. In WP admin, open Tools → Scheduled Actions and filter by gla/jobs/update_all_products/create_batch.
3. Expect: no new update_all_products actions queued. The shipping sync from GOOWOO-711 still runs.

Test 3: Delete secondary market schedules a resync
1. Delete the FR secondary market.
2. Trigger Action Scheduler.
3. Expect: the French sub-feed is emptied (cleanup), and products for France reappear under the primary feed.

Test 4: Update primary market countries schedules a resync
1. Add or remove a country from the primary market's target audience.
2. Trigger Action Scheduler.
3. Expect: a new update_all_products batch runs (visible in Scheduled Actions), and the `gla_update_all_products_last_sync` option timestamp advances (use `wp option get gla_update_all_products_last_sync` to retrieve)


### Additional details:

> Update - Push existing products to Google Merchant Center when a market is added, updated, or deleted