### PR TITLE
GOOWOO-677: Add Tracking to Notifications System

### DIFF
--- a/js/src/notifications-system/index.js
+++ b/js/src/notifications-system/index.js
@@ -16,6 +16,15 @@ import {
 import Notification from './notification';
 import useNotificationsSystemMap from './useNotificationsSystemMap';
 import { GLA_NOTIFICATION_DISMISSED } from '~/constants';
+import { recordGlaEvent, CONTEXT_MARKETING_OVERVIEW } from '~/utils/tracks';
+
+/**
+ * A merchant dismisses a notification.
+ *
+ * @event gla_notifications_system_notification_dismissed
+ * @property {string} context Where the notification is shown, e.g. `'marketing-overview'`.
+ * @property {string} id The notification ID.
+ */
 
 /**
  * Creates a notification component.
@@ -23,6 +32,7 @@ import { GLA_NOTIFICATION_DISMISSED } from '~/constants';
  * @param {string} id Notification ID, used to call dismissNotification on dismiss.
  * @param {number} triggeredAt Unix timestamp (seconds) when the notification was triggered.
  * @return {Function} A function that returns a React component.
+ * @fires gla_notifications_system_notification_dismissed with `{ context: 'marketing-overview', id }`.
  */
 function createNotificationComponent( id, triggeredAt ) {
 	return function NotificationComponent() {
@@ -39,6 +49,10 @@ function createNotificationComponent( id, triggeredAt ) {
 		const handleDismiss = () => {
 			dismissNotification( id );
 			doAction( GLA_NOTIFICATION_DISMISSED );
+			recordGlaEvent( 'gla_notifications_system_notification_dismissed', {
+				context: CONTEXT_MARKETING_OVERVIEW,
+				id,
+			} );
 		};
 
 		return createElement( Notification, {

--- a/js/src/notifications-system/notification.js
+++ b/js/src/notifications-system/notification.js
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
 import { dateI18n } from '@wordpress/date';
+import { addQueryArgs } from '@wordpress/url';
 import { CardBody, Flex, FlexBlock, FlexItem } from '@wordpress/components';
 import { closeSmall } from '@wordpress/icons';
 
@@ -14,7 +16,27 @@ import { useAppDispatch } from '~/data';
 import AppButton from '~/components/app-button';
 import NotificationSkeleton from './notification-skeleton';
 import googleLogoURL from '~/images/logo/google-g-logo.svg';
+import {
+	recordGlaEvent,
+	CONTEXT_MARKETING_OVERVIEW,
+	REFERRER_TYPE_NOTIFICATION,
+} from '~/utils/tracks';
 import './notification.scss';
+
+/**
+ * Appends the notification's referrer info to a CTA href, so the destination
+ * flow can attribute its own tracking events back to this notification.
+ *
+ * @param {string} href Original CTA destination.
+ * @param {string} notificationId Notification ID to attribute the referral to.
+ * @return {string} `href` with `referrer_type`/`referrer_id` query params appended.
+ */
+function withReferrer( href, notificationId ) {
+	return addQueryArgs( href, {
+		referrer_type: REFERRER_TYPE_NOTIFICATION,
+		referrer_id: notificationId,
+	} );
+}
 
 /**
  * @typedef {Object} NotificationAction
@@ -23,6 +45,23 @@ import './notification.scss';
  * @property {string} children Button label.
  * @property {string} [target] Link target (e.g. '_blank').
  * @property {string} [rel] Link rel attribute.
+ */
+
+/**
+ * The `Notification` component is rendered.
+ *
+ * @event gla_notifications_system_notification_shown
+ * @property {string} context Where the notification is shown, e.g. `'marketing-overview'`.
+ * @property {string} id The notification ID.
+ */
+
+/**
+ * A merchant clicks a notification's CTA.
+ *
+ * @event gla_notifications_system_notification_cta_clicked
+ * @property {string} context Where the notification is shown, e.g. `'marketing-overview'`.
+ * @property {string} id The notification ID.
+ * @property {string} href The CTA link's destination.
  */
 
 /**
@@ -36,6 +75,8 @@ import './notification.scss';
  * @param {NotificationAction[]} props.actions CTA buttons.
  * @param {Function} [props.onDismiss] Callback invoked after dismissNotification succeeds.
  * @param {boolean} [props.isReady] Whether the notification data is ready. Renders a skeleton when false.
+ * @fires gla_notifications_system_notification_shown with `{ context: 'marketing-overview', id }`.
+ * @fires gla_notifications_system_notification_cta_clicked with `{ context: 'marketing-overview', id, href }`.
  */
 const Notification = ( {
 	id,
@@ -47,6 +88,17 @@ const Notification = ( {
 	isReady,
 } ) => {
 	const { dismissNotification } = useAppDispatch();
+
+	useEffect( () => {
+		if ( isReady === false ) {
+			return;
+		}
+
+		recordGlaEvent( 'gla_notifications_system_notification_shown', {
+			context: CONTEXT_MARKETING_OVERVIEW,
+			id,
+		} );
+	}, [ id, isReady ] );
 
 	if ( isReady === false ) {
 		return <NotificationSkeleton />;
@@ -64,6 +116,14 @@ const Notification = ( {
 		} catch {
 			// dismissNotification failed, do not dismiss from slot store
 		}
+	};
+
+	const handleCtaClick = ( href ) => {
+		recordGlaEvent( 'gla_notifications_system_notification_cta_clicked', {
+			context: CONTEXT_MARKETING_OVERVIEW,
+			id,
+			href,
+		} );
 	};
 
 	return (
@@ -105,9 +165,10 @@ const Notification = ( {
 										key={ actionId }
 										className="gla-notification__action"
 										variant="link"
-										href={ href }
+										href={ withReferrer( href, id ) }
 										target={ target }
 										rel={ rel }
+										onClick={ () => handleCtaClick( href ) }
 									>
 										{ children }
 									</AppButton>

--- a/js/src/notifications-system/woo-marketing-notifications-slot/components/notifications-panel/index.js
+++ b/js/src/notifications-system/woo-marketing-notifications-slot/components/notifications-panel/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useEffect } from '@wordpress/element';
 import {
 	Card,
 	CardHeader,
@@ -16,17 +16,37 @@ import { Badge } from '@woocommerce/components';
  * Internal dependencies
  */
 import useNotifications from '../../hooks/useNotifications';
+import { recordGlaEvent, CONTEXT_MARKETING_OVERVIEW } from '~/utils/tracks';
 import './index.scss';
+
+/**
+ * The `NotificationsPanel` component is rendered.
+ *
+ * @event gla_notifications_system_notifications_panel_shown
+ * @property {string} context Where the panel is shown, e.g. `'marketing-overview'`.
+ */
 
 /**
  * Renders the list of active notifications for the Woo Marketing Notifications Slot.
  *
  * @return {JSX.Element|null} A panel of notification cards, or null if there are no active notifications.
+ * @fires gla_notifications_system_notifications_panel_shown with `{ context: 'marketing-overview' }`.
  */
 const NotificationsPanel = () => {
 	const { notifications } = useNotifications();
+	const hasNotifications = notifications.length > 0;
 
-	if ( ! notifications.length ) {
+	useEffect( () => {
+		if ( ! hasNotifications ) {
+			return;
+		}
+
+		recordGlaEvent( 'gla_notifications_system_notifications_panel_shown', {
+			context: CONTEXT_MARKETING_OVERVIEW,
+		} );
+	}, [ hasNotifications ] );
+
+	if ( ! hasNotifications ) {
 		return null;
 	}
 

--- a/js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/setup-paid-ads.js
+++ b/js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/setup-paid-ads.js
@@ -35,10 +35,20 @@ import AppSpinner from '~/components/app-spinner';
  */
 
 /**
+ * Continuing the ads-only onboarding flow with a paid campaign configured.
+ *
+ * @event gla_ads_only_onboarding_with_paid_ads_continue_button_click
+ * @property {string} level The selected level of the budget recommendation, e.g. 'low', 'recommended', 'high', 'custom'.
+ * @property {number} budget The budget for the campaign.
+ * @property {string} audiences The targeted audiences for the campaign.
+ */
+
+/**
  * Renders the onboarding step for setting up the paid ads (Google Ads account and paid campaign)
  * or skipping it, and then completing the onboarding flow.
  *
  * @fires gla_ads_only_onboarding_with_cyo_incentive_selected
+ * @fires gla_ads_only_onboarding_with_paid_ads_continue_button_click
  *
  * @param {Object} props
  * @param {Function} props.onSubmit Callback fired when the user submits the paid ads creation form. Passes dailyBudget and hasConfirmedEuPoliticalContent.

--- a/js/src/utils/tracks.js
+++ b/js/src/utils/tracks.js
@@ -4,6 +4,8 @@
 import { recordEvent, queueRecordEvent } from '@woocommerce/tracks';
 import { select } from '@wordpress/data';
 import { createHooks } from '@wordpress/hooks';
+import { getQuery } from '@woocommerce/navigation';
+import { pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -29,6 +31,8 @@ filterPropertiesMap.set( FILTER_BUDGET_RECOMMENDATIONS, [
 	'recommended_budget',
 ] );
 
+const REFERRER_QUERY_PROPERTIES = [ 'referrer_type', 'referrer_id' ];
+
 /*
  * Please be aware of when to use these context values
  * - 'setup-mc': Extension onboarding (a.k.a Merchant Center Setup or MC Setup)
@@ -44,6 +48,12 @@ filterPropertiesMap.set( FILTER_BUDGET_RECOMMENDATIONS, [
 export const CONTEXT_EXTENSION_ONBOARDING = 'setup-mc';
 export const CONTEXT_ADS_ONBOARDING = 'setup-ads';
 export const CONTEXT_ADS_ONLY_ONBOARDING = 'setup-ads-only';
+export const CONTEXT_MARKETING_OVERVIEW = 'marketing-overview';
+
+/**
+ * Referrer type indicating a flow was entered from a notification's CTA.
+ */
+export const REFERRER_TYPE_NOTIFICATION = 'notification';
 
 /**
  * When table pagination is changed by entering page via "Go to page" input.
@@ -66,6 +76,10 @@ export const CONTEXT_ADS_ONLY_ONBOARDING = 'setup-ads-only';
  * - gla_version: Plugin version
  * - gla_mc_id: Google Merchant Center account ID if connected
  * - gla_ads_id: Google Ads account ID if connected
+ * - referrer_type/referrer_id: Carried over from the current URL when the
+ *   flow was entered from a referring surface (e.g. a notification CTA via
+ *   `REFERRER_TYPE_NOTIFICATION`), so downstream events can be attributed
+ *   back to it.
  *
  * @param {Object} [eventProperties] The event properties to be included base properties.
  * @return {Object} Event properties with base event properties.
@@ -76,6 +90,7 @@ export function addBaseEventProperties( eventProperties ) {
 
 	const mixedProperties = {
 		...eventProperties,
+		...pick( getQuery(), REFERRER_QUERY_PROPERTIES ),
 		[ `${ slug }_version` ]: version,
 	};
 

--- a/js/src/utils/tracks.js
+++ b/js/src/utils/tracks.js
@@ -11,7 +11,7 @@ import { pick } from 'lodash';
  * Internal dependencies
  */
 import { glaData } from '~/constants';
-import { STORE_KEY } from '~/data/constants';
+import { STORE_KEY } from '~/data';
 
 /**
  * @typedef { import("~/data/actions").CountryCode } CountryCode

--- a/js/src/utils/tracks.js
+++ b/js/src/utils/tracks.js
@@ -11,7 +11,7 @@ import { pick } from 'lodash';
  * Internal dependencies
  */
 import { glaData } from '~/constants';
-import { STORE_KEY } from '~/data';
+import { STORE_KEY } from '~/data/constants';
 
 /**
  * @typedef { import("~/data/actions").CountryCode } CountryCode

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
 			},
 			{
 				"path": "./js/build/index.js",
-				"maxSize": "21.5 kB"
+				"maxSize": "21.6 kB"
 			},
 			{
 				"path": "./js/build/commons.js",
@@ -162,7 +162,7 @@
 			},
 			{
 				"path": "./js/build/woo-marketing-notifications-slot.js",
-				"maxSize": "5 kB"
+				"maxSize": "17.9 kB"
 			},
 			{
 				"path": "./js/build/vendors.js",

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -236,7 +236,18 @@ Selecting a "Choose Your Own" incentive offer when setting up paid ads during on
 `context` | `string` | The context in which the incentive offer is selected, e.g. 'create-ads', 'edit-ads', 'setup-ads', 'setup-mc', or 'setup-ads-only'.
 `level` | `string` | The level of the selected incentive offer, e.g. 'low', 'medium', or 'high'.
 #### Emitters
-- [`exports`](../../js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/setup-paid-ads.js#L47)
+- [`exports`](../../js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/setup-paid-ads.js#L57)
+
+### [`gla_ads_only_onboarding_with_paid_ads_continue_button_click`](../../js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/setup-paid-ads.js#L37)
+Continuing the ads-only onboarding flow with a paid campaign configured.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`level` | `string` | The selected level of the budget recommendation, e.g. 'low', 'recommended', 'high', 'custom'.
+`budget` | `number` | The budget for the campaign.
+`audiences` | `string` | The targeted audiences for the campaign.
+#### Emitters
+- [`exports`](../../js/src/pages/onboarding/setup-stepper/saved-ads-only-setup-stepper/setup-paid-ads.js#L57)
 
 ### [`gla_ads_set_up_billing_click`](../../js/src/components/paid-ads/billing-card/billing-setup-card.js#L22)
 "Set up billing" button for Google Ads account is clicked.
@@ -424,7 +435,7 @@ Triggered when "continue" to edit program button is clicked.
 #### Emitters
 - [`EditProgramPromptModal`](../../js/src/pages/dashboard/all-programs-table-card/edit-program-button/edit-program-prompt-modal.js#L31) when "Continue to edit" is clicked.
 
-### [`gla_datepicker_update`](../../js/src/utils/tracks.js#L141)
+### [`gla_datepicker_update`](../../js/src/utils/tracks.js#L156)
 Triggered when datepicker (date ranger picker) is updated,
  with report name and data that comes from `DateRangeFilterPicker`'s `onRangeSelect` callback
 #### Properties
@@ -440,14 +451,14 @@ Triggered when datepicker (date ranger picker) is updated,
 - [`ProductsReportFilters`](../../js/src/pages/reports/products/products-report-filters.js#L41)
 - [`ProgramsReportFilters`](../../js/src/pages/reports/programs/programs-report-filters.js#L43)
 
-### [`gla_disconnected_accounts`](../../js/src/pages/settings/linked-accounts.js#L33)
+### [`gla_disconnected_accounts`](../../js/src/pages/settings/linked-accounts.js#L34)
 Accounts are disconnected from the Setting page
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | (`all-accounts`\|`ads-account`) - indicate which accounts have been disconnected.
 #### Emitters
-- [`exports`](../../js/src/pages/settings/linked-accounts.js#L43)
+- [`exports`](../../js/src/pages/settings/linked-accounts.js#L44)
 
 ### [`gla_documentation_link_click`](../../js/src/components/app-documentation-link/index.js#L6)
 When a documentation link is clicked.
@@ -619,7 +630,7 @@ Clicking on faq item to collapse or expand it.
 	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-google-mc-account', action: 'expand' }`.
 	- with `{ context: 'setup-mc-accounts', id: 'why-do-i-need-a-google-mc-account', action: 'collapse' }`.
 
-### [`gla_filter`](../../js/src/utils/tracks.js#L153)
+### [`gla_filter`](../../js/src/utils/tracks.js#L168)
 Triggered when changing products & variations filter,
  with data that comes from
  `FilterPicker`'s `onFilterSelect` callback.
@@ -654,7 +665,7 @@ Triggered when the skip button is clicked during Gen AI asset generation progres
 #### Emitters
 - [`SkipButton`](../../js/src/components/paid-ads/gen-ai-progress/skip-button.js#L27) when the skip button is clicked.
 
-### [`gla_google_account_connect_button_click`](../../js/src/utils/tracks.js#L185)
+### [`gla_google_account_connect_button_click`](../../js/src/utils/tracks.js#L200)
 Clicking on the button to connect Google account.
 #### Properties
 | name | type | description |
@@ -674,7 +685,7 @@ Clicking on the "connect to a different Google account" button.
 #### Emitters
 - [`SwitchAccountButton`](../../js/src/components/google-account-card/switch-account-button.js#L25)
 
-### [`gla_google_ads_promo_create_campaign_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L35)
+### [`gla_google_ads_promo_create_campaign_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L37)
 Google Ads Promo "Create campaign" button is clicked.
 #### Properties
 | name | type | description |
@@ -682,7 +693,7 @@ Google Ads Promo "Create campaign" button is clicked.
 `context` | `string` | Context of the Google Ads Promo.
 `href` | `string` | URL of the "Create campaign" button.
 #### Emitters
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L52) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&subpath=%2Fcampaigns%2Fcreate&path=%2Fgoogle%2Fdashboard' }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L54) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&subpath=%2Fcampaigns%2Fcreate&path=%2Fgoogle%2Fdashboard' }`.
 
 ### [`gla_google_ads_promo_dismiss_click`](../../js/src/meta-boxes/channel-visibility/promo-cta.js#L14)
 Google Ads Promo "Dismiss" button is clicked.
@@ -702,9 +713,9 @@ Google Ads Promo "Get started" button is clicked.
 `href` | `string` | URL of the "Get started" button.
 #### Emitters
 - [`GetStartedCTA`](../../js/src/meta-boxes/channel-visibility/get-started-cta.js#L28) with `{ context: channel-visibility-meta-box, href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc' }`.
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L52) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc' }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L54) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc' }`.
 
-### [`gla_google_ads_promo_get_started_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L27)
+### [`gla_google_ads_promo_get_started_click`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L29)
 Google Ads Promo "Get started" button is clicked.
 #### Properties
 | name | type | description |
@@ -713,29 +724,29 @@ Google Ads Promo "Get started" button is clicked.
 `href` | `string` | URL of the "Get started" button.
 #### Emitters
 - [`GetStartedCTA`](../../js/src/meta-boxes/channel-visibility/get-started-cta.js#L28) with `{ context: channel-visibility-meta-box, href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc' }`.
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L52) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc' }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L54) with `{ context: 'order-attribution-meta-box', href: 'admin.php?page=wc-admin&path=%2Fgoogle%2Fsetup-mc' }`.
 
-### [`gla_google_ads_promo_shown`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L27)
+### [`gla_google_ads_promo_shown`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L28)
 Google Ads Promo banner is shown.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | Context of the Google Ads Promo.
 #### Emitters
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L41) with `{ context: channel-visibility-meta-box }`.
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L52) with `{ context: 'order-attribution-meta-box' }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L42) with `{ context: channel-visibility-meta-box }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L54) with `{ context: 'order-attribution-meta-box' }`.
 
-### [`gla_google_ads_promo_shown`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L20)
+### [`gla_google_ads_promo_shown`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L22)
 Google Ads Promo component is shown.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | Context of the Google Ads Promo.
 #### Emitters
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L41) with `{ context: channel-visibility-meta-box }`.
-- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L52) with `{ context: 'order-attribution-meta-box' }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/channel-visibility/google-ads-promo.js#L42) with `{ context: channel-visibility-meta-box }`.
+- [`GoogleAdsPromo`](../../js/src/meta-boxes/order-attribution/google-ads-promo.js#L54) with `{ context: 'order-attribution-meta-box' }`.
 
-### [`gla_google_mc_link_click`](../../js/src/utils/tracks.js#L195)
+### [`gla_google_mc_link_click`](../../js/src/utils/tracks.js#L210)
 Clicking on a Google Merchant Center link.
 #### Properties
 | name | type | description |
@@ -764,7 +775,7 @@ Clicking on the "Scan for assets" button.
 #### Emitters
 - [`exports`](../../js/src/components/paid-ads/asset-group/asset-group-header/assets-loader.js#L99)
 
-### [`gla_launch_paid_campaign_button_click`](../../js/src/utils/tracks.js#L173)
+### [`gla_launch_paid_campaign_button_click`](../../js/src/utils/tracks.js#L188)
 Triggered when the "Launch paid campaign" button is clicked to add a new paid campaign in the Google Ads setup flow.
 #### Properties
 | name | type | description |
@@ -787,14 +798,14 @@ Clicking on the button to link the YouTube account.
 #### Emitters
 - [`ConnectedYouTubeAccountCard`](../../js/src/components/youtube-account-card/connected-youtube-account-card.js#L42) When the user clicks on the button to link the YouTube account.
 
-### [`gla_mc_account_connect_button_click`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L23)
+### [`gla_mc_account_connect_button_click`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L24)
 Clicking on the button to connect an existing Google Merchant Center account.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `id` | `number` | The account ID to be connected.
 #### Emitters
-- [`ConnectMC`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L48)
+- [`ConnectMC`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L49)
 
 ### [`gla_mc_account_connect_different_account_button_click`](../../js/src/components/google-mc-account-card/disconnect-account-button.js#L16)
 Clicking on the "connect to a different Google Merchant Center account" button.
@@ -809,7 +820,7 @@ Clicking on the button to reclaim URL for a Google Merchant Center account.
 #### Emitters
 - [`ReclaimUrlCard`](../../js/src/components/google-mc-account-card/reclaim-url-card/index.js#L42)
 
-### [`gla_mc_account_switch_account_button_click`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L30)
+### [`gla_mc_account_switch_account_button_click`](../../js/src/components/google-mc-account-card/connect-mc/index.js#L31)
 Clicking on the "Switch account" button to select a different Google Merchant Center account to connect.
 #### Properties
 | name | type | description |
@@ -845,7 +856,7 @@ Clicking on the "Yes, I want a new account" button in the warning modal for crea
 - [`ReviewRequest`](../../js/src/pages/product-feed/review-request/index.js#L31) with `action: 'request-review-success' | 'maybe-later' | 'dismiss', context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L247) with `action: 'create-paid-campaign' | 'maybe-later' | 'view-product-feed' | 'dismiss' | 'view-enhanced-conversions-settings'`
 
-### [`gla_modal_closed`](../../js/src/utils/tracks.js#L251)
+### [`gla_modal_closed`](../../js/src/utils/tracks.js#L266)
 A modal is closed.
 #### Properties
 | name | type | description |
@@ -883,7 +894,7 @@ Clicking on a text link within the modal content
 - [`ReviewRequest`](../../js/src/pages/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L247) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
 
-### [`gla_modal_open`](../../js/src/utils/tracks.js#L264)
+### [`gla_modal_open`](../../js/src/utils/tracks.js#L279)
 A modal is open
 #### Properties
 | name | type | description |
@@ -894,6 +905,46 @@ A modal is open
 - [`ChangePriceModal`](../../js/src/pages/price-benchmark/change-price-modal/index.js#L74) with `{ context: 'price-benchmark-change-price-modal' }` and the product ID.
 - [`ReviewRequest`](../../js/src/pages/product-feed/review-request/index.js#L31) with `context: REQUEST_REVIEW`
 - [`SubmissionSuccessGuide`](../../js/src/pages/product-feed/submission-success-guide/index.js#L247) with `context: GUIDE_NAMES.SUBMISSION_SUCCESS`
+
+### [`gla_notifications_system_notification_cta_clicked`](../../js/src/notifications-system/notification.js#L58)
+A merchant clicks a notification's CTA.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Where the notification is shown, e.g. `'marketing-overview'`.
+`id` | `string` | The notification ID.
+`href` | `string` | The CTA link's destination.
+#### Emitters
+- [`Notification`](../../js/src/notifications-system/notification.js#L81) with `{ context: 'marketing-overview', id, href }`.
+
+### [`gla_notifications_system_notification_dismissed`](../../js/src/notifications-system/index.js#L21)
+A merchant dismisses a notification.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Where the notification is shown, e.g. `'marketing-overview'`.
+`id` | `string` | The notification ID.
+#### Emitters
+- [`createNotificationComponent`](../../js/src/notifications-system/index.js#L37) with `{ context: 'marketing-overview', id }`.
+
+### [`gla_notifications_system_notification_shown`](../../js/src/notifications-system/notification.js#L50)
+The `Notification` component is rendered.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Where the notification is shown, e.g. `'marketing-overview'`.
+`id` | `string` | The notification ID.
+#### Emitters
+- [`Notification`](../../js/src/notifications-system/notification.js#L81) with `{ context: 'marketing-overview', id }`.
+
+### [`gla_notifications_system_notifications_panel_shown`](../../js/src/notifications-system/woo-marketing-notifications-slot/components/notifications-panel/index.js#L22)
+The `NotificationsPanel` component is rendered.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Where the panel is shown, e.g. `'marketing-overview'`.
+#### Emitters
+- [`NotificationsPanel`](../../js/src/notifications-system/woo-marketing-notifications-slot/components/notifications-panel/index.js#L35) with `{ context: 'marketing-overview' }`.
 
 ### [`gla_onboarding_complete_button_click`](../../js/src/pages/onboarding/setup-stepper/skip-button.js#L17)
 Clicking on the skip paid ads button to complete the onboarding flow.
@@ -940,7 +991,7 @@ Clicking on the button to open the invitation page for claiming the newly create
 #### Emitters
 - [`ClaimAccountButton`](../../js/src/components/google-ads-account-card/claim-account-button.js#L32) When the user clicks on the button to claim the account.
 
-### [`gla_paid_campaign_step`](../../js/src/utils/tracks.js#L211)
+### [`gla_paid_campaign_step`](../../js/src/utils/tracks.js#L226)
 Triggered when moving to another step during creating/editing a campaign.
 #### Properties
 | name | type | description |
@@ -952,7 +1003,7 @@ Triggered when moving to another step during creating/editing a campaign.
 - [`CreatePaidAdsCampaign`](../../js/src/pages/create-paid-ads-campaign/index.js#L50)
 	- with `{ context: 'create-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
 	- with `{ context: 'create-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
-- [`EditPaidAdsCampaign`](../../js/src/pages/edit-paid-ads-campaign/index.js#L70)
+- [`EditPaidAdsCampaign`](../../js/src/pages/edit-paid-ads-campaign/index.js#L71)
 	- with `{ context: 'edit-ads', triggered_by: 'step1-continue-button', action: 'go-to-step2' }`.
 	- with `{ context: 'edit-ads', triggered_by: 'stepper-step1-button', action: 'go-to-step1' }`.
 
@@ -1099,7 +1150,7 @@ Clicking on the "Or, select another page" button.
 #### Emitters
 - [`exports`](../../js/src/components/paid-ads/asset-group/asset-group-header/final-url-card.js#L40)
 
-### [`gla_setup_ads`](../../js/src/utils/tracks.js#L203)
+### [`gla_setup_ads`](../../js/src/utils/tracks.js#L218)
 Triggered on events during ads onboarding
 #### Properties
 | name | type | description |
@@ -1122,7 +1173,7 @@ Clicking on faq items to collapse or expand it in the Onboarding Flow or creatin
 #### Emitters
 - [`Faqs`](../../js/src/components/paid-ads/ads-campaign/faqs.js#L25)
 
-### [`gla_setup_mc`](../../js/src/utils/tracks.js#L164)
+### [`gla_setup_mc`](../../js/src/utils/tracks.js#L179)
 Setup Merchant Center
 #### Properties
 | name | type | description |
@@ -1188,7 +1239,7 @@ Clicking on the submit button on the campaign creation or editing page.
 #### Emitters
 - [`exports`](../../js/src/components/paid-ads/asset-group/asset-group.js#L73)
 
-### [`gla_table_go_to_page`](../../js/src/utils/tracks.js#L48)
+### [`gla_table_go_to_page`](../../js/src/utils/tracks.js#L58)
 When table pagination is changed by entering page via "Go to page" input.
 #### Properties
 | name | type | description |
@@ -1197,7 +1248,7 @@ When table pagination is changed by entering page via "Go to page" input.
 `page` | `string` | Page number (starting at 1)
 #### Emitters
 - [`ProductFeedTableCard`](../../js/src/pages/product-feed/product-feed-table-card/index.js#L65) with `context: 'product-feed'`
-- [`recordTablePageEvent`](../../js/src/utils/tracks.js#L127) with the given `{ context, page }`.
+- [`recordTablePageEvent`](../../js/src/utils/tracks.js#L142) with the given `{ context, page }`.
 
 ### [`gla_table_header_toggle`](../../js/src/components/app-table-card/index.js#L12)
 Toggling display of table columns
@@ -1211,7 +1262,7 @@ Toggling display of table columns
 - [`AppTableCard`](../../js/src/components/app-table-card/index.js#L74) upon toggling column visibility
 - [`recordColumnToggleEvent`](../../js/src/components/app-table-card/index.js#L29) with given `report: trackEventReportId, column: toggled`
 
-### [`gla_table_page_click`](../../js/src/utils/tracks.js#L56)
+### [`gla_table_page_click`](../../js/src/utils/tracks.js#L66)
 When table pagination is clicked
 #### Properties
 | name | type | description |
@@ -1220,7 +1271,7 @@ When table pagination is clicked
 `direction` | `string` | Direction of page to be changed. `("next" \| "previous")`
 #### Emitters
 - [`ProductFeedTableCard`](../../js/src/pages/product-feed/product-feed-table-card/index.js#L65) with `context: 'product-feed'`
-- [`recordTablePageEvent`](../../js/src/utils/tracks.js#L127) with the given `{ context, direction }`.
+- [`recordTablePageEvent`](../../js/src/utils/tracks.js#L142) with the given `{ context, direction }`.
 
 ### [`gla_table_sort`](../../js/src/components/app-table-card/index.js#L38)
 Sorting table


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-677/fe-notification-tracking-analytics

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Confirm tracking is allowed in `WooCommerce > Settings > Advanced > Woo.com`
2. Run command `localStorage.setItem( 'debug', 'wc-admin:*' )` in console.
3. Make sure that events are triggered properly with the properties mentioned in AC
4. Clicking through a notification CTA will append the following parameters to the URL:
	* `referrer_type`: notification
	* `referrer_id`: <notification ID>
5. Any events triggered when the above URL params are present will be passed along the tracking data. For e.g when creating a new campaign, the `wcadmin_gla_launch_paid_campaign_button_click` event will now emit the `referrer_id` and `referrer_type` properties.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
