### PR TITLE
GOOWOO-793: Product status refresh rejects legacy-format product IDs

### DIFF
--- a/src/Jobs/Update/PluginUpdate.php
+++ b/src/Jobs/Update/PluginUpdate.php
@@ -46,6 +46,11 @@ class PluginUpdate implements Service, InstallableInterface {
 		'1.12.6' => [
 			UpdateAllProducts::class,
 		],
+		// Merchant API release: re-sync all products so ids synced under the legacy Content API
+		// (colon format, rejected by the Merchant API) are rewritten to the Merchant API format.
+		'3.8.0'  => [
+			UpdateAllProducts::class,
+		],
 	];
 
 	/**

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwa
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\Transients;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductMetaHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
@@ -393,8 +394,10 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		/** @var ProductHelper $product_helper */
 		$product_helper = $this->container->get( ProductHelper::class );
 		/** @var MapiProductsService $mapi_products */
-		$mapi_products       = $this->container->get( MapiProductsService::class );
-		$visibility_meta_key = $this->prefix_meta_key( ProductMetaHandler::KEY_VISIBILITY );
+		$mapi_products = $this->container->get( MapiProductsService::class );
+		/** @var BatchProductHelper $batch_product_helper */
+		$batch_product_helper = $this->container->get( BatchProductHelper::class );
+		$visibility_meta_key  = $this->prefix_meta_key( ProductMetaHandler::KEY_VISIBILITY );
 
 		// Map each synced Merchant API product ID back to its WooCommerce product.
 		$google_id_to_wc_id = [];
@@ -416,6 +419,10 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			}
 
 			foreach ( $product_helper->get_synced_google_product_ids( $wc_product ) ?? [] as $google_id ) {
+				// Skip legacy (pre-migration) colon-format ids; the Merchant API rejects them as invalid names.
+				if ( null === $batch_product_helper->parse_mapi_identity( (string) $google_id ) ) {
+					continue;
+				}
 				$google_id_to_wc_id[ $google_id ] = $wc_product_id;
 			}
 		}

--- a/tests/Unit/Jobs/Update/PluginUpdateTest.php
+++ b/tests/Unit/Jobs/Update/PluginUpdateTest.php
@@ -1,0 +1,53 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs\Update;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\Update\PluginUpdate;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class PluginUpdateTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Jobs\Update
+ */
+class PluginUpdateTest extends UnitTest {
+
+	/** @var MockObject|JobRepository $job_repository */
+	protected $job_repository;
+
+	/** @var PluginUpdate $plugin_update */
+	protected $plugin_update;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->job_repository = $this->createMock( JobRepository::class );
+		$this->plugin_update  = new PluginUpdate( $this->job_repository );
+	}
+
+	public function test_upgrading_to_mapi_release_schedules_full_product_resync() {
+		$update_all_products = $this->createMock( UpdateAllProducts::class );
+		$update_all_products->expects( $this->once() )->method( 'schedule' );
+
+		// 3.7.3 is above the older 1.x entries, so only the 3.8.0 job fires: a store upgrading
+		// from the Content API era must re-sync every product to pick up Merchant API ids.
+		$this->job_repository->expects( $this->once() )
+			->method( 'get' )
+			->with( UpdateAllProducts::class )
+			->willReturn( $update_all_products );
+
+		$this->plugin_update->install( '3.7.3', '3.8.0' );
+	}
+
+	public function test_upgrading_within_mapi_versions_does_not_reschedule_resync() {
+		// No-refire boundary guard, not fix verification: the fires-on-upgrade case is covered by
+		// test_upgrading_to_mapi_release_schedules_full_product_resync. This pins the gate at `<` so
+		// a store already on the Merchant API release (>= 3.8.0) never re-runs the re-sync.
+		$this->job_repository->expects( $this->never() )->method( 'get' );
+
+		$this->plugin_update->install( '3.8.0', '3.8.1' );
+	}
+}

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -12,6 +12,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\Transients;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\Attributes\AttributeManager;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
@@ -116,6 +120,16 @@ class MerchantStatusesTest extends UnitTest {
 		$this->container->addShared( UpdateMerchantProductStatuses::class, $this->update_merchant_product_statuses_job );
 		$this->container->addShared( UpdateAllProducts::class, $this->update_all_product_job );
 		$this->container->addShared( DeleteAllProducts::class, $this->delete_all_product_job );
+		$this->container->addShared(
+			BatchProductHelper::class,
+			new BatchProductHelper(
+				$this->createMock( ProductMetaHandler::class ),
+				$this->product_helper,
+				$this->createMock( TargetAudience::class ),
+				$this->createMock( AttributeMappingRulesQuery::class ),
+				$this->createMock( AttributeManager::class )
+			)
+		);
 
 		$this->job_repository = new JobRepository();
 		$this->job_repository->set_container( $this->container );
@@ -700,6 +714,100 @@ class MerchantStatusesTest extends UnitTest {
 
 		$this->merchant_statuses->process_product_statuses(
 			$product_statuses
+		);
+	}
+
+	public function test_process_product_statuses_skips_legacy_google_ids() {
+		$product_valid  = WC_Helper_Product::create_simple_product();
+		$product_legacy = WC_Helper_Product::create_simple_product();
+
+		$this->product_repository->method( 'find_by_ids_as_associative_array' )
+		->willReturnCallback(
+			function ( $ids ) use ( $product_valid, $product_legacy ) {
+				$map = [
+					$product_valid->get_id()  => $product_valid,
+					$product_legacy->get_id() => $product_legacy,
+				];
+				return array_intersect_key( $map, array_flip( $ids ) );
+			}
+		);
+
+		$this->options->method( 'get' )->willReturn( null );
+
+		// product_valid carries a Merchant API id; product_legacy still has a pre-migration
+		// colon-format id that the Merchant API rejects as an invalid name.
+		$this->product_helper->method( 'get_synced_google_product_ids' )
+		->willReturnCallback(
+			function ( $product ) use ( $product_legacy ) {
+				if ( $product->get_id() === $product_legacy->get_id() ) {
+					return [ 'ES' => $this->get_mc_id( $product->get_id() ) ];
+				}
+				return [ 'ES' => $this->get_mapi_id( $product->get_id() ) ];
+			}
+		);
+
+		// Only the valid Merchant API id reaches the products service; the legacy id is filtered out.
+		$this->mapi_products_service->expects( $this->once() )
+		->method( 'get_many' )
+		->with( [ $this->get_mapi_id( $product_valid->get_id() ) ] )
+		->willReturn( [] );
+
+		$this->merchant_statuses->process_product_statuses(
+			[
+				[
+					'mc_id'           => $this->get_mc_id( $product_valid->get_id() ),
+					'product_id'      => $product_valid->get_id(),
+					'status'          => MCStatus::APPROVED,
+					'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
+				],
+				[
+					'mc_id'           => $this->get_mc_id( $product_legacy->get_id() ),
+					'product_id'      => $product_legacy->get_id(),
+					'status'          => MCStatus::APPROVED,
+					'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
+				],
+			]
+		);
+	}
+
+	public function test_process_product_statuses_keeps_valid_ids_when_a_product_has_mixed_ids() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->product_repository->method( 'find_by_ids_as_associative_array' )
+		->willReturnCallback(
+			function ( $ids ) use ( $product ) {
+				return array_intersect_key( [ $product->get_id() => $product ], array_flip( $ids ) );
+			}
+		);
+
+		$this->options->method( 'get' )->willReturn( null );
+
+		// One product synced in two countries: a legacy colon-format id and a Merchant API id.
+		$this->product_helper->method( 'get_synced_google_product_ids' )
+		->willReturnCallback(
+			function ( $wc_product ) {
+				return [
+					'ES' => $this->get_mc_id( $wc_product->get_id() ),
+					'US' => $this->get_mapi_id( $wc_product->get_id() ),
+				];
+			}
+		);
+
+		// Only the Merchant API id reaches the products service; the legacy id is dropped.
+		$this->mapi_products_service->expects( $this->once() )
+		->method( 'get_many' )
+		->with( [ $this->get_mapi_id( $product->get_id() ) ] )
+		->willReturn( [] );
+
+		$this->merchant_statuses->process_product_statuses(
+			[
+				[
+					'mc_id'           => $this->get_mapi_id( $product->get_id() ),
+					'product_id'      => $product->get_id(),
+					'status'          => MCStatus::APPROVED,
+					'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
+				],
+			]
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Products synced before the Merchant API migration kept legacy Content API ids (colon format, e.g. online:en:US:gla_209). The Merchant Center status refresh sent those straight to the Merchant API, which rejects them as "Invalid name", so those products never got a status update and the log filled with errors. This fixes the errors and corrects the underlying ids.

Closes https://linear.app/a8c/issue/GOOWOO-793/product-status-refresh-rejects-legacy-format-product-ids

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->


- On a store with products synced under the old Content API (colon-format ids in the `_wc_gla_google_ids` meta), let the Product Feed status refresh run.
- Before: "Invalid name" errors in the logs; the status batch fails.
- After: no such errors; valid products show statuses; legacy-id products are skipped, not errored.
- To simulate on a clean store, set a product's _wc_gla_google_ids meta to a colon value like ['US' => 'online:en:US:gla_123'].
- Simulate the Merchant API upgrade (set the stored db version below 3.8.0, then run the installer). UpdateAllProducts is scheduled; after Action Scheduler runs it, the legacy products' stored ids become en~US~gla_123 and statuses resolve on the next refresh.



### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
