### PR TITLE
GOOWOO-757: Migrate content.accounts.link to MAPI AccountService resource

### DIFF
--- a/src/API/Google/Mapi/Services/MapiAccountServicesService.php
+++ b/src/API/Google/Mapi/Services/MapiAccountServicesService.php
@@ -1,0 +1,112 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MapiPaths;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountServicesService
+ *
+ * Reads and writes the account services for the connected account through the
+ * Merchant API accounts.services resource. The Google Ads link is an account
+ * service provided by providers/GOOGLE_ADS.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services
+ */
+class MapiAccountServicesService implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	private const GOOGLE_ADS_PROVIDER = 'providers/GOOGLE_ADS';
+
+	/** @var MerchantApiClient */
+	protected $client;
+
+	/**
+	 * MapiAccountServicesService constructor.
+	 *
+	 * @param MerchantApiClient $client
+	 */
+	public function __construct( MerchantApiClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * List the account services for the connected merchant account.
+	 *
+	 * @return array AccountService resources decoded as arrays (empty when none exist).
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function get_services(): array {
+		return $this->client->get( $this->build_path() )['accountServices'] ?? [];
+	}
+
+	/**
+	 * Find the Google Ads link service for a given Ads account id.
+	 *
+	 * @param int $ads_id The Google Ads account id.
+	 *
+	 * @return array|null The AccountService for the link, or null when there is none.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function get_google_ads_link( int $ads_id ): ?array {
+		$link = null;
+		foreach ( $this->get_services() as $service ) {
+			if ( self::GOOGLE_ADS_PROVIDER !== ( $service['provider'] ?? '' ) || (string) $ads_id !== (string) ( $service['externalAccountId'] ?? '' ) ) {
+				continue;
+			}
+
+			// A propose call can leave a rejected or pending duplicate alongside an
+			// established link (the Merchant API has no way to delete a service), so prefer
+			// an ESTABLISHED match and fall back to the first non-established one otherwise.
+			if ( 'ESTABLISHED' === ( $service['handshake']['approvalState'] ?? '' ) ) {
+				return $service;
+			}
+
+			$link = $link ?? $service;
+		}
+
+		return $link;
+	}
+
+	/**
+	 * Propose a Google Ads account link (the merchant side of the handshake).
+	 *
+	 * @param int $ads_id The Google Ads account id to link.
+	 *
+	 * @return array The proposed AccountService resource decoded as an array.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	public function propose_google_ads_link( int $ads_id ): array {
+		return $this->client->post(
+			$this->build_path() . ':propose',
+			[
+				'provider'       => self::GOOGLE_ADS_PROVIDER,
+				'accountService' => [
+					'externalAccountId'   => (string) $ads_id,
+					'campaignsManagement' => (object) [],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Build the services resource path for the connected merchant account.
+	 *
+	 * @return string
+	 */
+	protected function build_path(): string {
+		return sprintf(
+			'%s/accounts/%s/services',
+			MapiPaths::ACCOUNTS,
+			$this->options->get_merchant_id()
+		);
+	}
+}

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountBusinessInfoService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountServicesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountUsersService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
@@ -15,7 +16,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Exception as Googl
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\Exception as GoogleServiceException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Account;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountAdsLink;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\RequestPhoneVerificationRequest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\RequestReviewFreeListingsRequest;
@@ -65,18 +65,27 @@ class Merchant implements OptionsAwareInterface {
 	protected $users_service;
 
 	/**
+	 * The Merchant API account services service.
+	 *
+	 * @var MapiAccountServicesService
+	 */
+	protected $services_service;
+
+	/**
 	 * Merchant constructor.
 	 *
 	 * @param ShoppingContent                $service
 	 * @param MapiAccountHomepageService     $homepage_service
 	 * @param MapiAccountBusinessInfoService $business_info_service
 	 * @param MapiAccountUsersService        $users_service
+	 * @param MapiAccountServicesService     $services_service
 	 */
-	public function __construct( ShoppingContent $service, MapiAccountHomepageService $homepage_service, MapiAccountBusinessInfoService $business_info_service, MapiAccountUsersService $users_service ) {
+	public function __construct( ShoppingContent $service, MapiAccountHomepageService $homepage_service, MapiAccountBusinessInfoService $business_info_service, MapiAccountUsersService $users_service, MapiAccountServicesService $services_service ) {
 		$this->service               = $service;
 		$this->homepage_service      = $homepage_service;
 		$this->business_info_service = $business_info_service;
 		$this->users_service         = $users_service;
+		$this->services_service      = $services_service;
 	}
 
 	/**
@@ -312,23 +321,18 @@ class Merchant implements OptionsAwareInterface {
 	 * @throws ExceptionWithResponseData When unable to retrieve or update account data.
 	 */
 	public function link_ads_id( int $ads_id ): bool {
-		$account   = $this->get_account();
-		$ads_links = $account->getAdsLinks() ?? [];
-
-		// Stop early if we already have a link setup.
-		foreach ( $ads_links as $link ) {
-			if ( $ads_id === absint( $link->getAdsId() ) ) {
-				return $link->getStatus() !== 'active';
+		try {
+			$link = $this->services_service->get_google_ads_link( $ads_id );
+			if ( null === $link ) {
+				$link = $this->services_service->propose_google_ads_link( $ads_id );
 			}
+		} catch ( MerchantApiException $e ) {
+			throw new ExceptionWithResponseData( $e->getMessage(), $e->getCode(), $e, $e->get_response_body() );
 		}
 
-		$link = new AccountAdsLink();
-		$link->setAdsId( $ads_id );
-		$link->setStatus( 'active' );
-		$account->setAdsLinks( array_merge( $ads_links, [ $link ] ) );
-		$this->update_account( $account );
-
-		return true;
+		// The MAPI handshake is ESTABLISHED once both sides have approved; anything
+		// else means the Ads-side acceptance is still pending.
+		return 'ESTABLISHED' !== ( $link['handshake']['approvalState'] ?? '' );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -26,6 +26,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAcc
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountRegionsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountServicesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountShippingSettingsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountUsersService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
@@ -123,6 +124,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		MapiAccountUsersService::class            => true,
 		MapiAccountShippingSettingsService::class => true,
 		MapiAccountRegionsService::class          => true,
+		MapiAccountServicesService::class         => true,
 		SiteVerification::class                   => true,
 		Settings::class                           => true,
 	];
@@ -159,7 +161,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( BudgetMetrics::class, GoogleAdsClient::class );
 		$this->share( BudgetRecommendations::class, GoogleAdsClient::class );
 
-		$this->share( Merchant::class, ShoppingContent::class, MapiAccountHomepageService::class, MapiAccountBusinessInfoService::class, MapiAccountUsersService::class );
+		$this->share( Merchant::class, ShoppingContent::class, MapiAccountHomepageService::class, MapiAccountBusinessInfoService::class, MapiAccountUsersService::class, MapiAccountServicesService::class );
 		$this->share( MerchantMetrics::class, MerchantApiClient::class, GoogleAdsClient::class, WP::class, TransientsInterface::class );
 		$this->share( MerchantReport::class, ProductHelper::class, MerchantApiClient::class );
 
@@ -240,6 +242,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( MapiAccountUsersService::class, MerchantApiClient::class );
 		$this->share( MapiAccountShippingSettingsService::class, MerchantApiClient::class );
 		$this->share( MapiAccountRegionsService::class, MerchantApiClient::class );
+		$this->share( MapiAccountServicesService::class, MerchantApiClient::class );
 	}
 
 	/**

--- a/tests/Unit/API/Google/Mapi/Services/MapiAccountServicesServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiAccountServicesServiceTest.php
@@ -1,0 +1,140 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountServicesService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MapiAccountServicesServiceTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services
+ */
+class MapiAccountServicesServiceTest extends UnitTest {
+
+	protected const MERCHANT_ID = 12345;
+	protected const PATH        = 'accounts/v1/accounts/12345/services';
+
+	/** @var MockObject|MerchantApiClient */
+	protected $client;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var MapiAccountServicesService */
+	protected $service;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->client  = $this->createMock( MerchantApiClient::class );
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_merchant_id' )->willReturn( self::MERCHANT_ID );
+
+		$this->service = new MapiAccountServicesService( $this->client );
+		$this->service->set_options_object( $this->options );
+	}
+
+	public function test_get_services() {
+		$services = [ [ 'name' => 'accounts/12345/services/x' ] ];
+
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::PATH )
+			->willReturn( [ 'accountServices' => $services ] );
+
+		$this->assertSame( $services, $this->service->get_services() );
+	}
+
+	public function test_get_services_empty() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::PATH )
+			->willReturn( [] );
+
+		$this->assertSame( [], $this->service->get_services() );
+	}
+
+	public function test_get_google_ads_link_found() {
+		$link = [
+			'provider'          => 'providers/GOOGLE_ADS',
+			'externalAccountId' => '999',
+			'handshake'         => [ 'approvalState' => 'ESTABLISHED' ],
+		];
+
+		$this->client->method( 'get' )->willReturn(
+			[
+				'accountServices' => [
+					[
+						'provider'          => 'providers/140802286',
+						'externalAccountId' => '999',
+					],
+					$link,
+				],
+			]
+		);
+
+		$this->assertSame( $link, $this->service->get_google_ads_link( 999 ) );
+	}
+
+	public function test_get_google_ads_link_prefers_established() {
+		$pending     = [
+			'provider'          => 'providers/GOOGLE_ADS',
+			'externalAccountId' => '999',
+			'handshake'         => [ 'approvalState' => 'PENDING' ],
+		];
+		$established = [
+			'provider'          => 'providers/GOOGLE_ADS',
+			'externalAccountId' => '999',
+			'handshake'         => [ 'approvalState' => 'ESTABLISHED' ],
+		];
+
+		$this->client->method( 'get' )->willReturn( [ 'accountServices' => [ $pending, $established ] ] );
+
+		$this->assertSame( $established, $this->service->get_google_ads_link( 999 ) );
+	}
+
+	public function test_get_google_ads_link_none() {
+		$this->client->method( 'get' )->willReturn(
+			[
+				'accountServices' => [
+					[
+						'provider'          => 'providers/GOOGLE_ADS',
+						'externalAccountId' => '111',
+					],
+				],
+			]
+		);
+
+		$this->assertNull( $this->service->get_google_ads_link( 999 ) );
+	}
+
+	public function test_propose_google_ads_link() {
+		$response = [
+			'name'      => 'accounts/12345/services/x',
+			'handshake' => [ 'approvalState' => 'PENDING' ],
+		];
+
+		$this->client->expects( $this->once() )
+			->method( 'post' )
+			->with(
+				self::PATH . ':propose',
+				[
+					'provider'       => 'providers/GOOGLE_ADS',
+					'accountService' => [
+						'externalAccountId'   => '999',
+						'campaignsManagement' => (object) [],
+					],
+				]
+			)
+			->willReturn( $response );
+
+		$this->assertSame( $response, $this->service->propose_google_ads_link( 999 ) );
+	}
+}

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountBusinessInfoService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountServicesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountUsersService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
@@ -16,7 +17,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Exception as Googl
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\Exception as GoogleServiceException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\Account;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountAdsLink;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\AccountUser;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent\RequestPhoneVerificationResponse;
@@ -50,6 +50,9 @@ class MerchantTest extends UnitTest {
 	/** @var MockObject|MapiAccountUsersService $users_service */
 	protected $users_service;
 
+	/** @var MockObject|MapiAccountServicesService $services_service */
+	protected $services_service;
+
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
@@ -73,8 +76,9 @@ class MerchantTest extends UnitTest {
 		$this->homepage_service      = $this->createMock( MapiAccountHomepageService::class );
 		$this->business_info_service = $this->createMock( MapiAccountBusinessInfoService::class );
 		$this->users_service         = $this->createMock( MapiAccountUsersService::class );
+		$this->services_service      = $this->createMock( MapiAccountServicesService::class );
 		$this->options               = $this->createMock( OptionsInterface::class );
-		$this->merchant              = new Merchant( $this->service, $this->homepage_service, $this->business_info_service, $this->users_service );
+		$this->merchant              = new Merchant( $this->service, $this->homepage_service, $this->business_info_service, $this->users_service, $this->services_service );
 		$this->merchant->set_options_object( $this->options );
 
 		$this->merchant_id = 12345;
@@ -351,87 +355,72 @@ class MerchantTest extends UnitTest {
 	}
 
 	public function test_link_ads_id() {
-		$account = $this->createMock( Account::class );
-		$ads_id  = 12345;
+		$ads_id = 12345;
 
-		$account->expects( $this->once() )
-			->method( 'getAdsLinks' )
-			->willReturn( [] );
+		$this->services_service->expects( $this->once() )
+			->method( 'get_google_ads_link' )
+			->with( $ads_id )
+			->willReturn( null );
 
-		$account->expects( $this->once() )
-			->method( 'setAdsLinks' )
-			->with(
-				$this->callback(
-					function ( array $links ) use ( $ads_id ) {
-						$this->assertEquals( $ads_id, $links[0]->getAdsId() );
-						$this->assertEquals( 'active', $links[0]->getStatus() );
+		$this->services_service->expects( $this->once() )
+			->method( 'propose_google_ads_link' )
+			->with( $ads_id )
+			->willReturn( [ 'handshake' => [ 'approvalState' => 'PENDING' ] ] );
 
-						return true;
-					}
-				)
-			);
+		$this->assertTrue( $this->merchant->link_ads_id( $ads_id ) );
+	}
 
-		$this->mock_get_account( $account );
+	public function test_link_ads_id_propose_established() {
+		$ads_id = 12345;
 
-		$this->service->accounts->expects( $this->once() )
-			->method( 'update' )
-			->willReturn( $account );
+		$this->services_service->method( 'get_google_ads_link' )->willReturn( null );
 
-		$this->assertTrue(
-			$this->merchant->link_ads_id( $ads_id )
-		);
+		$this->services_service->expects( $this->once() )
+			->method( 'propose_google_ads_link' )
+			->with( $ads_id )
+			->willReturn( [ 'handshake' => [ 'approvalState' => 'ESTABLISHED' ] ] );
+
+		$this->assertFalse( $this->merchant->link_ads_id( $ads_id ) );
 	}
 
 	public function test_link_ads_id_exist_link_awaiting_approval() {
-		$account  = $this->createMock( Account::class );
-		$ads_link = $this->createMock( AccountAdsLink::class );
-		$ads_id   = 12345;
+		$ads_id = 12345;
 
-		$ads_link->expects( $this->any() )
-			->method( 'getAdsId' )
-			->willReturn( $ads_id );
+		$this->services_service->expects( $this->once() )
+			->method( 'get_google_ads_link' )
+			->with( $ads_id )
+			->willReturn( [ 'handshake' => [ 'approvalState' => 'PENDING' ] ] );
 
-		$ads_link->expects( $this->any() )
-			->method( 'getStatus' )
-			->willReturn( 'pending' );
+		$this->services_service->expects( $this->never() )->method( 'propose_google_ads_link' );
 
-		$account->expects( $this->once() )
-			->method( 'getAdsLinks' )
-			->willReturn( [ $ads_link ] );
-
-		$account->expects( $this->never() )->method( 'setAdsLinks' );
-
-		$this->mock_get_account( $account );
-
-		$this->service->accounts->expects( $this->never() )->method( 'update' );
-
-		$this->assertTrue(
-			$this->merchant->link_ads_id( $ads_id )
-		);
+		$this->assertTrue( $this->merchant->link_ads_id( $ads_id ) );
 	}
 
 	public function test_ads_id_already_linked() {
-		$account  = $this->createMock( Account::class );
-		$ads_link = $this->createMock( AccountAdsLink::class );
-		$ads_id   = 12345;
+		$ads_id = 12345;
 
-		$ads_link->expects( $this->any() )
-			->method( 'getAdsId' )
-			->willReturn( $ads_id );
+		$this->services_service->expects( $this->once() )
+			->method( 'get_google_ads_link' )
+			->with( $ads_id )
+			->willReturn( [ 'handshake' => [ 'approvalState' => 'ESTABLISHED' ] ] );
 
-		$ads_link->expects( $this->any() )
-			->method( 'getStatus' )
-			->willReturn( 'active' );
+		$this->services_service->expects( $this->never() )->method( 'propose_google_ads_link' );
 
-		$account->expects( $this->once() )
-			->method( 'getAdsLinks' )
-			->willReturn( [ $ads_link ] );
+		$this->assertFalse( $this->merchant->link_ads_id( $ads_id ) );
+	}
 
-		$this->mock_get_account( $account );
+	public function test_link_ads_id_translates_exception() {
+		$body = [ 'error' => [ 'code' => 500, 'message' => 'Internal error', 'status' => 'INTERNAL' ] ];
+		$this->services_service->method( 'get_google_ads_link' )
+			->willThrowException( new MerchantApiException( 500, $body, __METHOD__ ) );
 
-		$this->assertFalse(
-			$this->merchant->link_ads_id( $ads_id )
-		);
+		try {
+			$this->merchant->link_ads_id( 12345 );
+			$this->fail( 'Expected ExceptionWithResponseData to be thrown.' );
+		} catch ( ExceptionWithResponseData $e ) {
+			$this->assertSame( 500, $e->getCode() );
+			$this->assertSame( $body, $e->get_response_data() );
+		}
 	}
 
 	public function test_get_business_info() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-757/migrate-contentaccountslink-to-mapi-accountservice-resource

Moves the Google Ads account link off the Content API (content.accounts.link / AccountAdsLink) onto the Merchant API accounts.services

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

- With GLA connected to a Merchant Center account, go through onboarding to the Connect your Google Ads account step and link (or create) an Ads account.
- Confirm the step completes. If the Ads side still needs to approve, the flow reports the link as pending rather than erroring.
- In Google Ads (or MC -> linked accounts), confirm the account link appears.
- Re-enter the flow / reconnect the same Ads account , confirm the already established link is detected: no duplicate proposal, no error.
- 

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
