### PR TITLE
GOOWOO-675 Signal Detection Tracking Off

### DIFF
--- a/js/src/notifications-system/useNotificationsSystemMap.js
+++ b/js/src/notifications-system/useNotificationsSystemMap.js
@@ -14,7 +14,7 @@ import {
 	getProductFeedUrl,
 	getSettingsUrl,
 	getSetupAdsUrl,
-	getWCAdvancedSettingsUrl,
+	getWCTrackingSettingsUrl,
 	getOnboardingUrl,
 	getWCCouponsUrl,
 } from '~/utils/urls';
@@ -31,7 +31,7 @@ const getStartedUrl = getGetStartedUrl();
 const setupAdsUrl = getSetupAdsUrl();
 const dashboardUrl = getDashboardUrl();
 const settingsUrl = getSettingsUrl();
-const wcAdvancedSettingsUrl = getWCAdvancedSettingsUrl();
+const wcTrackingSettingsUrl = getWCTrackingSettingsUrl();
 const onboardingUrl = getOnboardingUrl();
 const wcCouponsUrl = getWCCouponsUrl();
 
@@ -177,7 +177,7 @@ const STATIC_MAP = {
 		actions: [
 			{
 				id: 'turn-on-tracking',
-				href: wcAdvancedSettingsUrl,
+				href: wcTrackingSettingsUrl,
 				children: __( 'Turn on tracking', 'google-listings-and-ads' ),
 			},
 		],

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -89,10 +89,11 @@ export const getSettingsUrl = () => {
 	return getNewPath( null, settingsPath, null );
 };
 
-export const getWCAdvancedSettingsUrl = () => {
+export const getWCTrackingSettingsUrl = () => {
 	return addQueryArgs( 'admin.php', {
 		page: 'wc-settings',
 		tab: 'advanced',
+		section: 'woocommerce_com',
 	} );
 };
 

--- a/src/Notification/Evaluators/TrackingOffEvaluator.php
+++ b/src/Notification/Evaluators/TrackingOffEvaluator.php
@@ -7,8 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WPAwareInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WPAwareTrait;
+use WC_Site_Tracking;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -17,16 +16,15 @@ defined( 'ABSPATH' ) || exit;
  *
  * Fires when WooCommerce usage tracking is disabled.
  *
+ * Uses the same source of truth as the client-side isWCTracksEnabled() helper
+ * (WC_Site_Tracking::is_tracking_enabled(), which is what populates
+ * window.wcTracks.isEnabled), so the signal stays in sync with how the rest of
+ * the plugin reads the tracking opt-in — including the tracking filters, not just
+ * the raw woocommerce_allow_tracking option.
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
  */
-class TrackingOffEvaluator implements NotificationEvaluatorInterface, WPAwareInterface, Service {
-
-	use WPAwareTrait;
-
-	/**
-	 * WooCommerce option that stores whether usage tracking is enabled.
-	 */
-	private const WC_ALLOW_TRACKING_OPTION = 'woocommerce_allow_tracking';
+class TrackingOffEvaluator implements NotificationEvaluatorInterface, Service {
 
 	/**
 	 * Get the notification's unique ID.
@@ -43,7 +41,7 @@ class TrackingOffEvaluator implements NotificationEvaluatorInterface, WPAwareInt
 	 * @return bool
 	 */
 	public function should_show(): bool {
-		return 'yes' !== $this->wp->get_option( self::WC_ALLOW_TRACKING_OPTION, 'no' );
+		return ! $this->is_wc_tracking_enabled();
 	}
 
 	/**
@@ -62,5 +60,22 @@ class TrackingOffEvaluator implements NotificationEvaluatorInterface, WPAwareInt
 	 */
 	public function get_snooze_duration(): ?int {
 		return NotificationSnoozeDurations::TRACKING_OFF;
+	}
+
+	/**
+	 * Whether WooCommerce usage tracking is enabled.
+	 *
+	 * Mirrors the client-side isWCTracksEnabled() helper by reading the same value
+	 * WooCommerce uses for window.wcTracks.isEnabled. When the tracking subsystem is
+	 * unavailable, tracking is treated as disabled (matching that helper).
+	 *
+	 * @return bool
+	 */
+	protected function is_wc_tracking_enabled(): bool {
+		if ( ! class_exists( WC_Site_Tracking::class ) ) {
+			return false;
+		}
+
+		return WC_Site_Tracking::is_tracking_enabled();
 	}
 }

--- a/src/Notification/Evaluators/TrackingOffEvaluator.php
+++ b/src/Notification/Evaluators/TrackingOffEvaluator.php
@@ -71,7 +71,7 @@ class TrackingOffEvaluator implements NotificationEvaluatorInterface, Service {
 	 *
 	 * @return bool
 	 */
-	protected function is_wc_tracking_enabled(): bool {
+	private function is_wc_tracking_enabled(): bool {
 		if ( ! class_exists( WC_Site_Tracking::class ) ) {
 			return false;
 		}

--- a/tests/Unit/Notification/Evaluators/TrackingOffEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/TrackingOffEvaluatorTest.php
@@ -6,9 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Ev
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\TrackingOffEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
-use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use PHPUnit\Framework\MockObject\MockObject;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -19,9 +17,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class TrackingOffEvaluatorTest extends UnitTest {
 
-	/** @var MockObject|WP $wp */
-	protected $wp;
-
 	/** @var TrackingOffEvaluator $evaluator */
 	protected $evaluator;
 
@@ -31,9 +26,7 @@ class TrackingOffEvaluatorTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->wp        = $this->createMock( WP::class );
 		$this->evaluator = new TrackingOffEvaluator();
-		$this->evaluator->set_wp_proxy_object( $this->wp );
 	}
 
 	public function test_get_id() {
@@ -49,18 +42,25 @@ class TrackingOffEvaluatorTest extends UnitTest {
 	}
 
 	public function test_should_show_when_tracking_disabled() {
-		$this->wp->method( 'get_option' )
-			->with( 'woocommerce_allow_tracking', 'no' )
-			->willReturn( 'no' );
+		update_option( 'woocommerce_allow_tracking', 'no' );
 
 		$this->assertTrue( $this->evaluator->should_show() );
 	}
 
 	public function test_should_not_show_when_tracking_enabled() {
-		$this->wp->method( 'get_option' )
-			->with( 'woocommerce_allow_tracking', 'no' )
-			->willReturn( 'yes' );
+		update_option( 'woocommerce_allow_tracking', 'yes' );
 
 		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_show_when_tracking_disabled_by_filter() {
+		// Even with the opt-in on, a tracking filter can turn tracking off. The signal
+		// should track that (matching isWCTracksEnabled), not just the raw option.
+		update_option( 'woocommerce_allow_tracking', 'yes' );
+		add_filter( 'woocommerce_apply_tracking', '__return_false' );
+
+		$this->assertTrue( $this->evaluator->should_show() );
+
+		remove_filter( 'woocommerce_apply_tracking', '__return_false' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Implements the signal that detects merchants who have not opted in to WooCommerce usage tracking, so the engine can fire the tracking notification.

**Changes**

- TrackingOffEvaluator - `should_show()` now returns `! is_wc_tracking_enabled()`, where `is_wc_tracking_enabled()` calls `WC_Site_Tracking::is_tracking_enabled()`.
  - When the tracking subsystem is unavailable, tracking is treated as disabled - matching `isWCTracksEnabled()` (`!!window.wcTracks?.isEnabled → false`).

Closes https://linear.app/a8c/issue/GOOWOO-675/be-signal-detection-case-10-tracking-off

### Screenshots:
N/A


### Detailed test instructions:

Note on caching: unlike the coupon/sales signals, this evaluator is not cached - it re-checks on every load, so there is no transient to clear between changes.

**Observing the signal**

Test 1 - Fires when tracking is off
- WooCommerce → Settings → Advanced → "WooCommerce.com" and untick "Allow usage tracking".
Expected: "tracking-off" is present.

Test 2 - Does not fire when tracking is on
- WooCommerce → Settings → Advanced → "WooCommerce.com" and tick "Allow usage tracking".
Expected: "tracking-off" is absent.

Test 3 - Cross-check against the client value
- On a wp-admin page console: ` console.log( 'wcTracks.isEnabled =', window.wcTracks?.isEnabled );`
Expected: the "tracking-off" notification is present exactly when this is false/undefined, and absent when it is true.

Test 4 - Fires once per merchant
- Turn tracking off (Test 1) so the notification appears, then dismiss it.
Expected: it stays dismissed and does not reappear.
