### PR TITLE
[GOOWOO-772] Multi-lingual feeds: fix feedLabel, shipping-currency, and sync-tracking bugs

### DIFF
--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAcc
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountShippingSettingsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
@@ -161,11 +162,15 @@ class Settings implements ContainerAwareInterface {
 
 		$country_currency_map = $this->build_country_currency_map();
 
+		/** @var WPML $wpml */
+		$wpml = $this->container->get( WPML::class );
+
 		if ( $this->should_get_shipping_rates_from_woocommerce() ) {
 			return new WCShippingSettingsAdapter(
 				[
 					'currency'             => $currency,
 					'country_currency_map' => $country_currency_map,
+					'wpml'                 => $wpml,
 					'rates_collections'    => $this->get_shipping_rates_collections_from_woocommerce(),
 					'delivery_times'       => $times,
 					'accountId'            => $this->get_account_id(),
@@ -177,6 +182,7 @@ class Settings implements ContainerAwareInterface {
 			[
 				'currency'             => $currency,
 				'country_currency_map' => $country_currency_map,
+				'wpml'                 => $wpml,
 				'db_rates'             => $this->get_shipping_rates_from_database(),
 				'delivery_times'       => $times,
 				'accountId'            => $this->get_account_id(),
@@ -185,22 +191,51 @@ class Settings implements ContainerAwareInterface {
 	}
 
 	/**
-	 * Returns a `[ country => currency ]` map for every participating,
+	 * Returns a `[ country => currency[] ]` map for every participating,
 	 * non-manual market.
 	 *
-	 * Each market contributes its country and the first entry of its `currency[]`
-	 * array. Manual markets are skipped — they don't get an MC shipping service.
-	 * Markets excluded from syncing while currency conversion is unavailable
-	 * are skipped for the same reason.
+	 * Each primary target country carries the store currency plus the primary
+	 * market's additional participating currencies; each secondary market's
+	 * country carries that market's participating currencies. Every listed
+	 * currency gets its own shipping service for the country, because Google
+	 * requires the shipping currency to match the product price currency.
+	 * Manual markets are skipped — they don't get an MC shipping service.
+	 * Markets and currencies excluded from syncing while currency conversion
+	 * is unavailable are skipped for the same reason.
 	 *
-	 * @return array<string, string>
+	 * @return array<string, string[]>
 	 */
 	protected function build_country_currency_map(): array {
 		/** @var MarketService $market_service */
 		$market_service = $this->container->get( MarketService::class );
 
+		/** @var WC $wc_proxy */
+		$wc_proxy       = $this->container->get( WC::class );
+		$store_currency = $wc_proxy->get_woocommerce_currency();
+
 		$map = [];
-		foreach ( $market_service->get_participating_markets() as $market ) {
+
+		$primary = $market_service->get_primary_market();
+
+		if ( 'manual' !== ( $primary['shipping_rate'] ?? null ) ) {
+			$primary_currencies = array_values(
+				array_unique(
+					array_merge(
+						[ $store_currency ],
+						$market_service->get_participating_currencies( $primary )
+					)
+				)
+			);
+
+			foreach ( (array) ( $primary['countries'] ?? [] ) as $country ) {
+				$map[ $country ] = $primary_currencies;
+			}
+		}
+
+		foreach ( $market_service->get_participating_markets() as $market_id => $market ) {
+			if ( 'primary' === $market_id ) {
+				continue;
+			}
 			if ( 'manual' === ( $market['shipping_rate'] ?? null ) ) {
 				continue;
 			}
@@ -208,30 +243,13 @@ class Settings implements ContainerAwareInterface {
 			if ( ! $country ) {
 				continue;
 			}
-			$map[ $country ] = $this->resolve_market_currency( $market );
+
+			$currencies = $market_service->get_participating_currencies( $market );
+
+			$map[ $country ] = ! empty( $currencies ) ? $currencies : [ $store_currency ];
 		}
 
 		return $map;
-	}
-
-	/**
-	 * Resolves a market's currency, taking the first element of its `currency[]`
-	 * array and falling back to the store currency.
-	 *
-	 * @param array $market
-	 * @return string
-	 */
-	private function resolve_market_currency( array $market ): string {
-		if ( ! empty( $market['currency'] ) && is_array( $market['currency'] ) ) {
-			$first = reset( $market['currency'] );
-			if ( is_string( $first ) && '' !== $first ) {
-				return $first;
-			}
-		}
-
-		/** @var WC $wc_proxy */
-		$wc_proxy = $this->container->get( WC::class );
-		return $wc_proxy->get_woocommerce_currency();
 	}
 
 	/**

--- a/src/Integration/WPML.php
+++ b/src/Integration/WPML.php
@@ -184,6 +184,10 @@ class WPML implements IntegrationInterface {
 			return null;
 		}
 
+		if ( ! $this->is_active_currency( $currency ) ) {
+			return null;
+		}
+
 		$custom_prices = $this->get_wcml_custom_prices( (int) $product->get_id(), $currency );
 		if ( false !== $custom_prices ) {
 			return isset( $custom_prices['_regular_price'] ) && '' !== $custom_prices['_regular_price']
@@ -210,6 +214,10 @@ class WPML implements IntegrationInterface {
 	 */
 	public function get_product_sale_price_in_currency( WC_Product $product, string $currency ): ?float {
 		if ( ! $this->is_active() || ! $this->is_wcml_multi_currency_on() ) {
+			return null;
+		}
+
+		if ( ! $this->is_active_currency( $currency ) ) {
 			return null;
 		}
 
@@ -268,6 +276,45 @@ class WPML implements IntegrationInterface {
 		$to   = $to_meta ? gmdate( DateTime::ATOM, (int) $to_meta ) : '';
 
 		return sprintf( '%s/%s', $from, $to );
+	}
+
+	/**
+	 * Converts a store-currency amount into the given currency via WCML.
+	 *
+	 * Used for plain amounts with no product attached, such as shipping rates
+	 * and free-shipping thresholds; the product price converters above handle
+	 * per-product manual prices and sale dates.
+	 *
+	 * @param float  $amount   Amount in the store currency.
+	 * @param string $currency ISO 4217 currency code to convert into.
+	 *
+	 * @return float|null Converted amount, or null when WPML is inactive or
+	 *                    WCML multi-currency is off.
+	 */
+	public function convert_amount( float $amount, string $currency ): ?float {
+		if ( ! $this->is_active() || ! $this->is_wcml_multi_currency_on() ) {
+			return null;
+		}
+
+		if ( ! $this->is_active_currency( $currency ) ) {
+			return null;
+		}
+
+		return (float) apply_filters( 'wcml_raw_price_amount', $amount, $currency );
+	}
+
+	/**
+	 * Whether WCML can convert amounts into the given currency: it must be one
+	 * of WCML's active currencies. WCML's conversion filter returns 0 for a
+	 * currency it does not have active, so converting into an inactive
+	 * currency must read as unavailable, never as a zero amount.
+	 *
+	 * @param string $currency ISO 4217 currency code.
+	 *
+	 * @return bool
+	 */
+	protected function is_active_currency( string $currency ): bool {
+		return in_array( $currency, $this->get_active_currency_codes(), true );
 	}
 
 	/**

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -159,14 +159,23 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	}
 
 	/**
-	 * Whether any stored secondary market is priced in a currency other than
-	 * the store currency, i.e. depends on conversion availability to take part.
+	 * Whether any stored secondary market or the primary market carries a
+	 * currency other than the store currency, i.e. depends on conversion
+	 * availability for at least one of its feeds to take part.
 	 *
 	 * @return bool
 	 */
 	private function has_markets_requiring_conversion(): bool {
 		foreach ( $this->get_stored_secondary_markets() as $market ) {
-			if ( get_woocommerce_currency() !== $this->get_market_currency( $market ) ) {
+			foreach ( $this->get_market_currencies( $market ) as $currency ) {
+				if ( get_woocommerce_currency() !== $currency ) {
+					return true;
+				}
+			}
+		}
+
+		foreach ( $this->get_existing_primary_currencies() as $currency ) {
+			if ( get_woocommerce_currency() !== $currency ) {
 				return true;
 			}
 		}
@@ -269,20 +278,18 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	/**
 	 * Whether a secondary market currently takes part in syncing to Google.
 	 *
-	 * A market priced in the store currency always takes part. A market priced
-	 * in any other currency takes part only while price conversion is
-	 * available (WPML active with WCML multi-currency on).
+	 * A market takes part when at least one of its currencies does: the store
+	 * currency always takes part, and any other currency only while price
+	 * conversion is available (WPML active with WCML multi-currency on). A
+	 * market with a mix of convertible and unconvertible currencies keeps
+	 * syncing the currencies it can.
 	 *
 	 * @param array $market The market config.
 	 *
 	 * @return bool
 	 */
 	private function is_market_participating( array $market ): bool {
-		if ( get_woocommerce_currency() === $this->get_market_currency( $market ) ) {
-			return true;
-		}
-
-		return $this->wpml->can_convert_currency();
+		return ! empty( $this->get_participating_currencies( $market ) );
 	}
 
 	/**
@@ -460,7 +467,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	public function update_market( string $id, array $config ): array {
 		if ( 'primary' === $id ) {
 			$language_change_pending = array_key_exists( 'language', $config );
-			$primary_existing_langs  = $language_change_pending ? $this->get_existing_primary_languages() : [];
+			$primary_existing_langs  = $this->get_existing_primary_languages();
 			$primary_countries       = $language_change_pending ? $this->target_audience->get_target_countries() : [];
 
 			$existing_target = $this->options->get( OptionsInterface::TARGET_AUDIENCE, [] );
@@ -485,6 +492,11 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			$merged_language    = $merged_mc['language'] ?? [];
 			$existing_currency  = $existing_mc['currency'] ?? [];
 			$merged_currency    = $merged_mc['currency'] ?? [];
+
+			$removed_currencies = array_diff( $existing_currency, $merged_currency );
+			if ( ! empty( $removed_currencies ) ) {
+				$this->schedule_primary_currency_cleanup( $removed_currencies, $primary_existing_langs );
+			}
 
 			$resync_needed = $existing_countries !== $merged_countries
 				|| array_diff( $existing_language, $merged_language ) !== []
@@ -529,7 +541,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 					$this->get_market_feed_label_variants(
 						$old_feed_label,
 						is_array( $existing['language'] ?? null ) ? $existing['language'] : [],
-						$this->get_market_currency( $existing )
+						$this->get_market_currencies( $existing )
 					),
 					$new_labels
 				)
@@ -608,6 +620,49 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	}
 
 	/**
+	 * Schedules cleanup of the primary market's entries for currencies removed
+	 * from its configured currency list.
+	 *
+	 * Each removed currency's entries sit under one derived label per primary
+	 * language, based on the main feed label. The store currency is never
+	 * cleaned up here: its entries live under the bare main feed label, which
+	 * stays current regardless of the configured currency list.
+	 *
+	 * @param array $removed_currencies Currency codes removed from the primary market.
+	 * @param array $languages          The primary languages before the update.
+	 */
+	private function schedule_primary_currency_cleanup( array $removed_currencies, array $languages ): void {
+		$main_feed_label = $this->get_main_feed_label();
+
+		if ( '' === $main_feed_label ) {
+			return;
+		}
+
+		$labels    = [];
+		$languages = empty( $languages ) ? [ '' ] : $languages;
+
+		foreach ( $removed_currencies as $currency ) {
+			$currency = (string) $currency;
+			if ( '' === $currency || get_woocommerce_currency() === $currency ) {
+				continue;
+			}
+
+			foreach ( $languages as $language ) {
+				$labels[] = $this->get_market_feed_label( $main_feed_label, (string) $language, $currency );
+			}
+		}
+
+		$labels = array_values( array_unique( $labels ) );
+
+		if ( empty( $labels ) ) {
+			return;
+		}
+
+		$this->job_repository->get( CleanupOrphanedMarketProductsJob::class )
+			->schedule( [ 'feed_labels' => $labels ] );
+	}
+
+	/**
 	 * Returns the primary market's language list from the MERCHANT_CENTER option,
 	 * falling back to a single-entry list with the site-derived default. Mirrors
 	 * the language fallback in get_primary_market() but does not trigger the
@@ -623,6 +678,23 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		}
 
 		return [ $this->get_site_primary_language() ];
+	}
+
+	/**
+	 * Returns the primary market's currency list from the MERCHANT_CENTER option,
+	 * falling back to a single-entry list with the site-derived default. Mirrors
+	 * get_existing_primary_languages() for the currency field.
+	 *
+	 * @return array
+	 */
+	private function get_existing_primary_currencies(): array {
+		$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
+		if ( is_array( $mc_settings['currency'] ?? null ) ) {
+			return $mc_settings['currency'];
+		}
+
+		return [ $this->get_site_primary_currency() ];
 	}
 
 	/**
@@ -715,7 +787,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 						'feed_labels' => $this->get_market_feed_label_variants(
 							$feed_label,
 							is_array( $deleted_config['language'] ?? null ) ? $deleted_config['language'] : [],
-							$this->get_market_currency( $deleted_config )
+							$this->get_market_currencies( $deleted_config )
 						),
 					]
 				);
@@ -738,11 +810,12 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 	/**
 	 * Returns every valid `google_ids` tracking key across all configured markets:
-	 * one derived feed label per market.
+	 * one derived feed label per market language-currency pair.
 	 *
-	 * The primary market keeps its bare label so existing entries keep the
-	 * identity they already have in Google Merchant Center; each secondary
-	 * market contributes its currency-derived label.
+	 * The primary market keeps its bare label for the store currency so
+	 * existing entries keep the identity they already have in Google Merchant
+	 * Center, and contributes derived labels for its additional currencies;
+	 * each secondary market contributes its language-currency derived labels.
 	 *
 	 * @return string[]
 	 */
@@ -804,20 +877,54 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	}
 
 	/**
-	 * Returns a market's effective currency code: the first configured entry
-	 * of its `currency[]` list, or the store currency when none is set. This
-	 * is the currency the market's prices are submitted in.
+	 * Returns a market's configured currency codes in stored order without
+	 * duplicates, or a single-entry list with the store currency when none is
+	 * configured. Every configured currency produces its own feeds; see
+	 * get_participating_currencies() for the subset currently allowed to sync.
 	 *
 	 * @param array $market The market config.
 	 *
-	 * @return string
+	 * @return string[]
 	 */
-	private function get_market_currency( array $market ): string {
-		$currency = is_array( $market['currency'] ?? null )
-			? (string) ( $market['currency'][0] ?? '' )
-			: (string) ( $market['currency'] ?? '' );
+	private function get_market_currencies( array $market ): array {
+		$configured = is_array( $market['currency'] ?? null )
+			? $market['currency']
+			: [ $market['currency'] ?? '' ];
 
-		return '' === $currency ? get_woocommerce_currency() : $currency;
+		$currencies = [];
+		foreach ( $configured as $currency ) {
+			$currency = (string) $currency;
+			if ( '' !== $currency ) {
+				$currencies[] = $currency;
+			}
+		}
+
+		$currencies = array_values( array_unique( $currencies ) );
+
+		return empty( $currencies ) ? [ get_woocommerce_currency() ] : $currencies;
+	}
+
+	/**
+	 * Returns the market currencies that currently take part in syncing: the
+	 * store currency always takes part, and any other currency only while
+	 * price conversion is available (WPML active with WCML multi-currency on).
+	 *
+	 * @param array $market The market config.
+	 *
+	 * @return string[]
+	 */
+	public function get_participating_currencies( array $market ): array {
+		$store_currency = get_woocommerce_currency();
+		$can_convert    = $this->wpml->can_convert_currency();
+
+		return array_values(
+			array_filter(
+				$this->get_market_currencies( $market ),
+				function ( string $currency ) use ( $store_currency, $can_convert ): bool {
+					return $currency === $store_currency || $can_convert;
+				}
+			)
+		);
 	}
 
 	/**
@@ -860,46 +967,70 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * Returns each market's derived feed labels together with the languages they match.
 	 *
 	 * The primary market contributes its bare main feed label with the primary
-	 * language list. Each participating secondary market contributes one
-	 * language-currency derived label per configured language, each paired with
-	 * that single language; a market with no configured languages contributes
-	 * one site-language label paired with an empty list (matching every
-	 * language). Excluded markets (see get_participating_markets()) contribute
-	 * nothing, which is what lets the stale-entry cleanup remove their
-	 * Merchant Center entries.
+	 * language list (the store currency's feed, kept bare so existing entries
+	 * keep their Merchant Center identity), plus one derived label per primary
+	 * language per additional participating primary currency. Each
+	 * participating secondary market contributes one language-currency derived
+	 * label per configured language per participating currency, each paired
+	 * with that single language; a market with no configured languages
+	 * contributes one site-language label per participating currency, paired
+	 * with an empty list (matching every language). Excluded markets and
+	 * currencies (see get_participating_currencies()) contribute nothing,
+	 * which is what lets the stale-entry cleanup remove their Merchant Center
+	 * entries.
 	 *
 	 * @return array<int, array{feed_label: string, languages: array}>
 	 */
 	private function get_market_labels_with_languages(): array {
+		$main_feed_label   = $this->get_main_feed_label();
+		$primary_languages = $this->get_existing_primary_languages();
+
 		$markets = [
 			[
-				'feed_label' => $this->get_main_feed_label(),
-				'languages'  => $this->get_existing_primary_languages(),
+				'feed_label' => $main_feed_label,
+				'languages'  => $primary_languages,
 			],
 		];
+
+		$primary_extra_currencies = array_diff(
+			$this->get_participating_currencies( [ 'currency' => $this->get_existing_primary_currencies() ] ),
+			[ get_woocommerce_currency() ]
+		);
+
+		if ( '' !== $main_feed_label ) {
+			foreach ( $primary_extra_currencies as $currency ) {
+				foreach ( $primary_languages as $language ) {
+					$markets[] = [
+						'feed_label' => $this->get_market_feed_label( $main_feed_label, (string) $language, $currency ),
+						'languages'  => [ (string) $language ],
+					];
+				}
+			}
+		}
 
 		foreach ( $this->get_participating_secondary_markets() as $market ) {
 			$market          = $this->apply_site_locale_when_not_multilingual( $market );
 			$base_feed_label = (string) ( $market['feed_label'] ?? '' );
-			$currency        = $this->get_market_currency( $market );
 			$languages       = is_array( $market['language'] ?? null ) ? $market['language'] : [];
 
-			if ( empty( $languages ) ) {
-				// A market with no configured languages accepts every product;
-				// all its entries sync under the site-language label, so it
-				// contributes that single label matching every language.
-				$markets[] = [
-					'feed_label' => $this->get_market_feed_label( $base_feed_label, '', $currency ),
-					'languages'  => [],
-				];
-				continue;
-			}
+			foreach ( $this->get_participating_currencies( $market ) as $currency ) {
+				if ( empty( $languages ) ) {
+					// A market with no configured languages accepts every product;
+					// all its entries sync under the site-language label, so it
+					// contributes that single label matching every language.
+					$markets[] = [
+						'feed_label' => $this->get_market_feed_label( $base_feed_label, '', $currency ),
+						'languages'  => [],
+					];
+					continue;
+				}
 
-			foreach ( $languages as $language ) {
-				$markets[] = [
-					'feed_label' => $this->get_market_feed_label( $base_feed_label, (string) $language, $currency ),
-					'languages'  => [ (string) $language ],
-				];
+				foreach ( $languages as $language ) {
+					$markets[] = [
+						'feed_label' => $this->get_market_feed_label( $base_feed_label, (string) $language, $currency ),
+						'languages'  => [ (string) $language ],
+					];
+				}
 			}
 		}
 
@@ -908,33 +1039,39 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 	/**
 	 * Returns every `google_ids` key a market's entries can be stored under:
-	 * the stored base feed label, the superseded currency-only label, and one
-	 * language-currency label per configured language.
+	 * the stored base feed label and one language-currency label per
+	 * configured language per configured currency.
 	 *
-	 * The base label and the currency-only label are always included so
-	 * entries synced before the language component was added to the scheme
-	 * are still found and cleaned up.
+	 * The base label is included so entries synced under the earliest scheme,
+	 * which used the stored label verbatim, are still found and cleaned up.
+	 * The intermediate currency-only scheme is not covered: it never shipped,
+	 * so its keys cannot exist outside stores that ran intermediate builds.
 	 *
 	 * @param string $feed_label The market's stored feed label.
 	 * @param array  $languages  The market's configured language codes. An
-	 *                           empty list contributes the site-language label.
-	 * @param string $currency   The market's effective currency code.
+	 *                           empty list contributes the site-language labels.
+	 * @param array  $currencies The market's configured currency codes. An
+	 *                           empty list contributes the store-currency labels.
 	 *
 	 * @return string[]
 	 */
-	private function get_market_feed_label_variants( string $feed_label, array $languages, string $currency ): array {
-		if ( '' === $currency ) {
-			$currency = get_woocommerce_currency();
+	private function get_market_feed_label_variants( string $feed_label, array $languages, array $currencies ): array {
+		if ( empty( $currencies ) ) {
+			$currencies = [ get_woocommerce_currency() ];
 		}
 
-		$variants = [
-			$feed_label,
-			$feed_label . '-' . strtoupper( $currency ),
-		];
-
+		$variants  = [ $feed_label ];
 		$languages = empty( $languages ) ? [ '' ] : $languages;
-		foreach ( $languages as $language ) {
-			$variants[] = $this->get_market_feed_label( $feed_label, (string) $language, $currency );
+
+		foreach ( $currencies as $currency ) {
+			$currency = (string) $currency;
+			if ( '' === $currency ) {
+				$currency = get_woocommerce_currency();
+			}
+
+			foreach ( $languages as $language ) {
+				$variants[] = $this->get_market_feed_label( $feed_label, (string) $language, $currency );
+			}
 		}
 
 		return array_values( array_unique( $variants ) );
@@ -942,11 +1079,11 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 	/**
 	 * Returns the current derived feed label set for a market config: one
-	 * language-currency label per configured language (the site-language
-	 * label when no languages are configured).
+	 * language-currency label per configured language per configured currency
+	 * (the site-language labels when no languages are configured).
 	 *
 	 * @param string $feed_label The market's stored feed label.
-	 * @param array  $market     The market config the languages and currency come from.
+	 * @param array  $market     The market config the languages and currencies come from.
 	 *
 	 * @return string[]
 	 */
@@ -955,11 +1092,12 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			? $market['language']
 			: [ '' ];
 
-		$currency = $this->get_market_currency( $market );
-		$labels   = [];
+		$labels = [];
 
-		foreach ( $languages as $language ) {
-			$labels[] = $this->get_market_feed_label( $feed_label, (string) $language, $currency );
+		foreach ( $this->get_market_currencies( $market ) as $currency ) {
+			foreach ( $languages as $language ) {
+				$labels[] = $this->get_market_feed_label( $feed_label, (string) $language, $currency );
+			}
 		}
 
 		return array_values( array_unique( $labels ) );

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -302,6 +302,48 @@ class BatchProductHelper implements Service {
 						'country' => $main_feed_label,
 						'input'   => $this->generate_product_input( $product, $main_feed_label, $main_feed_label, $this->market_service->get_all_countries(), $mapping_rules, $product_language ),
 					];
+
+					// The bare-label entry above carries the store currency;
+					// each additional participating primary currency gets its
+					// own derived-label entry with converted prices.
+					foreach ( $this->market_service->get_participating_currencies( $primary_market ) as $primary_currency ) {
+						if ( get_woocommerce_currency() === $primary_currency ) {
+							continue;
+						}
+
+						if ( ! $this->product_priced_in_currency( $product, $primary_currency ) ) {
+							do_action(
+								'woocommerce_gla_debug_message',
+								sprintf( 'Skipping the %s primary market entry for product (ID: %s): its price cannot be converted into that currency.', $primary_currency, $product->get_id() ),
+								__METHOD__
+							);
+
+							continue;
+						}
+
+						$primary_currency_label = $this->market_service->get_market_feed_label( $main_feed_label, $product_language, $primary_currency );
+
+						$primary_currency_validation = $this->validate_product(
+							$this->product_factory->create( $product, $main_feed_label, $mapping_rules, $primary_currency_label, $product_language, $primary_currency )
+						);
+						if ( $primary_currency_validation instanceof BatchInvalidProductEntry ) {
+							$this->mark_as_invalid( $primary_currency_validation );
+
+							do_action(
+								'woocommerce_gla_debug_message',
+								sprintf( 'Skipping product (ID: %s) because it does not pass validation for the %s primary market feed: %s', $product->get_id(), $primary_currency, wp_json_encode( $primary_currency_validation ) ),
+								__METHOD__
+							);
+
+							continue 2;
+						}
+
+						$product_entries[] = [
+							'product' => $product,
+							'country' => $main_feed_label,
+							'input'   => $this->generate_product_input( $product, $main_feed_label, $primary_currency_label, $this->market_service->get_all_countries(), $mapping_rules, $product_language, $primary_currency ),
+						];
+					}
 				}
 
 				// Participating markets only: a market priced in a non-store
@@ -322,31 +364,49 @@ class BatchProductHelper implements Service {
 					// (both falling back to site defaults inside the
 					// derivation). A market with no configured languages
 					// accepts every product under its site-language label.
-					$market_currency   = $this->extract_currency( $market );
-					$market_language   = empty( $market['language'] ) ? '' : $product_language;
-					$market_feed_label = $this->market_service->get_market_feed_label( $market['feed_label'], $market_language, $market_currency );
+					// Every participating currency produces its own entry.
+					$market_language = empty( $market['language'] ) ? '' : $product_language;
 
-					$secondary_validation = $this->validate_product(
-						$this->product_factory->create( $product, $market['country'], $mapping_rules, $market_feed_label, $product_language, $market_currency )
-					);
-					if ( $secondary_validation instanceof BatchInvalidProductEntry ) {
-						$this->mark_as_invalid( $secondary_validation );
+					foreach ( $this->market_service->get_participating_currencies( $market ) as $market_currency ) {
+						if ( ! $this->product_priced_in_currency( $product, $market_currency ) ) {
+							do_action(
+								'woocommerce_gla_debug_message',
+								sprintf( 'Skipping the %s entry of secondary market %s for product (ID: %s): its price cannot be converted into that currency.', $market_currency, $market_id, $product->get_id() ),
+								__METHOD__
+							);
 
-						do_action(
-							'woocommerce_gla_debug_message',
-							sprintf( 'Skipping product (ID: %s) because it does not pass validation for secondary market %s: %s', $product->get_id(), $market_id, wp_json_encode( $secondary_validation ) ),
-							__METHOD__
+							continue;
+						}
+
+						$market_feed_label = $this->market_service->get_market_feed_label( $market['feed_label'], $market_language, $market_currency );
+
+						// Store-currency entries need no conversion, so they
+						// carry no currency override and price exactly as a
+						// single-currency market's entries always have.
+						$currency_override = get_woocommerce_currency() === $market_currency ? '' : $market_currency;
+
+						$secondary_validation = $this->validate_product(
+							$this->product_factory->create( $product, $market['country'], $mapping_rules, $market_feed_label, $product_language, $currency_override )
 						);
+						if ( $secondary_validation instanceof BatchInvalidProductEntry ) {
+							$this->mark_as_invalid( $secondary_validation );
 
-						continue 2;
+							do_action(
+								'woocommerce_gla_debug_message',
+								sprintf( 'Skipping product (ID: %s) because it does not pass validation for secondary market %s: %s', $product->get_id(), $market_id, wp_json_encode( $secondary_validation ) ),
+								__METHOD__
+							);
+
+							continue 3;
+						}
+
+						// Secondary market shipping is scoped to the market's own country.
+						$product_entries[] = [
+							'product' => $product,
+							'country' => $market['country'],
+							'input'   => $this->generate_product_input( $product, $market['country'], $market_feed_label, [ $market['country'] ], $mapping_rules, $product_language, $currency_override ),
+						];
 					}
-
-					// Secondary market shipping is scoped to the market's own country.
-					$product_entries[] = [
-						'product' => $product,
-						'country' => $market['country'],
-						'input'   => $this->generate_product_input( $product, $market['country'], $market_feed_label, [ $market['country'] ], $mapping_rules, $product_language, $market_currency ),
-					];
 				}
 
 				if ( ! empty( $product_entries ) ) {
@@ -433,19 +493,24 @@ class BatchProductHelper implements Service {
 	}
 
 	/**
-	 * Extracts a single currency code from a market config.
+	 * Whether a product can be priced in the given currency.
 	 *
-	 * Each MC product carries exactly one price.currency. Markets store currency
-	 * as an array of codes; the first entry is used.
+	 * The store currency always qualifies. Any other currency qualifies only
+	 * when WPML can produce a converted or manually set price for the product,
+	 * so a product is never submitted with a store-currency price under a
+	 * non-store-currency feed label.
 	 *
-	 * @param array $market A market config array as returned by MarketService.
+	 * @param WC_Product $product
+	 * @param string     $currency ISO 4217 currency code.
 	 *
-	 * @return string The single currency code, or empty string when none is set.
+	 * @return bool
 	 */
-	private static function extract_currency( array $market ): string {
-		return is_array( $market['currency'] ?? null )
-			? (string) ( $market['currency'][0] ?? '' )
-			: (string) ( $market['currency'] ?? '' );
+	private function product_priced_in_currency( WC_Product $product, string $currency ): bool {
+		if ( get_woocommerce_currency() === $currency ) {
+			return true;
+		}
+
+		return null !== $this->wpml->get_product_price_in_currency( $product, $currency );
 	}
 
 	/**

--- a/src/Product/WCProductInputAdapter.php
+++ b/src/Product/WCProductInputAdapter.php
@@ -330,22 +330,31 @@ class WCProductInputAdapter {
 
 	/**
 	 * Map the regular price, applying tax inclusion/exclusion rules.
+	 *
+	 * With a currency override set, the price is always the converted value;
+	 * when no converted value is available the price is left unset, so a
+	 * store-currency amount is never submitted under a non-store-currency
+	 * feed label.
 	 */
 	protected function map_price(): void {
-		if ( '' !== $this->currency_override && null !== $this->wpml ) {
-			$converted = $this->wpml->get_product_price_in_currency( $this->wc_product, $this->currency_override );
+		if ( '' !== $this->currency_override ) {
+			$converted = null !== $this->wpml
+				? $this->wpml->get_product_price_in_currency( $this->wc_product, $this->currency_override )
+				: null;
 
-			if ( null !== $converted ) {
-				$price = $this->tax_excluded
-					? wc_get_price_excluding_tax( $this->wc_product, [ 'price' => $converted ] )
-					: wc_get_price_including_tax( $this->wc_product, [ 'price' => $converted ] );
-
-				/** This filter is documented in src/Product/WCProductAdapter.php */
-				$price = apply_filters( 'woocommerce_gla_product_attribute_value_price', $price, $this->wc_product, $this->tax_excluded );
-
-				$this->attributes['price'] = $this->to_money( (float) $price, strtoupper( $this->currency_override ) );
+			if ( null === $converted ) {
 				return;
 			}
+
+			$price = $this->tax_excluded
+				? wc_get_price_excluding_tax( $this->wc_product, [ 'price' => $converted ] )
+				: wc_get_price_including_tax( $this->wc_product, [ 'price' => $converted ] );
+
+			/** This filter is documented in src/Product/WCProductAdapter.php */
+			$price = apply_filters( 'woocommerce_gla_product_attribute_value_price', $price, $this->wc_product, $this->tax_excluded );
+
+			$this->attributes['price'] = $this->to_money( (float) $price, strtoupper( $this->currency_override ) );
+			return;
 		}
 
 		$regular_price = $this->wc_product->get_regular_price();

--- a/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -42,12 +43,19 @@ abstract class AbstractShippingSettingsAdapter {
 	protected $regions = [];
 
 	/**
-	 * Optional map of country code => ISO 4217 currency code used to override
-	 * `$currency` on a per-country basis. Populated from configured markets.
+	 * Optional map of country code => list of ISO 4217 currency codes used to
+	 * override `$currency` on a per-country basis. Populated from configured
+	 * markets; each listed currency gets its own shipping service.
 	 *
-	 * @var array<string, string>
+	 * @var array<string, string[]>
 	 */
 	protected $country_currency_map = [];
+
+	/**
+	 * @var WPML|null WPML integration used to convert amounts for services in
+	 *                a non-store currency.
+	 */
+	protected $wpml;
 
 	/**
 	 * AbstractShippingSettingsAdapter constructor.
@@ -64,6 +72,9 @@ abstract class AbstractShippingSettingsAdapter {
 		$this->country_currency_map = isset( $properties['country_currency_map'] ) && is_array( $properties['country_currency_map'] )
 			? $properties['country_currency_map']
 			: [];
+		$this->wpml                 = isset( $properties['wpml'] ) && $properties['wpml'] instanceof WPML
+			? $properties['wpml']
+			: null;
 
 		$this->map_gla_data( $properties );
 	}
@@ -87,15 +98,63 @@ abstract class AbstractShippingSettingsAdapter {
 	}
 
 	/**
-	 * Returns the currency to use for a given country's shipping service,
-	 * preferring the per-country mapping when supplied and falling back to the
-	 * adapter's default `$currency` otherwise.
+	 * Returns the currencies whose shipping services a given country needs,
+	 * preferring the per-country mapping when supplied and falling back to a
+	 * single-entry list with the adapter's default `$currency` otherwise.
+	 * Every returned currency gets its own service for the country.
 	 *
 	 * @param string $country
-	 * @return string
+	 * @return string[]
 	 */
-	protected function get_currency_for_country( string $country ): string {
-		return $this->country_currency_map[ $country ] ?? $this->currency;
+	protected function get_currencies_for_country( string $country ): array {
+		$currencies = $this->country_currency_map[ $country ] ?? [];
+		$currencies = array_values( array_filter( array_map( 'strval', (array) $currencies ) ) );
+
+		return empty( $currencies ) ? [ $this->currency ] : $currencies;
+	}
+
+	/**
+	 * Converts a store-currency amount into the given service currency.
+	 *
+	 * The store currency needs no conversion and is returned unchanged. Any
+	 * other currency is converted via the WPML integration, returning null
+	 * when no integration was provided or conversion is unavailable, so the
+	 * caller can leave that currency's service out.
+	 *
+	 * @param float  $amount   Amount in the store currency.
+	 * @param string $currency ISO 4217 currency code of the service.
+	 *
+	 * @return float|null
+	 */
+	protected function convert_amount_for_service( float $amount, string $currency ): ?float {
+		if ( $currency === $this->currency ) {
+			return $amount;
+		}
+
+		if ( null === $this->wpml ) {
+			return null;
+		}
+
+		return $this->wpml->convert_amount( $amount, $currency );
+	}
+
+	/**
+	 * Reports a currency's shipping service left out for a country because its
+	 * amounts cannot be converted into that currency.
+	 *
+	 * @param string $country
+	 * @param string $currency
+	 */
+	protected function report_country_missing_conversion( string $country, string $currency ): void {
+		do_action(
+			'woocommerce_gla_error',
+			sprintf(
+				'Skipping the %1$s shipping service for country %2$s: the shipping amounts cannot be converted into that currency. Its Merchant Center shipping service is left out of the sync until currency conversion is available.',
+				$currency,
+				$country
+			),
+			__METHOD__
+		);
 	}
 
 	/**
@@ -190,6 +249,7 @@ abstract class AbstractShippingSettingsAdapter {
 		unset( $data['currency'] );
 		unset( $data['delivery_times'] );
 		unset( $data['country_currency_map'] );
+		unset( $data['wpml'] );
 	}
 
 	/**

--- a/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
@@ -42,6 +42,13 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	/**
 	 * Map the shipping rates stored for each country in DB to shipping services.
 	 *
+	 * Every currency mapped to a row's country gets its own service, so
+	 * products priced in each currency find a currency-matching shipping
+	 * service. A row's amount is used directly for its own currency's
+	 * service; rows stored in the store currency are converted for each
+	 * additional mapped currency, and a currency with no conversion path is
+	 * left out with an error.
+	 *
 	 * @param array[] $db_rates
 	 *
 	 * @return void
@@ -49,7 +56,7 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	protected function map_db_rates( array $db_rates ): void {
 		// Per-row currency drives the synced service so multi-market stores don't
 		// have their secondary-market rates pushed in the primary store currency.
-		// Fall back to the per-country currency map for legacy rows missing one.
+		// Legacy rows missing a currency are treated as store-currency rows.
 		foreach ( $db_rates as $db_rate ) {
 			$country = $db_rate['country'] ?? null;
 			$rate    = $db_rate['rate'] ?? null;
@@ -71,26 +78,72 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 				continue;
 			}
 
-			$currency = ! empty( $db_rate['currency'] )
-				? $db_rate['currency']
-				: $this->get_currency_for_country( $country );
+			$row_currency = ! empty( $db_rate['currency'] ) ? $db_rate['currency'] : $this->currency;
 
-			$service = $this->create_shipping_service( $country, $currency, (float) $rate );
+			// A country without a mapped currency list keeps the row's own
+			// currency driving its single service, exactly as before markets
+			// carried multiple currencies.
+			$service_currencies = isset( $this->country_currency_map[ $country ] )
+				? $this->get_currencies_for_country( $country )
+				: [ $row_currency ];
 
-			if ( isset( $options['free_shipping_threshold'] ) ) {
-				$minimum_order_value = (float) $options['free_shipping_threshold'];
+			foreach ( $service_currencies as $service_currency ) {
+				$service_rate = $this->resolve_row_amount( (float) $rate, $row_currency, $service_currency );
 
-				if ( $rate > 0 ) {
-					// Add a conditional free-shipping service if the current rate is not free.
-					$this->services[] = $this->create_conditional_free_shipping_service( $country, $currency, $minimum_order_value );
-				} else {
-					// Set the minimum order value if the current rate is free.
-					$service['minimumOrderValue'] = $this->mapi_price( $minimum_order_value, $currency );
+				if ( null === $service_rate ) {
+					$this->report_country_missing_conversion( $country, $service_currency );
+					continue;
 				}
-			}
 
-			$this->services[] = $service;
+				$minimum_order_value = null;
+				if ( isset( $options['free_shipping_threshold'] ) ) {
+					$minimum_order_value = $this->resolve_row_amount( (float) $options['free_shipping_threshold'], $row_currency, $service_currency );
+
+					if ( null === $minimum_order_value ) {
+						$this->report_country_missing_conversion( $country, $service_currency );
+						continue;
+					}
+				}
+
+				$service = $this->create_shipping_service( $country, $service_currency, $service_rate );
+
+				if ( null !== $minimum_order_value ) {
+					if ( $service_rate > 0 ) {
+						// Add a conditional free-shipping service if the current rate is not free.
+						$this->services[] = $this->create_conditional_free_shipping_service( $country, $service_currency, $minimum_order_value );
+					} else {
+						// Set the minimum order value if the current rate is free.
+						$service['minimumOrderValue'] = $this->mapi_price( $minimum_order_value, $service_currency );
+					}
+				}
+
+				$this->services[] = $service;
+			}
 		}
+	}
+
+	/**
+	 * Resolves a row amount for a service currency: the amount as-is when the
+	 * row is stored in the service currency, the converted amount when the row
+	 * is stored in the store currency, and null when neither applies (there is
+	 * no conversion path between two non-store currencies).
+	 *
+	 * @param float  $amount           Amount as stored on the row.
+	 * @param string $row_currency     Currency the row is stored in.
+	 * @param string $service_currency Currency of the service being built.
+	 *
+	 * @return float|null
+	 */
+	protected function resolve_row_amount( float $amount, string $row_currency, string $service_currency ): ?float {
+		if ( $service_currency === $row_currency ) {
+			return $amount;
+		}
+
+		if ( $row_currency !== $this->currency ) {
+			return null;
+		}
+
+		return $this->convert_amount_for_service( $amount, $service_currency );
 	}
 
 	/**

--- a/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
@@ -68,8 +68,17 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 			// array_merge would renumber them, breaking the table -> region reference.
 			$this->regions = array_replace( $this->regions, $this->get_location_rates_regions( $rates_collection->get_location_rates() ) );
 
+			// Every currency mapped to the country gets its own service, so
+			// products priced in each currency find a currency-matching
+			// shipping service.
 			foreach ( $rates_collection->get_rates_grouped_by_service() as $service_collection ) {
-				$this->services[] = $this->create_shipping_service( $service_collection );
+				foreach ( $this->get_currencies_for_country( $rates_collection->get_country() ) as $service_currency ) {
+					$service = $this->create_shipping_service( $service_collection, $service_currency );
+
+					if ( null !== $service ) {
+						$this->services[] = $service;
+					}
+				}
 			}
 		}
 	}
@@ -116,34 +125,60 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	}
 
 	/**
-	 * Create a shipping service.
+	 * Create a shipping service in the given currency.
+	 *
+	 * Rate group prices must be in the same currency as the service they
+	 * belong to, so for a non-store currency every rate amount and the
+	 * minimum order value are converted before the service is built. When
+	 * any amount cannot be converted the whole service is left out (null)
+	 * with an error, so a store-currency amount is never sent under a
+	 * non-store-currency service.
 	 *
 	 * @param ServiceRatesCollection $service_collection
+	 * @param string                 $currency ISO 4217 currency code of the service.
 	 *
-	 * @return array
+	 * @return array|null The service, or null when its amounts cannot be
+	 *                    converted into the given currency.
 	 */
-	protected function create_shipping_service( ServiceRatesCollection $service_collection ): array {
-		$country  = $service_collection->get_country();
-		$currency = $this->get_currency_for_country( $country );
+	protected function create_shipping_service( ServiceRatesCollection $service_collection, string $currency ): ?array {
+		$country = $service_collection->get_country();
 
-		// Rate group prices must be in the same currency as the service they
-		// belong to, so the per-country currency is resolved before building them.
 		$rate_groups   = [];
 		$shipping_area = $service_collection->get_shipping_area();
 		foreach ( $service_collection->get_rates_grouped_by_shipping_class() as $class => $location_rates ) {
+			$converted_rates = $this->convert_location_rates( $location_rates, $currency );
+
+			if ( null === $converted_rates ) {
+				$this->report_country_missing_conversion( $country, $currency );
+
+				return null;
+			}
+
 			$applicable_classes    = ! empty( $class ) ? [ $class ] : [];
-			$rate_groups[ $class ] = $this->create_rate_group( $location_rates, $shipping_area, $applicable_classes, $currency );
+			$rate_groups[ $class ] = $this->create_rate_group( $converted_rates, $shipping_area, $applicable_classes, $currency );
+		}
+
+		$min_order_amount = $service_collection->get_min_order_amount();
+		if ( $min_order_amount ) {
+			$min_order_amount = $this->convert_amount_for_service( (float) $min_order_amount, $currency );
+
+			if ( null === $min_order_amount ) {
+				$this->report_country_missing_conversion( $country, $currency );
+
+				return null;
+			}
 		}
 
 		$service = [
 			'serviceName'       => sprintf(
-				/* translators: %1 is a random 4-digit string, %2 is the country code */
-				__( '[%1$s] Google for WooCommerce generated service - %2$s', 'google-listings-and-ads' ),
+				/* translators: %1 is a random 4-digit string, %2 is the country code, %3 is the currency code */
+				__( '[%1$s] Google for WooCommerce generated service - %2$s (%3$s)', 'google-listings-and-ads' ),
 				sprintf( '%04x', wp_rand( 0, 0xffff ) ),
-				$country
+				$country,
+				$currency
 			),
 			'active'            => true,
-			// One service per country; deliveryCountries is an array as MAPI requires.
+			// One service per country and currency; deliveryCountries is an array as MAPI requires.
 			'deliveryCountries' => [ $country ],
 			'currencyCode'      => $currency,
 			'deliveryTime'      => $this->get_delivery_time( $country ),
@@ -151,12 +186,43 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 			'rateGroups'        => array_values( $rate_groups ),
 		];
 
-		$min_order_amount = $service_collection->get_min_order_amount();
 		if ( $min_order_amount ) {
 			$service['minimumOrderValue'] = $this->mapi_price( (float) $min_order_amount, $currency );
 		}
 
 		return $service;
+	}
+
+	/**
+	 * Returns the location rates with every amount converted into the given
+	 * currency, or the rates unchanged for the store currency. Returns null
+	 * when any amount cannot be converted.
+	 *
+	 * @param LocationRate[] $location_rates
+	 * @param string         $currency ISO 4217 currency code of the service.
+	 *
+	 * @return LocationRate[]|null
+	 */
+	protected function convert_location_rates( array $location_rates, string $currency ): ?array {
+		if ( $currency === $this->currency ) {
+			return $location_rates;
+		}
+
+		$converted = [];
+		foreach ( $location_rates as $location_rate ) {
+			$amount = $this->convert_amount_for_service( (float) $location_rate->get_shipping_rate()->get_rate(), $currency );
+
+			if ( null === $amount ) {
+				return null;
+			}
+
+			$shipping_rate = clone $location_rate->get_shipping_rate();
+			$shipping_rate->set_rate( $amount );
+
+			$converted[] = new LocationRate( $location_rate->get_location(), $shipping_rate );
+		}
+
+		return $converted;
 	}
 
 	/**

--- a/tests/Unit/API/Google/SettingsTest.php
+++ b/tests/Unit/API/Google/SettingsTest.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAcc
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -57,6 +58,9 @@ class SettingsTest extends UnitTest {
 	/** @var MockObject|ShippingZone */
 	protected $shipping_zone;
 
+	/** @var MockObject|WPML */
+	protected $wpml;
+
 	/** @var Container */
 	protected $container;
 
@@ -75,6 +79,25 @@ class SettingsTest extends UnitTest {
 		$this->shipping_rate_query = $this->createMock( ShippingRateQuery::class );
 		$this->shipping_zone       = $this->createMock( ShippingZone::class );
 
+		// Amounts convert one-to-one so currency assertions stay readable;
+		// tests exercising real conversion arithmetic live in the adapter tests.
+		$this->wpml = $this->createMock( WPML::class );
+		$this->wpml->method( 'convert_amount' )->willReturnCallback(
+			static function ( float $amount ): float {
+				return $amount;
+			}
+		);
+
+		// Mirrors MarketService::get_participating_currencies() with every
+		// configured currency treated as convertible.
+		$this->market_service->method( 'get_participating_currencies' )->willReturnCallback(
+			static function ( array $market ): array {
+				$configured = is_array( $market['currency'] ?? null ) ? $market['currency'] : [];
+
+				return array_values( array_unique( array_filter( array_map( 'strval', $configured ) ) ) );
+			}
+		);
+
 		$this->container = new Container();
 		$this->container->addShared( MapiAccountRegionsService::class, $this->regions_service );
 		$this->container->addShared( MarketService::class, $this->market_service );
@@ -84,6 +107,7 @@ class SettingsTest extends UnitTest {
 		$this->container->addShared( ShippingTimeQuery::class, $this->shipping_time_query );
 		$this->container->addShared( ShippingRateQuery::class, $this->shipping_rate_query );
 		$this->container->addShared( ShippingZone::class, $this->shipping_zone );
+		$this->container->addShared( WPML::class, $this->wpml );
 
 		$this->settings = new Settings();
 		$this->settings->set_container( $this->container );
@@ -227,10 +251,18 @@ class SettingsTest extends UnitTest {
 	}
 
 	public function test_generate_shipping_settings_skips_manual_markets_from_currency_map(): void {
+		$this->market_service->method( 'get_primary_market' )->willReturn(
+			[
+				'countries'     => [ 'US' ],
+				'country'       => null,
+				'currency'      => [ 'USD' ],
+				'shipping_rate' => 'flat',
+			]
+		);
 		$this->market_service->method( 'get_participating_markets' )->willReturn(
 			[
 				'primary' => [
-					'country'       => 'US',
+					'country'       => null,
 					'currency'      => [ 'USD' ],
 					'shipping_rate' => 'flat',
 					'shipping_time' => 'flat',
@@ -248,13 +280,65 @@ class SettingsTest extends UnitTest {
 
 		$map = $this->invoke( 'build_country_currency_map' );
 
-		$this->assertSame( [ 'US' => 'USD' ], $map );
+		$this->assertSame( [ 'US' => [ 'USD' ] ], $map );
 	}
 
-	public function test_generate_shipping_settings_prefers_per_row_currency_over_country_map(): void {
-		// MarketService says FR is USD, but the DB row for FR carries EUR. The
-		// per-row currency must win so secondary-market rates aren't silently
-		// rewritten to the primary store currency.
+	public function test_country_currency_map_includes_primary_countries_with_extra_currencies(): void {
+		$this->market_service->method( 'get_primary_market' )->willReturn(
+			[
+				'countries'     => [ 'US', 'GB' ],
+				'country'       => null,
+				'currency'      => [ 'USD', 'EUR' ],
+				'shipping_rate' => 'flat',
+			]
+		);
+		$this->market_service->method( 'get_participating_markets' )->willReturn( [] );
+
+		$this->wc_proxy->method( 'get_woocommerce_currency' )->willReturn( 'USD' );
+
+		$map = $this->invoke( 'build_country_currency_map' );
+
+		$this->assertSame(
+			[
+				'US' => [ 'USD', 'EUR' ],
+				'GB' => [ 'USD', 'EUR' ],
+			],
+			$map
+		);
+	}
+
+	public function test_country_currency_map_lists_every_participating_currency_of_a_market(): void {
+		$this->market_service->method( 'get_participating_markets' )->willReturn(
+			[
+				'ae' => [
+					'country'       => 'AE',
+					'currency'      => [ 'USD', 'AED' ],
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+			]
+		);
+
+		$this->wc_proxy->method( 'get_woocommerce_currency' )->willReturn( 'USD' );
+
+		$map = $this->invoke( 'build_country_currency_map' );
+
+		$this->assertSame( [ 'AE' => [ 'USD', 'AED' ] ], $map );
+	}
+
+	public function test_flat_mode_leaves_out_service_when_row_currency_conflicts_with_market_currencies(): void {
+		// MarketService says FR sells in USD, but the DB row for FR carries EUR
+		// amounts. There is no conversion path between the two, so no FR
+		// service is synced (a mislabelled or mismatched service would cause
+		// disapprovals) and the conflict is reported.
+		$reported = [];
+		add_action(
+			'woocommerce_gla_error',
+			function ( $message ) use ( &$reported ) {
+				$reported[] = $message;
+			}
+		);
+
 		$this->market_service->method( 'get_participating_markets' )->willReturn(
 			[
 				'primary' => [
@@ -318,13 +402,16 @@ class SettingsTest extends UnitTest {
 
 		$this->assertInstanceOf( DBShippingSettingsAdapter::class, $adapter );
 
-		$by_country = [];
-		foreach ( $adapter->get_services() as $service ) {
-			$by_country[ $service['deliveryCountries'][0] ] = $service;
-		}
+		$countries = array_map(
+			static function ( array $service ): string {
+				return $service['deliveryCountries'][0];
+			},
+			$adapter->get_services()
+		);
 
-		$this->assertSame( 'USD', $by_country['US']['currencyCode'] );
-		$this->assertSame( 'EUR', $by_country['FR']['currencyCode'] );
+		$this->assertSame( [ 'US' ], $countries );
+		$this->assertCount( 1, $reported );
+		$this->assertStringContainsString( 'FR', $reported[0] );
 	}
 
 	public function test_generate_shipping_settings_routes_automatic_mode_through_wc_adapter(): void {

--- a/tests/Unit/Integration/WPMLTest.php
+++ b/tests/Unit/Integration/WPMLTest.php
@@ -425,6 +425,49 @@ class WPMLTest extends UnitTest {
 		$this->assertSame( 8.0, $integration->get_product_price_in_currency( $product, 'EUR' ) );
 	}
 
+	public function test_convert_amount_returns_null_when_not_active(): void {
+		$integration = $this->create_integration( false );
+
+		$this->assertNull( $integration->convert_amount( 10.0, 'EUR' ) );
+	}
+
+	public function test_convert_amount_returns_null_when_wcml_multi_currency_off(): void {
+		$integration = $this->create_integration( true, [], false );
+
+		$this->assertNull( $integration->convert_amount( 10.0, 'EUR' ) );
+	}
+
+	public function test_convert_amount_returns_converted_amount(): void {
+		$integration = $this->create_integration( true, [], true );
+
+		add_filter(
+			'wcml_raw_price_amount',
+			function ( $price ) {
+				return (float) $price * 0.8;
+			}
+		);
+
+		$this->assertSame( 8.0, $integration->convert_amount( 10.0, 'EUR' ) );
+	}
+
+	public function test_convert_amount_returns_null_for_inactive_currency(): void {
+		$integration = $this->create_integration( true, [ get_woocommerce_currency(), 'EUR' ], true );
+
+		// WCML's conversion filter returns 0 for a currency it does not have
+		// active, so an inactive currency must read as unconvertible, never
+		// as a zero amount.
+		$this->assertNull( $integration->convert_amount( 10.0, 'AED' ) );
+	}
+
+	public function test_get_product_price_in_currency_returns_null_for_inactive_currency(): void {
+		$integration = $this->create_integration( true, [ get_woocommerce_currency(), 'EUR' ], true );
+
+		$product = $this->createMock( WC_Product::class );
+		$product->method( 'get_regular_price' )->willReturn( '10' );
+
+		$this->assertNull( $integration->get_product_price_in_currency( $product, 'AED' ) );
+	}
+
 	public function test_get_product_sale_price_in_currency_returns_null_when_not_active(): void {
 		$integration = $this->create_integration( false );
 
@@ -711,6 +754,13 @@ class WPMLTest extends UnitTest {
 	 */
 	private function create_integration( bool $is_active, array $currency_codes = [], ?bool $wcml_multi_currency_on = null, $custom_prices = false ): WPML {
 		$methods = [ 'is_active', 'get_wcml_custom_prices' ];
+
+		// Conversion only happens into WCML-active currencies, so
+		// multi-currency tests get a permissive default set covering the
+		// store currency and EUR unless the test supplies its own codes.
+		if ( empty( $currency_codes ) && true === $wcml_multi_currency_on ) {
+			$currency_codes = [ get_woocommerce_currency(), 'EUR' ];
+		}
 
 		if ( ! empty( $currency_codes ) ) {
 			$methods[] = 'get_active_currency_codes';

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -943,7 +943,7 @@ class MarketServiceTest extends UnitTest {
 
 		$this->cleanup_job->expects( $this->once() )
 			->method( 'schedule' )
-			->with( [ 'feed_labels' => [ 'GB', 'GB-GBP', 'GB-EN-GBP' ] ] );
+			->with( [ 'feed_labels' => [ 'GB', 'GB-EN-GBP' ] ] );
 
 		// feed_label rename alone does not touch country/currency/shipping_rate/shipping_time.
 		$this->shipping_settings_job->expects( $this->never() )
@@ -969,7 +969,7 @@ class MarketServiceTest extends UnitTest {
 		// the market's entries and the old label's entries become orphans.
 		$this->cleanup_job->expects( $this->once() )
 			->method( 'schedule' )
-			->with( [ 'feed_labels' => [ 'GB', 'GB-GBP', 'GB-EN-GBP' ] ] );
+			->with( [ 'feed_labels' => [ 'GB', 'GB-EN-GBP' ] ] );
 
 		$this->market_service->update_market( 'gb', [ 'currency' => [ 'EUR' ] ] );
 	}
@@ -1027,7 +1027,7 @@ class MarketServiceTest extends UnitTest {
 		// orphans the old language's label; the new label is left alone.
 		$this->cleanup_job->expects( $this->once() )
 			->method( 'schedule' )
-			->with( [ 'feed_labels' => [ 'GB', 'GB-GBP', 'GB-EN-GBP' ] ] );
+			->with( [ 'feed_labels' => [ 'GB', 'GB-EN-GBP' ] ] );
 
 		$this->market_service->update_market( 'gb', [ 'language' => [ 'ga' ] ] );
 	}
@@ -1604,7 +1604,7 @@ class MarketServiceTest extends UnitTest {
 
 		$this->cleanup_job->expects( $this->once() )
 			->method( 'schedule' )
-			->with( [ 'feed_labels' => [ 'GB', 'GB-GBP', 'GB-EN-GBP' ] ] );
+			->with( [ 'feed_labels' => [ 'GB', 'GB-EN-GBP' ] ] );
 
 		// Non-manual shipping_rate → shipping sync also scheduled.
 		$this->shipping_settings_job->expects( $this->once() )
@@ -3316,10 +3316,10 @@ class MarketServiceTest extends UnitTest {
 
 		// A removed language's entries live under its own derived label, so
 		// label-based cleanup covers them; the removed label plus the
-		// pre-language-scheme keys are cleaned, the surviving label is not.
+		// verbatim-label key are cleaned, the surviving label is not.
 		$this->cleanup_job->expects( $this->once() )
 			->method( 'schedule' )
-			->with( [ 'feed_labels' => [ 'GB', 'GB-GBP', 'GB-CY-GBP' ] ] );
+			->with( [ 'feed_labels' => [ 'GB', 'GB-CY-GBP' ] ] );
 		$this->language_cleanup_job->expects( $this->never() )->method( 'schedule' );
 
 		$this->market_service->update_market( 'gb', [ 'language' => [ 'en' ] ] );
@@ -3378,7 +3378,7 @@ class MarketServiceTest extends UnitTest {
 
 		$this->cleanup_job->expects( $this->once() )
 			->method( 'schedule' )
-			->with( [ 'feed_labels' => [ 'GB', 'GB-GBP', 'GB-EN-GBP', 'GB-CY-GBP' ] ] );
+			->with( [ 'feed_labels' => [ 'GB', 'GB-EN-GBP', 'GB-CY-GBP' ] ] );
 		$this->language_cleanup_job->expects( $this->never() )->method( 'schedule' );
 
 		$this->market_service->update_market(
@@ -4039,6 +4039,211 @@ class MarketServiceTest extends UnitTest {
 				'feed_label' => 'GB',
 			]
 		);
+	}
+
+	public function test_get_participating_currencies_drops_foreign_currency_without_conversion(): void {
+		$this->wpml->method( 'can_convert_currency' )->willReturn( false );
+
+		$market = [ 'currency' => [ get_woocommerce_currency(), 'AED' ] ];
+
+		$this->assertSame( [ get_woocommerce_currency() ], $this->market_service->get_participating_currencies( $market ) );
+	}
+
+	public function test_get_participating_currencies_includes_foreign_currency_with_conversion(): void {
+		$this->wpml->method( 'can_convert_currency' )->willReturn( true );
+
+		$market = [ 'currency' => [ get_woocommerce_currency(), 'AED' ] ];
+
+		$this->assertSame( [ get_woocommerce_currency(), 'AED' ], $this->market_service->get_participating_currencies( $market ) );
+	}
+
+	public function test_get_all_feed_labels_includes_every_currency_of_a_market(): void {
+		$this->wpml->method( 'is_active' )->willReturn( true );
+		$this->wpml->method( 'can_convert_currency' )->willReturn( true );
+
+		$secondary = [
+			'ae' => [
+				'country'    => 'AE',
+				'language'   => [ 'en', 'fr' ],
+				'currency'   => [ get_woocommerce_currency(), 'AED' ],
+				'feed_label' => 'AE',
+			],
+		];
+
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => $secondary ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$result = $this->market_service->get_all_feed_labels();
+
+		$store_currency = get_woocommerce_currency();
+		$this->assertContains( 'US', $result );
+		$this->assertContains( 'AE-EN-' . $store_currency, $result );
+		$this->assertContains( 'AE-FR-' . $store_currency, $result );
+		$this->assertContains( 'AE-EN-AED', $result );
+		$this->assertContains( 'AE-FR-AED', $result );
+		$this->assertCount( 5, $result );
+	}
+
+	public function test_get_all_feed_labels_excludes_non_participating_currency(): void {
+		$this->wpml->method( 'is_active' )->willReturn( true );
+		$this->wpml->method( 'can_convert_currency' )->willReturn( false );
+
+		$secondary = [
+			'ae' => [
+				'country'    => 'AE',
+				'language'   => [ 'en' ],
+				'currency'   => [ get_woocommerce_currency(), 'AED' ],
+				'feed_label' => 'AE',
+			],
+		];
+
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => $secondary ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		$result = $this->market_service->get_all_feed_labels();
+
+		$this->assertContains( 'AE-EN-' . get_woocommerce_currency(), $result );
+		$this->assertNotContains( 'AE-EN-AED', $result );
+	}
+
+	public function test_get_all_feed_labels_includes_primary_extra_currency_labels(): void {
+		$this->wpml->method( 'is_active' )->willReturn( true );
+		$this->wpml->method( 'can_convert_currency' )->willReturn( true );
+
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [],
+				OptionsInterface::MERCHANT_CENTER => [
+					'language' => [ 'en', 'fr' ],
+					'currency' => [ get_woocommerce_currency(), 'EUR' ],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'GB', [ 'GB' ] );
+
+		$result = $this->market_service->get_all_feed_labels();
+
+		// The store currency keeps the bare label; only the extra currency
+		// gets per-language derived labels.
+		$this->assertContains( 'GB', $result );
+		$this->assertContains( 'GB-EN-EUR', $result );
+		$this->assertContains( 'GB-FR-EUR', $result );
+		$this->assertNotContains( 'GB-EN-' . get_woocommerce_currency(), $result );
+		$this->assertCount( 3, $result );
+	}
+
+	public function test_update_market_schedules_cleanup_for_removed_currency_labels(): void {
+		$existing = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP', 'EUR' ],
+				'feed_label' => 'GB',
+			],
+		];
+
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+
+		// Removing EUR orphans the EUR label; the still-configured GBP
+		// language label stays out of the cleanup set.
+		$this->cleanup_job->expects( $this->once() )
+			->method( 'schedule' )
+			->with( [ 'feed_labels' => [ 'GB', 'GB-EN-EUR' ] ] );
+
+		$this->market_service->update_market( 'gb', [ 'currency' => [ 'GBP' ] ] );
+	}
+
+	public function test_update_market_primary_schedules_cleanup_for_removed_currency(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'language' => [ 'en', 'fr' ],
+					'currency' => [ get_woocommerce_currency(), 'EUR' ],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'GB' ] ],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'GB', [ 'GB' ] );
+
+		$this->cleanup_job->expects( $this->once() )
+			->method( 'schedule' )
+			->with( [ 'feed_labels' => [ 'GB-EN-EUR', 'GB-FR-EUR' ] ] );
+
+		$this->market_service->update_market( 'primary', [ 'currency' => [ get_woocommerce_currency() ] ] );
+	}
+
+	public function test_update_market_primary_removing_store_currency_schedules_no_cleanup(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'language' => [ 'en' ],
+					'currency' => [ get_woocommerce_currency(), 'EUR' ],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'GB' ] ],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'GB', [ 'GB' ] );
+
+		// The store currency's entries live under the bare main feed label,
+		// which stays current, so removing the store currency from the
+		// configured list must not clean anything up.
+		$this->cleanup_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market( 'primary', [ 'currency' => [ 'EUR' ] ] );
+	}
+
+	public function test_delete_market_schedules_cleanup_with_every_currency_label(): void {
+		$store_currency = get_woocommerce_currency();
+
+		$existing = [
+			'ae' => [
+				'country'    => 'AE',
+				'language'   => [ 'en', 'fr' ],
+				'currency'   => [ $store_currency, 'AED' ],
+				'feed_label' => 'AE',
+			],
+		];
+
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => $existing ] );
+		$this->options->method( 'update' )->willReturn( true );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->cleanup_job->expects( $this->once() )
+			->method( 'schedule' )
+			->with(
+				[
+					'feed_labels' => [
+						'AE',
+						'AE-EN-' . $store_currency,
+						'AE-FR-' . $store_currency,
+						'AE-EN-AED',
+						'AE-FR-AED',
+					],
+				]
+			);
+
+		$this->market_service->delete_market( 'ae' );
+	}
+
+	public function test_conversion_availability_change_with_primary_extra_currency_schedules(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::CURRENCY_CONVERSION_AVAILABLE => 'yes',
+				OptionsInterface::MARKETS         => [],
+				OptionsInterface::MERCHANT_CENTER => [
+					'currency' => [ get_woocommerce_currency(), 'EUR' ],
+				],
+			]
+		);
+		$this->wpml->method( 'can_convert_currency' )->willReturn( false );
+
+		$this->shipping_settings_job->expects( $this->once() )->method( 'schedule' );
+		$this->update_all_products_job->expects( $this->once() )->method( 'schedule' );
+
+		$this->invoke_conversion_availability_handler();
 	}
 
 	/**

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -71,6 +71,15 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 	/** @var AttributeMappingRulesQuery $rules_query */
 	protected $rules_query;
 
+	/**
+	 * Converted price per currency code returned by the WPML stub configured in
+	 * set_up_market_service_stubs(); a null value marks the currency as
+	 * unconvertible. Currencies not in the map convert to the product's own price.
+	 *
+	 * @var array<string, float|null>
+	 */
+	protected $wpml_converted_prices = [];
+
 	public function test_filter_synced_products_all_synced() {
 		$synced_product = WC_Helper_Product::create_simple_product();
 		$this->product_helper->mark_as_synced( $synced_product, $this->generate_google_product_mock() );
@@ -1298,7 +1307,7 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertSame( 'AUD', $captured_currencies_by_country['AU'] );
 	}
 
-	public function test_primary_entry_uses_store_currency_regardless_of_market_currency_array() {
+	public function test_primary_bare_label_entry_keeps_store_currency_and_extra_currency_adds_derived_entry() {
 		$product = WC_Helper_Product::create_simple_product();
 
 		$this->set_up_market_service_stubs(
@@ -1308,7 +1317,7 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 					'country'    => 'US',
 					'feed_label' => 'US',
 					'language'   => 'en',
-					'currency'   => [ 'EUR' ],
+					'currency'   => [ get_woocommerce_currency(), 'EUR' ],
 				],
 			]
 		);
@@ -1318,8 +1327,131 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 
 		$results = $this->batch_product_helper->generate_mapi_update_entries( [ $product ] );
 
-		$this->assertCount( 1, $results );
+		$this->assertCount( 2, $results );
+
+		// The bare-label entry always prices in the store currency.
+		$this->assertSame( 'US', $results[0]['input']->get_feed_label() );
 		$this->assertSame( get_woocommerce_currency(), $results[0]['input']->get_attributes()['price']['currencyCode'] );
+
+		// The additional currency gets its own derived-label entry with
+		// converted prices; both entries stay attached to the primary country.
+		$this->assertSame( 'US-EN-EUR', $results[1]['input']->get_feed_label() );
+		$this->assertSame( 'EUR', $results[1]['input']->get_attributes()['price']['currencyCode'] );
+		$this->assertSame( 'US', $results[1]['country'] );
+	}
+
+	public function test_secondary_market_with_two_currencies_emits_one_entry_per_currency() {
+		$product        = WC_Helper_Product::create_simple_product();
+		$store_currency = get_woocommerce_currency();
+
+		$this->set_up_market_service_stubs(
+			[ 'US', 'AE' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => 'en',
+				],
+				'ae'      => [
+					'country'    => 'AE',
+					'feed_label' => 'AE',
+					'language'   => [ 'en' ],
+					'currency'   => [ $store_currency, 'AED' ],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$results = $this->batch_product_helper->generate_mapi_update_entries( [ $product ] );
+
+		$this->assertCount( 3, $results );
+
+		$labels = array_map(
+			static function ( array $entry ): string {
+				return $entry['input']->get_feed_label();
+			},
+			$results
+		);
+
+		$this->assertContains( 'AE-EN-' . $store_currency, $labels );
+		$this->assertContains( 'AE-EN-AED', $labels );
+
+		foreach ( $results as $entry ) {
+			if ( 'AE-EN-AED' === $entry['input']->get_feed_label() ) {
+				$this->assertSame( 'AED', $entry['input']->get_attributes()['price']['currencyCode'] );
+			}
+			if ( 'AE-EN-' . $store_currency === $entry['input']->get_feed_label() ) {
+				$this->assertSame( $store_currency, $entry['input']->get_attributes()['price']['currencyCode'] );
+			}
+		}
+	}
+
+	public function test_unconvertible_currency_skips_only_that_currency_entry() {
+		$product        = WC_Helper_Product::create_simple_product();
+		$store_currency = get_woocommerce_currency();
+
+		// AED has no converted price, so its entry is skipped while the
+		// store-currency entry and the primary entry still sync.
+		$this->wpml_converted_prices['AED'] = null;
+
+		$this->set_up_market_service_stubs(
+			[ 'US', 'AE' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => 'en',
+				],
+				'ae'      => [
+					'country'    => 'AE',
+					'feed_label' => 'AE',
+					'language'   => [ 'en' ],
+					'currency'   => [ $store_currency, 'AED' ],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$results = $this->batch_product_helper->generate_mapi_update_entries( [ $product ] );
+
+		$this->assertCount( 2, $results );
+
+		$labels = array_map(
+			static function ( array $entry ): string {
+				return $entry['input']->get_feed_label();
+			},
+			$results
+		);
+
+		$this->assertContains( 'US', $labels );
+		$this->assertContains( 'AE-EN-' . $store_currency, $labels );
+		$this->assertNotContains( 'AE-EN-AED', $labels );
+	}
+
+	public function test_stale_entry_generators_keep_every_configured_currency_label() {
+		$products         = $this->create_and_return_supported_test_products();
+		$stale_product    = $products[0];
+		$stale_product_id = $stale_product->get_id();
+
+		$this->market_service->expects( $this->any() )
+			->method( 'get_all_feed_labels' )
+			->willReturn( [ 'US', 'AE-EN-USD', 'AE-EN-AED' ] );
+
+		$google_ids = [
+			'AE-EN-USD' => "en~AE-EN-USD~gla_{$stale_product_id}",
+			'AE-EN-AED' => "en~AE-EN-AED~gla_{$stale_product_id}",
+			'DK'        => "en~DK~gla_{$stale_product_id}",
+		];
+		$this->product_meta->update_google_ids( $stale_product, $google_ids );
+
+		$results = $this->batch_product_helper->generate_stale_products_delete_entries( $products );
+
+		$this->assertCount( 1, $results );
+		$this->assertContains( $google_ids['DK'], array_column( $results, 'google_id' ) );
 	}
 
 	/**
@@ -1354,6 +1486,38 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->market_service->method( 'get_all_countries' )->willReturn( $all_countries );
 		$this->market_service->method( 'get_participating_markets' )->willReturn( $markets );
 		$this->market_service->method( 'get_main_feed_label' )->willReturn( $main_feed_label );
+
+		// Mirrors MarketService::get_participating_currencies() with every
+		// configured currency treated as convertible: the market's configured
+		// currencies without duplicates, or the store currency when none are
+		// configured.
+		$this->market_service->method( 'get_participating_currencies' )->willReturnCallback(
+			static function ( array $market ): array {
+				$configured = is_array( $market['currency'] ?? null )
+					? $market['currency']
+					: [ $market['currency'] ?? '' ];
+
+				$currencies = array_values( array_unique( array_filter( array_map( 'strval', $configured ) ) ) );
+
+				return empty( $currencies ) ? [ get_woocommerce_currency() ] : $currencies;
+			}
+		);
+
+		// Non-store-currency entries are skipped when no converted price is
+		// available, so the WPML stub returns the product's own price for any
+		// requested currency; a test can mark a currency unconvertible via
+		// $this->wpml_converted_prices before calling this helper.
+		$this->wpml->method( 'get_product_price_in_currency' )->willReturnCallback(
+			function ( WC_Product $product, string $currency ): ?float {
+				if ( array_key_exists( $currency, $this->wpml_converted_prices ) ) {
+					return $this->wpml_converted_prices[ $currency ];
+				}
+
+				$price = $product->get_regular_price();
+
+				return '' === $price ? null : (float) $price;
+			}
+		);
 
 		// Mirrors MarketService::get_market_feed_label(): the stored label plus
 		// the uppercase two-letter language code plus the uppercase currency,

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductInputAdapter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
@@ -115,6 +116,31 @@ class WCProductInputAdapterTest extends UnitTest {
 		$product->save();
 
 		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertArrayNotHasKey( 'price', $attrs );
+	}
+
+	public function test_omits_price_when_currency_override_cannot_be_converted() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '19.99' );
+		$product->save();
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_product_price_in_currency' )->willReturn( null );
+
+		$attrs = ( new WCProductInputAdapter( $product, 'AE', null, [], [], [], 'AE-EN-AED', '', 'AED', $wpml ) )->get_product_input()->get_attributes();
+
+		// A store-currency amount must never be submitted under a
+		// non-store-currency feed label, so the price stays unset.
+		$this->assertArrayNotHasKey( 'price', $attrs );
+	}
+
+	public function test_omits_price_when_currency_override_set_without_wpml() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( '19.99' );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'AE', null, [], [], [], 'AE-EN-AED', '', 'AED', null ) )->get_product_input()->get_attributes();
 
 		$this->assertArrayNotHasKey( 'price', $attrs );
 	}

--- a/tests/Unit/Shipping/GoogleAdapter/DBShippingSettingsAdapterTest.php
+++ b/tests/Unit/Shipping/GoogleAdapter/DBShippingSettingsAdapterTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping\GoogleAdapter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\DBShippingSettingsAdapter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 
@@ -470,6 +471,7 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 				'country_currency_map' => [
 					'FR' => 'EUR',
 				],
+				'wpml'                 => $this->create_wpml_doubling_converter(),
 				'delivery_times'       => [
 					'US' => [
 						'time'     => 1,
@@ -494,7 +496,123 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 			} elseif ( 'FR' === $service['deliveryCountries'][0] ) {
 				$this->assertEquals( 'EUR', $service['currencyCode'] );
 				$this->assertEquals( 'EUR', $service['rateGroups'][0]['singleValue']['flatRate']['currencyCode'] );
+
+				// The store-currency amount is converted, not relabelled:
+				// 5 USD doubles to 10 EUR under the test converter.
+				$this->assertSame( '10000000', $service['rateGroups'][0]['singleValue']['flatRate']['amountMicros'] );
 			}
 		}
+	}
+
+	public function test_creates_one_service_per_currency_for_a_multi_currency_country() {
+		$db_rates = [
+			[
+				'country' => 'AE',
+				'rate'    => 50,
+				'options' => [
+					'free_shipping_threshold' => 200,
+				],
+			],
+		];
+
+		$settings = new DBShippingSettingsAdapter(
+			[
+				'currency'             => 'USD',
+				'country_currency_map' => [
+					'AE' => [ 'USD', 'AED' ],
+				],
+				'wpml'                 => $this->create_wpml_doubling_converter(),
+				'delivery_times'       => [
+					'AE' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
+				'db_rates'             => $db_rates,
+			]
+		);
+
+		$services = $settings->get_services();
+
+		// One paid service plus one conditional free-shipping service per currency.
+		$this->assertCount( 4, $services );
+
+		$paid_by_currency = [];
+		foreach ( $services as $service ) {
+			$this->assertEquals( 'AE', $service['deliveryCountries'][0] );
+
+			if ( 0.0 !== (float) $service['rateGroups'][0]['singleValue']['flatRate']['amountMicros'] ) {
+				$paid_by_currency[ $service['currencyCode'] ] = $service;
+			}
+		}
+
+		// The store-currency service keeps the row amount; the AED service
+		// carries the converted amount (50 doubled to 100).
+		$this->assertSame( '50000000', $paid_by_currency['USD']['rateGroups'][0]['singleValue']['flatRate']['amountMicros'] );
+		$this->assertSame( '100000000', $paid_by_currency['AED']['rateGroups'][0]['singleValue']['flatRate']['amountMicros'] );
+	}
+
+	public function test_row_in_non_store_currency_only_serves_its_own_currency() {
+		$reported = [];
+		add_action(
+			'woocommerce_gla_error',
+			function ( $message ) use ( &$reported ) {
+				$reported[] = $message;
+			}
+		);
+
+		$db_rates = [
+			[
+				'country'  => 'FR',
+				'currency' => 'EUR',
+				'rate'     => 8,
+				'options'  => [],
+			],
+		];
+
+		$settings = new DBShippingSettingsAdapter(
+			[
+				'currency'             => 'USD',
+				'country_currency_map' => [
+					'FR' => [ 'EUR', 'USD' ],
+				],
+				'wpml'                 => $this->create_wpml_doubling_converter(),
+				'delivery_times'       => [
+					'FR' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
+				'db_rates'             => $db_rates,
+			]
+		);
+
+		$services = $settings->get_services();
+
+		// There is no conversion path between two non-store currencies, so
+		// only the row's own currency gets a service and the other mapped
+		// currency is reported.
+		$this->assertCount( 1, $services );
+		$this->assertEquals( 'EUR', $services[0]['currencyCode'] );
+		$this->assertSame( '8000000', $services[0]['rateGroups'][0]['singleValue']['flatRate']['amountMicros'] );
+		$this->assertCount( 1, $reported );
+		$this->assertStringContainsString( 'USD', $reported[0] );
+	}
+
+	/**
+	 * Returns a WPML mock whose convert_amount() doubles the amount, making
+	 * converted values visible in assertions.
+	 *
+	 * @return WPML
+	 */
+	private function create_wpml_doubling_converter(): WPML {
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'convert_amount' )->willReturnCallback(
+			static function ( float $amount ): float {
+				return $amount * 2;
+			}
+		);
+
+		return $wpml;
 	}
 }

--- a/tests/Unit/Shipping/GoogleAdapter/WCShippingSettingsAdapterTest.php
+++ b/tests/Unit/Shipping/GoogleAdapter/WCShippingSettingsAdapterTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Shipping\GoogleAdapter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\CountryRatesCollection;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\GoogleAdapter\WCShippingSettingsAdapter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingLocation;
@@ -399,6 +400,7 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 				'country_currency_map' => [
 					'FR' => 'EUR',
 				],
+				'wpml'                 => $this->create_wpml_doubling_converter(),
 				'rates_collections'    => [
 					new CountryRatesCollection( 'US', [ $us_rate ] ),
 					new CountryRatesCollection( 'FR', [ $fr_rate, $fr_min ] ),
@@ -456,6 +458,7 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 				'country_currency_map' => [
 					'FR' => 'EUR',
 				],
+				'wpml'                 => $this->create_wpml_doubling_converter(),
 				'rates_collections'    => [
 					new CountryRatesCollection( 'US', [ $us_country_rate ] ),
 					new CountryRatesCollection( 'FR', [ $fr_country_rate, $fr_postcode_rate, $fr_state_rate ] ),
@@ -482,6 +485,13 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 						$expected_currency,
 						$rate_group['singleValue']['flatRate']['currencyCode']
 					);
+
+					// Non-store-currency amounts are the converted values, not
+					// the store-currency amounts relabelled: 50 USD doubles to
+					// 100 EUR under the test converter.
+					if ( 'EUR' === $expected_currency ) {
+						$this->assertSame( '100000000', $rate_group['singleValue']['flatRate']['amountMicros'] );
+					}
 				}
 
 				if ( isset( $rate_group['mainTable'] ) ) {
@@ -496,5 +506,107 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 				}
 			}
 		}
+	}
+
+	public function test_creates_one_service_per_currency_for_a_multi_currency_country() {
+		$ae_rate = new LocationRate( new ShippingLocation( 1, 'AE' ), new ShippingRate( 50 ) );
+
+		$settings = new WCShippingSettingsAdapter(
+			[
+				'currency'             => 'USD',
+				'country_currency_map' => [
+					'AE' => [ 'USD', 'AED' ],
+				],
+				'wpml'                 => $this->create_wpml_doubling_converter(),
+				'rates_collections'    => [
+					new CountryRatesCollection( 'AE', [ $ae_rate ] ),
+				],
+				'delivery_times'       => [
+					'AE' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
+			]
+		);
+
+		$services = $settings->get_services();
+
+		$this->assertCount( 2, $services );
+
+		$by_currency = [];
+		foreach ( $services as $service ) {
+			$by_currency[ $service['currencyCode'] ] = $service;
+			$this->assertEquals( 'AE', $service['deliveryCountries'][0] );
+		}
+
+		// The store-currency service keeps the WooCommerce amount; the AED
+		// service carries the converted amount (50 doubled to 100).
+		$this->assertSame( '50000000', $by_currency['USD']['rateGroups'][0]['singleValue']['flatRate']['amountMicros'] );
+		$this->assertSame( '100000000', $by_currency['AED']['rateGroups'][0]['singleValue']['flatRate']['amountMicros'] );
+
+		// Service names must be unique within the Merchant Center account.
+		$this->assertNotEquals( $by_currency['USD']['serviceName'], $by_currency['AED']['serviceName'] );
+	}
+
+	public function test_leaves_out_non_store_currency_service_when_conversion_unavailable() {
+		$reported = [];
+		add_action(
+			'woocommerce_gla_error',
+			function ( $message ) use ( &$reported ) {
+				$reported[] = $message;
+			}
+		);
+
+		$ae_rate = new LocationRate( new ShippingLocation( 1, 'AE' ), new ShippingRate( 50 ) );
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'convert_amount' )->willReturn( null );
+
+		$settings = new WCShippingSettingsAdapter(
+			[
+				'currency'             => 'USD',
+				'country_currency_map' => [
+					'AE' => [ 'USD', 'AED' ],
+				],
+				'wpml'                 => $wpml,
+				'rates_collections'    => [
+					new CountryRatesCollection( 'AE', [ $ae_rate ] ),
+				],
+				'delivery_times'       => [
+					'AE' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
+			]
+		);
+
+		$services = $settings->get_services();
+
+		// The store-currency service still syncs; the unconvertible AED
+		// service is left out with an error naming the country and currency.
+		$this->assertCount( 1, $services );
+		$this->assertEquals( 'USD', $services[0]['currencyCode'] );
+		$this->assertCount( 1, $reported );
+		$this->assertStringContainsString( 'AED', $reported[0] );
+		$this->assertStringContainsString( 'AE', $reported[0] );
+	}
+
+	/**
+	 * Returns a WPML mock whose convert_amount() doubles the amount, making
+	 * converted values visible in assertions.
+	 *
+	 * @return WPML
+	 */
+	private function create_wpml_doubling_converter(): WPML {
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'convert_amount' )->willReturnCallback(
+			static function ( float $amount ): float {
+				return $amount * 2;
+			}
+		);
+
+		return $wpml;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-772/multi-lingual-feeds-fix-feedlabel-shipping-currency-and-sync-tracking

### Screenshots:

The primary market on this test install is UK / GBP so the feed label is `GB`. All other markets, including EUR for UK uses the `country-language-currency` format.

<img width="3440" height="1293" alt="Screenshot 2026-07-16 at 14 02 55" src="https://github.com/user-attachments/assets/eafaf7d0-6ae8-49bc-ab49-fcfb9a575b2f" />


### Detailed test instructions:

- On a WPML store with WCML multi-currency on, add a secondary market with two languages and two currencies (for example Belgium, Dutch and Spanish, USD and AUD). Create a published, priced product with an image in each language.
- Add a second currency to the primary market (for example EUR).
- Run a full sync:

```
 wp option delete gla_mapi_data_sources

wp eval '
$repository = woogle_get_container()->get( Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository::class );
$repository->get( Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts::class )->schedule();
echo "scheduled" . PHP_EOL;'

wp action-scheduler run --batches=0 --force
```

- In Merchant Centre Data sources expect one feed per language-currency pair: BE-NL-USD, BE-NL-AUD, BE-ES-USD, BE-ES-AUD, plus GB-EN-EUR alongside the unchanged bare GB feed. Each product appears only in its own language's feeds, priced in the feed's currency.
- In the account's shipping settings expect one service per country per currency, named with the currency, amounts in that currency.
- Remove one currency from the market and resync: that currency's feeds empty out, the others are untouched.
- Turn WCML multi-currency off and resync: only store-currency feeds keep syncing.


### Additional details:

> Add - Allow multiple currencies per market