### PR TITLE
[GOOWOO-831] No feed generated for primary market, and syncing products throws internal errors after adding Cameroon as secondary market

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
 			},
 			{
 				"path": "./google-listings-and-ads.zip",
-				"maxSize": "8.6 mB",
+				"maxSize": "8.65 mB",
 				"compression": "none"
 			}
 		],

--- a/package.json
+++ b/package.json
@@ -211,11 +211,7 @@
 			},
 			{
 				"path": "./google-listings-and-ads.zip",
-<<<<<<< HEAD
-				"maxSize": "8.65 mB",
-=======
 				"maxSize": "8.7 mB",
->>>>>>> feature/multi-lingual-support
 				"compression": "none"
 			}
 		],

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -327,7 +327,8 @@ class CoreServiceProvider extends AbstractServiceProvider {
 			AttributeMappingRulesQuery::class,
 			MarketService::class,
 			WPML::class,
-			AttributeManager::class
+			AttributeManager::class,
+			MapiDataSourcesService::class
 		);
 		$this->share_with_tags(
 			ProductSyncer::class,

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -3,7 +3,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\GoogleListingsAndAdsException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
@@ -75,6 +77,11 @@ class BatchProductHelper implements Service {
 	protected $attribute_manager;
 
 	/**
+	 * @var MapiDataSourcesService
+	 */
+	protected $data_sources;
+
+	/**
 	 * BatchProductHelper constructor.
 	 *
 	 * @param ProductMetaHandler         $meta_handler
@@ -85,6 +92,7 @@ class BatchProductHelper implements Service {
 	 * @param MarketService              $market_service
 	 * @param WPML                       $wpml
 	 * @param AttributeManager           $attribute_manager
+	 * @param MapiDataSourcesService     $data_sources
 	 */
 	public function __construct(
 		ProductMetaHandler $meta_handler,
@@ -94,7 +102,8 @@ class BatchProductHelper implements Service {
 		AttributeMappingRulesQuery $attribute_mapping_rules_query,
 		MarketService $market_service,
 		WPML $wpml,
-		AttributeManager $attribute_manager
+		AttributeManager $attribute_manager,
+		MapiDataSourcesService $data_sources
 	) {
 		$this->meta_handler                  = $meta_handler;
 		$this->product_helper                = $product_helper;
@@ -104,6 +113,7 @@ class BatchProductHelper implements Service {
 		$this->market_service                = $market_service;
 		$this->wpml                          = $wpml;
 		$this->attribute_manager             = $attribute_manager;
+		$this->data_sources                  = $data_sources;
 	}
 
 	/**
@@ -298,7 +308,7 @@ class BatchProductHelper implements Service {
 					$primary_input = $this->generate_product_input( $product, $main_feed_label, $main_feed_label, $this->market_service->get_all_countries(), $mapping_rules, $product_language );
 					$primary_hash  = $this->product_input_hash( $primary_input );
 
-					if ( ! $this->can_skip_unchanged_product( $product, $primary_hash ) ) {
+					if ( ! $this->can_skip_unchanged_product( $product, $primary_hash, $primary_input->get_content_language(), $primary_input->get_feed_label() ) ) {
 						$product_entries[] = [
 							'product' => $product,
 							'country' => $main_feed_label,
@@ -345,7 +355,7 @@ class BatchProductHelper implements Service {
 						$primary_currency_input = $this->generate_product_input( $product, $main_feed_label, $primary_currency_label, $this->market_service->get_all_countries(), $mapping_rules, $product_language, $primary_currency );
 						$primary_currency_hash  = $this->product_input_hash( $primary_currency_input );
 
-						if ( $this->can_skip_unchanged_product( $product, $primary_currency_hash ) ) {
+						if ( $this->can_skip_unchanged_product( $product, $primary_currency_hash, $primary_currency_input->get_content_language(), $primary_currency_input->get_feed_label() ) ) {
 							continue;
 						}
 
@@ -463,7 +473,7 @@ class BatchProductHelper implements Service {
 			$input = $this->generate_product_input( $product, $market['country'], $market_feed_label, [ $market['country'] ], $mapping_rules, $product_language, $currency_override, $market_exchange_rate );
 			$hash  = $this->product_input_hash( $input );
 
-			if ( $this->can_skip_unchanged_product( $product, $hash ) ) {
+			if ( $this->can_skip_unchanged_product( $product, $hash, $input->get_content_language(), $input->get_feed_label() ) ) {
 				continue;
 			}
 
@@ -598,33 +608,58 @@ class BatchProductHelper implements Service {
 	}
 
 	/**
-	 * A stable hash of the ProductInput payload, used to skip re-syncing products
+	 * A stable hash of the ProductInput payload, used to skip re-syncing entries
 	 * whose Merchant API payload is unchanged since the last successful sync.
+	 *
+	 * The entry's resolved data source resource name is mixed into the hash. The
+	 * name embeds the Merchant Center account and the data source identity, so
+	 * connecting a different account or recreating a deleted data source changes
+	 * the hash, and an entry the destination has never received cannot be skipped
+	 * as "unchanged". Resolving also guarantees the data source exists before the
+	 * entry is submitted.
 	 *
 	 * @param ProductInput $input
 	 *
 	 * @return string
+	 * @throws MerchantApiException When resolving the entry's data source fails; callers
+	 *                              generating entries catch this per product.
 	 */
 	protected function product_input_hash( ProductInput $input ): string {
-		return md5( (string) wp_json_encode( $input->to_array() ) );
+		$data_source = $this->data_sources->ensure_data_source_for(
+			$input->get_content_language(),
+			$input->get_feed_label()
+		);
+
+		return md5( $data_source . (string) wp_json_encode( $input->to_array() ) );
 	}
 
 	/**
-	 * Whether a product can be skipped because its payload is unchanged since the last
-	 * successful sync. Products old enough to be due for expiry resubmission are never
-	 * skipped, and woocommerce_gla_force_product_resync forces a full re-sync.
+	 * Whether an entry can be skipped because its payload is unchanged since the last
+	 * successful sync of the same (content language, feed label) entry. Hashes are
+	 * stored keyed per entry; a legacy single-string value never matches, which forces
+	 * one full resubmission and migrates the meta to the keyed format. Products old
+	 * enough to be due for expiry resubmission are never skipped, and
+	 * woocommerce_gla_force_product_resync forces a full re-sync.
 	 *
 	 * @param WC_Product $product
-	 * @param string     $hash    The current ProductInput hash.
+	 * @param string     $hash             The current ProductInput hash.
+	 * @param string     $content_language The entry's content language.
+	 * @param string     $feed_label       The entry's feed label.
 	 *
 	 * @return bool
 	 */
-	protected function can_skip_unchanged_product( WC_Product $product, string $hash ): bool {
+	protected function can_skip_unchanged_product( WC_Product $product, string $hash, string $content_language, string $feed_label ): bool {
 		if ( apply_filters( 'woocommerce_gla_force_product_resync', false, $product ) ) {
 			return false;
 		}
 
-		if ( $this->meta_handler->get_sync_hash( $product ) !== $hash ) {
+		$hashes = $this->meta_handler->get_sync_hash( $product );
+
+		if ( ! is_array( $hashes ) ) {
+			return false;
+		}
+
+		if ( ( $hashes[ $content_language . '|' . $feed_label ] ?? null ) !== $hash ) {
 			return false;
 		}
 

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -616,7 +616,9 @@ class BatchProductHelper implements Service {
 	 * connecting a different account or recreating a deleted data source changes
 	 * the hash, and an entry the destination has never received cannot be skipped
 	 * as "unchanged". Resolving also guarantees the data source exists before the
-	 * entry is submitted.
+	 * entry is submitted. The resolution runs even for entries that are then
+	 * skipped as unchanged: the resource name is part of the hashed payload, so
+	 * it must be resolved before the skip check can compare hashes.
 	 *
 	 * @param ProductInput $input
 	 *
@@ -659,6 +661,8 @@ class BatchProductHelper implements Service {
 			return false;
 		}
 
+		// The "|" delimiter follows the same convention as the MapiDataSourcesService
+		// cache key; never reuse this key format with values that can contain "|".
 		if ( ( $hashes[ $content_language . '|' . $feed_label ] ?? null ) !== $hash ) {
 			return false;
 		}

--- a/src/Product/ProductHelper.php
+++ b/src/Product/ProductHelper.php
@@ -129,14 +129,27 @@ class ProductHelper implements Service {
 	}
 
 	/**
-	 * Store the hash of the ProductInput payload last successfully synced, used to
-	 * skip re-syncing unchanged products.
+	 * Store the hash of the ProductInput payload last successfully synced for one
+	 * (content language, feed label) entry, used to skip re-syncing unchanged
+	 * entries. Hashes are keyed per entry so a product synced to several markets
+	 * or languages tracks each one separately. A legacy single-string value is
+	 * replaced by the keyed format on the first write.
 	 *
 	 * @param WC_Product $product
 	 * @param string     $hash
+	 * @param string     $content_language The entry's content language.
+	 * @param string     $feed_label       The entry's feed label.
 	 */
-	public function update_sync_hash( WC_Product $product, string $hash ): void {
-		$this->meta_handler->update_sync_hash( $product, $hash );
+	public function update_sync_hash( WC_Product $product, string $hash, string $content_language, string $feed_label ): void {
+		$hashes = $this->meta_handler->get_sync_hash( $product );
+
+		if ( ! is_array( $hashes ) ) {
+			$hashes = [];
+		}
+
+		$hashes[ $content_language . '|' . $feed_label ] = $hash;
+
+		$this->meta_handler->update_sync_hash( $product, $hashes );
 	}
 
 	/**
@@ -144,6 +157,7 @@ class ProductHelper implements Service {
 	 */
 	public function mark_as_unsynced( $product ): void {
 		$this->meta_handler->delete_synced_at( $product );
+		$this->meta_handler->delete_sync_hash( $product );
 		if ( ! $this->is_sync_ready( $product ) ) {
 			$this->meta_handler->delete_sync_status( $product );
 		} else {

--- a/src/Product/ProductMetaHandler.php
+++ b/src/Product/ProductMetaHandler.php
@@ -75,7 +75,9 @@ class ProductMetaHandler implements Service, Registerable {
 		self::KEY_MC_STATUS              => 'string',
 		// Keyed by "{contentLanguage}|{feedLabel}"; a product tracks one hash per
 		// synced entry. Reads may still return a legacy string stored before this
-		// was an array, which consumers treat as no-match.
+		// was an array, which consumers treat as no-match. If a caller still passes
+		// a plain string, update() intentionally casts it to a single-element array;
+		// that array holds no entry key, so it is also treated as no-match.
 		self::KEY_SYNC_HASH              => 'array',
 	];
 

--- a/src/Product/ProductMetaHandler.php
+++ b/src/Product/ProductMetaHandler.php
@@ -44,9 +44,9 @@ defined( 'ABSPATH' ) || exit;
  * @method update_mc_status( WC_Product $product, string $value )
  * @method delete_mc_status( WC_Product $product )
  * @method get_mc_status( WC_Product $product ): string|null
- * @method update_sync_hash( WC_Product $product, string $value )
+ * @method update_sync_hash( WC_Product $product, array $value )
  * @method delete_sync_hash( WC_Product $product )
- * @method get_sync_hash( WC_Product $product ): string|null
+ * @method get_sync_hash( WC_Product $product ): array|string|null
  */
 class ProductMetaHandler implements Service, Registerable {
 
@@ -73,7 +73,10 @@ class ProductMetaHandler implements Service, Registerable {
 		self::KEY_SYNC_FAILED_AT         => 'int',
 		self::KEY_SYNC_STATUS            => 'string',
 		self::KEY_MC_STATUS              => 'string',
-		self::KEY_SYNC_HASH              => 'string',
+		// Keyed by "{contentLanguage}|{feedLabel}"; a product tracks one hash per
+		// synced entry. Reads may still return a legacy string stored before this
+		// was an array, which consumers treat as no-match.
+		self::KEY_SYNC_HASH              => 'array',
 	];
 
 	/**

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -150,7 +150,12 @@ class ProductSyncer implements Service {
 					$this->batch_helper->mark_as_synced( $synced_entry );
 
 					if ( isset( $entry['hash'] ) ) {
-						$this->product_helper->update_sync_hash( $entry['product'], $entry['hash'] );
+						$this->product_helper->update_sync_hash(
+							$entry['product'],
+							$entry['hash'],
+							$entry['input']->get_content_language(),
+							$entry['input']->get_feed_label()
+						);
 					}
 				} elseif ( isset( $result['failures'][ $index ] ) ) {
 					$invalid_entry = $this->build_invalid_entry( $entry['product']->get_id(), $result['failures'][ $index ] );

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -149,7 +149,7 @@ class ProductSyncer implements Service {
 					$updated_products[] = $synced_entry;
 					$this->batch_helper->mark_as_synced( $synced_entry );
 
-					if ( isset( $entry['hash'] ) ) {
+					if ( isset( $entry['hash'], $entry['input'] ) ) {
 						$this->product_helper->update_sync_hash(
 							$entry['product'],
 							$entry['hash'],

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -25,6 +25,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Containe
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingContent;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
@@ -133,7 +134,8 @@ class MerchantStatusesTest extends UnitTest {
 				$this->createMock( AttributeMappingRulesQuery::class ),
 				$this->createMock( MarketService::class ),
 				$this->createMock( WPML::class ),
-				$this->createMock( AttributeManager::class )
+				$this->createMock( AttributeManager::class ),
+				$this->createMock( MapiDataSourcesService::class )
 			)
 		);
 

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidClass;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
@@ -70,6 +71,9 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 
 	/** @var AttributeMappingRulesQuery $rules_query */
 	protected $rules_query;
+
+	/** @var MockObject|MapiDataSourcesService $data_sources */
+	protected $data_sources;
 
 	/**
 	 * Converted price per currency code returned by the WPML stub configured in
@@ -886,7 +890,8 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			$this->rules_query,
 			$this->market_service,
 			$this->wpml,
-			$this->container->get( AttributeManager::class )
+			$this->container->get( AttributeManager::class ),
+			$this->data_sources
 		);
 
 		$this->set_up_market_service_stubs(
@@ -1327,7 +1332,8 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			$this->rules_query,
 			$this->market_service,
 			$this->wpml,
-			$this->container->get( AttributeManager::class )
+			$this->container->get( AttributeManager::class ),
+			$this->data_sources
 		);
 
 		$this->set_up_market_service_stubs(
@@ -1382,7 +1388,8 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			$this->rules_query,
 			$this->market_service,
 			$this->wpml,
-			$this->container->get( AttributeManager::class )
+			$this->container->get( AttributeManager::class ),
+			$this->data_sources
 		);
 
 		$this->set_up_market_service_stubs(
@@ -1437,7 +1444,8 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			$this->rules_query,
 			$this->market_service,
 			$this->wpml,
-			$this->container->get( AttributeManager::class )
+			$this->container->get( AttributeManager::class ),
+			$this->data_sources
 		);
 
 		$this->set_up_market_service_stubs(
@@ -1499,7 +1507,8 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			$this->rules_query,
 			$this->market_service,
 			$this->wpml,
-			$this->container->get( AttributeManager::class )
+			$this->container->get( AttributeManager::class ),
+			$this->data_sources
 		);
 
 		$this->set_up_market_service_stubs(
@@ -1553,7 +1562,8 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			$this->rules_query,
 			$this->market_service,
 			$this->wpml,
-			$this->container->get( AttributeManager::class )
+			$this->container->get( AttributeManager::class ),
+			$this->data_sources
 		);
 
 		$this->set_up_market_service_stubs(
@@ -1843,10 +1853,11 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		// First pass builds the entry and its payload hash.
 		$entries = $this->batch_product_helper->generate_mapi_update_entries( [ $product ] );
 		$this->assertCount( 1, $entries );
-		$hash = $entries[0]['hash'];
+		$hash      = $entries[0]['hash'];
+		$entry_key = $entries[0]['input']->get_content_language() . '|' . $entries[0]['input']->get_feed_label();
 
 		// Simulate a successful sync of that payload.
-		$this->product_meta->update_sync_hash( $product, $hash );
+		$this->product_meta->update_sync_hash( $product, [ $entry_key => $hash ] );
 		$this->product_meta->update_synced_at( $product, time() );
 
 		// Unchanged and recently synced: skipped.
@@ -1872,9 +1883,10 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
 		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
 
-		$product = WC_Helper_Product::create_simple_product();
-		$entries = $this->batch_product_helper->generate_mapi_update_entries( [ $product ] );
-		$this->product_meta->update_sync_hash( $product, $entries[0]['hash'] );
+		$product   = WC_Helper_Product::create_simple_product();
+		$entries   = $this->batch_product_helper->generate_mapi_update_entries( [ $product ] );
+		$entry_key = $entries[0]['input']->get_content_language() . '|' . $entries[0]['input']->get_feed_label();
+		$this->product_meta->update_sync_hash( $product, [ $entry_key => $entries[0]['hash'] ] );
 		$this->product_meta->update_synced_at( $product, time() );
 
 		// Would be skipped without the filter.
@@ -1902,9 +1914,10 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
 		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
 
-		$product = WC_Helper_Product::create_simple_product();
-		$entries = $this->batch_product_helper->generate_mapi_update_entries( [ $product ] );
-		$this->product_meta->update_sync_hash( $product, $entries[0]['hash'] );
+		$product   = WC_Helper_Product::create_simple_product();
+		$entries   = $this->batch_product_helper->generate_mapi_update_entries( [ $product ] );
+		$entry_key = $entries[0]['input']->get_content_language() . '|' . $entries[0]['input']->get_feed_label();
+		$this->product_meta->update_sync_hash( $product, [ $entry_key => $entries[0]['hash'] ] );
 		// Synced 30 days ago: past the 25-day resubmission window.
 		$this->product_meta->update_synced_at( $product, time() - ( 30 * DAY_IN_SECONDS ) );
 
@@ -1920,6 +1933,126 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		remove_all_filters( 'woocommerce_gla_sync_hash_freshness' );
 
 		$this->assertCount( 1, $entries2 );
+	}
+
+	public function test_skip_is_scoped_to_the_entry_own_key() {
+		$this->set_up_market_service_stubs(
+			[ 'US', 'DE' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => 'en',
+				],
+				'de'      => [
+					'country'    => 'DE',
+					'feed_label' => 'DE',
+					'language'   => [ 'de' ],
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$entries = $this->batch_product_helper->generate_mapi_update_entries( [ $product ] );
+		$this->assertCount( 2, $entries );
+
+		$first_key    = $entries[0]['input']->get_content_language() . '|' . $entries[0]['input']->get_feed_label();
+		$second_label = $entries[1]['input']->get_feed_label();
+
+		// Only the first entry was successfully synced.
+		$this->product_meta->update_sync_hash( $product, [ $first_key => $entries[0]['hash'] ] );
+		$this->product_meta->update_synced_at( $product, time() );
+
+		// The first entry is skipped by its own key; the second entry is not
+		// skipped by the first entry's hash and is generated again.
+		$remaining = $this->batch_product_helper->generate_mapi_update_entries( [ $product ] );
+		$this->assertCount( 1, $remaining );
+		$this->assertSame( $second_label, $remaining[0]['input']->get_feed_label() );
+	}
+
+	public function test_legacy_string_sync_hash_never_matches() {
+		$this->set_up_market_service_stubs(
+			[ 'US' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => 'en',
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$entries = $this->batch_product_helper->generate_mapi_update_entries( [ $product ] );
+		$this->assertCount( 1, $entries );
+
+		// Store the matching hash in the legacy single-string format, written
+		// directly because the meta handler now casts values to the keyed array.
+		$product->update_meta_data( '_wc_gla_sync_hash', $entries[0]['hash'] );
+		$product->save_meta_data();
+		$this->product_meta->update_synced_at( $product, time() );
+
+		// A legacy value never matches, so the entry is resubmitted and the
+		// meta migrates to the keyed format on the next successful sync.
+		$this->assertCount( 1, $this->batch_product_helper->generate_mapi_update_entries( [ $product ] ) );
+	}
+
+	public function test_data_source_name_change_invalidates_the_stored_hash() {
+		$this->set_up_market_service_stubs(
+			[ 'US' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => 'en',
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$build_helper = function ( string $data_source_name ): BatchProductHelper {
+			$data_sources = $this->createMock( MapiDataSourcesService::class );
+			$data_sources->method( 'ensure_data_source_for' )->willReturn( $data_source_name );
+
+			return new BatchProductHelper(
+				$this->product_meta,
+				$this->product_helper,
+				$this->validator,
+				$this->product_factory,
+				$this->rules_query,
+				$this->market_service,
+				$this->wpml,
+				$this->container->get( AttributeManager::class ),
+				$data_sources
+			);
+		};
+
+		$product        = WC_Helper_Product::create_simple_product();
+		$helper_first   = $build_helper( 'accounts/1/dataSources/111' );
+		$entries_first  = $helper_first->generate_mapi_update_entries( [ $product ] );
+		$this->assertCount( 1, $entries_first );
+
+		$entry_key = $entries_first[0]['input']->get_content_language() . '|' . $entries_first[0]['input']->get_feed_label();
+		$this->product_meta->update_sync_hash( $product, [ $entry_key => $entries_first[0]['hash'] ] );
+		$this->product_meta->update_synced_at( $product, time() );
+
+		// Same data source: the unchanged payload is skipped.
+		$this->assertEmpty( $helper_first->generate_mapi_update_entries( [ $product ] ) );
+
+		// The data source was recreated (or the account changed): the resource
+		// name differs, the hash no longer matches, and the entry resubmits.
+		$helper_second  = $build_helper( 'accounts/1/dataSources/222' );
+		$entries_second = $helper_second->generate_mapi_update_entries( [ $product ] );
+		$this->assertCount( 1, $entries_second );
+		$this->assertNotSame( $entries_first[0]['hash'], $entries_second[0]['hash'] );
 	}
 
 	/**
@@ -2046,6 +2179,7 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->wpml                 = $this->createMock( WPML::class );
 		$this->validator            = $this->createMock( ValidatorInterface::class );
 		$this->rules_query          = $this->createMock( AttributeMappingRulesQuery::class );
+		$this->data_sources         = $this->createMock( MapiDataSourcesService::class );
 		$this->product_meta         = $this->container->get( ProductMetaHandler::class );
 		$this->wc                   = $this->container->get( WC::class );
 		$this->product_factory      = $this->container->get( ProductFactory::class );
@@ -2058,7 +2192,8 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			$this->rules_query,
 			$this->market_service,
 			$this->wpml,
-			$this->container->get( AttributeManager::class )
+			$this->container->get( AttributeManager::class ),
+			$this->data_sources
 		);
 	}
 }

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -2035,9 +2035,9 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			);
 		};
 
-		$product        = WC_Helper_Product::create_simple_product();
-		$helper_first   = $build_helper( 'accounts/1/dataSources/111' );
-		$entries_first  = $helper_first->generate_mapi_update_entries( [ $product ] );
+		$product       = WC_Helper_Product::create_simple_product();
+		$helper_first  = $build_helper( 'accounts/1/dataSources/111' );
+		$entries_first = $helper_first->generate_mapi_update_entries( [ $product ] );
 		$this->assertCount( 1, $entries_first );
 
 		$entry_key = $entries_first[0]['input']->get_content_language() . '|' . $entries_first[0]['input']->get_feed_label();

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
@@ -2053,6 +2054,32 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$entries_second = $helper_second->generate_mapi_update_entries( [ $product ] );
 		$this->assertCount( 1, $entries_second );
 		$this->assertNotSame( $entries_first[0]['hash'], $entries_second[0]['hash'] );
+	}
+
+	public function test_data_source_resolution_failure_skips_the_product() {
+		$this->set_up_market_service_stubs(
+			[ 'US' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => 'en',
+				],
+			]
+		);
+
+		$this->validator->expects( $this->any() )->method( 'validate' )->willReturn( [] );
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$this->data_sources->method( 'ensure_data_source_for' )
+			->willThrowException( new MerchantApiException( 500, [], __METHOD__ ) );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		// The resolution failure is caught per product inside
+		// generate_mapi_update_entries(); the product is skipped and the
+		// exception does not fail the whole batch.
+		$this->assertSame( [], $this->batch_product_helper->generate_mapi_update_entries( [ $product ] ) );
 	}
 
 	/**

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -358,6 +358,8 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 
 		// First mark the product as synced to update its meta data
 		$this->product_helper->mark_as_synced( $variation, $this->generate_google_product_mock() );
+		$this->product_helper->update_sync_hash( $variation, 'somehash', 'en', 'US' );
+		$this->product_helper->update_sync_hash( $parent, 'somehash', 'en', 'US' );
 
 		$this->product_helper->mark_as_unsynced( $variation );
 
@@ -371,6 +373,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 			$this->assertEmpty( $this->product_meta->get_errors( $product ) );
 			$this->assertEmpty( $this->product_meta->get_failed_sync_attempts( $product ) );
 			$this->assertEmpty( $this->product_meta->get_sync_failed_at( $product ) );
+			$this->assertEmpty( $this->product_meta->get_sync_hash( $product ) );
 		}
 	}
 
@@ -380,6 +383,8 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 
 		// First mark the product as synced to update its meta data
 		$this->product_helper->mark_as_synced( $variation, $this->generate_google_product_mock() );
+		$this->product_helper->update_sync_hash( $variation, 'somehash', 'en', 'US' );
+		$this->product_helper->update_sync_hash( $parent, 'somehash', 'en', 'US' );
 
 		// make the variation orphan by setting its parent to 0
 		$variation->set_parent_id( 0 );
@@ -395,10 +400,12 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		// will be deleted when calling mark_as_unsynced.
 		$this->assertEquals( null, $this->product_meta->get_sync_status( $variation ) );
 		$this->assertEmpty( $this->product_meta->get_google_ids( $variation ) );
+		$this->assertEmpty( $this->product_meta->get_sync_hash( $variation ) );
 
 		$this->assertNotEmpty( $this->product_meta->get_synced_at( $parent ) );
 		$this->assertEquals( SyncStatus::SYNCED, $this->product_meta->get_sync_status( $parent ) );
 		$this->assertNotEmpty( $this->product_meta->get_google_ids( $parent ) );
+		$this->assertSame( [ 'en|US' => 'somehash' ], $this->product_meta->get_sync_hash( $parent ) );
 	}
 
 	/**

--- a/tests/Unit/Product/ProductHelperTest.php
+++ b/tests/Unit/Product/ProductHelperTest.php
@@ -287,6 +287,7 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		$product = call_user_func( $callback );
 		// First mark the product as synced to update its meta data
 		$this->product_helper->mark_as_synced( $product, $this->generate_google_product_mock() );
+		$this->product_helper->update_sync_hash( $product, 'somehash', 'en', 'US' );
 
 		$this->product_helper->mark_as_unsynced( $product );
 
@@ -296,6 +297,42 @@ class ProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertEmpty( $this->product_meta->get_errors( $product ) );
 		$this->assertEmpty( $this->product_meta->get_failed_sync_attempts( $product ) );
 		$this->assertEmpty( $this->product_meta->get_sync_failed_at( $product ) );
+		$this->assertEmpty( $this->product_meta->get_sync_hash( $product ) );
+	}
+
+	public function test_update_sync_hash_keys_by_language_and_feed_label() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->product_helper->update_sync_hash( $product, 'hash-us', 'en', 'US' );
+		$this->product_helper->update_sync_hash( $product, 'hash-de', 'de', 'DE-DE-EUR' );
+
+		$this->assertSame(
+			[
+				'en|US'        => 'hash-us',
+				'de|DE-DE-EUR' => 'hash-de',
+			],
+			$this->product_meta->get_sync_hash( $product )
+		);
+
+		// Updating one entry leaves the other keys untouched.
+		$this->product_helper->update_sync_hash( $product, 'hash-us-2', 'en', 'US' );
+		$this->assertSame(
+			[
+				'en|US'        => 'hash-us-2',
+				'de|DE-DE-EUR' => 'hash-de',
+			],
+			$this->product_meta->get_sync_hash( $product )
+		);
+	}
+
+	public function test_update_sync_hash_replaces_a_legacy_string_value() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->update_meta_data( '_wc_gla_sync_hash', 'legacy-hash' );
+		$product->save_meta_data();
+
+		$this->product_helper->update_sync_hash( $product, 'hash-us', 'en', 'US' );
+
+		$this->assertSame( [ 'en|US' => 'hash-us' ], $this->product_meta->get_sync_hash( $product ) );
 	}
 
 	public function test_mark_as_unsynced_remove_sync_status_for_unsyncable_products() {

--- a/tests/Unit/Product/ProductMetaHandlerTest.php
+++ b/tests/Unit/Product/ProductMetaHandlerTest.php
@@ -86,6 +86,15 @@ class ProductMetaHandlerTest extends WP_UnitTestCase {
 		$this->assertEquals( 12345, $value );
 	}
 
+	public function test_sync_hash_stores_and_returns_the_keyed_array() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->product_meta_handler->update( $product, ProductMetaHandler::KEY_SYNC_HASH, [ 'en|US' => 'hash-a' ] );
+
+		$this->assertSame( [ 'en|US' => 'hash-a' ], $product->get_meta( '_wc_gla_sync_hash', true ) );
+		$this->assertSame( [ 'en|US' => 'hash-a' ], $this->product_meta_handler->get( $product, ProductMetaHandler::KEY_SYNC_HASH ) );
+	}
+
 	public function test_update_throws_exception_invalid_meta_key() {
 		$this->expectException( InvalidMeta::class );
 		$this->product_meta_handler->update( $this->generate_simple_product_mock(), 'invalid_meta_key_test', 1 );

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
@@ -89,6 +90,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 										$this->market_service,
 										$this->createMock( WPML::class ),
 										$this->container->get( AttributeManager::class ),
+										$this->createMock( MapiDataSourcesService::class ),
 									]
 								)
 								->getMock();
@@ -185,6 +187,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 										$this->market_service,
 										$this->createMock( WPML::class ),
 										$this->container->get( AttributeManager::class ),
+										$this->createMock( MapiDataSourcesService::class ),
 									]
 								)
 								->getMock();
@@ -255,6 +258,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 										$this->market_service,
 										$this->createMock( WPML::class ),
 										$this->container->get( AttributeManager::class ),
+										$this->createMock( MapiDataSourcesService::class ),
 									]
 								)
 								->getMock();
@@ -317,6 +321,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 										$this->market_service,
 										$this->createMock( WPML::class ),
 										$this->container->get( AttributeManager::class ),
+										$this->createMock( MapiDataSourcesService::class ),
 									]
 								)
 								->getMock();
@@ -351,7 +356,8 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 
 		$this->get_product_syncer( [ 'batch_helper' => $batch_helper ] )->update( $synced_products );
 
-		$this->assertEquals( 'testhash123', $this->product_meta->get_sync_hash( $product ) );
+		// The hash is stored under the entry's own (content language, feed label) key.
+		$this->assertEquals( [ 'en|US' => 'testhash123' ], $this->product_meta->get_sync_hash( $product ) );
 	}
 
 	public function test_update_connection_errors_are_retried_not_dropped() {
@@ -369,6 +375,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 										$this->market_service,
 										$this->createMock( WPML::class ),
 										$this->container->get( AttributeManager::class ),
+										$this->createMock( MapiDataSourcesService::class ),
 									]
 								)
 								->getMock();
@@ -426,6 +433,7 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 										$this->market_service,
 										$this->createMock( WPML::class ),
 										$this->container->get( AttributeManager::class ),
+										$this->createMock( MapiDataSourcesService::class ),
 									]
 								)
 								->getMock();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-831/no-feed-generated-for-primary-market-and-syncing-products-throws


### Screenshots:

N/A


### Detailed test instructions:

Prerequisites

- A test store running WooCommerce and this build of Google for WooCommerce, fully onboarded to a real Google Merchant Centre account you control. Scenario 2 needs a second Merchant Centre account.
- At least 5 published, sync-ready simple products.

**Scenario 1: unchanged products are skipped correctly on a multi-market store**

- On the plugin's Markets page, add a secondary market for a country not already targeted, priced in the store currency.
- Sync. Expected: submissions succeed with no errors, and Merchant Centre shows a feed per market, each holding every product.
- Sync again with no changes. Expected: "0 products successfully submitted to Google." and no errors. (Before this fix, a store with more than one market resubmitted entries on every sync.)
- Edit one product's title, then sync.

Expected: only that product is resubmitted, once per market it belongs to.


**Scenario 2: reconnecting to a different Merchant Centre account repopulates every feed**

- With the store synced from scenario 1, disconnect the Google connection from the plugin's settings.
- Complete onboarding again using a different Merchant Centre account.
- Sync.

Expected: every product submits, and the new account's Data sources page shows every market's feed with the full product count. (Before this fix, products could be silently skipped as already synced, leaving the primary market's feed missing in the new account, which is this ticket's headline symptom.)

**Scenario 3: a feed deleted in Merchant Centre is rebuilt**

- With the store synced, delete one of the plugin's data sources in Merchant Centre (Settings, Data sources, the row's three-dot Actions menu).
- On the store, run `wp option delete gla_mapi_data_sources`. This clears the plugin's cached feed references; the cache going stale is a separate known issue tracked as GOOWOO-832 and is not part of this change.
- Sync.

Expected: the deleted feed is recreated and repopulated with every product, with no errors.

**Scenario 4: upgrading from a previous build resubmits once, then settles**

- On a store synced using the previous build, upgrade the plugin to this build and change nothing else.
- Sync.

Expected: every product resubmits (stored sync state migrates to a new per-feed format).

- Sync again.

Expected: "0 products successfully submitted to Google." and no errors.

### Additional details:

> Fix - No feed generated for primary market, and syncing products throws internal errors after adding Cameroon as secondary market