### PR TITLE
Fix: delete Merchant Center products stored under legacy Content API ids

### DIFF
--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -311,7 +311,7 @@ class BatchProductHelper implements Service {
 			}
 
 			foreach ( $google_ids as $google_id ) {
-				$identity = $this->parse_mapi_identity( (string) $google_id );
+				$identity = $this->parse_deletable_identity( (string) $google_id );
 				if ( null === $identity ) {
 					continue;
 				}
@@ -344,6 +344,32 @@ class BatchProductHelper implements Service {
 		}
 
 		return [ $parts[0], $parts[1], $parts[2] ];
+	}
+
+	/**
+	 * Resolve a stored google product id into a MAPI identity [language, feed, offerId] for
+	 * deletion, accepting both the native MAPI id (`en~US~gla_29`) and the legacy Content API id
+	 * (`online:en:US:gla_29`) that pre-migration syncs stored. This lets products synced before the
+	 * MAPI cutover still be removed from Merchant Center. Returns null if neither format matches.
+	 *
+	 * @param string $google_id
+	 *
+	 * @return array{0: string, 1: string, 2: string}|null
+	 */
+	public function parse_deletable_identity( string $google_id ): ?array {
+		$identity = $this->parse_mapi_identity( $google_id );
+		if ( null !== $identity ) {
+			return $identity;
+		}
+
+		// Legacy Content API id: channel:language:country:offerId. The target country is the feed
+		// for these single-feed products.
+		$parts = explode( ':', $google_id, 4 );
+		if ( count( $parts ) === 4 ) {
+			return [ $parts[1], $parts[2], $parts[3] ];
+		}
+
+		return null;
 	}
 
 	/**
@@ -391,7 +417,7 @@ class BatchProductHelper implements Service {
 			$stale_ids  = array_diff_key( $google_ids, array_flip( $keep_countries ) );
 
 			foreach ( $stale_ids as $google_id ) {
-				$identity = $this->parse_mapi_identity( (string) $google_id );
+				$identity = $this->parse_deletable_identity( (string) $google_id );
 				if ( null === $identity ) {
 					continue;
 				}

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -333,6 +333,10 @@ class BatchProductHelper implements Service {
 	 * Parse a MAPI Google product id (e.g. `en~US~gla_29`) into its identity array
 	 * [language, feed, offerId].
 	 *
+	 * Tilde-only by design: a legacy Content API id (`online:en:US:gla_29`) returns null so the
+	 * status-read path skips it (the Merchant API rejects legacy ids as invalid resource names).
+	 * Deletion paths that must also accept legacy ids use parse_deletable_identity() instead.
+	 *
 	 * @param string $google_id
 	 *
 	 * @return array{0: string, 1: string, 2: string}|null
@@ -362,10 +366,11 @@ class BatchProductHelper implements Service {
 			return $identity;
 		}
 
-		// Legacy Content API id: channel:language:country:offerId. The target country is the feed
-		// for these single-feed products.
+		// Legacy Content API id: online:language:country:offerId. The target country is the feed
+		// for these single-feed products; only the `online` channel was ever stored, so anything
+		// else is not a legacy id we can delete.
 		$parts = explode( ':', $google_id, 4 );
-		if ( count( $parts ) === 4 ) {
+		if ( count( $parts ) === 4 && 'online' === $parts[0] ) {
 			return [ $parts[1], $parts[2], $parts[3] ];
 		}
 

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -281,7 +281,7 @@ class ProductSyncer implements Service {
 	public function delete_by_id_map( array $product_id_map ): BatchProductResponse {
 		$entries = [];
 		foreach ( $product_id_map as $google_id => $wc_product_id ) {
-			$identity = $this->batch_helper->parse_mapi_identity( (string) $google_id );
+			$identity = $this->batch_helper->parse_deletable_identity( (string) $google_id );
 			if ( null === $identity ) {
 				continue;
 			}

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -245,6 +245,49 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertEmpty( $results );
 	}
 
+	public function test_generate_mapi_delete_entries_deletes_legacy_colon_id() {
+		// A product synced before the MAPI cutover stores a legacy Content
+		// API id (online:lang:country:offerId). It must still produce a delete entry instead of
+		// being skipped, otherwise it lingers in Merchant Center after the product is deleted.
+		$products = $this->create_and_return_supported_test_products();
+		$product  = $products[0];
+
+		$this->product_helper->mark_as_synced(
+			$product,
+			$this->generate_google_product_mock( "online:en:US:gla_{$product->get_id()}", 'US' )
+		);
+
+		$results = $this->batch_product_helper->generate_mapi_delete_entries( [ $product ] );
+
+		$this->assertCount( 1, $results );
+		$this->assertSame( "online:en:US:gla_{$product->get_id()}", $results[0]['google_id'] );
+		$this->assertSame( 'en', $results[0]['input']->get_content_language() );
+		$this->assertSame( 'US', $results[0]['input']->get_feed_label() );
+		$this->assertSame( "gla_{$product->get_id()}", $results[0]['input']->get_offer_id() );
+	}
+
+	public function test_parse_deletable_identity_accepts_mapi_and_legacy_ids() {
+		$this->assertSame(
+			[ 'en', 'US', 'gla_29' ],
+			$this->batch_product_helper->parse_deletable_identity( 'en~US~gla_29' )
+		);
+		$this->assertSame(
+			[ 'en', 'US', 'gla_29' ],
+			$this->batch_product_helper->parse_deletable_identity( 'online:en:US:gla_29' )
+		);
+		$this->assertNull( $this->batch_product_helper->parse_deletable_identity( 'malformed-id' ) );
+	}
+
+	public function test_parse_mapi_identity_rejects_legacy_colon_id() {
+		// parse_mapi_identity stays tilde-only: the status read path relies on it returning null for
+		// legacy ids, which the Merchant API rejects as invalid resource names.
+		$this->assertNull( $this->batch_product_helper->parse_mapi_identity( 'online:en:US:gla_29' ) );
+		$this->assertSame(
+			[ 'en', 'US', 'gla_29' ],
+			$this->batch_product_helper->parse_mapi_identity( 'en~US~gla_29' )
+		);
+	}
+
 	public function test_generate_stale_products_delete_entries() {
 		$products         = $this->create_and_return_supported_test_products();
 		$stale_product    = $products[0];
@@ -305,6 +348,35 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertContains( $stale_google_ids['AU'], $google_ids );
 		$this->assertContains( $stale_google_ids['DK'], $google_ids );
 		$this->assertNotContains( $stale_google_ids['US'], $google_ids );
+	}
+
+	public function test_generate_stale_countries_delete_entries_handles_legacy_colon_id() {
+		// Regression (GOOWOO-802): the stale-country cleanup path must convert a legacy Content API
+		// id, not skip it, or the entry for the stale country lingers in Merchant Center.
+		$products         = $this->create_and_return_supported_test_products();
+		$stale_product    = $products[0];
+		$stale_product_id = $stale_product->get_id();
+
+		$this->target_audience->expects( $this->once() )
+			->method( 'get_main_target_country' )
+			->willReturn( 'US' );
+
+		// AU is stale (not the main country) and stored under the legacy colon format.
+		$this->product_meta->update_google_ids(
+			$stale_product,
+			[
+				'AU' => "online:en:AU:gla_{$stale_product_id}",
+				'US' => "online:en:US:gla_{$stale_product_id}",
+			]
+		);
+
+		$results = $this->batch_product_helper->generate_stale_countries_delete_entries( $products );
+
+		$this->assertCount( 1, $results );
+		$this->assertSame( "online:en:AU:gla_{$stale_product_id}", $results[0]['google_id'] );
+		$this->assertSame( 'en', $results[0]['input']->get_content_language() );
+		$this->assertSame( 'AU', $results[0]['input']->get_feed_label() );
+		$this->assertSame( "gla_{$stale_product_id}", $results[0]['input']->get_offer_id() );
 	}
 
 	public function test_generate_mapi_update_entries_merges_parent_and_variation_attributes() {

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -276,6 +276,10 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			$this->batch_product_helper->parse_deletable_identity( 'online:en:US:gla_29' )
 		);
 		$this->assertNull( $this->batch_product_helper->parse_deletable_identity( 'malformed-id' ) );
+
+		// A four-part colon string that is not an `online` Content API id is not a legacy id.
+		$this->assertNull( $this->batch_product_helper->parse_deletable_identity( 'local:en:US:gla_29' ) );
+		$this->assertNull( $this->batch_product_helper->parse_deletable_identity( 'foo:bar:baz:qux' ) );
 	}
 
 	public function test_parse_mapi_identity_rejects_legacy_colon_id() {
@@ -317,6 +321,35 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertContains( $stale_google_ids['AU'], $google_ids );
 		$this->assertContains( $stale_google_ids['DK'], $google_ids );
 		$this->assertNotContains( $stale_google_ids['US'], $google_ids );
+	}
+
+	public function test_generate_stale_products_delete_entries_handles_legacy_colon_id() {
+		// Regression (GOOWOO-802): the stale-products cleanup path must convert a legacy Content API
+		// id, not skip it, or the out-of-audience country's entry lingers in Merchant Center.
+		$products         = $this->create_and_return_supported_test_products();
+		$stale_product    = $products[0];
+		$stale_product_id = $stale_product->get_id();
+
+		$this->target_audience->expects( $this->once() )
+			->method( 'get_target_countries' )
+			->willReturn( [ 'US' ] );
+
+		// AU is no longer in the target audience and stored under the legacy colon format.
+		$this->product_meta->update_google_ids(
+			$stale_product,
+			[
+				'AU' => "online:en:AU:gla_{$stale_product_id}",
+				'US' => "online:en:US:gla_{$stale_product_id}",
+			]
+		);
+
+		$results = $this->batch_product_helper->generate_stale_products_delete_entries( $products );
+
+		$this->assertCount( 1, $results );
+		$this->assertSame( "online:en:AU:gla_{$stale_product_id}", $results[0]['google_id'] );
+		$this->assertSame( 'en', $results[0]['input']->get_content_language() );
+		$this->assertSame( 'AU', $results[0]['input']->get_feed_label() );
+		$this->assertSame( "gla_{$stale_product_id}", $results[0]['input']->get_offer_id() );
 	}
 
 	public function test_generate_stale_countries_delete_entries() {

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -539,6 +539,35 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 		$this->assertEmpty( $results->get_errors() );
 	}
 
+	public function test_delete_by_id_map_deletes_legacy_colon_id() {
+		// The resync cleanup path must delete products stored under the
+		// pre-MAPI Content API id, converting it to the MAPI identity instead of skipping it.
+		$product   = WC_Helper_Product::create_simple_product();
+		$legacy_id = "online:en:US:gla_{$product->get_id()}";
+		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock( $legacy_id, 'US' ) );
+
+		$captured = null;
+		$this->mapi_inputs->expects( $this->once() )
+			->method( 'delete_many' )
+			->willReturnCallback(
+				function ( array $inputs ) use ( &$captured ) {
+					$captured = $inputs[0];
+					return [
+						'successes' => [ 0 => $inputs[0] ],
+						'failures'  => [],
+					];
+				}
+			);
+
+		$results = $this->product_syncer->delete_by_id_map( [ $legacy_id => $product->get_id() ] );
+
+		$this->assertInstanceOf( ProductInput::class, $captured );
+		$this->assertSame( 'en', $captured->get_content_language() );
+		$this->assertSame( 'US', $captured->get_feed_label() );
+		$this->assertSame( "gla_{$product->get_id()}", $captured->get_offer_id() );
+		$this->assertCount( 1, $results->get_products() );
+	}
+
 	protected function assert_delete_results_are_valid( $results, $deleted_products, $rejected_products ) {
 		$this->assertEquals( 1, did_action( 'woocommerce_gla_batch_deleted_products' ) );
 		$this->assertEquals( 1, did_action( 'woocommerce_gla_batch_retry_delete_products' ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-802/mapi-integration-stale-products-left-in-the-merchant-center

Products synced before the MAPI migration store a legacy Content API Google id (online:en:US:gla_123), while MAPI-synced products use the tilde id (en~US~gla_123). The delete paths parsed only the tilde format via `BatchProductHelper::parse_mapi_identity()`, so a legacy-id product was silently skipped and lingered in Merchant Center after it was deleted from the store. 


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

- On the previous (Content API) build, create a product and sync it to Merchant Center.
- Update to the MAPI build.
- Delete the product from the store without resyncing first.
- Resync all products.
- Confirm the product is gone from Merchant Center

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
