### PR TITLE
GOOWOO-836 Update notifications condition to rely on Ads setup complete

### DIFF
--- a/src/Notification/Evaluators/EnhancedConversionsOffEvaluator.php
+++ b/src/Notification/Evaluators/EnhancedConversionsOffEvaluator.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class EnhancedConversionsOffEvaluator
  *
- * Fires when Ads setup is complete and enhanced conversions are disabled.
+ * Fires when the Ads account is connected and enhanced conversions are disabled.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
  */
@@ -42,7 +42,7 @@ class EnhancedConversionsOffEvaluator implements NotificationEvaluatorInterface,
 	 * @return bool
 	 */
 	public function should_show(): bool {
-		if ( ! $this->ads_service->is_setup_complete() ) {
+		if ( ! $this->ads_service->connected_account() ) {
 			return false;
 		}
 

--- a/tests/Unit/Notification/Evaluators/EnhancedConversionsOffEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/EnhancedConversionsOffEvaluatorTest.php
@@ -55,8 +55,8 @@ class EnhancedConversionsOffEvaluatorTest extends UnitTest {
 		$this->assertEquals( NotificationSnoozeDurations::ENHANCED_CONVERSIONS_OFF, $this->evaluator->get_snooze_duration() );
 	}
 
-	public function test_should_show_when_ads_complete_and_enhanced_conversions_disabled() {
-		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+	public function test_should_show_when_ads_account_connected_and_enhanced_conversions_disabled() {
+		$this->ads_service->method( 'connected_account' )->willReturn( true );
 		$this->options->method( 'get' )
 			->with( OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED, false )
 			->willReturn( false );
@@ -64,14 +64,14 @@ class EnhancedConversionsOffEvaluatorTest extends UnitTest {
 		$this->assertTrue( $this->evaluator->should_show() );
 	}
 
-	public function test_should_not_show_when_ads_incomplete() {
-		$this->ads_service->method( 'is_setup_complete' )->willReturn( false );
+	public function test_should_not_show_when_ads_account_not_connected() {
+		$this->ads_service->method( 'connected_account' )->willReturn( false );
 
 		$this->assertFalse( $this->evaluator->should_show() );
 	}
 
 	public function test_should_not_show_when_enhanced_conversions_enabled() {
-		$this->ads_service->method( 'is_setup_complete' )->willReturn( true );
+		$this->ads_service->method( 'connected_account' )->willReturn( true );
 		$this->options->method( 'get' )
 			->with( OptionsInterface::ADS_ENHANCED_CONVERSIONS_ENABLED, false )
 			->willReturn( true );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-836/fix-enhancedconversionsoffevaluator-checks-ads-setup-complete-instead

Changes the enhanced-conversions-off notification condition to be tied to whether Ads account connected, not whether full Ads setup finished.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the plugin's Ads onboarding flow.
2. Connect a Google Ads account, and skip campaign creation
4. In the plugin area, check that the enhanced-conversions-off notification now appears, even though Ads onboarding isn't fully complete (since campaign creation was skipped).
5. Enable enhanced conversions and confirm the notification disappears.
6. Disable enhanced conversions again, but disconnect the Ads account entirely and check if the notification stays hidden.
7. Reconnect the Ads account with enhanced conversions still off, the notification should reappear.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Update condition that displays notification to rely on ads setup complete
