### PR TITLE
GOOWOO-663 Signal Detection Paused Campaigns

### DIFF
--- a/src/Notification/Evaluators/PausedCampaignEvaluator.php
+++ b/src/Notification/Evaluators/PausedCampaignEvaluator.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class PausedCampaignEvaluator
  *
- * Fires when at least one campaign is paused.
+ * Fires when the merchant has at least one campaign that is not in enabled status.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
  */
@@ -60,13 +60,19 @@ class PausedCampaignEvaluator implements NotificationEvaluatorInterface, AdsAwar
 		}
 
 		try {
-			foreach ( $this->ads_campaign->get_campaigns( true, false ) as $campaign ) {
-				if ( CampaignStatus::PAUSED === $campaign['status'] ) {
-					return true;
-				}
-			}
+			$campaigns = $this->ads_campaign->get_campaigns( true, false );
 		} catch ( ExceptionWithResponseData $e ) {
 			return false;
+		}
+
+		if ( empty( $campaigns ) ) {
+			return false;
+		}
+
+		foreach ( $campaigns as $campaign ) {
+			if ( CampaignStatus::ENABLED !== $campaign['status'] ) {
+				return true;
+			}
 		}
 
 		return false;

--- a/tests/Unit/Notification/Evaluators/PausedCampaignEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/PausedCampaignEvaluatorTest.php
@@ -61,6 +61,15 @@ class PausedCampaignEvaluatorTest extends UnitTest {
 		$this->assertFalse( $this->evaluator->should_show() );
 	}
 
+	public function test_should_not_show_when_no_campaigns() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_campaign->method( 'get_campaigns' )
+			->with( true, false )
+			->willReturn( [] );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
 	public function test_should_show_when_paused_campaign_present() {
 		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
 		$this->ads_campaign->method( 'get_campaigns' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds signal detection for the `paused-campaign` notification so merchants with an inactive Google Ads campaign are surfaced in the notifications engine.

- Detects merchants with at least one campaign that is not in enabled status (paused or otherwise inactive).

- Skips merchants with no campaigns (handled by skipped-campaign-creation).

- Uses the cached campaigns response via `AdsCampaign::get_campaigns( true, false ) `and `CachedNotificationEvaluatorTrait`.

- Result is cached per user for one hour; notification state is recorded once per merchant via NotificationService.

Closes https://linear.app/a8c/issue/GOOWOO-663/be-signal-detection-case-51-paused-campaign

### Screenshots:
N/A

### Detailed test instructions:

**Prerequisites**

- Store with Google for WooCommerce connected and ads onboarding complete (`glaData.adsSetupComplete` is `true`).

- Test as an admin user who can manage GLA.

**Verify via REST API**

`GET /wp-json/wc/gla/notifications`
Look for an entry with `"id": "paused-campaign"`.

Scenario 1 - Notification should show
State: Ads onboarding complete, at least one campaign exists, and none are enabled.

Examples:

1. Create a campaign during onboarding, then pause it in Google Ads or the GLA dashboard.

2. Have only paused Performance Max campaigns.

Expected: Response includes "id": "paused-campaign" with a triggered_at timestamp.

Scenario 2 - Notification should not show
State: No campaigns exist.
Expected: No paused-campaign entry. (skipped-campaign-creation may appear instead.)

Scenario 3 - Notification should not show
State: At least one campaign is enabled.
Expected: No paused-campaign entry.

Scenario 4 - Dismissal / snooze
State: paused-campaign is showing.

1. Dismiss the notification in the UI.

2. Reload and call the endpoint again within 7 days.

Expected: Notification is hidden until the snooze period ends.

**Note**: Evaluator results are cached for 1 hour per user, wait for the cache to expire or clear the transient `gla_notif_paused-campaign_{user_id}`.