### PR TITLE
Fix: GOOWOO-809: MAPI integration: `redemptionChannel` should not be scalar

### DIFF
--- a/src/Coupon/WCCouponAdapter.php
+++ b/src/Coupon/WCCouponAdapter.php
@@ -177,7 +177,8 @@ class WCCouponAdapter implements Validatable {
 			'promotionId'       => $this->promotion_id,
 			'contentLanguage'   => $this->content_language,
 			'targetCountry'     => $this->target_country,
-			'redemptionChannel' => $this->redemption_channel,
+			// redemptionChannel is a repeated field in the Merchant API schema, so send an array.
+			'redemptionChannel' => [ $this->redemption_channel ],
 			'attributes'        => $attributes,
 		];
 	}

--- a/tests/Unit/API/Google/Mapi/Services/MapiPromotionsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiPromotionsServiceTest.php
@@ -48,7 +48,7 @@ class MapiPromotionsServiceTest extends UnitTest {
 			'promotionId'       => 'gla_15',
 			'contentLanguage'   => 'en',
 			'targetCountry'     => 'US',
-			'redemptionChannel' => 'ONLINE',
+			'redemptionChannel' => [ 'ONLINE' ],
 			'attributes'        => [ 'genericRedemptionCode' => 'SAVE10' ],
 		];
 

--- a/tests/Unit/Coupon/WCCouponAdapterTest.php
+++ b/tests/Unit/Coupon/WCCouponAdapterTest.php
@@ -48,7 +48,7 @@ class WCCouponAdapterTest extends UnitTest {
 		);
 
 		$promotion = $adapted_coupon->get_promotion();
-		$this->assertEquals( 'ONLINE', $promotion['redemptionChannel'] );
+		$this->assertSame( [ 'ONLINE' ], $promotion['redemptionChannel'] );
 	}
 
 	public function test_content_language_is_set_by_default_to_en() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-809/mapi-integration-redemptionchannel-should-not-be-scalar
`
CouponAdapter::get_promotion()` sent `redemptionChannel` as a scalar (`"redemptionChannel":"ONLINE"`), but the `promotions_v1` schema defines it as a repeated field (`redemptionChannel[]`), i.e. ["ONLINE"]. 


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
