### PR TITLE
Fix: GOOWOO-808: MAPI integration: lowercase availability ENUMs

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -1182,7 +1182,7 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 					'description'  => 'Inserted via Connection Test.',
 					'link'         => home_url( '/' ),
 					'imageLink'    => 'https://via.placeholder.com/250',
-					'availability' => 'in_stock',
+					'availability' => 'IN_STOCK',
 					'condition'    => 'new',
 					'price'        => [
 						'amountMicros' => '19990000',
@@ -1232,7 +1232,7 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 						'description'  => 'Inserted via Connection Test.',
 						'link'         => home_url( '/' ),
 						'imageLink'    => 'https://via.placeholder.com/250',
-						'availability' => 'in_stock',
+						'availability' => 'IN_STOCK',
 						'condition'    => 'new',
 						'price'        => [
 							'amountMicros' => '19990000',

--- a/src/Product/WCProductInputAdapter.php
+++ b/src/Product/WCProductInputAdapter.php
@@ -24,9 +24,9 @@ class WCProductInputAdapter {
 
 	use PluginHelper;
 
-	public const AVAILABILITY_IN_STOCK     = 'in_stock';
-	public const AVAILABILITY_OUT_OF_STOCK = 'out_of_stock';
-	public const AVAILABILITY_BACKORDER    = 'backorder';
+	public const AVAILABILITY_IN_STOCK     = 'IN_STOCK';
+	public const AVAILABILITY_OUT_OF_STOCK = 'OUT_OF_STOCK';
+	public const AVAILABILITY_BACKORDER    = 'BACKORDER';
 
 	public const IMAGE_SIZE_FULL = 'full';
 
@@ -130,6 +130,10 @@ class WCProductInputAdapter {
 		$this->map_gla_attributes();
 		$this->map_gtin();
 		$this->override_attributes();
+
+		// Availability can arrive lowercase from a mapping rule or the override filter (e.g. the
+		// pre-orders integration's `preorder`); send the Merchant API's uppercase enum regardless.
+		$this->normalize_availability();
 	}
 
 	/**
@@ -299,6 +303,19 @@ class WCProductInputAdapter {
 		}
 
 		$this->attributes['availability'] = $availability;
+	}
+
+	/**
+	 * Normalise availability to the Merchant API's uppercase enum casing (IN_STOCK, OUT_OF_STOCK,
+	 * PREORDER, BACKORDER). map_availability() already emits the enum. This uppercases a value that
+	 * arrived through attribute mapping or the override filter (e.g. the pre-orders integration's
+	 * lowercase `preorder`), so every path sends the documented casing rather than relying on the
+	 * Merchant API normalising it.
+	 */
+	protected function normalize_availability(): void {
+		if ( ! empty( $this->attributes['availability'] ) && is_string( $this->attributes['availability'] ) ) {
+			$this->attributes['availability'] = strtoupper( $this->attributes['availability'] );
+		}
 	}
 
 	/**

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -126,7 +126,7 @@ class WCProductInputAdapterTest extends UnitTest {
 
 		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
 
-		$this->assertSame( 'in_stock', $attrs['availability'] );
+		$this->assertSame( 'IN_STOCK', $attrs['availability'] );
 	}
 
 	public function test_maps_availability_out_of_stock() {
@@ -136,7 +136,38 @@ class WCProductInputAdapterTest extends UnitTest {
 
 		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
 
-		$this->assertSame( 'out_of_stock', $attrs['availability'] );
+		$this->assertSame( 'OUT_OF_STOCK', $attrs['availability'] );
+	}
+
+	public function test_maps_availability_backorder() {
+		$product = WC_Helper_Product::create_simple_product( false );
+		$product->set_manage_stock( true );
+		$product->set_stock_status( 'instock' );
+		$product->set_backorders( 'yes' );
+		$product->set_stock_quantity( 0 );
+		$product->save();
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'BACKORDER', $attrs['availability'] );
+	}
+
+	public function test_uppercases_availability_set_via_override_filter() {
+		// Value injected by the override filter (e.g. the pre-orders integration's
+		// lowercase `preorder`) must still be sent as the Merchant API's uppercase enum.
+		$product = WC_Helper_Product::create_simple_product();
+
+		$cb = static function ( array $overrides ): array {
+			$overrides['availability'] = 'preorder';
+			return $overrides;
+		};
+		add_filter( 'woocommerce_gla_product_attribute_values', $cb );
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		remove_filter( 'woocommerce_gla_product_attribute_values', $cb );
+
+		$this->assertSame( 'PREORDER', $attrs['availability'] );
 	}
 
 	public function test_omits_images_when_product_has_none() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-808/mapi-integration-lowercase-availability-enums

`WCProductInputAdapter` sent the availability attribute in lowercase (in_stock, out_of_stock, backorder, and preorder via the pre-orders integration), but the Merchant API's `ProductAttributes.availability` is a documented uppercase enum (IN_STOCK, OUT_OF_STOCK, PREORDER, BACKORDER).

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
