### PR TITLE
fix(notifications): avoid duplicate store reg and glaData clobber

### DIFF
--- a/js/src/data/index.js
+++ b/js/src/data/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { registerStore, useDispatch, dispatch } from '@wordpress/data';
+import { registerStore, select, useDispatch, dispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import { getHistory } from '@woocommerce/navigation';
 
@@ -18,49 +18,56 @@ import reducer from './reducer';
 import { createErrorResponseCatcher } from './apiFetchMiddlewares';
 import { getReconnectAccountUrl } from '~/utils/urls';
 
-registerStore( STORE_KEY, {
-	actions,
-	selectors,
-	resolvers,
-	controls,
-	reducer,
-} );
+// This module is bundled separately per script entry, so more than one entry
+// (e.g. the main app and the notifications-system bundle) can import it on
+// the same page. Guard against re-running this setup — and re-registering
+// the store, which `@wordpress/data` only warns about rather than prevents —
+// so only the first bundle to load performs it.
+if ( ! select( STORE_KEY ) ) {
+	registerStore( STORE_KEY, {
+		actions,
+		selectors,
+		resolvers,
+		controls,
+		reducer,
+	} );
 
-dispatch( STORE_KEY ).hydratePrefetchedData( glaData.initialWpData );
+	dispatch( STORE_KEY ).hydratePrefetchedData( glaData.initialWpData );
 
-apiFetch.use(
-	createErrorResponseCatcher( ( response ) => {
-		if ( glaData.mcSetupComplete && response.status === 401 ) {
-			return ( response.json || response.text )
-				.call( response )
-				.then( ( errorInfo ) => {
-					if ( typeof errorInfo === 'string' ) {
-						return { message: errorInfo };
-					}
-					return errorInfo;
-				} )
-				.then( ( errorInfo ) => {
-					const url = getReconnectAccountUrl( errorInfo.code );
+	apiFetch.use(
+		createErrorResponseCatcher( ( response ) => {
+			if ( glaData.mcSetupComplete && response.status === 401 ) {
+				return ( response.json || response.text )
+					.call( response )
+					.then( ( errorInfo ) => {
+						if ( typeof errorInfo === 'string' ) {
+							return { message: errorInfo };
+						}
+						return errorInfo;
+					} )
+					.then( ( errorInfo ) => {
+						const url = getReconnectAccountUrl( errorInfo.code );
 
-					if ( url ) {
-						getHistory().replace( url );
-					}
+						if ( url ) {
+							getHistory().replace( url );
+						}
 
-					return errorInfo;
-				} )
-				.then( ( errorInfo ) => {
-					// Inject the status code to let the subsequent handlers can identify the 401 response error.
-					return Promise.reject( {
-						...errorInfo,
-						statusCode: response.status,
+						return errorInfo;
+					} )
+					.then( ( errorInfo ) => {
+						// Inject the status code to let the subsequent handlers can identify the 401 response error.
+						return Promise.reject( {
+							...errorInfo,
+							statusCode: response.status,
+						} );
 					} );
-				} );
-		}
+			}
 
-		// Throws error response to subsequent middlewares
-		throw response;
-	} )
-);
+			// Throws error response to subsequent middlewares
+			throw response;
+		} )
+	);
+}
 
 export { STORE_KEY };
 

--- a/src/Admin/NotificationsSystem.php
+++ b/src/Admin/NotificationsSystem.php
@@ -23,6 +23,13 @@ defined( 'ABSPATH' ) || exit;
  * current SPA route is the Marketing overview page before fetching or
  * rendering any notifications.
  *
+ * The main `google-listings-and-ads` bundle isn't guaranteed to be present on
+ * every page this bundle loads on (e.g. the core WooCommerce Marketing
+ * overview page), so this bundle provides its own fallback `glaData`. It's
+ * injected as `window.glaData = window.glaData || {...}` (a merge, not an
+ * unconditional `var glaData = {...}` assignment) so that on pages where the
+ * main bundle's richer `glaData` is already present, this doesn't clobber it.
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Admin
  */
 class NotificationsSystem implements Service, Registerable {
@@ -66,7 +73,7 @@ class NotificationsSystem implements Service, Registerable {
 
 				$build_dir = "{$this->get_root_dir()}/js/build";
 
-				$script = ( new AdminScriptWithBuiltDependenciesAsset(
+				$script = new AdminScriptWithBuiltDependenciesAsset(
 					'google-listings-and-ads-notifications-system',
 					'js/build/notifications-system',
 					"{$build_dir}/notifications-system.asset.php",
@@ -76,7 +83,7 @@ class NotificationsSystem implements Service, Registerable {
 							'version'      => $this->get_version(),
 						]
 					)
-				) )->add_inline_script( 'glaData', $this->get_gla_data() );
+				);
 
 				$style = new AdminStyleAsset(
 					'google-listings-and-ads-notifications-system-css',
@@ -87,17 +94,25 @@ class NotificationsSystem implements Service, Registerable {
 
 				$this->assets_handler->register_many( [ $script, $style ] );
 				$this->assets_handler->enqueue_many( [ $script, $style ] );
+
+				wp_add_inline_script(
+					$script->get_handle(),
+					'window.glaData = window.glaData || ' . wp_json_encode( $this->get_gla_data() ) . ';',
+					'before'
+				);
 			}
 		);
 	}
 
 	/**
-	 * Get the inline glaData required by the notifications-system bundle.
+	 * Get the fallback glaData required by the notifications-system bundle when
+	 * the main bundle's own glaData isn't present on the current page.
 	 *
 	 * @return array
 	 */
 	private function get_gla_data(): array {
 		return [
+			'slug'          => $this->get_slug(),
 			'dateFormat'    => get_option( 'date_format' ),
 			'initialWpData' => [
 				'version' => $this->get_version(),

--- a/tests/Unit/Admin/NotificationsSystemTest.php
+++ b/tests/Unit/Admin/NotificationsSystemTest.php
@@ -4,13 +4,11 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\NotificationsSystem;
-use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminScriptWithBuiltDependenciesAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\Asset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
-use ReflectionClass;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -72,9 +70,6 @@ class NotificationsSystemTest extends UnitTest {
 	public function test_enqueues_assets_on_marketing_overview_page() {
 		$this->set_marketing_overview_page();
 
-		$this->options->method( 'get_merchant_id' )->willReturn( 123 );
-		$this->options->method( 'get_ads_id' )->willReturn( 456 );
-
 		$this->assets_handler->expects( $this->once() )
 			->method( 'register_many' )
 			->with(
@@ -115,9 +110,6 @@ class NotificationsSystemTest extends UnitTest {
 		$_GET['page'] = 'wc-admin';
 		$_GET['path'] = '/analytics/overview';
 
-		$this->options->method( 'get_merchant_id' )->willReturn( 123 );
-		$this->options->method( 'get_ads_id' )->willReturn( 456 );
-
 		$this->assets_handler->expects( $this->once() )->method( 'register_many' );
 		$this->assets_handler->expects( $this->once() )->method( 'enqueue_many' );
 
@@ -137,7 +129,7 @@ class NotificationsSystemTest extends UnitTest {
 		do_action( 'admin_enqueue_scripts' );
 	}
 
-	public function test_adds_gla_data_inline_script_to_notifications_bundle() {
+	public function test_gla_data_fallback_does_not_overwrite_existing_gla_data() {
 		$this->set_marketing_overview_page();
 
 		update_option( 'date_format', 'F j, Y' );
@@ -145,29 +137,23 @@ class NotificationsSystemTest extends UnitTest {
 		$this->options->method( 'get_merchant_id' )->willReturn( 123 );
 		$this->options->method( 'get_ads_id' )->willReturn( 456 );
 
-		$this->assets_handler->expects( $this->once() )
-			->method( 'register_many' )
-			->with(
-				$this->callback(
-					function ( array $assets ) {
-						$script   = $this->get_script_asset( $assets );
-						$gla_data = $this->get_inline_script_data( $script, 'glaData' );
-
-						$this->assertSame( 'F j, Y', $gla_data['dateFormat'] );
-						$this->assertSame( 123, $gla_data['initialWpData']['mcId'] );
-						$this->assertSame( 456, $gla_data['initialWpData']['adsId'] );
-						$this->assertNotEmpty( $gla_data['initialWpData']['version'] );
-
-						return true;
-					}
-				)
-			);
-
-		$this->assets_handler->expects( $this->once() )->method( 'enqueue_many' );
-
 		$this->notifications_system->register();
 		set_current_screen( 'dashboard' );
 		do_action( 'admin_enqueue_scripts' );
+
+		$inline_scripts = wp_scripts()->get_data( 'google-listings-and-ads-notifications-system', 'before' );
+		$this->assertNotEmpty( $inline_scripts );
+
+		$inline_script = implode( '', (array) $inline_scripts );
+
+		// Must merge into (not overwrite) `window.glaData`, since the main
+		// bundle's own `glaData` isn't guaranteed present on this page (e.g.
+		// the core WooCommerce Marketing overview page).
+		$this->assertStringContainsString( 'window.glaData = window.glaData ||', $inline_script );
+		$this->assertStringContainsString( '"slug":"gla"', $inline_script );
+		$this->assertStringContainsString( '"dateFormat":"F j, Y"', $inline_script );
+		$this->assertStringContainsString( '"mcId":123', $inline_script );
+		$this->assertStringContainsString( '"adsId":456', $inline_script );
 	}
 
 	/**
@@ -195,42 +181,6 @@ class NotificationsSystemTest extends UnitTest {
 		foreach ( $expected_handles as $expected_handle ) {
 			$this->assertContains( $expected_handle, $handles );
 		}
-	}
-
-	/**
-	 * Get the script asset from a list of registered assets.
-	 *
-	 * @param Asset[] $assets
-	 *
-	 * @return AdminScriptWithBuiltDependenciesAsset
-	 */
-	private function get_script_asset( array $assets ): AdminScriptWithBuiltDependenciesAsset {
-		foreach ( $assets as $asset ) {
-			if ( $asset instanceof AdminScriptWithBuiltDependenciesAsset ) {
-				return $asset;
-			}
-		}
-
-		$this->fail( 'Expected AdminScriptWithBuiltDependenciesAsset in registered assets.' );
-	}
-
-	/**
-	 * Get inline script data from a script asset.
-	 *
-	 * @param AdminScriptWithBuiltDependenciesAsset $script
-	 * @param string                                $variable_name
-	 *
-	 * @return array
-	 */
-	private function get_inline_script_data( AdminScriptWithBuiltDependenciesAsset $script, string $variable_name ): array {
-		$reflection = new ReflectionClass( $script );
-		$property   = $reflection->getProperty( 'inline_scripts' );
-		$property->setAccessible( true );
-		$inline_scripts = $property->getValue( $script );
-
-		$this->assertArrayHasKey( $variable_name, $inline_scripts );
-
-		return $inline_scripts[ $variable_name ];
 	}
 
 	/**

--- a/tests/Unit/Admin/NotificationsSystemTest.php
+++ b/tests/Unit/Admin/NotificationsSystemTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Admin;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Admin\NotificationsSystem;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\Asset;
+use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
@@ -137,7 +138,11 @@ class NotificationsSystemTest extends UnitTest {
 		$this->options->method( 'get_merchant_id' )->willReturn( 123 );
 		$this->options->method( 'get_ads_id' )->willReturn( 456 );
 
-		$this->notifications_system->register();
+		// This test checks WordPress's actual registered script data below, so it
+		// needs a real handler here instead of the mocked $this->assets_handler.
+		$notifications_system = new NotificationsSystem( new AssetsHandler(), $this->options );
+
+		$notifications_system->register();
 		set_current_screen( 'dashboard' );
 		do_action( 'admin_enqueue_scripts' );
 


### PR DESCRIPTION
Notifications bundle and main bundle can both load on same wc-admin page (SPA nav). Register STORE_KEY only if not already registered, and merge fallback glaData via `window.glaData || {...}` instead of overwriting it inline.

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-788/fix-dead-notification-slot-bundle-wiring-minor-fe-issues-in

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
