### PR TITLE
GOOWOO-828: Wire up search/sort/pagination in market data views

### DIFF
--- a/js/src/pages/markets/components/market-data-views/index.js
+++ b/js/src/pages/markets/components/market-data-views/index.js
@@ -30,7 +30,7 @@ const DEFAULT_VIEW = {
  * and the per-row actions.
  */
 const MarketDataViews = () => {
-	const { DataViews } = window.wp.dataviews;
+	const { DataViews, filterSortAndPaginate } = window.wp.dataviews;
 	const { fields, data, hasFinishedResolution } = useMarketDataViewsConfig();
 	const [ view, setView ] = useState( DEFAULT_VIEW );
 	const [ editingMarket, setEditingMarket ] = useState( null );
@@ -42,10 +42,18 @@ const MarketDataViews = () => {
 	// Derive it inline so a scenario change (e.g. the markets resolver landing
 	// after first render) updates the visible columns. The user's view-state
 	// changes (sorting, pagination) still flow through `setView`.
-	const viewWithFields = {
-		...view,
-		fields: fields.map( ( field ) => field.id ),
-	};
+	const viewWithFields = useMemo(
+		() => ( {
+			...view,
+			fields: fields.map( ( field ) => field.id ),
+		} ),
+		[ view, fields ]
+	);
+
+	const { data: processedData, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( data, viewWithFields, fields ),
+		[ data, viewWithFields, fields, filterSortAndPaginate ]
+	);
 
 	const ACTIONS = useMemo(
 		() => [
@@ -80,13 +88,10 @@ const MarketDataViews = () => {
 				getItemId={ ( item ) => item.id }
 				fields={ fields }
 				actions={ ACTIONS }
-				data={ data }
+				data={ processedData }
 				view={ viewWithFields }
 				onChangeView={ setView }
-				paginationInfo={ {
-					totalItems: data.length,
-					totalPages: 1,
-				} }
+				paginationInfo={ paginationInfo }
 				defaultLayouts={ { table: {} } }
 				isLoading={ ! hasFinishedResolution }
 			/>

--- a/js/src/pages/markets/components/market-data-views/index.test.js
+++ b/js/src/pages/markets/components/market-data-views/index.test.js
@@ -2,8 +2,9 @@
  * External dependencies
  */
 import '@testing-library/jest-dom';
-import { render, screen, within } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { filterSortAndPaginate } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
@@ -131,7 +132,9 @@ const DataViewsStub = ( props ) => {
 
 beforeEach( () => {
 	dataViewsCalls.length = 0;
-	window.wp = { dataviews: { DataViews: DataViewsStub } };
+	window.wp = {
+		dataviews: { DataViews: DataViewsStub, filterSortAndPaginate },
+	};
 	// shipping_rate: null triggers buildDefaultConfig (the two-column legacy
 	// shape this test suite was written against).
 	useSettings.mockReturnValue( { settings: { shipping_rate: null } } );
@@ -398,5 +401,23 @@ describe( 'MarketDataViews', () => {
 			totalItems: SAMPLE_MARKETS.length,
 			totalPages: 1,
 		} );
+	} );
+
+	test( 'filters rows by Market label when onChangeView sets a search term', () => {
+		render( <MarketDataViews /> );
+
+		const { onChangeView, view } = dataViewsCalls[ 0 ];
+		act( () => {
+			onChangeView( { ...view, search: 'France' } );
+		} );
+
+		expect(
+			screen.getByRole( 'cell', { name: 'France' } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'cell', {
+				name: 'Primary Market (2 countries)',
+			} )
+		).not.toBeInTheDocument();
 	} );
 } );

--- a/js/src/pages/markets/components/market-data-views/index.test.js
+++ b/js/src/pages/markets/components/market-data-views/index.test.js
@@ -420,4 +420,20 @@ describe( 'MarketDataViews', () => {
 			} )
 		).not.toBeInTheDocument();
 	} );
+
+	test( 'matches the primary Market row when searching a country grouped under it', () => {
+		render( <MarketDataViews /> );
+
+		const { onChangeView, view } = dataViewsCalls[ 0 ];
+		act( () => {
+			onChangeView( { ...view, search: 'Mauritius' } );
+		} );
+
+		expect(
+			screen.getByRole( 'cell', { name: 'Primary Market (2 countries)' } )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'cell', { name: 'France' } )
+		).not.toBeInTheDocument();
+	} );
 } );

--- a/js/src/pages/markets/hooks/useMarketDataViewsConfig.js
+++ b/js/src/pages/markets/hooks/useMarketDataViewsConfig.js
@@ -71,7 +71,7 @@ const ALL_FIELDS = {
 		enableHiding: false,
 		enableSorting: false,
 		enableGlobalSearch: true,
-		getValue: ( { item } ) => item.label,
+		getValue: ( { item } ) => item.marketSearchValue || item.label,
 		render: ( { item } ) => {
 			return (
 				<span className="gla-markets-table__market-cell">
@@ -379,6 +379,32 @@ const buildDefaultConfig = ( { markets, countryNames, timesByCountry } ) => {
 };
 
 /**
+ * Adds a `marketSearchValue` to primary-market rows so the Market column's
+ * global search also matches on the names of countries grouped under the
+ * primary market (rendered as e.g. "Primary Market (3 countries)", which
+ * otherwise hides those country names from search).
+ *
+ * @param {Array.<Object>} data Pre-formatted rows from a scenario builder.
+ * @param {Object.<string,string>} countryNames Mapping of country code to country name.
+ * @return {Array.<Object>} Rows with `marketSearchValue` added to primary-market rows.
+ */
+const withMarketSearchValue = ( data, countryNames ) =>
+	data.map( ( row ) => {
+		if ( ! isPrimaryMarket( row ) || ! row.countries?.length ) {
+			return row;
+		}
+
+		const countryLabels = row.countries
+			.map( ( code ) => countryNames[ code ] || code )
+			.join( ' ' );
+
+		return {
+			...row,
+			marketSearchValue: `${ row.label } ${ countryLabels }`,
+		};
+	} );
+
+/**
  * Single source of truth for the MarketDataViews `{ fields, data }` shape.
  *
  * Picks the active scenario from `settings.shipping_rate` and
@@ -411,8 +437,10 @@ const useMarketDataViewsConfig = () => {
 	const shippingRateMethod = settings.shipping_rate;
 
 	if ( shippingRateMethod === SHIPPING_RATE_METHOD.MANUAL ) {
+		const { fields, data } = buildManualConfig( { markets } );
 		return {
-			...buildManualConfig( { markets } ),
+			fields,
+			data: withMarketSearchValue( data, countryNames ),
 			hasFinishedResolution,
 		};
 	}
@@ -425,11 +453,13 @@ const useMarketDataViewsConfig = () => {
 	);
 
 	if ( shippingRateMethod === SHIPPING_RATE_METHOD.AUTOMATIC ) {
+		const { fields, data } = buildAutomaticConfig( {
+			markets,
+			timesByCountry,
+		} );
 		return {
-			...buildAutomaticConfig( {
-				markets,
-				timesByCountry,
-			} ),
+			fields,
+			data: withMarketSearchValue( data, countryNames ),
 			hasFinishedResolution,
 		};
 	}
@@ -438,18 +468,26 @@ const useMarketDataViewsConfig = () => {
 		( shippingRatesData || [] ).map( ( rate ) => [ rate.country, rate ] )
 	);
 	if ( shippingRateMethod === SHIPPING_RATE_METHOD.FLAT ) {
+		const { fields, data } = buildFlatConfig( {
+			markets,
+			ratesByCountry,
+			timesByCountry,
+		} );
 		return {
-			...buildFlatConfig( {
-				markets,
-				ratesByCountry,
-				timesByCountry,
-			} ),
+			fields,
+			data: withMarketSearchValue( data, countryNames ),
 			hasFinishedResolution,
 		};
 	}
 
+	const { fields, data } = buildDefaultConfig( {
+		markets,
+		countryNames,
+		timesByCountry,
+	} );
 	return {
-		...buildDefaultConfig( { markets, countryNames, timesByCountry } ),
+		fields,
+		data: withMarketSearchValue( data, countryNames ),
 		hasFinishedResolution,
 	};
 };

--- a/js/src/pages/markets/hooks/useMarketDataViewsConfig.js
+++ b/js/src/pages/markets/hooks/useMarketDataViewsConfig.js
@@ -70,6 +70,8 @@ const ALL_FIELDS = {
 		label: __( 'Market', 'google-listings-and-ads' ),
 		enableHiding: false,
 		enableSorting: false,
+		enableGlobalSearch: true,
+		getValue: ( { item } ) => item.label,
 		render: ( { item } ) => {
 			return (
 				<span className="gla-markets-table__market-cell">


### PR DESCRIPTION
DataViews rendered raw `data` and a static paginationInfo, so search/sort/filter controls updated view state but never touched what was displayed. Run data through dataviews' filterSortAndPaginate and mark the Market field searchable via getValue/enableGlobalSearch.

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-828/bug-markets-search-box-does-not-filtersearch-markets

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the markets tab and add a few markets
2. Searching should work without any issues.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
