### PR TITLE
Version bump: 3.8.0-beta-1

### DIFF
--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Google for WooCommerce
  * Plugin URL: https://wordpress.org/plugins/google-listings-and-ads/
  * Description: Native integration with Google that allows merchants to easily display their products across Google’s network.
- * Version: 3.7.3
+ * Version: 3.8.0-beta-1
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
@@ -33,7 +33,7 @@ use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_GLA_VERSION', '3.7.3' ); // WRCS: DEFINED_VERSION.
+define( 'WC_GLA_VERSION', '3.8.0-beta-1' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.4' );
 define( 'WC_GLA_MIN_WC_VER', '10.6' );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "google-listings-and-ads",
-	"version": "3.7.3",
+	"version": "3.8.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "google-listings-and-ads",
-			"version": "3.7.3",
+			"version": "3.8.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@woocommerce/components": "^12.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "google-listings-and-ads",
 	"title": "Google for WooCommerce",
-	"version": "3.7.3",
+	"version": "3.8.0",
 	"description": "Google for WooCommerce",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-804

- Plugin version and `WC_GLA_VERSION` constants are set to 3.8.0-beta-1
- The 'version' in package.json and package-lock.json are bumped to 3.8.0

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a zip from this branch by running `npm run build`
2. Upgrade or install the plugin from this zip.
3. Confirm that the plugin version is 3.8.0-beta-1