### PR TITLE
GOOWOO-796: Filter currency options by selected languages in market modal

### DIFF
--- a/js/src/pages/markets/components/market-fields/locale-section/currency-select-control.js
+++ b/js/src/pages/markets/components/market-fields/locale-section/currency-select-control.js
@@ -11,6 +11,7 @@ import { useAdaptiveFormContext } from '~/components/adaptive-form';
 import AppSearchableSelectControl from '~/components/app-searchable-select-control';
 import AppInputControl from '~/components/app-input-control';
 import useAvailableStoreCurrencies from '~/hooks/useAvailableStoreCurrencies';
+import getValidCurrencyCodes from '../../../utils/getValidCurrencyCodes';
 
 /**
  * Renders the currency select control within the market edit form.
@@ -38,11 +39,20 @@ const CurrencySelectControl = () => {
 		);
 	}
 
-	const options = currencies?.map( ( currency ) => ( {
-		key: currency.code,
-		value: currency.code,
-		label: currency.code,
-	} ) );
+	const { selected: selectedLanguages } = getInputProps( 'language' );
+	const validCurrencyCodes = getValidCurrencyCodes(
+		currencies,
+		selectedLanguages
+	);
+
+	// Filter currencies to only include those that are valid for the selected languages
+	const options = currencies
+		?.filter( ( currency ) => validCurrencyCodes.has( currency.code ) )
+		.map( ( currency ) => ( {
+			key: currency.code,
+			value: currency.code,
+			label: currency.code,
+		} ) );
 
 	const { onChange, selected } = getInputProps( 'currency' );
 	const selectedOptions =

--- a/js/src/pages/markets/components/market-fields/locale-section/language-select-control.js
+++ b/js/src/pages/markets/components/market-fields/locale-section/language-select-control.js
@@ -10,7 +10,8 @@ import { glaData } from '~/constants';
 import { useAdaptiveFormContext } from '~/components/adaptive-form';
 import AppSearchableSelectControl from '~/components/app-searchable-select-control';
 import AppInputControl from '~/components/app-input-control';
-import useAvailableStoreLanguages from '~/hooks/useAvailableStoreLanguages';
+import useAvailableLanguagesCurrencies from '~/hooks/useAvailableLanguagesCurrencies';
+import getValidCurrencyCodes from '../../../utils/getValidCurrencyCodes';
 
 /**
  * Renders the language select control within the market edit form.
@@ -23,7 +24,8 @@ const LanguageSelectControl = () => {
 		getInputProps,
 		adapter: { renderRequestedValidation },
 	} = useAdaptiveFormContext();
-	const { languages, hasFinishedResolution } = useAvailableStoreLanguages();
+	const { languages, currencies, hasFinishedResolution } =
+		useAvailableLanguagesCurrencies();
 
 	if ( ! glaData.isMultiLingualStore ) {
 		return (
@@ -45,10 +47,39 @@ const LanguageSelectControl = () => {
 	} ) );
 
 	const { onChange, selected } = getInputProps( 'language' );
+	const currencyInputProps = getInputProps( 'currency' );
 
 	const selectedOptions =
 		options?.filter( ( option ) => selected?.includes( option.value ) ) ??
 		[];
+
+	/**
+	 * Language change handler
+	 * Updates the currency selection to only include currencies that are valid
+	 * for the new language selection.
+	 *
+	 * @param {Array<{value: string}>} changedOptions The new language options.
+	 * @return {void}
+	 */
+	const handleLanguageChange = ( changedOptions ) => {
+		const newLanguages = changedOptions.map( ( option ) => option.value );
+		onChange( newLanguages );
+
+		const validCurrencyCodes = getValidCurrencyCodes(
+			currencies,
+			newLanguages
+		);
+		const selectedCurrencies = currencyInputProps.selected ?? [];
+
+		// Currently-selected currency codes that are still valid for the new language selection.
+		const prunedCurrencies = selectedCurrencies.filter( ( code ) =>
+			validCurrencyCodes.has( code )
+		);
+
+		if ( prunedCurrencies.length !== selectedCurrencies.length ) {
+			currencyInputProps.onChange( prunedCurrencies );
+		}
+	};
 
 	return (
 		<div>
@@ -57,9 +88,7 @@ const LanguageSelectControl = () => {
 				options={ options }
 				disabled={ ! hasFinishedResolution }
 				selected={ selectedOptions }
-				onChange={ ( changedOptions ) =>
-					onChange( changedOptions.map( ( option ) => option.value ) )
-				}
+				onChange={ handleLanguageChange }
 				helperText={ __(
 					"Languages and currencies are populated from your multilingual plugin. You can remove them per market but can't add ones the plugin doesn't provide.",
 					'google-listings-and-ads'

--- a/js/src/pages/markets/components/market-fields/locale-section/language-select-control.js
+++ b/js/src/pages/markets/components/market-fields/locale-section/language-select-control.js
@@ -22,6 +22,7 @@ import getValidCurrencyCodes from '../../../utils/getValidCurrencyCodes';
 const LanguageSelectControl = () => {
 	const {
 		getInputProps,
+		setValues,
 		adapter: { renderRequestedValidation },
 	} = useAdaptiveFormContext();
 	const { languages, currencies, hasFinishedResolution } =
@@ -46,7 +47,7 @@ const LanguageSelectControl = () => {
 		label: language.label,
 	} ) );
 
-	const { onChange, selected } = getInputProps( 'language' );
+	const { selected } = getInputProps( 'language' );
 	const currencyInputProps = getInputProps( 'currency' );
 
 	const selectedOptions =
@@ -63,7 +64,6 @@ const LanguageSelectControl = () => {
 	 */
 	const handleLanguageChange = ( changedOptions ) => {
 		const newLanguages = changedOptions.map( ( option ) => option.value );
-		onChange( newLanguages );
 
 		const validCurrencyCodes = getValidCurrencyCodes(
 			currencies,
@@ -76,9 +76,12 @@ const LanguageSelectControl = () => {
 			validCurrencyCodes.has( code )
 		);
 
-		if ( prunedCurrencies.length !== selectedCurrencies.length ) {
-			currencyInputProps.onChange( prunedCurrencies );
-		}
+		setValues( {
+			language: newLanguages,
+			...( prunedCurrencies.length !== selectedCurrencies.length
+				? { currency: prunedCurrencies }
+				: {} ),
+		} );
 	};
 
 	return (

--- a/js/src/pages/markets/utils/getValidCurrencyCodes.js
+++ b/js/src/pages/markets/utils/getValidCurrencyCodes.js
@@ -1,10 +1,16 @@
 /**
+ * @typedef {Object} CurrencyWithLanguages
+ * @property {string} code ISO 4217 currency code (e.g. `"USD", "EUR"`).
+ * @property {Array<string>} [languages] Language codes this currency is enabled for.
+ */
+
+/**
  * Determines which currencies are valid for the given selected language(s).
  * A currency is valid if it's enabled for at least one of the selected
  * languages (union across multiple selected languages). If no language is
  * selected, every currency is considered valid.
  *
- * @param {Array<{code: string, languages?: Array<string>}>} currencies Available currencies, each with the language codes it's enabled for.
+ * @param {Array<CurrencyWithLanguages>} currencies Available currencies, each with the language codes it's enabled for.
  * @param {Array<string>} selectedLanguages Currently selected language codes.
  * @return {Set<string>} Set of valid currency codes.
  */

--- a/js/src/pages/markets/utils/getValidCurrencyCodes.js
+++ b/js/src/pages/markets/utils/getValidCurrencyCodes.js
@@ -1,0 +1,27 @@
+/**
+ * Determines which currencies are valid for the given selected language(s).
+ * A currency is valid if it's enabled for at least one of the selected
+ * languages (union across multiple selected languages). If no language is
+ * selected, every currency is considered valid.
+ *
+ * @param {Array<{code: string, languages?: Array<string>}>} currencies Available currencies, each with the language codes it's enabled for.
+ * @param {Array<string>} selectedLanguages Currently selected language codes.
+ * @return {Set<string>} Set of valid currency codes.
+ */
+export default function getValidCurrencyCodes( currencies, selectedLanguages ) {
+	const allCurrencies = currencies ?? [];
+
+	if ( ! selectedLanguages?.length ) {
+		return new Set( allCurrencies.map( ( currency ) => currency.code ) );
+	}
+
+	return new Set(
+		allCurrencies
+			.filter( ( currency ) =>
+				currency.languages?.some( ( code ) =>
+					selectedLanguages.includes( code )
+				)
+			)
+			.map( ( currency ) => currency.code )
+	);
+}

--- a/js/src/pages/markets/utils/getValidCurrencyCodes.test.js
+++ b/js/src/pages/markets/utils/getValidCurrencyCodes.test.js
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+import getValidCurrencyCodes from './getValidCurrencyCodes';
+
+const CURRENCIES = [
+	{ code: 'USD', symbol: '$', languages: [ 'en', 'fr' ] },
+	{ code: 'EUR', symbol: '€', languages: [ 'en', 'fr' ] },
+	{ code: 'AED', symbol: 'د.إ', languages: [ 'fr' ] },
+	{ code: 'GBP', symbol: '£', languages: [ 'de' ] },
+];
+
+describe( 'getValidCurrencyCodes', () => {
+	test( 'returns every currency code when no language is selected', () => {
+		expect( Array.from( getValidCurrencyCodes( CURRENCIES, [] ) ) ).toEqual(
+			[ 'USD', 'EUR', 'AED', 'GBP' ]
+		);
+		expect(
+			Array.from( getValidCurrencyCodes( CURRENCIES, undefined ) )
+		).toEqual( [ 'USD', 'EUR', 'AED', 'GBP' ] );
+	} );
+
+	test( 'excludes currencies not enabled for the selected language', () => {
+		expect(
+			Array.from( getValidCurrencyCodes( CURRENCIES, [ 'fr' ] ) )
+		).toEqual( [ 'USD', 'EUR', 'AED' ] );
+	} );
+
+	test( 'includes currencies valid for any of the selected languages (union)', () => {
+		expect(
+			Array.from( getValidCurrencyCodes( CURRENCIES, [ 'fr', 'de' ] ) )
+		).toEqual( [ 'USD', 'EUR', 'AED', 'GBP' ] );
+	} );
+
+	test( 'returns an empty array when no currency matches the selected language', () => {
+		expect(
+			Array.from( getValidCurrencyCodes( CURRENCIES, [ 'es' ] ) )
+		).toEqual( [] );
+	} );
+
+	test( 'treats a missing currencies list as empty', () => {
+		expect(
+			Array.from( getValidCurrencyCodes( undefined, [ 'fr' ] ) )
+		).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-796/filter-currency-options-by-selected-languages-in-market-form

Update market modals language and currency inputs to only support valid currencies based on the selected languages.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

**Setup:** Multilingual store with languages/currencies mocked (or the real GOOWOO-795 endpoint once available) → languages: English, French, German; currencies: USD/EUR (en, fr), AED (fr only), GBP (en, de).

**Language input**
1. Select French → confirm the currency list updates to only en/fr-enabled currencies.
2. Add German on top of French → confirm currencies valid for either language now appear (union, not intersection).
3. Remove all languages → confirm every currency becomes selectable again.

**Currency input**
1. With French selected, confirm GBP (de-only) is not in the dropdown at all.
2. Select a currency, then remove the language that enabled it → confirm that currency is automatically deselected, without a separate action.
3. Confirm currency selection stays untouched when removing a language that isn't the only one enabling it (e.g. USD stays selected if you remove French but English is still selected).

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
