### PR TITLE
Fix GOOWOO-555: wrap Linked accounts description in <p> for mobile spacing

### DIFF
--- a/js/src/pages/settings/linked-accounts-section-wrapper.js
+++ b/js/src/pages/settings/linked-accounts-section-wrapper.js
@@ -25,7 +25,7 @@ export default function LinkedAccountsSectionWrapper( props ) {
 	return (
 		<Section
 			title={ __( 'Linked accounts', 'google-listings-and-ads' ) }
-			description={ description }
+			description={ <p>{ description }</p> }
 			{ ...props }
 		/>
 	);

--- a/js/src/pages/settings/linked-accounts-section-wrapper.test.js
+++ b/js/src/pages/settings/linked-accounts-section-wrapper.test.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import LinkedAccountsSectionWrapper from './linked-accounts-section-wrapper';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+
+jest.mock( '~/hooks/useGoogleMCAccount', () =>
+	jest.fn().mockName( 'useGoogleMCAccount' )
+);
+
+describe( 'LinkedAccountsSectionWrapper', () => {
+	it( 'wraps the description in a <p> so it receives the section paragraph spacing', () => {
+		useGoogleMCAccount.mockReturnValue( { hasGoogleMCConnection: true } );
+
+		const { container } = render( <LinkedAccountsSectionWrapper /> );
+
+		// The section stylesheet only applies bottom margin to <p> elements in
+		// the header, so the description must be wrapped in a <p> to be spaced
+		// away from the boxes when the layout stacks on mobile.
+		const paragraph = container.querySelector( '.gla-section__header p' );
+		expect( paragraph ).toBeInTheDocument();
+		expect( paragraph ).toHaveTextContent(
+			/required to use this extension/
+		);
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The **Linked accounts** section description on the Settings page had no bottom margin on mobile. When the section layout stacks (mobile), the description sat flush against the account boxes below, unlike every other section.

The shared `Section` component renders its header `description` raw, and the section stylesheet applies a bottom margin only to `<p>` elements in the header (`.gla-section__header p { margin: 0 0 $grid-unit; }`). `LinkedAccountsSectionWrapper` passed its description as a bare string, so it received no spacing. This wraps the description in a `<p>`, matching the other sections (e.g. `enhanced-conversions/setup-enhanced-conversions.js`), so it picks up the standard header spacing. Adds a Jest regression test.

Reported in Linear: [GOOWOO-555](https://linear.app/a8c/issue/GOOWOO-555)

### Screenshots:

| Before | After |
|---|---|
| <img width="888" height="1830" alt="GOOWOO-555-linked-accounts-mobile-before" src="https://github.com/user-attachments/assets/fef1a4cc-18ec-4f38-bdeb-d17935ae1801" /> | <img width="888" height="1830" alt="GOOWOO-555-linked-accounts-mobile-after" src="https://github.com/user-attachments/assets/22ddc7f9-24d8-4711-83a2-3d2ec2baf6c2" /> |

### Detailed test instructions:

**Environment:** WordPress + WooCommerce + Google for WooCommerce (this branch); a connected Google Merchant Center account.
**Preconditions:** On the Settings page at a mobile width (or dev-tools device mode) so the section layout stacks.

1. Go to **Marketing → Google for WooCommerce → Settings**.
2. Narrow the viewport to mobile width.
3. Find the **Linked accounts** section.

**Validation:** There is a clear gap between the description ("A WordPress.com account…") and the account boxes below, consistent with the other sections.

**Automated:** `npm run test:js -- js/src/pages/settings/linked-accounts-section-wrapper.test.js` — asserts the description renders inside `.gla-section__header p` (red before the fix, green after).

### Additional details:

Markup-only change; no behavioral change. Regression test added.

### Changelog entry

Fix - Add missing spacing under the Linked accounts section description on mobile view.

---

This PR was created during the p6q7sZ-lkg-p2 via team Ceres' [`/bug-blitz` Claude skill](https://github.com/Automattic/public-resources-squad/blob/trunk/.claude/skills/bug-blitz/skill.md). The fix was authored with Claude Code assistance by a Happiness Engineer who encounters this bug in support tickets.