### PR TITLE
WOOAI-749: Allow custom attributes

### DIFF
--- a/src/Product/WCProductAdapter.php
+++ b/src/Product/WCProductAdapter.php
@@ -69,6 +69,12 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 	protected $product_category_ids;
 
 	/**
+	 * @var array Custom attributes to attach to the product, as plain arrays matching the
+	 *            Google `CustomAttribute` shape. Populated via self::add_custom_attribute().
+	 */
+	protected $custom_attributes = [];
+
+	/**
 	 * Initialize this object's properties from an array.
 	 *
 	 * @param array $properties Used to seed this object's properties.
@@ -156,8 +162,11 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		 *
 		 * @param WC_Product       $wc_product The WooCommerce product object.
 		 * @param WCProductAdapter $this       The Adapted Google product object. All WooCommerce product properties
-		 *                                     are already mapped to this object.
+		 *                                     are already mapped to this object. Custom attributes can be attached
+		 *                                     to the product by calling `$this->add_custom_attribute( [ 'name' => ...,
+		 *                                     'value' => ... ] )` on it from within this filter.
 		 *
+		 * @see WCProductAdapter::add_custom_attribute for attaching Google custom attributes to the product.
 		 * @see \Google\Service\ShoppingContent\Product for the list of product properties that can be overridden.
 		 * @see WCProductAdapter::map_gla_attributes for the docuementation of `woocommerce_gla_product_attribute_value_{$attribute_id}`
 		 *                                           filter, which allows modifying some attributes such as GTIN, MPN, etc.
@@ -166,9 +175,62 @@ class WCProductAdapter extends GoogleProduct implements Validatable {
 		 */
 		$attributes = apply_filters( 'woocommerce_gla_product_attribute_values', [], $this->wc_product, $this );
 
+		// Custom attributes added via self::add_custom_attribute() (typically from within the filter
+		// above) are merged into the overrides so the base class converts them to typed
+		// CustomAttribute objects and attaches them to the product.
+		if ( ! empty( $this->custom_attributes ) ) {
+			$existing                       = $attributes['customAttributes'] ?? $this->getCustomAttributes() ?? [];
+			$attributes['customAttributes'] = array_merge( $existing, $this->custom_attributes );
+		}
+
 		if ( ! empty( $attributes ) ) {
 			parent::mapTypes( $attributes );
 		}
+	}
+
+	/**
+	 * Get the custom attributes buffered for this product.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @return array
+	 */
+	public function get_custom_attributes(): array {
+		return $this->custom_attributes;
+	}
+
+	/**
+	 * Replace the custom attributes buffered for this product.
+	 *
+	 * Each entry is a plain array matching the Google `CustomAttribute` shape, e.g.
+	 * `[ 'name' => 'foo', 'value' => 'bar' ]` or
+	 * `[ 'name' => 'foo', 'groupValues' => [ [ 'name' => 'k', 'value' => 'v' ] ] ]`.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @param array $custom_attributes
+	 *
+	 * @return void
+	 */
+	public function set_custom_attributes( array $custom_attributes ): void {
+		$this->custom_attributes = array_values( $custom_attributes );
+	}
+
+	/**
+	 * Append a single custom attribute to this product.
+	 *
+	 * Intended for use from the `woocommerce_gla_product_attribute_values` filter, where the adapter
+	 * is passed as the third argument, so extensions can attach custom attributes without modifying
+	 * core code.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @param array $custom_attribute A plain array matching the Google `CustomAttribute` shape.
+	 *
+	 * @return void
+	 */
+	public function add_custom_attribute( array $custom_attribute ): void {
+		$this->custom_attributes[] = $custom_attribute;
 	}
 
 	/**

--- a/tests/Unit/Product/WCProductAdapterTest.php
+++ b/tests/Unit/Product/WCProductAdapterTest.php
@@ -1678,6 +1678,99 @@ class WCProductAdapterTest extends UnitTest {
 		);
 	}
 
+	public function test_custom_attributes_can_be_added_via_filter() {
+		add_filter(
+			'woocommerce_gla_product_attribute_values',
+			function ( array $attributes, WC_Product $product, WCProductAdapter $google_product ) {
+				$google_product->add_custom_attribute(
+					[
+						'name'        => 'native_commerce',
+						'groupValues' => [
+							[
+								'name'  => 'checkout_eligibility',
+								'value' => 'true',
+							],
+						],
+					]
+				);
+				$google_product->add_custom_attribute(
+					[
+						'name'  => 'merchant_item_id',
+						'value' => (string) $product->get_id(),
+					]
+				);
+
+				return $attributes;
+			},
+			10,
+			3
+		);
+
+		$product         = WC_Helper_Product::create_simple_product();
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'    => $product,
+				'targetCountry' => 'US',
+			]
+		);
+
+		$custom_attributes = $adapted_product->getCustomAttributes();
+		$this->assertCount( 2, $custom_attributes );
+
+		$this->assertEquals( 'native_commerce', $custom_attributes[0]->getName() );
+		$this->assertEquals( 'checkout_eligibility', $custom_attributes[0]->getGroupValues()[0]->getName() );
+		$this->assertEquals( 'true', $custom_attributes[0]->getGroupValues()[0]->getValue() );
+
+		$this->assertEquals( 'merchant_item_id', $custom_attributes[1]->getName() );
+		$this->assertEquals( (string) $product->get_id(), $custom_attributes[1]->getValue() );
+	}
+
+	public function test_custom_attribute_accessors() {
+		$adapted_product = new WCProductAdapter(
+			[
+				'wc_product'    => WC_Helper_Product::create_simple_product(),
+				'targetCountry' => 'US',
+			]
+		);
+
+		$this->assertEquals( [], $adapted_product->get_custom_attributes() );
+
+		$adapted_product->add_custom_attribute(
+			[
+				'name'  => 'x',
+				'value' => '1',
+			]
+		);
+		$this->assertEquals(
+			[
+				[
+					'name'  => 'x',
+					'value' => '1',
+				],
+			],
+			$adapted_product->get_custom_attributes()
+		);
+
+		// set_custom_attributes replaces (and reindexes) the buffered list.
+		$adapted_product->set_custom_attributes(
+			[
+				2 => [
+					'name'  => 'y',
+					'value' => '2',
+				],
+			]
+		);
+		$this->assertEquals(
+			[
+				[
+					'name'  => 'y',
+					'value' => '2',
+				],
+			],
+			$adapted_product->get_custom_attributes()
+		);
+	}
+
 	/**
 	 * Validate a product property and return the first violation.
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of https://linear.app/a8c/issue/WOOAI-749/ucp-integrate-google-listings-and-ads-plugin

This PR introduces custom attributes for Google Merchant Center integration.
It is an adaptation of [the already merged PR](https://github.com/woocommerce/google-listings-and-ads/pull/3522) that will take effect after API migration is complete.

This PR is aiming to get custom attributes into the plugin code sooner, bypassing the API migration project blocker.

### Screenshots:
<img width="736" height="245" alt="Screenshot 2026-07-10 at 8 26 32 PM" src="https://github.com/user-attachments/assets/e0c39f71-0017-4dfb-99c2-3347275fe7bc" />


### Detailed test instructions:
1. Add a code snippet:
```php
add_filter( 'woocommerce_gla_product_attribute_values', function ( $overrides, $product, $adapter ) {
    $adapter->add_custom_attribute( [
        'name'        => 'native_commerce',
        'groupValues' => [ [ 'name' => 'checkout_eligibility', 'value' => 'true' ] ],
    ] );
    return $overrides;
}, 10, 3 );
```
2. Sync a product.
3. Open the product in MC, confirm "Additional details" contain the parameter:
```
native_commerce: [native_commerce_checkout_eligibility: True]
```

### Changelog entry
> Dev - Allow extensions to attach Merchant API custom attributes to synced products via the woocommerce_gla_product_attribute_values filter.