### PR TITLE
[GOOWOO-795] Add per-language currency availability to languages-currencies endpoint

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/MarketsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/MarketsController.php
@@ -322,8 +322,13 @@ class MarketsController extends BaseController {
 						'items' => [
 							'type'       => 'object',
 							'properties' => [
-								'code'   => [ 'type' => 'string' ],
-								'symbol' => [ 'type' => 'string' ],
+								'code'      => [ 'type' => 'string' ],
+								'symbol'    => [ 'type' => 'string' ],
+								'languages' => [
+									'description' => __( 'Active language codes the currency is enabled for.', 'google-listings-and-ads' ),
+									'type'        => 'array',
+									'items'       => [ 'type' => 'string' ],
+								],
 							],
 						],
 					],

--- a/src/Integration/WPML.php
+++ b/src/Integration/WPML.php
@@ -160,7 +160,11 @@ class WPML implements IntegrationInterface {
 	 * Returns the store's active currencies from WCML when multi-currency is enabled,
 	 * or the WooCommerce store currency as a single entry otherwise.
 	 *
-	 * @return array<int, array{code: string, symbol: string}>
+	 * Each currency carries the active language codes it is enabled for, per WCML's
+	 * per-language currency configuration. When WCML multi-currency is off, every
+	 * currency lists all active language codes.
+	 *
+	 * @return array<int, array{code: string, symbol: string, languages: string[]}>
 	 */
 	public function get_currencies(): array {
 		if ( ! $this->is_active() ) {
@@ -338,14 +342,65 @@ class WPML implements IntegrationInterface {
 	}
 
 	/**
+	 * Returns the active language codes a currency is enabled for, according to WCML's
+	 * per-language currency configuration ("Currencies to display for each language").
+	 *
+	 * WCML stores the configuration as an integer flag per language code. A language
+	 * with no stored flag counts as enabled, matching WCML's own default for newly
+	 * added languages. Flags for languages that are no longer active are ignored.
+	 *
+	 * @param string   $currency              ISO 4217 currency code.
+	 * @param string[] $active_language_codes Active WPML language codes.
+	 *
+	 * @return string[]
+	 */
+	protected function get_enabled_language_codes_for_currency( string $currency, array $active_language_codes ): array {
+		$flags = $this->get_wcml_settings()['currency_options'][ $currency ]['languages'] ?? [];
+
+		if ( ! is_array( $flags ) ) {
+			$flags = [];
+		}
+
+		$enabled = [];
+
+		foreach ( $active_language_codes as $language_code ) {
+			if ( ! isset( $flags[ $language_code ] ) || $flags[ $language_code ] ) {
+				$enabled[] = $language_code;
+			}
+		}
+
+		return $enabled;
+	}
+
+	/**
+	 * Returns WCML's stored settings, or an empty array when unavailable.
+	 *
+	 * @return array
+	 */
+	protected function get_wcml_settings(): array {
+		global $woocommerce_wpml;
+
+		if ( ! isset( $woocommerce_wpml ) || ! is_object( $woocommerce_wpml ) || ! method_exists( $woocommerce_wpml, 'get_settings' ) ) {
+			return [];
+		}
+
+		$settings = $woocommerce_wpml->get_settings();
+
+		return is_array( $settings ) ? $settings : [];
+	}
+
+	/**
 	 * @param string[] $codes
 	 *
-	 * @return array<int, array{code: string, symbol: string}>
+	 * @return array<int, array{code: string, symbol: string, languages: string[]}>
 	 */
 	private function get_formatted_currencies( array $codes ): array {
 		if ( ! function_exists( 'get_woocommerce_currency_symbol' ) ) {
 			return [];
 		}
+
+		$active_language_codes = array_column( $this->get_languages(), 'code' );
+		$multi_currency_on     = $this->is_wcml_multi_currency_on();
 
 		$result = [];
 
@@ -361,8 +416,11 @@ class WPML implements IntegrationInterface {
 			}
 
 			$result[] = [
-				'code'   => $code,
-				'symbol' => html_entity_decode( $symbol, ENT_QUOTES, 'UTF-8' ),
+				'code'      => $code,
+				'symbol'    => html_entity_decode( $symbol, ENT_QUOTES, 'UTF-8' ),
+				'languages' => $multi_currency_on
+					? $this->get_enabled_language_codes_for_currency( $code, $active_language_codes )
+					: $active_language_codes,
 			];
 		}
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -148,12 +148,14 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 	public function test_get_languages_currencies_returns_currencies_from_market_service(): void {
 		$currencies = [
 			[
-				'code'   => 'USD',
-				'symbol' => '$',
+				'code'      => 'USD',
+				'symbol'    => '$',
+				'languages' => [ 'en', 'fr' ],
 			],
 			[
-				'code'   => 'EUR',
-				'symbol' => '€',
+				'code'      => 'EUR',
+				'symbol'    => '€',
+				'languages' => [ 'fr' ],
 			],
 		];
 
@@ -185,6 +187,9 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertArrayHasKey( 'label', $schema['properties']['languages']['items']['properties'] );
 		$this->assertArrayHasKey( 'code', $schema['properties']['currencies']['items']['properties'] );
 		$this->assertArrayHasKey( 'symbol', $schema['properties']['currencies']['items']['properties'] );
+		$this->assertArrayHasKey( 'languages', $schema['properties']['currencies']['items']['properties'] );
+		$this->assertEquals( 'array', $schema['properties']['currencies']['items']['properties']['languages']['type'] );
+		$this->assertEquals( 'string', $schema['properties']['currencies']['items']['properties']['languages']['items']['type'] );
 	}
 
 	public function test_post_market_returns_201_on_success(): void {

--- a/tests/Unit/Integration/WPMLTest.php
+++ b/tests/Unit/Integration/WPMLTest.php
@@ -323,12 +323,14 @@ class WPMLTest extends UnitTest {
 		$this->assertEquals(
 			[
 				[
-					'code'   => 'USD',
-					'symbol' => '$',
+					'code'      => 'USD',
+					'symbol'    => '$',
+					'languages' => [],
 				],
 				[
-					'code'   => 'EUR',
-					'symbol' => '€',
+					'code'      => 'EUR',
+					'symbol'    => '€',
+					'languages' => [],
 				],
 			],
 			$integration->get_currencies()
@@ -344,8 +346,9 @@ class WPMLTest extends UnitTest {
 		$this->assertSame(
 			[
 				[
-					'code'   => $currency,
-					'symbol' => $symbol,
+					'code'      => $currency,
+					'symbol'    => $symbol,
+					'languages' => [],
 				],
 			],
 			$integration->get_currencies()
@@ -358,8 +361,106 @@ class WPMLTest extends UnitTest {
 		$this->assertSame(
 			[
 				[
-					'code'   => 'USD',
-					'symbol' => '$',
+					'code'      => 'USD',
+					'symbol'    => '$',
+					'languages' => [],
+				],
+			],
+			$integration->get_currencies()
+		);
+	}
+
+	public function test_get_currencies_languages_reflect_wcml_per_language_config(): void {
+		$integration = $this->create_integration(
+			true,
+			[ 'USD', 'AED' ],
+			true,
+			false,
+			[
+				'currency_options' => [
+					'USD' => [
+						'languages' => [
+							'en' => 1,
+							'fr' => 1,
+						],
+					],
+					'AED' => [
+						'languages' => [
+							'en' => 0,
+							'fr' => 1,
+						],
+					],
+				],
+			]
+		);
+
+		$this->add_active_languages_filter();
+
+		$this->assertEquals(
+			[
+				[
+					'code'      => 'USD',
+					'symbol'    => '$',
+					'languages' => [ 'en', 'fr' ],
+				],
+				[
+					'code'      => 'AED',
+					'symbol'    => html_entity_decode( get_woocommerce_currency_symbol( 'AED' ), ENT_QUOTES, 'UTF-8' ),
+					'languages' => [ 'fr' ],
+				],
+			],
+			$integration->get_currencies()
+		);
+	}
+
+	public function test_get_currencies_languages_default_to_enabled_when_flags_missing(): void {
+		// EUR has no stored entry at all; USD only has a flag for a language that is
+		// no longer active. Both cases must resolve to all active languages, matching
+		// WCML's own default of enabling currencies for newly added languages.
+		$integration = $this->create_integration(
+			true,
+			[ 'USD', 'EUR' ],
+			true,
+			false,
+			[
+				'currency_options' => [
+					'USD' => [
+						'languages' => [ 'de' => 0 ],
+					],
+				],
+			]
+		);
+
+		$this->add_active_languages_filter();
+
+		$this->assertEquals(
+			[
+				[
+					'code'      => 'USD',
+					'symbol'    => '$',
+					'languages' => [ 'en', 'fr' ],
+				],
+				[
+					'code'      => 'EUR',
+					'symbol'    => '€',
+					'languages' => [ 'en', 'fr' ],
+				],
+			],
+			$integration->get_currencies()
+		);
+	}
+
+	public function test_get_currencies_languages_include_all_active_languages_when_multi_currency_off(): void {
+		$integration = $this->create_integration( true, [ 'USD' ], false );
+
+		$this->add_active_languages_filter();
+
+		$this->assertEquals(
+			[
+				[
+					'code'      => 'USD',
+					'symbol'    => '$',
+					'languages' => [ 'en', 'fr' ],
 				],
 			],
 			$integration->get_currencies()
@@ -702,14 +803,36 @@ class WPMLTest extends UnitTest {
 	}
 
 	/**
+	 * Registers an active-languages filter returning English and French.
+	 */
+	private function add_active_languages_filter(): void {
+		add_filter(
+			'wpml_active_languages',
+			function () {
+				return [
+					'en' => [
+						'code'            => 'en',
+						'translated_name' => 'English',
+					],
+					'fr' => [
+						'code'            => 'fr',
+						'translated_name' => 'French',
+					],
+				];
+			}
+		);
+	}
+
+	/**
 	 * @param bool                        $is_active
 	 * @param string[]                    $currency_codes
 	 * @param bool|null                   $wcml_multi_currency_on When non-null, stubs is_wcml_multi_currency_on() to this value.
 	 * @param array<string, string>|false $custom_prices          Return value for get_wcml_custom_prices() (default false = auto mode).
+	 * @param array|null                  $wcml_settings          When non-null, stubs get_wcml_settings() to this WCML settings map.
 	 *
 	 * @return WPML&MockObject
 	 */
-	private function create_integration( bool $is_active, array $currency_codes = [], ?bool $wcml_multi_currency_on = null, $custom_prices = false ): WPML {
+	private function create_integration( bool $is_active, array $currency_codes = [], ?bool $wcml_multi_currency_on = null, $custom_prices = false, ?array $wcml_settings = null ): WPML {
 		$methods = [ 'is_active', 'get_wcml_custom_prices' ];
 
 		if ( ! empty( $currency_codes ) ) {
@@ -718,6 +841,10 @@ class WPMLTest extends UnitTest {
 
 		if ( null !== $wcml_multi_currency_on ) {
 			$methods[] = 'is_wcml_multi_currency_on';
+		}
+
+		if ( null !== $wcml_settings ) {
+			$methods[] = 'get_wcml_settings';
 		}
 
 		$integration = $this->createPartialMock( WPML::class, $methods );
@@ -730,6 +857,10 @@ class WPMLTest extends UnitTest {
 
 		if ( null !== $wcml_multi_currency_on ) {
 			$integration->method( 'is_wcml_multi_currency_on' )->willReturn( $wcml_multi_currency_on );
+		}
+
+		if ( null !== $wcml_settings ) {
+			$integration->method( 'get_wcml_settings' )->willReturn( $wcml_settings );
 		}
 
 		return $integration;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-795/add-per-language-currency-availability-to-languages-currencies

### Screenshots:

N/A


### Detailed test instructions:

**Store configuration**

- Has at least two active languages (WPML, then Languages), for example English and French.
- Has: Multi-currency on: WooCommerce, then WooCommerce Multilingual & Multicurrency, Multi-currency tab, "Enable the multicurrency mode" ticked.
- Has at least two currencies besides the shop's default, added on the same tab with any exchange rate.
- In the "Currencies to display for each language" table, leave every box ticked to start.

**Test 1: currency unticked for one language**

- In the "Currencies to display for each language" table, untick one currency under one language only (for example UAE dirham under English) and save.
- Go to Marketing, then Google for WooCommerce. Press F12 (Windows) or Cmd+Option+I (Mac), click the "Console" tab, paste this and press Enter:

```
wp.apiFetch( { path: '/wc/gla/mc/markets/languages-currencies' } ).then( ( data ) => console.log( JSON.stringify( data, null, 2 ) ) );
```

Pass: in the text block that appears, the currency you unticked shows only the still-ticked language, `"languages": ["fr"]`, and every other currency lists all language codes.

Fail: the unticked language still appears, any currency has no `"languages"` entry, or an error message appears instead of the text block.

**Test 2: currency ticked back on**

- Go to WooCommerce, then WooCommerce Multilingual & Multicurrency, Multi-currency tab. In the "Currencies to display for each language" table, tick UAE dirham under English again and save.
- Go to Marketing, then Google for WooCommerce. Press F12 (Windows) or Cmd+Option+I (Mac), click the "Console" tab, paste this and press Enter:

```
wp.apiFetch( { path: '/wc/gla/mc/markets/languages-currencies' } ).then( ( data ) => console.log( JSON.stringify( data, null, 2 ) ) );
```

Pass: UAE dirham shows all language codes again, `"languages": ["en", "fr"]`.

Fail: `"en"` is missing from UAE dirham's list, or an error message appears instead of the text block.

**Test 3: multi-currency disabled**

- Go to WooCommerce, then WooCommerce Multilingual & Multicurrency, Multi-currency tab. Untick "Enable the multicurrency mode" and save.
- Go to Marketing, then Google for WooCommerce. Press F12 (Windows) or Cmd+Option+I (Mac), click the "Console" tab, paste this and press Enter:

```
wp.apiFetch( { path: '/wc/gla/mc/markets/languages-currencies' } ).then( ( data ) => console.log( JSON.stringify( data, null, 2 ) ) );
```

Pass: only the shop's default currency appears, and its "languages" lists all active language codes.

Fail: other currencies still appear, the "languages" entry is missing or incomplete, or an error message appears instead of the text block.

Afterwards: on the Multi-currency tab, tick "Enable the multicurrency mode" again and save, so the site is back to its original state.

### Additional details:

> Add - Add per-language currency availability to languages-currencies endpoint

>
