### PR TITLE
Fix: send required inputValues when requesting an account re-review

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
+++ b/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php
@@ -137,10 +137,12 @@ class RequestReviewController extends BaseOptionsController {
 					throw new Exception( __( 'This review request must be completed in Merchant Center.', 'google-listings-and-ads' ), 400 );
 				}
 
-				// The account-review flow completes with no input values.
+				// Confirm the flow's required inputs (the "resolved all issues" checkbox);
+				// triggeraction rejects an empty inputValues when the flow has a required input.
 				$this->merchant->trigger_review_action(
 					(string) ( $action['actionContext'] ?? '' ),
-					(string) ( $action['flowId'] ?? '' )
+					(string) ( $action['flowId'] ?? '' ),
+					$action['inputValues'] ?? []
 				);
 
 				return $this->set_under_review_status();
@@ -289,8 +291,8 @@ class RequestReviewController extends BaseOptionsController {
 	 * redirect action so a working "Request review" control stays visible instead of silently
 	 * disappearing.
 	 *
-	 * `actionContext`/`flowId` are consumed only server-side by the POST handler (which
-	 * re-renders fresh), so they are stripped from the client-facing payload here.
+	 * `actionContext`/`flowId`/`inputValues` are consumed only server-side by the POST handler
+	 * (which re-renders fresh), so they are stripped from the client-facing payload here.
 	 *
 	 * @return array
 	 * @throws Exception If the render fails.
@@ -307,7 +309,11 @@ class RequestReviewController extends BaseOptionsController {
 		}
 
 		if ( is_array( $review_status['reviewAction'] ?? null ) ) {
-			unset( $review_status['reviewAction']['actionContext'], $review_status['reviewAction']['flowId'] );
+			unset(
+				$review_status['reviewAction']['actionContext'],
+				$review_status['reviewAction']['flowId'],
+				$review_status['reviewAction']['inputValues']
+			);
 		}
 
 		return $review_status;

--- a/src/Google/RequestReviewStatuses.php
+++ b/src/Google/RequestReviewStatuses.php
@@ -106,7 +106,8 @@ class RequestReviewStatuses implements Service {
 
 			// An in-app action is only triggerable with an action context and a flow id;
 			// skip it otherwise so we never post an empty flow to triggeraction.
-			$flow_id = $action['builtinUserInputAction']['flows'][0]['id'] ?? '';
+			$flow    = $action['builtinUserInputAction']['flows'][0] ?? [];
+			$flow_id = $flow['id'] ?? '';
 			if ( isset( $action['builtinUserInputAction']['actionContext'] ) && '' !== $flow_id ) {
 				return [
 					'type'          => 'in_app',
@@ -114,11 +115,42 @@ class RequestReviewStatuses implements Service {
 					'buttonLabel'   => $action['buttonLabel'] ?? '',
 					'actionContext' => $action['builtinUserInputAction']['actionContext'],
 					'flowId'        => $flow_id,
+					'inputValues'   => $this->build_input_values( $flow['inputs'] ?? [] ),
 				];
 			}
 		}
 
 		return null;
+	}
+
+	/**
+	 * Build the triggeraction inputValues for a review flow's input fields.
+	 *
+	 * The account-review flow gates on a confirmation checkbox ("I have resolved all the
+	 * issues"), so triggeraction rejects an empty inputValues when the flow has a required input.
+	 * Every checkbox in this flow is such a confirmation, which the merchant asserts by clicking
+	 * Request review, so all checkboxes are confirmed rather than keyed off the `required` flag
+	 * (which the render is not guaranteed to set). Text and choice inputs have no server-side
+	 * value and are left to the Merchant Center redirect flow.
+	 *
+	 * @param array $inputs The flow's InputField list.
+	 *
+	 * @return array<int, array{inputFieldId: string, checkboxInputValue: array{value: bool}}>
+	 */
+	private function build_input_values( array $inputs ): array {
+		$input_values = [];
+
+		foreach ( $inputs as $input ) {
+			$id = $input['id'] ?? '';
+			if ( '' !== $id && isset( $input['checkboxInput'] ) ) {
+				$input_values[] = [
+					'inputFieldId'       => $id,
+					'checkboxInputValue' => [ 'value' => true ],
+				];
+			}
+		}
+
+		return $input_values;
 	}
 
 	/**

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/RequestReviewControllerTest.php
@@ -226,6 +226,40 @@ class RequestReviewControllerTest extends RESTControllerUnitTest {
 		);
 	}
 
+	public function test_request_review_passes_confirmation_input_values() {
+		$action = $this->in_app_action();
+		$action['builtinUserInputAction']['flows'][0]['inputs'] = [
+			[
+				'id'            => 'confirm',
+				'required'      => true,
+				'checkboxInput' => [],
+			],
+		];
+
+		$this->merchant->expects( $this->once() )
+			->method( 'get_account_review_status' )
+			->willReturn(
+				$this->render_response( RequestReviewStatuses::SEVERITY_ERROR, 'Account suspended', [ $action ] )
+			);
+
+		$this->merchant->expects( $this->once() )
+			->method( 'trigger_review_action' )
+			->with(
+				'ctx-token',
+				'flow-1',
+				[
+					[
+						'inputFieldId'       => 'confirm',
+						'checkboxInputValue' => [ 'value' => true ],
+					],
+				]
+			)
+			->willReturn( [ 'name' => 'accounts/12345/action' ] );
+
+		$response = $this->do_post_request_review();
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
 	public function test_request_review_ineligible() {
 		$this->merchant->expects( $this->once() )
 			->method( 'get_account_review_status' )

--- a/tests/Unit/Google/RequestReviewStatusesTest.php
+++ b/tests/Unit/Google/RequestReviewStatusesTest.php
@@ -145,8 +145,60 @@ class RequestReviewStatusesTest extends UnitTest {
 				'buttonLabel'   => 'Request review',
 				'actionContext' => 'ctx-token',
 				'flowId'        => 'flow-1',
+				'inputValues'   => [],
 			],
 			$result['reviewAction']
+		);
+	}
+
+	public function test_in_app_action_builds_checkbox_input_values() {
+		$action = [
+			'isAvailable'            => true,
+			'buttonLabel'            => 'Request review',
+			'builtinUserInputAction' => [
+				'actionContext' => 'ctx-token',
+				'flows'         => [
+					[
+						'id'     => 'flow-1',
+						'inputs' => [
+							[
+								'id'        => 'notes',
+								'textInput' => [],
+							],
+							[
+								'id'            => 'confirm',
+								'required'      => true,
+								'checkboxInput' => [],
+							],
+							[
+								'id'            => 'optin',
+								'required'      => false,
+								'checkboxInput' => [],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$result = $this->statuses->get_statuses_from_response(
+			$this->response( [ $this->issue( RequestReviewStatuses::SEVERITY_ERROR, 'Suspended', [ $action ] ) ] )
+		);
+
+		// Every checkbox is confirmed regardless of its required flag; the text field carries no
+		// server-side value.
+		$this->assertSame(
+			[
+				[
+					'inputFieldId'       => 'confirm',
+					'checkboxInputValue' => [ 'value' => true ],
+				],
+				[
+					'inputFieldId'       => 'optin',
+					'checkboxInputValue' => [ 'value' => true ],
+				],
+			],
+			$result['reviewAction']['inputValues']
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-799/mamerchant-api-migrationpi-integration-not-possible-to-request-a-site

Requesting an account re-review (Product Feeds -> Request review) failed with HTTP 400 `[actionInput.inputValues] Invalid user input.` The Merchant API account review flow has a required confirmation input (the "I have resolved all the issue(s)" checkbox), but the plugin triggered the action with an empty `inputValues`: `RequestReviewStatuses::find_review_action` captured only the flow's `actionContext` and `id` and dropped its input fields, and the controller then triggered with no values.

This captures the flow's input fields and confirms each checkbox as `{ inputFieldId, checkboxInputValue: { value: true } }`, passes them through to `triggeraction`, and strips the server-only `inputValues` from the client payload. Server-side only, no UI change.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

- Go to Product Feeds and click "Request review", check the confirmation box, and submit.
- Confirm the request succeeds (status flips to "under review") instead of the 400 [actionInput.inputValues] Invalid user input error seen before the fix.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
