### PR TITLE
GOOWOO-665 Signal Detection Active Campaign but Zero Sales

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -337,7 +337,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( SalesNotGrowingEvaluator::class );
 		$this->share_with_tags( WcInstallTimestamp::class, WP::class );
 		$this->share_with_tags( PausedCampaignEvaluator::class, AdsCampaign::class );
-		$this->share_with_tags( CampaignNoSalesEvaluator::class, AdsCampaign::class, AdsReport::class );
+		$this->share_with_tags( CampaignNoSalesEvaluator::class, AdsCampaign::class, AdsReport::class, AdsRecommendationsService::class );
 		$this->share_with_tags( RecommendationsAvailableEvaluator::class, AdsRecommendationsService::class, AdsCampaign::class );
 
 		// Product attributes

--- a/src/Notification/Evaluators/CampaignNoSalesEvaluator.php
+++ b/src/Notification/Evaluators/CampaignNoSalesEvaluator.php
@@ -78,6 +78,7 @@ class CampaignNoSalesEvaluator implements NotificationEvaluatorInterface, AdsAwa
 					'CAMPAIGN_BUDGET',
 					'MARGINAL_ROI_CAMPAIGN_BUDGET',
 				],
+				// campaign_id = 0 fetches recommendations account-wide, not filtered to a specific campaign.
 				'campaign_id' => 0,
 			]
 		);

--- a/src/Notification/Evaluators/CampaignNoSalesEvaluator.php
+++ b/src/Notification/Evaluators/CampaignNoSalesEvaluator.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsRecommendationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsReport;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
@@ -21,7 +22,8 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class CampaignNoSalesEvaluator
  *
- * Fires when at least one enabled campaign has recorded zero conversions over the last 90 days.
+ * Fires when at least one enabled campaign has recorded zero attributed sales and no raise budget
+ * recommendation is available.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
  */
@@ -36,15 +38,20 @@ class CampaignNoSalesEvaluator implements NotificationEvaluatorInterface, AdsAwa
 	/** @var AdsReport */
 	private $ads_report;
 
+	/** @var AdsRecommendationsService */
+	private $ads_recommendations;
+
 	/**
 	 * CampaignNoSalesEvaluator constructor.
 	 *
-	 * @param AdsCampaign $ads_campaign
-	 * @param AdsReport   $ads_report
+	 * @param AdsCampaign               $ads_campaign
+	 * @param AdsReport                 $ads_report
+	 * @param AdsRecommendationsService $ads_recommendations
 	 */
-	public function __construct( AdsCampaign $ads_campaign, AdsReport $ads_report ) {
-		$this->ads_campaign = $ads_campaign;
-		$this->ads_report   = $ads_report;
+	public function __construct( AdsCampaign $ads_campaign, AdsReport $ads_report, AdsRecommendationsService $ads_recommendations ) {
+		$this->ads_campaign        = $ads_campaign;
+		$this->ads_report          = $ads_report;
+		$this->ads_recommendations = $ads_recommendations;
 	}
 
 	/**
@@ -63,6 +70,20 @@ class CampaignNoSalesEvaluator implements NotificationEvaluatorInterface, AdsAwa
 	 */
 	protected function evaluate_condition(): bool {
 		if ( ! $this->ads_service->is_setup_complete() ) {
+			return false;
+		}
+
+		$budget_recommendations = $this->ads_recommendations->get_recommendations(
+			[
+				'types'       => [
+					'CAMPAIGN_BUDGET',
+					'MARGINAL_ROI_CAMPAIGN_BUDGET',
+				],
+				'campaign_id' => 0,
+			]
+		);
+
+		if ( ! empty( $budget_recommendations ) ) {
 			return false;
 		}
 

--- a/src/Notification/Evaluators/CampaignNoSalesEvaluator.php
+++ b/src/Notification/Evaluators/CampaignNoSalesEvaluator.php
@@ -15,7 +15,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Notification\CachedNotificationE
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
-use DateTime;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -102,15 +101,10 @@ class CampaignNoSalesEvaluator implements NotificationEvaluatorInterface, AdsAwa
 			return false;
 		}
 
-		$timezone = wp_timezone();
-		$now      = new DateTime( 'now', $timezone );
-
 		try {
 			$report_data = $this->ads_report->get_report_data(
 				'campaigns',
 				[
-					'after'  => ( clone $now )->modify( '-90 days' ),
-					'before' => $now,
 					'fields' => [ 'conversions' ],
 				]
 			);

--- a/tests/Unit/Notification/Evaluators/CampaignNoSalesEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/CampaignNoSalesEvaluatorTest.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsRecommendationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsReport;
@@ -32,6 +33,9 @@ class CampaignNoSalesEvaluatorTest extends UnitTest {
 	/** @var MockObject|AdsReport $ads_report */
 	protected $ads_report;
 
+	/** @var MockObject|AdsRecommendationsService $ads_recommendations */
+	protected $ads_recommendations;
+
 	/** @var CampaignNoSalesEvaluator $evaluator */
 	protected $evaluator;
 
@@ -41,11 +45,29 @@ class CampaignNoSalesEvaluatorTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->ads_service  = $this->createMock( AdsService::class );
-		$this->ads_campaign = $this->createMock( AdsCampaign::class );
-		$this->ads_report   = $this->createMock( AdsReport::class );
-		$this->evaluator    = new CampaignNoSalesEvaluator( $this->ads_campaign, $this->ads_report );
+		$this->ads_service         = $this->createMock( AdsService::class );
+		$this->ads_campaign        = $this->createMock( AdsCampaign::class );
+		$this->ads_report          = $this->createMock( AdsReport::class );
+		$this->ads_recommendations = $this->createMock( AdsRecommendationsService::class );
+		$this->evaluator           = new CampaignNoSalesEvaluator( $this->ads_campaign, $this->ads_report, $this->ads_recommendations );
 		$this->evaluator->set_ads_object( $this->ads_service );
+	}
+
+	/**
+	 * Mock no raise budget recommendations available.
+	 */
+	private function mock_no_raise_budget_recommendations(): void {
+		$this->ads_recommendations->method( 'get_recommendations' )
+			->with(
+				[
+					'types'       => [
+						'CAMPAIGN_BUDGET',
+						'MARGINAL_ROI_CAMPAIGN_BUDGET',
+					],
+					'campaign_id' => 0,
+				]
+			)
+			->willReturn( [] );
 	}
 
 	public function test_get_id() {
@@ -62,6 +84,33 @@ class CampaignNoSalesEvaluatorTest extends UnitTest {
 
 	public function test_should_not_show_when_ads_incomplete() {
 		$this->ads_service->method( 'is_setup_complete' )->willReturn( false );
+		$this->ads_recommendations->expects( $this->never() )->method( 'get_recommendations' );
+		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
+		$this->ads_report->expects( $this->never() )->method( 'get_report_data' );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_raise_budget_recommendation_available() {
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_recommendations->method( 'get_recommendations' )
+			->with(
+				[
+					'types'       => [
+						'CAMPAIGN_BUDGET',
+						'MARGINAL_ROI_CAMPAIGN_BUDGET',
+					],
+					'campaign_id' => 0,
+				]
+			)
+			->willReturn(
+				[
+					[
+						'id'   => 1,
+						'type' => 'CAMPAIGN_BUDGET',
+					],
+				]
+			);
 		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
 		$this->ads_report->expects( $this->never() )->method( 'get_report_data' );
 
@@ -70,6 +119,7 @@ class CampaignNoSalesEvaluatorTest extends UnitTest {
 
 	public function test_should_show_when_enabled_campaign_has_zero_conversions() {
 		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->mock_no_raise_budget_recommendations();
 		$this->ads_campaign->method( 'get_campaigns' )
 			->with( true, false )
 			->willReturn(
@@ -114,6 +164,7 @@ class CampaignNoSalesEvaluatorTest extends UnitTest {
 
 	public function test_should_not_show_when_enabled_campaigns_have_conversions() {
 		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->mock_no_raise_budget_recommendations();
 		$this->ads_campaign->method( 'get_campaigns' )
 			->with( true, false )
 			->willReturn(
@@ -143,6 +194,7 @@ class CampaignNoSalesEvaluatorTest extends UnitTest {
 
 	public function test_should_show_when_enabled_campaign_missing_from_report() {
 		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->mock_no_raise_budget_recommendations();
 		$this->ads_campaign->method( 'get_campaigns' )
 			->with( true, false )
 			->willReturn(
@@ -163,6 +215,7 @@ class CampaignNoSalesEvaluatorTest extends UnitTest {
 
 		set_transient( 'gla_notif_campaign-no-sales_' . $user_id, 0, HOUR_IN_SECONDS );
 
+		$this->ads_recommendations->expects( $this->never() )->method( 'get_recommendations' );
 		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
 		$this->ads_report->expects( $this->never() )->method( 'get_report_data' );
 

--- a/tests/Unit/Notification/Evaluators/CampaignNoSalesEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/CampaignNoSalesEvaluatorTest.php
@@ -12,7 +12,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\Campaign
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use DateTime;
 use PHPUnit\Framework\MockObject\MockObject;
 
 defined( 'ABSPATH' ) || exit;
@@ -137,14 +136,9 @@ class CampaignNoSalesEvaluatorTest extends UnitTest {
 		$this->ads_report->method( 'get_report_data' )
 			->with(
 				'campaigns',
-				$this->callback(
-					function ( array $args ): bool {
-						return isset( $args['after'], $args['before'], $args['fields'] )
-							&& $args['after'] instanceof DateTime
-							&& $args['before'] instanceof DateTime
-							&& [ 'conversions' ] === $args['fields'];
-					}
-				)
+				[
+					'fields' => [ 'conversions' ],
+				]
 			)
 			->willReturn(
 				[


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds signal detection for the `campaign-no-sales` notification and tightens when it fires.

- Detects merchants with at least one enabled Google Ads campaign that has zero attributed conversions and no raise budget recommendation (CAMPAIGN_BUDGET / MARGINAL_ROI_CAMPAIGN_BUDGET)

- Skips this signal when a raise budget recommendation is available, so the recommendations path handles that case instead

- Uses cached Google Ads API responses via `AdsRecommendationsService` and `AdsReport`

- Removes the previous 90-day report window so zero-sales is evaluated across the campaign’s full lifetime, not just the last 90 days

Closes https://linear.app/a8c/issue/GOOWOO-665/be-signal-detection-case-52-active-campaign-but-zero-sales

### Screenshots:

N/A

### Detailed test instructions:

#### Setup

- Use a store with Google for WooCommerce fully connected (Ads setup complete).

- Log in as an admin who can manage WooCommerce.

- Go to Marketing (`/wp-admin/admin.php?page=wc-admin&path=/marketing`).

#### Should show notification

1. Ensure at least one Google Ads campaign is Enabled.
2. Confirm that campaign has zero conversions (all-time, not just last 90 days).
3. Confirm there is no raise budget recommendation in Google Ads / the GLA dashboard.
4. Reload Marketing and verify the “Drive traffic from Google Ads” notification appears.
5. Optionally check `GET /wp-json/wc/gla/notifications` - response should include `"id": "campaign-no-sales"`.

#### Should not show notification
**Scenario**: Raise budget recommendation available
**Expected**: No campaign-no-sales

**Scenario**: Enabled campaign has conversions
**Expected**: No notification

**Scenario**: All campaigns paused/removed
**Expected**: No notification

**Scenario**: Ads setup incomplete
**Expected**: No notification

**Scenario**: Notification permanently dismissed
**Expected**: No notification after dismiss

### Additional details:

We've removed the 90 days condition check as per our discussion [here](https://linear.app/a8c/issue/GOOWOO-665/be-signal-detection-case-52-active-campaign-but-zero-sales#comment-4d0a0c4e)
