### PR TITLE
Fix GOOWOO-651 Signal Detection Skipped Campaign

### DIFF
--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -325,7 +325,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 
 		// Notifications.
 		$this->share_with_tags( NotificationService::class, WP::class );
-		$this->share_with_tags( SkippedCampaignEvaluator::class, AdsCampaign::class, OnboardingCompleted::class );
+		$this->share_with_tags( SkippedCampaignEvaluator::class, OnboardingCompleted::class );
 		$this->share_with_tags( AbandonedOnboardingEvaluator::class, MerchantAccountState::class );
 		$this->share_with_tags( NotOnboarded90DaysEvaluator::class, OnboardingCompleted::class );
 		$this->share_with_tags( EnhancedConversionsOffEvaluator::class );

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -325,7 +325,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 
 		// Notifications.
 		$this->share_with_tags( NotificationService::class, WP::class );
-		$this->share_with_tags( SkippedCampaignEvaluator::class, AdsCampaign::class );
+		$this->share_with_tags( SkippedCampaignEvaluator::class, AdsCampaign::class, OnboardingCompleted::class );
 		$this->share_with_tags( AbandonedOnboardingEvaluator::class, MerchantAccountState::class );
 		$this->share_with_tags( NotOnboarded90DaysEvaluator::class, OnboardingCompleted::class );
 		$this->share_with_tags( EnhancedConversionsOffEvaluator::class );

--- a/src/Notification/Evaluators/SkippedCampaignEvaluator.php
+++ b/src/Notification/Evaluators/SkippedCampaignEvaluator.php
@@ -5,9 +5,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignType;
-use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\CachedNotificationEvaluatorTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
@@ -20,8 +17,9 @@ defined( 'ABSPATH' ) || exit;
  * Class SkippedCampaignEvaluator
  *
  * Fires when the merchant finished onboarding but skipped campaign creation: onboarding
- * is complete, Ads setup was not completed, and the account has no Performance Max
- * campaigns (enabled or paused) — including any created outside the onboarding flow.
+ * is complete and Ads setup was not completed. Ads setup is marked complete once the
+ * merchant creates a campaign through the plugin, so an incomplete Ads setup is a
+ * reliable indicator that they skipped campaign creation.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
  */
@@ -30,20 +28,15 @@ class SkippedCampaignEvaluator implements NotificationEvaluatorInterface, AdsAwa
 	use AdsAwareTrait;
 	use CachedNotificationEvaluatorTrait;
 
-	/** @var AdsCampaign */
-	private $ads_campaign;
-
 	/** @var OnboardingCompleted */
 	private $onboarding_completed;
 
 	/**
 	 * SkippedCampaignEvaluator constructor.
 	 *
-	 * @param AdsCampaign         $ads_campaign
 	 * @param OnboardingCompleted $onboarding_completed
 	 */
-	public function __construct( AdsCampaign $ads_campaign, OnboardingCompleted $onboarding_completed ) {
-		$this->ads_campaign         = $ads_campaign;
+	public function __construct( OnboardingCompleted $onboarding_completed ) {
 		$this->onboarding_completed = $onboarding_completed;
 	}
 
@@ -67,24 +60,9 @@ class SkippedCampaignEvaluator implements NotificationEvaluatorInterface, AdsAwa
 			return false;
 		}
 
-		// If Ads setup was completed, the merchant did not skip campaign creation.
-		if ( $this->ads_service->is_setup_complete() ) {
-			return false;
-		}
-
-		try {
-			// Any Performance Max campaign (enabled or paused, including ones created
-			// outside the onboarding flow) means the merchant did not skip campaigns.
-			foreach ( $this->ads_campaign->get_campaigns( true, false ) as $campaign ) {
-				if ( CampaignType::PERFORMANCE_MAX === $campaign['type'] ) {
-					return false;
-				}
-			}
-		} catch ( ExceptionWithResponseData $e ) {
-			return false;
-		}
-
-		return true;
+		// Ads setup is marked complete once the merchant creates a campaign through the
+		// plugin, so an incomplete Ads setup means they skipped campaign creation.
+		return ! $this->ads_service->is_setup_complete();
 	}
 
 	/**

--- a/src/Notification/Evaluators/SkippedCampaignEvaluator.php
+++ b/src/Notification/Evaluators/SkippedCampaignEvaluator.php
@@ -6,20 +6,22 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignType;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\CachedNotificationEvaluatorTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Class SkippedCampaignEvaluator
  *
- * Fires when Ads setup is complete and the merchant has no enabled Performance Max campaigns.
+ * Fires when the merchant finished onboarding but skipped campaign creation: onboarding
+ * is complete, Ads setup was not completed, and the account has no Performance Max
+ * campaigns (enabled or paused) — including any created outside the onboarding flow.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
  */
@@ -31,13 +33,18 @@ class SkippedCampaignEvaluator implements NotificationEvaluatorInterface, AdsAwa
 	/** @var AdsCampaign */
 	private $ads_campaign;
 
+	/** @var OnboardingCompleted */
+	private $onboarding_completed;
+
 	/**
 	 * SkippedCampaignEvaluator constructor.
 	 *
-	 * @param AdsCampaign $ads_campaign
+	 * @param AdsCampaign         $ads_campaign
+	 * @param OnboardingCompleted $onboarding_completed
 	 */
-	public function __construct( AdsCampaign $ads_campaign ) {
-		$this->ads_campaign = $ads_campaign;
+	public function __construct( AdsCampaign $ads_campaign, OnboardingCompleted $onboarding_completed ) {
+		$this->ads_campaign         = $ads_campaign;
+		$this->onboarding_completed = $onboarding_completed;
 	}
 
 	/**
@@ -55,16 +62,21 @@ class SkippedCampaignEvaluator implements NotificationEvaluatorInterface, AdsAwa
 	 * @return bool
 	 */
 	protected function evaluate_condition(): bool {
-		if ( ! $this->ads_service->is_setup_complete() ) {
+		// Only merchants who finished onboarding are candidates for "skipped campaign".
+		if ( ! $this->onboarding_completed->is_onboarding_complete() ) {
+			return false;
+		}
+
+		// If Ads setup was completed, the merchant did not skip campaign creation.
+		if ( $this->ads_service->is_setup_complete() ) {
 			return false;
 		}
 
 		try {
+			// Any Performance Max campaign (enabled or paused, including ones created
+			// outside the onboarding flow) means the merchant did not skip campaigns.
 			foreach ( $this->ads_campaign->get_campaigns( true, false ) as $campaign ) {
-				if (
-					CampaignType::PERFORMANCE_MAX === $campaign['type']
-					&& CampaignStatus::ENABLED === $campaign['status']
-				) {
+				if ( CampaignType::PERFORMANCE_MAX === $campaign['type'] ) {
 					return false;
 				}
 			}

--- a/tests/Unit/Notification/Evaluators/SkippedCampaignEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/SkippedCampaignEvaluatorTest.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignType;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -27,6 +28,9 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 	/** @var MockObject|AdsCampaign $ads_campaign */
 	protected $ads_campaign;
 
+	/** @var MockObject|OnboardingCompleted $onboarding_completed */
+	protected $onboarding_completed;
+
 	/** @var SkippedCampaignEvaluator $evaluator */
 	protected $evaluator;
 
@@ -36,9 +40,10 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->ads_service  = $this->createMock( AdsService::class );
-		$this->ads_campaign = $this->createMock( AdsCampaign::class );
-		$this->evaluator    = new SkippedCampaignEvaluator( $this->ads_campaign );
+		$this->ads_service          = $this->createMock( AdsService::class );
+		$this->ads_campaign         = $this->createMock( AdsCampaign::class );
+		$this->onboarding_completed = $this->createMock( OnboardingCompleted::class );
+		$this->evaluator            = new SkippedCampaignEvaluator( $this->ads_campaign, $this->onboarding_completed );
 		$this->evaluator->set_ads_object( $this->ads_service );
 	}
 
@@ -54,15 +59,23 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 		$this->assertNull( $this->evaluator->get_snooze_duration() );
 	}
 
-	public function test_should_not_show_when_ads_incomplete() {
-		$this->ads_service->method( 'is_setup_complete' )->willReturn( false );
+	public function test_should_not_show_when_onboarding_incomplete() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( false );
 		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
 
 		$this->assertFalse( $this->evaluator->should_show() );
 	}
 
-	public function test_should_show_when_ads_complete_and_no_campaigns() {
+	public function test_should_not_show_when_ads_setup_complete() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
 		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_show_when_onboarded_ads_skipped_and_no_campaigns() {
+		$this->mock_onboarded_with_ads_skipped();
 		$this->ads_campaign->method( 'get_campaigns' )
 			->with( true, false )
 			->willReturn( [] );
@@ -70,25 +83,8 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 		$this->assertTrue( $this->evaluator->should_show() );
 	}
 
-	public function test_should_show_when_ads_complete_and_only_paused_pmax_campaign() {
-		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
-		$this->ads_campaign->method( 'get_campaigns' )
-			->with( true, false )
-			->willReturn(
-				[
-					[
-						'id'     => 1,
-						'type'   => CampaignType::PERFORMANCE_MAX,
-						'status' => CampaignStatus::PAUSED,
-					],
-				]
-			);
-
-		$this->assertTrue( $this->evaluator->should_show() );
-	}
-
-	public function test_should_show_when_ads_complete_and_only_non_pmax_enabled_campaign() {
-		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+	public function test_should_show_when_only_non_pmax_campaign_present() {
+		$this->mock_onboarded_with_ads_skipped();
 		$this->ads_campaign->method( 'get_campaigns' )
 			->with( true, false )
 			->willReturn(
@@ -105,7 +101,7 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 	}
 
 	public function test_should_not_show_when_enabled_pmax_campaign_present() {
-		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->mock_onboarded_with_ads_skipped();
 		$this->ads_campaign->method( 'get_campaigns' )
 			->with( true, false )
 			->willReturn(
@@ -121,8 +117,25 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 		$this->assertFalse( $this->evaluator->should_show() );
 	}
 
-	public function test_should_not_show_when_enabled_pmax_campaign_created_outside_onboarding() {
-		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+	public function test_should_not_show_when_only_paused_pmax_campaign_present() {
+		$this->mock_onboarded_with_ads_skipped();
+		$this->ads_campaign->method( 'get_campaigns' )
+			->with( true, false )
+			->willReturn(
+				[
+					[
+						'id'     => 1,
+						'type'   => CampaignType::PERFORMANCE_MAX,
+						'status' => CampaignStatus::PAUSED,
+					],
+				]
+			);
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_pmax_campaign_created_outside_onboarding() {
+		$this->mock_onboarded_with_ads_skipped();
 		$this->ads_campaign->method( 'get_campaigns' )
 			->with( true, false )
 			->willReturn(
@@ -151,5 +164,13 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
 
 		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	/**
+	 * Mock a merchant that finished onboarding but did not complete Ads setup.
+	 */
+	private function mock_onboarded_with_ads_skipped(): void {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( false );
 	}
 }

--- a/tests/Unit/Notification/Evaluators/SkippedCampaignEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/SkippedCampaignEvaluatorTest.php
@@ -4,9 +4,6 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignType;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationCacheKeys;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
@@ -26,9 +23,6 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 	/** @var MockObject|AdsService $ads_service */
 	protected $ads_service;
 
-	/** @var MockObject|AdsCampaign $ads_campaign */
-	protected $ads_campaign;
-
 	/** @var MockObject|OnboardingCompleted $onboarding_completed */
 	protected $onboarding_completed;
 
@@ -42,9 +36,8 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 		parent::setUp();
 
 		$this->ads_service          = $this->createMock( AdsService::class );
-		$this->ads_campaign         = $this->createMock( AdsCampaign::class );
 		$this->onboarding_completed = $this->createMock( OnboardingCompleted::class );
-		$this->evaluator            = new SkippedCampaignEvaluator( $this->ads_campaign, $this->onboarding_completed );
+		$this->evaluator            = new SkippedCampaignEvaluator( $this->onboarding_completed );
 		$this->evaluator->set_ads_object( $this->ads_service );
 	}
 
@@ -62,7 +55,7 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 
 	public function test_should_not_show_when_onboarding_incomplete() {
 		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( false );
-		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
+		$this->ads_service->expects( $this->never() )->method( 'is_setup_complete' );
 
 		$this->assertFalse( $this->evaluator->should_show() );
 	}
@@ -70,108 +63,24 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 	public function test_should_not_show_when_ads_setup_complete() {
 		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
 		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
-		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
 
 		$this->assertFalse( $this->evaluator->should_show() );
 	}
 
-	public function test_should_show_when_onboarded_ads_skipped_and_no_campaigns() {
-		$this->mock_onboarded_with_ads_skipped();
-		$this->ads_campaign->method( 'get_campaigns' )
-			->with( true, false )
-			->willReturn( [] );
+	public function test_should_show_when_onboarded_and_ads_setup_incomplete() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->ads_service->method( 'is_setup_complete' )->willReturn( false );
 
 		$this->assertTrue( $this->evaluator->should_show() );
 	}
 
-	public function test_should_show_when_only_non_pmax_campaign_present() {
-		$this->mock_onboarded_with_ads_skipped();
-		$this->ads_campaign->method( 'get_campaigns' )
-			->with( true, false )
-			->willReturn(
-				[
-					[
-						'id'     => 1,
-						'type'   => CampaignType::SHOPPING,
-						'status' => CampaignStatus::ENABLED,
-					],
-				]
-			);
-
-		$this->assertTrue( $this->evaluator->should_show() );
-	}
-
-	public function test_should_not_show_when_enabled_pmax_campaign_present() {
-		$this->mock_onboarded_with_ads_skipped();
-		$this->ads_campaign->method( 'get_campaigns' )
-			->with( true, false )
-			->willReturn(
-				[
-					[
-						'id'     => 1,
-						'type'   => CampaignType::PERFORMANCE_MAX,
-						'status' => CampaignStatus::ENABLED,
-					],
-				]
-			);
-
-		$this->assertFalse( $this->evaluator->should_show() );
-	}
-
-	public function test_should_not_show_when_only_paused_pmax_campaign_present() {
-		$this->mock_onboarded_with_ads_skipped();
-		$this->ads_campaign->method( 'get_campaigns' )
-			->with( true, false )
-			->willReturn(
-				[
-					[
-						'id'     => 1,
-						'type'   => CampaignType::PERFORMANCE_MAX,
-						'status' => CampaignStatus::PAUSED,
-					],
-				]
-			);
-
-		$this->assertFalse( $this->evaluator->should_show() );
-	}
-
-	public function test_should_not_show_when_pmax_campaign_created_outside_onboarding() {
-		$this->mock_onboarded_with_ads_skipped();
-		$this->ads_campaign->method( 'get_campaigns' )
-			->with( true, false )
-			->willReturn(
-				[
-					[
-						'id'     => 1,
-						'type'   => CampaignType::SHOPPING,
-						'status' => CampaignStatus::ENABLED,
-					],
-					[
-						'id'     => 2,
-						'type'   => CampaignType::PERFORMANCE_MAX,
-						'status' => CampaignStatus::ENABLED,
-					],
-				]
-			);
-
-		$this->assertFalse( $this->evaluator->should_show() );
-	}
-
-	public function test_cache_hit_skips_api_call() {
+	public function test_cache_hit_skips_evaluation() {
 		$user_id = $this->login_as_administrator();
 
 		set_transient( NotificationCacheKeys::for_user( 'skipped-campaign-creation', $user_id ), 0, HOUR_IN_SECONDS );
 
-		$this->ads_campaign->expects( $this->never() )->method( 'get_campaigns' );
+		$this->onboarding_completed->expects( $this->never() )->method( 'is_onboarding_complete' );
 
 		$this->assertFalse( $this->evaluator->should_show() );
-	}
-
-	/**
-	 * Mock a merchant that finished onboarding but did not complete Ads setup.
-	 */
-	private function mock_onboarded_with_ads_skipped(): void {
-		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
-		$this->ads_service->method( 'is_setup_complete' )->willReturn( false );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR addresses the issues reported below:
Looking at t[he PR](https://github.com/woocommerce/google-listings-and-ads/pull/3513/changes#diff-7d0a5fed40640f09ca50fcfd63fe86a0128168d5d9e30e82a288b31e950413d7R57-R75), I think there's one important part that was missed. Right now, we're only checking whether there are any PMax campaigns.

However, the requirement is that the notification should be shown only if the merchant skipped ads creation and does not have any PMax campaigns.

From what I can see, we're currently not [rendering the notification when Ads setup is not complete](https://github.com/woocommerce/google-listings-and-ads/pull/3513/changes#diff-7d0a5fed40640f09ca50fcfd63fe86a0128168d5d9e30e82a288b31e950413d7R59), which is the opposite of the required behavior. The notification should be shown when Ads setup is not complete and the merchant does not have any PMax campaigns.

The solution:
1. Inverted the Ads-setup check. It was firing when Ads setup was complete; now it fires when Ads setup is not complete (i.e. the merchant skipped campaign creation).
2. Paused campaigns no longer trigger it. We were only checking enabled PMax campaigns, so pausing all campaigns made it fire. Now any non-removed PMax campaign (enabled or paused) suppresses it — paused campaigns are covered by the separate paused-campaign notification. This also covers PMax campaigns created outside the onboarding flow.
3. Added an onboarding-complete gate. "completed G4W onboarding", and without this the signal would fire for merchants still mid-onboarding (who should get abandoned-onboarding instead). It's a single `OnboardingCompleted::is_onboarding_complete()` check

Closes https://linear.app/a8c/issue/GOOWOO-651/be-signal-detection-case-1-skipped-campaign-creation

### Detailed test instructions:

The testing instructions are the same as the parent PR [here](https://github.com/woocommerce/google-listings-and-ads/pull/3513)


### Additional details:

This is a remediation PR for the parent task [GOOWOO-651](https://linear.app/a8c/issue/GOOWOO-651/be-signal-detection-case-1-skipped-campaign-creation#comment-996b829e)