### PR TITLE
Fix: map sale price and sale price effective date for MAPI sync

### DIFF
--- a/src/Product/WCProductInputAdapter.php
+++ b/src/Product/WCProductInputAdapter.php
@@ -7,6 +7,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductIn
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMapping\AttributeMappingHelper;
+use DateInterval;
+use WC_DateTime;
 use WC_Product;
 use WC_Product_Variable;
 use WC_Product_Variation;
@@ -122,6 +124,7 @@ class WCProductInputAdapter {
 		$this->map_images();
 		$this->map_availability();
 		$this->map_price();
+		$this->map_sale_price();
 		$this->map_shipping();
 		$this->map_product_types();
 
@@ -317,6 +320,103 @@ class WCProductInputAdapter {
 		$price = apply_filters( 'woocommerce_gla_product_attribute_value_price', $price, $this->wc_product, $this->tax_excluded );
 
 		$this->attributes['price'] = $this->to_money( (float) $price, get_woocommerce_currency() );
+	}
+
+	/**
+	 * Map the sale price and sale price effective date, applying tax inclusion/exclusion rules.
+	 * Ported from WCProductAdapter::map_wc_product_sale_price to preserve behavior.
+	 */
+	protected function map_sale_price(): void {
+		// Grab the sale price of the base product. Some plugins (Dynamic pricing as an
+		// example) filter the active price, but not the sale price. If the active price
+		// < the regular price treat it as a sale price.
+		$regular_price = $this->wc_product->get_regular_price();
+		$sale_price    = $this->wc_product->get_sale_price();
+		$active_price  = $this->wc_product->get_price();
+		if (
+			( empty( $sale_price ) && $active_price < $regular_price ) ||
+			( ! empty( $sale_price ) && $active_price < $sale_price )
+		) {
+			$sale_price = $active_price;
+		}
+
+		if ( '' === $sale_price ) {
+			return;
+		}
+
+		$sale_price = $this->tax_excluded
+			? wc_get_price_excluding_tax( $this->wc_product, [ 'price' => $sale_price ] )
+			: wc_get_price_including_tax( $this->wc_product, [ 'price' => $sale_price ] );
+
+		/** This filter is documented in src/Product/WCProductAdapter.php */
+		$sale_price = apply_filters( 'woocommerce_gla_product_attribute_value_sale_price', $sale_price, $this->wc_product, $this->tax_excluded );
+
+		// If the sale price dates no longer apply, make sure we don't include a sale price.
+		$now                 = new WC_DateTime();
+		$sale_price_end_date = $this->wc_product->get_date_on_sale_to();
+		if ( ! empty( $sale_price_end_date ) && $sale_price_end_date < $now ) {
+			return;
+		}
+
+		$this->attributes['salePrice'] = $this->to_money( (float) $sale_price, get_woocommerce_currency() );
+
+		$effective_date = $this->get_sale_price_effective_date();
+		if ( null !== $effective_date ) {
+			$this->attributes['salePriceEffectiveDate'] = $effective_date;
+		}
+	}
+
+	/**
+	 * Return the sale effective dates for the WooCommerce product as a Merchant API
+	 * Interval (`startTime`/`endTime` RFC3339 timestamps), omitting either bound when
+	 * unset. Date-branch logic ported from WCProductAdapter::get_wc_product_sale_price_effective_date.
+	 *
+	 * @return array|null
+	 */
+	protected function get_sale_price_effective_date(): ?array {
+		$start_date = $this->wc_product->get_date_on_sale_from();
+		$end_date   = $this->wc_product->get_date_on_sale_to();
+
+		$now = new WC_DateTime();
+		// if we have a sale end date in the future, but no start date, set the start date to now()
+		if (
+			! empty( $end_date ) &&
+			$end_date > $now &&
+			empty( $start_date )
+		) {
+			$start_date = $now;
+		}
+		// if we have a sale start date in the past, but no end date, do not include the start date.
+		if (
+			! empty( $start_date ) &&
+			$start_date < $now &&
+			empty( $end_date )
+		) {
+			$start_date = null;
+		}
+		// if we have a start date in the future, but no end date, assume a one-day sale.
+		if (
+			! empty( $start_date ) &&
+			$start_date > $now &&
+			empty( $end_date )
+		) {
+			$end_date = clone $start_date;
+			$end_date->add( new DateInterval( 'P1D' ) );
+		}
+
+		if ( empty( $start_date ) && empty( $end_date ) ) {
+			return null;
+		}
+
+		$effective_date = [];
+		if ( ! empty( $start_date ) ) {
+			$effective_date['startTime'] = (string) $start_date;
+		}
+		if ( ! empty( $end_date ) ) {
+			$effective_date['endTime'] = (string) $end_date;
+		}
+
+		return $effective_date;
 	}
 
 	/**

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\WCProductInputAdapter;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Tools\HelperTrait\ProductTrait;
+use WC_DateTime;
 use WC_Helper_Product;
 
 defined( 'ABSPATH' ) || exit;
@@ -117,6 +118,189 @@ class WCProductInputAdapterTest extends UnitTest {
 		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
 
 		$this->assertArrayNotHasKey( 'price', $attrs );
+	}
+
+	public function test_maps_sale_price_and_effective_date() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'             => 80,
+				'regular_price'     => 100,
+				'sale_price'        => 80,
+				'date_on_sale_from' => '2021-01-01',
+				'date_on_sale_to'   => '2099-01-01',
+			]
+		);
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame(
+			[
+				'amountMicros' => '100000000',
+				'currencyCode' => get_woocommerce_currency(),
+			],
+			$attrs['price']
+		);
+		$this->assertSame(
+			[
+				'amountMicros' => '80000000',
+				'currencyCode' => get_woocommerce_currency(),
+			],
+			$attrs['salePrice']
+		);
+		$this->assertSame(
+			[
+				'startTime' => (string) $product->get_date_on_sale_from(),
+				'endTime'   => (string) $product->get_date_on_sale_to(),
+			],
+			$attrs['salePriceEffectiveDate']
+		);
+	}
+
+	public function test_sale_price_is_not_set_if_empty() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 100,
+				'regular_price' => 100,
+				'sale_price'    => '',
+			]
+		);
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertArrayNotHasKey( 'salePrice', $attrs );
+		$this->assertArrayNotHasKey( 'salePriceEffectiveDate', $attrs );
+	}
+
+	public function test_sale_price_is_set_if_zero() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 100,
+				'regular_price' => 100,
+				'sale_price'    => 0,
+			]
+		);
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( '0', $attrs['salePrice']['amountMicros'] );
+	}
+
+	public function test_sale_price_is_not_set_if_sale_end_date_passed() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'           => 100,
+				'regular_price'   => 100,
+				'sale_price'      => 50,
+				'date_on_sale_to' => '0000-01-01',
+			]
+		);
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertArrayNotHasKey( 'salePrice', $attrs );
+		$this->assertArrayNotHasKey( 'salePriceEffectiveDate', $attrs );
+	}
+
+	public function test_sale_price_effective_date_start_is_set_to_now_if_empty() {
+		$now = (string) ( new WC_DateTime( 'now' ) );
+
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'           => 50,
+				'regular_price'   => 100,
+				'sale_price'      => 50,
+				'date_on_sale_to' => '2099-01-01',
+			]
+		);
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertArrayHasKey( 'salePriceEffectiveDate', $attrs );
+		$this->assertNotEmpty( $attrs['salePriceEffectiveDate']['startTime'] );
+		$this->assertGreaterThanOrEqual( new WC_DateTime( $now ), new WC_DateTime( $attrs['salePriceEffectiveDate']['startTime'] ) );
+		$this->assertSame( (string) new WC_DateTime( '2099-01-01' ), $attrs['salePriceEffectiveDate']['endTime'] );
+	}
+
+	public function test_sale_price_effective_date_start_is_not_set_if_in_past_and_no_end_date() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'             => 50,
+				'regular_price'     => 100,
+				'sale_price'        => 50,
+				'date_on_sale_from' => '0000-01-01',
+			]
+		);
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertArrayNotHasKey( 'salePriceEffectiveDate', $attrs );
+	}
+
+	public function test_sale_price_effective_date_end_is_set_to_one_day_if_start_in_future_but_no_end() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'             => 100,
+				'regular_price'     => 100,
+				'sale_price'        => 50,
+				'date_on_sale_from' => '2099-01-01',
+			]
+		);
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame(
+			[
+				'startTime' => (string) new WC_DateTime( '2099-01-01' ),
+				'endTime'   => (string) new WC_DateTime( '2099-01-02' ),
+			],
+			$attrs['salePriceEffectiveDate']
+		);
+	}
+
+	public function test_sale_price_effective_date_is_not_set_if_not_set() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 50,
+				'regular_price' => 100,
+				'sale_price'    => 50,
+			]
+		);
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertArrayHasKey( 'salePrice', $attrs );
+		$this->assertArrayNotHasKey( 'salePriceEffectiveDate', $attrs );
+	}
+
+	public function test_applies_sale_price_attribute_value_filter() {
+		add_filter(
+			'woocommerce_gla_product_attribute_value_sale_price',
+			function () {
+				return 20;
+			}
+		);
+
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 50,
+				'regular_price' => 100,
+				'sale_price'    => 50,
+			]
+		);
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+		remove_all_filters( 'woocommerce_gla_product_attribute_value_sale_price' );
+
+		$this->assertSame( '20000000', $attrs['salePrice']['amountMicros'] );
 	}
 
 	public function test_maps_availability_in_stock() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-803.

WCProductInputAdapter only mapped the regular price, so sale prices never synced through the Merchant API product sync path (GOOWOO-803). Ports the sale price and sale date logic from WCProductAdapter, adapted to the Merchant API's Price/Interval attribute shapes.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
