### PR TITLE
GOOWOO-833: Add Croatia to the list of supported countries

### DIFF
--- a/src/Google/GoogleHelper.php
+++ b/src/Google/GoogleHelper.php
@@ -118,6 +118,12 @@ class GoogleHelper implements Service {
 			'currency' => 'XOF',
 			'id'       => 2384,
 		],
+		// Croatia
+		'HR' => [
+			'code'     => 'HR',
+			'currency' => 'EUR',
+			'id'       => 2191,
+		],
 		// Czechia
 		'CZ' => [
 			'code'     => 'CZ',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-833/add-croatia-to-list-of-approved-countries

Adds Croatia (`HR`) to the list of Google Merchant Center supported countries in `GoogleHelper::SUPPORTED_COUNTRIES`, using ISO 3166-1 numeric location ID `2191` and currency `EUR` (Croatia adopted the euro in 2023).

Google added Croatia as an approved country for Google Shopping/Ads in July 2026, but this plugin didn't reflect it yet, so merchants based in Croatia were blocked during onboarding with a "country is not supported" error.

Reference: https://support.google.com/merchants/answer/160637?hl=en

### Screenshots:

<img width="986" height="912" alt="image" src="https://github.com/user-attachments/assets/665fb38a-b923-4122-9d6d-fce5526b7347" />


### Detailed test instructions:

1. Check out this branch.
2. Set your WooCommerce store's base country to Croatia (WooCommerce → Settings → General → Store address).
3. Go to Marketing → Google Listings & Ads and run through onboarding, confirm the "country is not supported" error no longer appears and Croatia is selectable as a target country.
4. Confirm the target country maps to EUR.
5. Run `./vendor/bin/phpunit --filter GoogleHelperTest` to confirm existing unit tests still pass.

### Additional details:

n/a

### Changelog entry

> Add - Adds Croatia (HR) to the list of countries supported by Google Merchant Center.
