### PR TITLE
GOOWOO-731: Fix shipping times not updating during onboarding

### DIFF
--- a/js/src/components/adaptive-form/adaptive-form.js
+++ b/js/src/components/adaptive-form/adaptive-form.js
@@ -25,7 +25,9 @@ function isEvent( value ) {
 /**
  * @typedef {Object} AdaptiveFormHandler
  * @property {(initialValues: Object) => void} resetForm Reset form with given initial values.
- * @property {(name: string, value: *) => void} setValue Set the `name` field of the form states to the given `value`.
+ * @property {(name: string | Object, value?: *) => void} setValue Set the `name` field of the form
+ *   states to the given `value`. Alternatively, pass a single object of `{ fieldName: value }` pairs
+ *   to update multiple fields together as one atomic, queued update.
  */
 
 /**
@@ -147,11 +149,18 @@ function AdaptiveForm( { onSubmit, extendAdapter, children, ...props }, ref ) {
 					// Ref:
 					// - https://github.com/woocommerce/woocommerce/blob/7.1.0/packages/js/components/src/form/form.tsx#L209-L211
 					// - https://github.com/woocommerce/woocommerce/blob/7.1.0/packages/js/components/src/form/form.tsx#L182-L197
+					const valuesToSet =
+						typeof name === 'object' && name !== null
+							? name
+							: { [ name ]: value };
+
 					if ( formContext.setValues ) {
-						formContext.setValues( { [ name ]: value } );
+						formContext.setValues( valuesToSet );
 					} else {
 						// WC < 7.1 goes here as `setValues` was introduced in 7.1.
-						setValue( name, value );
+						Object.keys( valuesToSet ).forEach( ( key ) =>
+							setValue( key, valuesToSet[ key ] )
+						);
 					}
 				};
 

--- a/js/src/components/adaptive-form/adaptive-form.js
+++ b/js/src/components/adaptive-form/adaptive-form.js
@@ -25,9 +25,7 @@ function isEvent( value ) {
 /**
  * @typedef {Object} AdaptiveFormHandler
  * @property {(initialValues: Object) => void} resetForm Reset form with given initial values.
- * @property {(name: string | Object, value?: *) => void} setValue Set the `name` field of the form
- *   states to the given `value`. Alternatively, pass a single object of `{ fieldName: value }` pairs
- *   to update multiple fields together as one atomic, queued update.
+ * @property {(name: string, value: *) => void} setValue Set the `name` field of the form states to the given `value`.
  */
 
 /**
@@ -149,18 +147,11 @@ function AdaptiveForm( { onSubmit, extendAdapter, children, ...props }, ref ) {
 					// Ref:
 					// - https://github.com/woocommerce/woocommerce/blob/7.1.0/packages/js/components/src/form/form.tsx#L209-L211
 					// - https://github.com/woocommerce/woocommerce/blob/7.1.0/packages/js/components/src/form/form.tsx#L182-L197
-					const valuesToSet =
-						typeof name === 'object' && name !== null
-							? name
-							: { [ name ]: value };
-
 					if ( formContext.setValues ) {
-						formContext.setValues( valuesToSet );
+						formContext.setValues( { [ name ]: value } );
 					} else {
 						// WC < 7.1 goes here as `setValues` was introduced in 7.1.
-						Object.keys( valuesToSet ).forEach( ( key ) =>
-							setValue( key, valuesToSet[ key ] )
-						);
+						setValue( name, value );
 					}
 				};
 

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -245,9 +245,8 @@ const SetupFreeListings = ( {
 							} ) ),
 					  ]
 					: filteredRates;
-			if ( nextRates.length !== values.shipping_country_rates.length ) {
-				setValue( 'shipping_country_rates', nextRates );
-			}
+			const ratesChanged =
+				nextRates.length !== values.shipping_country_rates.length;
 
 			// For times: filter removed countries AND add newly added countries.
 			const filteredTimes = values.shipping_country_times.filter(
@@ -273,9 +272,18 @@ const SetupFreeListings = ( {
 							} ) ),
 					  ]
 					: filteredTimes;
+			const timesChanged =
+				nextTimes.length !== values.shipping_country_times.length;
 
-			if ( nextTimes.length !== values.shipping_country_times.length ) {
-				setValue( 'shipping_country_times', nextTimes );
+			if ( ratesChanged || timesChanged ) {
+				setValue( {
+					...( ratesChanged && {
+						shipping_country_rates: nextRates,
+					} ),
+					...( timesChanged && {
+						shipping_country_times: nextTimes,
+					} ),
+				} );
 			}
 		}
 	};

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { createSlotFill } from '@wordpress/components';
 import { pick, noop } from 'lodash';
 
@@ -14,7 +14,9 @@ import {
 } from '~/constants';
 import AppSpinner from '~/components/app-spinner';
 import AppButton from '~/components/app-button';
-import AdaptiveForm from '~/components/adaptive-form';
+import AdaptiveForm, {
+	useAdaptiveFormContext,
+} from '~/components/adaptive-form';
 import ValidationErrors from '~/components/validation-errors';
 import checkErrors from '~/components/free-listings/configure-product-listings/checkErrors';
 import getOfferFreeShippingInitialValue from '~/utils/getOfferFreeShippingInitialValue';
@@ -59,6 +61,99 @@ const getSettings = ( values ) => {
 const alwaysTrue = () => true;
 
 const { Fill, Slot } = createSlotFill( 'gla/SetupFreeListings/SubmitButton' );
+
+/**
+ * Watches the resolved audience countries and keeps `shipping_country_rates` /
+ * `shipping_country_times` in sync whenever countries are added to or removed
+ * from the audience — filling in newly added countries with the currently
+ * selected flat rate/time, and dropping entries for countries no longer in
+ * the audience.
+ *
+ * @param {Object} props
+ * @param {(values: Object) => Array<CountryCode>} props.resolveFinalCountries Callback to resolve the given form `values` to the final list of audience countries.
+ * @param {string} props.currencyCode Store currency code, used when filling in a rate for a newly added country.
+ */
+const SyncShippingWithAudience = ( { resolveFinalCountries, currencyCode } ) => {
+	const { values, setValues } = useAdaptiveFormContext();
+	const audienceCountries = resolveFinalCountries( values );
+	const audienceCountriesKey = audienceCountries.join( ',' );
+	const isFirstRun = useRef( true );
+
+	useEffect( () => {
+		if ( isFirstRun.current ) {
+			isFirstRun.current = false;
+			return;
+		}
+
+		const filteredRates = values.shipping_country_rates.filter(
+			( shippingCountryRate ) =>
+				audienceCountries.includes( shippingCountryRate.country )
+		);
+		const missingCountries = audienceCountries.filter(
+			( country ) =>
+				! filteredRates.some( ( rate ) => rate.country === country )
+		);
+		const existingThreshold = filteredRates.find(
+			isNonFreeShippingRate
+		)?.options?.free_shipping_threshold;
+		const nextRates =
+			values.flat_shipping_rate !== undefined &&
+			missingCountries.length > 0
+				? [
+						...filteredRates,
+						...missingCountries.map( ( country ) => ( {
+							options: {
+								free_shipping_threshold: existingThreshold,
+							},
+							country,
+							currency: currencyCode,
+							rate: values.flat_shipping_rate,
+						} ) ),
+				  ]
+				: filteredRates;
+		const ratesChanged =
+			nextRates.length !== values.shipping_country_rates.length;
+
+		// For times: filter removed countries AND add newly added countries.
+		const filteredTimes = values.shipping_country_times.filter(
+			( shippingTime ) =>
+				audienceCountries.includes( shippingTime.countryCode )
+		);
+		const missingTimesCountries = audienceCountries.filter(
+			( country ) =>
+				! filteredTimes.some(
+					( shippingTime ) => shippingTime.countryCode === country
+				)
+		);
+		const nextTimes =
+			values.flat_shipping_min_time !== null &&
+			values.flat_shipping_max_time !== null &&
+			missingTimesCountries.length > 0
+				? [
+						...filteredTimes,
+						...missingTimesCountries.map( ( countryCode ) => ( {
+							countryCode,
+							time: values.flat_shipping_min_time,
+							maxTime: values.flat_shipping_max_time,
+						} ) ),
+				  ]
+				: filteredTimes;
+		const timesChanged =
+			nextTimes.length !== values.shipping_country_times.length;
+
+		if ( ratesChanged || timesChanged ) {
+			setValues( {
+				...( ratesChanged && { shipping_country_rates: nextRates } ),
+				...( timesChanged && {
+					shipping_country_times: nextTimes,
+				} ),
+			} );
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ audienceCountriesKey ] );
+
+	return null;
+};
 
 /**
  * Setup step to configure product feed.
@@ -215,76 +310,6 @@ const SetupFreeListings = ( {
 		} else if ( TARGET_AUDIENCE_FIELDS.includes( change.name ) ) {
 			onTargetAudienceChange( pick( values, TARGET_AUDIENCE_FIELDS ) );
 
-			// Sync shipping_country_rates with the updated audience countries.
-			const audienceCountries = resolveFinalCountries( values );
-
-			// Filter removed countries AND fill in newly added countries using the current flat rate.
-			const filteredRates = values.shipping_country_rates.filter(
-				( shippingCountryRate ) =>
-					audienceCountries.includes( shippingCountryRate.country )
-			);
-			const missingCountries = audienceCountries.filter(
-				( country ) =>
-					! filteredRates.some( ( rate ) => rate.country === country )
-			);
-			const existingThreshold = filteredRates.find(
-				isNonFreeShippingRate
-			)?.options?.free_shipping_threshold;
-			const nextRates =
-				values.flat_shipping_rate !== undefined &&
-				missingCountries.length > 0
-					? [
-							...filteredRates,
-							...missingCountries.map( ( country ) => ( {
-								options: {
-									free_shipping_threshold: existingThreshold,
-								},
-								country,
-								currency: currencyCode,
-								rate: values.flat_shipping_rate,
-							} ) ),
-					  ]
-					: filteredRates;
-			const ratesChanged =
-				nextRates.length !== values.shipping_country_rates.length;
-
-			// For times: filter removed countries AND add newly added countries.
-			const filteredTimes = values.shipping_country_times.filter(
-				( shippingTime ) =>
-					audienceCountries.includes( shippingTime.countryCode )
-			);
-			const missingTimesCountries = audienceCountries.filter(
-				( country ) =>
-					! filteredTimes.some(
-						( shippingTime ) => shippingTime.countryCode === country
-					)
-			);
-			const nextTimes =
-				values.flat_shipping_min_time !== null &&
-				values.flat_shipping_max_time !== null &&
-				missingTimesCountries.length > 0
-					? [
-							...filteredTimes,
-							...missingTimesCountries.map( ( countryCode ) => ( {
-								countryCode,
-								time: values.flat_shipping_min_time,
-								maxTime: values.flat_shipping_max_time,
-							} ) ),
-					  ]
-					: filteredTimes;
-			const timesChanged =
-				nextTimes.length !== values.shipping_country_times.length;
-
-			if ( ratesChanged || timesChanged ) {
-				setValue( {
-					...( ratesChanged && {
-						shipping_country_rates: nextRates,
-					} ),
-					...( timesChanged && {
-						shipping_country_times: nextTimes,
-					} ),
-				} );
-			}
 		}
 	};
 
@@ -353,6 +378,10 @@ const SetupFreeListings = ( {
 
 					return (
 						<>
+							<SyncShippingWithAudience
+								resolveFinalCountries={ resolveFinalCountries }
+								currencyCode={ currencyCode }
+							/>
 							<FormContent />
 							<Fill>
 								<AppButton

--- a/js/src/components/free-listings/setup-free-listings/index.js
+++ b/js/src/components/free-listings/setup-free-listings/index.js
@@ -73,7 +73,10 @@ const { Fill, Slot } = createSlotFill( 'gla/SetupFreeListings/SubmitButton' );
  * @param {(values: Object) => Array<CountryCode>} props.resolveFinalCountries Callback to resolve the given form `values` to the final list of audience countries.
  * @param {string} props.currencyCode Store currency code, used when filling in a rate for a newly added country.
  */
-const SyncShippingWithAudience = ( { resolveFinalCountries, currencyCode } ) => {
+const SyncShippingWithAudience = ( {
+	resolveFinalCountries,
+	currencyCode,
+} ) => {
 	const { values, setValues } = useAdaptiveFormContext();
 	const audienceCountries = resolveFinalCountries( values );
 	const audienceCountriesKey = audienceCountries.join( ',' );
@@ -93,9 +96,8 @@ const SyncShippingWithAudience = ( { resolveFinalCountries, currencyCode } ) => 
 			( country ) =>
 				! filteredRates.some( ( rate ) => rate.country === country )
 		);
-		const existingThreshold = filteredRates.find(
-			isNonFreeShippingRate
-		)?.options?.free_shipping_threshold;
+		const existingThreshold = filteredRates.find( isNonFreeShippingRate )
+			?.options?.free_shipping_threshold;
 		const nextRates =
 			values.flat_shipping_rate !== undefined &&
 			missingCountries.length > 0
@@ -309,7 +311,6 @@ const SetupFreeListings = ( {
 			}
 		} else if ( TARGET_AUDIENCE_FIELDS.includes( change.name ) ) {
 			onTargetAudienceChange( pick( values, TARGET_AUDIENCE_FIELDS ) );
-
 		}
 	};
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes [GOOWOO-731](https://linear.app/a8c/issue/GOOWOO-731/qa-only-onboarding-flow#comment-89bf645d).

When a merchant adds or removes an audience country during onboarding (or on the Settings/Markets shipping-times flow), the "Estimated shipping times" values for that country are not saved to the database. The DB only updates when the shipping time (min/max) field itself is edited — country-only changes are silently dropped. Shipping rates do not have this problem; only shipping times are affected.

Root cause: the country-add/remove handler queued two separate form updates (rates, then times) through a one-at-a-time update queue; the rates update always went through, the times update was lost.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go through onboarding (or re-onboard after disconnecting) on a store where the simplified flat shipping rate/time options are shown.
2. On "Configure your product listings," set the audience to 2+ countries and note the shipping time min/max values.
3. Add a new country to the audience — do not touch the shipping time input.
4. Complete onboarding (or reload if testing via Settings).
5. Check the DB (`GET /wp-json/wc/gla/mc/shipping/times` or the Settings shipping-times view) — the new country has no shipping time entry.
6. Repeat step 3 by removing a country instead — its shipping time entry is never deleted from the DB.
7. For comparison: change the shipping time value itself (no country change) — this saves correctly, confirming the bug is specific to country add/remove.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
