### PR TITLE
GOOWOO-765: Update WP sidebar notification badge count on notification dismissal

### DIFF
--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -161,4 +161,5 @@ export const EU_POLITICAL_ADVERTISING_DECLARATION_REQUIRED_ERROR_CODE =
 	'eu_political_advertising_declaration_required';
 
 // Notification hooks
-export const GLA_NOTIFICATION_DISMISSED = 'gla_notification_dismissed';
+export const GLA_NOTIFICATION_DISMISSED =
+	'gla_notifications_system_notification_dismissed';

--- a/js/src/constants.js
+++ b/js/src/constants.js
@@ -159,3 +159,6 @@ export const GEN_AI_ASSET_TYPES = {
 
 export const EU_POLITICAL_ADVERTISING_DECLARATION_REQUIRED_ERROR_CODE =
 	'eu_political_advertising_declaration_required';
+
+// Notification hooks
+export const GLA_NOTIFICATION_DISMISSED = 'gla_notification_dismissed';

--- a/js/src/notification-manager/index.js
+++ b/js/src/notification-manager/index.js
@@ -3,22 +3,29 @@
  */
 import { addAction } from '@wordpress/hooks';
 
+/**
+ * Internal dependencies
+ */
+import { GLA_NOTIFICATION_DISMISSED } from '~/constants';
+
 ( function () {
-	const badge = document.querySelector(
-		'#toplevel_page_woocommerce-marketing .update-plugins'
+	const marketingMenu = document.getElementById(
+		'toplevel_page_woocommerce-marketing'
 	);
+
+	if ( ! marketingMenu ) {
+		return;
+	}
+
+	const badge = marketingMenu.querySelector( '.update-plugins' );
 
 	if ( ! badge ) {
 		return;
 	}
 
-	const marketingMenu = document.getElementById(
-		'toplevel_page_woocommerce-marketing'
-	);
-
 	const observer = new MutationObserver( function () {
 		if ( marketingMenu.classList.contains( 'wp-has-current-submenu' ) ) {
-			const subMenu = document.querySelector(
+			const subMenu = marketingMenu.querySelector(
 				'[href="admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard"]'
 			);
 
@@ -31,8 +38,8 @@ import { addAction } from '@wordpress/hooks';
 				subMenu.appendChild( badge );
 			}
 		} else {
-			const topMenu = document.querySelector(
-				'.toplevel_page_woocommerce-marketing > a > .wp-menu-name'
+			const topMenu = marketingMenu.querySelector(
+				':scope > a > .wp-menu-name'
 			);
 
 			if ( topMenu && ! topMenu.contains( badge ) ) {
@@ -51,30 +58,29 @@ import { addAction } from '@wordpress/hooks';
 		attributeFilter: [ 'class' ],
 	} );
 
-	addAction(
-		'gla_notification_dismissed',
-		'gla/notification-manager',
-		function () {
-			const countEl = badge.querySelector( '.update-count' );
+	function handleNotificationDismissed() {
+		const countEl = badge.querySelector( '.update-count' );
 
-			if ( ! countEl ) {
-				return;
-			}
-
-			const newCount = Math.max(
-				0,
-				parseInt( countEl.textContent, 10 ) - 1
-			);
-
-			if ( newCount === 0 ) {
-				badge.style.display = 'none';
-			} else {
-				countEl.textContent = newCount;
-				badge.className = badge.className.replace(
-					/\bcount-\d+\b/,
-					'count-' + newCount
-				);
-			}
+		if ( ! countEl ) {
+			return;
 		}
+
+		const newCount = Math.max( 0, parseInt( countEl.textContent, 10 ) - 1 );
+
+		if ( newCount === 0 ) {
+			badge.style.display = 'none';
+		} else {
+			countEl.textContent = newCount;
+			badge.className = badge.className.replace(
+				/\bcount-\d+\b/,
+				'count-' + newCount
+			);
+		}
+	}
+
+	addAction(
+		GLA_NOTIFICATION_DISMISSED,
+		'gla/notification-manager',
+		handleNotificationDismissed
 	);
 } )();

--- a/js/src/notification-manager/index.js
+++ b/js/src/notification-manager/index.js
@@ -45,4 +45,33 @@
 		attributes: true,
 		attributeFilter: [ 'class' ],
 	} );
+
+	if ( wp && wp.hooks ) {
+		wp.hooks.addAction(
+			'gla_notification_dismissed',
+			'gla/notification-manager',
+			function () {
+				const countEl = badge.querySelector( '.update-count' );
+
+				if ( ! countEl ) {
+					return;
+				}
+
+				const newCount = Math.max(
+					0,
+					parseInt( countEl.textContent, 10 ) - 1
+				);
+
+				if ( newCount === 0 ) {
+					badge.style.display = 'none';
+				} else {
+					countEl.textContent = newCount;
+					badge.className = badge.className.replace(
+						/\bcount-\d+\b/,
+						'count-' + newCount
+					);
+				}
+			}
+		);
+	}
 } )();

--- a/js/src/notification-manager/index.js
+++ b/js/src/notification-manager/index.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { addAction } from '@wordpress/hooks';
+
 ( function () {
 	const badge = document.querySelector(
 		'#toplevel_page_woocommerce-marketing .update-plugins'
@@ -46,32 +51,30 @@
 		attributeFilter: [ 'class' ],
 	} );
 
-	if ( wp && wp.hooks ) {
-		wp.hooks.addAction(
-			'gla_notification_dismissed',
-			'gla/notification-manager',
-			function () {
-				const countEl = badge.querySelector( '.update-count' );
+	addAction(
+		'gla_notification_dismissed',
+		'gla/notification-manager',
+		function () {
+			const countEl = badge.querySelector( '.update-count' );
 
-				if ( ! countEl ) {
-					return;
-				}
-
-				const newCount = Math.max(
-					0,
-					parseInt( countEl.textContent, 10 ) - 1
-				);
-
-				if ( newCount === 0 ) {
-					badge.style.display = 'none';
-				} else {
-					countEl.textContent = newCount;
-					badge.className = badge.className.replace(
-						/\bcount-\d+\b/,
-						'count-' + newCount
-					);
-				}
+			if ( ! countEl ) {
+				return;
 			}
-		);
-	}
+
+			const newCount = Math.max(
+				0,
+				parseInt( countEl.textContent, 10 ) - 1
+			);
+
+			if ( newCount === 0 ) {
+				badge.style.display = 'none';
+			} else {
+				countEl.textContent = newCount;
+				badge.className = badge.className.replace(
+					/\bcount-\d+\b/,
+					'count-' + newCount
+				);
+			}
+		}
+	);
 } )();

--- a/js/src/notifications-system/index.js
+++ b/js/src/notifications-system/index.js
@@ -3,6 +3,7 @@
  */
 import { resolveSelect } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
+import { doAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -37,6 +38,7 @@ function createNotificationComponent( id, triggeredAt ) {
 
 		const handleDismiss = () => {
 			dismissNotification( id );
+			doAction( 'gla_notification_dismissed' );
 		};
 
 		return createElement( Notification, {

--- a/js/src/notifications-system/index.js
+++ b/js/src/notifications-system/index.js
@@ -16,6 +16,7 @@ import {
 } from './woo-marketing-notifications-slot';
 import Notification from './notification';
 import useNotificationsSystemMap from './useNotificationsSystemMap';
+import { GLA_NOTIFICATION_DISMISSED } from '~/constants';
 
 /**
  * Creates a notification component.
@@ -38,7 +39,7 @@ function createNotificationComponent( id, triggeredAt ) {
 
 		const handleDismiss = () => {
 			dismissNotification( id );
-			doAction( 'gla_notification_dismissed' );
+			doAction( GLA_NOTIFICATION_DISMISSED );
 		};
 
 		return createElement( Notification, {

--- a/js/src/notifications-system/woo-marketing-notifications-slot/hooks/useDismissNotification.js
+++ b/js/src/notifications-system/woo-marketing-notifications-slot/hooks/useDismissNotification.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useDispatch } from '@wordpress/data';
+import { doAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -11,7 +12,10 @@ import { STORE_KEY } from '../data/constants';
 const useDismissNotification = () => {
 	const { dismissNotification } = useDispatch( STORE_KEY );
 
-	return dismissNotification;
+	return ( id ) => {
+		dismissNotification( id );
+		doAction( 'gla_notification_dismissed' );
+	};
 };
 
 export default useDismissNotification;

--- a/js/src/notifications-system/woo-marketing-notifications-slot/hooks/useDismissNotification.js
+++ b/js/src/notifications-system/woo-marketing-notifications-slot/hooks/useDismissNotification.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useDispatch } from '@wordpress/data';
-import { doAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -12,10 +11,7 @@ import { STORE_KEY } from '../data/constants';
 const useDismissNotification = () => {
 	const { dismissNotification } = useDispatch( STORE_KEY );
 
-	return ( id ) => {
-		dismissNotification( id );
-		doAction( 'gla_notification_dismissed' );
-	};
+	return dismissNotification;
 };
 
 export default useDismissNotification;

--- a/src/Menu/NotificationManager.php
+++ b/src/Menu/NotificationManager.php
@@ -75,7 +75,7 @@ class NotificationManager implements ContainerAwareInterface, Service, Registera
 			"{$this->get_root_dir()}/js/build/notification-manager.asset.php",
 			new BuiltScriptDependencyArray(
 				[
-					'dependencies' => [],
+					'dependencies' => [ 'wp-hooks' ],
 					'version'      => $this->get_version(),
 				]
 			),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes [GOOWOO-765](https://linear.app/a8c/issue/GOOWOO-765/notification-badge-count-not-updated-after-dismissing-a-notification).

When a GLA notification is dismissed, fires a `gla_notification_dismissed` action via `@wordpress/hooks` and listens for it in `notification-manager/index.js` to decrement the sidebar badge count directly in the DOM, hiding it entirely when it reaches zero.


### Screenshots:
<img width="1266" height="405" alt="Screenshot 2026-07-03 at 14 47 46" src="https://github.com/user-attachments/assets/f5f9e054-dfe5-4db4-9c2a-d11a43e1c01b" />

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. When one or more notifications are active, hit any page on your WP admin
2. Notice that there is a badge next to **Marketing -> Googlw for WooCommerce** with the number of notifications present in the plugin
3. Remove one or more notifications
4. Notice that the number decreases without having to refresh the page
5. Remove all notifications
6. Notice that the badge disappeared


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
