### PR TITLE
fix(notifications): load notification bundles on all wc-admin pages for SPA nav

### DIFF
--- a/js/src/notifications-system/index.js
+++ b/js/src/notifications-system/index.js
@@ -4,6 +4,7 @@
 import { resolveSelect } from '@wordpress/data';
 import { createElement } from '@wordpress/element';
 import { doAction } from '@wordpress/hooks';
+import { getPath, getHistory } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -67,11 +68,23 @@ function createNotificationComponent( id, triggeredAt ) {
 	};
 }
 
+const MARKETING_OVERVIEW_PATH = '/marketing';
+
+let hasInitialized = false;
+
 /**
  * Initializes the notifications system by fetching notifications from the GLA store
  * and registering them in the marketing notifications store.
+ *
+ * Guarded to run at most once per page session, since `registerNotificationsInMarketingSlot`
+ * appends to the store with no id-based dedup.
  */
 async function initNotifications() {
+	if ( hasInitialized ) {
+		return;
+	}
+	hasInitialized = true;
+
 	const glaNotifications =
 		await resolveSelect( STORE_KEY ).getNotifications();
 
@@ -90,4 +103,20 @@ async function initNotifications() {
 	registerNotificationsInMarketingSlot( notifications );
 }
 
-initNotifications();
+/**
+ * The notifications-system bundle is enqueued on every wc-admin page (it's a
+ * single-page app, so any page can SPA-navigate to Marketing overview without
+ * a full reload). Only fetch/register notifications once the current SPA
+ * route is actually the Marketing overview page.
+ */
+function initNotificationsIfOnMarketingOverview() {
+	if ( getPath() === MARKETING_OVERVIEW_PATH ) {
+		initNotifications();
+	}
+}
+
+initNotificationsIfOnMarketingOverview();
+
+// `getHistory().listen()` only fires on subsequent SPA navigations, not for
+// the current location, so the initial check above still runs separately.
+getHistory().listen( initNotificationsIfOnMarketingOverview );

--- a/src/Admin/NotificationsSystem.php
+++ b/src/Admin/NotificationsSystem.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin;
 
+use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminScriptWithBuiltDependenciesAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminStyleAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
@@ -17,8 +18,10 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class NotificationsSystem
  *
- * Enqueues the notifications-system JS bundle and its paired CSS on the
- * WooCommerce Marketing overview page (page=wc-admin&path=/marketing).
+ * Enqueues the notifications-system JS bundle and its paired CSS on all
+ * wc-admin pages. The bundle itself decides, client-side, whether the
+ * current SPA route is the Marketing overview page before fetching or
+ * rendering any notifications.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin
  */
@@ -57,7 +60,7 @@ class NotificationsSystem implements Service, Registerable {
 		add_action(
 			'admin_enqueue_scripts',
 			function () {
-				if ( ! $this->is_marketing_overview_page() ) {
+				if ( ! PageController::is_admin_page() ) {
 					return;
 				}
 
@@ -102,17 +105,5 @@ class NotificationsSystem implements Service, Registerable {
 				'adsId'   => $this->options->get_ads_id() ?: null,
 			],
 		];
-	}
-
-	/**
-	 * Determine if the current admin page is the WooCommerce Marketing overview page.
-	 *
-	 * @return bool
-	 */
-	private function is_marketing_overview_page(): bool {
-		$page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-		$path = isset( $_GET['path'] ) ? sanitize_text_field( wp_unslash( $_GET['path'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-
-		return 'wc-admin' === $page && '/marketing' === $path;
 	}
 }

--- a/src/Admin/NotificationsSystemSlot.php
+++ b/src/Admin/NotificationsSystemSlot.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Admin;
 
+use Automattic\WooCommerce\Admin\PageController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminScriptWithBuiltDependenciesAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminStyleAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
@@ -16,8 +17,9 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class NotificationsSystemSlot
  *
- * Registers and enqueues the plugin-agnostic notification slot bundle on the
- * WooCommerce Marketing overview page (page=wc-admin&path=/marketing).
+ * Registers and enqueues the plugin-agnostic notification slot bundle on all
+ * wc-admin pages, so the shared marketing-notifications store is always
+ * available regardless of which wc-admin route the SPA session started on.
  *
  * The slot bundle is registered with a stable, shared handle so that other
  * plugins can declare it as a script dependency without depending on GLA.
@@ -49,7 +51,7 @@ class NotificationsSystemSlot implements Service, Registerable {
 		add_action(
 			'admin_enqueue_scripts',
 			function () {
-				if ( ! $this->is_marketing_overview_page() ) {
+				if ( ! PageController::is_admin_page() ) {
 					return;
 				}
 
@@ -81,17 +83,5 @@ class NotificationsSystemSlot implements Service, Registerable {
 				$this->assets_handler->enqueue( $slot_style );
 			}
 		);
-	}
-
-	/**
-	 * Determine if the current admin page is the WooCommerce Marketing overview page.
-	 *
-	 * @return bool
-	 */
-	private function is_marketing_overview_page(): bool {
-		$page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-		$path = isset( $_GET['path'] ) ? sanitize_text_field( wp_unslash( $_GET['path'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-
-		return 'wc-admin' === $page && '/marketing' === $path;
 	}
 }

--- a/tests/Unit/Admin/NotificationsSystemSlotTest.php
+++ b/tests/Unit/Admin/NotificationsSystemSlotTest.php
@@ -102,9 +102,20 @@ class NotificationsSystemSlotTest extends UnitTest {
 		do_action( 'admin_enqueue_scripts' );
 	}
 
-	public function test_does_not_enqueue_assets_on_other_admin_pages() {
+	public function test_enqueues_assets_on_any_wc_admin_page() {
 		$_GET['page'] = 'wc-admin';
 		$_GET['path'] = '/analytics/overview';
+
+		$this->assets_handler->expects( $this->exactly( 2 ) )->method( 'register' );
+		$this->assets_handler->expects( $this->exactly( 2 ) )->method( 'enqueue' );
+
+		$this->notifications_system_slot->register();
+		set_current_screen( 'dashboard' );
+		do_action( 'admin_enqueue_scripts' );
+	}
+
+	public function test_does_not_enqueue_assets_outside_wc_admin() {
+		$_GET['page'] = 'wc-settings';
 
 		$this->assets_handler->expects( $this->never() )->method( 'register' );
 		$this->assets_handler->expects( $this->never() )->method( 'enqueue' );

--- a/tests/Unit/Admin/NotificationsSystemTest.php
+++ b/tests/Unit/Admin/NotificationsSystemTest.php
@@ -111,9 +111,23 @@ class NotificationsSystemTest extends UnitTest {
 		do_action( 'admin_enqueue_scripts' );
 	}
 
-	public function test_does_not_enqueue_assets_on_other_admin_pages() {
+	public function test_enqueues_assets_on_any_wc_admin_page() {
 		$_GET['page'] = 'wc-admin';
 		$_GET['path'] = '/analytics/overview';
+
+		$this->options->method( 'get_merchant_id' )->willReturn( 123 );
+		$this->options->method( 'get_ads_id' )->willReturn( 456 );
+
+		$this->assets_handler->expects( $this->once() )->method( 'register_many' );
+		$this->assets_handler->expects( $this->once() )->method( 'enqueue_many' );
+
+		$this->notifications_system->register();
+		set_current_screen( 'dashboard' );
+		do_action( 'admin_enqueue_scripts' );
+	}
+
+	public function test_does_not_enqueue_assets_outside_wc_admin() {
+		$_GET['page'] = 'wc-settings';
 
 		$this->assets_handler->expects( $this->never() )->method( 'register_many' );
 		$this->assets_handler->expects( $this->never() )->method( 'enqueue_many' );


### PR DESCRIPTION
## Summary

Closes https://linear.app/a8c/issue/GOOWOO-788/fix-dead-notification-slot-bundle-wiring-minor-fe-issues-in

- Marketing notifications bundles were only enqueued when the server detected `page=wc-admin&path=/marketing`. SPA navigations don't trigger a full reload, so arriving at Marketing overview from another wc-admin route left the bundles absent.
- PHP: replaced server-side `is_marketing_overview_page()` check with `PageController::is_admin_page()` in both `NotificationsSystem` and `NotificationsSystemSlot` so bundles are available on all wc-admin pages.
- JS: gated `initNotifications()` behind a `getPath()` check at load time and subscribed to `getHistory().listen()` for subsequent SPA navigations. A module-level `hasInitialized` flag prevents duplicate store registrations.

## Test plan

- [ ] Navigate directly to `/wp-admin/admin.php?page=wc-admin&path=/marketing` — notifications appear as before
- [ ] Navigate to any other wc-admin page first (e.g. WooCommerce > Orders), then SPA-navigate to Marketing overview — notifications load correctly
- [ ] Refresh on Marketing overview — no duplicate notifications registered
- [ ] Confirm `notification-manager.js` and slot bundle are enqueued on non-marketing wc-admin pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)