### PR TITLE
Fix: GOOWOO-817: MAPI integration: audit other lowercase enum attributes (condition, gender, ageGroup)

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -1183,7 +1183,7 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 					'link'         => home_url( '/' ),
 					'imageLink'    => 'https://via.placeholder.com/250',
 					'availability' => 'IN_STOCK',
-					'condition'    => 'new',
+					'condition'    => 'NEW',
 					'price'        => [
 						'amountMicros' => '19990000',
 						'currencyCode' => 'USD',
@@ -1233,7 +1233,7 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 						'link'         => home_url( '/' ),
 						'imageLink'    => 'https://via.placeholder.com/250',
 						'availability' => 'IN_STOCK',
-						'condition'    => 'new',
+						'condition'    => 'NEW',
 						'price'        => [
 							'amountMicros' => '19990000',
 							'currencyCode' => 'USD',

--- a/src/Product/WCProductInputAdapter.php
+++ b/src/Product/WCProductInputAdapter.php
@@ -134,9 +134,12 @@ class WCProductInputAdapter {
 		$this->map_gtin();
 		$this->override_attributes();
 
-		// Availability can arrive lowercase from a mapping rule or the override filter (e.g. the
-		// pre-orders integration's `preorder`); send the Merchant API's uppercase enum regardless.
-		$this->normalize_availability();
+		// availability, condition, gender, ageGroup and sizeType are all Merchant API enums
+		// (IN_STOCK, NEW, MALE, ADULT, REGULAR, etc.), but their values can arrive lowercase
+		// from a mapping rule, merchant-configured attribute meta, or the override filter
+		// (e.g. the pre-orders integration's `preorder`) — all of which store/accept the
+		// lowercase option keys used by the admin UI. Uppercase them here regardless of source.
+		$this->normalize_enum_attributes();
 	}
 
 	/**
@@ -309,15 +312,27 @@ class WCProductInputAdapter {
 	}
 
 	/**
-	 * Normalise availability to the Merchant API's uppercase enum casing (IN_STOCK, OUT_OF_STOCK,
-	 * PREORDER, BACKORDER). map_availability() already emits the enum. This uppercases a value that
-	 * arrived through attribute mapping or the override filter (e.g. the pre-orders integration's
-	 * lowercase `preorder`), so every path sends the documented casing rather than relying on the
-	 * Merchant API normalising it.
+	 * Normalise availability, condition, gender, ageGroup and sizeTypes to the Merchant API's
+	 * uppercase enum casing (e.g. IN_STOCK, NEW, MALE, ADULT, REGULAR). map_availability()
+	 * already emits an uppercase value, but all of these can also arrive lowercase through
+	 * attribute mapping or the override filter (e.g. the pre-orders integration's lowercase
+	 * `preorder`, or the lowercase option keys the admin UI stores for the others), so every
+	 * path needs uppercasing here rather than relying on the Merchant API normalising it.
 	 */
-	protected function normalize_availability(): void {
-		if ( ! empty( $this->attributes['availability'] ) && is_string( $this->attributes['availability'] ) ) {
-			$this->attributes['availability'] = strtoupper( $this->attributes['availability'] );
+	protected function normalize_enum_attributes(): void {
+		foreach ( [ 'availability', 'condition', 'gender', 'ageGroup' ] as $attribute_id ) {
+			if ( ! empty( $this->attributes[ $attribute_id ] ) && is_string( $this->attributes[ $attribute_id ] ) ) {
+				$this->attributes[ $attribute_id ] = strtoupper( $this->attributes[ $attribute_id ] );
+			}
+		}
+
+		if ( ! empty( $this->attributes['sizeTypes'] ) && is_array( $this->attributes['sizeTypes'] ) ) {
+			$this->attributes['sizeTypes'] = array_map(
+				function ( $size_type ) {
+					return is_string( $size_type ) ? strtoupper( $size_type ) : $size_type;
+				},
+				$this->attributes['sizeTypes']
+			);
 		}
 	}
 

--- a/src/Product/WCProductInputAdapter.php
+++ b/src/Product/WCProductInputAdapter.php
@@ -134,11 +134,12 @@ class WCProductInputAdapter {
 		$this->map_gtin();
 		$this->override_attributes();
 
-		// availability, condition, gender, ageGroup and sizeType are all Merchant API enums
-		// (IN_STOCK, NEW, MALE, ADULT, REGULAR, etc.), but their values can arrive lowercase
-		// from a mapping rule, merchant-configured attribute meta, or the override filter
-		// (e.g. the pre-orders integration's `preorder`) — all of which store/accept the
-		// lowercase option keys used by the admin UI. Uppercase them here regardless of source.
+		// availability, condition, gender, ageGroup and sizeType (remapped to the plural
+		// sizeTypes MAPI key by set_attribute()) are all Merchant API enums (IN_STOCK, NEW,
+		// MALE, ADULT, REGULAR, etc.), but their values can arrive lowercase from a mapping
+		// rule, merchant-configured attribute meta, or the override filter (e.g. the
+		// pre-orders integration's `preorder`) — all of which store/accept the lowercase
+		// option keys used by the admin UI. Uppercase them here regardless of source.
 		$this->normalize_enum_attributes();
 	}
 
@@ -318,6 +319,8 @@ class WCProductInputAdapter {
 	 * attribute mapping or the override filter (e.g. the pre-orders integration's lowercase
 	 * `preorder`, or the lowercase option keys the admin UI stores for the others), so every
 	 * path needs uppercasing here rather than relying on the Merchant API normalising it.
+	 * Note: sizeType (singular) is remapped to the plural sizeTypes array key by
+	 * set_attribute(), which is why this operates on sizeTypes rather than sizeType.
 	 */
 	protected function normalize_enum_attributes(): void {
 		foreach ( [ 'availability', 'condition', 'gender', 'ageGroup' ] as $attribute_id ) {

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -418,6 +418,45 @@ class WCProductInputAdapterTest extends UnitTest {
 		$this->assertSame( [ 'PETITE' ], $attrs['sizeTypes'] );
 	}
 
+	public function test_uppercases_enum_attributes_set_via_mapping_rule() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$rules = [
+			[
+				'attribute'               => 'condition',
+				'source'                  => 'refurbished',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+			[
+				'attribute'               => 'gender',
+				'source'                  => 'female',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+			[
+				'attribute'               => 'ageGroup',
+				'source'                  => 'toddler',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+			[
+				'attribute'               => 'sizeType',
+				'source'                  => 'petite',
+				'category_condition_type' => 'ALL',
+				'categories'              => '',
+			],
+		];
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US', null, [], [], $rules ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( 'REFURBISHED', $attrs['condition'] );
+		$this->assertSame( 'FEMALE', $attrs['gender'] );
+		$this->assertSame( 'TODDLER', $attrs['ageGroup'] );
+		$this->assertSame( [ 'PETITE' ], $attrs['sizeTypes'] );
+	}
+
 	public function test_omits_images_when_product_has_none() {
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_image_id( '' );

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -354,6 +354,70 @@ class WCProductInputAdapterTest extends UnitTest {
 		$this->assertSame( 'PREORDER', $attrs['availability'] );
 	}
 
+	public function test_uppercases_condition_set_via_override_filter() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$cb = static function ( array $overrides ): array {
+			$overrides['condition'] = 'refurbished';
+			return $overrides;
+		};
+		add_filter( 'woocommerce_gla_product_attribute_values', $cb );
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		remove_filter( 'woocommerce_gla_product_attribute_values', $cb );
+
+		$this->assertSame( 'REFURBISHED', $attrs['condition'] );
+	}
+
+	public function test_uppercases_gender_set_via_override_filter() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$cb = static function ( array $overrides ): array {
+			$overrides['gender'] = 'female';
+			return $overrides;
+		};
+		add_filter( 'woocommerce_gla_product_attribute_values', $cb );
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		remove_filter( 'woocommerce_gla_product_attribute_values', $cb );
+
+		$this->assertSame( 'FEMALE', $attrs['gender'] );
+	}
+
+	public function test_uppercases_age_group_set_via_override_filter() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$cb = static function ( array $overrides ): array {
+			$overrides['ageGroup'] = 'toddler';
+			return $overrides;
+		};
+		add_filter( 'woocommerce_gla_product_attribute_values', $cb );
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		remove_filter( 'woocommerce_gla_product_attribute_values', $cb );
+
+		$this->assertSame( 'TODDLER', $attrs['ageGroup'] );
+	}
+
+	public function test_uppercases_size_types_set_via_override_filter() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$cb = static function ( array $overrides ): array {
+			$overrides['sizeTypes'] = [ 'petite' ];
+			return $overrides;
+		};
+		add_filter( 'woocommerce_gla_product_attribute_values', $cb );
+
+		$attrs = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		remove_filter( 'woocommerce_gla_product_attribute_values', $cb );
+
+		$this->assertSame( [ 'PETITE' ], $attrs['sizeTypes'] );
+	}
+
 	public function test_omits_images_when_product_has_none() {
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_image_id( '' );
@@ -578,9 +642,9 @@ class WCProductInputAdapterTest extends UnitTest {
 		$this->assertSame( 'Cotton', $attrs['material'] );
 		$this->assertSame( 'Striped', $attrs['pattern'] );
 		$this->assertSame( 'MPN123', $attrs['mpn'] );
-		$this->assertSame( 'new', $attrs['condition'] );
-		$this->assertSame( 'adult', $attrs['ageGroup'] );
-		$this->assertSame( 'unisex', $attrs['gender'] );
+		$this->assertSame( 'NEW', $attrs['condition'] );
+		$this->assertSame( 'ADULT', $attrs['ageGroup'] );
+		$this->assertSame( 'UNISEX', $attrs['gender'] );
 	}
 
 	public function test_maps_size_attribute() {
@@ -608,7 +672,7 @@ class WCProductInputAdapterTest extends UnitTest {
 		) )->get_product_input()->get_attributes();
 
 		$this->assertSame( [ '00012345678905' ], $attrs['gtins'] );
-		$this->assertSame( [ 'regular' ], $attrs['sizeTypes'] );
+		$this->assertSame( [ 'REGULAR' ], $attrs['sizeTypes'] );
 		$this->assertArrayNotHasKey( 'gtin', $attrs );
 		$this->assertArrayNotHasKey( 'sizeType', $attrs );
 	}


### PR DESCRIPTION
## Summary
- Follow-up to GOOWOO-808 (#3614), which fixed `WCProductInputAdapter` sending lowercase `availability` values instead of the Merchant API's uppercase enum.
- Audited the other enum-shaped attributes passed through `map_gla_attributes()`/`map_attribute_mapping_rules()` → `set_attribute()`, and confirmed against the Merchant API's generated client source (`googleapis/php-shopping-merchant-products`) that `condition`, `gender`, `ageGroup`, and `sizeType` are all uppercase enums, same as `availability`.
- Folds the existing `normalize_availability()` into a single `normalize_enum_attributes()` that uppercases `availability`, `condition`, `gender`, `ageGroup`, and each entry of `sizeTypes`, called once after mapping rules, per-product attribute values, and the override filter have all been applied — so every source path (admin UI attribute meta, mapping rules, and the `woocommerce_gla_product_attribute_values` override filter) sends the documented casing.
- Updates `ConnectionTest`'s hardcoded sample payload (`condition`) to match.

## Confirmed enum casing (via Google's generated PHP client source)
| Attribute | Our lowercase keys | Merchant API enum |
|---|---|---|
| `condition` | new, refurbished, used | `NEW`, `REFURBISHED`, `USED` |
| `gender` | male, female, unisex | `MALE`, `FEMALE`, `UNISEX` |
| `ageGroup` | newborn, infant, toddler, kids, adult | `NEWBORN`, `INFANT`, `TODDLER`, `KIDS`, `ADULT` |
| `sizeType` | regular, petite, plus, tall, big, maternity | `REGULAR`, `PETITE`, `PLUS`, `TALL`, `BIG`, `MATERNITY` |

(`sizeSystem` was also checked — its values are already uppercase country codes, so it's unaffected.)

## Test plan
- [ ] `test_maps_string_attributes()` and `test_maps_array_attributes()` updated to assert uppercase output for lowercase input.
- [ ] New override-filter tests added for `condition`, `gender`, `ageGroup`, and `sizeTypes`, mirroring the existing `test_uppercases_availability_set_via_override_filter()` pattern.
- [ ] Run `WCProductInputAdapterTest` in a WP test environment to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)