### PR TITLE
Fix: prevent MerchantMetrics TypeError during MAPI upgrade

### DIFF
--- a/src/API/Google/MerchantMetrics.php
+++ b/src/API/Google/MerchantMetrics.php
@@ -57,12 +57,20 @@ class MerchantMetrics implements OptionsAwareInterface {
 	/**
 	 * MerchantMetrics constructor.
 	 *
+	 * The $mapi_client type hint is intentionally left off. During a plugin
+	 * upgrade WordPress overwrites files in place mid-request, so this class can
+	 * be loaded fresh (new signature) while the DI provider is still the old one
+	 * in memory, injecting the legacy ShoppingContent client. Omitting the hint
+	 * lets that transient construction succeed instead of fatally erroring; the
+	 * following request resolves the correct MerchantApiClient. See the guard in
+	 * RESTControllers::register_controllers() for the complementary protection.
+	 *
 	 * @param MerchantApiClient   $mapi_client
 	 * @param GoogleAdsClient     $ads_client
 	 * @param WP                  $wp
 	 * @param TransientsInterface $transients
 	 */
-	public function __construct( MerchantApiClient $mapi_client, GoogleAdsClient $ads_client, WP $wp, TransientsInterface $transients ) {
+	public function __construct( $mapi_client, GoogleAdsClient $ads_client, WP $wp, TransientsInterface $transients ) {
 		$this->mapi_client = $mapi_client;
 		$this->ads_client  = $ads_client;
 		$this->wp          = $wp;

--- a/src/API/Site/RESTControllers.php
+++ b/src/API/Site/RESTControllers.php
@@ -47,8 +47,19 @@ class RESTControllers implements ContainerAwareInterface, Service, Registerable 
 	 * failure on a single page render from taking down the whole admin.
 	 */
 	protected function register_controllers(): void {
-		/** @var BaseController[] $controllers */
-		$controllers = $this->container->get( 'rest_controller' );
+		try {
+			/** @var BaseController[] $controllers */
+			$controllers = $this->container->get( 'rest_controller' );
+		} catch ( \Throwable $e ) {
+			// Transient during the plugin upgrade flow: in-memory DI definitions
+			// lag the new class files on disk, so a changed constructor signature
+			// can throw a TypeError while resolving the tagged controllers. This
+			// self-heals on the next request; catching it here prevents a single
+			// page render from taking down the whole admin.
+			do_action( 'woocommerce_gla_error', $e->getMessage(), __METHOD__ );
+			return;
+		}
+
 		foreach ( $controllers as $controller ) {
 			try {
 				$this->validate_instanceof( $controller, BaseController::class );

--- a/tests/Unit/API/Site/RESTControllersTest.php
+++ b/tests/Unit/API/Site/RESTControllersTest.php
@@ -131,4 +131,45 @@ class RESTControllersTest extends UnitTest {
 
 		$this->assertCount( 3, $captured, 'One error expected per invalid entry (string, stdClass, null).' );
 	}
+
+	/**
+	 * Regression: when resolving the whole 'rest_controller' tag throws (e.g. a
+	 * TypeError from a dependency whose constructor signature changed mid-upgrade,
+	 * per GOOWOO-800), registration must catch it, log via woocommerce_gla_error,
+	 * and return without propagating the fatal to the rest of the admin page.
+	 *
+	 * Uses a TypeError specifically, not a plain Exception: TypeError extends
+	 * \Error, not \Exception, so this also locks in that the catch clause is
+	 * \Throwable (broad enough to cover Error subclasses) rather than just
+	 * \Exception, which would silently miss the exact failure this PR fixes.
+	 */
+	public function test_register_controllers_catches_error_thrown_while_resolving_tag() {
+		$container = $this->createMock( ContainerInterface::class );
+		$container->method( 'get' )
+			->with( 'rest_controller' )
+			->willThrowException(
+				new \TypeError(
+					'MerchantMetrics::__construct(): Argument #1 ($mapi_client) must be of type MerchantApiClient, ShoppingContent given'
+				)
+			);
+
+		$captured = [];
+		$listener = function ( $message ) use ( &$captured ) {
+			$captured[] = $message;
+		};
+		add_action( 'woocommerce_gla_error', $listener );
+
+		$rest_controllers = new RESTControllers();
+		$rest_controllers->set_container( $container );
+
+		$reflection = new \ReflectionClass( $rest_controllers );
+		$method     = $reflection->getMethod( 'register_controllers' );
+		$method->setAccessible( true );
+		$method->invoke( $rest_controllers );
+
+		remove_action( 'woocommerce_gla_error', $listener );
+
+		$this->assertCount( 1, $captured, 'The TypeError should be logged instead of propagating as a fatal.' );
+		$this->assertStringContainsString( 'MerchantMetrics', $captured[0] );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

WordPress swaps plugin files in place mid-request. So, on the upgrade request the old DI provider (wiring `MerchantMetrics` with `ShoppingContent`) runs against the new `MerchantMetrics` (which now requires `MerchantApiClient`). Old provider + new class = TypeError. It's transient and clears on the next request, but it surfaces a fatal to users.

Fix:

- `RESTControllers::register_controllers()` — wrap the controller resolution in try/catch and log via `woocommerce_gla_error` instead of fataling. Covers all future upgrades.
- `MerchantMetrics::__construct()` — drop the strict `$mapi_client` type hint. This class loads fresh from disk during the crashing request, so loosening its hint lets construction survive this upgrade. 

**Important**: Strict type hint to be restored in the next release.

Closes GOOWOO-800: MAPI integration: Fatal error when upgrading to the latest version


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a site with the latest stable Google for WooCommerce version.
2. Upgrade to the MAPI pre-release.
3.  See the error during upgrade. 
4. Create a zip file off this branch. 
5. Create a site with the latest stable Google for WooCommerce version.
6. Upgrade to the MAPI pre-release.
7. Confirm the error is resolved.
