### PR TITLE
[GOOWOO-380] Display notification banner encouraging user to update their plugin before deprecation of API

### DIFF
--- a/src/Admin/MerchantApiMigrationNotice.php
+++ b/src/Admin/MerchantApiMigrationNotice.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use stdClass;
@@ -50,12 +51,19 @@ class MerchantApiMigrationNotice implements Service, Registerable, Conditional {
 	protected $wp;
 
 	/**
+	 * @var MerchantCenterService
+	 */
+	protected $merchant_center;
+
+	/**
 	 * MerchantApiMigrationNotice constructor.
 	 *
-	 * @param WP $wp
+	 * @param WP                    $wp
+	 * @param MerchantCenterService $merchant_center
 	 */
-	public function __construct( WP $wp ) {
-		$this->wp = $wp;
+	public function __construct( WP $wp, MerchantCenterService $merchant_center ) {
+		$this->wp              = $wp;
+		$this->merchant_center = $merchant_center;
 	}
 
 	/**
@@ -88,6 +96,10 @@ class MerchantApiMigrationNotice implements Service, Registerable, Conditional {
 	 */
 	private function should_render(): bool {
 		if ( ! $this->wp->current_user_can( 'update_plugins' ) ) {
+			return false;
+		}
+
+		if ( ! $this->merchant_center->is_connected() ) {
 			return false;
 		}
 

--- a/src/Admin/MerchantApiMigrationNotice.php
+++ b/src/Admin/MerchantApiMigrationNotice.php
@@ -103,7 +103,9 @@ class MerchantApiMigrationNotice implements Service, Registerable, Conditional {
 			return false;
 		}
 
-		if ( ! version_compare( $this->get_version(), self::MIGRATION_TARGET_VERSION, '<' ) ) {
+		$target = $this->pad_version( self::MIGRATION_TARGET_VERSION );
+
+		if ( ! version_compare( $this->pad_version( $this->get_version() ), $target, '<' ) ) {
 			return false;
 		}
 
@@ -112,7 +114,25 @@ class MerchantApiMigrationNotice implements Service, Registerable, Conditional {
 			return false;
 		}
 
-		return version_compare( $update->new_version ?? '', self::MIGRATION_TARGET_VERSION, '>=' );
+		return version_compare( $this->pad_version( $update->new_version ?? '' ), $target, '>=' );
+	}
+
+	/**
+	 * Pad a version string to at least three components so `version_compare`
+	 * treats versions like "3.8" and "3.8.0" as equal.
+	 *
+	 * @param string $version Version string.
+	 *
+	 * @return string
+	 */
+	private function pad_version( string $version ): string {
+		$parts = explode( '.', $version );
+
+		while ( count( $parts ) < 3 ) {
+			$parts[] = '0';
+		}
+
+		return implode( '.', $parts );
 	}
 
 	/**

--- a/src/Admin/MerchantApiMigrationNotice.php
+++ b/src/Admin/MerchantApiMigrationNotice.php
@@ -123,13 +123,7 @@ class MerchantApiMigrationNotice implements Service, Registerable {
 	 * @return string
 	 */
 	private function pad_version( string $version ): string {
-		$parts = explode( '.', $version );
-
-		while ( count( $parts ) < 3 ) {
-			$parts[] = '0';
-		}
-
-		return implode( '.', $parts );
+		return implode( '.', array_pad( explode( '.', $version ), 3, '0' ) );
 	}
 
 	/**

--- a/src/Admin/MerchantApiMigrationNotice.php
+++ b/src/Admin/MerchantApiMigrationNotice.php
@@ -1,0 +1,145 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+use stdClass;
+
+/**
+ * Class MerchantApiMigrationNotice
+ *
+ * Renders a non-dismissible admin warning banner urging merchants to update the
+ * plugin before Google retires the Content API for Shopping on 18 August 2026.
+ *
+ * The banner only renders while an update at or above the migration target
+ * version is available and the installed version is still below it, so it
+ * disappears on its own once the merchant updates.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin
+ */
+class MerchantApiMigrationNotice implements Service, Registerable, Conditional {
+
+	use AdminConditional;
+	use PluginHelper;
+
+	/**
+	 * The first plugin version using the Merchant API. The banner renders only
+	 * while an update at or above this version is available and the installed
+	 * version is below it.
+	 *
+	 * @var string
+	 */
+	public const MIGRATION_TARGET_VERSION = '3.8.0';
+
+	/**
+	 * Google's announcement of the Content API deprecation date.
+	 *
+	 * @var string
+	 */
+	public const MIGRATION_DETAILS_URL = 'https://ads-developers.googleblog.com/2026/04/merchant-api-is-coming-to-google-ads.html';
+
+	/**
+	 * @var WP
+	 */
+	protected $wp;
+
+	/**
+	 * MerchantApiMigrationNotice constructor.
+	 *
+	 * @param WP $wp
+	 */
+	public function __construct( WP $wp ) {
+		$this->wp = $wp;
+	}
+
+	/**
+	 * Register a service.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_action( 'admin_notices', [ $this, 'maybe_render' ] );
+		add_action( 'network_admin_notices', [ $this, 'maybe_render' ] );
+	}
+
+	/**
+	 * Render the migration notice when a qualifying update is available.
+	 *
+	 * @return void
+	 */
+	public function maybe_render(): void {
+		if ( ! $this->should_render() ) {
+			return;
+		}
+
+		$this->render();
+	}
+
+	/**
+	 * Whether the migration notice should render.
+	 *
+	 * @return bool
+	 */
+	private function should_render(): bool {
+		if ( ! $this->wp->current_user_can( 'update_plugins' ) ) {
+			return false;
+		}
+
+		if ( ! version_compare( $this->get_version(), self::MIGRATION_TARGET_VERSION, '<' ) ) {
+			return false;
+		}
+
+		$update = $this->get_available_update();
+		if ( null === $update ) {
+			return false;
+		}
+
+		return version_compare( $update->new_version ?? '', self::MIGRATION_TARGET_VERSION, '>=' );
+	}
+
+	/**
+	 * Get the available update entry for this plugin, if WordPress is reporting one.
+	 *
+	 * @return stdClass|null
+	 */
+	private function get_available_update(): ?stdClass {
+		$transient = $this->wp->get_site_transient( 'update_plugins' );
+
+		if ( ! is_object( $transient ) || empty( $transient->response ) || ! is_array( $transient->response ) ) {
+			return null;
+		}
+
+		return $transient->response[ $this->get_plugin_basename() ] ?? null;
+	}
+
+	/**
+	 * Render the migration notice.
+	 *
+	 * @return void
+	 */
+	private function render(): void {
+		$message = sprintf(
+			/* translators: 1: opening strong tag 2: closing strong tag 3: opening strong tag 4: closing strong tag */
+			__( '%1$sCritical Update:%2$s Your Google for WooCommerce connection will stop working after %3$sAugust 18, 2026%4$s due to mandatory Google API changes. Update your plugin today to keep your product sync and ads running smoothly.', 'google-listings-and-ads' ),
+			'<strong>',
+			'</strong>',
+			'<strong>',
+			'</strong>'
+		);
+
+		printf(
+			'<div class="notice notice-warning"><p>%1$s</p><p><a href="%2$s" class="button button-primary">%3$s</a> <a href="%4$s" class="button button-secondary" target="_blank" rel="noopener noreferrer">%5$s</a></p></div>',
+			wp_kses_post( $message ),
+			esc_url( self_admin_url( 'plugins.php' ) ),
+			esc_html__( 'Update Plugin Now', 'google-listings-and-ads' ),
+			esc_url( self::MIGRATION_DETAILS_URL ),
+			esc_html__( 'Read Migration Details', 'google-listings-and-ads' )
+		);
+	}
+}

--- a/src/Admin/MerchantApiMigrationNotice.php
+++ b/src/Admin/MerchantApiMigrationNotice.php
@@ -3,8 +3,6 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\AdminConditional;
-use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
@@ -24,9 +22,8 @@ use stdClass;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin
  */
-class MerchantApiMigrationNotice implements Service, Registerable, Conditional {
+class MerchantApiMigrationNotice implements Service, Registerable {
 
-	use AdminConditional;
 	use PluginHelper;
 
 	/**

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -95,7 +95,7 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 		);
 		$this->share_with_tags( PHPViewFactory::class );
 		$this->share_with_tags( Redirect::class, WP::class, OnboardingCompleted::class );
-		$this->share_with_tags( MerchantApiMigrationNotice::class, WP::class );
+		$this->share_with_tags( MerchantApiMigrationNotice::class, WP::class, MerchantCenterService::class );
 
 		// Share bulk edit views
 		$this->share_with_tags( CouponBulkEdit::class, CouponMetaHandler::class, MerchantCenterService::class, TargetAudience::class );

--- a/src/Internal/DependencyManagement/AdminServiceProvider.php
+++ b/src/Internal/DependencyManagement/AdminServiceProvider.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagem
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Admin;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\BulkEdit\BulkEditInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\BulkEdit\CouponBulkEdit;
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MerchantApiMigrationNotice;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\CouponChannelVisibilityMetaBox;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInitializer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MetaBox\MetaBoxInterface;
@@ -54,24 +55,25 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 	 * @var array
 	 */
 	protected $provides = [
-		Admin::class               => true,
-		AttributeMapping::class    => true,
-		BulkEditInitializer::class => true,
-		ConnectionTest::class      => true,
-		CouponBulkEdit::class      => true,
-		Dashboard::class           => true,
-		NotificationManager::class => true,
-		GetStarted::class          => true,
-		MetaBoxInterface::class    => true,
-		MetaBoxInitializer::class  => true,
-		ProductFeed::class         => true,
-		Redirect::class            => true,
-		Reports::class             => true,
-		Settings::class            => true,
-		SetupAds::class            => true,
-		SetupMerchantCenter::class => true,
-		Shipping::class            => true,
-		Service::class             => true,
+		Admin::class                      => true,
+		AttributeMapping::class           => true,
+		BulkEditInitializer::class        => true,
+		ConnectionTest::class             => true,
+		CouponBulkEdit::class             => true,
+		Dashboard::class                  => true,
+		MerchantApiMigrationNotice::class => true,
+		NotificationManager::class        => true,
+		GetStarted::class                 => true,
+		MetaBoxInterface::class           => true,
+		MetaBoxInitializer::class         => true,
+		ProductFeed::class                => true,
+		Redirect::class                   => true,
+		Reports::class                    => true,
+		Settings::class                   => true,
+		SetupAds::class                   => true,
+		SetupMerchantCenter::class        => true,
+		Shipping::class                   => true,
+		Service::class                    => true,
 	];
 
 	/**
@@ -93,6 +95,7 @@ class AdminServiceProvider extends AbstractServiceProvider implements Conditiona
 		);
 		$this->share_with_tags( PHPViewFactory::class );
 		$this->share_with_tags( Redirect::class, WP::class, OnboardingCompleted::class );
+		$this->share_with_tags( MerchantApiMigrationNotice::class, WP::class );
 
 		// Share bulk edit views
 		$this->share_with_tags( CouponBulkEdit::class, CouponMetaHandler::class, MerchantCenterService::class, TargetAudience::class );

--- a/src/Proxies/WP.php
+++ b/src/Proxies/WP.php
@@ -385,4 +385,27 @@ class WP {
 	public function delete_option( ...$arguments ) {
 		return delete_option( ...$arguments );
 	}
+
+	/**
+	 * Wrapper of get_site_transient.
+	 *
+	 * @param string $transient Transient name.
+	 *
+	 * @return mixed Value of the transient, or false if it does not exist.
+	 */
+	public function get_site_transient( string $transient ) {
+		return get_site_transient( $transient );
+	}
+
+	/**
+	 * Wrapper of current_user_can.
+	 *
+	 * @param string $capability Capability name.
+	 * @param mixed  ...$args    Optional further parameters, typically starting with an object ID.
+	 *
+	 * @return bool Whether the current user has the given capability.
+	 */
+	public function current_user_can( string $capability, ...$args ): bool {
+		return current_user_can( $capability, ...$args );
+	}
 }

--- a/tests/Unit/Admin/MerchantApiMigrationNoticeTest.php
+++ b/tests/Unit/Admin/MerchantApiMigrationNoticeTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MerchantApiMigrationNotice;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 
 use PHPUnit\Framework\MockObject\MockObject;
@@ -16,6 +17,9 @@ class MerchantApiMigrationNoticeTest extends TestCase {
 	/** @var MockObject|WP $wp */
 	protected $wp;
 
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
 	/**
 	 * Setup tests
 	 *
@@ -24,7 +28,8 @@ class MerchantApiMigrationNoticeTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->wp = $this->createMock( WP::class );
+		$this->wp              = $this->createMock( WP::class );
+		$this->merchant_center = $this->createMock( MerchantCenterService::class );
 	}
 
 	/**
@@ -56,6 +61,21 @@ class MerchantApiMigrationNoticeTest extends TestCase {
 		$this->wp->method( 'get_site_transient' )->with( 'update_plugins' )->willReturn( $this->get_transient_with_update( '3.8.0' ) );
 
 		$instance = $this->get_notice_instance( '3.7.5' );
+
+		$this->assertSame( '', $this->capture_render_output( $instance ) );
+	}
+
+	/**
+	 * Test nothing renders when Merchant Center is not connected, even when a
+	 * qualifying update is available.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_render_outputs_nothing_when_merchant_center_is_not_connected(): void {
+		$this->wp->method( 'current_user_can' )->with( 'update_plugins' )->willReturn( true );
+		$this->wp->method( 'get_site_transient' )->with( 'update_plugins' )->willReturn( $this->get_transient_with_update( '3.8.0' ) );
+
+		$instance = $this->get_notice_instance( '3.7.5', false );
 
 		$this->assertSame( '', $this->capture_render_output( $instance ) );
 	}
@@ -215,7 +235,7 @@ class MerchantApiMigrationNoticeTest extends TestCase {
 	 * @return void
 	 */
 	public function test_can_be_instantiated_with_real_wp_proxy(): void {
-		$this->assertInstanceOf( MerchantApiMigrationNotice::class, new MerchantApiMigrationNotice( new WP() ) );
+		$this->assertInstanceOf( MerchantApiMigrationNotice::class, new MerchantApiMigrationNotice( new WP(), $this->merchant_center ) );
 	}
 
 	/**
@@ -223,12 +243,15 @@ class MerchantApiMigrationNoticeTest extends TestCase {
 	 * basename stubbed, leaving all rendering logic real.
 	 *
 	 * @param string $installed_version Value returned by the stubbed `get_version`.
+	 * @param bool   $is_connected      Value returned by the stubbed `MerchantCenterService::is_connected`.
 	 *
 	 * @return MockObject|MerchantApiMigrationNotice
 	 */
-	private function get_notice_instance( string $installed_version = '3.7.5' ) {
+	private function get_notice_instance( string $installed_version = '3.7.5', bool $is_connected = true ) {
+		$this->merchant_center->method( 'is_connected' )->willReturn( $is_connected );
+
 		$instance = $this->getMockBuilder( MerchantApiMigrationNotice::class )
-			->setConstructorArgs( [ $this->wp ] )
+			->setConstructorArgs( [ $this->wp, $this->merchant_center ] )
 			->onlyMethods( [ 'get_version', 'get_plugin_basename' ] )
 			->getMock();
 

--- a/tests/Unit/Admin/MerchantApiMigrationNoticeTest.php
+++ b/tests/Unit/Admin/MerchantApiMigrationNoticeTest.php
@@ -177,7 +177,7 @@ class MerchantApiMigrationNoticeTest extends TestCase {
 		$this->assertStringContainsString( 'August 18, 2026', $output );
 		$this->assertStringContainsString( 'Update Plugin Now', $output );
 		$this->assertStringContainsString( 'Read Migration Details', $output );
-		$this->assertStringContainsString( 'href="' . esc_url( admin_url( 'plugins.php' ) ) . '"', $output );
+		$this->assertStringContainsString( 'href="' . esc_url( self_admin_url( 'plugins.php' ) ) . '"', $output );
 		$this->assertStringContainsString( 'href="' . esc_url( MerchantApiMigrationNotice::MIGRATION_DETAILS_URL ) . '"', $output );
 		$this->assertStringContainsString( 'https://ads-developers.googleblog.com/2026/04/merchant-api-is-coming-to-google-ads.html', $output );
 		$this->assertStringContainsString( 'target="_blank"', $output );

--- a/tests/Unit/Admin/MerchantApiMigrationNoticeTest.php
+++ b/tests/Unit/Admin/MerchantApiMigrationNoticeTest.php
@@ -144,6 +144,41 @@ class MerchantApiMigrationNoticeTest extends TestCase {
 	}
 
 	/**
+	 * Test nothing renders when the installed version is a two-part string equal
+	 * to the migration target ("3.8" vs "3.8.0"), which raw `version_compare`
+	 * would wrongly treat as below the target.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_render_outputs_nothing_when_installed_version_is_two_part_equal_to_target(): void {
+		$this->wp->method( 'current_user_can' )->with( 'update_plugins' )->willReturn( true );
+		$this->wp->method( 'get_site_transient' )->with( 'update_plugins' )->willReturn( $this->get_transient_with_update( '3.9.0' ) );
+
+		$instance = $this->get_notice_instance( '3.8' );
+
+		$this->assertSame( '', $this->capture_render_output( $instance ) );
+	}
+
+	/**
+	 * Test the banner renders when the available update is a two-part string equal
+	 * to the migration target ("3.8" vs "3.8.0"), which raw `version_compare`
+	 * would wrongly treat as below the target.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_render_outputs_banner_when_available_version_is_two_part_equal_to_target(): void {
+		$this->wp->method( 'current_user_can' )->with( 'update_plugins' )->willReturn( true );
+		$this->wp->method( 'get_site_transient' )->with( 'update_plugins' )->willReturn( $this->get_transient_with_update( '3.8' ) );
+
+		$instance = $this->get_notice_instance( '3.7.5' );
+
+		$output = $this->capture_render_output( $instance );
+
+		$this->assertStringContainsString( 'notice-warning', $output );
+		$this->assertStringContainsString( 'Critical Update:', $output );
+	}
+
+	/**
 	 * Test nothing renders when the installed version is above the migration target.
 	 *
 	 * @return void

--- a/tests/Unit/Admin/MerchantApiMigrationNoticeTest.php
+++ b/tests/Unit/Admin/MerchantApiMigrationNoticeTest.php
@@ -1,0 +1,276 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Admin\MerchantApiMigrationNotice;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class MerchantApiMigrationNoticeTest extends TestCase {
+
+	protected const PLUGIN_BASENAME = 'google-listings-and-ads/google-listings-and-ads.php';
+
+	/** @var MockObject|WP $wp */
+	protected $wp;
+
+	/**
+	 * Setup tests
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->wp = $this->createMock( WP::class );
+	}
+
+	/**
+	 * Test `register` hooks `maybe_render` into both admin notice actions at default priority.
+	 *
+	 * @return void
+	 */
+	public function test_register_hooks_admin_notices_and_network_admin_notices(): void {
+		$instance = $this->get_notice_instance();
+
+		$instance->register();
+
+		$this->assertSame( 10, has_action( 'admin_notices', [ $instance, 'maybe_render' ] ) );
+		$this->assertSame( 10, has_action( 'network_admin_notices', [ $instance, 'maybe_render' ] ) );
+
+		// Plain TestCase does not reset global hooks between tests.
+		remove_action( 'admin_notices', [ $instance, 'maybe_render' ] );
+		remove_action( 'network_admin_notices', [ $instance, 'maybe_render' ] );
+	}
+
+	/**
+	 * Test nothing renders for users who cannot update plugins, even when a
+	 * qualifying update is available.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_render_outputs_nothing_when_user_lacks_update_plugins_capability(): void {
+		$this->wp->method( 'current_user_can' )->with( 'update_plugins' )->willReturn( false );
+		$this->wp->method( 'get_site_transient' )->with( 'update_plugins' )->willReturn( $this->get_transient_with_update( '3.8.0' ) );
+
+		$instance = $this->get_notice_instance( '3.7.5' );
+
+		$this->assertSame( '', $this->capture_render_output( $instance ) );
+	}
+
+	/**
+	 * Test nothing renders when the update transient is `false` (the value
+	 * WordPress returns before its first update check has run).
+	 *
+	 * @return void
+	 */
+	public function test_maybe_render_outputs_nothing_when_transient_is_false(): void {
+		$this->wp->method( 'current_user_can' )->with( 'update_plugins' )->willReturn( true );
+		$this->wp->method( 'get_site_transient' )->with( 'update_plugins' )->willReturn( false );
+
+		$instance = $this->get_notice_instance( '3.7.5' );
+
+		$this->assertSame( '', $this->capture_render_output( $instance ) );
+	}
+
+	/**
+	 * Test nothing renders when the transient carries no update entry for this plugin.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_render_outputs_nothing_when_transient_has_no_response_for_this_plugin(): void {
+		$transient           = new \stdClass();
+		$transient->response = [
+			'some-other-plugin/some-other-plugin.php' => (object) [ 'new_version' => '9.9.9' ],
+		];
+
+		$this->wp->method( 'current_user_can' )->with( 'update_plugins' )->willReturn( true );
+		$this->wp->method( 'get_site_transient' )->with( 'update_plugins' )->willReturn( $transient );
+
+		$instance = $this->get_notice_instance( '3.7.5' );
+
+		$this->assertSame( '', $this->capture_render_output( $instance ) );
+	}
+
+	/**
+	 * Test nothing renders when the available update is below the migration target version.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_render_outputs_nothing_when_available_version_is_below_target(): void {
+		$this->wp->method( 'current_user_can' )->with( 'update_plugins' )->willReturn( true );
+		$this->wp->method( 'get_site_transient' )->with( 'update_plugins' )->willReturn( $this->get_transient_with_update( '3.7.99' ) );
+
+		$instance = $this->get_notice_instance( '3.7.5' );
+
+		$this->assertSame( '', $this->capture_render_output( $instance ) );
+	}
+
+	/**
+	 * Test nothing renders when the installed version equals the migration target,
+	 * even though a newer update is available.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_render_outputs_nothing_when_installed_version_equals_target(): void {
+		$this->wp->method( 'current_user_can' )->with( 'update_plugins' )->willReturn( true );
+		$this->wp->method( 'get_site_transient' )->with( 'update_plugins' )->willReturn( $this->get_transient_with_update( '3.9.0' ) );
+
+		$instance = $this->get_notice_instance( '3.8.0' );
+
+		$this->assertSame( '', $this->capture_render_output( $instance ) );
+	}
+
+	/**
+	 * Test nothing renders when the installed version is above the migration target.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_render_outputs_nothing_when_installed_version_is_above_target(): void {
+		$this->wp->method( 'current_user_can' )->with( 'update_plugins' )->willReturn( true );
+		$this->wp->method( 'get_site_transient' )->with( 'update_plugins' )->willReturn( $this->get_transient_with_update( '4.0.0' ) );
+
+		$instance = $this->get_notice_instance( '3.9.15' );
+
+		$this->assertSame( '', $this->capture_render_output( $instance ) );
+	}
+
+	/**
+	 * Test the banner renders with the expected markup when the migration target
+	 * version is available and the installed version is below it.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_render_outputs_banner_when_target_version_available(): void {
+		$this->wp->method( 'current_user_can' )->with( 'update_plugins' )->willReturn( true );
+		$this->wp->method( 'get_site_transient' )->with( 'update_plugins' )->willReturn( $this->get_transient_with_update( '3.8.0' ) );
+
+		$instance = $this->get_notice_instance( '3.7.5' );
+
+		$output = $this->capture_render_output( $instance );
+
+		$this->assertStringContainsString( 'notice-warning', $output );
+		$this->assertStringNotContainsString( 'is-dismissible', $output );
+		$this->assertStringContainsString( 'Critical Update:', $output );
+		$this->assertStringContainsString( 'August 18, 2026', $output );
+		$this->assertStringContainsString( 'Update Plugin Now', $output );
+		$this->assertStringContainsString( 'Read Migration Details', $output );
+		$this->assertStringContainsString( 'href="' . esc_url( admin_url( 'plugins.php' ) ) . '"', $output );
+		$this->assertStringContainsString( 'href="' . esc_url( MerchantApiMigrationNotice::MIGRATION_DETAILS_URL ) . '"', $output );
+		$this->assertStringContainsString( 'https://ads-developers.googleblog.com/2026/04/merchant-api-is-coming-to-google-ads.html', $output );
+		$this->assertStringContainsString( 'target="_blank"', $output );
+		$this->assertStringContainsString( 'rel="noopener noreferrer"', $output );
+	}
+
+	/**
+	 * Test the banner renders when the available version is newer than the target,
+	 * covering migration releases past the cut-off without code change.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_render_outputs_banner_when_available_version_is_newer_than_target(): void {
+		$this->wp->method( 'current_user_can' )->with( 'update_plugins' )->willReturn( true );
+		$this->wp->method( 'get_site_transient' )->with( 'update_plugins' )->willReturn( $this->get_transient_with_update( '4.1.2' ) );
+
+		$instance = $this->get_notice_instance( '3.7.5' );
+
+		$output = $this->capture_render_output( $instance );
+
+		$this->assertStringContainsString( 'notice-warning', $output );
+		$this->assertStringContainsString( 'Critical Update:', $output );
+	}
+
+	/**
+	 * Test every rendered href is unchanged by a second pass through `esc_url`,
+	 * confirming the markup builder escapes its links.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_render_escapes_links_via_esc_url(): void {
+		$this->wp->method( 'current_user_can' )->with( 'update_plugins' )->willReturn( true );
+		$this->wp->method( 'get_site_transient' )->with( 'update_plugins' )->willReturn( $this->get_transient_with_update( '3.8.0' ) );
+
+		$instance = $this->get_notice_instance( '3.7.5' );
+
+		$output = $this->capture_render_output( $instance );
+
+		preg_match_all( '/href="([^"]*)"/', $output, $matches );
+		$this->assertCount( 2, $matches[1] );
+
+		foreach ( $matches[1] as $href ) {
+			$this->assertNotSame( '', $href );
+			$this->assertSame( $href, esc_url( $href ) );
+			$this->assertStringNotContainsString( ' ', $href );
+			$this->assertStringNotContainsString( '<', $href );
+		}
+	}
+
+	/**
+	 * Smoke test in place of a provider-level test (no test file currently exists
+	 * for `AdminServiceProvider`): the class is constructable with its real
+	 * container dependency.
+	 *
+	 * @return void
+	 */
+	public function test_can_be_instantiated_with_real_wp_proxy(): void {
+		$this->assertInstanceOf( MerchantApiMigrationNotice::class, new MerchantApiMigrationNotice( new WP() ) );
+	}
+
+	/**
+	 * Get a partial mock of the notice with the installed version and plugin
+	 * basename stubbed, leaving all rendering logic real.
+	 *
+	 * @param string $installed_version Value returned by the stubbed `get_version`.
+	 *
+	 * @return MockObject|MerchantApiMigrationNotice
+	 */
+	private function get_notice_instance( string $installed_version = '3.7.5' ) {
+		$instance = $this->getMockBuilder( MerchantApiMigrationNotice::class )
+			->setConstructorArgs( [ $this->wp ] )
+			->onlyMethods( [ 'get_version', 'get_plugin_basename' ] )
+			->getMock();
+
+		$instance->method( 'get_version' )->willReturn( $installed_version );
+		$instance->method( 'get_plugin_basename' )->willReturn( self::PLUGIN_BASENAME );
+
+		return $instance;
+	}
+
+	/**
+	 * Build an `update_plugins` transient object reporting an available update
+	 * for this plugin.
+	 *
+	 * @param string $new_version Available version to report.
+	 *
+	 * @return object
+	 */
+	private function get_transient_with_update( string $new_version ): object {
+		$transient           = new \stdClass();
+		$transient->response = [
+			self::PLUGIN_BASENAME => (object) [
+				'id'          => 'w.org/plugins/google-listings-and-ads',
+				'slug'        => 'google-listings-and-ads',
+				'plugin'      => self::PLUGIN_BASENAME,
+				'new_version' => $new_version,
+			],
+		];
+
+		return $transient;
+	}
+
+	/**
+	 * Run `maybe_render` and return everything it echoes.
+	 *
+	 * @param MerchantApiMigrationNotice $instance Notice instance under test.
+	 *
+	 * @return string
+	 */
+	private function capture_render_output( MerchantApiMigrationNotice $instance ): string {
+		ob_start();
+		$instance->maybe_render();
+
+		return ob_get_clean();
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-635/display-notification-banner-encouraging-user-to-update-their-plugin


### Screenshots:

<img width="1721" height="265" alt="Screenshot 2026-07-06 at 12 52 40" src="https://github.com/user-attachments/assets/4d5a6b4c-7087-492e-b29a-df44ed9f062d" />

### Detailed test instructions:

1. In a MU Plugin, add the following filter to simulate the 3.8.0 release being available:

```
add_filter(
    'site_transient_update_plugins',
    function ( $transient ) {
        $available_version = '3.8.0';

        if ( null === $available_version ) {
            return $transient;
        }

        // The transient is false until WordPress has run its first update check.
        if ( ! is_object( $transient ) ) {
            $transient = new stdClass();
        }
        if ( ! isset( $transient->response ) || ! is_array( $transient->response ) ) {
            $transient->response = [];
        }

        $basename = 'google-listings-and-ads/google-listings-and-ads.php';

        $transient->response[ $basename ] = (object) [
            'id'          => 'w.org/plugins/google-listings-and-ads',
            'slug'        => 'google-listings-and-ads',
            'plugin'      => $basename,
            'new_version' => $available_version,
            'url'         => 'https://wordpress.org/plugins/google-listings-and-ads/',
            'package'     => '',
        ];

        return $transient;
    }
);
```

2. Open WP Admin, confirm you see the notification on all admin pages
3. Remove the filter
4. Confirm the notification is no longer displayed
5. Change the version from `3.8.0` to `3.8` (i.e. no `.0` suffix); refresh the admin page and confirm the notice persists
6. Disconnect from the merchant centre; refresh the admin page and confirm the notice no longer displays (i.e. does not display when merchant centre is not connected).
7. Reconnect to the merchant centre
8. In the plugin root file: `google-listings-and-ads.php` change the `WC_GLA_VERSION` to `3.8.2` - confirm the notice is no longer shown.

Note: The version check is against the constant only; the version in the plugin header is ignored.

### Additional details:

> Add - Added update notification when plugin version 3.8.0 is available