### PR TITLE
[GOOWOO-743] Implement the language matching model for product sync to Google Merchant Centre

### DIFF
--- a/src/Integration/WPML.php
+++ b/src/Integration/WPML.php
@@ -44,6 +44,29 @@ class WPML implements IntegrationInterface {
 	}
 
 	/**
+	 * Returns the WPML language code for a given post ID.
+	 *
+	 * @param int $post_id The post ID.
+	 *
+	 * @return string The language code, or empty string when WPML is inactive or no language is recorded.
+	 */
+	public function get_post_language( int $post_id ): string {
+		if ( ! $this->is_active() ) {
+			return '';
+		}
+
+		$details = apply_filters( 'wpml_post_language_details', null, $post_id );
+
+		if ( ! is_array( $details ) ) {
+			return '';
+		}
+
+		$code = $details['language_code'] ?? '';
+
+		return is_string( $code ) ? $code : '';
+	}
+
+	/**
 	 * Returns the store's active WPML languages.
 	 *
 	 * @return array<int, array{code: string, label: string}>

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -330,7 +330,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			ValidatorInterface::class,
 			ProductFactory::class,
 			AttributeMappingRulesQuery::class,
-			MarketService::class
+			MarketService::class,
+			WPML::class
 		);
 		$this->share_with_tags(
 			ProductSyncer::class,

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Product as GoogleProduct;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -62,6 +63,11 @@ class BatchProductHelper implements Service {
 	protected $market_service;
 
 	/**
+	 * @var WPML
+	 */
+	protected $wpml;
+
+	/**
 	 * BatchProductHelper constructor.
 	 *
 	 * @param ProductMetaHandler         $meta_handler
@@ -70,6 +76,7 @@ class BatchProductHelper implements Service {
 	 * @param ProductFactory             $product_factory
 	 * @param AttributeMappingRulesQuery $attribute_mapping_rules_query
 	 * @param MarketService              $market_service
+	 * @param WPML                       $wpml
 	 */
 	public function __construct(
 		ProductMetaHandler $meta_handler,
@@ -77,7 +84,8 @@ class BatchProductHelper implements Service {
 		ValidatorInterface $validator,
 		ProductFactory $product_factory,
 		AttributeMappingRulesQuery $attribute_mapping_rules_query,
-		MarketService $market_service
+		MarketService $market_service,
+		WPML $wpml
 	) {
 		$this->meta_handler                  = $meta_handler;
 		$this->product_helper                = $product_helper;
@@ -85,6 +93,7 @@ class BatchProductHelper implements Service {
 		$this->product_factory               = $product_factory;
 		$this->attribute_mapping_rules_query = $attribute_mapping_rules_query;
 		$this->market_service                = $market_service;
+		$this->wpml                          = $wpml;
 	}
 
 	/**
@@ -198,6 +207,7 @@ class BatchProductHelper implements Service {
 	public function validate_and_generate_update_request_entries( array $products ): array {
 		$request_entries = [];
 		$mapping_rules   = $this->attribute_mapping_rules_query->get_results();
+		$wpml_active     = $this->market_service->has_multilingual_support();
 
 		foreach ( $products as $product ) {
 			$this->validate_instanceof( $product, WC_Product::class );
@@ -218,45 +228,53 @@ class BatchProductHelper implements Service {
 					continue;
 				}
 
-				$primary_market = $this->market_service->get_primary_market();
-
-				// validate the product
-				$adapted_product   = $this->product_factory->create(
-					$product,
-					$primary_market['country'],
-					$mapping_rules,
-					$primary_market['feed_label'],
-					$this->extract_language( $primary_market )
-				);
-				$validation_result = $this->validate_product( $adapted_product );
-				if ( $validation_result instanceof BatchInvalidProductEntry ) {
-					$this->mark_as_invalid( $validation_result );
-
-					do_action(
-						'woocommerce_gla_debug_message',
-						sprintf( 'Skipping product (ID: %s) because it does not pass validation: %s', $product->get_id(), wp_json_encode( $validation_result ) ),
-						__METHOD__
-					);
-
-					continue;
-				}
-
-				// add shipping for all countries across all markets
-				$all_countries = $this->market_service->get_all_countries();
-				array_walk( $all_countries, [ $adapted_product, 'add_shipping_country' ] );
+				$product_language = $wpml_active ? $this->wpml->get_post_language( $product->get_id() ) : '';
 
 				// Stage entries per product so a throw or validation failure in
 				// any secondary market discards the whole product's entries
 				// preventing the primary feed from receiving the product while
 				// a secondary feed silently misses it.
-				$product_entries   = [];
-				$product_entries[] = new BatchProductRequestEntry(
-					$product->get_id(),
-					$adapted_product
-				);
+				$product_entries = [];
+
+				$primary_market = $this->market_service->get_primary_market();
+
+				if ( $this->product_matches_market( $product_language, $primary_market, $wpml_active ) ) {
+					$adapted_product   = $this->product_factory->create(
+						$product,
+						$primary_market['country'],
+						$mapping_rules,
+						$primary_market['feed_label'],
+						$product_language
+					);
+					$validation_result = $this->validate_product( $adapted_product );
+					if ( $validation_result instanceof BatchInvalidProductEntry ) {
+						$this->mark_as_invalid( $validation_result );
+
+						do_action(
+							'woocommerce_gla_debug_message',
+							sprintf( 'Skipping product (ID: %s) because it does not pass validation: %s', $product->get_id(), wp_json_encode( $validation_result ) ),
+							__METHOD__
+						);
+
+						continue;
+					}
+
+					// add shipping for all countries across all markets
+					$all_countries = $this->market_service->get_all_countries();
+					array_walk( $all_countries, [ $adapted_product, 'add_shipping_country' ] );
+
+					$product_entries[] = new BatchProductRequestEntry(
+						$product->get_id(),
+						$adapted_product
+					);
+				}
 
 				foreach ( $this->market_service->get_markets() as $market_id => $market ) {
 					if ( 'primary' === $market_id ) {
+						continue;
+					}
+
+					if ( ! $this->product_matches_market( $product_language, $market, $wpml_active ) ) {
 						continue;
 					}
 
@@ -265,7 +283,7 @@ class BatchProductHelper implements Service {
 						$market['country'],
 						$mapping_rules,
 						$market['feed_label'],
-						$this->extract_language( $market )
+						$product_language
 					);
 
 					$secondary_validation = $this->validate_product( $secondary_adapter );
@@ -289,7 +307,9 @@ class BatchProductHelper implements Service {
 					);
 				}
 
-				array_push( $request_entries, ...$product_entries );
+				if ( ! empty( $product_entries ) ) {
+					array_push( $request_entries, ...$product_entries );
+				}
 			} catch ( GoogleListingsAndAdsException $exception ) {
 				do_action(
 					'woocommerce_gla_error',
@@ -305,19 +325,41 @@ class BatchProductHelper implements Service {
 	}
 
 	/**
-	 * Extracts a single language code from a market config.
+	 * Determines whether a product's language matches a market's accepted languages.
 	 *
-	 * Each MC product carries exactly one contentLanguage. Markets store
-	 * language as an array of codes; the first entry is used.
+	 * When WPML is inactive the matching step is skipped and every product matches every market.
+	 * When WPML is active an empty market language list also matches every product (it means
+	 * "this market accepts any product"). Otherwise the product's WPML language must be in
+	 * the market's language list, after converting any locale-form values ("en_US") to the
+	 * short-code form ("en") that WPML uses.
 	 *
-	 * @param array $market A market config array as returned by MarketService.
+	 * @param string $product_language The product's WPML language code, or empty string.
+	 * @param array  $market           A market config array as returned by MarketService.
+	 * @param bool   $wpml_active      Whether WPML is active for this site.
 	 *
-	 * @return string The single language code, or empty string when none is set.
+	 * @return bool
 	 */
-	protected function extract_language( array $market ): string {
-		return is_array( $market['language'] ?? null )
-			? (string) ( $market['language'][0] ?? '' )
-			: (string) ( $market['language'] ?? '' );
+	protected function product_matches_market( string $product_language, array $market, bool $wpml_active ): bool {
+		if ( ! $wpml_active ) {
+			return true;
+		}
+
+		$market_languages = is_array( $market['language'] ?? null ) ? $market['language'] : [];
+
+		if ( empty( $market_languages ) ) {
+			return true;
+		}
+
+		$normalised = array_map(
+			static function ( $value ) {
+				$value = (string) $value;
+
+				return false === strpos( $value, '_' ) ? $value : strtolower( substr( $value, 0, 2 ) );
+			},
+			$market_languages
+		);
+
+		return in_array( $product_language, $normalised, true );
 	}
 
 	/**

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -339,7 +339,7 @@ class BatchProductHelper implements Service {
 	 *
 	 * @return bool
 	 */
-	protected function product_matches_market( string $product_language, array $market, bool $wpml_active ): bool {
+	private static function product_matches_market( string $product_language, array $market, bool $wpml_active ): bool {
 		if ( ! $wpml_active ) {
 			return true;
 		}

--- a/tests/Unit/Integration/WPMLTest.php
+++ b/tests/Unit/Integration/WPMLTest.php
@@ -18,6 +18,8 @@ class WPMLTest extends UnitTest {
 
 	public function tearDown(): void {
 		remove_all_filters( 'wpml_active_languages' );
+		remove_all_filters( 'wpml_default_language' );
+		remove_all_filters( 'wpml_post_language_details' );
 
 		parent::tearDown();
 	}
@@ -149,6 +151,51 @@ class WPMLTest extends UnitTest {
 		);
 
 		$this->assertSame( [], $integration->get_languages() );
+	}
+
+	public function test_get_post_language_returns_empty_when_not_active(): void {
+		$integration = $this->create_integration( false );
+
+		$this->assertSame( '', $integration->get_post_language( 42 ) );
+	}
+
+	public function test_get_post_language_returns_code_from_filter(): void {
+		$integration = $this->create_integration( true );
+
+		add_filter(
+			'wpml_post_language_details',
+			function () {
+				return [ 'language_code' => 'fr' ];
+			}
+		);
+
+		$this->assertSame( 'fr', $integration->get_post_language( 42 ) );
+	}
+
+	public function test_get_post_language_returns_empty_when_filter_returns_non_array(): void {
+		$integration = $this->create_integration( true );
+
+		add_filter(
+			'wpml_post_language_details',
+			function () {
+				return null;
+			}
+		);
+
+		$this->assertSame( '', $integration->get_post_language( 42 ) );
+	}
+
+	public function test_get_post_language_returns_empty_when_filter_missing_language_code(): void {
+		$integration = $this->create_integration( true );
+
+		add_filter(
+			'wpml_post_language_details',
+			function () {
+				return [ 'other' => 'value' ];
+			}
+		);
+
+		$this->assertSame( '', $integration->get_post_language( 42 ) );
 	}
 
 	public function test_get_currencies_returns_empty_when_not_active(): void {

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductFactory;
@@ -54,6 +55,9 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 
 	/** @var MockObject|MarketService $market_service */
 	protected $market_service;
+
+	/** @var MockObject|WPML $wpml */
+	protected $wpml;
 
 	/** @var BatchProductHelper $batch_product_helper */
 	protected $batch_product_helper;
@@ -393,6 +397,251 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		}
 	}
 
+	public function test_validate_and_generate_update_request_entries_wpml_match_emits_with_product_language() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->market_service->method( 'has_multilingual_support' )->willReturn( true );
+		$this->wpml->method( 'get_post_language' )->willReturn( 'fr' );
+
+		$this->set_up_market_service_stubs(
+			[ 'US', 'FR' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => [ 'en' ],
+				],
+				'fr-fr'   => [
+					'country'    => 'FR',
+					'feed_label' => 'FR-fr',
+					'language'   => [ 'fr', 'en' ],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$results = $this->batch_product_helper->validate_and_generate_update_request_entries( [ $product ] );
+
+		// Product language 'fr' is not in primary's ['en']; only the FR-fr secondary entry is emitted.
+		$this->assertCount( 1, $results );
+		$entry = $results[0];
+		$this->assertSame( 'FR', $entry->get_product()->getTargetCountry() );
+		$this->assertSame( 'FR-fr', $entry->get_product()->getFeedLabel() );
+		$this->assertSame( 'fr', $entry->get_product()->getContentLanguage() );
+	}
+
+	public function test_validate_and_generate_update_request_entries_wpml_match_alternate_language_in_set() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->market_service->method( 'has_multilingual_support' )->willReturn( true );
+		$this->wpml->method( 'get_post_language' )->willReturn( 'en' );
+
+		$this->set_up_market_service_stubs(
+			[ 'US', 'FR' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => [],
+				],
+				'fr-fr'   => [
+					'country'    => 'FR',
+					'feed_label' => 'FR-fr',
+					'language'   => [ 'fr', 'en' ],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$results = $this->batch_product_helper->validate_and_generate_update_request_entries( [ $product ] );
+
+		$secondary_entries = array_filter(
+			$results,
+			static function ( BatchProductRequestEntry $entry ) {
+				return 'FR-fr' === $entry->get_product()->getFeedLabel();
+			}
+		);
+
+		$this->assertCount( 1, $secondary_entries );
+		$entry = array_values( $secondary_entries )[0];
+		$this->assertSame( 'en', $entry->get_product()->getContentLanguage() );
+	}
+
+	public function test_validate_and_generate_update_request_entries_wpml_no_match_emits_no_entry_for_market() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->market_service->method( 'has_multilingual_support' )->willReturn( true );
+		$this->wpml->method( 'get_post_language' )->willReturn( 'de' );
+
+		$this->set_up_market_service_stubs(
+			[ 'US', 'FR' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => [ 'en' ],
+				],
+				'fr-fr'   => [
+					'country'    => 'FR',
+					'feed_label' => 'FR-fr',
+					'language'   => [ 'fr', 'en' ],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$results = $this->batch_product_helper->validate_and_generate_update_request_entries( [ $product ] );
+
+		// Product language 'de' is in neither market's list; nothing is emitted.
+		$this->assertCount( 0, $results );
+	}
+
+	public function test_validate_and_generate_update_request_entries_wpml_primary_locale_form_matches_short_code() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->market_service->method( 'has_multilingual_support' )->willReturn( true );
+		$this->wpml->method( 'get_post_language' )->willReturn( 'en' );
+
+		$this->set_up_market_service_stubs(
+			[ 'US' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => [ 'en_US' ],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$results = $this->batch_product_helper->validate_and_generate_update_request_entries( [ $product ] );
+
+		// 'en_US' in the market list is converted to 'en' before comparison, so the product matches the primary.
+		$this->assertCount( 1, $results );
+		$this->assertSame( 'US', $results[0]->get_product()->getFeedLabel() );
+		$this->assertSame( 'en', $results[0]->get_product()->getContentLanguage() );
+	}
+
+	public function test_validate_and_generate_update_request_entries_wpml_inactive_empty_language_emits_for_every_market() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->market_service->method( 'has_multilingual_support' )->willReturn( false );
+
+		$this->set_up_market_service_stubs(
+			[ 'US', 'FR' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => [],
+				],
+				'fr-fr'   => [
+					'country'    => 'FR',
+					'feed_label' => 'FR-fr',
+					'language'   => [],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$results = $this->batch_product_helper->validate_and_generate_update_request_entries( [ $product ] );
+
+		$this->assertCount( 2, $results );
+
+		// When WPML is inactive and no $language is passed to ProductFactory::create(), the
+		// adapter's default contentLanguage from get_locale() is used. The empty string is
+		// the signal: WCProductAdapter::set_language() is not called and the default stands.
+		foreach ( $results as $entry ) {
+			$this->assertNotSame( '', $entry->get_product()->getContentLanguage() );
+		}
+	}
+
+	public function test_validate_and_generate_update_request_entries_wpml_inactive_non_empty_language_ignored() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->market_service->method( 'has_multilingual_support' )->willReturn( false );
+
+		$this->set_up_market_service_stubs(
+			[ 'US', 'FR' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => [ 'en' ],
+				],
+				'fr-fr'   => [
+					'country'    => 'FR',
+					'feed_label' => 'FR-fr',
+					'language'   => [ 'fr' ],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$results = $this->batch_product_helper->validate_and_generate_update_request_entries( [ $product ] );
+
+		// With WPML inactive, the market's language[] is ignored: every market still emits an entry.
+		$this->assertCount( 2, $results );
+	}
+
+	public function test_validate_and_generate_update_request_entries_wpml_variable_product_matching_variations_only() {
+		$variable    = WC_Helper_Product::create_variation_product();
+		$variations  = array_map( 'wc_get_product', $variable->get_children() );
+		$matching_id = $variations[0]->get_id();
+
+		$this->market_service->method( 'has_multilingual_support' )->willReturn( true );
+		$this->wpml->method( 'get_post_language' )
+			->willReturnCallback(
+				static function ( int $post_id ) use ( $matching_id ) {
+					return $post_id === $matching_id ? 'fr' : 'de';
+				}
+			);
+
+		$this->set_up_market_service_stubs(
+			[ 'US', 'FR' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => [],
+				],
+				'fr-fr'   => [
+					'country'    => 'FR',
+					'feed_label' => 'FR-fr',
+					'language'   => [ 'fr' ],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$results = $this->batch_product_helper->validate_and_generate_update_request_entries( [ $variable ] );
+
+		$fr_entries = array_filter(
+			$results,
+			static function ( BatchProductRequestEntry $entry ) {
+				return 'FR-fr' === $entry->get_product()->getFeedLabel();
+			}
+		);
+
+		$this->assertCount( 1, $fr_entries );
+		$entry = array_values( $fr_entries )[0];
+		$this->assertSame( $matching_id, $entry->get_wc_product_id() );
+	}
+
 	public function test_validate_and_generate_update_request_entries_skips_invalid_product() {
 		$products = $this->create_and_return_supported_test_products();
 
@@ -471,7 +720,8 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			$this->validator,
 			$factory_mock,
 			$this->rules_query,
-			$this->market_service
+			$this->market_service,
+			$this->wpml
 		);
 
 		$this->set_up_market_service_stubs(
@@ -705,12 +955,13 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 		$this->market_service       = $this->createMock( MarketService::class );
+		$this->wpml                 = $this->createMock( WPML::class );
 		$this->validator            = $this->createMock( ValidatorInterface::class );
 		$this->rules_query          = $this->createMock( AttributeMappingRulesQuery::class );
 		$this->product_meta         = $this->container->get( ProductMetaHandler::class );
 		$this->product_factory      = $this->container->get( ProductFactory::class );
 		$this->wc                   = $this->container->get( WC::class );
 		$this->product_helper       = new ProductHelper( $this->product_meta, $this->wc, $this->market_service );
-		$this->batch_product_helper = new BatchProductHelper( $this->product_meta, $this->product_helper, $this->validator, $this->product_factory, $this->rules_query, $this->market_service );
+		$this->batch_product_helper = new BatchProductHelper( $this->product_meta, $this->product_helper, $this->validator, $this->product_factory, $this->rules_query, $this->market_service, $this->wpml );
 	}
 }

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntr
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleProductService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
@@ -82,6 +83,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 										$product_factory,
 										$this->rules_query,
 										$this->market_service,
+										$this->createMock( WPML::class ),
 									]
 								)
 								->getMock();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-743/implement-the-language-matching-model-for-product-sync-to-google

### Screenshots:

N/A


### Detailed test instructions:

Prerequisites:
1. Ensure you have WPML installed and configured with at least 2 languages e.g. English and French
2. Ensure you have the primary market set to use one language e.g. English and a secondary market with the other e.g. French


Test Steps:
1. Create a product only in the secondary language (French) - do not create a primary language version. Ensure this has a title / description / image / price and is in stock
2. Wait up to 15 minutes - the product is pushed to Google but takes some time to show up. You may be able to speed this up by noting the product ID, navigate to "Connection Test", scroll down to the "Product Sync" section, enter the product ID and click "Sync Product with Merchant Centre"
3. Open the Merchant Centre - double check you are looking at the same account that is configured in the plugin.
4. Find the new French product and click on it
5. Confirm you see "Countries: France" in the status panel


### Additional details:

> Add - Implement the language matching model for product sync to Google Merchant Centre