### PR TITLE
GOOWOO-819: Move pill to Marketing Overview submenu item

### DIFF
--- a/js/src/notification-manager/index.js
+++ b/js/src/notification-manager/index.js
@@ -23,10 +23,10 @@ import { GLA_NOTIFICATION_DISMISSED } from '~/constants';
 		return;
 	}
 
-	const observer = new MutationObserver( function () {
+	function placeBadge() {
 		if ( marketingMenu.classList.contains( 'wp-has-current-submenu' ) ) {
 			const subMenu = marketingMenu.querySelector(
-				'[href="admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard"]'
+				'.wp-submenu [href="admin.php?page=wc-admin&path=%2Fmarketing"]'
 			);
 
 			if ( subMenu && ! subMenu.contains( badge ) ) {
@@ -51,7 +51,14 @@ import { GLA_NOTIFICATION_DISMISSED } from '~/constants';
 				topMenu.appendChild( badge );
 			}
 		}
-	} );
+	}
+
+	// Place immediately for the server-rendered initial state (a hard page
+	// load never fires a class mutation), then keep watching for SPA route
+	// changes that toggle the submenu classes.
+	placeBadge();
+
+	const observer = new MutationObserver( placeBadge );
 
 	observer.observe( marketingMenu, {
 		attributes: true,

--- a/src/Menu/Dashboard.php
+++ b/src/Menu/Dashboard.php
@@ -21,6 +21,11 @@ class Dashboard implements Service, Registerable {
 	public const MARKETING_MENU_SLUG = 'woocommerce-marketing';
 
 	/**
+	 * WooCommerce core's Marketing > Overview page path.
+	 */
+	public const MARKETING_OVERVIEW_PATH = '/marketing';
+
+	/**
 	 * Onboarding completed status.
 	 *
 	 * @var OnboardingCompleted

--- a/src/Menu/NotificationManager.php
+++ b/src/Menu/NotificationManager.php
@@ -6,8 +6,6 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Menu;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\Admin\PageController;
-use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsRecommendationsService;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AdminScriptWithBuiltDependenciesAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\Assets\AssetsHandlerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
@@ -22,7 +20,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Value\BuiltScriptDependencyArray
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Menu
  *
  * Manages the display of a single, aggregated notification pill in the admin menu.
- * It relies on a filter to gather the total count from various contributors.
+ * It relies on a filter to gather the total count, currently contributed to solely
+ * by the NotificationService, though the filter remains open for other contributors.
  */
 class NotificationManager implements ContainerAwareInterface, Service, Registerable {
 
@@ -58,8 +57,6 @@ class NotificationManager implements ContainerAwareInterface, Service, Registera
 		// all other menu items have been registered by WooCommerce and other plugins.
 		add_action( 'admin_menu', [ $this, 'display_aggregated_notification_pill' ], 20 );
 
-		add_filter( 'google_for_woocommerce_admin_menu_notification_count', [ $this, 'performance_max_ad_strength_count' ] );
-		add_filter( 'google_for_woocommerce_admin_menu_notification_count', [ $this, 'raise_budget_recommendations_count' ] );
 		add_filter( 'google_for_woocommerce_admin_menu_notification_count', [ $this, 'notifications_count' ] );
 	}
 
@@ -104,7 +101,7 @@ class NotificationManager implements ContainerAwareInterface, Service, Registera
 	 *
 	 * @return bool True if the current page is a Marketing child page, false otherwise.
 	 */
-	private function is_marketing_page(): bool {
+	protected function is_marketing_page(): bool {
 		global $pagenow;
 
 		$current_page_slug = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
@@ -179,16 +176,16 @@ class NotificationManager implements ContainerAwareInterface, Service, Registera
 			$is_on_marketing_child_page = $this->is_marketing_page();
 
 			if ( $is_on_marketing_child_page ) {
-				// If on a Marketing child page, add the pill to the 'Google for WooCommerce' sub-menu item.
+				// If on a Marketing child page, add the pill to the 'Overview' sub-menu item.
 				// This means the user has the Marketing menu expanded and is viewing one of its sub-pages.
-				$marketing_parent_slug            = Dashboard::MARKETING_MENU_SLUG; // Use constant for parent slug
-				$google_for_woocommerce_menu_path = Dashboard::PATH; // Use constant for GfW path
+				$marketing_parent_slug   = Dashboard::MARKETING_MENU_SLUG; // Use constant for parent slug
+				$marketing_overview_path = Dashboard::MARKETING_OVERVIEW_PATH; // Use constant for Overview path
 
 				if ( isset( $submenu[ $marketing_parent_slug ] ) ) {
 					foreach ( $submenu[ $marketing_parent_slug ] as $key => $submenu_item ) {
 						// Use the submenu's slug (index 2) for robustness against translations.
 						// The slug will contain the path defined by the plugin.
-						if ( isset( $submenu_item[2] ) && strpos( $submenu_item[2], $google_for_woocommerce_menu_path ) !== false ) {
+						if ( isset( $submenu_item[2] ) && strpos( $submenu_item[2], $marketing_overview_path ) !== false ) {
 							$submenu[ $marketing_parent_slug ][ $key ][0] .= $badge_html; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 							break;
 						}
@@ -204,95 +201,6 @@ class NotificationManager implements ContainerAwareInterface, Service, Registera
 				}
 			}
 		}
-	}
-
-	/**
-	 * Returns the initial notification count for the admin menu.
-	 *
-	 * @param int $count The initial count.
-	 * @return int The updated notification count, which is either 1 (if there are recommendations) or 0 (if there are no recommendations).
-	 */
-	public function performance_max_ad_strength_count( int $count ): int {
-		global $wpdb;
-
-		$query        = $this->container->get( AdsRecommendationsService::class );
-		$ads_campaign = $this->container->get( AdsCampaign::class );
-		$campaign     = $ads_campaign->get_highest_spend_campaign();
-
-		// Return early if there is no highest spend campaign.
-		if ( empty( $campaign ) || ! isset( $campaign['id'] ) ) {
-			return $count;
-		}
-
-		// Check IMPROVE_PERFORMANCE_MAX_AD_STRENGTH recommendations for highest spend campaign.
-		$recommendations = $query->get_recommendations(
-			[
-				'types'       => [ 'IMPROVE_PERFORMANCE_MAX_AD_STRENGTH' ],
-				'campaign_id' => $campaign['id'],
-			]
-		);
-
-		// Return early if there are no recommendations.
-		if ( empty( $recommendations ) ) {
-			return $count;
-		}
-
-		// Check recommendation dates and user preference.
-		$preferences = get_user_meta( get_current_user_id(), "{$wpdb->prefix}persisted_preferences", true );
-
-		// If the user has not interacted with a recommendation yet.
-		if ( ! is_array( $preferences ) || ! isset( $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['actionType'] ) || ! isset( $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['actionTime'] ) ) {
-			return ++$count;
-		}
-
-		$action_time = $preferences['woocommerce/google-listings-and-ads']['pmax-improve-assets-banner']['actionTime'];
-
-		if ( time() > $action_time + ( 30 * DAY_IN_SECONDS ) ) {
-			return ++$count;
-		}
-
-		return $count;
-	}
-
-	/**
-	 * Returns the count for Raise Budget Recommendations.
-	 *
-	 * @param int $count The initial count.
-	 * @return int The updated notification count for Raise Budget Recommendations.
-	 */
-	public function raise_budget_recommendations_count( int $count ): int {
-		global $wpdb;
-
-		$query           = $this->container->get( AdsRecommendationsService::class );
-		$recommendations = $query->get_recommendations(
-			[
-				'types'       => [
-					'CAMPAIGN_BUDGET',
-					'MARGINAL_ROI_CAMPAIGN_BUDGET',
-				],
-				'campaign_id' => 0,
-			]
-		);
-
-		if ( empty( $recommendations ) ) {
-			return $count;
-		}
-
-		// Check recommendation dates and user preference.
-		$preferences = get_user_meta( get_current_user_id(), "{$wpdb->prefix}persisted_preferences", true );
-
-		// If the user has not interacted with a recommendation yet.
-		if ( ! is_array( $preferences ) || ! isset( $preferences['woocommerce/google-listings-and-ads']['raise-budget-recommendation-banner']['actionType'] ) || ! isset( $preferences['woocommerce/google-listings-and-ads']['raise-budget-recommendation-banner']['actionTime'] ) ) {
-			return ++$count;
-		}
-
-		$action_time = $preferences['woocommerce/google-listings-and-ads']['raise-budget-recommendation-banner']['actionTime'];
-
-		if ( time() > $action_time + ( 30 * DAY_IN_SECONDS ) ) {
-			return ++$count;
-		}
-
-		return $count;
 	}
 
 	/**

--- a/src/Menu/NotificationManager.php
+++ b/src/Menu/NotificationManager.php
@@ -65,7 +65,7 @@ class NotificationManager implements ContainerAwareInterface, Service, Registera
 	 *
 	 * @return void
 	 */
-	private function register_assets(): void {
+	protected function register_assets(): void {
 		$notification_manager = new AdminScriptWithBuiltDependenciesAsset(
 			'notification-manager',
 			'js/build/notification-manager',

--- a/tests/Unit/Menu/NotificationManagerTest.php
+++ b/tests/Unit/Menu/NotificationManagerTest.php
@@ -113,10 +113,12 @@ class NotificationManagerTest extends UnitTest {
 			);
 
 		// Force the "user is viewing one of the Marketing child pages" branch without
-		// depending on the real PageController singleton's registered page state.
+		// depending on the real PageController singleton's registered page state, and
+		// skip real asset registration (it reads the built js/build/ file, which
+		// isn't guaranteed to exist in a unit test run).
 		$this->notification_manager = $this->getMockBuilder( NotificationManager::class )
 			->setConstructorArgs( [ $this->assets_handler, $this->notification_service ] )
-			->onlyMethods( [ 'is_marketing_page' ] )
+			->onlyMethods( [ 'is_marketing_page', 'register_assets' ] )
 			->getMock();
 
 		$this->notification_manager->method( 'is_marketing_page' )->willReturn( true );

--- a/tests/Unit/Menu/NotificationManagerTest.php
+++ b/tests/Unit/Menu/NotificationManagerTest.php
@@ -43,6 +43,16 @@ class NotificationManagerTest extends UnitTest {
 		$this->notification_manager = new NotificationManager( $this->assets_handler, $this->notification_service );
 	}
 
+	/**
+	 * Runs after each test is executed.
+	 */
+	public function tearDown(): void {
+		remove_filter( 'google_for_woocommerce_admin_menu_notification_count', [ $this->notification_manager, 'notifications_count' ] );
+		remove_action( 'admin_menu', [ $this->notification_manager, 'display_aggregated_notification_pill' ], 20 );
+
+		parent::tearDown();
+	}
+
 	public function test_notifications_count_increments_by_the_number_of_active_notifications() {
 		$this->notification_service->method( 'get_notifications' )
 			->willReturn(
@@ -89,7 +99,60 @@ class NotificationManagerTest extends UnitTest {
 
 		$this->assertEquals( 'Marketing', $menu[0][0] );
 		$this->assertEquals( 'Google for WooCommerce', $submenu[ Dashboard::MARKETING_MENU_SLUG ][0][0] );
+	}
 
-		remove_filter( 'google_for_woocommerce_admin_menu_notification_count', [ $this->notification_manager, 'notifications_count' ] );
+	public function test_badge_moved_to_overview_when_on_marketing_child_page() {
+		$this->notification_service->method( 'get_notifications' )
+			->willReturn(
+				[
+					[
+						'id'           => 'notification-a',
+						'triggered_at' => 1,
+					],
+				]
+			);
+
+		// Force the "user is viewing one of the Marketing child pages" branch without
+		// depending on the real PageController singleton's registered page state.
+		$this->notification_manager = $this->getMockBuilder( NotificationManager::class )
+			->setConstructorArgs( [ $this->assets_handler, $this->notification_service ] )
+			->onlyMethods( [ 'is_marketing_page' ] )
+			->getMock();
+
+		$this->notification_manager->method( 'is_marketing_page' )->willReturn( true );
+
+		add_filter( 'google_for_woocommerce_admin_menu_notification_count', [ $this->notification_manager, 'notifications_count' ] );
+
+		global $menu, $submenu;
+		$menu    = [ // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			[ 'Marketing', 'manage_woocommerce', Dashboard::MARKETING_MENU_SLUG ],
+		];
+		$submenu = [ // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			Dashboard::MARKETING_MENU_SLUG => [
+				[ 'Overview', 'manage_woocommerce', 'admin.php?page=wc-admin&path=' . Dashboard::MARKETING_OVERVIEW_PATH ],
+				[ 'Google for WooCommerce', 'manage_woocommerce', Dashboard::PATH ],
+			],
+		];
+
+		$this->notification_manager->display_aggregated_notification_pill();
+
+		$this->assertStringContainsString( 'update-plugins', $submenu[ Dashboard::MARKETING_MENU_SLUG ][0][0] );
+		$this->assertEquals( 'Google for WooCommerce', $submenu[ Dashboard::MARKETING_MENU_SLUG ][1][0] );
+	}
+
+	public function test_register_only_wires_notifications_count_into_aggregation_filter() {
+		$this->notification_service->method( 'get_notifications' )
+			->willReturn(
+				[
+					[
+						'id'           => 'notification-a',
+						'triggered_at' => 1,
+					],
+				]
+			);
+
+		$this->notification_manager->register();
+
+		$this->assertEquals( 1, apply_filters( 'google_for_woocommerce_admin_menu_notification_count', 0 ) );
 	}
 }


### PR DESCRIPTION
The pill targeted "Google for WooCommerce" via a hardcoded `%2Fgoogle%2Fdashboard` href, so it never appeared once the SPA routed elsewhere or on hard page loads (MutationObserver only fires on class mutation, not initial render). Target the stable "Overview" (`/marketing`) item instead, place the badge immediately on load, and keep watching for SPA nav via the observer.

Also drop `performance_max_ad_strength_count` and
`raise_budget_recommendations_count` as contributors to the aggregated count — only `notifications_count` feeds the pill now.

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-819/notifications-pill-does-not-show-up-in-the-correct-menu-item

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. Trigger at least one active notification (via a registered evaluator, or stub NotificationService::get_notifications()) so the pill has something to render
2. With a test campaign that has Raise Budget / PMax ad-strength recommendations pending, confirm those do NOT add to the pill count — only the new notifications system should
3. Marketing collapsed (any non-Marketing page) → pill on top-level "Marketing"
4. Hard-load `/wp-admin/admin.php?page=wc-admin&path=/marketing` directly → pill on "Overview" immediately, no click needed to relocate
5. SPA-navigate Overview → Google for WooCommerce → Attributes → back to Overview → pill follows to Overview and stays, regardless of which subpage is active
6. Confirm pill never lands on "Google for WooCommerce" in any state


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
