### PR TITLE
[GOOWOO-769] AdsAssetGenerationService throws fatal error on plugin update (3.7.0 → 3.7.2)

### DIFF
--- a/src/API/Site/RESTControllers.php
+++ b/src/API/Site/RESTControllers.php
@@ -4,6 +4,8 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidClass;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
@@ -20,6 +22,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwa
 class RESTControllers implements ContainerAwareInterface, Service, Registerable {
 
 	use ContainerAwareTrait;
+	use ValidateInterface;
 
 	/**
 	 * Register a service.
@@ -39,24 +42,18 @@ class RESTControllers implements ContainerAwareInterface, Service, Registerable 
 	 * The DI container can return a class-name string instead of an instance
 	 * when the underlying class fails to autoload at definition-resolution time.
 	 * That has been observed during the plugin upgrade flow, where in-memory
-	 * autoload state lagged the new files on disk and triggered a fatal
-	 * `InvalidClass` from the previous validate-then-throw approach. Skip
-	 * non-instance entries here and log them so a transient autoload failure
-	 * on a single page render does not take down the whole admin.
+	 * autoload state lagged the new files on disk. Catching the InvalidClass
+	 * exception thrown by validate_instanceof prevents a transient autoload
+	 * failure on a single page render from taking down the whole admin.
 	 */
 	protected function register_controllers(): void {
+		/** @var BaseController[] $controllers */
 		$controllers = $this->container->get( 'rest_controller' );
 		foreach ( $controllers as $controller ) {
-			if ( ! $controller instanceof BaseController ) {
-				$description = is_string( $controller )
-					? sprintf( 'class-name string "%s"', $controller )
-					: ( is_object( $controller ) ? sprintf( 'instance of %s', get_class( $controller ) ) : gettype( $controller ) );
-
-				do_action(
-					'woocommerce_gla_debug_message',
-					sprintf( 'Expected a BaseController instance from the container; got %s. Skipping.', $description ),
-					__METHOD__
-				);
+			try {
+				$this->validate_instanceof( $controller, BaseController::class );
+			} catch ( InvalidClass $e ) {
+				do_action( 'woocommerce_gla_error', $e->getMessage(), __METHOD__ );
 				continue;
 			}
 			$controller->register();

--- a/src/API/Site/RESTControllers.php
+++ b/src/API/Site/RESTControllers.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
@@ -21,7 +20,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwa
 class RESTControllers implements ContainerAwareInterface, Service, Registerable {
 
 	use ContainerAwareTrait;
-	use ValidateInterface;
 
 	/**
 	 * Register a service.
@@ -37,12 +35,30 @@ class RESTControllers implements ContainerAwareInterface, Service, Registerable 
 
 	/**
 	 * Register our individual rest controllers.
+	 *
+	 * The DI container can return a class-name string instead of an instance
+	 * when the underlying class fails to autoload at definition-resolution time.
+	 * That has been observed during the plugin upgrade flow, where in-memory
+	 * autoload state lagged the new files on disk and triggered a fatal
+	 * `InvalidClass` from the previous validate-then-throw approach. Skip
+	 * non-instance entries here and log them so a transient autoload failure
+	 * on a single page render does not take down the whole admin.
 	 */
 	protected function register_controllers(): void {
-		/** @var BaseController[] $controllers */
 		$controllers = $this->container->get( 'rest_controller' );
 		foreach ( $controllers as $controller ) {
-			$this->validate_instanceof( $controller, BaseController::class );
+			if ( ! $controller instanceof BaseController ) {
+				$description = is_string( $controller )
+					? sprintf( 'class-name string "%s"', $controller )
+					: ( is_object( $controller ) ? sprintf( 'instance of %s', get_class( $controller ) ) : gettype( $controller ) );
+
+				do_action(
+					'woocommerce_gla_debug_message',
+					sprintf( 'Expected a BaseController instance from the container; got %s. Skipping.', $description ),
+					__METHOD__
+				);
+				continue;
+			}
 			$controller->register();
 		}
 	}

--- a/src/Ads/AdsAssetGenerationService.php
+++ b/src/Ads/AdsAssetGenerationService.php
@@ -76,7 +76,24 @@ class AdsAssetGenerationService implements OptionsAwareInterface, Service {
 	 */
 	public function __construct( GoogleAdsClient $client ) {
 		$this->google_ads_client = $client;
-		$this->client            = $client->getAssetGenerationServiceClient();
+	}
+
+	/**
+	 * Lazily resolve the Asset Generation service client.
+	 *
+	 * Why: building the V23 service client at construction time runs during
+	 * REST controller registration on `rest_api_init`, before the Google Ads
+	 * V23 client library is guaranteed to be fully loaded. Deferring it to
+	 * the first call site avoids a fatal during plugin update / admin boot.
+	 *
+	 * @return \Google\Ads\GoogleAds\V23\Services\Client\AssetGenerationServiceClient
+	 */
+	protected function get_client() {
+		if ( ! isset( $this->client ) ) {
+			$this->client = $this->google_ads_client->getAssetGenerationServiceClient();
+		}
+
+		return $this->client;
 	}
 
 	/**
@@ -117,7 +134,7 @@ class AdsAssetGenerationService implements OptionsAwareInterface, Service {
 		);
 
 		try {
-			$response = $this->client->generateText( $request );
+			$response = $this->get_client()->generateText( $request );
 
 			$results = [];
 			foreach ( $response->getGeneratedText() as $text_asset ) {
@@ -186,7 +203,7 @@ class AdsAssetGenerationService implements OptionsAwareInterface, Service {
 		$request = new GenerateImagesRequest( $request_data );
 
 		try {
-			$response = $this->client->generateImages( $request );
+			$response = $this->get_client()->generateImages( $request );
 
 			$results = [];
 			foreach ( $response->getGeneratedImages() as $image_asset ) {

--- a/src/Ads/AdsAssetGenerationService.php
+++ b/src/Ads/AdsAssetGenerationService.php
@@ -88,7 +88,7 @@ class AdsAssetGenerationService implements OptionsAwareInterface, Service {
 	 *
 	 * @return \Google\Ads\GoogleAds\V23\Services\Client\AssetGenerationServiceClient
 	 */
-	protected function get_client() {
+	private function get_client() {
 		if ( ! isset( $this->client ) ) {
 			$this->client = $this->google_ads_client->getAssetGenerationServiceClient();
 		}

--- a/tests/Unit/API/Site/RESTControllersTest.php
+++ b/tests/Unit/API/Site/RESTControllersTest.php
@@ -19,7 +19,7 @@ class RESTControllersTest extends UnitTest {
 	 * Regression: when the DI container returns a class-name string instead of
 	 * a resolved BaseController instance (observed during plugin upgrade when
 	 * autoloader state lags new files on disk), registration must skip the
-	 * entry and log a debug message rather than throwing a fatal.
+	 * entry and log an error rather than throwing a fatal.
 	 */
 	public function test_register_controllers_skips_string_entries_without_fatal() {
 		$controller = $this->createMock( BaseController::class );
@@ -36,13 +36,10 @@ class RESTControllersTest extends UnitTest {
 			);
 
 		$captured = [];
-		$listener = function ( $message, $context ) use ( &$captured ) {
-			$captured[] = [
-				'message' => $message,
-				'context' => $context,
-			];
+		$listener = function ( $message ) use ( &$captured ) {
+			$captured[] = $message;
 		};
-		add_action( 'woocommerce_gla_debug_message', $listener, 10, 2 );
+		add_action( 'woocommerce_gla_error', $listener, 10, 2 );
 
 		$rest_controllers = new RESTControllers();
 		$rest_controllers->set_container( $container );
@@ -52,12 +49,11 @@ class RESTControllersTest extends UnitTest {
 		$method->setAccessible( true );
 		$method->invoke( $rest_controllers );
 
-		remove_action( 'woocommerce_gla_debug_message', $listener, 10 );
+		remove_action( 'woocommerce_gla_error', $listener, 10 );
 
-		$this->assertCount( 1, $captured, 'A debug message should be logged for the skipped string entry.' );
-		$this->assertStringContainsString( 'Expected a BaseController instance', $captured[0]['message'] );
-		$this->assertStringContainsString( 'class-name string', $captured[0]['message'] );
-		$this->assertStringContainsString( 'AssetGenerationController', $captured[0]['message'] );
+		$this->assertCount( 1, $captured, 'An error should be logged for the skipped string entry.' );
+		$this->assertStringContainsString( 'must implement', $captured[0] );
+		$this->assertStringContainsString( 'BaseController', $captured[0] );
 	}
 
 	/**
@@ -75,7 +71,7 @@ class RESTControllersTest extends UnitTest {
 		$listener = function ( $message ) use ( &$captured ) {
 			$captured[] = $message;
 		};
-		add_action( 'woocommerce_gla_debug_message', $listener );
+		add_action( 'woocommerce_gla_error', $listener );
 
 		$rest_controllers = new RESTControllers();
 		$rest_controllers->set_container( $container );
@@ -85,17 +81,18 @@ class RESTControllersTest extends UnitTest {
 		$method->setAccessible( true );
 		$method->invoke( $rest_controllers );
 
-		remove_action( 'woocommerce_gla_debug_message', $listener );
+		remove_action( 'woocommerce_gla_error', $listener );
 
 		$this->assertCount( 1, $captured );
-		$this->assertStringContainsString( 'instance of stdClass', $captured[0] );
+		$this->assertStringContainsString( 'stdClass', $captured[0] );
+		$this->assertStringContainsString( 'must implement', $captured[0] );
 	}
 
 	/**
 	 * The loop must keep registering valid controllers no matter where invalid
 	 * entries appear in the container's returned array, and log exactly one
-	 * debug message per invalid entry. Proves a single bad entry never
-	 * cascades into skipping otherwise-valid controllers.
+	 * error per invalid entry. Proves a single bad entry never cascades into
+	 * skipping otherwise-valid controllers.
 	 */
 	public function test_register_controllers_registers_valid_entries_alongside_invalid_ones() {
 		$first  = $this->createMock( BaseController::class );
@@ -120,7 +117,7 @@ class RESTControllersTest extends UnitTest {
 		$listener = function ( $message ) use ( &$captured ) {
 			$captured[] = $message;
 		};
-		add_action( 'woocommerce_gla_debug_message', $listener );
+		add_action( 'woocommerce_gla_error', $listener );
 
 		$rest_controllers = new RESTControllers();
 		$rest_controllers->set_container( $container );
@@ -130,8 +127,8 @@ class RESTControllersTest extends UnitTest {
 		$method->setAccessible( true );
 		$method->invoke( $rest_controllers );
 
-		remove_action( 'woocommerce_gla_debug_message', $listener );
+		remove_action( 'woocommerce_gla_error', $listener );
 
-		$this->assertCount( 3, $captured, 'One debug message expected per invalid entry (string, stdClass, null).' );
+		$this->assertCount( 3, $captured, 'One error expected per invalid entry (string, stdClass, null).' );
 	}
 }

--- a/tests/Unit/API/Site/RESTControllersTest.php
+++ b/tests/Unit/API/Site/RESTControllersTest.php
@@ -1,0 +1,137 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\RESTControllers;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Container\ContainerInterface;
+
+/**
+ * Class RESTControllersTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site
+ */
+class RESTControllersTest extends UnitTest {
+
+	/**
+	 * Regression: when the DI container returns a class-name string instead of
+	 * a resolved BaseController instance (observed during plugin upgrade when
+	 * autoloader state lags new files on disk), registration must skip the
+	 * entry and log a debug message rather than throwing a fatal.
+	 */
+	public function test_register_controllers_skips_string_entries_without_fatal() {
+		$controller = $this->createMock( BaseController::class );
+		$controller->expects( $this->once() )->method( 'register' );
+
+		$container = $this->createMock( ContainerInterface::class );
+		$container->method( 'get' )
+			->with( 'rest_controller' )
+			->willReturn(
+				[
+					'Automattic\\WooCommerce\\GoogleListingsAndAds\\API\\Site\\Controllers\\Ads\\AssetGenerationController',
+					$controller,
+				]
+			);
+
+		$captured = [];
+		$listener = function ( $message, $context ) use ( &$captured ) {
+			$captured[] = [
+				'message' => $message,
+				'context' => $context,
+			];
+		};
+		add_action( 'woocommerce_gla_debug_message', $listener, 10, 2 );
+
+		$rest_controllers = new RESTControllers();
+		$rest_controllers->set_container( $container );
+
+		$reflection = new \ReflectionClass( $rest_controllers );
+		$method     = $reflection->getMethod( 'register_controllers' );
+		$method->setAccessible( true );
+		$method->invoke( $rest_controllers );
+
+		remove_action( 'woocommerce_gla_debug_message', $listener, 10 );
+
+		$this->assertCount( 1, $captured, 'A debug message should be logged for the skipped string entry.' );
+		$this->assertStringContainsString( 'Expected a BaseController instance', $captured[0]['message'] );
+		$this->assertStringContainsString( 'class-name string', $captured[0]['message'] );
+		$this->assertStringContainsString( 'AssetGenerationController', $captured[0]['message'] );
+	}
+
+	/**
+	 * Regression: a non-BaseController object (e.g. plain stdClass) must also
+	 * be skipped rather than fatal. Locks the defensive check against any
+	 * future tagged binding returning the wrong type.
+	 */
+	public function test_register_controllers_skips_non_base_controller_objects() {
+		$container = $this->createMock( ContainerInterface::class );
+		$container->method( 'get' )
+			->with( 'rest_controller' )
+			->willReturn( [ new \stdClass() ] );
+
+		$captured = [];
+		$listener = function ( $message ) use ( &$captured ) {
+			$captured[] = $message;
+		};
+		add_action( 'woocommerce_gla_debug_message', $listener );
+
+		$rest_controllers = new RESTControllers();
+		$rest_controllers->set_container( $container );
+
+		$reflection = new \ReflectionClass( $rest_controllers );
+		$method     = $reflection->getMethod( 'register_controllers' );
+		$method->setAccessible( true );
+		$method->invoke( $rest_controllers );
+
+		remove_action( 'woocommerce_gla_debug_message', $listener );
+
+		$this->assertCount( 1, $captured );
+		$this->assertStringContainsString( 'instance of stdClass', $captured[0] );
+	}
+
+	/**
+	 * The loop must keep registering valid controllers no matter where invalid
+	 * entries appear in the container's returned array, and log exactly one
+	 * debug message per invalid entry. Proves a single bad entry never
+	 * cascades into skipping otherwise-valid controllers.
+	 */
+	public function test_register_controllers_registers_valid_entries_alongside_invalid_ones() {
+		$first  = $this->createMock( BaseController::class );
+		$second = $this->createMock( BaseController::class );
+		$first->expects( $this->once() )->method( 'register' );
+		$second->expects( $this->once() )->method( 'register' );
+
+		$container = $this->createMock( ContainerInterface::class );
+		$container->method( 'get' )
+			->with( 'rest_controller' )
+			->willReturn(
+				[
+					$first,
+					'Automattic\\WooCommerce\\GoogleListingsAndAds\\Bogus\\ClassNameOne',
+					new \stdClass(),
+					$second,
+					null,
+				]
+			);
+
+		$captured = [];
+		$listener = function ( $message ) use ( &$captured ) {
+			$captured[] = $message;
+		};
+		add_action( 'woocommerce_gla_debug_message', $listener );
+
+		$rest_controllers = new RESTControllers();
+		$rest_controllers->set_container( $container );
+
+		$reflection = new \ReflectionClass( $rest_controllers );
+		$method     = $reflection->getMethod( 'register_controllers' );
+		$method->setAccessible( true );
+		$method->invoke( $rest_controllers );
+
+		remove_action( 'woocommerce_gla_debug_message', $listener );
+
+		$this->assertCount( 3, $captured, 'One debug message expected per invalid entry (string, stdClass, null).' );
+	}
+}

--- a/tests/Unit/Ads/AdsAssetGenerationServiceTest.php
+++ b/tests/Unit/Ads/AdsAssetGenerationServiceTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Ads;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAssetGenerationService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\GoogleAdsClientTrait;
@@ -13,6 +14,7 @@ use Google\Ads\GoogleAds\V23\Services\GenerateImagesResponse;
 use Google\ApiCore\ApiException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Exception;
+use RuntimeException;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -275,5 +277,35 @@ class AdsAssetGenerationServiceTest extends UnitTest {
 			->willReturn( $response );
 
 		$this->service->generate_images( [] );
+	}
+
+	/**
+	 * Regression: constructing the service must not eagerly build the
+	 * Google Ads V23 Asset Generation service client. The container resolves
+	 * this class during `rest_api_init` (via REST controller tags), which
+	 * happens before V23 service clients are guaranteed to be loadable —
+	 * eager construction in 3.7.x produced a fatal on admin page loads after
+	 * a plugin update.
+	 */
+	public function test_constructor_does_not_resolve_service_client() {
+		$ads_client = $this->createMock( GoogleAdsClient::class );
+		$ads_client->expects( $this->never() )->method( 'getAssetGenerationServiceClient' );
+
+		new AdsAssetGenerationService( $ads_client );
+	}
+
+	/**
+	 * Regression: even when the underlying V23 service client factory
+	 * throws, constructing the service must succeed — the factory call is
+	 * deferred to the first generate_* call site.
+	 */
+	public function test_constructor_succeeds_when_service_client_factory_throws() {
+		$ads_client = $this->createMock( GoogleAdsClient::class );
+		$ads_client->method( 'getAssetGenerationServiceClient' )
+			->willThrowException( new RuntimeException( 'V23 Service Clients are not fully loaded.' ) );
+
+		new AdsAssetGenerationService( $ads_client );
+
+		$this->assertTrue( true, 'Constructor must not invoke the V23 service client factory.' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-769/adsassetgenerationservice-throws-fatal-error-on-plugin-update-370-372

### Screenshots:

N/A


### Detailed test instructions:

1. Install 3.7.0 from https://downloads.wordpress.org/plugin/google-listings-and-ads.3.7.0.zip
2. Generate ZIP from `npm run archive`
3. In WP admin, navigate to Plugins; confirm you see the 3.7.0 plugin - activate it if not already active
4. On the Plugins page click "Add Plugin", then "Upload Plugin"
5. Select the ZIP file from the project directory (the one created with `npm run archive`), click Install Now
6. Confirm you want to replace the existing plugin
7. Confirm the plugin updates - you'll see an error on the page (full details on the Linear task)
8. Navigate to Plugins and confirm site loads and plugin was updated.

This only impacts 3.7.0 -> 3.7.1 and 3.7.0 -> 3.7.2 (3.7.1 -> 3.7.2 does not have this issue).


### Additional details:

> Fix - Fix fatal error on plugin update from version 3.7.0.