### PR TITLE
Backport – Fix: Avoid fatal errors in image-proxy endpoint

### DIFF
--- a/src/API/Site/Controllers/Ads/AssetImageProxyController.php
+++ b/src/API/Site/Controllers/Ads/AssetImageProxyController.php
@@ -278,6 +278,25 @@ class AssetImageProxyController extends BaseController {
 	}
 
 	/**
+	 * Determine whether a rest_pre_serve_request $result is this endpoint's own successful
+	 * image response, i.e. one built by create_image_response(), and should be served as
+	 * raw binary rather than left to WordPress's default JSON handling.
+	 *
+	 * @param mixed $result The value passed to serve_image_response() by WordPress.
+	 *
+	 * @return bool
+	 */
+	private function is_image_proxy_response( $result ): bool {
+		if ( ! $result instanceof Response ) {
+			return false;
+		}
+
+		$headers = $result->get_headers();
+
+		return 200 === $result->get_status() && isset( $headers['X-GLA-Image-Proxy'] );
+	}
+
+	/**
 	 * Serve image proxy response as raw binary, bypassing JSON encoding.
 	 *
 	 * Hooked onto the `rest_pre_serve_request` filter from create_image_response(), so it's
@@ -299,12 +318,7 @@ class AssetImageProxyController extends BaseController {
 			return true;
 		}
 
-		if ( ! $result instanceof Response ) {
-			return false;
-		}
-
-		$headers = $result->get_headers();
-		if ( $result->get_status() !== 200 || ! isset( $headers['X-GLA-Image-Proxy'] ) ) {
+		if ( ! $this->is_image_proxy_response( $result ) ) {
 			return false;
 		}
 

--- a/src/API/Site/Controllers/Ads/AssetImageProxyController.php
+++ b/src/API/Site/Controllers/Ads/AssetImageProxyController.php
@@ -50,6 +50,12 @@ class AssetImageProxyController extends BaseController {
 
 	/**
 	 * Register rest routes with WordPress.
+	 *
+	 * Note: this runs on every REST API request (WP fires `rest_api_init` unconditionally
+	 * for route discovery), not just requests to this endpoint, so nothing here should
+	 * attach global filters. The `rest_pre_serve_request` filter is instead attached from
+	 * within `create_image_response()`, which only runs once this endpoint has actually
+	 * been dispatched and produced an image response.
 	 */
 	public function register_routes(): void {
 		$this->register_route(
@@ -64,8 +70,6 @@ class AssetImageProxyController extends BaseController {
 				'schema' => $this->get_api_response_schema_callback(),
 			]
 		);
-
-		add_filter( 'rest_pre_serve_request', [ $this, 'serve_image_response' ], 10, 4 );
 	}
 
 	/**
@@ -249,12 +253,20 @@ class AssetImageProxyController extends BaseController {
 	 *
 	 * Returns a WP_REST_Response that is served as raw binary via rest_pre_serve_request.
 	 *
+	 * The filter is attached here, rather than in register_routes(), so it's only ever
+	 * added when this endpoint has actually produced an image to serve — not on every
+	 * REST API request site-wide. WP_REST_Server::serve_request() dispatches the matched
+	 * route's callback (which reaches this method) before applying rest_pre_serve_request,
+	 * so attaching it here still reaches WP in time to affect this response.
+	 *
 	 * @param string $image_data   The image binary data.
 	 * @param string $content_type The content type of the image.
 	 *
 	 * @return Response
 	 */
 	private function create_image_response( string $image_data, string $content_type ): Response {
+		add_filter( 'rest_pre_serve_request', [ $this, 'serve_image_response' ], 10, 4 );
+
 		$response = new Response( $image_data, 200 );
 		$response->header( 'Content-Type', $content_type );
 		$response->header( 'Content-Length', (string) strlen( $image_data ) );
@@ -268,16 +280,27 @@ class AssetImageProxyController extends BaseController {
 	/**
 	 * Serve image proxy response as raw binary, bypassing JSON encoding.
 	 *
-	 * @param bool             $served  Whether the request has already been served.
-	 * @param Response         $result  The response to serve.
+	 * Hooked onto the `rest_pre_serve_request` filter from create_image_response(), so it's
+	 * only attached during requests that actually reach this endpoint's success path — not
+	 * on every REST request site-wide. That filter is still global, though: other unrelated
+	 * callbacks hooked onto it can pass values that aren't strictly booleans (e.g. null)
+	 * before this one runs, so $served and $result must stay untyped/nullable here rather
+	 * than throwing under strict_types.
+	 *
+	 * @param mixed            $served  Whether the request has already been served.
+	 * @param mixed            $result  The response to serve.
 	 * @param \WP_REST_Request $request The request instance.
 	 * @param \WP_REST_Server  $server  The server instance.
 	 *
 	 * @return bool True if served, false to allow default handling.
 	 */
-	public function serve_image_response( bool $served, Response $result, $request, $server ): bool {
+	public function serve_image_response( $served, $result, $request, $server ): bool {
 		if ( $served ) {
 			return true;
+		}
+
+		if ( ! $result instanceof Response ) {
+			return false;
 		}
 
 		$headers = $result->get_headers();

--- a/src/API/Site/Controllers/Ads/AssetImageProxyController.php
+++ b/src/API/Site/Controllers/Ads/AssetImageProxyController.php
@@ -287,14 +287,14 @@ class AssetImageProxyController extends BaseController {
 	 * before this one runs, so $served and $result must stay untyped/nullable here rather
 	 * than throwing under strict_types.
 	 *
-	 * @param mixed            $served  Whether the request has already been served.
-	 * @param mixed            $result  The response to serve.
-	 * @param \WP_REST_Request $request The request instance.
-	 * @param \WP_REST_Server  $server  The server instance.
+	 * @param mixed            $served   Whether the request has already been served.
+	 * @param mixed            $result   The response to serve.
+	 * @param \WP_REST_Request $_request Unused; required by the rest_pre_serve_request signature.
+	 * @param \WP_REST_Server  $_server  Unused; required by the rest_pre_serve_request signature.
 	 *
 	 * @return bool True if served, false to allow default handling.
 	 */
-	public function serve_image_response( $served, $result, $request, $server ): bool {
+	public function serve_image_response( $served, $result, $_request, $_server ): bool {
 		if ( $served ) {
 			return true;
 		}
@@ -321,6 +321,9 @@ class AssetImageProxyController extends BaseController {
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $result->get_data();
+
+		// This response has been served; no need to keep evaluating it on this filter for the rest of the request.
+		remove_filter( 'rest_pre_serve_request', [ $this, 'serve_image_response' ], 10 );
 
 		return true;
 	}

--- a/tests/Unit/API/Site/Controllers/Ads/AssetImageProxyControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetImageProxyControllerTest.php
@@ -464,7 +464,7 @@ class AssetImageProxyControllerTest extends RESTControllerUnitTest {
 				$this->make_image_proxy_response( 404 ),
 				false,
 			],
-			'not a WP_REST_Response'            => [
+			'not a WP_REST_Response'           => [
 				new WP_Error( 'some_error' ),
 				false,
 			],

--- a/tests/Unit/API/Site/Controllers/Ads/AssetImageProxyControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetImageProxyControllerTest.php
@@ -442,4 +442,29 @@ class AssetImageProxyControllerTest extends RESTControllerUnitTest {
 
 		$this->assertFalse( $result );
 	}
+
+	/**
+	 * Regression test for GOOWOO-834: serve_image_response() must still correctly serve
+	 * the proxied image when $served is a falsy non-bool value — WordPress passed a
+	 * literal null in production — rather than mistaking it for "already served" or
+	 * failing before reaching the success path.
+	 */
+	public function test_serve_image_response_serves_image_when_served_is_null(): void {
+		$image_data = base64_decode( '/9j/4AAQSkZJRg==' ); // Minimal valid JPEG header.
+
+		$response = new Response( $image_data, 200 );
+		$response->header( 'Content-Type', 'image/jpeg' );
+		$response->header( 'X-GLA-Image-Proxy', '1' );
+
+		$request = new Request( 'GET', self::ROUTE_IMAGE_PROXY );
+
+		global $wp_rest_server;
+
+		ob_start();
+		$served = $this->controller->serve_image_response( null, $response, $request, $wp_rest_server );
+		$output = ob_get_clean();
+
+		$this->assertTrue( $served );
+		$this->assertEquals( $image_data, $output );
+	}
 }

--- a/tests/Unit/API/Site/Controllers/Ads/AssetImageProxyControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetImageProxyControllerTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AssetImageProxyController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use ReflectionMethod;
 use WP_Error;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
@@ -443,7 +444,64 @@ class AssetImageProxyControllerTest extends RESTControllerUnitTest {
 		$this->assertFalse( $result );
 	}
 
-	// serve_image_response()'s header()/echo success path isn't covered here: WP's PHPUnit
-	// bootstrap emits output before tests run, so header() always throws "headers already
-	// sent" under this suite's convertWarningsToExceptions config.
+	/**
+	 * Data provider for is_image_proxy_response(), the guard serve_image_response() uses
+	 * to decide whether a rest_pre_serve_request $result is its own image to serve raw.
+	 *
+	 * @return array[]
+	 */
+	public function data_image_proxy_response_candidates(): array {
+		return [
+			'own image response'               => [
+				$this->make_image_proxy_response( 200 ),
+				true,
+			],
+			'missing X-GLA-Image-Proxy header' => [
+				new Response( [ 'message' => 'ok' ], 200 ),
+				false,
+			],
+			'non-200 status'                   => [
+				$this->make_image_proxy_response( 404 ),
+				false,
+			],
+			'not a WP_REST_Response'            => [
+				new WP_Error( 'some_error' ),
+				false,
+			],
+		];
+	}
+
+	/**
+	 * Build a Response carrying the X-GLA-Image-Proxy header that create_image_response()
+	 * sets on a successful image fetch.
+	 *
+	 * @param int $status The response status.
+	 *
+	 * @return Response
+	 */
+	private function make_image_proxy_response( int $status ): Response {
+		$response = new Response( 'binary-data', $status );
+		$response->header( 'X-GLA-Image-Proxy', '1' );
+
+		return $response;
+	}
+
+	/**
+	 * Test that is_image_proxy_response() correctly identifies this endpoint's own
+	 * successful image response, and rejects anything else, independent of the
+	 * header()/echo side effects in serve_image_response() that this suite can't
+	 * exercise directly (WP's PHPUnit bootstrap emits output before tests run, so
+	 * header() always throws "headers already sent" under convertWarningsToExceptions).
+	 *
+	 * @dataProvider data_image_proxy_response_candidates
+	 *
+	 * @param mixed $result   The candidate value.
+	 * @param bool  $expected Whether it should be identified as this endpoint's own image response.
+	 */
+	public function test_is_image_proxy_response( $result, bool $expected ): void {
+		$method = new ReflectionMethod( AssetImageProxyController::class, 'is_image_proxy_response' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected, $method->invoke( $this->controller, $result ) );
+	}
 }

--- a/tests/Unit/API/Site/Controllers/Ads/AssetImageProxyControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetImageProxyControllerTest.php
@@ -443,28 +443,7 @@ class AssetImageProxyControllerTest extends RESTControllerUnitTest {
 		$this->assertFalse( $result );
 	}
 
-	/**
-	 * Regression test for GOOWOO-834: serve_image_response() must still correctly serve
-	 * the proxied image when $served is a falsy non-bool value — WordPress passed a
-	 * literal null in production — rather than mistaking it for "already served" or
-	 * failing before reaching the success path.
-	 */
-	public function test_serve_image_response_serves_image_when_served_is_null(): void {
-		$image_data = base64_decode( '/9j/4AAQSkZJRg==' ); // Minimal valid JPEG header.
-
-		$response = new Response( $image_data, 200 );
-		$response->header( 'Content-Type', 'image/jpeg' );
-		$response->header( 'X-GLA-Image-Proxy', '1' );
-
-		$request = new Request( 'GET', self::ROUTE_IMAGE_PROXY );
-
-		global $wp_rest_server;
-
-		ob_start();
-		$served = $this->controller->serve_image_response( null, $response, $request, $wp_rest_server );
-		$output = ob_get_clean();
-
-		$this->assertTrue( $served );
-		$this->assertEquals( $image_data, $output );
-	}
+	// serve_image_response()'s header()/echo success path isn't covered here: WP's PHPUnit
+	// bootstrap emits output before tests run, so header() always throws "headers already
+	// sent" under this suite's convertWarningsToExceptions config.
 }

--- a/tests/Unit/API/Site/Controllers/Ads/AssetImageProxyControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetImageProxyControllerTest.php
@@ -6,6 +6,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\AssetImageProxyController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use WP_Error;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
 
 /**
  * Class AssetImageProxyControllerTest
@@ -386,5 +388,58 @@ class AssetImageProxyControllerTest extends RESTControllerUnitTest {
 		$data = $response->get_data();
 		$this->assertArrayHasKey( 'code', $data );
 		$this->assertEquals( 'rest_forbidden', $data['code'] );
+	}
+
+	/**
+	 * Data provider of non-bool values for $served, the kind of value another callback
+	 * hooked onto the shared `rest_pre_serve_request` filter chain could pass through.
+	 *
+	 * @return array[]
+	 */
+	public function data_non_bool_served_values(): array {
+		return [
+			'null'         => [ null ],
+			'zero'         => [ 0 ],
+			'empty string' => [ '' ],
+			'empty array'  => [ [] ],
+		];
+	}
+
+	/**
+	 * Regression test for GOOWOO-834: `rest_pre_serve_request` is a global filter, so
+	 * WordPress core or another plugin's callback earlier in the same chain can pass a
+	 * non-bool value for $served (a literal `null` did exactly this in production). A
+	 * strict `bool` type hint on that parameter caused an uncaught TypeError for REST
+	 * responses that had nothing to do with this endpoint. serve_image_response() must
+	 * tolerate this instead of crashing.
+	 *
+	 * @dataProvider data_non_bool_served_values
+	 *
+	 * @param mixed $served A non-bool value for the $served argument.
+	 */
+	public function test_serve_image_response_does_not_throw_on_non_bool_served( $served ): void {
+		$unrelated_response = new Response( [ 'some' => 'data' ], 200 );
+		$request            = new Request( 'GET', '/wp/v2/posts' );
+
+		global $wp_rest_server;
+
+		$result = $this->controller->serve_image_response( $served, $unrelated_response, $request, $wp_rest_server );
+
+		$this->assertFalse( $result, 'A response without the image-proxy header should not be served as raw binary.' );
+	}
+
+	/**
+	 * Regression test for GOOWOO-834: $result may not be a WP_REST_Response at all if an
+	 * earlier callback on the same filter chain replaced it (e.g. with a WP_Error).
+	 * serve_image_response() must not assume the type.
+	 */
+	public function test_serve_image_response_does_not_throw_on_non_response_result(): void {
+		$request = new Request( 'GET', '/wp/v2/posts' );
+
+		global $wp_rest_server;
+
+		$result = $this->controller->serve_image_response( false, new WP_Error( 'some_error' ), $request, $wp_rest_server );
+
+		$this->assertFalse( $result );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes GOOWOO-834.

This backports #3630 to the release/3.8.1 branch.

### Test instructions

- Confirm that all commits from #3630 have been cherry-picked to this
- Manually verify the image-proxy endpoint still streams raw binary images correctly, and that other REST endpoints (e.g. /wc/gla/*, core /wp/v2/*) are unaffected