### PR TITLE
GOOWOO-756: Migrate content.shippingsettings.update to MAPI accounts.shippingSettings.insert

### DIFF
--- a/src/API/Google/Mapi/Services/MapiAccountRegionsService.php
+++ b/src/API/Google/Mapi/Services/MapiAccountRegionsService.php
@@ -1,0 +1,120 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MapiPaths;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountRegionsService
+ *
+ * Reads and writes the shipping regions for the connected account through the
+ * Merchant API accounts.regions resource. Regions replace the Content API's
+ * inline shippingSettings.postalCodeGroups and are referenced from rate-group
+ * tables by their region id.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services
+ */
+class MapiAccountRegionsService implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/** @var MerchantApiClient */
+	protected $client;
+
+	/**
+	 * MapiAccountRegionsService constructor.
+	 *
+	 * @param MerchantApiClient $client
+	 */
+	public function __construct( MerchantApiClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * List the regions defined for the connected merchant account.
+	 *
+	 * @return array Region resources decoded as arrays (empty when none exist).
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function get_regions(): array {
+		$response = $this->client->get( $this->build_path() );
+
+		return $response['regions'] ?? [];
+	}
+
+	/**
+	 * Create a region for the connected merchant account.
+	 *
+	 * @param string $region_id The region id (referenced by rate-group tables).
+	 * @param array  $region    The Region resource to write.
+	 *
+	 * @return array The stored Region resource decoded as an array.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function insert_region( string $region_id, array $region ): array {
+		return $this->client->post(
+			$this->build_path() . '?regionId=' . rawurlencode( $region_id ),
+			$region
+		);
+	}
+
+	/**
+	 * Update a region for the connected merchant account.
+	 *
+	 * @param string $region_id   The region id.
+	 * @param array  $region      The Region fields to write.
+	 * @param string $update_mask Comma-separated list of fields to update.
+	 *
+	 * @return array The stored Region resource decoded as an array.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function update_region( string $region_id, array $region, string $update_mask ): array {
+		return $this->client->patch(
+			$this->build_region_path( $region_id ) . '?updateMask=' . rawurlencode( $update_mask ),
+			$region
+		);
+	}
+
+	/**
+	 * Delete a region for the connected merchant account.
+	 *
+	 * @param string $region_id The region id.
+	 *
+	 * @return array Decoded response body (empty on success).
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function delete_region( string $region_id ): array {
+		return $this->client->delete( $this->build_region_path( $region_id ) );
+	}
+
+	/**
+	 * Build the regions collection path for the connected merchant account.
+	 *
+	 * @return string
+	 */
+	protected function build_path(): string {
+		return sprintf(
+			'%s/accounts/%s/regions',
+			MapiPaths::ACCOUNTS,
+			$this->options->get_merchant_id()
+		);
+	}
+
+	/**
+	 * Build the path for a single region.
+	 *
+	 * @param string $region_id
+	 *
+	 * @return string
+	 */
+	protected function build_region_path( string $region_id ): string {
+		return $this->build_path() . '/' . rawurlencode( $region_id );
+	}
+}

--- a/src/API/Google/Mapi/Services/MapiAccountRegionsService.php
+++ b/src/API/Google/Mapi/Services/MapiAccountRegionsService.php
@@ -38,18 +38,6 @@ class MapiAccountRegionsService implements OptionsAwareInterface {
 	}
 
 	/**
-	 * List the regions defined for the connected merchant account.
-	 *
-	 * @return array Region resources decoded as arrays (empty when none exist).
-	 * @throws MerchantApiException On a non-2xx MAPI response.
-	 */
-	public function get_regions(): array {
-		$response = $this->client->get( $this->build_path() );
-
-		return $response['regions'] ?? [];
-	}
-
-	/**
 	 * Create a region for the connected merchant account.
 	 *
 	 * @param string $region_id The region id (referenced by rate-group tables).
@@ -80,18 +68,6 @@ class MapiAccountRegionsService implements OptionsAwareInterface {
 			$this->build_region_path( $region_id ) . '?updateMask=' . rawurlencode( $update_mask ),
 			$region
 		);
-	}
-
-	/**
-	 * Delete a region for the connected merchant account.
-	 *
-	 * @param string $region_id The region id.
-	 *
-	 * @return array Decoded response body (empty on success).
-	 * @throws MerchantApiException On a non-2xx MAPI response.
-	 */
-	public function delete_region( string $region_id ): array {
-		return $this->client->delete( $this->build_region_path( $region_id ) );
 	}
 
 	/**

--- a/src/API/Google/Mapi/Services/MapiAccountServicesService.php
+++ b/src/API/Google/Mapi/Services/MapiAccountServicesService.php
@@ -1,0 +1,112 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MapiPaths;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountServicesService
+ *
+ * Reads and writes the account services for the connected account through the
+ * Merchant API accounts.services resource. The Google Ads link is an account
+ * service provided by providers/GOOGLE_ADS.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services
+ */
+class MapiAccountServicesService implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	private const GOOGLE_ADS_PROVIDER = 'providers/GOOGLE_ADS';
+
+	/** @var MerchantApiClient */
+	protected $client;
+
+	/**
+	 * MapiAccountServicesService constructor.
+	 *
+	 * @param MerchantApiClient $client
+	 */
+	public function __construct( MerchantApiClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * List the account services for the connected merchant account.
+	 *
+	 * @return array AccountService resources decoded as arrays (empty when none exist).
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function get_services(): array {
+		return $this->client->get( $this->build_path() )['accountServices'] ?? [];
+	}
+
+	/**
+	 * Find the Google Ads link service for a given Ads account id.
+	 *
+	 * @param int $ads_id The Google Ads account id.
+	 *
+	 * @return array|null The AccountService for the link, or null when there is none.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function get_google_ads_link( int $ads_id ): ?array {
+		$link = null;
+		foreach ( $this->get_services() as $service ) {
+			if ( self::GOOGLE_ADS_PROVIDER !== ( $service['provider'] ?? '' ) || (string) $ads_id !== (string) ( $service['externalAccountId'] ?? '' ) ) {
+				continue;
+			}
+
+			// A propose call can leave a rejected or pending duplicate alongside an
+			// established link (the Merchant API has no way to delete a service), so prefer
+			// an ESTABLISHED match and fall back to the first non-established one otherwise.
+			if ( 'ESTABLISHED' === ( $service['handshake']['approvalState'] ?? '' ) ) {
+				return $service;
+			}
+
+			$link = $link ?? $service;
+		}
+
+		return $link;
+	}
+
+	/**
+	 * Propose a Google Ads account link (the merchant side of the handshake).
+	 *
+	 * @param int $ads_id The Google Ads account id to link.
+	 *
+	 * @return array The proposed AccountService resource decoded as an array.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function propose_google_ads_link( int $ads_id ): array {
+		return $this->client->post(
+			$this->build_path() . ':propose',
+			[
+				'provider'       => self::GOOGLE_ADS_PROVIDER,
+				'accountService' => [
+					'externalAccountId'   => (string) $ads_id,
+					'campaignsManagement' => (object) [],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Build the services resource path for the connected merchant account.
+	 *
+	 * @return string
+	 */
+	protected function build_path(): string {
+		return sprintf(
+			'%s/accounts/%s/services',
+			MapiPaths::ACCOUNTS,
+			$this->options->get_merchant_id()
+		);
+	}
+}

--- a/src/API/Google/Mapi/Services/MapiAccountShippingSettingsService.php
+++ b/src/API/Google/Mapi/Services/MapiAccountShippingSettingsService.php
@@ -36,28 +36,11 @@ class MapiAccountShippingSettingsService implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Retrieve the shipping settings for the connected merchant account.
-	 *
-	 * The Merchant API returns a 404 when the account has no shipping settings
-	 * yet; that is mapped to an empty array so callers can treat it as "none".
-	 *
-	 * @return array ShippingSettings resource decoded as an array, empty when none exist.
-	 * @throws MerchantApiException On a non-2xx MAPI response other than 404.
-	 */
-	public function get_shipping_settings(): array {
-		try {
-			return $this->client->get( $this->build_path() );
-		} catch ( MerchantApiException $e ) {
-			if ( 404 === $e->get_http_status() ) {
-				return [];
-			}
-
-			throw $e;
-		}
-	}
-
-	/**
 	 * Insert (create or replace) the shipping settings for the connected merchant account.
+	 *
+	 * The shippingSettings:insert custom method is an unconditional full replacement,
+	 * so it takes no etag / If-Match precondition (the resource's etag only guards a
+	 * read-modify-write, which this write path does not perform).
 	 *
 	 * @param array $shipping_settings ShippingSettings resource to write.
 	 *

--- a/src/API/Google/Mapi/Services/MapiAccountShippingSettingsService.php
+++ b/src/API/Google/Mapi/Services/MapiAccountShippingSettingsService.php
@@ -1,0 +1,83 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MapiPaths;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountShippingSettingsService
+ *
+ * Reads and writes the shipping settings for the connected account through the
+ * Merchant API accounts.shippingSettings resource.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services
+ */
+class MapiAccountShippingSettingsService implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/** @var MerchantApiClient */
+	protected $client;
+
+	/**
+	 * MapiAccountShippingSettingsService constructor.
+	 *
+	 * @param MerchantApiClient $client
+	 */
+	public function __construct( MerchantApiClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * Retrieve the shipping settings for the connected merchant account.
+	 *
+	 * The Merchant API returns a 404 when the account has no shipping settings
+	 * yet; that is mapped to an empty array so callers can treat it as "none".
+	 *
+	 * @return array ShippingSettings resource decoded as an array, empty when none exist.
+	 * @throws MerchantApiException On a non-2xx MAPI response other than 404.
+	 */
+	public function get_shipping_settings(): array {
+		try {
+			return $this->client->get( $this->build_path() );
+		} catch ( MerchantApiException $e ) {
+			if ( 404 === $e->get_http_status() ) {
+				return [];
+			}
+
+			throw $e;
+		}
+	}
+
+	/**
+	 * Insert (create or replace) the shipping settings for the connected merchant account.
+	 *
+	 * @param array $shipping_settings ShippingSettings resource to write.
+	 *
+	 * @return array The stored ShippingSettings resource decoded as an array.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function insert_shipping_settings( array $shipping_settings ): array {
+		return $this->client->post( $this->build_path() . ':insert', $shipping_settings );
+	}
+
+	/**
+	 * Build the shippingSettings resource path for the connected merchant account.
+	 *
+	 * @return string
+	 */
+	protected function build_path(): string {
+		return sprintf(
+			'%s/accounts/%s/shippingSettings',
+			MapiPaths::ACCOUNTS,
+			$this->options->get_merchant_id()
+		);
+	}
+}

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountBusinessInfoService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountServicesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountUsersService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
@@ -15,7 +16,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Exception as Googl
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\Exception as GoogleServiceException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Account;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountAdsLink;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\RequestPhoneVerificationRequest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\RequestReviewFreeListingsRequest;
@@ -65,18 +65,27 @@ class Merchant implements OptionsAwareInterface {
 	protected $users_service;
 
 	/**
+	 * The Merchant API account services service.
+	 *
+	 * @var MapiAccountServicesService
+	 */
+	protected $services_service;
+
+	/**
 	 * Merchant constructor.
 	 *
 	 * @param ShoppingContent                $service
 	 * @param MapiAccountHomepageService     $homepage_service
 	 * @param MapiAccountBusinessInfoService $business_info_service
 	 * @param MapiAccountUsersService        $users_service
+	 * @param MapiAccountServicesService     $services_service
 	 */
-	public function __construct( ShoppingContent $service, MapiAccountHomepageService $homepage_service, MapiAccountBusinessInfoService $business_info_service, MapiAccountUsersService $users_service ) {
+	public function __construct( ShoppingContent $service, MapiAccountHomepageService $homepage_service, MapiAccountBusinessInfoService $business_info_service, MapiAccountUsersService $users_service, MapiAccountServicesService $services_service ) {
 		$this->service               = $service;
 		$this->homepage_service      = $homepage_service;
 		$this->business_info_service = $business_info_service;
 		$this->users_service         = $users_service;
+		$this->services_service      = $services_service;
 	}
 
 	/**
@@ -312,23 +321,18 @@ class Merchant implements OptionsAwareInterface {
 	 * @throws ExceptionWithResponseData When unable to retrieve or update account data.
 	 */
 	public function link_ads_id( int $ads_id ): bool {
-		$account   = $this->get_account();
-		$ads_links = $account->getAdsLinks() ?? [];
-
-		// Stop early if we already have a link setup.
-		foreach ( $ads_links as $link ) {
-			if ( $ads_id === absint( $link->getAdsId() ) ) {
-				return $link->getStatus() !== 'active';
+		try {
+			$link = $this->services_service->get_google_ads_link( $ads_id );
+			if ( null === $link ) {
+				$link = $this->services_service->propose_google_ads_link( $ads_id );
 			}
+		} catch ( MerchantApiException $e ) {
+			throw new ExceptionWithResponseData( $e->getMessage(), $e->getCode(), $e, $e->get_response_body() );
 		}
 
-		$link = new AccountAdsLink();
-		$link->setAdsId( $ads_id );
-		$link->setStatus( 'active' );
-		$account->setAdsLinks( array_merge( $ads_links, [ $link ] ) );
-		$this->update_account( $account );
-
-		return true;
+		// The MAPI handshake is ESTABLISHED once both sides have approved; anything
+		// else means the Ads-side acceptance is still pending.
+		return 'ESTABLISHED' !== ( $link['handshake']['approvalState'] ?? '' );
 	}
 
 	/**

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -108,9 +108,12 @@ class Settings implements ContainerAwareInterface {
 			try {
 				$regions_service->insert_region( (string) $region_id, $region );
 			} catch ( MerchantApiException $e ) {
-				// The Merchant API reports an already existing region as a 400, so we
-				// do not branch on the status: fall back to updating it to match the
-				// current settings, which surfaces its own error for a genuine failure.
+				// The Merchant API reports an already-existing region as a 400.
+				if ( 400 !== $e->get_http_status() ) {
+					do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
+					throw $e;
+				}
+
 				$regions_service->update_region( (string) $region_id, $region, 'displayName,postalCodeArea' );
 			}
 		}

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -16,15 +16,14 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\CountryRatesCollection;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\AbstractShippingSettingsAdapter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\DBShippingSettingsAdapter;
-use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\MapiShippingSettingsConverter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\WCShippingSettingsAdapter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountAddress;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountTax;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountTaxTaxRule as TaxRule;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ShippingSettings;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -77,15 +76,14 @@ class Settings implements ContainerAwareInterface {
 			return;
 		}
 
-		$settings  = $this->generate_shipping_settings();
-		$converter = new MapiShippingSettingsConverter();
+		$adapter = $this->generate_shipping_settings();
 
 		// Regions must exist before the settings that reference them are inserted.
-		$this->sync_shipping_regions( $converter->convert_regions( $settings ) );
+		$this->sync_shipping_regions( $adapter->get_regions() );
 
 		/** @var MapiAccountShippingSettingsService $shipping_service */
 		$shipping_service = $this->container->get( MapiAccountShippingSettingsService::class );
-		$shipping_service->insert_shipping_settings( $converter->convert( $settings ) );
+		$shipping_service->insert_shipping_settings( [ 'services' => $adapter->get_services() ] );
 	}
 
 	/**
@@ -141,13 +139,13 @@ class Settings implements ContainerAwareInterface {
 	}
 
 	/**
-	 * Generate a ShippingSettings object for syncing the store shipping settings to Merchant Center.
+	 * Generate the shipping settings adapter for syncing the store shipping settings to Merchant Center.
 	 *
-	 * @return ShippingSettings
+	 * @return AbstractShippingSettingsAdapter
 	 *
 	 * @since 2.1.0
 	 */
-	protected function generate_shipping_settings(): ShippingSettings {
+	protected function generate_shipping_settings(): AbstractShippingSettingsAdapter {
 		$times = $this->get_shipping_times();
 
 		/** @var WC $wc_proxy */
@@ -160,7 +158,6 @@ class Settings implements ContainerAwareInterface {
 					'currency'          => $currency,
 					'rates_collections' => $this->get_shipping_rates_collections_from_woocommerce(),
 					'delivery_times'    => $times,
-					'accountId'         => $this->get_account_id(),
 				]
 			);
 		}
@@ -170,7 +167,6 @@ class Settings implements ContainerAwareInterface {
 				'currency'       => $currency,
 				'db_rates'       => $this->get_shipping_rates_from_database(),
 				'delivery_times' => $times,
-				'accountId'      => $this->get_account_id(),
 			]
 		);
 	}

--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -3,6 +3,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountRegionsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountShippingSettingsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\NotificationsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
@@ -14,6 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\CountryRatesCollection;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\DBShippingSettingsAdapter;
+use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\MapiShippingSettingsConverter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\WCShippingSettingsAdapter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent;
@@ -73,13 +77,45 @@ class Settings implements ContainerAwareInterface {
 			return;
 		}
 
-		$settings = $this->generate_shipping_settings();
+		$settings  = $this->generate_shipping_settings();
+		$converter = new MapiShippingSettingsConverter();
 
-		$this->get_shopping_service()->shippingsettings->update(
-			$this->get_merchant_id(),
-			$this->get_account_id(),
-			$settings
-		);
+		// Regions must exist before the settings that reference them are inserted.
+		$this->sync_shipping_regions( $converter->convert_regions( $settings ) );
+
+		/** @var MapiAccountShippingSettingsService $shipping_service */
+		$shipping_service = $this->container->get( MapiAccountShippingSettingsService::class );
+		$shipping_service->insert_shipping_settings( $converter->convert( $settings ) );
+	}
+
+	/**
+	 * Create or update the Merchant API regions referenced by the shipping settings.
+	 *
+	 * Regions replace the Content API's inline postalCodeGroups; they are created
+	 * up front so the rate-group tables can reference them by id.
+	 *
+	 * @param array<string, array> $regions Map of region id to Region resource.
+	 *
+	 * @throws MerchantApiException If a region cannot be created or updated.
+	 */
+	protected function sync_shipping_regions( array $regions ): void {
+		if ( empty( $regions ) ) {
+			return;
+		}
+
+		/** @var MapiAccountRegionsService $regions_service */
+		$regions_service = $this->container->get( MapiAccountRegionsService::class );
+
+		foreach ( $regions as $region_id => $region ) {
+			try {
+				$regions_service->insert_region( (string) $region_id, $region );
+			} catch ( MerchantApiException $e ) {
+				// The Merchant API reports an already existing region as a 400, so we
+				// do not branch on the status: fall back to updating it to match the
+				// current settings, which surfaces its own error for a genuine failure.
+				$regions_service->update_region( (string) $region_id, $region, 'displayName,postalCodeArea' );
+			}
+		}
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -26,6 +26,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAcc
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountRegionsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountServicesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountShippingSettingsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountUsersService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
@@ -123,6 +124,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		MapiAccountUsersService::class            => true,
 		MapiAccountShippingSettingsService::class => true,
 		MapiAccountRegionsService::class          => true,
+		MapiAccountServicesService::class         => true,
 		SiteVerification::class                   => true,
 		Settings::class                           => true,
 	];
@@ -159,7 +161,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( BudgetMetrics::class, GoogleAdsClient::class );
 		$this->share( BudgetRecommendations::class, GoogleAdsClient::class );
 
-		$this->share( Merchant::class, ShoppingContent::class, MapiAccountHomepageService::class, MapiAccountBusinessInfoService::class, MapiAccountUsersService::class );
+		$this->share( Merchant::class, ShoppingContent::class, MapiAccountHomepageService::class, MapiAccountBusinessInfoService::class, MapiAccountUsersService::class, MapiAccountServicesService::class );
 		$this->share( MerchantMetrics::class, MerchantApiClient::class, GoogleAdsClient::class, WP::class, TransientsInterface::class );
 		$this->share( MerchantReport::class, ProductHelper::class, MerchantApiClient::class );
 
@@ -240,6 +242,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( MapiAccountUsersService::class, MerchantApiClient::class );
 		$this->share( MapiAccountShippingSettingsService::class, MerchantApiClient::class );
 		$this->share( MapiAccountRegionsService::class, MerchantApiClient::class );
+		$this->share( MapiAccountServicesService::class, MerchantApiClient::class );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -25,6 +25,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClien
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountBusinessInfoService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountRegionsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountShippingSettingsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountUsersService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
@@ -85,42 +87,44 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * @var array
 	 */
 	protected $provides = [
-		Client::class                         => true,
-		ShoppingContent::class                => true,
-		GoogleAdsClient::class                => true,
-		GuzzleClient::class                   => true,
-		Middleware::class                     => true,
-		Merchant::class                       => true,
-		MerchantMetrics::class                => true,
-		Ads::class                            => true,
-		AdsIncentives::class                  => true,
-		AdsAssetGroup::class                  => true,
-		AdsCampaign::class                    => true,
-		AdsCampaignAsset::class               => true,
-		AdsCampaignBudget::class              => true,
-		AdsCampaignLabel::class               => true,
-		AdsConversionAction::class            => true,
-		AdsReport::class                      => true,
-		AdsRecommendationsService::class      => true,
-		AdsAssetGenerationService::class      => true,
-		AdsAssetGroupAsset::class             => true,
-		AdsAsset::class                       => true,
-		BudgetMetrics::class                  => true,
-		BudgetRecommendations::class          => true,
-		'connect_server_root'                 => true,
-		Connection::class                     => true,
-		GoogleProductService::class           => true,
-		GooglePromotionService::class         => true,
-		MerchantApiClient::class              => true,
-		MapiProductsService::class            => true,
-		MapiDataSourcesService::class         => true,
-		MapiProductInputsService::class       => true,
-		MapiAccountIssuesService::class       => true,
-		MapiAccountHomepageService::class     => true,
-		MapiAccountBusinessInfoService::class => true,
-		MapiAccountUsersService::class        => true,
-		SiteVerification::class               => true,
-		Settings::class                       => true,
+		Client::class                             => true,
+		ShoppingContent::class                    => true,
+		GoogleAdsClient::class                    => true,
+		GuzzleClient::class                       => true,
+		Middleware::class                         => true,
+		Merchant::class                           => true,
+		MerchantMetrics::class                    => true,
+		Ads::class                                => true,
+		AdsIncentives::class                      => true,
+		AdsAssetGroup::class                      => true,
+		AdsCampaign::class                        => true,
+		AdsCampaignAsset::class                   => true,
+		AdsCampaignBudget::class                  => true,
+		AdsCampaignLabel::class                   => true,
+		AdsConversionAction::class                => true,
+		AdsReport::class                          => true,
+		AdsRecommendationsService::class          => true,
+		AdsAssetGenerationService::class          => true,
+		AdsAssetGroupAsset::class                 => true,
+		AdsAsset::class                           => true,
+		BudgetMetrics::class                      => true,
+		BudgetRecommendations::class              => true,
+		'connect_server_root'                     => true,
+		Connection::class                         => true,
+		GoogleProductService::class               => true,
+		GooglePromotionService::class             => true,
+		MerchantApiClient::class                  => true,
+		MapiProductsService::class                => true,
+		MapiDataSourcesService::class             => true,
+		MapiProductInputsService::class           => true,
+		MapiAccountIssuesService::class           => true,
+		MapiAccountHomepageService::class         => true,
+		MapiAccountBusinessInfoService::class     => true,
+		MapiAccountUsersService::class            => true,
+		MapiAccountShippingSettingsService::class => true,
+		MapiAccountRegionsService::class          => true,
+		SiteVerification::class                   => true,
+		Settings::class                           => true,
 	];
 
 	/**
@@ -234,6 +238,8 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( MapiAccountHomepageService::class, MerchantApiClient::class );
 		$this->share( MapiAccountBusinessInfoService::class, MerchantApiClient::class );
 		$this->share( MapiAccountUsersService::class, MerchantApiClient::class );
+		$this->share( MapiAccountShippingSettingsService::class, MerchantApiClient::class );
+		$this->share( MapiAccountRegionsService::class, MerchantApiClient::class );
 	}
 
 	/**

--- a/src/Shipping/GoogleAdapter/AbstractRateGroupAdapter.php
+++ b/src/Shipping/GoogleAdapter/AbstractRateGroupAdapter.php
@@ -5,28 +5,36 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\LocationRate;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Price;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\RateGroup;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Value;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Class AbstractRateGroupAdapter
  *
+ * Builds a single Merchant API rate group (a main table keyed by region or
+ * location) from a set of location rates.
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
  * @since   2.1.0
  */
-abstract class AbstractRateGroupAdapter extends RateGroup {
+abstract class AbstractRateGroupAdapter {
+
+	use MapiPriceTrait;
+
 	/**
-	 * Initialize this object's properties from an array.
+	 * @var array The Merchant API rate group resource.
+	 */
+	protected $rate_group = [];
+
+	/**
+	 * AbstractRateGroupAdapter constructor.
 	 *
 	 * @param array $properties Used to seed this object's properties.
 	 *
 	 * @throws InvalidValue When the required parameters are not provided, or they are invalid.
 	 */
-	public function mapTypes( $properties ) {
+	public function __construct( array $properties ) {
 		if ( empty( $properties['currency'] ) || ! is_string( $properties['currency'] ) ) {
 			throw new InvalidValue( 'The value of "currency" must be a non empty string.' );
 		}
@@ -34,34 +42,36 @@ abstract class AbstractRateGroupAdapter extends RateGroup {
 			throw new InvalidValue( 'The value of "location_rates" must be a non empty array.' );
 		}
 
+		if ( ! empty( $properties['applicableShippingLabels'] ) ) {
+			$this->rate_group['applicableShippingLabels'] = array_values( (array) $properties['applicableShippingLabels'] );
+		}
+
 		$this->map_location_rates( $properties['location_rates'], $properties['currency'] );
-
-		// Remove the extra data before calling the parent method since it doesn't expect them.
-		unset( $properties['currency'] );
-		unset( $properties['location_rates'] );
-
-		parent::mapTypes( $properties );
 	}
 
 	/**
+	 * Get the Merchant API rate group.
+	 *
+	 * @return array
+	 */
+	public function to_array(): array {
+		return $this->rate_group;
+	}
+
+	/**
+	 * Build a Merchant API flat-rate value.
+	 *
 	 * @param float  $rate
 	 * @param string $currency
 	 *
-	 * @return Value
+	 * @return array
 	 */
-	protected function create_value_object( float $rate, string $currency ): Value {
-		$price = new Price(
-			[
-				'currency' => $currency,
-				'value'    => $rate,
-			]
-		);
-
-		return new Value( [ 'flatRate' => $price ] );
+	protected function create_value( float $rate, string $currency ): array {
+		return [ 'flatRate' => $this->mapi_price( $rate, $currency ) ];
 	}
 
 	/**
-	 * Map the location rates to the class properties.
+	 * Map the location rates onto the rate group's main table.
 	 *
 	 * @param LocationRate[] $location_rates
 	 * @param string         $currency

--- a/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
@@ -4,19 +4,23 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\DeliveryTime;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\ShippingSettings as GoogleShippingSettings;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Class AbstractShippingSettingsAdapter
  *
+ * Builds the Merchant API accounts.shippingSettings services (and the
+ * accounts.regions they reference) from the store shipping data.
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping
  *
  * @since   2.1.0
  */
-abstract class AbstractShippingSettingsAdapter extends GoogleShippingSettings {
+abstract class AbstractShippingSettingsAdapter {
+
+	use MapiPriceTrait;
+
 	/**
 	 * @var string
 	 */
@@ -28,48 +32,80 @@ abstract class AbstractShippingSettingsAdapter extends GoogleShippingSettings {
 	protected $delivery_times;
 
 	/**
-	 * Initialize this object's properties from an array.
+	 * @var array The Merchant API service resources.
+	 */
+	protected $services = [];
+
+	/**
+	 * @var array<string, array> Map of region id to Merchant API Region resource.
+	 */
+	protected $regions = [];
+
+	/**
+	 * AbstractShippingSettingsAdapter constructor.
 	 *
 	 * @param array $properties Used to seed this object's properties.
 	 *
-	 * @return void
-	 *
 	 * @throws InvalidValue When the required parameters are not provided, or they are invalid.
 	 */
-	public function mapTypes( $properties ) {
+	public function __construct( array $properties ) {
 		$this->validate_gla_data( $properties );
 
 		$this->currency       = $properties['currency'];
 		$this->delivery_times = $properties['delivery_times'];
 
 		$this->map_gla_data( $properties );
-
-		$this->unset_gla_data( $properties );
-
-		parent::mapTypes( $properties );
 	}
 
 	/**
-	 * Return estimated delivery time for a given country in days.
+	 * Get the Merchant API shipping services.
+	 *
+	 * @return array
+	 */
+	public function get_services(): array {
+		return $this->services;
+	}
+
+	/**
+	 * Get the Merchant API regions referenced by the services, keyed by region id.
+	 *
+	 * @return array<string, array>
+	 */
+	public function get_regions(): array {
+		return $this->regions;
+	}
+
+	/**
+	 * Return the Merchant API deliveryTime for a given country in days.
 	 *
 	 * @param string $country
 	 *
-	 * @return DeliveryTime
+	 * @return array
 	 *
 	 * @throws InvalidValue If no delivery time can be found for the country.
 	 */
-	protected function get_delivery_time( string $country ): DeliveryTime {
+	protected function get_delivery_time( string $country ): array {
 		if ( ! array_key_exists( $country, $this->delivery_times ) ) {
 			throw new InvalidValue( 'No estimated delivery time provided for country: ' . $country );
 		}
 
-		$time = new DeliveryTime();
-		$time->setMinHandlingTimeInDays( 0 );
-		$time->setMaxHandlingTimeInDays( 0 );
-		$time->setMinTransitTimeInDays( (int) $this->delivery_times[ $country ]['time'] );
-		$time->setMaxTransitTimeInDays( (int) $this->delivery_times[ $country ]['max_time'] );
+		return [
+			'minHandlingDays' => 0,
+			'maxHandlingDays' => 0,
+			'minTransitDays'  => (int) $this->delivery_times[ $country ]['time'],
+			'maxTransitDays'  => (int) $this->delivery_times[ $country ]['max_time'],
+		];
+	}
 
-		return $time;
+	/**
+	 * Build a Merchant API price for the store currency.
+	 *
+	 * @param float $amount
+	 *
+	 * @return array
+	 */
+	protected function create_price( float $amount ): array {
+		return $this->mapi_price( $amount, $this->currency );
 	}
 
 	/**
@@ -78,8 +114,6 @@ abstract class AbstractShippingSettingsAdapter extends GoogleShippingSettings {
 	 * @param array $data
 	 *
 	 * @throws InvalidValue When the required parameters are not provided, or they are invalid.
-	 *
-	 * @link AbstractShippingSettingsAdapter::mapTypes() The $data input comes from this method.
 	 */
 	protected function validate_gla_data( array $data ): void {
 		if ( empty( $data['currency'] ) || ! is_string( $data['currency'] ) ) {
@@ -91,17 +125,7 @@ abstract class AbstractShippingSettingsAdapter extends GoogleShippingSettings {
 	}
 
 	/**
-	 * Remove the extra data we added to the input array since the MC API doesn't expect them (and it will fail).
-	 *
-	 * @param array $data
-	 */
-	protected function unset_gla_data( array &$data ): void {
-		unset( $data['currency'] );
-		unset( $data['delivery_times'] );
-	}
-
-	/**
-	 * Parses the already validated input data and maps the provided shipping rates into MC shipping settings.
+	 * Parses the already validated input data and maps the provided shipping rates into services.
 	 *
 	 * @param array $data Validated data.
 	 */

--- a/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
@@ -100,6 +100,9 @@ abstract class AbstractShippingSettingsAdapter {
 	/**
 	 * Build a Merchant API price for the store currency.
 	 *
+	 * Convenience wrapper over MapiPriceTrait::mapi_price() that supplies the
+	 * adapter's configured currency.
+	 *
 	 * @param float $amount
 	 *
 	 * @return array

--- a/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
@@ -4,10 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Price;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\RateGroup;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Service as GoogleShippingService;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Value;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -20,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	/**
-	 * Parses the already validated input data and maps the provided shipping rates into MC shipping settings.
+	 * Parses the already validated input data and maps the provided shipping rates into services.
 	 *
 	 * @param array $data Validated data.
 	 */
@@ -34,8 +30,6 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	 * @param array $data
 	 *
 	 * @throws InvalidValue When the required parameters are not provided, or they are invalid.
-	 *
-	 * @link AbstractShippingSettingsAdapter::mapTypes() The $data input comes from this method.
 	 */
 	protected function validate_gla_data( array $data ): void {
 		parent::validate_gla_data( $data );
@@ -46,142 +40,96 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	}
 
 	/**
-	 * Remove the extra data we added to the input array since the MC API doesn't expect them (and it will fail).
-	 *
-	 * @param array $data
-	 */
-	protected function unset_gla_data( array &$data ): void {
-		unset( $data['db_rates'] );
-		parent::unset_gla_data( $data );
-	}
-
-	/**
-	 * Map the shipping rates stored for each country in DB to MC shipping settings.
+	 * Map the shipping rates stored for each country in DB to shipping services.
 	 *
 	 * @param array[] $db_rates
 	 *
 	 * @return void
 	 */
-	protected function map_db_rates( array $db_rates ) {
-		$services = [];
+	protected function map_db_rates( array $db_rates ): void {
 		foreach ( $db_rates as ['country' => $country, 'rate' => $rate, 'options' => $options] ) {
 			// No negative rates.
 			if ( $rate < 0 ) {
 				continue;
 			}
 
-			$service = $this->create_shipping_service( $country, $this->currency, (float) $rate );
+			$service = $this->create_shipping_service( $country, (float) $rate );
 
 			if ( isset( $options['free_shipping_threshold'] ) ) {
 				$minimum_order_value = (float) $options['free_shipping_threshold'];
 
 				if ( $rate > 0 ) {
 					// Add a conditional free-shipping service if the current rate is not free.
-					$services[] = $this->create_conditional_free_shipping_service( $country, $this->currency, $minimum_order_value );
+					$this->services[] = $this->create_conditional_free_shipping_service( $country, $minimum_order_value );
 				} else {
 					// Set the minimum order value if the current rate is free.
-					$service->setMinimumOrderValue(
-						new Price(
-							[
-								'value'    => $minimum_order_value,
-								'currency' => $this->currency,
-							]
-						)
-					);
+					$service['minimumOrderValue'] = $this->create_price( $minimum_order_value );
 				}
 			}
 
-			$services[] = $service;
+			$this->services[] = $service;
 		}
-
-		$this->setServices( $services );
 	}
 
 	/**
-	 * Create a rate group object for the shopping settings.
-	 *
-	 * @param string $currency
-	 * @param float  $rate
-	 *
-	 * @return RateGroup
-	 */
-	protected function create_rate_group_object( string $currency, float $rate ): RateGroup {
-		$price = new Price();
-		$price->setCurrency( $currency );
-		$price->setValue( $rate );
-
-		$value = new Value();
-		$value->setFlatRate( $price );
-
-		$rate_group = new RateGroup();
-
-		$rate_group->setSingleValue( $value );
-
-		$name = sprintf(
-		/* translators: %1 is the shipping rate, %2 is the currency (e.g. USD) */
-			__( 'Flat rate - %1$s %2$s', 'google-listings-and-ads' ),
-			$rate,
-			$currency
-		);
-
-		$rate_group->setName( $name );
-
-		return $rate_group;
-	}
-
-	/**
-	 * Create a shipping service object.
+	 * Create a shipping service.
 	 *
 	 * @param string $country
-	 * @param string $currency
 	 * @param float  $rate
 	 *
-	 * @return GoogleShippingService
+	 * @return array
 	 */
-	protected function create_shipping_service( string $country, string $currency, float $rate ): GoogleShippingService {
-		$unique  = sprintf( '%04x', wp_rand( 0, 0xffff ) );
-		$service = new GoogleShippingService();
-		$service->setActive( true );
-		$service->setDeliveryCountry( $country );
-		$service->setCurrency( $currency );
-		$service->setName(
-			sprintf(
-			/* translators: %1 is a random 4-digit string, %2 is the rate, %3 is the currency, %4 is the country code  */
+	protected function create_shipping_service( string $country, float $rate ): array {
+		$unique = sprintf( '%04x', wp_rand( 0, 0xffff ) );
+
+		return [
+			'serviceName'       => sprintf(
+				/* translators: %1 is a random 4-digit string, %2 is the rate, %3 is the currency, %4 is the country code */
 				__( '[%1$s] Google for WooCommerce generated service - %2$s %3$s to %4$s', 'google-listings-and-ads' ),
 				$unique,
 				$rate,
-				$currency,
+				$this->currency,
 				$country
-			)
-		);
-
-		$service->setRateGroups( [ $this->create_rate_group_object( $currency, $rate ) ] );
-		$service->setDeliveryTime( $this->get_delivery_time( $country ) );
-
-		return $service;
+			),
+			'active'            => true,
+			'deliveryCountries' => [ $country ],
+			'currencyCode'      => $this->currency,
+			'deliveryTime'      => $this->get_delivery_time( $country ),
+			'shipmentType'      => 'DELIVERY',
+			'rateGroups'        => [ $this->create_rate_group( $rate ) ],
+		];
 	}
 
 	/**
-	 * Create a free shipping service.
+	 * Create a single flat-rate rate group.
+	 *
+	 * @param float $rate
+	 *
+	 * @return array
+	 */
+	protected function create_rate_group( float $rate ): array {
+		return [
+			'name'        => sprintf(
+				/* translators: %1 is the shipping rate, %2 is the currency (e.g. USD) */
+				__( 'Flat rate - %1$s %2$s', 'google-listings-and-ads' ),
+				$rate,
+				$this->currency
+			),
+			'singleValue' => [ 'flatRate' => $this->create_price( $rate ) ],
+		];
+	}
+
+	/**
+	 * Create a free shipping service conditional on a minimum order value.
 	 *
 	 * @param string $country
-	 * @param string $currency
 	 * @param float  $minimum_order_value
 	 *
-	 * @return GoogleShippingService
+	 * @return array
 	 */
-	protected function create_conditional_free_shipping_service( string $country, string $currency, float $minimum_order_value ): GoogleShippingService {
-		$service = $this->create_shipping_service( $country, $currency, 0 );
-
-		// Set the minimum order value to be eligible for free shipping.
-		$service->setMinimumOrderValue(
-			new Price(
-				[
-					'value'    => $minimum_order_value,
-					'currency' => $currency,
-				]
-			)
-		);
+	protected function create_conditional_free_shipping_service( string $country, float $minimum_order_value ): array {
+		$service                      = $this->create_shipping_service( $country, 0 );
+		$service['minimumOrderValue'] = $this->create_price( $minimum_order_value );
 
 		return $service;
 	}

--- a/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
@@ -92,6 +92,7 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 				$country
 			),
 			'active'            => true,
+			// One service per country; deliveryCountries is an array as MAPI requires.
 			'deliveryCountries' => [ $country ],
 			'currencyCode'      => $this->currency,
 			'deliveryTime'      => $this->get_delivery_time( $country ),
@@ -108,13 +109,9 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	 * @return array
 	 */
 	protected function create_rate_group( float $rate ): array {
+		// No name: keep the rate-group shape consistent with the other adapters
+		// (WC / postcode / state), which do not set an optional display label.
 		return [
-			'name'        => sprintf(
-				/* translators: %1 is the shipping rate, %2 is the currency (e.g. USD) */
-				__( 'Flat rate - %1$s %2$s', 'google-listings-and-ads' ),
-				$rate,
-				$this->currency
-			),
 			'singleValue' => [ 'flatRate' => $this->create_price( $rate ) ],
 		];
 	}

--- a/src/Shipping/GoogleAdapter/MapiPriceTrait.php
+++ b/src/Shipping/GoogleAdapter/MapiPriceTrait.php
@@ -24,7 +24,7 @@ trait MapiPriceTrait {
 	 */
 	protected function mapi_price( float $amount, string $currency ): array {
 		return [
-			'amountMicros' => sprintf( '%.0f', round( $amount * 1000000 ) ),
+			'amountMicros' => sprintf( '%.0f', $amount * 1000000 ),
 			'currencyCode' => $currency,
 		];
 	}

--- a/src/Shipping/GoogleAdapter/MapiPriceTrait.php
+++ b/src/Shipping/GoogleAdapter/MapiPriceTrait.php
@@ -1,0 +1,31 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Trait MapiPriceTrait
+ *
+ * Builds a Merchant API price ({ amountMicros, currencyCode }) from a decimal
+ * amount. Formatting straight from the float to a string avoids truncating large
+ * amounts through a 32-bit int cast.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter
+ */
+trait MapiPriceTrait {
+
+	/**
+	 * @param float  $amount
+	 * @param string $currency
+	 *
+	 * @return array
+	 */
+	protected function mapi_price( float $amount, string $currency ): array {
+		return [
+			'amountMicros' => sprintf( '%.0f', round( $amount * 1000000 ) ),
+			'currencyCode' => $currency,
+		];
+	}
+}

--- a/src/Shipping/GoogleAdapter/PostcodesRateGroupAdapter.php
+++ b/src/Shipping/GoogleAdapter/PostcodesRateGroupAdapter.php
@@ -4,9 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\LocationRate;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Headers;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Row;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Table;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -19,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class PostcodesRateGroupAdapter extends AbstractRateGroupAdapter {
 	/**
-	 * Map the location rates to the class properties.
+	 * Map the location rates onto a table keyed by postcode region ids.
 	 *
 	 * @param LocationRate[] $location_rates
 	 * @param string         $currency
@@ -38,16 +35,12 @@ class PostcodesRateGroupAdapter extends AbstractRateGroupAdapter {
 			$postcode_name                  = $region->get_id();
 			$postal_codes[ $postcode_name ] = $postcode_name;
 
-			$rows[ $postcode_name ] = new Row( [ 'cells' => [ $this->create_value_object( $location_rate->get_shipping_rate()->get_rate(), $currency ) ] ] );
+			$rows[ $postcode_name ] = [ 'cells' => [ $this->create_value( (float) $location_rate->get_shipping_rate()->get_rate(), $currency ) ] ];
 		}
 
-		$table = new Table(
-			[
-				'rowHeaders' => new Headers( [ 'postalCodeGroupNames' => array_values( $postal_codes ) ] ),
-				'rows'       => array_values( $rows ),
-			]
-		);
-
-		$this->setMainTable( $table );
+		$this->rate_group['mainTable'] = [
+			'rowHeaders' => [ 'postalCodeGroupNames' => array_values( $postal_codes ) ],
+			'rows'       => array_values( $rows ),
+		];
 	}
 }

--- a/src/Shipping/GoogleAdapter/StatesRateGroupAdapter.php
+++ b/src/Shipping/GoogleAdapter/StatesRateGroupAdapter.php
@@ -4,10 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\LocationRate;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Headers;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\LocationIdSet;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Row;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Table;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -20,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class StatesRateGroupAdapter extends AbstractRateGroupAdapter {
 	/**
-	 * Map the location rates to the class properties.
+	 * Map the location rates onto a table keyed by geotarget location ids.
 	 *
 	 * @param LocationRate[] $location_rates
 	 * @param string         $currency
@@ -32,18 +28,14 @@ class StatesRateGroupAdapter extends AbstractRateGroupAdapter {
 		$rows             = [];
 		foreach ( $location_rates as $location_rate ) {
 			$location_id                      = $location_rate->get_location()->get_google_id();
-			$location_id_sets[ $location_id ] = new LocationIdSet( [ 'locationIds' => [ $location_id ] ] );
+			$location_id_sets[ $location_id ] = [ 'locationIds' => [ (string) $location_id ] ];
 
-			$rows[ $location_id ] = new Row( [ 'cells' => [ $this->create_value_object( $location_rate->get_shipping_rate()->get_rate(), $currency ) ] ] );
+			$rows[ $location_id ] = [ 'cells' => [ $this->create_value( (float) $location_rate->get_shipping_rate()->get_rate(), $currency ) ] ];
 		}
 
-		$table = new Table(
-			[
-				'rowHeaders' => new Headers( [ 'locations' => array_values( $location_id_sets ) ] ),
-				'rows'       => array_values( $rows ),
-			]
-		);
-
-		$this->setMainTable( $table );
+		$this->rate_group['mainTable'] = [
+			'rowHeaders' => [ 'locations' => array_values( $location_id_sets ) ],
+			'rows'       => array_values( $rows ),
+		];
 	}
 }

--- a/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
@@ -4,18 +4,11 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidArgument;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidClass;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\CountryRatesCollection;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\LocationRate;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ServiceRatesCollection;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingLocation;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\PostalCodeGroup;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\PostalCodeRange;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Price;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\RateGroup;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Service as GoogleShippingService;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Value;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -28,7 +21,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	/**
-	 * Parses the already validated input data and maps the provided shipping rates into MC shipping settings.
+	 * Parses the already validated input data and maps the provided shipping rates into services.
 	 *
 	 * @param array $data Validated data.
 	 */
@@ -42,8 +35,6 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	 * @param array $data
 	 *
 	 * @throws InvalidValue When the required parameters are not provided, or they are invalid.
-	 *
-	 * @link AbstractShippingSettingsAdapter::mapTypes() The $data input comes from this method.
 	 */
 	protected function validate_gla_data( array $data ): void {
 		parent::validate_gla_data( $data );
@@ -56,35 +47,22 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	}
 
 	/**
-	 * Remove the extra data we added to the input array since the MC API doesn't expect them (and it will fail).
-	 *
-	 * @param array $data
-	 */
-	protected function unset_gla_data( array &$data ): void {
-		unset( $data['rates_collections'] );
-		parent::unset_gla_data( $data );
-	}
-
-	/**
-	 * Map the collections of location rates for each country to the shipping settings.
+	 * Map the collections of location rates for each country to services and regions.
 	 *
 	 * @param CountryRatesCollection[] $rates_collections
 	 *
 	 * @return void
 	 */
-	protected function map_rates_collections( array $rates_collections ) {
-		$postcode_groups = [];
-		$services        = [];
+	protected function map_rates_collections( array $rates_collections ): void {
 		foreach ( $rates_collections as $rates_collection ) {
-			$postcode_groups = array_merge( $postcode_groups, $this->get_location_rates_postcode_groups( $rates_collection->get_location_rates() ) );
+			// array_replace, not array_merge: region ids are numeric strings and
+			// array_merge would renumber them, breaking the table -> region reference.
+			$this->regions = array_replace( $this->regions, $this->get_location_rates_regions( $rates_collection->get_location_rates() ) );
 
 			foreach ( $rates_collection->get_rates_grouped_by_service() as $service_collection ) {
-				$services[] = $this->create_shipping_service( $service_collection );
+				$this->services[] = $this->create_shipping_service( $service_collection );
 			}
 		}
-
-		$this->setServices( $services );
-		$this->setPostalCodeGroups( array_values( $postcode_groups ) );
 	}
 
 	/**
@@ -92,50 +70,45 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	 * @param string         $shipping_area
 	 * @param array          $applicable_classes
 	 *
-	 * @return RateGroup
+	 * @return array
 	 *
 	 * @throws InvalidArgument If an invalid value is provided for the shipping_area argument.
 	 */
-	protected function create_rate_group( array $location_rates, string $shipping_area, array $applicable_classes = [] ): RateGroup {
+	protected function create_rate_group( array $location_rates, string $shipping_area, array $applicable_classes = [] ): array {
 		switch ( $shipping_area ) {
 			case ShippingLocation::COUNTRY_AREA:
 				// Each country can only have one global rate.
 				$country_rate = $location_rates[ array_key_first( $location_rates ) ];
-				$rate_group   = $this->create_single_value_rate_group( $country_rate, $applicable_classes );
-				break;
+				return $this->create_single_value_rate_group( $country_rate, $applicable_classes );
 			case ShippingLocation::POSTCODE_AREA:
-				$rate_group = new PostcodesRateGroupAdapter(
+				return ( new PostcodesRateGroupAdapter(
 					[
 						'location_rates'           => $location_rates,
 						'currency'                 => $this->currency,
 						'applicableShippingLabels' => $applicable_classes,
 					]
-				);
-				break;
+				) )->to_array();
 			case ShippingLocation::STATE_AREA:
-				$rate_group = new StatesRateGroupAdapter(
+				return ( new StatesRateGroupAdapter(
 					[
 						'location_rates'           => $location_rates,
 						'currency'                 => $this->currency,
 						'applicableShippingLabels' => $applicable_classes,
 					]
-				);
-				break;
+				) )->to_array();
 			default:
 				throw new InvalidArgument( 'Invalid shipping area.' );
 		}
-
-		return $rate_group;
 	}
 
 	/**
-	 * Create a shipping service object.
+	 * Create a shipping service.
 	 *
 	 * @param ServiceRatesCollection $service_collection
 	 *
-	 * @return GoogleShippingService
+	 * @return array
 	 */
-	protected function create_shipping_service( ServiceRatesCollection $service_collection ): GoogleShippingService {
+	protected function create_shipping_service( ServiceRatesCollection $service_collection ): array {
 		$rate_groups   = [];
 		$shipping_area = $service_collection->get_shipping_area();
 		foreach ( $service_collection->get_rates_grouped_by_shipping_class() as $class => $location_rates ) {
@@ -144,47 +117,38 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 		}
 
 		$country = $service_collection->get_country();
-		$name    = sprintf(
-		/* translators: %1 is a random 4-digit string, %2 is the country code  */
-			__( '[%1$s] Google for WooCommerce generated service - %2$s', 'google-listings-and-ads' ),
-			sprintf( '%04x', wp_rand( 0, 0xffff ) ),
-			$country
-		);
-
-		$service = new GoogleShippingService(
-			[
-				'active'          => true,
-				'deliveryCountry' => $country,
-				'currency'        => $this->currency,
-				'name'            => $name,
-				'deliveryTime'    => $this->get_delivery_time( $country ),
-				'rateGroups'      => array_values( $rate_groups ),
-			]
-		);
+		$service = [
+			'serviceName'       => sprintf(
+				/* translators: %1 is a random 4-digit string, %2 is the country code */
+				__( '[%1$s] Google for WooCommerce generated service - %2$s', 'google-listings-and-ads' ),
+				sprintf( '%04x', wp_rand( 0, 0xffff ) ),
+				$country
+			),
+			'active'            => true,
+			'deliveryCountries' => [ $country ],
+			'currencyCode'      => $this->currency,
+			'deliveryTime'      => $this->get_delivery_time( $country ),
+			'shipmentType'      => 'DELIVERY',
+			'rateGroups'        => array_values( $rate_groups ),
+		];
 
 		$min_order_amount = $service_collection->get_min_order_amount();
 		if ( $min_order_amount ) {
-			$min_order_value = new Price(
-				[
-					'currency' => $this->currency,
-					'value'    => $min_order_amount,
-				]
-			);
-			$service->setMinimumOrderValue( $min_order_value );
+			$service['minimumOrderValue'] = $this->create_price( (float) $min_order_amount );
 		}
 
 		return $service;
 	}
 
 	/**
-	 * Extract and return the postcode groups for the given location rates.
+	 * Extract and return the Merchant API regions for the given location rates, keyed by region id.
 	 *
 	 * @param LocationRate[] $location_rates
 	 *
-	 * @return PostalCodeGroup[]
+	 * @return array<string, array>
 	 */
-	protected function get_location_rates_postcode_groups( array $location_rates ): array {
-		$postcode_groups = [];
+	protected function get_location_rates_regions( array $location_rates ): array {
+		$regions = [];
 
 		foreach ( $location_rates as $location_rate ) {
 			$location = $location_rate->get_location();
@@ -193,56 +157,52 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 			}
 			$region = $location->get_shipping_region();
 
-			$postcode_ranges = [];
+			$postal_codes = [];
 			foreach ( $region->get_postcode_ranges() as $postcode_range ) {
-				$postcode_ranges[] = new PostalCodeRange(
-					[
-						'postalCodeRangeBegin' => $postcode_range->get_start_code(),
-						'postalCodeRangeEnd'   => $postcode_range->get_end_code(),
-					]
-				);
+				$postal_code = [ 'begin' => (string) $postcode_range->get_start_code() ];
+				$end         = (string) $postcode_range->get_end_code();
+				if ( '' !== $end ) {
+					$postal_code['end'] = $end;
+				}
+				$postal_codes[] = $postal_code;
 			}
 
-			$postcode_groups[ $region->get_id() ] = new PostalCodeGroup(
-				[
-					'name'             => $region->get_id(),
-					'country'          => $location->get_country(),
-					'postalCodeRanges' => $postcode_ranges,
-				]
-			);
+			$regions[ $region->get_id() ] = [
+				'displayName'    => (string) $region->get_id(),
+				'postalCodeArea' => [
+					'regionCode'  => (string) $location->get_country(),
+					'postalCodes' => $postal_codes,
+				],
+			];
 		}
 
-		return $postcode_groups;
+		return $regions;
 	}
 
 	/**
 	 * @param LocationRate $location_rate
 	 * @param string[]     $shipping_classes
 	 *
-	 * @return RateGroup
+	 * @return array
 	 */
-	protected function create_single_value_rate_group( LocationRate $location_rate, array $shipping_classes = [] ): RateGroup {
-		$price = new Price(
-			[
-				'currency' => $this->currency,
-				'value'    => $location_rate->get_shipping_rate()->get_rate(),
-			]
-		);
+	protected function create_single_value_rate_group( LocationRate $location_rate, array $shipping_classes = [] ): array {
+		$rate_group = [
+			'singleValue' => [ 'flatRate' => $this->create_price( (float) $location_rate->get_shipping_rate()->get_rate() ) ],
+		];
 
-		return new RateGroup(
-			[
-				'singleValue'              => new Value( [ 'flatRate' => $price ] ),
-				'applicableShippingLabels' => $shipping_classes,
-			]
-		);
+		if ( ! empty( $shipping_classes ) ) {
+			$rate_group['applicableShippingLabels'] = array_values( $shipping_classes );
+		}
+
+		return $rate_group;
 	}
 
 	/**
 	 * @param array $rates_collections
 	 *
-	 * @throws InvalidClass If any of the objects in the array is not an instance of CountryRatesCollection.
+	 * @throws InvalidValue If any of the objects in the array is not an instance of CountryRatesCollection.
 	 */
-	protected function validate_rates_collections( array $rates_collections ) {
+	protected function validate_rates_collections( array $rates_collections ): void {
 		array_walk(
 			$rates_collections,
 			function ( $obj ) {

--- a/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
@@ -125,6 +125,7 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 				$country
 			),
 			'active'            => true,
+			// One service per country; deliveryCountries is an array as MAPI requires.
 			'deliveryCountries' => [ $country ],
 			'currencyCode'      => $this->currency,
 			'deliveryTime'      => $this->get_delivery_time( $country ),

--- a/tests/Unit/API/Google/Mapi/Services/MapiAccountRegionsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiAccountRegionsServiceTest.php
@@ -41,26 +41,6 @@ class MapiAccountRegionsServiceTest extends UnitTest {
 		$this->service->set_options_object( $this->options );
 	}
 
-	public function test_get_regions() {
-		$regions = [ [ 'name' => 'accounts/12345/regions/zone1' ] ];
-
-		$this->client->expects( $this->once() )
-			->method( 'get' )
-			->with( self::PATH )
-			->willReturn( [ 'regions' => $regions ] );
-
-		$this->assertSame( $regions, $this->service->get_regions() );
-	}
-
-	public function test_get_regions_empty() {
-		$this->client->expects( $this->once() )
-			->method( 'get' )
-			->with( self::PATH )
-			->willReturn( [] );
-
-		$this->assertSame( [], $this->service->get_regions() );
-	}
-
 	public function test_insert_region() {
 		$region   = [ 'displayName' => 'zone1' ];
 		$response = [ 'name' => 'accounts/12345/regions/zone1' ];
@@ -82,14 +62,5 @@ class MapiAccountRegionsServiceTest extends UnitTest {
 			->willReturn( [ 'name' => 'accounts/12345/regions/zone1' ] );
 
 		$this->service->update_region( 'zone1', $region, 'displayName,postalCodeArea' );
-	}
-
-	public function test_delete_region() {
-		$this->client->expects( $this->once() )
-			->method( 'delete' )
-			->with( self::PATH . '/zone1' )
-			->willReturn( [] );
-
-		$this->assertSame( [], $this->service->delete_region( 'zone1' ) );
 	}
 }

--- a/tests/Unit/API/Google/Mapi/Services/MapiAccountRegionsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiAccountRegionsServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountRegionsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountRegionsServiceTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services
+ */
+class MapiAccountRegionsServiceTest extends UnitTest {
+
+	protected const MERCHANT_ID = 12345;
+	protected const PATH        = 'accounts/v1/accounts/12345/regions';
+
+	/** @var MockObject|MerchantApiClient */
+	protected $client;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var MapiAccountRegionsService */
+	protected $service;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->client  = $this->createMock( MerchantApiClient::class );
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_merchant_id' )->willReturn( self::MERCHANT_ID );
+
+		$this->service = new MapiAccountRegionsService( $this->client );
+		$this->service->set_options_object( $this->options );
+	}
+
+	public function test_get_regions() {
+		$regions = [ [ 'name' => 'accounts/12345/regions/zone1' ] ];
+
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::PATH )
+			->willReturn( [ 'regions' => $regions ] );
+
+		$this->assertSame( $regions, $this->service->get_regions() );
+	}
+
+	public function test_get_regions_empty() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::PATH )
+			->willReturn( [] );
+
+		$this->assertSame( [], $this->service->get_regions() );
+	}
+
+	public function test_insert_region() {
+		$region   = [ 'displayName' => 'zone1' ];
+		$response = [ 'name' => 'accounts/12345/regions/zone1' ];
+
+		$this->client->expects( $this->once() )
+			->method( 'post' )
+			->with( self::PATH . '?regionId=zone1', $region )
+			->willReturn( $response );
+
+		$this->assertSame( $response, $this->service->insert_region( 'zone1', $region ) );
+	}
+
+	public function test_update_region() {
+		$region = [ 'displayName' => 'zone1' ];
+
+		$this->client->expects( $this->once() )
+			->method( 'patch' )
+			->with( self::PATH . '/zone1?updateMask=displayName%2CpostalCodeArea', $region )
+			->willReturn( [ 'name' => 'accounts/12345/regions/zone1' ] );
+
+		$this->service->update_region( 'zone1', $region, 'displayName,postalCodeArea' );
+	}
+
+	public function test_delete_region() {
+		$this->client->expects( $this->once() )
+			->method( 'delete' )
+			->with( self::PATH . '/zone1' )
+			->willReturn( [] );
+
+		$this->assertSame( [], $this->service->delete_region( 'zone1' ) );
+	}
+}

--- a/tests/Unit/API/Google/Mapi/Services/MapiAccountServicesServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiAccountServicesServiceTest.php
@@ -1,0 +1,140 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountServicesService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountServicesServiceTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services
+ */
+class MapiAccountServicesServiceTest extends UnitTest {
+
+	protected const MERCHANT_ID = 12345;
+	protected const PATH        = 'accounts/v1/accounts/12345/services';
+
+	/** @var MockObject|MerchantApiClient */
+	protected $client;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var MapiAccountServicesService */
+	protected $service;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->client  = $this->createMock( MerchantApiClient::class );
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_merchant_id' )->willReturn( self::MERCHANT_ID );
+
+		$this->service = new MapiAccountServicesService( $this->client );
+		$this->service->set_options_object( $this->options );
+	}
+
+	public function test_get_services() {
+		$services = [ [ 'name' => 'accounts/12345/services/x' ] ];
+
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::PATH )
+			->willReturn( [ 'accountServices' => $services ] );
+
+		$this->assertSame( $services, $this->service->get_services() );
+	}
+
+	public function test_get_services_empty() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::PATH )
+			->willReturn( [] );
+
+		$this->assertSame( [], $this->service->get_services() );
+	}
+
+	public function test_get_google_ads_link_found() {
+		$link = [
+			'provider'          => 'providers/GOOGLE_ADS',
+			'externalAccountId' => '999',
+			'handshake'         => [ 'approvalState' => 'ESTABLISHED' ],
+		];
+
+		$this->client->method( 'get' )->willReturn(
+			[
+				'accountServices' => [
+					[
+						'provider'          => 'providers/140802286',
+						'externalAccountId' => '999',
+					],
+					$link,
+				],
+			]
+		);
+
+		$this->assertSame( $link, $this->service->get_google_ads_link( 999 ) );
+	}
+
+	public function test_get_google_ads_link_prefers_established() {
+		$pending     = [
+			'provider'          => 'providers/GOOGLE_ADS',
+			'externalAccountId' => '999',
+			'handshake'         => [ 'approvalState' => 'PENDING' ],
+		];
+		$established = [
+			'provider'          => 'providers/GOOGLE_ADS',
+			'externalAccountId' => '999',
+			'handshake'         => [ 'approvalState' => 'ESTABLISHED' ],
+		];
+
+		$this->client->method( 'get' )->willReturn( [ 'accountServices' => [ $pending, $established ] ] );
+
+		$this->assertSame( $established, $this->service->get_google_ads_link( 999 ) );
+	}
+
+	public function test_get_google_ads_link_none() {
+		$this->client->method( 'get' )->willReturn(
+			[
+				'accountServices' => [
+					[
+						'provider'          => 'providers/GOOGLE_ADS',
+						'externalAccountId' => '111',
+					],
+				],
+			]
+		);
+
+		$this->assertNull( $this->service->get_google_ads_link( 999 ) );
+	}
+
+	public function test_propose_google_ads_link() {
+		$response = [
+			'name'      => 'accounts/12345/services/x',
+			'handshake' => [ 'approvalState' => 'PENDING' ],
+		];
+
+		$this->client->expects( $this->once() )
+			->method( 'post' )
+			->with(
+				self::PATH . ':propose',
+				[
+					'provider'       => 'providers/GOOGLE_ADS',
+					'accountService' => [
+						'externalAccountId'   => '999',
+						'campaignsManagement' => (object) [],
+					],
+				]
+			)
+			->willReturn( $response );
+
+		$this->assertSame( $response, $this->service->propose_google_ads_link( 999 ) );
+	}
+}

--- a/tests/Unit/API/Google/Mapi/Services/MapiAccountShippingSettingsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiAccountShippingSettingsServiceTest.php
@@ -1,0 +1,91 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountShippingSettingsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountShippingSettingsServiceTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services
+ */
+class MapiAccountShippingSettingsServiceTest extends UnitTest {
+
+	protected const MERCHANT_ID = 12345;
+	protected const PATH        = 'accounts/v1/accounts/12345/shippingSettings';
+
+	/** @var MockObject|MerchantApiClient */
+	protected $client;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var MapiAccountShippingSettingsService */
+	protected $service;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->client  = $this->createMock( MerchantApiClient::class );
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_merchant_id' )->willReturn( self::MERCHANT_ID );
+
+		$this->service = new MapiAccountShippingSettingsService( $this->client );
+		$this->service->set_options_object( $this->options );
+	}
+
+	public function test_get_shipping_settings() {
+		$settings = [
+			'name'     => 'accounts/12345/shippingSettings',
+			'services' => [],
+		];
+
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::PATH )
+			->willReturn( $settings );
+
+		$this->assertSame( $settings, $this->service->get_shipping_settings() );
+	}
+
+	public function test_get_shipping_settings_returns_empty_on_404() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::PATH )
+			->willThrowException( new MerchantApiException( 404, [], __METHOD__ ) );
+
+		$this->assertSame( [], $this->service->get_shipping_settings() );
+	}
+
+	public function test_get_shipping_settings_rethrows_other_errors() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->willThrowException( new MerchantApiException( 500, [], __METHOD__ ) );
+
+		$this->expectException( MerchantApiException::class );
+		$this->service->get_shipping_settings();
+	}
+
+	public function test_insert_shipping_settings() {
+		$body     = [ 'services' => [] ];
+		$response = [
+			'name' => 'accounts/12345/shippingSettings',
+			'etag' => 'abc',
+		];
+
+		$this->client->expects( $this->once() )
+			->method( 'post' )
+			->with( self::PATH . ':insert', $body )
+			->willReturn( $response );
+
+		$this->assertSame( $response, $this->service->insert_shipping_settings( $body ) );
+	}
+}

--- a/tests/Unit/API/Google/Mapi/Services/MapiAccountShippingSettingsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiAccountShippingSettingsServiceTest.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountShippingSettingsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
@@ -40,38 +39,6 @@ class MapiAccountShippingSettingsServiceTest extends UnitTest {
 
 		$this->service = new MapiAccountShippingSettingsService( $this->client );
 		$this->service->set_options_object( $this->options );
-	}
-
-	public function test_get_shipping_settings() {
-		$settings = [
-			'name'     => 'accounts/12345/shippingSettings',
-			'services' => [],
-		];
-
-		$this->client->expects( $this->once() )
-			->method( 'get' )
-			->with( self::PATH )
-			->willReturn( $settings );
-
-		$this->assertSame( $settings, $this->service->get_shipping_settings() );
-	}
-
-	public function test_get_shipping_settings_returns_empty_on_404() {
-		$this->client->expects( $this->once() )
-			->method( 'get' )
-			->with( self::PATH )
-			->willThrowException( new MerchantApiException( 404, [], __METHOD__ ) );
-
-		$this->assertSame( [], $this->service->get_shipping_settings() );
-	}
-
-	public function test_get_shipping_settings_rethrows_other_errors() {
-		$this->client->expects( $this->once() )
-			->method( 'get' )
-			->willThrowException( new MerchantApiException( 500, [], __METHOD__ ) );
-
-		$this->expectException( MerchantApiException::class );
-		$this->service->get_shipping_settings();
 	}
 
 	public function test_insert_shipping_settings() {

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountBusinessInfoService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountServicesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountUsersService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
@@ -16,7 +17,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Exception as Googl
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\Exception as GoogleServiceException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Account;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountAdsLink;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountUser;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\RequestPhoneVerificationResponse;
@@ -50,6 +50,9 @@ class MerchantTest extends UnitTest {
 	/** @var MockObject|MapiAccountUsersService $users_service */
 	protected $users_service;
 
+	/** @var MockObject|MapiAccountServicesService $services_service */
+	protected $services_service;
+
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
@@ -73,8 +76,9 @@ class MerchantTest extends UnitTest {
 		$this->homepage_service      = $this->createMock( MapiAccountHomepageService::class );
 		$this->business_info_service = $this->createMock( MapiAccountBusinessInfoService::class );
 		$this->users_service         = $this->createMock( MapiAccountUsersService::class );
+		$this->services_service      = $this->createMock( MapiAccountServicesService::class );
 		$this->options               = $this->createMock( OptionsInterface::class );
-		$this->merchant              = new Merchant( $this->service, $this->homepage_service, $this->business_info_service, $this->users_service );
+		$this->merchant              = new Merchant( $this->service, $this->homepage_service, $this->business_info_service, $this->users_service, $this->services_service );
 		$this->merchant->set_options_object( $this->options );
 
 		$this->merchant_id = 12345;
@@ -351,87 +355,72 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_link_ads_id() {
-		$account = $this->createMock( Account::class );
-		$ads_id  = 12345;
+		$ads_id = 12345;
 
-		$account->expects( $this->once() )
-			->method( 'getAdsLinks' )
-			->willReturn( [] );
+		$this->services_service->expects( $this->once() )
+			->method( 'get_google_ads_link' )
+			->with( $ads_id )
+			->willReturn( null );
 
-		$account->expects( $this->once() )
-			->method( 'setAdsLinks' )
-			->with(
-				$this->callback(
-					function ( array $links ) use ( $ads_id ) {
-						$this->assertEquals( $ads_id, $links[0]->getAdsId() );
-						$this->assertEquals( 'active', $links[0]->getStatus() );
+		$this->services_service->expects( $this->once() )
+			->method( 'propose_google_ads_link' )
+			->with( $ads_id )
+			->willReturn( [ 'handshake' => [ 'approvalState' => 'PENDING' ] ] );
 
-						return true;
-					}
-				)
-			);
+		$this->assertTrue( $this->merchant->link_ads_id( $ads_id ) );
+	}
 
-		$this->mock_get_account( $account );
+	public function test_link_ads_id_propose_established() {
+		$ads_id = 12345;
 
-		$this->service->accounts->expects( $this->once() )
-			->method( 'update' )
-			->willReturn( $account );
+		$this->services_service->method( 'get_google_ads_link' )->willReturn( null );
 
-		$this->assertTrue(
-			$this->merchant->link_ads_id( $ads_id )
-		);
+		$this->services_service->expects( $this->once() )
+			->method( 'propose_google_ads_link' )
+			->with( $ads_id )
+			->willReturn( [ 'handshake' => [ 'approvalState' => 'ESTABLISHED' ] ] );
+
+		$this->assertFalse( $this->merchant->link_ads_id( $ads_id ) );
 	}
 
 	public function test_link_ads_id_exist_link_awaiting_approval() {
-		$account  = $this->createMock( Account::class );
-		$ads_link = $this->createMock( AccountAdsLink::class );
-		$ads_id   = 12345;
+		$ads_id = 12345;
 
-		$ads_link->expects( $this->any() )
-			->method( 'getAdsId' )
-			->willReturn( $ads_id );
+		$this->services_service->expects( $this->once() )
+			->method( 'get_google_ads_link' )
+			->with( $ads_id )
+			->willReturn( [ 'handshake' => [ 'approvalState' => 'PENDING' ] ] );
 
-		$ads_link->expects( $this->any() )
-			->method( 'getStatus' )
-			->willReturn( 'pending' );
+		$this->services_service->expects( $this->never() )->method( 'propose_google_ads_link' );
 
-		$account->expects( $this->once() )
-			->method( 'getAdsLinks' )
-			->willReturn( [ $ads_link ] );
-
-		$account->expects( $this->never() )->method( 'setAdsLinks' );
-
-		$this->mock_get_account( $account );
-
-		$this->service->accounts->expects( $this->never() )->method( 'update' );
-
-		$this->assertTrue(
-			$this->merchant->link_ads_id( $ads_id )
-		);
+		$this->assertTrue( $this->merchant->link_ads_id( $ads_id ) );
 	}
 
 	public function test_ads_id_already_linked() {
-		$account  = $this->createMock( Account::class );
-		$ads_link = $this->createMock( AccountAdsLink::class );
-		$ads_id   = 12345;
+		$ads_id = 12345;
 
-		$ads_link->expects( $this->any() )
-			->method( 'getAdsId' )
-			->willReturn( $ads_id );
+		$this->services_service->expects( $this->once() )
+			->method( 'get_google_ads_link' )
+			->with( $ads_id )
+			->willReturn( [ 'handshake' => [ 'approvalState' => 'ESTABLISHED' ] ] );
 
-		$ads_link->expects( $this->any() )
-			->method( 'getStatus' )
-			->willReturn( 'active' );
+		$this->services_service->expects( $this->never() )->method( 'propose_google_ads_link' );
 
-		$account->expects( $this->once() )
-			->method( 'getAdsLinks' )
-			->willReturn( [ $ads_link ] );
+		$this->assertFalse( $this->merchant->link_ads_id( $ads_id ) );
+	}
 
-		$this->mock_get_account( $account );
+	public function test_link_ads_id_translates_exception() {
+		$body = [ 'error' => [ 'code' => 500, 'message' => 'Internal error', 'status' => 'INTERNAL' ] ];
+		$this->services_service->method( 'get_google_ads_link' )
+			->willThrowException( new MerchantApiException( 500, $body, __METHOD__ ) );
 
-		$this->assertFalse(
-			$this->merchant->link_ads_id( $ads_id )
-		);
+		try {
+			$this->merchant->link_ads_id( 12345 );
+			$this->fail( 'Expected ExceptionWithResponseData to be thrown.' );
+		} catch ( ExceptionWithResponseData $e ) {
+			$this->assertSame( 500, $e->getCode() );
+			$this->assertSame( $body, $e->get_response_data() );
+		}
 	}
 
 	public function test_get_business_info() {

--- a/tests/Unit/API/Google/SettingsTest.php
+++ b/tests/Unit/API/Google/SettingsTest.php
@@ -1,0 +1,94 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountRegionsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionMethod;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class SettingsTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ */
+class SettingsTest extends UnitTest {
+
+	/** @var MockObject|MapiAccountRegionsService */
+	protected $regions_service;
+
+	/** @var Settings */
+	protected $settings;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->regions_service = $this->createMock( MapiAccountRegionsService::class );
+
+		$container = new Container();
+		$container->addShared( MapiAccountRegionsService::class, $this->regions_service );
+
+		$this->settings = new Settings();
+		$this->settings->set_container( $container );
+	}
+
+	/**
+	 * Invoke the protected sync_shipping_regions().
+	 *
+	 * @param array $regions
+	 */
+	protected function sync_regions( array $regions ): void {
+		$method = new ReflectionMethod( Settings::class, 'sync_shipping_regions' );
+		$method->setAccessible( true );
+		$method->invoke( $this->settings, $regions );
+	}
+
+	public function test_sync_shipping_regions_noop_when_empty() {
+		$this->regions_service->expects( $this->never() )->method( 'insert_region' );
+		$this->regions_service->expects( $this->never() )->method( 'update_region' );
+
+		$this->sync_regions( [] );
+	}
+
+	public function test_sync_shipping_regions_inserts_new_regions() {
+		$region = [ 'displayName' => '90210' ];
+
+		$this->regions_service->expects( $this->once() )
+			->method( 'insert_region' )
+			->with( '90210', $region );
+		$this->regions_service->expects( $this->never() )
+			->method( 'update_region' );
+
+		$this->sync_regions( [ '90210' => $region ] );
+	}
+
+	public function test_sync_shipping_regions_updates_existing_region_on_400() {
+		$region = [ 'displayName' => '90210' ];
+
+		$this->regions_service->expects( $this->once() )
+			->method( 'insert_region' )
+			->willThrowException( new MerchantApiException( 400, [], __METHOD__ ) );
+		$this->regions_service->expects( $this->once() )
+			->method( 'update_region' )
+			->with( '90210', $region, 'displayName,postalCodeArea' );
+
+		$this->sync_regions( [ '90210' => $region ] );
+	}
+
+	public function test_sync_shipping_regions_rethrows_non_400() {
+		$this->regions_service->expects( $this->once() )
+			->method( 'insert_region' )
+			->willThrowException( new MerchantApiException( 401, [], __METHOD__ ) );
+		$this->regions_service->expects( $this->never() )
+			->method( 'update_region' );
+
+		$this->expectException( MerchantApiException::class );
+		$this->sync_regions( [ '90210' => [ 'displayName' => '90210' ] ] );
+	}
+}

--- a/tests/Unit/Shipping/GoogleAdapter/DBShippingSettingsAdapterTest.php
+++ b/tests/Unit/Shipping/GoogleAdapter/DBShippingSettingsAdapterTest.php
@@ -44,26 +44,30 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 			]
 		);
 
-		$services = $settings->getServices();
+		$services = $settings->get_services();
 
 		$this->assertCount( 2, $services );
-		$this->assertCount( 1, $services[0]->getRateGroups() );
-		$this->assertCount( 1, $services[1]->getRateGroups() );
+		$this->assertCount( 1, $services[0]['rateGroups'] );
+		$this->assertCount( 1, $services[1]['rateGroups'] );
 
 		foreach ( $services as $service ) {
-			// Assert that the delivery country of both services is either US or AU
-			$this->assertTrue( in_array( $service->getDeliveryCountry(), [ 'US', 'AU' ], true ) );
+			$country   = $service['deliveryCountries'][0];
+			$flat_rate = $service['rateGroups'][0]['singleValue']['flatRate'];
 
-			if ( 'US' === $service->getDeliveryCountry() ) {
-				$this->assertEquals( 'USD', $service->getRateGroups()[0]->getSingleValue()->getFlatRate()->getCurrency() );
-				$this->assertEquals( 10, $service->getRateGroups()[0]->getSingleValue()->getFlatRate()->getValue() );
-				$this->assertEquals( 1, $service->getDeliveryTime()->getMinTransitTimeInDays() );
-				$this->assertEquals( 3, $service->getDeliveryTime()->getMaxTransitTimeInDays() );
-			} elseif ( 'AU' === $service->getDeliveryCountry() ) {
-				$this->assertEquals( 'USD', $service->getRateGroups()[0]->getSingleValue()->getFlatRate()->getCurrency() );
-				$this->assertEquals( 50, $service->getRateGroups()[0]->getSingleValue()->getFlatRate()->getValue() );
-				$this->assertEquals( 2, $service->getDeliveryTime()->getMinTransitTimeInDays() );
-				$this->assertEquals( 4, $service->getDeliveryTime()->getMaxTransitTimeInDays() );
+			// Assert that the delivery country of both services is either US or AU.
+			$this->assertTrue( in_array( $country, [ 'US', 'AU' ], true ) );
+			$this->assertSame( 'DELIVERY', $service['shipmentType'] );
+
+			if ( 'US' === $country ) {
+				$this->assertEquals( 'USD', $flat_rate['currencyCode'] );
+				$this->assertEquals( '10000000', $flat_rate['amountMicros'] );
+				$this->assertEquals( 1, $service['deliveryTime']['minTransitDays'] );
+				$this->assertEquals( 3, $service['deliveryTime']['maxTransitDays'] );
+			} elseif ( 'AU' === $country ) {
+				$this->assertEquals( 'USD', $flat_rate['currencyCode'] );
+				$this->assertEquals( '50000000', $flat_rate['amountMicros'] );
+				$this->assertEquals( 2, $service['deliveryTime']['minTransitDays'] );
+				$this->assertEquals( 4, $service['deliveryTime']['maxTransitDays'] );
 			}
 		}
 	}
@@ -90,7 +94,7 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 			]
 		);
 
-		$this->assertEmpty( $settings->getServices() );
+		$this->assertEmpty( $settings->get_services() );
 	}
 
 	public function test_sets_free_shipping_threshold_on_free_rates() {
@@ -117,11 +121,11 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 			]
 		);
 
-		$services = $settings->getServices();
+		$services = $settings->get_services();
 
 		$this->assertCount( 1, $services );
-		$this->assertEquals( 100, $services[0]->getMinimumOrderValue()->getValue() );
-		$this->assertCount( 1, $services[0]->getRateGroups() );
+		$this->assertEquals( '100000000', $services[0]['minimumOrderValue']['amountMicros'] );
+		$this->assertCount( 1, $services[0]['rateGroups'] );
 	}
 
 	public function test_creates_zero_flat_rate_for_free_shipping_no_threshold() {
@@ -146,11 +150,11 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 			]
 		);
 
-		$services = $settings->getServices();
+		$services = $settings->get_services();
 
 		$this->assertCount( 1, $services );
-		$this->assertCount( 1, $services[0]->getRateGroups() );
-		$this->assertEquals( 0, $services[0]->getRateGroups()[0]->getSingleValue()->getFlatRate()->getValue() );
+		$this->assertCount( 1, $services[0]['rateGroups'] );
+		$this->assertEquals( '0', $services[0]['rateGroups'][0]['singleValue']['flatRate']['amountMicros'] );
 	}
 
 	public function test_creates_separate_service_for_free_shipping_threshold() {
@@ -177,17 +181,17 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 			]
 		);
 
-		$services = $settings->getServices();
+		$services = $settings->get_services();
 
 		$this->assertCount( 2, $services );
-		$this->assertCount( 1, $services[0]->getRateGroups() );
-		$this->assertCount( 1, $services[1]->getRateGroups() );
+		$this->assertCount( 1, $services[0]['rateGroups'] );
+		$this->assertCount( 1, $services[1]['rateGroups'] );
 
 		foreach ( $services as $service ) {
-			if ( 0.0 === (float) $service->getRateGroups()[0]->getSingleValue()->getFlatRate()->getValue() ) {
-				$this->assertEquals( 100, $service->getMinimumOrderValue()->getValue() );
+			if ( '0' === $service['rateGroups'][0]['singleValue']['flatRate']['amountMicros'] ) {
+				$this->assertEquals( '100000000', $service['minimumOrderValue']['amountMicros'] );
 			} else {
-				$this->assertNull( $service->getMinimumOrderValue() );
+				$this->assertArrayNotHasKey( 'minimumOrderValue', $service );
 			}
 		}
 	}

--- a/tests/Unit/Shipping/GoogleAdapter/PostcodesRateGroupAdapterTest.php
+++ b/tests/Unit/Shipping/GoogleAdapter/PostcodesRateGroupAdapterTest.php
@@ -11,7 +11,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\PostcodeRange;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRate;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRegion;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Row;
 
 /**
  * Class PostcodesRateGroupAdapterTest
@@ -36,32 +35,32 @@ class PostcodesRateGroupAdapterTest extends UnitTest {
 			]
 		);
 
-		$table = $rate_group->getMainTable();
+		$table = $rate_group->to_array()['mainTable'];
 
-		$this->assertCount( 2, $table->getRowHeaders()->getPostalCodeGroupNames() );
-		$this->assertCount( 2, $table->getRows() );
+		$this->assertCount( 2, $table['rowHeaders']['postalCodeGroupNames'] );
+		$this->assertCount( 2, $table['rows'] );
 
 		$this->assertEqualSets(
 			[
 				'123456',
 				'234567',
 			],
-			$table->getRowHeaders()->getPostalCodeGroupNames()
+			$table['rowHeaders']['postalCodeGroupNames']
 		);
 
 		$rates = array_map(
-			function ( Row $row ) {
-				$this->assertCount( 1, $row->getCells() );
+			function ( array $row ) {
+				$this->assertCount( 1, $row['cells'] );
 
-				return $row->getCells()[0]->getFlatRate()->getValue();
+				return $row['cells'][0]['flatRate']['amountMicros'];
 			},
-			$table->getRows()
+			$table['rows']
 		);
 
 		$this->assertEqualSets(
 			[
-				110,
-				410,
+				'110000000',
+				'410000000',
 			],
 			$rates
 		);

--- a/tests/Unit/Shipping/GoogleAdapter/StatesRateGroupAdapterTest.php
+++ b/tests/Unit/Shipping/GoogleAdapter/StatesRateGroupAdapterTest.php
@@ -9,8 +9,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingLocation;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\LocationRate;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRate;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\LocationIdSet;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Row;
 
 /**
  * Class StatesRateGroupAdapterTest
@@ -32,39 +30,39 @@ class StatesRateGroupAdapterTest extends UnitTest {
 			]
 		);
 
-		$table = $rate_group->getMainTable();
+		$table = $rate_group->to_array()['mainTable'];
 
-		$this->assertCount( 2, $table->getRowHeaders()->getLocations() );
-		$this->assertCount( 2, $table->getRows() );
+		$this->assertCount( 2, $table['rowHeaders']['locations'] );
+		$this->assertCount( 2, $table['rows'] );
 
 		$id_sets = array_map(
-			function ( LocationIdSet $location_id_set ) {
-				return $location_id_set->getLocationIds();
+			function ( array $location_id_set ) {
+				return $location_id_set['locationIds'];
 			},
-			$table->getRowHeaders()->getLocations()
+			$table['rowHeaders']['locations']
 		);
 
 		$this->assertEqualSets(
 			[
-				[ 1001 ],
-				[ 1002 ],
+				[ '1001' ],
+				[ '1002' ],
 			],
 			$id_sets
 		);
 
 		$rates = array_map(
-			function ( Row $row ) {
-				$this->assertCount( 1, $row->getCells() );
+			function ( array $row ) {
+				$this->assertCount( 1, $row['cells'] );
 
-				return $row->getCells()[0]->getFlatRate()->getValue();
+				return $row['cells'][0]['flatRate']['amountMicros'];
 			},
-			$table->getRows()
+			$table['rows']
 		);
 
 		$this->assertEqualSets(
 			[
-				110,
-				410,
+				'110000000',
+				'410000000',
 			],
 			$rates
 		);

--- a/tests/Unit/Shipping/GoogleAdapter/WCShippingSettingsAdapterTest.php
+++ b/tests/Unit/Shipping/GoogleAdapter/WCShippingSettingsAdapterTest.php
@@ -5,8 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping\Google
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\CountryRatesCollection;
-use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\PostcodesRateGroupAdapter;
-use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\StatesRateGroupAdapter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\WCShippingSettingsAdapter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingLocation;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\LocationRate;
@@ -14,10 +12,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\PostcodeRange;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRate;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingRegion;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\DeliveryTime;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\PostalCodeGroup;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Price;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Service as GoogleShippingService;
 
 /**
  * Class WCShippingSettingsAdapterTest
@@ -45,11 +39,12 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 			]
 		);
 
-		$services = $settings->getServices();
+		$services = $settings->get_services();
 
 		$this->assertCount( 1, $services );
-		$this->assertCount( 1, $services[0]->getRateGroups() );
-		$this->assertInstanceOf( PostcodesRateGroupAdapter::class, $services[0]->getRateGroups()[0] );
+		$this->assertCount( 1, $services[0]['rateGroups'] );
+		$this->assertArrayHasKey( 'postalCodeGroupNames', $services[0]['rateGroups'][0]['mainTable']['rowHeaders'] );
+		$this->assertArrayHasKey( '123456', $settings->get_regions() );
 	}
 
 	public function test_creates_rate_group_for_state_rates() {
@@ -71,11 +66,12 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 			]
 		);
 
-		$services = $settings->getServices();
+		$services = $settings->get_services();
 
 		$this->assertCount( 1, $services );
-		$this->assertCount( 1, $services[0]->getRateGroups() );
-		$this->assertInstanceOf( StatesRateGroupAdapter::class, $services[0]->getRateGroups()[0] );
+		$this->assertCount( 1, $services[0]['rateGroups'] );
+		$this->assertArrayHasKey( 'locations', $services[0]['rateGroups'][0]['mainTable']['rowHeaders'] );
+		$this->assertEmpty( $settings->get_regions() );
 	}
 
 	public function test_creates_separate_services_per_country_and_min_order_amount() {
@@ -106,27 +102,25 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 			]
 		);
 
-		$services = $settings->getServices();
+		$services = $settings->get_services();
 
 		$this->assertCount( 3, $services );
 
-		/** @var GoogleShippingService[] $min_order_services */
 		$min_order_services = array_filter(
 			$services,
-			function ( GoogleShippingService $service ) {
-				return null !== $service->getMinimumOrderValue();
+			function ( array $service ) {
+				return isset( $service['minimumOrderValue'] );
 			}
 		);
 		$this->assertCount( 1, $min_order_services );
 
 		$min_order_service = $min_order_services[ array_key_first( $min_order_services ) ];
-		$this->assertEquals( 'US', $min_order_service->getDeliveryCountry() );
-		$this->assertInstanceOf( Price::class, $min_order_service->getMinimumOrderValue() );
-		$this->assertEquals( 1000, $min_order_service->getMinimumOrderValue()->getValue() );
-		$this->assertEquals( 'USD', $min_order_service->getMinimumOrderValue()->getCurrency() );
+		$this->assertEquals( 'US', $min_order_service['deliveryCountries'][0] );
+		$this->assertEquals( '1000000000', $min_order_service['minimumOrderValue']['amountMicros'] );
+		$this->assertEquals( 'USD', $min_order_service['minimumOrderValue']['currencyCode'] );
 	}
 
-	public function test_sets_postcode_groups() {
+	public function test_sets_regions() {
 		$region_1        = new ShippingRegion(
 			'123456',
 			'US',
@@ -166,49 +160,42 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 			]
 		);
 
-		$postcode_groups = $settings->getPostalCodeGroups();
+		$regions = $settings->get_regions();
 
-		$this->assertCount( 3, $postcode_groups );
-
-		$postcode_names = array_map(
-			function ( PostalCodeGroup $postal_code_group ) {
-				return $postal_code_group->getName();
-			},
-			$postcode_groups
-		);
+		$this->assertCount( 3, $regions );
 		$this->assertEqualSets(
 			[
 				'123456',
 				'234567',
 				'345678',
 			],
-			$postcode_names
+			array_keys( $regions )
 		);
 
-		foreach ( $postcode_groups as $postal_code_group ) {
-			switch ( $postal_code_group->getName() ) {
+		foreach ( $regions as $region_id => $region ) {
+			switch ( $region_id ) {
 				case '123456':
-					$this->assertEquals( 'US', $postal_code_group->getCountry() );
-					$this->assertCount( 2, $postal_code_group->getPostalCodeRanges() );
-					foreach ( $postal_code_group->getPostalCodeRanges() as $postal_code_range ) {
-						if ( '2000' === $postal_code_range->getPostalCodeRangeBegin() ) {
-							$this->assertEquals( '2001', $postal_code_range->getPostalCodeRangeEnd() );
+					$this->assertEquals( 'US', $region['postalCodeArea']['regionCode'] );
+					$this->assertCount( 2, $region['postalCodeArea']['postalCodes'] );
+					foreach ( $region['postalCodeArea']['postalCodes'] as $postal_code ) {
+						if ( '2000' === $postal_code['begin'] ) {
+							$this->assertEquals( '2001', $postal_code['end'] );
 						} else {
-							$this->assertEquals( '1000', $postal_code_range->getPostalCodeRangeBegin() );
+							$this->assertEquals( '1000', $postal_code['begin'] );
 						}
 					}
 					break;
 				case '234567':
-					$this->assertEquals( 'US', $postal_code_group->getCountry() );
-					$this->assertCount( 1, $postal_code_group->getPostalCodeRanges() );
-					$this->assertEquals( '9000', $postal_code_group->getPostalCodeRanges()[0]->getPostalCodeRangeBegin() );
-					$this->assertEquals( '9001', $postal_code_group->getPostalCodeRanges()[0]->getPostalCodeRangeEnd() );
+					$this->assertEquals( 'US', $region['postalCodeArea']['regionCode'] );
+					$this->assertCount( 1, $region['postalCodeArea']['postalCodes'] );
+					$this->assertEquals( '9000', $region['postalCodeArea']['postalCodes'][0]['begin'] );
+					$this->assertEquals( '9001', $region['postalCodeArea']['postalCodes'][0]['end'] );
 					break;
 				case '345678':
-					$this->assertEquals( 'AU', $postal_code_group->getCountry() );
-					$this->assertCount( 1, $postal_code_group->getPostalCodeRanges() );
-					$this->assertEquals( '9000', $postal_code_group->getPostalCodeRanges()[0]->getPostalCodeRangeBegin() );
-					$this->assertEquals( '9001', $postal_code_group->getPostalCodeRanges()[0]->getPostalCodeRangeEnd() );
+					$this->assertEquals( 'AU', $region['postalCodeArea']['regionCode'] );
+					$this->assertCount( 1, $region['postalCodeArea']['postalCodes'] );
+					$this->assertEquals( '9000', $region['postalCodeArea']['postalCodes'][0]['begin'] );
+					$this->assertEquals( '9001', $region['postalCodeArea']['postalCodes'][0]['end'] );
 					break;
 				default:
 					break;
@@ -240,33 +227,29 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 			]
 		);
 
-		$services = $settings->getServices();
+		$services = $settings->get_services();
 
 		$this->assertCount( 2, $services );
 
-		/** @var GoogleShippingService[] $us_services */
 		$us_services = array_filter(
 			$services,
-			function ( GoogleShippingService $service ) {
-				return 'US' === $service->getDeliveryCountry();
+			function ( array $service ) {
+				return 'US' === $service['deliveryCountries'][0];
 			}
 		);
 		$us_service  = $us_services[ array_key_first( $us_services ) ];
-		$this->assertInstanceOf( DeliveryTime::class, $us_service->getDeliveryTime() );
-		$this->assertEquals( 10, $us_service->getDeliveryTime()->getMinTransitTimeInDays() );
-		$this->assertEquals( 10, $us_service->getDeliveryTime()->getMaxTransitTimeInDays() );
+		$this->assertEquals( 10, $us_service['deliveryTime']['minTransitDays'] );
+		$this->assertEquals( 10, $us_service['deliveryTime']['maxTransitDays'] );
 
-		/** @var GoogleShippingService[] $au_services */
 		$au_services = array_filter(
 			$services,
-			function ( GoogleShippingService $service ) {
-				return 'AU' === $service->getDeliveryCountry();
+			function ( array $service ) {
+				return 'AU' === $service['deliveryCountries'][0];
 			}
 		);
 		$au_service  = $au_services[ array_key_first( $au_services ) ];
-		$this->assertInstanceOf( DeliveryTime::class, $au_service->getDeliveryTime() );
-		$this->assertEquals( 5, $au_service->getDeliveryTime()->getMinTransitTimeInDays() );
-		$this->assertEquals( 6, $au_service->getDeliveryTime()->getMaxTransitTimeInDays() );
+		$this->assertEquals( 5, $au_service['deliveryTime']['minTransitDays'] );
+		$this->assertEquals( 6, $au_service['deliveryTime']['maxTransitDays'] );
 	}
 
 	public function test_sets_the_currency_provided() {
@@ -293,9 +276,9 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 			]
 		);
 
-		$this->assertCount( 2, $settings->getServices() );
-		$this->assertEquals( 'EUR', $settings->getServices()[0]->getCurrency() );
-		$this->assertEquals( 'EUR', $settings->getServices()[1]->getCurrency() );
+		$this->assertCount( 2, $settings->get_services() );
+		$this->assertEquals( 'EUR', $settings->get_services()[0]['currencyCode'] );
+		$this->assertEquals( 'EUR', $settings->get_services()[1]['currencyCode'] );
 	}
 
 	public function test_fails_if_no_rates_collections_provided() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-756/migrate-contentshippingsettingsupdate-to-mapi

Moves the store shipping sync off the Content API (shippingsettings.update) onto the Merchant API (accounts.shippingSettings.insert), with no remaining ShoppingContent dependency in shipping.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

- Set up flat-rate shipping in WooCommerce (a rate + a delivery time), with GLA shipping configured as flat.
- Save shipping settings to trigger the sync (this schedules the UpdateShippingSettings job).
- In Merchant Center -> Shipping and returns, confirm the generated services match the store (rate, currency, delivery days). Allow a few seconds before the change shows 
- Optional (zones): configure WooCommerce shipping zones by postcode or state, re-sync, and confirm postcode zones appear as regions referenced by the rate table and state zones as location based rates.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
