### PR TITLE
Fix: Verify data source during Merchant API product sync.

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
 			},
 			{
 				"path": "./google-listings-and-ads.zip",
-				"maxSize": "8.6 mB",
+				"maxSize": "8.7 mB",
 				"compression": "none"
 			}
 		],

--- a/src/API/Google/Mapi/Services/MapiDataSourcesService.php
+++ b/src/API/Google/Mapi/Services/MapiDataSourcesService.php
@@ -53,6 +53,14 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 	protected $client;
 
 	/**
+	 * Resource names confirmed to exist on the account during this request, so repeat
+	 * resolutions of the same data source do not re-issue a dataSources.get.
+	 *
+	 * @var array<string, true>
+	 */
+	private $verified_data_sources = [];
+
+	/**
 	 * MapiDataSourcesService constructor.
 	 *
 	 * @param MerchantApiClient $client
@@ -107,7 +115,16 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 		$cache     = (array) $this->options->get( OptionsInterface::MAPI_DATA_SOURCES, [] );
 
 		if ( isset( $cache[ $cache_key ] ) && '' !== $cache[ $cache_key ] ) {
-			return (string) $cache[ $cache_key ];
+			$name = (string) $cache[ $cache_key ];
+
+			if ( isset( $this->verified_data_sources[ $name ] ) || $this->data_source_exists( $name ) ) {
+				$this->verified_data_sources[ $name ] = true;
+				return $name;
+			}
+
+			// The cached data source is gone: drop it and re-resolve below.
+			unset( $cache[ $cache_key ] );
+			$this->options->update( OptionsInterface::MAPI_DATA_SOURCES, $cache );
 		}
 
 		$existing = $this->find_existing_data_source( $type, $content_language, $match_value );
@@ -118,7 +135,48 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 		$cache[ $cache_key ] = $name;
 		$this->options->update( OptionsInterface::MAPI_DATA_SOURCES, $cache );
 
+		// Just observed on the account (discovered or created), so it exists without a further request.
+		$this->verified_data_sources[ $name ] = true;
+
 		return $name;
+	}
+
+	/**
+	 * Whether a cached data source resource name still exists on the account.
+	 *
+	 * @param string $name Data source resource name.
+	 *
+	 * @return bool
+	 */
+	private function data_source_exists( string $name ): bool {
+		try {
+			$this->client->get( sprintf( '%s/%s', MapiPaths::DATASOURCES, $name ) );
+
+			return true;
+		} catch ( MerchantApiException $exception ) {
+			return 404 !== $exception->get_http_status();
+		}
+	}
+
+	/**
+	 * Drop the cached product data source for a (contentLanguage, feedLabel) pair, from both the
+	 * option cache and the verified-this-request set, so the next ensure_data_source_for() call
+	 * re-resolves it. Used to recover from a product insert rejected with "data source not found".
+	 *
+	 * @param string $content_language Language code.
+	 * @param string $feed_label       Feed label.
+	 */
+	public function forget_data_source_for( string $content_language, string $feed_label ): void {
+		$cache_key = self::PRODUCT_SOURCE['cache_prefix'] . $content_language . '|' . $feed_label;
+		$cache     = (array) $this->options->get( OptionsInterface::MAPI_DATA_SOURCES, [] );
+
+		if ( ! isset( $cache[ $cache_key ] ) ) {
+			return;
+		}
+
+		$name = (string) $cache[ $cache_key ];
+		unset( $cache[ $cache_key ], $this->verified_data_sources[ $name ] );
+		$this->options->update( OptionsInterface::MAPI_DATA_SOURCES, $cache );
 	}
 
 	/**

--- a/src/API/Google/Mapi/Services/MapiDataSourcesService.php
+++ b/src/API/Google/Mapi/Services/MapiDataSourcesService.php
@@ -144,6 +144,10 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 	/**
 	 * Whether a cached data source resource name still exists on the account.
 	 *
+	 * Only a 404 proves absence, so any other error (auth, transient 5xx) keeps the cached name:
+	 * discarding it there would force a needless list-or-create, and a genuinely missing source
+	 * still surfaces on the insert that follows.
+	 *
 	 * @param string $name Data source resource name.
 	 *
 	 * @return bool
@@ -159,15 +163,37 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 	}
 
 	/**
-	 * Drop the cached product data source for a (contentLanguage, feedLabel) pair, from both the
-	 * option cache and the verified-this-request set, so the next ensure_data_source_for() call
-	 * re-resolves it. Used to recover from a product insert rejected with "data source not found".
+	 * Drop the cached product data source for a (contentLanguage, feedLabel) pair, so the next
+	 * ensure_data_source_for() call re-resolves it. Used to recover from a product insert
+	 * rejected with "data source not found".
 	 *
 	 * @param string $content_language Language code.
 	 * @param string $feed_label       Feed label.
 	 */
 	public function forget_data_source_for( string $content_language, string $feed_label ): void {
-		$cache_key = self::PRODUCT_SOURCE['cache_prefix'] . $content_language . '|' . $feed_label;
+		$this->forget_data_source( self::PRODUCT_SOURCE, $content_language, $feed_label );
+	}
+
+	/**
+	 * Drop the cached promotion data source for a (contentLanguage, targetCountry) pair, so the
+	 * next ensure_promotion_data_source_for() call re-resolves it.
+	 *
+	 * @param string $content_language Language code.
+	 * @param string $target_country   Target country code.
+	 */
+	public function forget_promotion_data_source_for( string $content_language, string $target_country ): void {
+		$this->forget_data_source( self::PROMOTION_SOURCE, $content_language, $target_country );
+	}
+
+	/**
+	 * Drop a cached data source from both the option cache and the verified-this-request set.
+	 *
+	 * @param array  $type             One of the *_SOURCE descriptors.
+	 * @param string $content_language Language code.
+	 * @param string $match_value      Secondary identity value (feed label or target country).
+	 */
+	private function forget_data_source( array $type, string $content_language, string $match_value ): void {
+		$cache_key = $type['cache_prefix'] . $content_language . '|' . $match_value;
 		$cache     = (array) $this->options->get( OptionsInterface::MAPI_DATA_SOURCES, [] );
 
 		if ( ! isset( $cache[ $cache_key ] ) ) {
@@ -177,6 +203,24 @@ class MapiDataSourcesService implements OptionsAwareInterface {
 		$name = (string) $cache[ $cache_key ];
 		unset( $cache[ $cache_key ], $this->verified_data_sources[ $name ] );
 		$this->options->update( OptionsInterface::MAPI_DATA_SOURCES, $cache );
+	}
+
+	/**
+	 * Whether a failure is a "data source not found" rejection: a 404 whose message names the
+	 * data source. A write cannot 404 on the item it is creating, so a 404 is the data source.
+	 *
+	 * @param mixed $failure
+	 *
+	 * @return bool
+	 */
+	public static function is_missing_data_source_failure( $failure ): bool {
+		if ( ! $failure instanceof MerchantApiException || 404 !== $failure->get_http_status() ) {
+			return false;
+		}
+
+		$message = $failure->getMessage();
+
+		return false !== stripos( $message, 'data source' ) || false !== stripos( $message, 'datasource' );
 	}
 
 	/**

--- a/src/API/Google/Mapi/Services/MapiProductInputsService.php
+++ b/src/API/Google/Mapi/Services/MapiProductInputsService.php
@@ -132,12 +132,13 @@ class MapiProductInputsService implements OptionsAwareInterface {
 		$reresolved     = [];
 
 		foreach ( $result['failures'] as $index => $failure ) {
-			if ( ! isset( $inputs[ $index ] ) || ! $this->is_missing_data_source_failure( $failure ) ) {
+			if ( ! isset( $inputs[ $index ] ) || ! MapiDataSourcesService::is_missing_data_source_failure( $failure ) ) {
 				continue;
 			}
 
 			$input = $inputs[ $index ];
-			$pair  = $input->get_content_language() . '|' . $input->get_feed_label();
+			// Local grouping key, so each (language, feed) pair is re-resolved once per retry pass.
+			$pair = $input->get_content_language() . '|' . $input->get_feed_label();
 
 			if ( ! array_key_exists( $pair, $reresolved ) ) {
 				try {
@@ -187,24 +188,6 @@ class MapiProductInputsService implements OptionsAwareInterface {
 		$this->log( sprintf( 'productInputs.insert retried %d inputs after data source re-resolution: %d succeeded', count( $retry_inputs ), count( $retry_result['successes'] ) ), __METHOD__ );
 
 		return $result;
-	}
-
-	/**
-	 * Whether a batch failure is a "data source not found" rejection: a 404 whose message names the
-	 * data source. Insert cannot 404 on the product it is creating, so a 404 is the data source.
-	 *
-	 * @param mixed $failure The per-input failure recorded by run_in_batches().
-	 *
-	 * @return bool
-	 */
-	private function is_missing_data_source_failure( $failure ): bool {
-		if ( ! $failure instanceof MerchantApiException || 404 !== $failure->get_http_status() ) {
-			return false;
-		}
-
-		$message = $failure->getMessage();
-
-		return false !== stripos( $message, 'data source' ) || false !== stripos( $message, 'datasource' );
 	}
 
 	/**

--- a/src/API/Google/Mapi/Services/MapiProductInputsService.php
+++ b/src/API/Google/Mapi/Services/MapiProductInputsService.php
@@ -115,7 +115,96 @@ class MapiProductInputsService implements OptionsAwareInterface {
 
 		$this->log( sprintf( 'productInputs.insert batch of %d: %d succeeded, %d failed', count( $inputs ), count( $result['successes'] ), count( $result['failures'] ) ), __METHOD__ );
 
+		return $this->retry_missing_data_sources( $inputs, $result, $concurrency );
+	}
+
+	/**
+	 * Re-resolve data sources for inserts rejected with "data source not found" and retry them once.
+	 *
+	 * @param ProductInput[] $inputs      The inputs from the original insert_many() call.
+	 * @param array          $result      The first-pass result to merge retries into.
+	 * @param int            $concurrency Concurrent batch requests.
+	 *
+	 * @return array{successes: array<int, ProductInput>, failures: array<int, MerchantApiException>}
+	 */
+	private function retry_missing_data_sources( array $inputs, array $result, int $concurrency ): array {
+		$paths_by_index = [];
+		$reresolved     = [];
+
+		foreach ( $result['failures'] as $index => $failure ) {
+			if ( ! isset( $inputs[ $index ] ) || ! $this->is_missing_data_source_failure( $failure ) ) {
+				continue;
+			}
+
+			$input = $inputs[ $index ];
+			$pair  = $input->get_content_language() . '|' . $input->get_feed_label();
+
+			if ( ! array_key_exists( $pair, $reresolved ) ) {
+				try {
+					$this->data_sources->forget_data_source_for( $input->get_content_language(), $input->get_feed_label() );
+					$reresolved[ $pair ] = $this->data_sources->ensure_data_source_for( $input->get_content_language(), $input->get_feed_label() );
+				} catch ( MerchantApiException $exception ) {
+					// Re-resolution failed: leave the original failure in place for this pair's inputs.
+					$reresolved[ $pair ] = null;
+				}
+			}
+
+			if ( null !== $reresolved[ $pair ] ) {
+				$paths_by_index[ $index ] = $this->build_path( $reresolved[ $pair ] );
+			}
+		}
+
+		if ( empty( $paths_by_index ) ) {
+			return $result;
+		}
+
+		$retry_inputs = array_intersect_key( $inputs, $paths_by_index );
+
+		$retry_result = $this->run_in_batches(
+			$retry_inputs,
+			$concurrency,
+			__METHOD__,
+			function ( int $index, ProductInput $input ) use ( $paths_by_index ): array {
+				return [
+					'method' => 'POST',
+					'path'   => $paths_by_index[ $index ],
+					'body'   => $input->to_array(),
+				];
+			},
+			function ( array $body ): ProductInput {
+				return ProductInput::from_array( $body );
+			}
+		);
+
+		foreach ( $retry_result['successes'] as $index => $success ) {
+			$result['successes'][ $index ] = $success;
+			unset( $result['failures'][ $index ] );
+		}
+		foreach ( $retry_result['failures'] as $index => $failure ) {
+			$result['failures'][ $index ] = $failure;
+		}
+
+		$this->log( sprintf( 'productInputs.insert retried %d inputs after data source re-resolution: %d succeeded', count( $retry_inputs ), count( $retry_result['successes'] ) ), __METHOD__ );
+
 		return $result;
+	}
+
+	/**
+	 * Whether a batch failure is a "data source not found" rejection: a 404 whose message names the
+	 * data source. Insert cannot 404 on the product it is creating, so a 404 is the data source.
+	 *
+	 * @param mixed $failure The per-input failure recorded by run_in_batches().
+	 *
+	 * @return bool
+	 */
+	private function is_missing_data_source_failure( $failure ): bool {
+		if ( ! $failure instanceof MerchantApiException || 404 !== $failure->get_http_status() ) {
+			return false;
+		}
+
+		$message = $failure->getMessage();
+
+		return false !== stripos( $message, 'data source' ) || false !== stripos( $message, 'datasource' );
 	}
 
 	/**

--- a/src/API/Google/Merchant.php
+++ b/src/API/Google/Merchant.php
@@ -405,6 +405,14 @@ class Merchant implements OptionsAwareInterface {
 	 * @return bool
 	 */
 	public function update_merchant_id( int $id ): bool {
+		$previous_id = $this->options->get_merchant_id();
+
+		// Cached data source resource names embed the account id (accounts/{id}/dataSources/...),
+		// so a relink to a different account must not reuse the previous account's names.
+		if ( $previous_id && $previous_id !== $id ) {
+			$this->options->delete( OptionsInterface::MAPI_DATA_SOURCES );
+		}
+
 		return $this->options->update( OptionsInterface::MERCHANT_ID, $id );
 	}
 

--- a/src/Coupon/CouponSyncer.php
+++ b/src/Coupon/CouponSyncer.php
@@ -164,11 +164,6 @@ class CouponSyncer implements Service {
 		$promotion = $adapted_coupon->get_promotion();
 
 		try {
-			$data_source = $this->data_sources->ensure_promotion_data_source_for(
-				$promotion['contentLanguage'],
-				$promotion['targetCountry']
-			);
-
 			do_action(
 				'woocommerce_gla_debug_message',
 				sprintf(
@@ -178,7 +173,7 @@ class CouponSyncer implements Service {
 				),
 				__METHOD__
 			);
-			$response = $this->promotions_service->insert_promotion( $data_source, $promotion );
+			$response = $this->insert_promotion( $promotion );
 			$this->coupon_helper->mark_as_synced(
 				$coupon,
 				(string) ( $response['promotionId'] ?? '' ),
@@ -273,10 +268,6 @@ class CouponSyncer implements Service {
 			try {
 				$promotion                  = $coupon->get_google_promotion();
 				$promotion['targetCountry'] = $target_country;
-				$data_source                = $this->data_sources->ensure_promotion_data_source_for(
-					$promotion['contentLanguage'],
-					$target_country
-				);
 
 				do_action(
 					'woocommerce_gla_debug_message',
@@ -290,7 +281,7 @@ class CouponSyncer implements Service {
 				// DeleteCouponEntry is generated with the promotion effective date expired
 				// when the WC coupon can be deleted. To soft-delete the promotion on the
 				// Google side, we upsert it with the expired effective date.
-				$response = $this->promotions_service->insert_promotion( $data_source, $promotion );
+				$response = $this->insert_promotion( $promotion );
 				array_push( $deleted_promotions, $response );
 				if ( $wc_coupon_exist ) {
 					$this->coupon_helper->remove_google_id_by_country(
@@ -472,6 +463,44 @@ class CouponSyncer implements Service {
 					join( ', ', $internal_error_coupon_ids )
 				),
 				__METHOD__
+			);
+		}
+	}
+
+	/**
+	 * Upsert a promotion into its (contentLanguage, targetCountry) data source, retrying once with a
+	 * re-resolved data source when the cached one is rejected as missing. Mirrors the product path:
+	 * a data source can be deleted on the Google side after it was resolved.
+	 *
+	 * @param array $promotion The Promotion resource to write.
+	 *
+	 * @return array The stored Promotion resource.
+	 * @throws MerchantApiException On a non-2xx MAPI response.
+	 */
+	private function insert_promotion( array $promotion ): array {
+		$data_source = $this->data_sources->ensure_promotion_data_source_for(
+			$promotion['contentLanguage'],
+			$promotion['targetCountry']
+		);
+
+		try {
+			return $this->promotions_service->insert_promotion( $data_source, $promotion );
+		} catch ( MerchantApiException $exception ) {
+			if ( ! MapiDataSourcesService::is_missing_data_source_failure( $exception ) ) {
+				throw $exception;
+			}
+
+			$this->data_sources->forget_promotion_data_source_for(
+				$promotion['contentLanguage'],
+				$promotion['targetCountry']
+			);
+
+			return $this->promotions_service->insert_promotion(
+				$this->data_sources->ensure_promotion_data_source_for(
+					$promotion['contentLanguage'],
+					$promotion['targetCountry']
+				),
+				$promotion
 			);
 		}
 	}

--- a/tests/Unit/API/Google/Mapi/Services/MapiDataSourcesServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiDataSourcesServiceTest.php
@@ -42,18 +42,128 @@ class MapiDataSourcesServiceTest extends UnitTest {
 		$this->service->set_options_object( $this->options );
 	}
 
-	public function test_returns_cached_value_without_api_call() {
+	public function test_returns_cached_value_after_verifying_it_exists() {
 		$this->options->method( 'get' )->willReturn(
 			[
 				'product|en|US' => 'accounts/12345/dataSources/999',
 			]
 		);
-		$this->client->expects( $this->never() )->method( 'get' );
+		// A cache hit is verified once with a dataSources.get before it is trusted.
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( 'datasources/v1/accounts/12345/dataSources/999' )
+			->willReturn( [ 'name' => 'accounts/12345/dataSources/999' ] );
 		$this->client->expects( $this->never() )->method( 'post' );
 
 		$this->assertSame(
 			'accounts/12345/dataSources/999',
 			$this->service->ensure_data_source_for( 'en', 'US' )
+		);
+	}
+
+	public function test_verifies_cached_name_only_once_per_request() {
+		$this->options->method( 'get' )->willReturn(
+			[
+				'product|en|US' => 'accounts/12345/dataSources/999',
+			]
+		);
+		// Two resolutions of the same pair in one request verify the name only once.
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( 'datasources/v1/accounts/12345/dataSources/999' )
+			->willReturn( [ 'name' => 'accounts/12345/dataSources/999' ] );
+
+		$this->service->ensure_data_source_for( 'en', 'US' );
+		$this->service->ensure_data_source_for( 'en', 'US' );
+	}
+
+	public function test_drops_cached_name_and_re_resolves_when_verification_returns_404() {
+		$this->options->method( 'get' )->willReturn(
+			[
+				'product|en|US' => 'accounts/12345/dataSources/stale',
+			]
+		);
+
+		// Verification 404s (source gone), then discovery lists the real source.
+		$this->client->expects( $this->exactly( 2 ) )
+			->method( 'get' )
+			->withConsecutive(
+				[ 'datasources/v1/accounts/12345/dataSources/stale' ],
+				[ self::LIST_PATH ]
+			)
+			->willReturnOnConsecutiveCalls(
+				$this->throwException( new MerchantApiException( 404, [ 'error' => [ 'message' => 'Data source with id stale was not found.' ] ], 'get' ) ),
+				[
+					'dataSources' => [
+						[
+							'name'                     => 'accounts/12345/dataSources/fresh',
+							'displayName'              => 'Google for WooCommerce (en/US)',
+							'primaryProductDataSource' => [
+								'contentLanguage' => 'en',
+								'feedLabel'       => 'US',
+							],
+						],
+					],
+				]
+			);
+
+		// The stale entry is cleared, then the re-resolved name is written back.
+		$this->options->expects( $this->exactly( 2 ) )
+			->method( 'update' )
+			->withConsecutive(
+				[ OptionsInterface::MAPI_DATA_SOURCES, [] ],
+				[ OptionsInterface::MAPI_DATA_SOURCES, [ 'product|en|US' => 'accounts/12345/dataSources/fresh' ] ]
+			);
+
+		$this->assertSame(
+			'accounts/12345/dataSources/fresh',
+			$this->service->ensure_data_source_for( 'en', 'US' )
+		);
+	}
+
+	public function test_forget_data_source_for_removes_entry_so_next_resolution_bypasses_cache() {
+		// Stateful option so forget()'s write is visible to the following resolution.
+		$stored = [ OptionsInterface::MAPI_DATA_SOURCES => [ 'product|en|US' => 'accounts/12345/dataSources/999' ] ];
+		$this->options->method( 'get' )->willReturnCallback(
+			function ( string $key, $fallback = false ) use ( &$stored ) {
+				return $stored[ $key ] ?? $fallback;
+			}
+		);
+		$this->options->method( 'update' )->willReturnCallback(
+			function ( string $key, $value ) use ( &$stored ) {
+				$stored[ $key ] = $value;
+				return true;
+			}
+		);
+
+		// forget() clears the entry; the next resolution then discovers rather than verifying a cache hit.
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( self::LIST_PATH )
+			->willReturn(
+				[
+					'dataSources' => [
+						[
+							'name'                     => 'accounts/12345/dataSources/new',
+							'displayName'              => 'Google for WooCommerce (en/US)',
+							'primaryProductDataSource' => [
+								'contentLanguage' => 'en',
+								'feedLabel'       => 'US',
+							],
+						],
+					],
+				]
+			);
+
+		$this->service->forget_data_source_for( 'en', 'US' );
+
+		$this->assertSame(
+			'accounts/12345/dataSources/new',
+			$this->service->ensure_data_source_for( 'en', 'US' )
+		);
+		$this->assertSame(
+			[ 'product|en|US' => 'accounts/12345/dataSources/new' ],
+			$stored[ OptionsInterface::MAPI_DATA_SOURCES ]
 		);
 	}
 
@@ -288,13 +398,17 @@ class MapiDataSourcesServiceTest extends UnitTest {
 		);
 	}
 
-	public function test_returns_cached_promotion_data_source_without_api_call() {
+	public function test_returns_cached_promotion_data_source_after_verifying_it_exists() {
 		$this->options->method( 'get' )->willReturn(
 			[
 				'promotion|en|US' => 'accounts/12345/dataSources/300',
 			]
 		);
-		$this->client->expects( $this->never() )->method( 'get' );
+		// The shared verification runs for promotion sources too.
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( 'datasources/v1/accounts/12345/dataSources/300' )
+			->willReturn( [ 'name' => 'accounts/12345/dataSources/300' ] );
 		$this->client->expects( $this->never() )->method( 'post' );
 
 		$this->assertSame(

--- a/tests/Unit/API/Google/Mapi/Services/MapiDataSourcesServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiDataSourcesServiceTest.php
@@ -167,6 +167,53 @@ class MapiDataSourcesServiceTest extends UnitTest {
 		);
 	}
 
+	public function test_forget_promotion_data_source_for_removes_only_the_promotion_entry() {
+		$stored = [
+			OptionsInterface::MAPI_DATA_SOURCES => [
+				'product|en|US'   => 'accounts/12345/dataSources/100',
+				'promotion|en|US' => 'accounts/12345/dataSources/300',
+			],
+		];
+		$this->options->method( 'get' )->willReturnCallback(
+			function ( string $key, $fallback = false ) use ( &$stored ) {
+				return $stored[ $key ] ?? $fallback;
+			}
+		);
+		$this->options->method( 'update' )->willReturnCallback(
+			function ( string $key, $value ) use ( &$stored ) {
+				$stored[ $key ] = $value;
+				return true;
+			}
+		);
+
+		$this->service->forget_promotion_data_source_for( 'en', 'US' );
+
+		$this->assertSame(
+			[ 'product|en|US' => 'accounts/12345/dataSources/100' ],
+			$stored[ OptionsInterface::MAPI_DATA_SOURCES ]
+		);
+	}
+
+	public function test_is_missing_data_source_failure_only_matches_data_source_404s() {
+		$this->assertTrue(
+			MapiDataSourcesService::is_missing_data_source_failure(
+				new MerchantApiException( 404, [ 'error' => [ 'message' => '[dataSource] Data source with id 999 was not found.' ] ], __METHOD__ )
+			)
+		);
+		// A 404 that is not about the data source, and a non-404, are both left alone.
+		$this->assertFalse(
+			MapiDataSourcesService::is_missing_data_source_failure(
+				new MerchantApiException( 404, [ 'error' => [ 'message' => 'The resource was not found.' ] ], __METHOD__ )
+			)
+		);
+		$this->assertFalse(
+			MapiDataSourcesService::is_missing_data_source_failure(
+				new MerchantApiException( 500, [ 'error' => [ 'message' => 'data source blew up' ] ], __METHOD__ )
+			)
+		);
+		$this->assertFalse( MapiDataSourcesService::is_missing_data_source_failure( null ) );
+	}
+
 	public function test_reuses_existing_data_source_matching_language_and_feed() {
 		$this->options->method( 'get' )->willReturn( [] );
 		$this->client->expects( $this->once() )

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
@@ -589,4 +589,180 @@ class MapiProductInputsServiceTest extends UnitTest {
 		$this->assertSame( $this->expected_delete_path( $us_input, self::DS_EN_US ), $paths_seen[0][1] );
 		$this->assertSame( $this->expected_delete_path( $ca_input, self::DS_FR_CA ), $paths_seen[1][1] );
 	}
+
+	/**
+	 * A "data source not found" 404 for the given offer id, as run_in_batches records it.
+	 *
+	 * @param string $offer_id
+	 *
+	 * @return array
+	 */
+	protected function data_source_404( string $offer_id ): array {
+		return [
+			'status' => 404,
+			'body'   => [ 'error' => [ 'message' => '[dataSource] Data source with id 999 was not found.' ] ],
+		];
+	}
+
+	/**
+	 * A successful insert sub-response for the given offer id.
+	 *
+	 * @param string $offer_id
+	 *
+	 * @return array
+	 */
+	protected function insert_ok( string $offer_id ): array {
+		return [
+			'status' => 200,
+			'body'   => [
+				'name'    => 'accounts/12345/productInputs/' . $offer_id,
+				'offerId' => $offer_id,
+			],
+		];
+	}
+
+	public function test_insert_many_retries_after_data_source_re_resolution() {
+		$forgotten = [];
+		$this->data_sources->expects( $this->once() )
+			->method( 'forget_data_source_for' )
+			->with( 'en', 'US' )
+			->willReturnCallback(
+				function ( string $language, string $feed ) use ( &$forgotten ) {
+					$forgotten[] = $language . '|' . $feed;
+				}
+			);
+
+		$call = 0;
+		$this->client->method( 'batch_async' )
+			->willReturnCallback(
+				function ( array $requests ) use ( &$call ) {
+					++$call;
+					$results = [];
+					foreach ( $requests as $index => $sub ) {
+						// First pass: the data source 404s. Retry pass: it succeeds.
+						$results[ $index ] = 1 === $call
+							? $this->data_source_404( $sub['body']['offerId'] )
+							: $this->insert_ok( $sub['body']['offerId'] );
+					}
+					return Create::promiseFor( $results );
+				}
+			);
+
+		$result = $this->service->insert_many( [ $this->make_input( 'sku42', 'en', 'US' ) ] );
+
+		$this->assertSame( 2, $call, 'One retry round only.' );
+		$this->assertSame( [ 'en|US' ], $forgotten );
+		$this->assertCount( 1, $result['successes'] );
+		$this->assertCount( 0, $result['failures'] );
+		$this->assertSame( 'sku42', $result['successes'][0]->get_offer_id() );
+	}
+
+	public function test_insert_many_retry_that_fails_again_is_returned_as_failure() {
+		$this->data_sources->expects( $this->once() )->method( 'forget_data_source_for' );
+
+		$call = 0;
+		$this->client->method( 'batch_async' )
+			->willReturnCallback(
+				function ( array $requests ) use ( &$call ) {
+					++$call;
+					$results = [];
+					foreach ( $requests as $index => $sub ) {
+						$results[ $index ] = $this->data_source_404( $sub['body']['offerId'] );
+					}
+					return Create::promiseFor( $results );
+				}
+			);
+
+		$result = $this->service->insert_many( [ $this->make_input( 'sku42', 'en', 'US' ) ] );
+
+		$this->assertSame( 2, $call, 'Exactly one retry, then it stays failed.' );
+		$this->assertCount( 0, $result['successes'] );
+		$this->assertCount( 1, $result['failures'] );
+		$this->assertInstanceOf( MerchantApiException::class, $result['failures'][0] );
+	}
+
+	public function test_insert_many_does_not_retry_non_404_failures() {
+		$this->data_sources->expects( $this->never() )->method( 'forget_data_source_for' );
+
+		$call = 0;
+		$this->client->method( 'batch_async' )
+			->willReturnCallback(
+				function ( array $requests ) use ( &$call ) {
+					++$call;
+					$results = [];
+					foreach ( $requests as $index => $sub ) {
+						$results[ $index ] = [
+							'status' => 500,
+							'body'   => [ 'error' => [ 'message' => 'Internal error' ] ],
+						];
+					}
+					return Create::promiseFor( $results );
+				}
+			);
+
+		$result = $this->service->insert_many( [ $this->make_input( 'sku42', 'en', 'US' ) ] );
+
+		$this->assertSame( 1, $call, 'A 500 is not a data source problem, so no retry.' );
+		$this->assertCount( 1, $result['failures'] );
+	}
+
+	public function test_insert_many_does_not_retry_404_not_mentioning_data_source() {
+		$this->data_sources->expects( $this->never() )->method( 'forget_data_source_for' );
+
+		$call = 0;
+		$this->client->method( 'batch_async' )
+			->willReturnCallback(
+				function ( array $requests ) use ( &$call ) {
+					++$call;
+					$results = [];
+					foreach ( $requests as $index => $sub ) {
+						$results[ $index ] = [
+							'status' => 404,
+							'body'   => [ 'error' => [ 'message' => 'Some other resource was not found.' ] ],
+						];
+					}
+					return Create::promiseFor( $results );
+				}
+			);
+
+		$result = $this->service->insert_many( [ $this->make_input( 'sku42', 'en', 'US' ) ] );
+
+		$this->assertSame( 1, $call, 'A 404 that is not about the data source is not retried.' );
+		$this->assertCount( 1, $result['failures'] );
+	}
+
+	public function test_insert_many_keeps_original_failure_when_re_resolution_throws() {
+		$this->data_sources->method( 'forget_data_source_for' );
+		// The upfront resolution succeeds so the batch runs and 404s; the retry re-resolution then
+		// fails, so the input keeps its original failure and is not retried.
+		$resolve_calls = 0;
+		$this->data_sources->method( 'ensure_data_source_for' )
+			->willReturnCallback(
+				function () use ( &$resolve_calls ) {
+					if ( 0 === $resolve_calls++ ) {
+						return self::DS_EN_US;
+					}
+					throw new MerchantApiException( 500, [ 'error' => [ 'message' => 'list failed' ] ], 'test' );
+				}
+			);
+
+		$call = 0;
+		$this->client->method( 'batch_async' )
+			->willReturnCallback(
+				function ( array $requests ) use ( &$call ) {
+					++$call;
+					$results = [];
+					foreach ( $requests as $index => $sub ) {
+						$results[ $index ] = $this->data_source_404( $sub['body']['offerId'] );
+					}
+					return Create::promiseFor( $results );
+				}
+			);
+
+		$result = $this->service->insert_many( [ $this->make_input( 'sku42', 'en', 'US' ) ] );
+
+		$this->assertSame( 1, $call, 'A failed re-resolution means no retry batch.' );
+		$this->assertCount( 1, $result['failures'] );
+		$this->assertSame( 404, $result['failures'][0]->get_http_status() );
+	}
 }

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
@@ -591,13 +591,12 @@ class MapiProductInputsServiceTest extends UnitTest {
 	}
 
 	/**
-	 * A "data source not found" 404 for the given offer id, as run_in_batches records it.
-	 *
-	 * @param string $offer_id
+	 * A "data source not found" 404, as run_in_batches records it. The real rejection names the
+	 * data source, not the product, so this takes no offer id.
 	 *
 	 * @return array
 	 */
-	protected function data_source_404( string $offer_id ): array {
+	protected function data_source_404(): array {
 		return [
 			'status' => 404,
 			'body'   => [ 'error' => [ 'message' => '[dataSource] Data source with id 999 was not found.' ] ],
@@ -641,7 +640,7 @@ class MapiProductInputsServiceTest extends UnitTest {
 					foreach ( $requests as $index => $sub ) {
 						// First pass: the data source 404s. Retry pass: it succeeds.
 						$results[ $index ] = 1 === $call
-							? $this->data_source_404( $sub['body']['offerId'] )
+							? $this->data_source_404()
 							: $this->insert_ok( $sub['body']['offerId'] );
 					}
 					return Create::promiseFor( $results );
@@ -667,7 +666,7 @@ class MapiProductInputsServiceTest extends UnitTest {
 					++$call;
 					$results = [];
 					foreach ( $requests as $index => $sub ) {
-						$results[ $index ] = $this->data_source_404( $sub['body']['offerId'] );
+						$results[ $index ] = $this->data_source_404();
 					}
 					return Create::promiseFor( $results );
 				}
@@ -753,7 +752,7 @@ class MapiProductInputsServiceTest extends UnitTest {
 					++$call;
 					$results = [];
 					foreach ( $requests as $index => $sub ) {
-						$results[ $index ] = $this->data_source_404( $sub['body']['offerId'] );
+						$results[ $index ] = $this->data_source_404();
 					}
 					return Create::promiseFor( $results );
 				}

--- a/tests/Unit/API/Google/MerchantTest.php
+++ b/tests/Unit/API/Google/MerchantTest.php
@@ -516,6 +516,29 @@ class MerchantTest extends UnitTest {
 		$this->assertTrue( $this->merchant->update_merchant_id( $this->merchant_id ) );
 	}
 
+	public function test_update_merchant_id_clears_data_source_cache_when_id_changes() {
+		$this->options->expects( $this->once() )
+			->method( 'delete' )
+			->with( OptionsInterface::MAPI_DATA_SOURCES );
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::MERCHANT_ID, 999 )
+			->willReturn( true );
+
+		$this->assertTrue( $this->merchant->update_merchant_id( 999 ) );
+	}
+
+	public function test_update_merchant_id_keeps_data_source_cache_when_id_unchanged() {
+		// Re-saving the same account (setUp stores 12345) must not throw away still-valid cached names.
+		$this->options->expects( $this->never() )->method( 'delete' );
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::MERCHANT_ID, $this->merchant_id )
+			->willReturn( true );
+
+		$this->assertTrue( $this->merchant->update_merchant_id( $this->merchant_id ) );
+	}
+
 	public function test_get_account_review_status() {
 		$response = [
 			'renderedIssues' => [

--- a/tests/Unit/Coupon/CouponSyncerTest.php
+++ b/tests/Unit/Coupon/CouponSyncerTest.php
@@ -118,6 +118,45 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
 		$this->assert_coupon_has_errors( $coupon );
 	}
 
+	public function test_update_retries_once_with_a_re_resolved_promotion_data_source() {
+		// A promotion data source deleted on the Google side after it was resolved must be
+		// re-resolved and the upsert retried, not left as a coupon error.
+		$coupon = $this->create_ready_to_sync_coupon();
+		$this->validator->expects( $this->any() )
+			->method( 'validate' )
+			->willReturn( [] );
+
+		$this->data_sources->expects( $this->exactly( 2 ) )
+			->method( 'ensure_promotion_data_source_for' )
+			->willReturnOnConsecutiveCalls( 'dataSources/stale', 'dataSources/fresh' );
+		$this->data_sources->expects( $this->once() )
+			->method( 'forget_promotion_data_source_for' );
+
+		$seen_sources = [];
+		$this->promotions_service->expects( $this->exactly( 2 ) )
+			->method( 'insert_promotion' )
+			->willReturnCallback(
+				function ( string $data_source, array $promotion ) use ( &$seen_sources ) {
+					$seen_sources[] = $data_source;
+
+					if ( 1 === count( $seen_sources ) ) {
+						throw new MerchantApiException(
+							404,
+							[ 'error' => [ 'message' => '[dataSource] Data source with id 999 was not found.' ] ],
+							'insert_promotion'
+						);
+					}
+
+					return [ 'promotionId' => 'promo-1' ];
+				}
+			);
+
+		$this->coupon_syncer->update( $coupon );
+
+		$this->assertSame( [ 'dataSources/stale', 'dataSources/fresh' ], $seen_sources );
+		$this->assertEquals( 0, did_action( 'woocommerce_gla_retry_update_coupons' ) );
+	}
+
 	public function test_update_does_not_retry_on_non_5xx_error() {
 		$coupon = $this->create_ready_to_sync_coupon();
 		$this->validator->expects( $this->any() )

--- a/tests/Unit/Coupon/CouponSyncerTest.php
+++ b/tests/Unit/Coupon/CouponSyncerTest.php
@@ -136,7 +136,7 @@ class CouponSyncerTest extends ContainerAwareUnitTest {
 		$this->promotions_service->expects( $this->exactly( 2 ) )
 			->method( 'insert_promotion' )
 			->willReturnCallback(
-				function ( string $data_source, array $promotion ) use ( &$seen_sources ) {
+				function ( string $data_source ) use ( &$seen_sources ) {
 					$seen_sources[] = $data_source;
 
 					if ( 1 === count( $seen_sources ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-832/sync-all-products-fails-completely-datasource-data-source-with-id-was

"Sync All Products" fails for every product with `[dataSource] Data source with id … was not found` when the cached data source names in `gla_mapi_data_sources` point at sources that no longer exist. This happens after the account is relinked without a disconnect, a data source is deleted on Google, or an insert lands before a new source has propagated. The cache is never re-checked, and this error isn't retried, so once it starts the sync stays broken.

This makes the plugin recover on its own:
- `MapiDataSourcesService`: before trusting a cached data source, check it still exists (once per request); if it's gone, drop it and re-resolve.
- `MapiProductInputsService::insert_many()`: any insert rejected with "data source not found" gets its data source re-resolved and retried once.
- `Merchant::update_merchant_id()`: clear the cache when the connected account changes.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Sync products so `gla_mapi_data_sources` is populated.
2. Point an entry at a source that doesn't exist: `wp option patch update gla_mapi_data_sources 'product|en|US' 'accounts/<MERCHANT_ID>/dataSources/999999999999'`.
3. Run **Sync All Products**. Products should sync, and the entry should re-resolve to a real source. Before this change, every product failed with "Data source with id … was not found".

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Verify data source during Merchant API product sync.
