### PR TITLE
Add backward-compatibility guardrail to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,9 @@ Rules:
 
 - **Never add or remove a required method on an interface that external code can implement** — existing implementers fatal on load. Prefer adding the method to the concrete class, introducing a new interface, or supplying a default implementation in an abstract base class. If an interface change is unavoidable, flag it explicitly.
 - **Deprecate, don't rename.** Never rename or remove an existing public symbol in place: mark it `@deprecated`, introduce the replacement alongside it, and keep both working through a deprecation window.
-- **Don't implement or type-hint WooCommerce core's `Internal\` classes or interfaces** — core treats them as changeable in any release. If unavoidable, guard the dependency with `interface_exists()` / `method_exists()` checks so a core change doesn't fatal this plugin.
+- **Don't implement or type-hint WooCommerce core's `Internal\` classes or interfaces** — core treats them as changeable in any release. If unavoidable, guard the dependency with `class_exists()` / `interface_exists()` / `method_exists()` checks so a core change doesn't cause a fatal error in this plugin.
 
-> Why: WooCommerce 10.9.0 was reverted on WP Cloud after woocommerce/woocommerce#64394 added a required method to core's internal `FeedInterface`, fataling older WooCommerce Stripe Gateway versions that implemented it (fixed in woocommerce/woocommerce#65965). The same failure mode applies to any published WooCommerce extension.
+> Why: WooCommerce 10.9.0 was reverted on WP Cloud after woocommerce/woocommerce#64394 added a required method to core's internal `FeedInterface`, causing fatal errors in older WooCommerce Stripe Gateway versions that implemented it (fixed in woocommerce/woocommerce#65965). The same failure mode applies to any published WooCommerce extension.
 
 ### The compatibility surface is wider than PHP signatures
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md — Google for WooCommerce
+
+Guidelines for AI coding agents working in this repository (the `google-listings-and-ads` plugin, published as **Google for WooCommerce**). This plugin runs on live merchant stores and its public surface is consumed by other extensions, themes, and custom site code, so backward compatibility is a release-blocking concern.
+
+- **Namespace root:** `Automattic\WooCommerce\GoogleListingsAndAds\` (`src/`)
+- **Text domain / slug:** `google-listings-and-ads`
+
+## Backward Compatibility
+
+Any change to a **public or externally exposed** class, interface, function, method, hook, or REST endpoint signature is **high-risk** and **must state its backward-compatibility impact in the PR description** — regardless of whether the symbol lives in the `Internal` namespace. The `Internal` namespace is not a guarantee that a symbol is safe to change: third-party code implements and consumes some of these contracts in practice.
+
+Treat a symbol as **externally exposed** when it is implemented or consumed outside this plugin — by other extensions, themes, or custom site code — even if it lives under `Internal`. WordPress actions and filters this plugin fires or registers count as externally exposed: renaming a hook, changing its arguments, or dropping it breaks whatever is hooked in. When in doubt, assume it is exposed and state the BC impact.
+
+**Adding a method to an interface that external code can implement must be flagged explicitly.** It is a backward-incompatible change: existing implementers fatal on load because they no longer satisfy the contract. Likewise, **removing a required method from an interface is breaking** for existing implementers. Prefer a non-breaking alternative — add the method to the concrete class rather than the interface, introduce a separate new interface, or supply a default implementation via an abstract base class.
+
+**Deprecate, don't rename.** For existing public symbols (classes, interfaces, methods, constants, hooks), never rename or remove them in place. Mark the old symbol `@deprecated`, introduce the replacement alongside it, and keep both working through a deprecation window so external consumers have time to migrate.
+
+> Why this matters: a signature change to a shared contract can take down live stores. WooCommerce 10.9.0 was reverted on WP Cloud after PR #64394 added a required `get_entry_count(): int` method to `FeedInterface`, fataling older WooCommerce Stripe Gateway versions that implemented it (fixed in PR #65965). The same failure mode applies to any published WooCommerce extension.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,14 +7,16 @@ Guidelines for AI coding agents working in this repository (the `google-listings
 
 ## Backward Compatibility
 
-Any change to a **public or externally exposed** class, interface, function, method, hook, or REST endpoint signature is **high-risk** and **must state its backward-compatibility impact in the PR description** — regardless of whether the symbol lives in this plugin's `Internal` namespace. `Internal` is not a guarantee that a symbol is safe to change: other extensions, themes, and custom site code implement and consume these contracts in practice. When in doubt, assume it is exposed and state the BC impact.
+Any change to a **public or externally exposed** class, interface, function, method, hook, or REST endpoint signature is **high-risk** and **must state its backward-compatibility impact in the PR description**. An internal-looking name or location — including this plugin's `Internal` namespace — is not by itself a guarantee that a symbol is safe to change: other extensions, themes, and custom site code implement and consume some of these contracts in practice. See the exposed-surface list for what counts and the **Scope** note for what does not; when a symbol is genuinely reachable and useful to outside code, err toward treating it as exposed.
 
-For this plugin, externally exposed includes:
+**Externally exposed surface** — treat changes here as high-risk:
 
-- **Custom hooks** — the actions and filters this plugin fires (the `woocommerce_gla_` prefix). Renaming a hook, changing its arguments, or dropping it breaks whatever is hooked in.
+- **Custom hooks** — the actions and filters this plugin fires (the `woocommerce_gla_` prefix). These are documented integration points for merchant site code and other extensions. Renaming a hook, changing or reordering its arguments, or dropping it breaks whatever is hooked in; to retire one, fire it through `do_action_deprecated()` / `apply_filters_deprecated()` for a deprecation window.
 - **REST API** — the `wc/gla` routes, their request/response shapes, and their auth expectations.
-- **Public PHP** — any `public` class, method, or function under `Automattic\WooCommerce\GoogleListingsAndAds\` that another plugin or theme can autoload and call, including symbols under `Internal`.
+- **Public PHP** — any `public` class, method, or function under `Automattic\WooCommerce\GoogleListingsAndAds\` that another plugin or theme actually autoloads and calls, plus any symbol explicitly documented as extensible.
 - **Front-end globals** — the `glaData` JS global and any properties page scripts may read.
+
+**Scope — what is *not* a third-party contract:** the dependency-injection container and the `Internal\` classes that exist only so the container can construct and wire services are internal implementation, not an API other extensions build on. An ordinary signature change to one of them does **not** require a BC statement. When you are unsure whether a symbol is a contract, check the exposed surface above rather than assuming every `public` method is one.
 
 Rules:
 
@@ -23,3 +25,19 @@ Rules:
 - **Don't implement or type-hint WooCommerce core's `Internal\` classes or interfaces** — core treats them as changeable in any release. If unavoidable, guard the dependency with `interface_exists()` / `method_exists()` checks so a core change doesn't fatal this plugin.
 
 > Why: WooCommerce 10.9.0 was reverted on WP Cloud after woocommerce/woocommerce#64394 added a required method to core's internal `FeedInterface`, fataling older WooCommerce Stripe Gateway versions that implemented it (fixed in woocommerce/woocommerce#65965). The same failure mode applies to any published WooCommerce extension.
+
+### The compatibility surface is wider than PHP signatures
+
+WordPress exposes more contracts than class and function signatures. A change to any of the following is equally high-risk and needs the same backward-compatibility impact statement in the PR.
+
+- **Global state.** Code runs in admin, REST, CLI, cron, webhook, and front-end contexts, and not all set the globals a front-end request does (`$post`, `$wp_query`, an initialized session or cart). A new read of a global — or of `WC()->…` state — in a path reachable outside a standard request fatals or silently misbehaves where it isn't set. Guard the exact dependency (`function_exists`/`class_exists` for symbols, `isset` for variables, `did_action` for lifecycle) and verify `WC()` and the component are initialized before dereferencing.
+- **Multisite.** Site-scoped vs network-scoped options (`get_option` vs `get_site_option`), per-site tables, capabilities, and upload paths all differ under multisite. A change that reads or writes site state must state whether it behaves correctly under multisite, or say it wasn't tested there.
+- **Install layout.** WordPress can run in a subdirectory, with relocated `wp-content`, and behind reverse proxies. Never build paths or URLs by concatenation from the domain root; derive them (`plugins_url()`, `plugin_dir_path()`, `wp_upload_dir()`, and mind `home_url()` vs `site_url()`).
+
+### Before changing any public or externally exposed surface (agent checklist)
+
+1. Identify the contract you are touching: signature, hook, global/scope expectation, site topology, or install layout.
+2. Assume unseen consumers — you cannot enumerate third-party code; if the surface is reachable from outside this plugin, someone may consume it.
+3. Prefer the additive path (new optional method, appended hook argument, new symbol + deprecation) over changing what exists.
+4. State the impact in the PR description: what changed, who could consume it, and why it is safe or what the deprecation path is.
+5. If you cannot establish the impact, stop and flag it for review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,19 @@ Guidelines for AI coding agents working in this repository (the `google-listings
 
 ## Backward Compatibility
 
-Any change to a **public or externally exposed** class, interface, function, method, hook, or REST endpoint signature is **high-risk** and **must state its backward-compatibility impact in the PR description** — regardless of whether the symbol lives in the `Internal` namespace. The `Internal` namespace is not a guarantee that a symbol is safe to change: third-party code implements and consumes some of these contracts in practice.
+Any change to a **public or externally exposed** class, interface, function, method, hook, or REST endpoint signature is **high-risk** and **must state its backward-compatibility impact in the PR description** — regardless of whether the symbol lives in this plugin's `Internal` namespace. `Internal` is not a guarantee that a symbol is safe to change: other extensions, themes, and custom site code implement and consume these contracts in practice. When in doubt, assume it is exposed and state the BC impact.
 
-Treat a symbol as **externally exposed** when it is implemented or consumed outside this plugin — by other extensions, themes, or custom site code — even if it lives under `Internal`. WordPress actions and filters this plugin fires or registers count as externally exposed: renaming a hook, changing its arguments, or dropping it breaks whatever is hooked in. When in doubt, assume it is exposed and state the BC impact.
+For this plugin, externally exposed includes:
 
-**Adding a method to an interface that external code can implement must be flagged explicitly.** It is a backward-incompatible change: existing implementers fatal on load because they no longer satisfy the contract. Likewise, **removing a required method from an interface is breaking** for existing implementers. Prefer a non-breaking alternative — add the method to the concrete class rather than the interface, introduce a separate new interface, or supply a default implementation via an abstract base class.
+- **Custom hooks** — the actions and filters this plugin fires (the `woocommerce_gla_` prefix). Renaming a hook, changing its arguments, or dropping it breaks whatever is hooked in.
+- **REST API** — the `wc/gla` routes, their request/response shapes, and their auth expectations.
+- **Public PHP** — any `public` class, method, or function under `Automattic\WooCommerce\GoogleListingsAndAds\` that another plugin or theme can autoload and call, including symbols under `Internal`.
+- **Front-end globals** — the `glaData` JS global and any properties page scripts may read.
 
-**Deprecate, don't rename.** For existing public symbols (classes, interfaces, methods, constants, hooks), never rename or remove them in place. Mark the old symbol `@deprecated`, introduce the replacement alongside it, and keep both working through a deprecation window so external consumers have time to migrate.
+Rules:
 
-> Why this matters: a signature change to a shared contract can take down live stores. WooCommerce 10.9.0 was reverted on WP Cloud after PR #64394 added a required `get_entry_count(): int` method to `FeedInterface`, fataling older WooCommerce Stripe Gateway versions that implemented it (fixed in PR #65965). The same failure mode applies to any published WooCommerce extension.
+- **Never add or remove a required method on an interface that external code can implement** — existing implementers fatal on load. Prefer adding the method to the concrete class, introducing a new interface, or supplying a default implementation in an abstract base class. If an interface change is unavoidable, flag it explicitly.
+- **Deprecate, don't rename.** Never rename or remove an existing public symbol in place: mark it `@deprecated`, introduce the replacement alongside it, and keep both working through a deprecation window.
+- **Don't implement or type-hint WooCommerce core's `Internal\` classes or interfaces** — core treats them as changeable in any release. If unavoidable, guard the dependency with `interface_exists()` / `method_exists()` checks so a core change doesn't fatal this plugin.
+
+> Why: WooCommerce 10.9.0 was reverted on WP Cloud after woocommerce/woocommerce#64394 added a required method to core's internal `FeedInterface`, fataling older WooCommerce Stripe Gateway versions that implemented it (fixed in woocommerce/woocommerce#65965). The same failure mode applies to any published WooCommerce extension.


### PR DESCRIPTION
_Note: This PR is part of the wider WooCommerce quality effort focused on release stability and version compatibility. Tracking: PAY-825._

### What

Adds an `AGENTS.md` with a **Backward Compatibility** section. It tells AI coding agents and contributors to treat any change to a public or externally exposed signature — classes, interfaces, methods, hooks, REST endpoints — as high-risk, and to state the backward-compatibility impact in the PR description. It also warns against implementing or type-hinting WooCommerce core `Internal\` APIs, which core may change in any release.

### Why

This plugin runs on live merchant stores, and its public surface is used by other extensions, themes, and site code. A silent change to a shared signature can fatal those consumers on load. WooCommerce Core added the same guardrail after such a change forced a release to be reverted; this brings the plugin in line.

Docs-only change — no runtime code is affected.