### PR TITLE
GOOWOO-816 Fix Abandoned Onboarding Notification for Service Based Merchants

### DIFF
--- a/src/Internal/DependencyManagement/NotificationsServiceProvider.php
+++ b/src/Internal/DependencyManagement/NotificationsServiceProvider.php
@@ -70,7 +70,7 @@ class NotificationsServiceProvider extends AbstractServiceProvider {
 	public function register(): void {
 		$this->share_with_tags( NotificationService::class, WP::class );
 		$this->share_with_tags( SkippedCampaignEvaluator::class, AdsCampaign::class, OnboardingCompleted::class, ServiceBasedMerchantState::class );
-		$this->share_with_tags( AbandonedOnboardingEvaluator::class );
+		$this->share_with_tags( AbandonedOnboardingEvaluator::class, ServiceBasedMerchantState::class, OnboardingCompleted::class );
 		$this->share_with_tags( NotOnboarded90DaysEvaluator::class, OnboardingCompleted::class );
 		$this->share_with_tags( EnhancedConversionsOffEvaluator::class );
 		$this->share_with_tags( TrackingOffEvaluator::class );

--- a/src/Notification/Evaluators/AbandonedOnboardingEvaluator.php
+++ b/src/Notification/Evaluators/AbandonedOnboardingEvaluator.php
@@ -9,6 +9,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwa
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\ServiceBasedMerchantState;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -18,11 +20,34 @@ defined( 'ABSPATH' ) || exit;
  * Fires when onboarding is incomplete and the merchant abandoned at Step 1 (Account Setup)
  * or Step 2 (Product Feed Configuration), using the same step tracking as the mc/setup endpoint.
  *
+ * Service-based (ads-only) merchants never complete Merchant Center setup, so the Merchant
+ * Center–based setup status is not a reliable "abandoned onboarding" signal for them. For
+ * those merchants the Merchant Center check is excluded and the onboarding-complete flag is
+ * used instead: a service-based merchant who finished the ads-only onboarding is done, while
+ * one who has not is still genuinely mid-onboarding.
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
  */
 class AbandonedOnboardingEvaluator implements NotificationEvaluatorInterface, MerchantCenterAwareInterface, Service {
 
 	use MerchantCenterAwareTrait;
+
+	/** @var ServiceBasedMerchantState */
+	private $service_based_merchant_state;
+
+	/** @var OnboardingCompleted */
+	private $onboarding_completed;
+
+	/**
+	 * AbandonedOnboardingEvaluator constructor.
+	 *
+	 * @param ServiceBasedMerchantState $service_based_merchant_state
+	 * @param OnboardingCompleted       $onboarding_completed
+	 */
+	public function __construct( ServiceBasedMerchantState $service_based_merchant_state, OnboardingCompleted $onboarding_completed ) {
+		$this->service_based_merchant_state = $service_based_merchant_state;
+		$this->onboarding_completed         = $onboarding_completed;
+	}
 
 	/**
 	 * Get the notification's unique ID.
@@ -42,6 +67,15 @@ class AbandonedOnboardingEvaluator implements NotificationEvaluatorInterface, Me
 		// Google account connection is the first intentional GLA onboarding action.
 		if ( ! $this->merchant_center->is_google_connected() ) {
 			return false;
+		}
+
+		// Service-based (ads-only) merchants never complete Merchant Center setup, so the
+		// Merchant Center setup status would keep this notification firing indefinitely.
+		// Exclude the Merchant Center check for them and rely on the onboarding-complete
+		// flag: a service-based merchant who finished the ads-only onboarding is done,
+		// while one who has not is still genuinely mid-onboarding.
+		if ( $this->service_based_merchant_state->is_service_based_merchant() ) {
+			return ! $this->onboarding_completed->is_onboarding_complete();
 		}
 
 		$setup_status = $this->merchant_center->get_setup_status();

--- a/tests/Unit/Notification/Evaluators/AbandonedOnboardingEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/AbandonedOnboardingEvaluatorTest.php
@@ -7,6 +7,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterSer
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\AbandonedOnboardingEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\ServiceBasedMerchantState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -22,6 +24,12 @@ class AbandonedOnboardingEvaluatorTest extends UnitTest {
 	/** @var MockObject|MerchantCenterService $merchant_center */
 	protected $merchant_center;
 
+	/** @var MockObject|ServiceBasedMerchantState $service_based_merchant_state */
+	protected $service_based_merchant_state;
+
+	/** @var MockObject|OnboardingCompleted $onboarding_completed */
+	protected $onboarding_completed;
+
 	/** @var AbandonedOnboardingEvaluator $evaluator */
 	protected $evaluator;
 
@@ -31,9 +39,11 @@ class AbandonedOnboardingEvaluatorTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->merchant_center = $this->createMock( MerchantCenterService::class );
+		$this->merchant_center              = $this->createMock( MerchantCenterService::class );
+		$this->service_based_merchant_state = $this->createMock( ServiceBasedMerchantState::class );
+		$this->onboarding_completed         = $this->createMock( OnboardingCompleted::class );
 
-		$this->evaluator = new AbandonedOnboardingEvaluator();
+		$this->evaluator = new AbandonedOnboardingEvaluator( $this->service_based_merchant_state, $this->onboarding_completed );
 		$this->evaluator->set_merchant_center_object( $this->merchant_center );
 	}
 
@@ -58,13 +68,38 @@ class AbandonedOnboardingEvaluatorTest extends UnitTest {
 
 	public function test_should_not_show_when_setup_complete() {
 		$this->merchant_center->method( 'is_google_connected' )->willReturn( true );
+		$this->service_based_merchant_state->method( 'is_service_based_merchant' )->willReturn( false );
 		$this->merchant_center->method( 'get_setup_status' )->willReturn( [ 'status' => 'complete' ] );
 
 		$this->assertFalse( $this->evaluator->should_show() );
 	}
 
+	public function test_should_not_show_for_completed_service_based_merchant() {
+		// Regression: a service-based merchant who finished the ads-only onboarding never
+		// completes Merchant Center setup, so the MC setup status must not be consulted and
+		// the notification must not fire.
+		$this->merchant_center->method( 'is_google_connected' )->willReturn( true );
+		$this->service_based_merchant_state->method( 'is_service_based_merchant' )->willReturn( true );
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->merchant_center->expects( $this->never() )->method( 'get_setup_status' );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_show_for_service_based_merchant_mid_onboarding() {
+		// A service-based merchant who has not finished onboarding is still genuinely
+		// mid-onboarding and should receive the notification (Merchant Center step excluded).
+		$this->merchant_center->method( 'is_google_connected' )->willReturn( true );
+		$this->service_based_merchant_state->method( 'is_service_based_merchant' )->willReturn( true );
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( false );
+		$this->merchant_center->expects( $this->never() )->method( 'get_setup_status' );
+
+		$this->assertTrue( $this->evaluator->should_show() );
+	}
+
 	public function test_should_show_when_accounts_step() {
 		$this->merchant_center->method( 'is_google_connected' )->willReturn( true );
+		$this->service_based_merchant_state->method( 'is_service_based_merchant' )->willReturn( false );
 		$this->mock_setup_step( 'accounts' );
 
 		$this->assertTrue( $this->evaluator->should_show() );
@@ -72,6 +107,7 @@ class AbandonedOnboardingEvaluatorTest extends UnitTest {
 
 	public function test_should_show_when_product_listings_step() {
 		$this->merchant_center->method( 'is_google_connected' )->willReturn( true );
+		$this->service_based_merchant_state->method( 'is_service_based_merchant' )->willReturn( false );
 		$this->mock_setup_step( 'product_listings' );
 
 		$this->assertTrue( $this->evaluator->should_show() );
@@ -79,6 +115,7 @@ class AbandonedOnboardingEvaluatorTest extends UnitTest {
 
 	public function test_should_not_show_when_paid_ads_step() {
 		$this->merchant_center->method( 'is_google_connected' )->willReturn( true );
+		$this->service_based_merchant_state->method( 'is_service_based_merchant' )->willReturn( false );
 		$this->mock_setup_step( 'paid_ads' );
 
 		$this->assertFalse( $this->evaluator->should_show() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Problem
Service-based (ads-only) merchants who had already completed onboarding kept getting the
"Finish your Google Ads setup" notification. Because it snoozes for 30 days when dismissed,
it came back every 30 days forever, even though the merchant was fully set up.

Root cause
The notification is purely from the Merchant Center setup status.
That status only becomes "complete" when the Merchant Center settings-sync step runs — which
service-based merchants never do, since they finish through the ads-only completion path and
never set up Merchant Center. So the status stayed "incomplete" indefinitely and the
notification kept firing. The check never considered merchant type or whether onboarding was
actually complete.

Fix
For service-based merchants, skip the Merchant Center check entirely and use the
onboarding-complete flag instead: if they finished the ads-only onboarding, they're done and
the notification does not show; if they haven't, they're genuinely mid-onboarding and it still
shows. Shopping-merchant behavior is unchanged — they still use the existing Merchant Center
step logic.

Closes https://linear.app/a8c/issue/GOOWOO-816/fix-abandoned-onboarding-notification-re-fires-every-30-days-for


### Detailed test instructions:

Notes
- The notification renders on WooCommerce → Marketing → Overview
  panel), and is also returned by `GET /wc/gla/notifications` (as admin).
- It's per-user with a 30-day snooze; there is no transient to clear — just reload.

How to check
- UI: open Marketing → Overview and look for "Finish your Google Ads setup / Your Google Ads
  integration setup was interrupted".
- REST: `GET /wp-json/wc/gla/notifications --user=1` and look for id `abandoned-onboarding`.

Test 1 — Completed service-based merchant: should not appear
```
  wp option update gla_is_service_based_merchant yes
  wp option update gla_google_connected 1
  wp option update gla_onboarding_completed_at $(date +%s)
  wp option delete gla_mc_setup_completed_at
  wp user meta delete 1 gla_notifications_state
```
  Reload Marketing / re-read the REST endpoint.
  Expected: abandoned-onboarding is not present.

Test 2 — Service-based merchant still mid-onboarding: should appear
  `wp option delete gla_onboarding_completed_at `  (`keep service-based = yes, google connected = 1`)
  Reload.
  Expected: abandoned-onboarding is present.

Test 3 — Shopping merchant unchanged: should appear when mid-onboarding
  ```
wp option update gla_is_service_based_merchant no
  wp option delete gla_mc_setup_completed_at
```
  Reload.
  Expected: abandoned-onboarding is present (unchanged behavior).

Test 4 — No 30-day re-fire for a completed service-based merchant
  Start from Test 1 (completed service-based).
  If the notification is showing before the fix, dismiss it, then simulate the snooze expiring:
    `wp eval '$s=get_user_meta(1,"gla_notifications_state",true); $s["abandoned-onboarding"]["snoozed_until"]=time()-1; update_user_meta(1,"gla_notifications_state",$s);'`
  Reload.
  Expected: it stays hidden (does not come back after the snooze expires).

Alternatively
  As a service-based merchant (store with no physical products), connect Google and finish the
  ads-only onboarding so onboarding is marked complete and Merchant Center is never set up.
  Open Marketing → Overview.
  Expected: the Abandoned Onboarding notification does not appear.

Cleanup for test site
```
  wp option delete gla_is_service_based_merchant
  wp option delete gla_onboarding_completed_at
  wp option update gla_google_connected 0
  wp user meta delete 1 gla_notifications_state
```