### PR TITLE
Clean up orphaned Merchant Center entries when languages are removed from a market

### DIFF
--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -22,6 +22,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\AbstractProductSyncerBatchedJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedLanguageProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedMarketProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupSyncedProducts;
@@ -121,6 +123,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 		$this->share_product_syncer_job( ResubmitExpiringProducts::class );
 		$this->share_product_syncer_job( CleanupProductsJob::class );
 		$this->share_product_syncer_job( CleanupOrphanedMarketProductsJob::class, ProductHelper::class );
+		$this->share_product_syncer_job( CleanupOrphanedLanguageProductsJob::class, ProductHelper::class, WPML::class );
 		$this->share_product_syncer_job( CleanupSyncedProducts::class );
 
 		// share coupon syncer jobs.

--- a/src/Jobs/CleanupOrphanedLanguageProductsJob.php
+++ b/src/Jobs/CleanupOrphanedLanguageProductsJob.php
@@ -1,0 +1,175 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncerException;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CleanupOrphanedLanguageProductsJob
+ *
+ * Deletes Merchant Center entries left orphaned when a language is removed from
+ * a market's language set. Scheduled by MarketService when an update reduces
+ * the set of accepted languages; carries the market's identifying keys
+ * (feed_label for a secondary market, target country codes for the primary) and
+ * the language codes that were removed.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
+ */
+class CleanupOrphanedLanguageProductsJob extends AbstractProductSyncerJob {
+
+	/**
+	 * @var ProductHelper
+	 */
+	protected $product_helper;
+
+	/**
+	 * @var WPML
+	 */
+	protected $wpml;
+
+	/**
+	 * CleanupOrphanedLanguageProductsJob constructor.
+	 *
+	 * @param ActionSchedulerInterface  $action_scheduler
+	 * @param ActionSchedulerJobMonitor $monitor
+	 * @param ProductSyncer             $product_syncer
+	 * @param ProductRepository         $product_repository
+	 * @param MerchantCenterService     $merchant_center
+	 * @param ProductHelper             $product_helper
+	 * @param WPML                      $wpml
+	 */
+	public function __construct(
+		ActionSchedulerInterface $action_scheduler,
+		ActionSchedulerJobMonitor $monitor,
+		ProductSyncer $product_syncer,
+		ProductRepository $product_repository,
+		MerchantCenterService $merchant_center,
+		ProductHelper $product_helper,
+		WPML $wpml
+	) {
+		parent::__construct( $action_scheduler, $monitor, $product_syncer, $product_repository, $merchant_center );
+		$this->product_helper = $product_helper;
+		$this->wpml           = $wpml;
+	}
+
+	/**
+	 * Get the name of the job.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'cleanup_orphaned_language_products_job';
+	}
+
+	/**
+	 * Schedule the job.
+	 *
+	 * @param array $args Accepts `[ 'keys' => string[], 'removed_languages' => string[] ]`.
+	 *                    `keys` is the set of `google_ids` keys to inspect (a single
+	 *                    feed_label for a secondary market, target country codes
+	 *                    for the primary). `removed_languages` is the set of language
+	 *                    codes (short form, e.g. `fr`) that the market no longer accepts.
+	 *
+	 * @throws InvalidValue When either argument is missing or empty.
+	 */
+	public function schedule( array $args = [] ) {
+		$keys              = $args['keys'] ?? null;
+		$removed_languages = $args['removed_languages'] ?? null;
+
+		if ( ! is_array( $keys ) || empty( $keys ) ) {
+			throw InvalidValue::is_empty( 'keys' );
+		}
+
+		if ( ! is_array( $removed_languages ) || empty( $removed_languages ) ) {
+			throw InvalidValue::is_empty( 'removed_languages' );
+		}
+
+		$process_args = [
+			[
+				'keys'              => array_values( $keys ),
+				'removed_languages' => array_values( $removed_languages ),
+			],
+		];
+
+		if ( $this->can_schedule( $process_args ) ) {
+			$this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), $process_args );
+		}
+	}
+
+	/**
+	 * Process orphaned entries for products whose language is in the removed set.
+	 *
+	 * @param array $items Single-element array containing the scheduling args.
+	 *
+	 * @throws ProductSyncerException If the Merchant Center delete call fails.
+	 */
+	protected function process_items( array $items ) {
+		$keys    = is_array( $items['keys'] ?? null ) ? $items['keys'] : [];
+		$removed = is_array( $items['removed_languages'] ?? null ) ? $items['removed_languages'] : [];
+
+		if ( empty( $keys ) || empty( $removed ) ) {
+			return;
+		}
+
+		$product_ids = $this->product_repository->find_synced_product_ids();
+		if ( empty( $product_ids ) ) {
+			return;
+		}
+
+		$products        = $this->product_repository->find_by_ids( $product_ids );
+		$request_entries = [];
+
+		foreach ( $products as $product ) {
+			$product_language = $this->wpml->get_post_language( $product->get_id() );
+			if ( '' === $product_language || ! in_array( $product_language, $removed, true ) ) {
+				continue;
+			}
+
+			$google_ids = $this->product_helper->get_synced_google_product_ids( $product );
+			if ( empty( $google_ids ) ) {
+				continue;
+			}
+
+			foreach ( $keys as $key ) {
+				if ( empty( $google_ids[ $key ] ) ) {
+					continue;
+				}
+
+				$google_id                     = $google_ids[ $key ];
+				$request_entries[ $google_id ] = new BatchProductIDRequestEntry( $product->get_id(), $google_id );
+			}
+		}
+
+		if ( empty( $request_entries ) ) {
+			return;
+		}
+
+		$response = $this->product_syncer->delete_by_batch_requests( $request_entries );
+
+		foreach ( $response->get_products() as $deleted ) {
+			$google_product = $deleted->get_google_product();
+			if ( null === $google_product ) {
+				continue;
+			}
+
+			try {
+				$product = $this->product_helper->get_wc_product( $deleted->get_wc_product_id() );
+			} catch ( InvalidValue $exception ) {
+				continue;
+			}
+
+			$this->product_helper->remove_google_id( $product, $google_product->getId() );
+		}
+	}
+}

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedLanguageProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedMarketProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateShippingSettings;
@@ -284,7 +285,19 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 */
 	public function update_market( string $id, array $config ): array {
 		if ( 'primary' === $id ) {
+			$language_change_pending = array_key_exists( 'language', $config );
+			$primary_existing_langs  = $language_change_pending ? $this->get_existing_primary_languages() : [];
+			$primary_countries       = $language_change_pending ? $this->target_audience->get_target_countries() : [];
+
 			$this->update_primary_market_fanout( $config );
+
+			if ( $language_change_pending ) {
+				$this->schedule_language_cleanup(
+					$primary_existing_langs,
+					$config['language'],
+					$primary_countries
+				);
+			}
 
 			return $this->fire_market_updated_action( $id );
 		}
@@ -305,6 +318,14 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 				->schedule( [ 'feed_label' => $old_feed_label ] );
 		}
 
+		if ( $old_feed_label ) {
+			$this->schedule_language_cleanup(
+				$existing['language'] ?? [],
+				$merged['language'] ?? [],
+				[ $old_feed_label ]
+			);
+		}
+
 		$shipping_keys = [ 'country', 'currency', 'shipping_rate', 'shipping_time' ];
 		foreach ( $shipping_keys as $key ) {
 			if ( ( $existing[ $key ] ?? null ) !== ( $merged[ $key ] ?? null ) ) {
@@ -314,6 +335,80 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		}
 
 		return $this->fire_market_updated_action( $id );
+	}
+
+	/**
+	 * Schedules CleanupOrphanedLanguageProductsJob when languages were removed
+	 * from a market's `language[]` set.
+	 *
+	 * Language codes are normalised before comparison so locale-form values
+	 * (e.g. `en_US`) compare equal to WPML short codes (e.g. `en`).
+	 *
+	 * @param array         $existing_languages The market's languages before the update.
+	 * @param array         $new_languages      The market's languages after the update.
+	 * @param array<string> $keys               `google_ids` keys belonging to the market
+	 *                                          (feed_label for secondary, target countries for primary).
+	 */
+	private function schedule_language_cleanup( array $existing_languages, array $new_languages, array $keys ): void {
+		if ( empty( $keys ) ) {
+			return;
+		}
+
+		$normalised_existing = $this->normalise_language_codes( $existing_languages );
+		$normalised_new      = $this->normalise_language_codes( $new_languages );
+		$removed             = array_values( array_diff( $normalised_existing, $normalised_new ) );
+
+		if ( empty( $removed ) ) {
+			return;
+		}
+
+		$this->job_repository->get( CleanupOrphanedLanguageProductsJob::class )
+			->schedule(
+				[
+					'keys'              => $keys,
+					'removed_languages' => $removed,
+				]
+			);
+	}
+
+	/**
+	 * Returns the primary market's language list from the MERCHANT_CENTER option,
+	 * falling back to a single-entry list with the site-derived default. Mirrors
+	 * the language fallback in get_primary_market() but does not trigger the
+	 * shipping-rate or target-audience lookups that get_primary_market() performs.
+	 *
+	 * @return array
+	 */
+	private function get_existing_primary_languages(): array {
+		$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
+		if ( is_array( $mc_settings['language'] ?? null ) ) {
+			return $mc_settings['language'];
+		}
+
+		return [ $this->get_site_primary_language() ];
+	}
+
+	/**
+	 * Normalises an array of language codes to WPML's short-code form so that
+	 * locale strings (`en_US`) compare equal to short codes (`en`). Mirrors
+	 * the rule in BatchProductHelper::product_matches_market().
+	 *
+	 * @param array $codes
+	 *
+	 * @return string[]
+	 */
+	private function normalise_language_codes( array $codes ): array {
+		$normalised = [];
+		foreach ( $codes as $code ) {
+			$code = (string) $code;
+			if ( '' === $code ) {
+				continue;
+			}
+			$normalised[] = false === strpos( $code, '_' ) ? $code : strtolower( substr( $code, 0, 2 ) );
+		}
+
+		return array_values( array_unique( $normalised ) );
 	}
 
 	/**

--- a/tests/Unit/Jobs/CleanupOrphanedLanguageProductsJobTest.php
+++ b/tests/Unit/Jobs/CleanupOrphanedLanguageProductsJobTest.php
@@ -1,0 +1,358 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionScheduler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductEntry;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedLanguageProductsJob;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Product as GoogleProduct;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Helper_Product;
+
+/**
+ * Class CleanupOrphanedLanguageProductsJobTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs
+ */
+class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
+
+	/** @var MockObject|ActionScheduler $action_scheduler */
+	protected $action_scheduler;
+
+	/** @var MockObject|ActionSchedulerJobMonitor $monitor */
+	protected $monitor;
+
+	/** @var MockObject|ProductSyncer $product_syncer */
+	protected $product_syncer;
+
+	/** @var MockObject|ProductRepository $product_repository */
+	protected $product_repository;
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|ProductHelper $product_helper */
+	protected $product_helper;
+
+	/** @var MockObject|WPML $wpml */
+	protected $wpml;
+
+	/** @var CleanupOrphanedLanguageProductsJob $job */
+	protected $job;
+
+	protected const JOB_NAME          = 'cleanup_orphaned_language_products_job';
+	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->action_scheduler   = $this->createMock( ActionScheduler::class );
+		$this->monitor            = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->product_syncer     = $this->createMock( ProductSyncer::class );
+		$this->product_repository = $this->createMock( ProductRepository::class );
+		$this->merchant_center    = $this->createMock( MerchantCenterService::class );
+		$this->product_helper     = $this->createMock( ProductHelper::class );
+		$this->wpml               = $this->createMock( WPML::class );
+
+		$this->job = new CleanupOrphanedLanguageProductsJob(
+			$this->action_scheduler,
+			$this->monitor,
+			$this->product_syncer,
+			$this->product_repository,
+			$this->merchant_center,
+			$this->product_helper,
+			$this->wpml
+		);
+
+		$this->job->init();
+	}
+
+	public function test_job_name() {
+		$this->assertEquals( self::JOB_NAME, $this->job->get_name() );
+	}
+
+	public function test_schedule_throws_when_keys_missing() {
+		$this->expectException( InvalidValue::class );
+		$this->job->schedule( [ 'removed_languages' => [ 'fr' ] ] );
+	}
+
+	public function test_schedule_throws_when_keys_empty() {
+		$this->expectException( InvalidValue::class );
+		$this->job->schedule(
+			[
+				'keys'              => [],
+				'removed_languages' => [ 'fr' ],
+			]
+		);
+	}
+
+	public function test_schedule_throws_when_removed_languages_missing() {
+		$this->expectException( InvalidValue::class );
+		$this->job->schedule( [ 'keys' => [ 'GB' ] ] );
+	}
+
+	public function test_schedule_throws_when_removed_languages_empty() {
+		$this->expectException( InvalidValue::class );
+		$this->job->schedule(
+			[
+				'keys'              => [ 'GB' ],
+				'removed_languages' => [],
+			]
+		);
+	}
+
+	public function test_schedule_schedules_immediate_with_payload() {
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
+
+		$expected_payload = [
+			[
+				'keys'              => [ 'FR-fr' ],
+				'removed_languages' => [ 'fr' ],
+			],
+		];
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with( self::PROCESS_ITEM_HOOK, $expected_payload );
+
+		$this->job->schedule(
+			[
+				'keys'              => [ 'FR-fr' ],
+				'removed_languages' => [ 'fr' ],
+			]
+		);
+	}
+
+	public function test_process_items_deletes_entry_for_product_in_removed_language() {
+		$product   = WC_Helper_Product::create_simple_product();
+		$google_id = 'online:fr:FR-fr:gla_' . $product->get_id();
+
+		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
+		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
+
+		$this->wpml->method( 'get_post_language' )->with( $product->get_id() )->willReturn( 'fr' );
+
+		$this->product_helper->method( 'get_synced_google_product_ids' )
+			->with( $product )
+			->willReturn(
+				[
+					'FR-fr' => $google_id,
+					'US'    => 'online:en:US:gla_' . $product->get_id(),
+				]
+			);
+
+		$this->product_syncer->expects( $this->once() )
+			->method( 'delete_by_batch_requests' )
+			->with(
+				$this->callback(
+					function ( $entries ) use ( $product, $google_id ) {
+						if ( ! is_array( $entries ) || 1 !== count( $entries ) ) {
+							return false;
+						}
+						$entry = array_values( $entries )[0];
+						return $entry instanceof BatchProductIDRequestEntry
+							&& $entry->get_wc_product_id() === $product->get_id()
+							&& $entry->get_product_id() === $google_id;
+					}
+				)
+			)
+			->willReturn( new BatchProductResponse( [], [] ) );
+
+		do_action(
+			self::PROCESS_ITEM_HOOK,
+			[
+				'keys'              => [ 'FR-fr' ],
+				'removed_languages' => [ 'fr' ],
+			]
+		);
+	}
+
+	public function test_process_items_skips_products_whose_language_is_not_in_removed_set() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
+		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
+
+		$this->wpml->method( 'get_post_language' )->willReturn( 'en' );
+
+		$this->product_syncer->expects( $this->never() )->method( 'delete_by_batch_requests' );
+
+		do_action(
+			self::PROCESS_ITEM_HOOK,
+			[
+				'keys'              => [ 'FR-fr' ],
+				'removed_languages' => [ 'fr' ],
+			]
+		);
+	}
+
+	public function test_process_items_skips_products_with_no_entry_under_keys() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
+		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
+
+		$this->wpml->method( 'get_post_language' )->willReturn( 'fr' );
+
+		$this->product_helper->method( 'get_synced_google_product_ids' )
+			->with( $product )
+			->willReturn( [ 'US' => 'online:en:US:gla_' . $product->get_id() ] );
+
+		$this->product_syncer->expects( $this->never() )->method( 'delete_by_batch_requests' );
+
+		do_action(
+			self::PROCESS_ITEM_HOOK,
+			[
+				'keys'              => [ 'FR-fr' ],
+				'removed_languages' => [ 'fr' ],
+			]
+		);
+	}
+
+	public function test_process_items_calls_remove_google_id_on_success() {
+		$product   = WC_Helper_Product::create_simple_product();
+		$google_id = 'online:fr:FR-fr:gla_' . $product->get_id();
+
+		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
+		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
+		$this->wpml->method( 'get_post_language' )->willReturn( 'fr' );
+		$this->product_helper->method( 'get_synced_google_product_ids' )->willReturn( [ 'FR-fr' => $google_id ] );
+		$this->product_helper->method( 'get_wc_product' )->with( $product->get_id() )->willReturn( $product );
+
+		$google_product = $this->createMock( GoogleProduct::class );
+		$google_product->method( 'getId' )->willReturn( $google_id );
+		$deleted_entry = new BatchProductEntry( $product->get_id(), $google_product );
+
+		$this->product_syncer->method( 'delete_by_batch_requests' )
+			->willReturn( new BatchProductResponse( [ $deleted_entry ], [] ) );
+
+		$this->product_helper->expects( $this->once() )
+			->method( 'remove_google_id' )
+			->with( $product, $google_id );
+
+		do_action(
+			self::PROCESS_ITEM_HOOK,
+			[
+				'keys'              => [ 'FR-fr' ],
+				'removed_languages' => [ 'fr' ],
+			]
+		);
+	}
+
+	public function test_process_items_leaves_local_meta_intact_on_api_failure() {
+		$product   = WC_Helper_Product::create_simple_product();
+		$google_id = 'online:fr:FR-fr:gla_' . $product->get_id();
+
+		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
+		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
+		$this->wpml->method( 'get_post_language' )->willReturn( 'fr' );
+		$this->product_helper->method( 'get_synced_google_product_ids' )->willReturn( [ 'FR-fr' => $google_id ] );
+
+		$this->product_syncer->method( 'delete_by_batch_requests' )
+			->willReturn( new BatchProductResponse( [], [ 'error' => 'boom' ] ) );
+
+		$this->product_helper->expects( $this->never() )->method( 'remove_google_id' );
+
+		do_action(
+			self::PROCESS_ITEM_HOOK,
+			[
+				'keys'              => [ 'FR-fr' ],
+				'removed_languages' => [ 'fr' ],
+			]
+		);
+	}
+
+	public function test_process_items_handles_multiple_keys_for_primary_market() {
+		$product = WC_Helper_Product::create_simple_product();
+		$gb_id   = 'online:fr:GB:gla_' . $product->get_id();
+		$us_id   = 'online:fr:US:gla_' . $product->get_id();
+
+		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
+		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
+		$this->wpml->method( 'get_post_language' )->willReturn( 'fr' );
+
+		$this->product_helper->method( 'get_synced_google_product_ids' )
+			->with( $product )
+			->willReturn(
+				[
+					'GB' => $gb_id,
+					'US' => $us_id,
+				]
+			);
+
+		$this->product_syncer->expects( $this->once() )
+			->method( 'delete_by_batch_requests' )
+			->with(
+				$this->callback(
+					function ( $entries ) use ( $gb_id, $us_id ) {
+						if ( ! is_array( $entries ) || 2 !== count( $entries ) ) {
+							return false;
+						}
+						$ids = array_map(
+							static function ( $entry ) {
+								return $entry->get_product_id();
+							},
+							array_values( $entries )
+						);
+						sort( $ids );
+						$expected = [ $gb_id, $us_id ];
+						sort( $expected );
+						return $ids === $expected;
+					}
+				)
+			)
+			->willReturn( new BatchProductResponse( [], [] ) );
+
+		do_action(
+			self::PROCESS_ITEM_HOOK,
+			[
+				'keys'              => [ 'GB', 'US' ],
+				'removed_languages' => [ 'fr' ],
+			]
+		);
+	}
+
+	public function test_process_items_returns_early_when_no_synced_products() {
+		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [] );
+
+		$this->product_syncer->expects( $this->never() )->method( 'delete_by_batch_requests' );
+
+		do_action(
+			self::PROCESS_ITEM_HOOK,
+			[
+				'keys'              => [ 'GB' ],
+				'removed_languages' => [ 'fr' ],
+			]
+		);
+	}
+
+	public function test_process_items_skips_products_with_empty_wpml_language() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
+		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
+		$this->wpml->method( 'get_post_language' )->willReturn( '' );
+
+		$this->product_syncer->expects( $this->never() )->method( 'delete_by_batch_requests' );
+
+		do_action(
+			self::PROCESS_ITEM_HOOK,
+			[
+				'keys'              => [ 'GB' ],
+				'removed_languages' => [ 'fr' ],
+			]
+		);
+	}
+}

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedLanguageProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedMarketProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateShippingSettings;
@@ -50,6 +51,9 @@ class MarketServiceTest extends UnitTest {
 	/** @var MockObject|CleanupOrphanedMarketProductsJob */
 	protected $cleanup_job;
 
+	/** @var MockObject|CleanupOrphanedLanguageProductsJob */
+	protected $language_cleanup_job;
+
 	/** @var MockObject|UpdateShippingSettings */
 	protected $shipping_settings_job;
 
@@ -67,6 +71,7 @@ class MarketServiceTest extends UnitTest {
 		$this->wpml                  = $this->createMock( WPML::class );
 		$this->job_repository        = $this->createMock( JobRepository::class );
 		$this->cleanup_job           = $this->createMock( CleanupOrphanedMarketProductsJob::class );
+		$this->language_cleanup_job  = $this->createMock( CleanupOrphanedLanguageProductsJob::class );
 		$this->shipping_settings_job = $this->createMock( UpdateShippingSettings::class );
 
 		$this->job_repository->method( 'get' )
@@ -75,6 +80,8 @@ class MarketServiceTest extends UnitTest {
 					switch ( $classname ) {
 						case CleanupOrphanedMarketProductsJob::class:
 							return $this->cleanup_job;
+						case CleanupOrphanedLanguageProductsJob::class:
+							return $this->language_cleanup_job;
 						case UpdateShippingSettings::class:
 							return $this->shipping_settings_job;
 						default:
@@ -2205,6 +2212,174 @@ class MarketServiceTest extends UnitTest {
 		$this->market_service->delete_market( 'unknown' );
 
 		$this->assertFalse( $fired );
+	}
+
+	public function test_update_market_secondary_schedules_language_cleanup_when_language_removed(): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en', 'cy' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->language_cleanup_job->expects( $this->once() )
+			->method( 'schedule' )
+			->with(
+				[
+					'keys'              => [ 'GB' ],
+					'removed_languages' => [ 'cy' ],
+				]
+			);
+
+		$this->market_service->update_market( 'gb', [ 'language' => [ 'en' ] ] );
+	}
+
+	public function test_update_market_secondary_does_not_schedule_language_cleanup_when_language_added(): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->language_cleanup_job->expects( $this->never() )->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'language' => [ 'en', 'cy' ] ] );
+	}
+
+	public function test_update_market_secondary_does_not_schedule_language_cleanup_when_language_reordered(): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en', 'cy' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->language_cleanup_job->expects( $this->never() )->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'language' => [ 'cy', 'en' ] ] );
+	}
+
+	public function test_update_market_secondary_uses_old_feed_label_when_feed_label_also_changes(): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en', 'cy' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->language_cleanup_job->expects( $this->once() )
+			->method( 'schedule' )
+			->with(
+				[
+					'keys'              => [ 'GB' ],
+					'removed_languages' => [ 'cy' ],
+				]
+			);
+
+		$this->market_service->update_market(
+			'gb',
+			[
+				'language'   => [ 'en' ],
+				'feed_label' => 'GB-PROMO',
+			]
+		);
+	}
+
+	public function test_update_market_primary_schedules_language_cleanup_when_language_removed(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'language' => [ 'en', 'fr' ],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US', 'CA' ] );
+
+		$this->language_cleanup_job->expects( $this->once() )
+			->method( 'schedule' )
+			->with(
+				[
+					'keys'              => [ 'US', 'CA' ],
+					'removed_languages' => [ 'fr' ],
+				]
+			);
+
+		$this->market_service->update_market( 'primary', [ 'language' => [ 'en' ] ] );
+	}
+
+	public function test_update_market_primary_does_not_schedule_when_language_unchanged(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'language' => [ 'en', 'fr' ],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->language_cleanup_job->expects( $this->never() )->method( 'schedule' );
+
+		$this->market_service->update_market( 'primary', [ 'currency' => [ 'USD' ] ] );
+	}
+
+	public function test_update_market_primary_normalises_locale_form_against_short_codes(): void {
+		// Existing stored language uses the locale form 'en_US'; the merchant supplies
+		// short codes for the new value. Only the genuinely-removed code should be reported.
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'language' => [ 'en_US', 'fr' ],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$this->language_cleanup_job->expects( $this->once() )
+			->method( 'schedule' )
+			->with(
+				[
+					'keys'              => [ 'US' ],
+					'removed_languages' => [ 'fr' ],
+				]
+			);
+
+		$this->market_service->update_market( 'primary', [ 'language' => [ 'en' ] ] );
+	}
+
+	public function test_update_market_primary_does_not_schedule_when_target_audience_empty(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'language' => [ 'en', 'fr' ],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [] );
+
+		$this->language_cleanup_job->expects( $this->never() )->method( 'schedule' );
+
+		$this->market_service->update_market( 'primary', [ 'language' => [ 'en' ] ] );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-745/clean-up-orphaned-merchant-center-entries-when-languages-are-removed

### Screenshots:

Shows the actions for primary and secondary market have completed after running test steps:
<img width="3227" height="865" alt="Screenshot 2026-07-01 at 11 15 29" src="https://github.com/user-attachments/assets/50c943a1-1d94-4b87-bbaf-81464ed5f20f" />


### Detailed test instructions:

Prerequisites:
1. WooCommerce store with WPML active, at least two languages configured (e.g. English + French).
2. A handful of products, some assigned to `en`, some to `fr` (WPML translation set).
3. Plugin connected to a real Merchant Center account.
4. A secondary market configured for France 
5. A primary market covering GB with English and French
6. Run a full sync so that both en and fr products appear in MC under both primary and secondary keys.

Test 1: Primary market language removal
1. Edit the primary market and remove French from its languages, then save. (Note: if French was not setup, add it, save, then remove it and save)
2. Watch Action Scheduler (WooCommerce -> Status -> Scheduled Actions) for the `gla/jobs/cleanup_orphaned_language_products_job/process_item` action, this should exist but may be pending. Wait up to 3 minutes, refresh and confirm this shows as completed.
4. Verify in Merchant Centre

Test 2: Secondary market language removal
1. In the plugin, edit the France secondary market and remove fr from its languages so it becomes language = [ 'en' ]. Save.
2. Watch Action Scheduler (WooCommerce → Status → Scheduled Actions) for a gla/jobs/cleanup_orphaned_language_products_job/process_item action. It should fire almost immediately (schedule_immediate).
3. Once complete, reload Merchant Center. Filter Products by feed label = FR-fr. The French-language rows should no longer be present. English rows for the same feed label remain.

Test 3: negative cases (should not trigger cleanup)

1. Add a language to a market instead of removing one.
2. No cleanup job should be scheduled - verify this

### Additional details:

> Update - Clean up orphaned Merchant Center entries when languages are removed from a market