### PR TITLE
Add woocommerce_gla_mapi_report_query_response filter to MapiReportQuery

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = Unreleased =
 * Migrate Merchant Center reporting to the Merchant API
 * The `gla_merchant_query_response` filter is removed as part of dropping the Content API report layer.
+* Add the `woocommerce_gla_mapi_report_query_response` filter to `MapiReportQuery::query_results()`.
 
 = 3.7.3 - 2026-07-08 =
 * Add - Added update notification when plugin version 3.8.0 is available

--- a/src/API/Google/Query/MapiReportQuery.php
+++ b/src/API/Google/Query/MapiReportQuery.php
@@ -76,10 +76,18 @@ abstract class MapiReportQuery extends Query {
 			$body['pageToken'] = $this->search_args['pageToken'];
 		}
 
-		$this->results = $this->client->post(
+		$results = $this->client->post(
 			sprintf( '%s/accounts/%d/reports:search', MapiPaths::REPORTS, $this->id ),
 			$body
 		);
+
+		/**
+		 * Filter the report search response prior to setting the property.
+		 *
+		 * @param array $results The report search response.
+		 * @param array $body    The request body sent to the reports:search endpoint.
+		 */
+		$this->results = apply_filters( 'woocommerce_gla_mapi_report_query_response', $results, $body );
 	}
 
 	/**

--- a/tests/Unit/API/Google/MerchantReportTest.php
+++ b/tests/Unit/API/Google/MerchantReportTest.php
@@ -170,6 +170,43 @@ class MerchantReportTest extends UnitTest {
 		$this->assertNull( $report['statuses'][884]['expiration_date'] );
 	}
 
+	public function test_get_product_view_report_applies_response_filter() {
+		$this->product_helper->method( 'get_wc_product_id' )->willReturnCallback(
+			function ( $mc_id ) {
+				return 'en~US~gla_885' === $mc_id ? 885 : 0;
+			}
+		);
+
+		$this->mapi_client->method( 'post' )->willReturn(
+			[
+				'results'       => [],
+				'nextPageToken' => null,
+			]
+		);
+
+		add_filter(
+			'woocommerce_gla_mapi_report_query_response',
+			function () {
+				return [
+					'results'       => [
+						[
+							'productView' => [
+								'id' => 'en~US~gla_885',
+								'aggregatedReportingContextStatus' => 'ELIGIBLE',
+							],
+						],
+					],
+					'nextPageToken' => null,
+				];
+			}
+		);
+
+		$report = $this->merchant_report->get_product_view_report();
+
+		$this->assertArrayHasKey( 885, $report['statuses'] );
+		$this->assertSame( MCStatus::APPROVED, $report['statuses'][885]['status'] );
+	}
+
 	public function test_get_product_view_report_with_exception() {
 		$this->mapi_client->expects( $this->once() )
 			->method( 'post' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-801.

Restores similar functionality to the removed gla_merchant_query_response filter for the Merchant API report query path, as agreed in GOOWOO-801.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - woocommerce_gla_mapi_report_query_response filter to MapiReportQuery.
