### PR TITLE
Fix: Correct 3.8.0 changelog entries after label cleanup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,36 +1,11 @@
 *** Google for WooCommerce Changelog ***
 
 = 3.8.0 - 2026-07-20 =
-* Add - woocommerce_gla_mapi_report_query_response filter to MapiReportQuery.
-* Dev - Allow extensions to attach Merchant API custom attributes to synced products via the `woocommerce_gla_product_attribute_values` filter.
-* Fix - Break - Migrate to the Merchant API from the Content Shopping API.
-* Fix - Fix: GOOWOO-805: MAPI source label and debug logging.
-* Fix - Fix: GOOWOO-809: MAPI integration: `redemptionChannel` should not be scalar.
-* Fix - Fix: map sale price and sale price effective date for MAPI sync.
-* Fix - Fix: send required inputValues when requesting an account re-review.
-* Fix - GOOWOO-631: Phase 1.
-* Fix - GOOWOO-634: Phase 2: Product inserts.
-* Fix - GOOWOO-687: Phase 2: Product patch.
-* Fix - GOOWOO-692: Migrate product create + update sync to MAPI.
-* Fix - GOOWOO-709: Migrate product delete sync to MAPI.
-* Fix - GOOWOO-716: Cleanup: Migrate product create/update sync to the MAPI entirely.
-* Fix - GOOWOO-717 + GOOWOO-741: Migrate product status + listing to the Merchant API.
-* Fix - GOOWOO-723: Migrate product attributes and custom attribute mapping rules to the MAPI.
-* Fix - GOOWOO-744: Migrate reporting to the MAPI.
-* Fix - GOOWOO-756: Migrate content.shippingsettings.update to MAPI accounts.shippingSettings.insert.
-* Fix - GOOWOO-757: Migrate content.accounts.link to MAPI AccountService resource.
-* Fix - GOOWOO-760: Migrate content.freelistingsprogram.get to MAPI accounts.programs.get.
-* Fix - GOOWOO-786: MAPI product sync.
-* Fix - GOOWOO-793: Product status refresh rejects legacy-format product IDs.
-* Fix - Migrate coupon sync from the Content API to the Merchant API.
-* Fix - Migrate Merchant Center account issues to the MAPI.
-* Fix - Migrate Merchant Center business info and account access reads to the MAPI.
-* Fix - Migrate the Merchant Center website claim status and action to the Merchant API.
-
-= Unreleased =
-* Migrate Merchant Center reporting to the Merchant API
-* The `gla_merchant_query_response` filter is removed as part of dropping the Content API report layer.
-* Add the `woocommerce_gla_mapi_report_query_response` filter to `MapiReportQuery::query_results()`.
+* Break - Migrate to the Merchant API from the Content Shopping API.
+* Dev - Bump WooCommerce "tested up to" version 10.9.
+* Fix - Prevent adblockers from blocking auto-generated images in the preview.
+* Tweak - Enable brand guidelines on non-shopping campaigns.
+* Tweak - Remove beta block-based product editor integration ahead of its retirement in WooCommerce 11.0.
 
 = 3.7.3 - 2026-07-08 =
 * Add - Added update notification when plugin version 3.8.0 is available

--- a/readme.txt
+++ b/readme.txt
@@ -141,31 +141,11 @@ To allow your products to appear in all relevant locations, make sure you’ve c
 == Changelog ==
 
 = 3.8.0 - 2026-07-20 =
-* Add - woocommerce_gla_mapi_report_query_response filter to MapiReportQuery.
-* Dev - Allow extensions to attach Merchant API custom attributes to synced products via the `woocommerce_gla_product_attribute_values` filter.
-* Fix - Break - Migrate to the Merchant API from the Content Shopping API.
-* Fix - Fix: GOOWOO-805: MAPI source label and debug logging.
-* Fix - Fix: GOOWOO-809: MAPI integration: `redemptionChannel` should not be scalar.
-* Fix - Fix: map sale price and sale price effective date for MAPI sync.
-* Fix - Fix: send required inputValues when requesting an account re-review.
-* Fix - GOOWOO-631: Phase 1.
-* Fix - GOOWOO-634: Phase 2: Product inserts.
-* Fix - GOOWOO-687: Phase 2: Product patch.
-* Fix - GOOWOO-692: Migrate product create + update sync to MAPI.
-* Fix - GOOWOO-709: Migrate product delete sync to MAPI.
-* Fix - GOOWOO-716: Cleanup: Migrate product create/update sync to the MAPI entirely.
-* Fix - GOOWOO-717 + GOOWOO-741: Migrate product status + listing to the Merchant API.
-* Fix - GOOWOO-723: Migrate product attributes and custom attribute mapping rules to the MAPI.
-* Fix - GOOWOO-744: Migrate reporting to the MAPI.
-* Fix - GOOWOO-756: Migrate content.shippingsettings.update to MAPI accounts.shippingSettings.insert.
-* Fix - GOOWOO-757: Migrate content.accounts.link to MAPI AccountService resource.
-* Fix - GOOWOO-760: Migrate content.freelistingsprogram.get to MAPI accounts.programs.get.
-* Fix - GOOWOO-786: MAPI product sync.
-* Fix - GOOWOO-793: Product status refresh rejects legacy-format product IDs.
-* Fix - Migrate coupon sync from the Content API to the Merchant API.
-* Fix - Migrate Merchant Center account issues to the MAPI.
-* Fix - Migrate Merchant Center business info and account access reads to the MAPI.
-* Fix - Migrate the Merchant Center website claim status and action to the Merchant API.
+* Break - Migrate to the Merchant API from the Content Shopping API.
+* Dev - Bump WooCommerce "tested up to" version 10.9.
+* Fix - Prevent adblockers from blocking auto-generated images in the preview.
+* Tweak - Enable brand guidelines on non-shopping campaigns.
+* Tweak - Remove beta block-based product editor integration ahead of its retirement in WooCommerce 11.0.
 
 = 3.7.3 - 2026-07-08 =
 * Add - Added update notification when plugin version 3.8.0 is available


### PR DESCRIPTION
## Summary
- Corrects the `= 3.8.0 =` block in `changelog.txt` and `readme.txt`, which was generated by `.github/workflows/generate-changelog.yml` before the MAPI migration sub-PRs (#3422-#3605, #3562) were relabeled `changelog: none`.
- Trims the block down to the 5 PRs that still carry real changelog labels: #3595 (Break), #3248 (Fix), #3371 (Tweak), #3542 (Tweak), #3498 (Dev).
- Fixes a doubled `Fix - Break -` prefix that resulted from the workflow having no mapping for the `changelog: breaking` label.
- Removes a manually-added `= Unreleased =` block in `changelog.txt` whose content (reporting migration / filter changes) is now covered by the consolidated #3595 breaking-change entry.

This is a manual, one-off correction. A follow-up will update `generate-changelog.yml` itself (missing `changelog: breaking` mapping, non-idempotent prepend behavior, no `workflow_dispatch` entry point for re-runs).

## Test plan
- [x] Diff reviewed against current PR labels for everything merged into `develop` since 3.7.3
- [x] `changelog.txt` and `readme.txt` render correctly