### PR TITLE
GOOWOO-768 Extract Notification Services into a Dedicated Service Provider

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\DB
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\GoogleServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\IntegrationServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\JobServiceProvider;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\NotificationsServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\ProxyServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\RESTServiceProvider;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\ThirdPartyServiceProvider;
@@ -51,6 +52,7 @@ final class Container implements ContainerInterface {
 		ThirdPartyServiceProvider::class,
 		GoogleServiceProvider::class,
 		JobServiceProvider::class,
+		NotificationsServiceProvider::class,
 		IntegrationServiceProvider::class,
 		DBServiceProvider::class,
 		AdminServiceProvider::class,

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -17,7 +17,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AssetSuggestionsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsReport;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection as GoogleConnection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantMetrics;
@@ -70,20 +69,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ReviewAfterConversions as 
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\SetupCampaign as SetupCampaignNote;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\SetupCampaignTwoWeeks as SetupCampaign2Note;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\SetupCouponSharing as SetupCouponSharingNote;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\AbandonedOnboardingEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CampaignNoSalesEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CouponsNotSyncedEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\EnhancedConversionsOffEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\NotOnboarded90DaysEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\PausedCampaignEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ProductIssuesEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ReadyButNoSalesEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\RecommendationsAvailableEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SalesNotGrowingEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\Sold10ItemsEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\TrackingOffEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsSetupCompleted;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\MerchantAccountState;
@@ -148,85 +133,71 @@ class CoreServiceProvider extends AbstractServiceProvider {
 	 * @var array
 	 */
 	protected $provides = [
-		Installer::class                         => true,
-		AddressUtility::class                    => true,
-		AssetsHandlerInterface::class            => true,
-		ContactInformationNote::class            => true,
-		CompleteSetupTask::class                 => true,
-		CompleteSetupNote::class                 => true,
-		CouponHelper::class                      => true,
-		CouponMetaHandler::class                 => true,
-		CouponSyncer::class                      => true,
-		DateTimeUtility::class                   => true,
-		EventTracking::class                     => true,
-		GlobalSiteTag::class                     => true,
-		ISOUtility::class                        => true,
-		SiteVerificationEvents::class            => true,
-		OptionsInterface::class                  => true,
-		TransientsInterface::class               => true,
-		ReconnectWordPressNote::class            => true,
-		ReviewAfterClicksNote::class             => true,
-		RESTControllers::class                   => true,
-		Service::class                           => true,
-		SetupCampaignNote::class                 => true,
-		SetupCampaign2Note::class                => true,
-		SetupCouponSharingNote::class            => true,
-		NotificationService::class               => true,
-		AbandonedOnboardingEvaluator::class      => true,
-		EnhancedConversionsOffEvaluator::class   => true,
-		NotOnboarded90DaysEvaluator::class       => true,
-		ProductIssuesEvaluator::class            => true,
-		SkippedCampaignEvaluator::class          => true,
-		Sold10ItemsEvaluator::class              => true,
-		ReadyButNoSalesEvaluator::class          => true,
-		CouponsNotSyncedEvaluator::class         => true,
-		SalesNotGrowingEvaluator::class          => true,
-		PausedCampaignEvaluator::class           => true,
-		CampaignNoSalesEvaluator::class          => true,
-		RecommendationsAvailableEvaluator::class => true,
-		TrackingOffEvaluator::class              => true,
-		WcInstallTimestamp::class                => true,
-		TableManager::class                      => true,
-		TrackerSnapshot::class                   => true,
-		Tracks::class                            => true,
-		TracksInterface::class                   => true,
-		ProductSyncer::class                     => true,
-		ProductHelper::class                     => true,
-		ProductMetaHandler::class                => true,
-		SiteVerificationMeta::class              => true,
-		BatchProductHelper::class                => true,
-		ProductFilter::class                     => true,
-		ProductRepository::class                 => true,
-		ViewFactory::class                       => true,
-		DebugLogger::class                       => true,
-		MerchantStatuses::class                  => true,
-		PriceBenchmarks::class                   => true,
-		PhoneVerification::class                 => true,
-		PolicyComplianceCheck::class             => true,
-		ContactInformation::class                => true,
-		MerchantCenterService::class             => true,
-		TargetAudience::class                    => true,
-		MerchantAccountState::class              => true,
-		AdsAccountState::class                   => true,
-		DBInstaller::class                       => true,
-		AttributeManager::class                  => true,
-		ProductFactory::class                    => true,
-		AttributesTab::class                     => true,
-		VariationsAttributes::class              => true,
-		DeprecatedFilters::class                 => true,
-		ZoneLocationsParser::class               => true,
-		ZoneMethodsParser::class                 => true,
-		LocationRatesProcessor::class            => true,
-		ShippingZone::class                      => true,
-		AdsRecommendationsService::class         => true,
-		AdsAccountService::class                 => true,
-		MerchantAccountService::class            => true,
-		MarketingChannelRegistrar::class         => true,
-		OAuthService::class                      => true,
-		WPCLIMigrationGTIN::class                => true,
-		OnboardingCompleted::class               => true,
-		ServiceBasedMerchantState::class         => true,
-		ServiceBasedMerchantHooks::class         => true,
+		Installer::class                 => true,
+		AddressUtility::class            => true,
+		AssetsHandlerInterface::class    => true,
+		ContactInformationNote::class    => true,
+		CompleteSetupTask::class         => true,
+		CompleteSetupNote::class         => true,
+		CouponHelper::class              => true,
+		CouponMetaHandler::class         => true,
+		CouponSyncer::class              => true,
+		DateTimeUtility::class           => true,
+		EventTracking::class             => true,
+		GlobalSiteTag::class             => true,
+		ISOUtility::class                => true,
+		SiteVerificationEvents::class    => true,
+		OptionsInterface::class          => true,
+		TransientsInterface::class       => true,
+		ReconnectWordPressNote::class    => true,
+		ReviewAfterClicksNote::class     => true,
+		RESTControllers::class           => true,
+		Service::class                   => true,
+		SetupCampaignNote::class         => true,
+		SetupCampaign2Note::class        => true,
+		SetupCouponSharingNote::class    => true,
+		WcInstallTimestamp::class        => true,
+		TableManager::class              => true,
+		TrackerSnapshot::class           => true,
+		Tracks::class                    => true,
+		TracksInterface::class           => true,
+		ProductSyncer::class             => true,
+		ProductHelper::class             => true,
+		ProductMetaHandler::class        => true,
+		SiteVerificationMeta::class      => true,
+		BatchProductHelper::class        => true,
+		ProductFilter::class             => true,
+		ProductRepository::class         => true,
+		ViewFactory::class               => true,
+		DebugLogger::class               => true,
+		MerchantStatuses::class          => true,
+		PriceBenchmarks::class           => true,
+		PhoneVerification::class         => true,
+		PolicyComplianceCheck::class     => true,
+		ContactInformation::class        => true,
+		MerchantCenterService::class     => true,
+		TargetAudience::class            => true,
+		MerchantAccountState::class      => true,
+		AdsAccountState::class           => true,
+		DBInstaller::class               => true,
+		AttributeManager::class          => true,
+		ProductFactory::class            => true,
+		AttributesTab::class             => true,
+		VariationsAttributes::class      => true,
+		DeprecatedFilters::class         => true,
+		ZoneLocationsParser::class       => true,
+		ZoneMethodsParser::class         => true,
+		LocationRatesProcessor::class    => true,
+		ShippingZone::class              => true,
+		AdsRecommendationsService::class => true,
+		AdsAccountService::class         => true,
+		MerchantAccountService::class    => true,
+		MarketingChannelRegistrar::class => true,
+		OAuthService::class              => true,
+		WPCLIMigrationGTIN::class        => true,
+		OnboardingCompleted::class       => true,
+		ServiceBasedMerchantState::class => true,
+		ServiceBasedMerchantHooks::class => true,
 	];
 
 	/**
@@ -322,22 +293,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( SetupCouponSharingNote::class, MerchantStatuses::class );
 		$this->share_with_tags( NoteInitializer::class, ActionScheduler::class );
 
-		// Notifications.
-		$this->share_with_tags( NotificationService::class, WP::class );
-		$this->share_with_tags( SkippedCampaignEvaluator::class, OnboardingCompleted::class );
-		$this->share_with_tags( AbandonedOnboardingEvaluator::class );
-		$this->share_with_tags( NotOnboarded90DaysEvaluator::class, OnboardingCompleted::class );
-		$this->share_with_tags( EnhancedConversionsOffEvaluator::class );
-		$this->share_with_tags( TrackingOffEvaluator::class );
-		$this->share_with_tags( ProductIssuesEvaluator::class, ServiceBasedMerchantState::class );
-		$this->share_with_tags( Sold10ItemsEvaluator::class );
-		$this->share_with_tags( ReadyButNoSalesEvaluator::class, WC::class );
-		$this->share_with_tags( CouponsNotSyncedEvaluator::class, MerchantCenterService::class, TargetAudience::class );
-		$this->share_with_tags( SalesNotGrowingEvaluator::class );
 		$this->share_with_tags( WcInstallTimestamp::class, WP::class );
-		$this->share_with_tags( PausedCampaignEvaluator::class, AdsCampaign::class );
-		$this->share_with_tags( CampaignNoSalesEvaluator::class, AdsCampaign::class, AdsReport::class, AdsRecommendationsService::class );
-		$this->share_with_tags( RecommendationsAvailableEvaluator::class, AdsRecommendationsService::class, AdsCampaign::class );
 
 		// Product attributes
 		$this->conditionally_share_with_tags( AttributeManager::class, AttributeMappingRulesQuery::class, WC::class );

--- a/src/Internal/DependencyManagement/NotificationsServiceProvider.php
+++ b/src/Internal/DependencyManagement/NotificationsServiceProvider.php
@@ -1,0 +1,86 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsRecommendationsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsReport;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\AbandonedOnboardingEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CampaignNoSalesEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CouponsNotSyncedEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\EnhancedConversionsOffEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\NotOnboarded90DaysEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\PausedCampaignEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ProductIssuesEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ReadyButNoSalesEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\RecommendationsAvailableEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SalesNotGrowingEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\Sold10ItemsEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\TrackingOffEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\ServiceBasedMerchantState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class NotificationsServiceProvider
+ *
+ * Provides the notification service and its evaluators to the container. Keeping these
+ * registrations in a dedicated provider stops CoreServiceProvider from growing unbounded
+ * as new notifications are added.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement
+ */
+class NotificationsServiceProvider extends AbstractServiceProvider {
+
+	/**
+	 * @var array
+	 */
+	protected $provides = [
+		Service::class                           => true,
+		NotificationEvaluatorInterface::class    => true,
+		NotificationService::class               => true,
+		AbandonedOnboardingEvaluator::class      => true,
+		CampaignNoSalesEvaluator::class          => true,
+		CouponsNotSyncedEvaluator::class         => true,
+		EnhancedConversionsOffEvaluator::class   => true,
+		NotOnboarded90DaysEvaluator::class       => true,
+		PausedCampaignEvaluator::class           => true,
+		ProductIssuesEvaluator::class            => true,
+		ReadyButNoSalesEvaluator::class          => true,
+		RecommendationsAvailableEvaluator::class => true,
+		SalesNotGrowingEvaluator::class          => true,
+		SkippedCampaignEvaluator::class          => true,
+		Sold10ItemsEvaluator::class              => true,
+		TrackingOffEvaluator::class              => true,
+	];
+
+	/**
+	 * Registers the notification services with the container.
+	 */
+	public function register(): void {
+		$this->share_with_tags( NotificationService::class, WP::class );
+		$this->share_with_tags( SkippedCampaignEvaluator::class, OnboardingCompleted::class );
+		$this->share_with_tags( AbandonedOnboardingEvaluator::class );
+		$this->share_with_tags( NotOnboarded90DaysEvaluator::class, OnboardingCompleted::class );
+		$this->share_with_tags( EnhancedConversionsOffEvaluator::class );
+		$this->share_with_tags( TrackingOffEvaluator::class );
+		$this->share_with_tags( ProductIssuesEvaluator::class, ServiceBasedMerchantState::class );
+		$this->share_with_tags( Sold10ItemsEvaluator::class );
+		$this->share_with_tags( ReadyButNoSalesEvaluator::class, WC::class );
+		$this->share_with_tags( CouponsNotSyncedEvaluator::class, MerchantCenterService::class, TargetAudience::class );
+		$this->share_with_tags( SalesNotGrowingEvaluator::class );
+		$this->share_with_tags( PausedCampaignEvaluator::class, AdsCampaign::class );
+		$this->share_with_tags( CampaignNoSalesEvaluator::class, AdsCampaign::class, AdsReport::class, AdsRecommendationsService::class );
+		$this->share_with_tags( RecommendationsAvailableEvaluator::class, AdsRecommendationsService::class, AdsCampaign::class );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Moves all notification-related DI registrations out of `CoreServiceProvider` into a new dedicated `NotificationsServiceProvider`, so `CoreServiceProvider` stays focused and doesn't grow unbounded as new notifications are added. Pure refactor and no behavior change.

Closes https://linear.app/a8c/issue/GOOWOO-768/extract-notification-services-into-a-dedicated-service-provider

### Screenshots:
N/A

### Detailed test instructions:

This is a DI refactor with no behavior change, so the goal is to confirm the notification system still registers and works exactly as before.

1. Sanity - services resolve from the new provider
On any wp-admin page, open DevTools console and confirm the notifications endpoint responds normally (no fatal / 500):
`wp.apiFetch({ path: '/wc/gla/notifications' }).then( r => console.log( r.notifications ) );`

Expected: returns a notifications array (empty or populated), no errors. This proves `NotificationService` and the evaluator collection resolve through the new `NotificationsServiceProvider`.

2. A notification still fires end-to-end
Trigger any one signal to confirm evaluators still register and render - e.g. turn off usage tracking for tracking-off.

3. Dismissal still works
With a notification showing, dismiss it in the UI (or `wp.apiFetch({ path: '/wc/gla/notifications/<id>', method: 'DELETE' })`) → confirm it disappears and the badge count updates.

4. Menu badge still renders
Confirm the Google for WooCommerce menu item still shows the notification count pill when a notification is active.

5. Regression smoke test
- Load the Marketing / Google for WooCommerce dashboard pages — confirm they load normally (the container change is plugin-wide, so verify no fatal on any admin page).
- Check wp-content/debug.log (or WP debug output) for any "service not found" / container resolution errors.
