### PR TITLE
[GOOWOO-771] Fix fatal error on connection test: product sync

### DIFF
--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -239,11 +239,15 @@ class BatchProductHelper implements Service {
 				$primary_market = $this->market_service->get_primary_market();
 
 				if ( $this->product_matches_market( $product_language, $primary_market, $wpml_active ) ) {
+					// The primary market never stores scalar country/feed_label values
+					// (it is multi-country); its feed label is the main target country.
+					$main_feed_label = $this->market_service->get_main_feed_label();
+
 					$adapted_product   = $this->product_factory->create(
 						$product,
-						$primary_market['country'],
+						$main_feed_label,
 						$mapping_rules,
-						$primary_market['feed_label'],
+						$main_feed_label,
 						$product_language
 					);
 					$validation_result = $this->validate_product( $adapted_product );

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -197,11 +197,15 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			->method( 'get_primary_market' )
 			->willReturn(
 				[
-					'country'    => 'US',
-					'feed_label' => 'US',
+					'country'    => null,
+					'feed_label' => null,
 					'language'   => 'en',
 				]
 			);
+
+		$this->market_service->expects( $this->any() )
+			->method( 'get_main_feed_label' )
+			->willReturn( 'US' );
 
 		$this->market_service->expects( $this->any() )
 			->method( 'get_all_countries' )
@@ -672,11 +676,15 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			->method( 'get_primary_market' )
 			->willReturn(
 				[
-					'country'    => 'US',
-					'feed_label' => 'US',
+					'country'    => null,
+					'feed_label' => null,
 					'language'   => 'en',
 				]
 			);
+
+		$this->market_service->expects( $this->any() )
+			->method( 'get_main_feed_label' )
+			->willReturn( 'US' );
 
 		$this->market_service->expects( $this->any() )
 			->method( 'get_all_countries' )
@@ -811,11 +819,15 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			->method( 'get_primary_market' )
 			->willReturn(
 				[
-					'country'    => 'US',
-					'feed_label' => 'US',
+					'country'    => null,
+					'feed_label' => null,
 					'language'   => 'en',
 				]
 			);
+
+		$this->market_service->expects( $this->any() )
+			->method( 'get_main_feed_label' )
+			->willReturn( 'US' );
 
 		$this->market_service->expects( $this->any() )
 			->method( 'get_all_countries' )
@@ -1172,13 +1184,24 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 	/**
 	 * Configure the MarketService mock so the helper can build primary + secondary entries.
 	 *
+	 * The primary entry's feed_label is used as the get_main_feed_label() stub, then the
+	 * primary's country/feed_label keys are nulled to match the real MarketService contract:
+	 * get_primary_market() always returns null for both, and the primary feed label is only
+	 * exposed via get_main_feed_label().
+	 *
 	 * @param string[] $all_countries Return value for get_all_countries().
 	 * @param array[]  $markets       Return value for get_markets() keyed by market ID.
 	 */
 	private function set_up_market_service_stubs( array $all_countries, array $markets ): void {
+		$main_feed_label = $markets['primary']['feed_label'];
+
+		$markets['primary']['country']    = null;
+		$markets['primary']['feed_label'] = null;
+
 		$this->market_service->method( 'get_primary_market' )->willReturn( $markets['primary'] );
 		$this->market_service->method( 'get_all_countries' )->willReturn( $all_countries );
 		$this->market_service->method( 'get_markets' )->willReturn( $markets );
+		$this->market_service->method( 'get_main_feed_label' )->willReturn( $main_feed_label );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes: https://linear.app/a8c/issue/GOOWOO-771/fix-fatal-error-on-connection-test-product-sync

### Screenshots:

<img width="836" height="202" alt="Screenshot 2026-07-02 at 09 50 57" src="https://github.com/user-attachments/assets/e43ecb83-96de-4ac6-8845-3709d6c545a6" />

### Detailed test instructions:

1. Open WP Admin, navigate to Connection Test
2. Scroll to the end of the page, find the Product Sync section
3. Click: "Delete All Synced Products from Google Merchant Centre"
4. Confirm you see a response that confirms all synced products were deleted e.g. `28 synced products deleted from Google.`
5. Scroll to the end of the page, find the Product Sync section
6. Click: "Sync All Products from Google Merchant Centre"
7. Confirm you see a response that confirms all synced products were deleted e.g. `28 products successfully submitted to Google.`


### Additional details:

> Fix - Fix fatal error on connection test products sync