### PR TITLE
[GOOWOO-792] Fix sale prices syncing in the store currency with store-location tax on every feed entry

### DIFF
--- a/src/Product/WCProductInputAdapter.php
+++ b/src/Product/WCProductInputAdapter.php
@@ -467,8 +467,15 @@ class WCProductInputAdapter {
 	}
 
 	/**
-	 * Map the sale price and sale price effective date, applying tax inclusion/exclusion rules.
-	 * Ported from WCProductAdapter::map_wc_product_sale_price to preserve behavior.
+	 * Map the sale price and sale price effective date, applying the target
+	 * country's tax inclusion/exclusion rules.
+	 *
+	 * With a currency override set, the sale price is always the converted
+	 * value (WPML conversion when available, otherwise the market's fixed
+	 * exchange rate); when no converted value is available the sale price is
+	 * left unset, so a store-currency amount is never submitted under a
+	 * non-store-currency feed label. A sale that has already ended is never
+	 * converted or sent, and the effective dates come from the base product.
 	 */
 	protected function map_sale_price(): void {
 		// Grab the sale price of the base product. Some plugins (Dynamic pricing as an
@@ -488,13 +495,6 @@ class WCProductInputAdapter {
 			return;
 		}
 
-		$sale_price = $this->tax_excluded
-			? wc_get_price_excluding_tax( $this->wc_product, [ 'price' => $sale_price ] )
-			: wc_get_price_including_tax( $this->wc_product, [ 'price' => $sale_price ] );
-
-		/** This filter is documented in src/Product/WCProductAdapter.php */
-		$sale_price = apply_filters( 'woocommerce_gla_product_attribute_value_sale_price', $sale_price, $this->wc_product, $this->tax_excluded );
-
 		// If the sale price dates no longer apply, make sure we don't include a sale price.
 		$now                 = new WC_DateTime();
 		$sale_price_end_date = $this->wc_product->get_date_on_sale_to();
@@ -502,7 +502,30 @@ class WCProductInputAdapter {
 			return;
 		}
 
-		$this->attributes['salePrice'] = $this->to_money( (float) $sale_price, get_woocommerce_currency() );
+		if ( '' !== $this->currency_override ) {
+			$converted = null !== $this->wpml
+				? $this->wpml->get_product_sale_price_in_currency( $this->wc_product, $this->currency_override )
+				: null;
+
+			if ( null === $converted && $this->exchange_rate > 0 ) {
+				$converted = (float) $sale_price * $this->exchange_rate;
+			}
+
+			// No sale price in the override currency: leave it unset so a
+			// store-currency amount is never emitted under this feed label.
+			if ( null === $converted ) {
+				return;
+			}
+
+			$sale_price = $converted;
+		}
+
+		$sale_price = $this->apply_tax_for_target_country( (float) $sale_price );
+
+		/** This filter is documented in src/Product/WCProductAdapter.php */
+		$sale_price = apply_filters( 'woocommerce_gla_product_attribute_value_sale_price', $sale_price, $this->wc_product, $this->tax_excluded );
+
+		$this->attributes['salePrice'] = $this->to_money( (float) $sale_price, $this->effective_currency() );
 
 		$effective_date = $this->get_sale_price_effective_date();
 		if ( null !== $effective_date ) {

--- a/tests/Unit/Product/WCProductInputAdapterTest.php
+++ b/tests/Unit/Product/WCProductInputAdapterTest.php
@@ -1354,6 +1354,175 @@ class WCProductInputAdapterTest extends UnitTest {
 		$this->assertSame( 'EUR', $attrs['shipping'][0]['price']['currencyCode'] );
 	}
 
+	public function test_sale_price_uses_target_country_tax_rate_when_tax_included() {
+		$this->enable_taxes();
+		$this->insert_tax_rate_for_country( 'DE', '19.0000' );
+		$this->insert_tax_rate_for_country( 'US', '8.0000' );
+
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 50,
+				'regular_price' => 100,
+				'sale_price'    => 50,
+				'tax_status'    => 'taxable',
+				'tax_class'     => 'standard',
+			]
+		);
+
+		$attrs = ( new WCProductInputAdapter( $product, 'DE' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( '59500000', $attrs['salePrice']['amountMicros'] );
+
+		// Tax-excluded countries emit the untaxed sale price even when they have their own rate row.
+		$attrs_us = ( new WCProductInputAdapter( $product, 'US' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( '50000000', $attrs_us['salePrice']['amountMicros'] );
+	}
+
+	public function test_tax_exempt_sale_price_gets_no_tax_in_tax_included_country() {
+		$this->enable_taxes();
+		$this->insert_tax_rate_for_country( 'DE', '19.0000' );
+
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 50,
+				'regular_price' => 100,
+				'sale_price'    => 50,
+				'tax_status'    => 'none',
+			]
+		);
+
+		$attrs = ( new WCProductInputAdapter( $product, 'DE' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( '50000000', $attrs['salePrice']['amountMicros'] );
+	}
+
+	public function test_inclusive_entered_sale_prices_use_base_rate_before_target_rate() {
+		update_option( 'woocommerce_default_country', 'US:CA' );
+		$this->enable_taxes( true );
+		$this->insert_tax_rate_for_country( 'US', '8.0000' );
+		$this->insert_tax_rate_for_country( 'DE', '19.0000' );
+
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 54,
+				'regular_price' => 108,
+				'sale_price'    => 54,
+				'tax_status'    => 'taxable',
+				'tax_class'     => 'standard',
+			]
+		);
+
+		// 54.00 entered inclusive of the 8% base rate is 50.00 net, then 19% for the DE target.
+		$attrs = ( new WCProductInputAdapter( $product, 'DE' ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( '59500000', $attrs['salePrice']['amountMicros'] );
+	}
+
+	public function test_exchange_rate_converts_sale_price_when_wpml_unavailable() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 50,
+				'regular_price' => 100,
+				'sale_price'    => 50,
+			]
+		);
+
+		$attrs = ( new WCProductInputAdapter( $product, 'DE', null, [], [], [], '', '', 'EUR', null, 0.92 ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( '46000000', $attrs['salePrice']['amountMicros'] );
+		$this->assertSame( 'EUR', $attrs['salePrice']['currencyCode'] );
+	}
+
+	public function test_sale_price_exchange_rate_conversion_applies_before_target_country_tax() {
+		$this->enable_taxes();
+		$this->insert_tax_rate_for_country( 'DE', '19.0000' );
+
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 50,
+				'regular_price' => 100,
+				'sale_price'    => 50,
+				'tax_status'    => 'taxable',
+				'tax_class'     => 'standard',
+			]
+		);
+
+		// 50.00 converts to 46.00 EUR first, then the DE 19% rate applies: 54.74.
+		$attrs = ( new WCProductInputAdapter( $product, 'DE', null, [], [], [], '', '', 'EUR', null, 0.92 ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( '54740000', $attrs['salePrice']['amountMicros'] );
+		$this->assertSame( 'EUR', $attrs['salePrice']['currencyCode'] );
+	}
+
+	public function test_wpml_sale_price_conversion_preferred_over_exchange_rate() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 50,
+				'regular_price' => 100,
+				'sale_price'    => 50,
+			]
+		);
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_product_price_in_currency' )->willReturn( 90.0 );
+		$wpml->method( 'get_product_sale_price_in_currency' )->willReturn( 45.0 );
+
+		$attrs = ( new WCProductInputAdapter( $product, 'DE', null, [], [], [], '', '', 'EUR', $wpml, 0.92 ) )->get_product_input()->get_attributes();
+
+		$this->assertSame( '45000000', $attrs['salePrice']['amountMicros'] );
+		$this->assertSame( 'EUR', $attrs['salePrice']['currencyCode'] );
+	}
+
+	public function test_omits_sale_price_when_currency_override_cannot_be_converted() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'         => 50,
+				'regular_price' => 100,
+				'sale_price'    => 50,
+			]
+		);
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_product_price_in_currency' )->willReturn( 90.0 );
+		$wpml->method( 'get_product_sale_price_in_currency' )->willReturn( null );
+
+		$attrs = ( new WCProductInputAdapter( $product, 'DE', null, [], [], [], '', '', 'EUR', $wpml ) )->get_product_input()->get_attributes();
+
+		// The converted regular price is kept; the unconvertible sale price stays unset
+		// so a store-currency amount never appears under a non-store-currency feed label.
+		$this->assertSame( '90000000', $attrs['price']['amountMicros'] );
+		$this->assertArrayNotHasKey( 'salePrice', $attrs );
+		$this->assertArrayNotHasKey( 'salePriceEffectiveDate', $attrs );
+	}
+
+	public function test_omits_ended_sale_price_on_currency_override_path() {
+		$product = WC_Helper_Product::create_simple_product(
+			false,
+			[
+				'price'             => 100,
+				'regular_price'     => 100,
+				'sale_price'        => 50,
+				'date_on_sale_from' => '2020-01-01',
+				'date_on_sale_to'   => '2020-02-01',
+			]
+		);
+
+		$attrs = ( new WCProductInputAdapter( $product, 'DE', null, [], [], [], '', '', 'EUR', null, 0.92 ) )->get_product_input()->get_attributes();
+
+		// The ended sale is never converted and sent; the regular price still is.
+		$this->assertSame( '92000000', $attrs['price']['amountMicros'] );
+		$this->assertArrayNotHasKey( 'salePrice', $attrs );
+		$this->assertArrayNotHasKey( 'salePriceEffectiveDate', $attrs );
+	}
+
 	/**
 	 * Enables tax calculation for the test.
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-792/investigate-tax-handling-for-multi-feed-wpml-languages-markets-prices


### Screenshots:

N/A

### Detailed test instructions:

1. On you local / test store: set the store country to United Kingdom, currency to GBP. Activate WPML and WooCommerce Multilingual active with English and French, and the test build of Google for WooCommerce connected with the United Kingdom as target country.

2. WooCommerce > Settings > General: tick Enable tax rates and calculations.

3. WooCommerce > Settings > Tax > Standard rates: add GB / 20 / TAX and FR / 10 / TAX (the rates must differ so applying the wrong country's tax is detectable). 

4. WooCommerce > WooCommerce Multilingual & Multicurrency > Multi-currency: enable it, add EUR, automatic rates off, EUR rate exactly 1.15, EUR enabled for French.

5. In Marketing > Google for WooCommerce > Markets: edit Primary Market to United Kingdom / English / GBP; Add market France / French / EUR; delete any other secondary market.

6. Add a Simple product: regular price 100, sale price 80 (no dates), taxable, in stock, published; translate it into French (plus icon in the French flag column; prices copy automatically).

7. On the plugin page open the browser console (F12, or Cmd+Option+J on Mac) and run:

```
wp.apiFetch( { path: '/wc/gla/mc/markets', method: 'POST', data: { country: 'US', language: [ 'en' ], currency: [ 'CHF' ], exchange_rate: 1.10 } } ).then( console.log ).catch( console.error );
```

Expect black (not red) output showing the market, and a US row on the Markets tab after reloading.

8. Go to /wp-admin/admin.php?page=connection-test-admin-page, click "Sync All Products with Google Merchant Center", let Tools > Scheduled Actions finish (nothing Pending, nothing newly Failed), then allow Google 10 to 15 minutes.

9. In Merchant Centre > Products, open each entry of GOOWOO-792 Test and confirm exactly: GB = 120.00 / 96.00 GBP (20% British tax), FR-FR-EUR = 126.50 / 101.20 EUR (times 1.15, plus 10% French tax), US-EN-CHF = 110.00 / 88.00 CHF (times 1.10, no tax).

10. In the console, update the rate with the same snippet but path '/wc/gla/mc/markets/us' and data { exchange_rate: 1.20 }; WITHOUT running a manual sync, confirm a new update_all_products job appears in Tools > Scheduled Actions within a couple of minutes, and after it runs the US entry reads 120.00 / 96.00 CHF.

### Additional details:

> Fix - Fix sale prices syncing in the store currency with store-location tax on every feed entry