### PR TITLE
[GOOWOO-780] Hide add market button when only one country selected

### DIFF
--- a/js/src/pages/markets/components/add-market-button.js
+++ b/js/src/pages/markets/components/add-market-button.js
@@ -10,6 +10,7 @@ import { useState, useCallback } from '@wordpress/element';
 import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 import useSettings from '~/hooks/useSettings';
 import AppButton from '~/components/app-button';
+import usePrimaryMarketDetails from '../hooks/usePrimaryMarketDetails';
 import AddMarketModal from './add-market-modal';
 
 /**
@@ -20,6 +21,10 @@ import AddMarketModal from './add-market-modal';
 
 /**
  * Component for the "Add market" button on the markets page, which opens a modal to add a new market.
+ *
+ * Hidden when the primary market's audience covers only a single country, since
+ * markets are derived from the primary market's countries and none remain to add.
+ *
  * @fires gla_add_market_button_clicked event when the button is clicked
  */
 const AddMarketButton = () => {
@@ -27,9 +32,20 @@ const AddMarketButton = () => {
 	const { targetAudience, loaded: hasResolvedTargetAudience } =
 		useTargetAudienceFinalCountryCodes();
 	const { settings } = useSettings();
+	const {
+		data: primaryMarket,
+		hasFinishedResolution: hasResolvedPrimaryMarket,
+	} = usePrimaryMarketDetails();
 
 	const handleOpen = useCallback( () => setIsOpen( true ), [] );
 	const handleClose = useCallback( () => setIsOpen( false ), [] );
+
+	if (
+		! hasResolvedPrimaryMarket ||
+		primaryMarket?.countries?.length === 1
+	) {
+		return null;
+	}
 
 	return (
 		<>

--- a/js/src/pages/markets/components/add-market-button.js
+++ b/js/src/pages/markets/components/add-market-button.js
@@ -40,10 +40,7 @@ const AddMarketButton = () => {
 	const handleOpen = useCallback( () => setIsOpen( true ), [] );
 	const handleClose = useCallback( () => setIsOpen( false ), [] );
 
-	if (
-		! hasResolvedPrimaryMarket ||
-		primaryMarket?.countries?.length === 1
-	) {
+	if ( ! hasResolvedPrimaryMarket || primaryMarket?.countries?.length <= 1 ) {
 		return null;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-780/hide-add-market-button-when-primary-market-has-only-1-country

Hides the 'Add market' button from the Markets tab when only one country selected in audience.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Update the countries in the Audience section to have just one selected.
2. Navigate to the Markets tab and ensure there's **no 'Add market' button present**
3. Edit the Audience section back to inlcude more countries to ensure the button displays correctly when more than one country is chosen.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
