### PR TITLE
Fix: GOOWOO-805: MAPI source label and debug logging

### DIFF
--- a/src/API/Google/Mapi/Services/MapiDataSourcesService.php
+++ b/src/API/Google/Mapi/Services/MapiDataSourcesService.php
@@ -29,14 +29,18 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 
 	use OptionsAwareTrait;
 
-	/** Display name prefix used when creating the plugin's data sources. */
-	public const DATA_SOURCE_DISPLAY_NAME = 'Google for WooCommerce';
+	/** Display name prefix used when creating the plugin's data sources. Shown in Merchant Center's
+	 * data-source column, mirroring the legacy "Content API" label. */
+	public const DATA_SOURCE_DISPLAY_NAME = 'Merchant API';
 
 	/** Descriptor for the primary product data source. */
 	private const PRODUCT_SOURCE = [
 		'source_field' => 'primaryProductDataSource',
 		'match_field'  => 'feedLabel',
-		'cache_prefix' => '',
+		// Namespaced (was '') to invalidate resolutions cached before the resolver began adopting
+		// and renaming a pre-existing primary source (e.g. the legacy "Content API" one), so the
+		// one-time rename runs on existing installs.
+		'cache_prefix' => 'product|',
 	];
 
 	/** Descriptor for the promotion data source. */
@@ -107,8 +111,10 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 			return (string) $cache[ $cache_key ];
 		}
 
-		$name = $this->find_existing_data_source( $type, $content_language, $match_value )
-			?? $this->create_data_source( $type, $content_language, $match_value );
+		$existing = $this->find_existing_data_source( $type, $content_language, $match_value );
+		$name     = null !== $existing
+			? $this->adopt_data_source( $existing, $content_language, $match_value )
+			: $this->create_data_source( $type, $content_language, $match_value );
 
 		$cache[ $cache_key ] = $name;
 		$this->options->update( OptionsInterface::MAPI_DATA_SOURCES, $cache );
@@ -117,17 +123,31 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 	}
 
 	/**
-	 * List existing data sources and return the resource name of the one of the given
-	 * type matching the (contentLanguage, match) pair, if any.
+	 * The displayName the plugin gives its own data sources, used when creating one and when
+	 * adopting a pre-existing primary source, so a source fed by the plugin is labelled
+	 * consistently in Merchant Center regardless of how it was originally created.
+	 *
+	 * @param string $content_language
+	 * @param string $match_value
+	 *
+	 * @return string
+	 */
+	private function build_display_name( string $content_language, string $match_value ): string {
+		return sprintf( '%s (%s/%s)', self::DATA_SOURCE_DISPLAY_NAME, $content_language, $match_value );
+	}
+
+	/**
+	 * List existing data sources and return the one of the given type matching the
+	 * (contentLanguage, match) pair, if any.
 	 *
 	 * @param array  $type             One of the *_SOURCE descriptors.
 	 * @param string $content_language Language code.
 	 * @param string $match_value      Secondary identity value (feed label or target country).
 	 *
-	 * @return string|null
+	 * @return array|null The matched data source, or null when none matches.
 	 * @throws MerchantApiException On a non-2xx MAPI response.
 	 */
-	private function find_existing_data_source( array $type, string $content_language, string $match_value ): ?string {
+	private function find_existing_data_source( array $type, string $content_language, string $match_value ): ?array {
 		$page_token = '';
 
 		do {
@@ -143,7 +163,7 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 					$content_language === ( $descriptor['contentLanguage'] ?? '' )
 					&& $match_value === ( $descriptor[ $type['match_field'] ] ?? '' )
 				) {
-					return $source['name'];
+					return $source;
 				}
 			}
 
@@ -151,6 +171,31 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 		} while ( '' !== $page_token );
 
 		return null;
+	}
+
+	/**
+	 * Adopt a pre-existing data source: when its displayName differs (e.g. a legacy "Content API"
+	 * source), rename it to the plugin's name so its products stay in place and are re-attributed
+	 * to the Merchant API in Merchant Center rather than duplicated into a new source.
+	 *
+	 * @param array  $source           The matched data source.
+	 * @param string $content_language Language code.
+	 * @param string $match_value      Secondary identity value (feed label or target country).
+	 *
+	 * @return string The data source resource name.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	private function adopt_data_source( array $source, string $content_language, string $match_value ): string {
+		$display_name = $this->build_display_name( $content_language, $match_value );
+
+		if ( $display_name !== ( $source['displayName'] ?? '' ) ) {
+			$this->client->patch(
+				sprintf( '%s/%s?updateMask=displayName', MapiPaths::DATASOURCES, $source['name'] ),
+				[ 'displayName' => $display_name ]
+			);
+		}
+
+		return $source['name'];
 	}
 
 	/**
@@ -188,7 +233,7 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 		$response = $this->client->post(
 			sprintf( '%s/accounts/%s/dataSources', MapiPaths::DATASOURCES, $this->options->get_merchant_id() ),
 			[
-				'displayName'         => sprintf( '%s (%s/%s)', self::DATA_SOURCE_DISPLAY_NAME, $content_language, $match_value ),
+				'displayName'         => $this->build_display_name( $content_language, $match_value ),
 				$type['source_field'] => [
 					'contentLanguage'    => $content_language,
 					$type['match_field'] => $match_value,

--- a/src/API/Google/Mapi/Services/MapiDataSourcesService.php
+++ b/src/API/Google/Mapi/Services/MapiDataSourcesService.php
@@ -29,9 +29,8 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 
 	use OptionsAwareTrait;
 
-	/** Display name prefix used when creating the plugin's data sources. Shown in Merchant Center's
-	 * data-source column, mirroring the legacy "Content API" label. */
-	public const DATA_SOURCE_DISPLAY_NAME = 'Merchant API';
+	/** Display name prefix used when creating the plugin's data sources. */
+	public const DATA_SOURCE_DISPLAY_NAME = 'Google for WooCommerce';
 
 	/** Descriptor for the primary product data source. */
 	private const PRODUCT_SOURCE = [

--- a/src/API/Google/Mapi/Services/MapiDataSourcesService.php
+++ b/src/API/Google/Mapi/Services/MapiDataSourcesService.php
@@ -176,23 +176,37 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 	/**
 	 * Adopt a pre-existing data source: when its displayName differs (e.g. a legacy "Content API"
 	 * source), rename it to the plugin's name so its products stay in place and are re-attributed
-	 * to the Merchant API in Merchant Center rather than duplicated into a new source.
+	 * to the Merchant API in Merchant Center rather than duplicated into a new source. A failed
+	 * rename is logged and swallowed rather than propagated, so a transient MAPI error doesn't
+	 * fail the sync for an otherwise-usable data source.
 	 *
 	 * @param array  $source           The matched data source.
 	 * @param string $content_language Language code.
 	 * @param string $match_value      Secondary identity value (feed label or target country).
 	 *
 	 * @return string The data source resource name.
-	 * @throws MerchantApiException On a non-2xx MAPI response.
 	 */
 	private function adopt_data_source( array $source, string $content_language, string $match_value ): string {
 		$display_name = $this->build_display_name( $content_language, $match_value );
 
 		if ( $display_name !== ( $source['displayName'] ?? '' ) ) {
-			$this->client->patch(
-				sprintf( '%s/%s?updateMask=displayName', MapiPaths::DATASOURCES, $source['name'] ),
-				[ 'displayName' => $display_name ]
-			);
+			try {
+				$this->client->patch(
+					sprintf( '%s/%s?updateMask=displayName', MapiPaths::DATASOURCES, $source['name'] ),
+					[ 'displayName' => $display_name ]
+				);
+			} catch ( MerchantApiException $exception ) {
+				do_action(
+					'woocommerce_gla_error',
+					sprintf(
+						'Failed to rename data source %s to "%s": %s',
+						$source['name'],
+						$display_name,
+						$exception->getMessage()
+					),
+					__METHOD__
+				);
+			}
 		}
 
 		return $source['name'];

--- a/src/API/Google/Mapi/Services/MapiProductInputsService.php
+++ b/src/API/Google/Mapi/Services/MapiProductInputsService.php
@@ -59,10 +59,14 @@ class MapiProductInputsService implements OptionsAwareInterface {
 			$input->get_feed_label()
 		);
 
+		$this->log( sprintf( 'productInputs.insert %s: %s', $input->get_offer_id(), wp_json_encode( $input->to_array() ) ), __METHOD__ );
+
 		$body = $this->client->post(
 			$this->build_path( $data_source ),
 			$input->to_array()
 		);
+
+		$this->log( sprintf( 'productInputs.insert %s succeeded (%s)', $input->get_offer_id(), $body['name'] ?? '' ), __METHOD__ );
 
 		return ProductInput::from_array( $body );
 	}
@@ -87,9 +91,13 @@ class MapiProductInputsService implements OptionsAwareInterface {
 				$input->get_feed_label()
 			);
 			$paths_by_index[ $index ] = $this->build_path( $data_source );
+
+			// Bulk sync logs a lightweight per-item line; the full payload is logged only by the
+			// single-item insert()/patch() used by the debugger, to avoid a JSON dump per product.
+			$this->log( sprintf( 'productInputs.insert %s', $input->get_offer_id() ), __METHOD__ );
 		}
 
-		return $this->run_in_batches(
+		$result = $this->run_in_batches(
 			$inputs,
 			$concurrency,
 			__METHOD__,
@@ -104,6 +112,10 @@ class MapiProductInputsService implements OptionsAwareInterface {
 				return ProductInput::from_array( $body );
 			}
 		);
+
+		$this->log( sprintf( 'productInputs.insert batch of %d: %d succeeded, %d failed', count( $inputs ), count( $result['successes'] ), count( $result['failures'] ) ), __METHOD__ );
+
+		return $result;
 	}
 
 	/**
@@ -128,10 +140,14 @@ class MapiProductInputsService implements OptionsAwareInterface {
 			$input->get_feed_label()
 		);
 
+		$this->log( sprintf( 'productInputs.patch %s (%s): %s', $input->get_offer_id(), implode( ',', $mask ), wp_json_encode( $input->to_array() ) ), __METHOD__ );
+
 		$body = $this->client->patch(
 			$this->build_patch_path( $input, $mask, $data_source ),
 			$input->to_array()
 		);
+
+		$this->log( sprintf( 'productInputs.patch %s succeeded (%s)', $input->get_offer_id(), $body['name'] ?? '' ), __METHOD__ );
 
 		return ProductInput::from_array( $body );
 	}
@@ -163,6 +179,8 @@ class MapiProductInputsService implements OptionsAwareInterface {
 				$input->get_feed_label()
 			);
 			$paths_by_index[ $index ] = $this->build_patch_path( $input, $mask, $data_source );
+
+			$this->log( sprintf( 'productInputs.patch %s (%s)', $input->get_offer_id(), implode( ',', $mask ) ), __METHOD__ );
 		}
 
 		$client = $this->client;
@@ -189,6 +207,8 @@ class MapiProductInputsService implements OptionsAwareInterface {
 			]
 		) )->promise()->wait();
 
+		$this->log( sprintf( 'productInputs.patch batch of %d: %d succeeded, %d failed', count( $patches ), count( $successes ), count( $failures ) ), __METHOD__ );
+
 		return [
 			'successes' => $successes,
 			'failures'  => $failures,
@@ -209,7 +229,11 @@ class MapiProductInputsService implements OptionsAwareInterface {
 			$input->get_feed_label()
 		);
 
+		$this->log( sprintf( 'productInputs.delete %s', $input->get_offer_id() ), __METHOD__ );
+
 		$this->client->delete( $this->build_delete_path( $input, $data_source ) );
+
+		$this->log( sprintf( 'productInputs.delete %s succeeded', $input->get_offer_id() ), __METHOD__ );
 	}
 
 	/**
@@ -230,9 +254,11 @@ class MapiProductInputsService implements OptionsAwareInterface {
 				$input->get_feed_label()
 			);
 			$paths_by_index[ $index ] = $this->build_delete_path( $input, $data_source );
+
+			$this->log( sprintf( 'productInputs.delete %s', $input->get_offer_id() ), __METHOD__ );
 		}
 
-		return $this->run_in_batches(
+		$result = $this->run_in_batches(
 			$inputs,
 			$concurrency,
 			__METHOD__,
@@ -246,6 +272,10 @@ class MapiProductInputsService implements OptionsAwareInterface {
 				return $input;
 			}
 		);
+
+		$this->log( sprintf( 'productInputs.delete batch of %d: %d succeeded, %d failed', count( $inputs ), count( $result['successes'] ), count( $result['failures'] ) ), __METHOD__ );
+
+		return $result;
 	}
 
 	/**
@@ -320,6 +350,17 @@ class MapiProductInputsService implements OptionsAwareInterface {
 			'successes' => $successes,
 			'failures'  => $failures,
 		];
+	}
+
+	/**
+	 * Emit a debug-log entry for a Merchant API product write so the payload and outcome of a
+	 * push can be verified and troubleshot. Recorded only when GLA debug logging is enabled.
+	 *
+	 * @param string $message
+	 * @param string $method  Calling method, for the debug log's source attribution.
+	 */
+	private function log( string $message, string $method ): void {
+		do_action( 'woocommerce_gla_debug_message', $message, $method );
 	}
 
 	/**

--- a/tests/Unit/API/Google/Mapi/Services/MapiDataSourcesServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiDataSourcesServiceTest.php
@@ -67,7 +67,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 					'dataSources' => [
 						[
 							'name'                     => 'accounts/12345/dataSources/100',
-							'displayName'              => 'Merchant API (en/US)',
+							'displayName'              => 'Google for WooCommerce (en/US)',
 							'primaryProductDataSource' => [
 								'contentLanguage' => 'en',
 								'feedLabel'       => 'US',
@@ -115,7 +115,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 			->method( 'patch' )
 			->with(
 				self::LIST_PATH . '/100?updateMask=displayName',
-				[ 'displayName' => 'Merchant API (en/US)' ]
+				[ 'displayName' => 'Google for WooCommerce (en/US)' ]
 			);
 
 		$this->assertSame(
@@ -185,7 +185,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 				self::LIST_PATH,
 				$this->callback(
 					function ( $body ) {
-						return 'Merchant API (en/US)' === $body['displayName']
+						return 'Google for WooCommerce (en/US)' === $body['displayName']
 							&& 'en' === $body['primaryProductDataSource']['contentLanguage']
 							&& 'US' === $body['primaryProductDataSource']['feedLabel']
 							&& ! isset( $body['fileInput'] );
@@ -269,7 +269,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 					'dataSources' => [
 						[
 							'name'                     => 'accounts/12345/dataSources/200',
-							'displayName'              => 'Merchant API (en/US)',
+							'displayName'              => 'Google for WooCommerce (en/US)',
 							'primaryProductDataSource' => [
 								'contentLanguage' => 'en',
 								'feedLabel'       => 'US',
@@ -313,7 +313,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 					'dataSources' => [
 						[
 							'name'                => 'accounts/12345/dataSources/300',
-							'displayName'         => 'Merchant API (en/US)',
+							'displayName'         => 'Google for WooCommerce (en/US)',
 							'promotionDataSource' => [
 								'contentLanguage' => 'en',
 								'targetCountry'   => 'US',
@@ -360,7 +360,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 			->method( 'patch' )
 			->with(
 				self::LIST_PATH . '/300?updateMask=displayName',
-				[ 'displayName' => 'Merchant API (en/US)' ]
+				[ 'displayName' => 'Google for WooCommerce (en/US)' ]
 			);
 
 		$this->assertSame(
@@ -390,7 +390,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 				self::LIST_PATH,
 				$this->callback(
 					function ( $body ) {
-						return 'Merchant API (en/US)' === $body['displayName']
+						return 'Google for WooCommerce (en/US)' === $body['displayName']
 							&& 'en' === $body['promotionDataSource']['contentLanguage']
 							&& 'US' === $body['promotionDataSource']['targetCountry']
 							&& ! isset( $body['primaryProductDataSource'] );

--- a/tests/Unit/API/Google/Mapi/Services/MapiDataSourcesServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiDataSourcesServiceTest.php
@@ -44,7 +44,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 	public function test_returns_cached_value_without_api_call() {
 		$this->options->method( 'get' )->willReturn(
 			[
-				'en|US' => 'accounts/12345/dataSources/999',
+				'product|en|US' => 'accounts/12345/dataSources/999',
 			]
 		);
 		$this->client->expects( $this->never() )->method( 'get' );
@@ -66,7 +66,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 					'dataSources' => [
 						[
 							'name'                     => 'accounts/12345/dataSources/100',
-							'displayName'              => 'Some existing source',
+							'displayName'              => 'Merchant API (en/US)',
 							'primaryProductDataSource' => [
 								'contentLanguage' => 'en',
 								'feedLabel'       => 'US',
@@ -75,11 +75,46 @@ class MapiDataSourcesServiceTest extends UnitTest {
 					],
 				]
 			);
+		// Already the plugin's own source: adopted without a rename.
+		$this->client->expects( $this->never() )->method( 'patch' );
 		$this->options->expects( $this->once() )
 			->method( 'update' )
 			->with(
 				OptionsInterface::MAPI_DATA_SOURCES,
-				[ 'en|US' => 'accounts/12345/dataSources/100' ]
+				[ 'product|en|US' => 'accounts/12345/dataSources/100' ]
+			);
+
+		$this->assertSame(
+			'accounts/12345/dataSources/100',
+			$this->service->ensure_data_source_for( 'en', 'US' )
+		);
+	}
+
+	public function test_adopts_and_renames_a_foreign_primary_source() {
+		// GOOWOO-805: a pre-existing primary source (e.g. the legacy "Content API" one) is adopted
+		// and renamed in place, not duplicated into a new source, so its products keep their place
+		// and get re-attributed to the Merchant API.
+		$this->options->method( 'get' )->willReturn( [] );
+		$this->client->method( 'get' )->willReturn(
+			[
+				'dataSources' => [
+					[
+						'name'                     => 'accounts/12345/dataSources/100',
+						'displayName'              => 'Content API',
+						'primaryProductDataSource' => [
+							'contentLanguage' => 'en',
+							'feedLabel'       => 'US',
+						],
+					],
+				],
+			]
+		);
+		$this->client->expects( $this->never() )->method( 'post' );
+		$this->client->expects( $this->once() )
+			->method( 'patch' )
+			->with(
+				self::LIST_PATH . '/100?updateMask=displayName',
+				[ 'displayName' => 'Merchant API (en/US)' ]
 			);
 
 		$this->assertSame(
@@ -115,7 +150,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 				self::LIST_PATH,
 				$this->callback(
 					function ( $body ) {
-						return 'Google for WooCommerce (en/US)' === $body['displayName']
+						return 'Merchant API (en/US)' === $body['displayName']
 							&& 'en' === $body['primaryProductDataSource']['contentLanguage']
 							&& 'US' === $body['primaryProductDataSource']['feedLabel']
 							&& ! isset( $body['fileInput'] );
@@ -140,7 +175,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 			->method( 'update' )
 			->with(
 				OptionsInterface::MAPI_DATA_SOURCES,
-				[ 'fr|CA' => 'accounts/12345/dataSources/777' ]
+				[ 'product|fr|CA' => 'accounts/12345/dataSources/777' ]
 			);
 
 		$this->assertSame(
@@ -151,7 +186,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 
 	public function test_preserves_other_market_cache_entries_when_resolving_a_new_market() {
 		$this->options->method( 'get' )->willReturn(
-			[ 'en|US' => 'accounts/12345/dataSources/100' ]
+			[ 'product|en|US' => 'accounts/12345/dataSources/100' ]
 		);
 		$this->client->method( 'get' )->willReturn( [ 'dataSources' => [] ] );
 		$this->client->method( 'post' )->willReturn(
@@ -162,8 +197,8 @@ class MapiDataSourcesServiceTest extends UnitTest {
 			->with(
 				OptionsInterface::MAPI_DATA_SOURCES,
 				[
-					'en|US' => 'accounts/12345/dataSources/100',
-					'fr|CA' => 'accounts/12345/dataSources/200',
+					'product|en|US' => 'accounts/12345/dataSources/100',
+					'product|fr|CA' => 'accounts/12345/dataSources/200',
 				]
 			);
 
@@ -199,6 +234,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 					'dataSources' => [
 						[
 							'name'                     => 'accounts/12345/dataSources/200',
+							'displayName'              => 'Merchant API (en/US)',
 							'primaryProductDataSource' => [
 								'contentLanguage' => 'en',
 								'feedLabel'       => 'US',
@@ -242,7 +278,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 					'dataSources' => [
 						[
 							'name'                => 'accounts/12345/dataSources/300',
-							'displayName'         => 'Existing promotions',
+							'displayName'         => 'Merchant API (en/US)',
 							'promotionDataSource' => [
 								'contentLanguage' => 'en',
 								'targetCountry'   => 'US',
@@ -251,11 +287,45 @@ class MapiDataSourcesServiceTest extends UnitTest {
 					],
 				]
 			);
+		// Already the plugin's own source: adopted without a rename.
+		$this->client->expects( $this->never() )->method( 'patch' );
 		$this->options->expects( $this->once() )
 			->method( 'update' )
 			->with(
 				OptionsInterface::MAPI_DATA_SOURCES,
 				[ 'promotion|en|US' => 'accounts/12345/dataSources/300' ]
+			);
+
+		$this->assertSame(
+			'accounts/12345/dataSources/300',
+			$this->service->ensure_promotion_data_source_for( 'en', 'US' )
+		);
+	}
+
+	public function test_adopts_and_renames_a_foreign_promotion_source() {
+		// GOOWOO-805: a pre-existing promotion source that is not the plugin's own is adopted and
+		// renamed in place, mirroring the product-source behavior.
+		$this->options->method( 'get' )->willReturn( [] );
+		$this->client->method( 'get' )->willReturn(
+			[
+				'dataSources' => [
+					[
+						'name'                => 'accounts/12345/dataSources/300',
+						'displayName'         => 'Content API promotions',
+						'promotionDataSource' => [
+							'contentLanguage' => 'en',
+							'targetCountry'   => 'US',
+						],
+					],
+				],
+			]
+		);
+		$this->client->expects( $this->never() )->method( 'post' );
+		$this->client->expects( $this->once() )
+			->method( 'patch' )
+			->with(
+				self::LIST_PATH . '/300?updateMask=displayName',
+				[ 'displayName' => 'Merchant API (en/US)' ]
 			);
 
 		$this->assertSame(
@@ -285,7 +355,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 				self::LIST_PATH,
 				$this->callback(
 					function ( $body ) {
-						return 'Google for WooCommerce (en/US)' === $body['displayName']
+						return 'Merchant API (en/US)' === $body['displayName']
 							&& 'en' === $body['promotionDataSource']['contentLanguage']
 							&& 'US' === $body['promotionDataSource']['targetCountry']
 							&& ! isset( $body['primaryProductDataSource'] );
@@ -320,10 +390,10 @@ class MapiDataSourcesServiceTest extends UnitTest {
 	}
 
 	public function test_promotion_and_product_caches_do_not_collide() {
-		// A product data source is cached under 'en|US'; resolving a promotion for the
+		// A product data source is cached under 'product|en|US'; resolving a promotion for the
 		// same language/country must use a distinct key and never return the product source.
 		$this->options->method( 'get' )->willReturn(
-			[ 'en|US' => 'accounts/12345/dataSources/100' ]
+			[ 'product|en|US' => 'accounts/12345/dataSources/100' ]
 		);
 		$this->client->method( 'get' )->willReturn( [ 'dataSources' => [] ] );
 		$this->client->method( 'post' )->willReturn(
@@ -334,7 +404,7 @@ class MapiDataSourcesServiceTest extends UnitTest {
 			->with(
 				OptionsInterface::MAPI_DATA_SOURCES,
 				[
-					'en|US'           => 'accounts/12345/dataSources/100',
+					'product|en|US'   => 'accounts/12345/dataSources/100',
 					'promotion|en|US' => 'accounts/12345/dataSources/300',
 				]
 			);

--- a/tests/Unit/API/Google/Mapi/Services/MapiDataSourcesServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiDataSourcesServiceTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\Services;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
@@ -115,6 +116,40 @@ class MapiDataSourcesServiceTest extends UnitTest {
 			->with(
 				self::LIST_PATH . '/100?updateMask=displayName',
 				[ 'displayName' => 'Merchant API (en/US)' ]
+			);
+
+		$this->assertSame(
+			'accounts/12345/dataSources/100',
+			$this->service->ensure_data_source_for( 'en', 'US' )
+		);
+	}
+
+	public function test_still_returns_the_source_when_the_rename_fails() {
+		// GOOWOO-805 follow-up: a failed rename (e.g. transient MAPI error) must not fail the
+		// sync — the pre-existing source is still usable, only its label update is skipped.
+		$this->options->method( 'get' )->willReturn( [] );
+		$this->client->method( 'get' )->willReturn(
+			[
+				'dataSources' => [
+					[
+						'name'                     => 'accounts/12345/dataSources/100',
+						'displayName'              => 'Content API',
+						'primaryProductDataSource' => [
+							'contentLanguage' => 'en',
+							'feedLabel'       => 'US',
+						],
+					],
+				],
+			]
+		);
+		$this->client->method( 'patch' )->willThrowException(
+			new MerchantApiException( 500, [], 'patch' )
+		);
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				OptionsInterface::MAPI_DATA_SOURCES,
+				[ 'product|en|US' => 'accounts/12345/dataSources/100' ]
 			);
 
 		$this->assertSame(

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
@@ -124,14 +124,14 @@ class MapiProductInputsServiceTest extends UnitTest {
 		);
 
 		$messages = [];
-		add_action(
-			'woocommerce_gla_debug_message',
-			static function ( $message ) use ( &$messages ) {
-				$messages[] = $message;
-			}
-		);
+		$callback = static function ( $message ) use ( &$messages ) {
+			$messages[] = $message;
+		};
+		add_action( 'woocommerce_gla_debug_message', $callback );
 
 		$this->service->insert( $input );
+
+		remove_action( 'woocommerce_gla_debug_message', $callback );
 
 		$logged = implode( "\n", $messages );
 		$this->assertStringContainsString( 'productInputs.insert sku42', $logged );

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
@@ -113,6 +113,31 @@ class MapiProductInputsServiceTest extends UnitTest {
 		$this->assertSame( 'sku42', $result->get_offer_id() );
 	}
 
+	public function test_insert_logs_the_payload_via_debug_message() {
+		// The Merchant API push must be logged so syncs can be verified/troubleshot.
+		$input = $this->make_input();
+		$this->client->method( 'post' )->willReturn(
+			[
+				'name'    => 'accounts/12345/productInputs/online~en~US~sku42',
+				'offerId' => 'sku42',
+			]
+		);
+
+		$messages = [];
+		add_action(
+			'woocommerce_gla_debug_message',
+			static function ( $message ) use ( &$messages ) {
+				$messages[] = $message;
+			}
+		);
+
+		$this->service->insert( $input );
+
+		$logged = implode( "\n", $messages );
+		$this->assertStringContainsString( 'productInputs.insert sku42', $logged );
+		$this->assertStringContainsString( '"title":"Test"', $logged );
+	}
+
 	public function test_insert_routes_different_market_to_a_different_data_source() {
 		$input = $this->make_input( 'sku42', 'fr', 'CA' );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-805/mapi-debugger-tool-not-exercising-the-merchant-api-path

Add debug logging for Merchant API product syncs, and adopt/rename a pre-existing "Content API"-labeled data source in place (to "Google for WooCommerce") instead of duplicating it, so a merchant's existing products stay attributed to one source once synced via Merchant API.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->


- With debug logging on, run a sync (or push from the Connection Test tool) and check the `google-for-woocommerce` WooCommerce log for `productInputs.*` entries.
- On an account whose products show "Content API" as their source, resync and confirm the source now reads "Google for WooCommerce (en/US)" with the same products.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>