### PR TITLE
GOOWOO 825: Notifications: Update evaluator names and ids

### DIFF
--- a/js/src/notifications-system/useNotificationsSystemMap.js
+++ b/js/src/notifications-system/useNotificationsSystemMap.js
@@ -78,7 +78,7 @@ const STATIC_MAP = {
 			},
 		],
 	},
-	'sold-10-items': {
+	'paid-orders': {
 		title: __(
 			'Drive more sales with Google Ads',
 			'google-listings-and-ads'
@@ -88,7 +88,7 @@ const STATIC_MAP = {
 				"Congrats on your first 10 sales – now let's find your next customer. Reach high-intent shoppers across Google. Get $500 USD or more in Google ad credit. Offer for new advertisers only. <link>Terms apply.</link>",
 				'google-listings-and-ads'
 			),
-			{ link: <TermsApplyLink linkId="sold-10-items" /> }
+			{ link: <TermsApplyLink linkId="paid-orders" /> }
 		),
 		actions: [
 			{

--- a/js/src/notifications-system/useNotificationsSystemMap.js
+++ b/js/src/notifications-system/useNotificationsSystemMap.js
@@ -267,7 +267,7 @@ const useNotificationsSystemMap = () => {
 					},
 				],
 			},
-			'not-onboarded-90-days': {
+			'not-onboarded': {
 				isReady: hasFinishedResolution,
 				title: __(
 					'Finish your Google for WooCommerce connection',

--- a/src/Internal/DependencyManagement/NotificationsServiceProvider.php
+++ b/src/Internal/DependencyManagement/NotificationsServiceProvider.php
@@ -13,7 +13,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\Abandone
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CampaignNoSalesEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CouponsNotSyncedEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\EnhancedConversionsOffEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\NotOnboarded90DaysEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\NotOnboardedEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\PausedCampaignEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ProductIssuesEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ReadyButNoSalesEvaluator;
@@ -55,7 +55,7 @@ class NotificationsServiceProvider extends AbstractServiceProvider {
 		CampaignNoSalesEvaluator::class          => true,
 		CouponsNotSyncedEvaluator::class         => true,
 		EnhancedConversionsOffEvaluator::class   => true,
-		NotOnboarded90DaysEvaluator::class       => true,
+		NotOnboardedEvaluator::class             => true,
 		PausedCampaignEvaluator::class           => true,
 		ProductIssuesEvaluator::class            => true,
 		ReadyButNoSalesEvaluator::class          => true,
@@ -74,7 +74,7 @@ class NotificationsServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( NotificationCacheInvalidator::class );
 		$this->share_with_tags( SkippedCampaignEvaluator::class, AdsCampaign::class, OnboardingCompleted::class, ServiceBasedMerchantState::class );
 		$this->share_with_tags( AbandonedOnboardingEvaluator::class );
-		$this->share_with_tags( NotOnboarded90DaysEvaluator::class, OnboardingCompleted::class );
+		$this->share_with_tags( NotOnboardedEvaluator::class, OnboardingCompleted::class );
 		$this->share_with_tags( EnhancedConversionsOffEvaluator::class );
 		$this->share_with_tags( TrackingOffEvaluator::class );
 		$this->share_with_tags( ProductIssuesEvaluator::class, ServiceBasedMerchantState::class );

--- a/src/Internal/DependencyManagement/NotificationsServiceProvider.php
+++ b/src/Internal/DependencyManagement/NotificationsServiceProvider.php
@@ -20,7 +20,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ReadyBut
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\RecommendationsAvailableEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SalesNotGrowingEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\Sold10ItemsEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\PaidOrdersEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\TrackingOffEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationCacheInvalidator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
@@ -62,7 +62,7 @@ class NotificationsServiceProvider extends AbstractServiceProvider {
 		RecommendationsAvailableEvaluator::class => true,
 		SalesNotGrowingEvaluator::class          => true,
 		SkippedCampaignEvaluator::class          => true,
-		Sold10ItemsEvaluator::class              => true,
+		PaidOrdersEvaluator::class               => true,
 		TrackingOffEvaluator::class              => true,
 	];
 
@@ -78,7 +78,7 @@ class NotificationsServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( EnhancedConversionsOffEvaluator::class );
 		$this->share_with_tags( TrackingOffEvaluator::class );
 		$this->share_with_tags( ProductIssuesEvaluator::class, ServiceBasedMerchantState::class );
-		$this->share_with_tags( Sold10ItemsEvaluator::class );
+		$this->share_with_tags( PaidOrdersEvaluator::class );
 		$this->share_with_tags( ReadyButNoSalesEvaluator::class, WC::class );
 		$this->share_with_tags( CouponsNotSyncedEvaluator::class, MerchantCenterService::class, TargetAudience::class );
 		$this->share_with_tags( SalesNotGrowingEvaluator::class );

--- a/src/Internal/DependencyManagement/NotificationsServiceProvider.php
+++ b/src/Internal/DependencyManagement/NotificationsServiceProvider.php
@@ -19,7 +19,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ProductI
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ReadyButNoSalesEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\RecommendationsAvailableEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SalesNotGrowingEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignCreationEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\PaidOrdersEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\TrackingOffEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationCacheInvalidator;
@@ -61,7 +61,7 @@ class NotificationsServiceProvider extends AbstractServiceProvider {
 		ReadyButNoSalesEvaluator::class          => true,
 		RecommendationsAvailableEvaluator::class => true,
 		SalesNotGrowingEvaluator::class          => true,
-		SkippedCampaignEvaluator::class          => true,
+		SkippedCampaignCreationEvaluator::class  => true,
 		PaidOrdersEvaluator::class               => true,
 		TrackingOffEvaluator::class              => true,
 	];
@@ -72,7 +72,7 @@ class NotificationsServiceProvider extends AbstractServiceProvider {
 	public function register(): void {
 		$this->share_with_tags( NotificationService::class, WP::class );
 		$this->share_with_tags( NotificationCacheInvalidator::class );
-		$this->share_with_tags( SkippedCampaignEvaluator::class, AdsCampaign::class, OnboardingCompleted::class, ServiceBasedMerchantState::class );
+		$this->share_with_tags( SkippedCampaignCreationEvaluator::class, AdsCampaign::class, OnboardingCompleted::class, ServiceBasedMerchantState::class );
 		$this->share_with_tags( AbandonedOnboardingEvaluator::class );
 		$this->share_with_tags( NotOnboardedEvaluator::class, OnboardingCompleted::class );
 		$this->share_with_tags( EnhancedConversionsOffEvaluator::class );

--- a/src/Notification/Evaluators/NotOnboardedEvaluator.php
+++ b/src/Notification/Evaluators/NotOnboardedEvaluator.php
@@ -17,7 +17,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WPAwareTrait;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class NotOnboarded90DaysEvaluator
+ * Class NotOnboardedEvaluator
  *
  * Fires when Google for WooCommerce onboarding is not complete, WooCommerce onboarding
  * has been completed or skipped, and either WooCommerce or the plugin has been active
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
  */
-class NotOnboarded90DaysEvaluator implements NotificationEvaluatorInterface, OptionsAwareInterface, WPAwareInterface, Service {
+class NotOnboardedEvaluator implements NotificationEvaluatorInterface, OptionsAwareInterface, WPAwareInterface, Service {
 
 	use OptionsAwareTrait;
 	use WPAwareTrait;
@@ -39,7 +39,7 @@ class NotOnboarded90DaysEvaluator implements NotificationEvaluatorInterface, Opt
 	private $onboarding_completed;
 
 	/**
-	 * NotOnboarded90DaysEvaluator constructor.
+	 * NotOnboardedEvaluator constructor.
 	 *
 	 * @param OnboardingCompleted $onboarding_completed
 	 */
@@ -53,7 +53,7 @@ class NotOnboarded90DaysEvaluator implements NotificationEvaluatorInterface, Opt
 	 * @return string
 	 */
 	public function get_id(): string {
-		return 'not-onboarded-90-days';
+		return 'not-onboarded';
 	}
 
 	/**
@@ -85,7 +85,7 @@ class NotOnboarded90DaysEvaluator implements NotificationEvaluatorInterface, Opt
 	 * @return int
 	 */
 	public function get_priority(): int {
-		return NotificationPriorities::NOT_ONBOARDED_90_DAYS;
+		return NotificationPriorities::NOT_ONBOARDED;
 	}
 
 	/**
@@ -94,7 +94,7 @@ class NotOnboarded90DaysEvaluator implements NotificationEvaluatorInterface, Opt
 	 * @return int|null
 	 */
 	public function get_snooze_duration(): ?int {
-		return NotificationSnoozeDurations::NOT_ONBOARDED_90_DAYS;
+		return NotificationSnoozeDurations::NOT_ONBOARDED;
 	}
 
 	/**

--- a/src/Notification/Evaluators/PaidOrdersEvaluator.php
+++ b/src/Notification/Evaluators/PaidOrdersEvaluator.php
@@ -13,13 +13,13 @@ use Automattic\WooCommerce\Utilities\OrderUtil;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class Sold10ItemsEvaluator
+ * Class PaidOrdersEvaluator
  *
  * Fires once the merchant has 10 or more paid WooCommerce orders with revenue.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
  */
-class Sold10ItemsEvaluator implements SiteScopedNotificationEvaluatorInterface, Service {
+class PaidOrdersEvaluator implements SiteScopedNotificationEvaluatorInterface, Service {
 
 	use CachedNotificationEvaluatorTrait;
 
@@ -31,7 +31,7 @@ class Sold10ItemsEvaluator implements SiteScopedNotificationEvaluatorInterface, 
 	 * @return string
 	 */
 	public function get_id(): string {
-		return 'sold-10-items';
+		return 'paid-orders';
 	}
 
 	/**
@@ -49,7 +49,7 @@ class Sold10ItemsEvaluator implements SiteScopedNotificationEvaluatorInterface, 
 	 * @return int
 	 */
 	public function get_priority(): int {
-		return NotificationPriorities::SOLD_10_ITEMS;
+		return NotificationPriorities::PAID_ORDERS;
 	}
 
 	/**
@@ -58,7 +58,7 @@ class Sold10ItemsEvaluator implements SiteScopedNotificationEvaluatorInterface, 
 	 * @return int|null
 	 */
 	public function get_snooze_duration(): ?int {
-		return NotificationSnoozeDurations::SOLD_10_ITEMS;
+		return NotificationSnoozeDurations::PAID_ORDERS;
 	}
 
 	/**

--- a/src/Notification/Evaluators/SkippedCampaignCreationEvaluator.php
+++ b/src/Notification/Evaluators/SkippedCampaignCreationEvaluator.php
@@ -21,7 +21,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\ServiceBasedMerchantStat
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class SkippedCampaignEvaluator
+ * Class SkippedCampaignCreationEvaluator
  *
  * Fires when the merchant finished onboarding but skipped campaign creation: onboarding
  * is complete and the account has no enabled Performance Max campaigns — including any
@@ -38,7 +38,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
  */
-class SkippedCampaignEvaluator implements InvalidatableNotificationEvaluatorInterface, AdsAwareInterface, OptionsAwareInterface, Service {
+class SkippedCampaignCreationEvaluator implements InvalidatableNotificationEvaluatorInterface, AdsAwareInterface, OptionsAwareInterface, Service {
 
 	use AdsAwareTrait;
 	use CachedNotificationEvaluatorTrait;
@@ -54,7 +54,7 @@ class SkippedCampaignEvaluator implements InvalidatableNotificationEvaluatorInte
 	private $service_based_merchant_state;
 
 	/**
-	 * SkippedCampaignEvaluator constructor.
+	 * SkippedCampaignCreationEvaluator constructor.
 	 *
 	 * @param AdsCampaign               $ads_campaign
 	 * @param OnboardingCompleted       $onboarding_completed

--- a/src/Notification/NotificationPriorities.php
+++ b/src/Notification/NotificationPriorities.php
@@ -20,7 +20,7 @@ class NotificationPriorities {
 	public const NOT_ONBOARDED_90_DAYS     = 40;
 	public const ENHANCED_CONVERSIONS_OFF  = 50;
 	public const TRACKING_OFF              = 60;
-	public const SOLD_10_ITEMS             = 70;
+	public const PAID_ORDERS               = 70;
 	public const READY_BUT_NO_SALES        = 80;
 	public const COUPONS_NOT_SYNCED        = 90;
 	public const SALES_NOT_GROWING         = 100;

--- a/src/Notification/NotificationPriorities.php
+++ b/src/Notification/NotificationPriorities.php
@@ -17,7 +17,7 @@ class NotificationPriorities {
 	public const PRODUCT_ISSUES            = 10;
 	public const SKIPPED_CAMPAIGN_CREATION = 20;
 	public const ABANDONED_ONBOARDING      = 30;
-	public const NOT_ONBOARDED_90_DAYS     = 40;
+	public const NOT_ONBOARDED             = 40;
 	public const ENHANCED_CONVERSIONS_OFF  = 50;
 	public const TRACKING_OFF              = 60;
 	public const PAID_ORDERS               = 70;

--- a/src/Notification/NotificationSnoozeDurations.php
+++ b/src/Notification/NotificationSnoozeDurations.php
@@ -23,7 +23,7 @@ class NotificationSnoozeDurations {
 	public const NOT_ONBOARDED_90_DAYS     = 30 * DAY_IN_SECONDS;
 	public const ENHANCED_CONVERSIONS_OFF  = 7 * DAY_IN_SECONDS;
 	public const TRACKING_OFF              = 7 * DAY_IN_SECONDS;
-	public const SOLD_10_ITEMS             = 7 * DAY_IN_SECONDS;
+	public const PAID_ORDERS               = 7 * DAY_IN_SECONDS;
 	public const READY_BUT_NO_SALES        = 7 * DAY_IN_SECONDS;
 	public const COUPONS_NOT_SYNCED        = 7 * DAY_IN_SECONDS;
 	public const SALES_NOT_GROWING         = 7 * DAY_IN_SECONDS;

--- a/src/Notification/NotificationSnoozeDurations.php
+++ b/src/Notification/NotificationSnoozeDurations.php
@@ -20,7 +20,7 @@ class NotificationSnoozeDurations {
 	public const UNTIL_NEXT_LOGIN = -1;
 
 	public const ABANDONED_ONBOARDING      = 30 * DAY_IN_SECONDS;
-	public const NOT_ONBOARDED_90_DAYS     = 30 * DAY_IN_SECONDS;
+	public const NOT_ONBOARDED             = 30 * DAY_IN_SECONDS;
 	public const ENHANCED_CONVERSIONS_OFF  = 7 * DAY_IN_SECONDS;
 	public const TRACKING_OFF              = 7 * DAY_IN_SECONDS;
 	public const PAID_ORDERS               = 7 * DAY_IN_SECONDS;

--- a/tests/Unit/DependencyManagement/CoreServiceProviderTest.php
+++ b/tests/Unit/DependencyManagement/CoreServiceProviderTest.php
@@ -14,7 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ProductI
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ReadyButNoSalesEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\RecommendationsAvailableEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SalesNotGrowingEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignCreationEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\PaidOrdersEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\TrackingOffEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
@@ -51,7 +51,7 @@ class CoreServiceProviderTest extends ContainerAwareUnitTest {
 		ReadyButNoSalesEvaluator::class,
 		RecommendationsAvailableEvaluator::class,
 		SalesNotGrowingEvaluator::class,
-		SkippedCampaignEvaluator::class,
+		SkippedCampaignCreationEvaluator::class,
 		PaidOrdersEvaluator::class,
 		TrackingOffEvaluator::class,
 	];

--- a/tests/Unit/DependencyManagement/CoreServiceProviderTest.php
+++ b/tests/Unit/DependencyManagement/CoreServiceProviderTest.php
@@ -15,7 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ReadyBut
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\RecommendationsAvailableEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SalesNotGrowingEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\Sold10ItemsEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\PaidOrdersEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\TrackingOffEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationService;
@@ -52,7 +52,7 @@ class CoreServiceProviderTest extends ContainerAwareUnitTest {
 		RecommendationsAvailableEvaluator::class,
 		SalesNotGrowingEvaluator::class,
 		SkippedCampaignEvaluator::class,
-		Sold10ItemsEvaluator::class,
+		PaidOrdersEvaluator::class,
 		TrackingOffEvaluator::class,
 	];
 

--- a/tests/Unit/DependencyManagement/CoreServiceProviderTest.php
+++ b/tests/Unit/DependencyManagement/CoreServiceProviderTest.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\Abandone
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CampaignNoSalesEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CouponsNotSyncedEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\EnhancedConversionsOffEvaluator;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\NotOnboarded90DaysEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\NotOnboardedEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\PausedCampaignEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ProductIssuesEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\ReadyButNoSalesEvaluator;
@@ -45,7 +45,7 @@ class CoreServiceProviderTest extends ContainerAwareUnitTest {
 		CampaignNoSalesEvaluator::class,
 		CouponsNotSyncedEvaluator::class,
 		EnhancedConversionsOffEvaluator::class,
-		NotOnboarded90DaysEvaluator::class,
+		NotOnboardedEvaluator::class,
 		PausedCampaignEvaluator::class,
 		ProductIssuesEvaluator::class,
 		ReadyButNoSalesEvaluator::class,

--- a/tests/Unit/Notification/Evaluators/NotOnboardedEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/NotOnboardedEvaluatorTest.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\NotOnboarded90DaysEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\NotOnboardedEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
@@ -15,11 +15,11 @@ use PHPUnit\Framework\MockObject\MockObject;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class NotOnboarded90DaysEvaluatorTest
+ * Class NotOnboardedEvaluatorTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators
  */
-class NotOnboarded90DaysEvaluatorTest extends UnitTest {
+class NotOnboardedEvaluatorTest extends UnitTest {
 
 	/** @var MockObject|OnboardingCompleted $onboarding_completed */
 	protected $onboarding_completed;
@@ -30,7 +30,7 @@ class NotOnboarded90DaysEvaluatorTest extends UnitTest {
 	/** @var MockObject|WP $wp */
 	protected $wp;
 
-	/** @var NotOnboarded90DaysEvaluator $evaluator */
+	/** @var NotOnboardedEvaluator $evaluator */
 	protected $evaluator;
 
 	/**
@@ -43,21 +43,21 @@ class NotOnboarded90DaysEvaluatorTest extends UnitTest {
 		$this->options              = $this->createMock( OptionsInterface::class );
 		$this->wp                   = $this->createMock( WP::class );
 
-		$this->evaluator = new NotOnboarded90DaysEvaluator( $this->onboarding_completed );
+		$this->evaluator = new NotOnboardedEvaluator( $this->onboarding_completed );
 		$this->evaluator->set_options_object( $this->options );
 		$this->evaluator->set_wp_proxy_object( $this->wp );
 	}
 
 	public function test_get_id() {
-		$this->assertEquals( 'not-onboarded-90-days', $this->evaluator->get_id() );
+		$this->assertEquals( 'not-onboarded', $this->evaluator->get_id() );
 	}
 
 	public function test_get_priority() {
-		$this->assertEquals( NotificationPriorities::NOT_ONBOARDED_90_DAYS, $this->evaluator->get_priority() );
+		$this->assertEquals( NotificationPriorities::NOT_ONBOARDED, $this->evaluator->get_priority() );
 	}
 
 	public function test_get_snooze_duration() {
-		$this->assertEquals( NotificationSnoozeDurations::NOT_ONBOARDED_90_DAYS, $this->evaluator->get_snooze_duration() );
+		$this->assertEquals( NotificationSnoozeDurations::NOT_ONBOARDED, $this->evaluator->get_snooze_duration() );
 	}
 
 	public function test_should_show_when_not_onboarded_and_wc_installed_over_90_days_ago() {

--- a/tests/Unit/Notification/Evaluators/PaidOrdersEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/PaidOrdersEvaluatorTest.php
@@ -3,7 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\Sold10ItemsEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\PaidOrdersEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationCacheKeys;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
@@ -13,13 +13,13 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class Sold10ItemsEvaluatorTest
+ * Class PaidOrdersEvaluatorTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators
  */
-class Sold10ItemsEvaluatorTest extends UnitTest {
+class PaidOrdersEvaluatorTest extends UnitTest {
 
-	/** @var Sold10ItemsEvaluator $evaluator */
+	/** @var PaidOrdersEvaluator $evaluator */
 	protected $evaluator;
 
 	/**
@@ -28,11 +28,11 @@ class Sold10ItemsEvaluatorTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->evaluator = new Sold10ItemsEvaluator();
+		$this->evaluator = new PaidOrdersEvaluator();
 	}
 
 	public function test_get_id() {
-		$this->assertEquals( 'sold-10-items', $this->evaluator->get_id() );
+		$this->assertEquals( 'paid-orders', $this->evaluator->get_id() );
 	}
 
 	public function test_implements_site_scoped_notification_interface() {
@@ -40,11 +40,11 @@ class Sold10ItemsEvaluatorTest extends UnitTest {
 	}
 
 	public function test_get_priority() {
-		$this->assertEquals( NotificationPriorities::SOLD_10_ITEMS, $this->evaluator->get_priority() );
+		$this->assertEquals( NotificationPriorities::PAID_ORDERS, $this->evaluator->get_priority() );
 	}
 
 	public function test_get_snooze_duration() {
-		$this->assertEquals( NotificationSnoozeDurations::SOLD_10_ITEMS, $this->evaluator->get_snooze_duration() );
+		$this->assertEquals( NotificationSnoozeDurations::PAID_ORDERS, $this->evaluator->get_snooze_duration() );
 	}
 
 	public function test_should_show_when_ten_or_more_revenue_orders() {
@@ -62,7 +62,7 @@ class Sold10ItemsEvaluatorTest extends UnitTest {
 	public function test_cache_hit_skips_query() {
 		$evaluator = $this->create_evaluator_with_revenue_order_threshold( false );
 
-		set_transient( NotificationCacheKeys::for_site( 'sold-10-items' ), 1, HOUR_IN_SECONDS );
+		set_transient( NotificationCacheKeys::for_site( 'paid-orders' ), 1, HOUR_IN_SECONDS );
 
 		$evaluator->expects( $this->never() )->method( 'has_minimum_revenue_orders' );
 
@@ -98,10 +98,10 @@ class Sold10ItemsEvaluatorTest extends UnitTest {
 	 *
 	 * @param bool $meets_threshold
 	 *
-	 * @return Sold10ItemsEvaluator|\PHPUnit\Framework\MockObject\MockObject
+	 * @return PaidOrdersEvaluator|\PHPUnit\Framework\MockObject\MockObject
 	 */
-	private function create_evaluator_with_revenue_order_threshold( bool $meets_threshold ): Sold10ItemsEvaluator {
-		$evaluator = $this->getMockBuilder( Sold10ItemsEvaluator::class )
+	private function create_evaluator_with_revenue_order_threshold( bool $meets_threshold ): PaidOrdersEvaluator {
+		$evaluator = $this->getMockBuilder( PaidOrdersEvaluator::class )
 			->onlyMethods( [ 'has_minimum_revenue_orders' ] )
 			->getMock();
 

--- a/tests/Unit/Notification/Evaluators/SkippedCampaignCreationEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/SkippedCampaignCreationEvaluatorTest.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\CampaignType;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
-use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\SkippedCampaignCreationEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationCacheKeys;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
@@ -20,11 +20,11 @@ use PHPUnit\Framework\MockObject\MockObject;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class SkippedCampaignEvaluatorTest
+ * Class SkippedCampaignCreationEvaluatorTest
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators
  */
-class SkippedCampaignEvaluatorTest extends UnitTest {
+class SkippedCampaignCreationEvaluatorTest extends UnitTest {
 
 	/** @var MockObject|AdsService $ads_service */
 	protected $ads_service;
@@ -41,7 +41,7 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 	/** @var MockObject|ServiceBasedMerchantState $service_based_merchant_state */
 	protected $service_based_merchant_state;
 
-	/** @var SkippedCampaignEvaluator $evaluator */
+	/** @var SkippedCampaignCreationEvaluator $evaluator */
 	protected $evaluator;
 
 	/**
@@ -55,7 +55,7 @@ class SkippedCampaignEvaluatorTest extends UnitTest {
 		$this->onboarding_completed         = $this->createMock( OnboardingCompleted::class );
 		$this->options                      = $this->createMock( OptionsInterface::class );
 		$this->service_based_merchant_state = $this->createMock( ServiceBasedMerchantState::class );
-		$this->evaluator                    = new SkippedCampaignEvaluator( $this->ads_campaign, $this->onboarding_completed, $this->service_based_merchant_state );
+		$this->evaluator                    = new SkippedCampaignCreationEvaluator( $this->ads_campaign, $this->onboarding_completed, $this->service_based_merchant_state );
 		$this->evaluator->set_ads_object( $this->ads_service );
 		$this->evaluator->set_options_object( $this->options );
 	}

--- a/tests/Unit/Notification/NotificationCacheInvalidatorTest.php
+++ b/tests/Unit/Notification/NotificationCacheInvalidatorTest.php
@@ -83,17 +83,17 @@ class NotificationCacheInvalidatorTest extends UnitTest {
 
 	public function test_evaluator_without_the_interface_is_ignored() {
 		$plain = $this->createMock( NotificationEvaluatorInterface::class );
-		$plain->method( 'get_id' )->willReturn( 'sold-10-items' );
+		$plain->method( 'get_id' )->willReturn( 'paid-orders' );
 
 		$this->set_evaluators( [ $plain ] );
 		$this->invalidator->register();
 
-		set_transient( NotificationCacheKeys::for_site( 'sold-10-items' ), 1, HOUR_IN_SECONDS );
+		set_transient( NotificationCacheKeys::for_site( 'paid-orders' ), 1, HOUR_IN_SECONDS );
 
 		do_action( 'woocommerce_gla_updated_campaign' );
 
 		// A trend-only evaluator declares no hooks, so its cache survives (TTL-only).
-		$this->assertSame( 1, (int) get_transient( NotificationCacheKeys::for_site( 'sold-10-items' ) ) );
+		$this->assertSame( 1, (int) get_transient( NotificationCacheKeys::for_site( 'paid-orders' ) ) );
 	}
 
 	public function test_all_declared_hooks_invalidate_the_evaluator() {

--- a/tests/Unit/Notification/NotificationServiceTest.php
+++ b/tests/Unit/Notification/NotificationServiceTest.php
@@ -251,7 +251,7 @@ class NotificationServiceTest extends UnitTest {
 	public function test_site_scoped_notification_persists_state_in_site_option() {
 		$this->set_evaluators(
 			[
-				$this->create_mocked_evaluator( 'sold-10-items', 10, true, null, true ),
+				$this->create_mocked_evaluator( 'paid-orders', 10, true, null, true ),
 			]
 		);
 
@@ -260,19 +260,19 @@ class NotificationServiceTest extends UnitTest {
 		$site_state = get_option( 'gla_' . OptionsInterface::NOTIFICATIONS_SITE_STATE, [] );
 		$user_state = get_user_meta( get_current_user_id(), 'gla_notifications_state', true );
 
-		$this->assertNotEmpty( $site_state['sold-10-items']['triggered_at'] );
-		$this->assertFalse( isset( $user_state['sold-10-items'] ) );
+		$this->assertNotEmpty( $site_state['paid-orders']['triggered_at'] );
+		$this->assertFalse( isset( $user_state['paid-orders'] ) );
 	}
 
 	public function test_site_scoped_dismiss_is_shared_across_users() {
 		$this->set_evaluators(
 			[
-				$this->create_mocked_evaluator( 'sold-10-items', 10, true, null, true ),
+				$this->create_mocked_evaluator( 'paid-orders', 10, true, null, true ),
 			]
 		);
 
 		$this->service->get_notifications();
-		$this->service->dismiss( 'sold-10-items' );
+		$this->service->dismiss( 'paid-orders' );
 
 		$second_admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $second_admin_id );
@@ -283,7 +283,7 @@ class NotificationServiceTest extends UnitTest {
 	public function test_triggered_at_is_set_once_for_site_scoped_notifications() {
 		$this->set_evaluators(
 			[
-				$this->create_mocked_evaluator( 'sold-10-items', 10, true, null, true ),
+				$this->create_mocked_evaluator( 'paid-orders', 10, true, null, true ),
 			]
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/u/notifications-use-generic-names-for-sold10itemsevaluator-and

- Update `Sold10ItemsEvaluator` class name to `PaidOrdersEvaluator` including any relevant keys and constants
- Update `NotOnboarded90DaysEvaluator` class name to `NotOnboardedEvaluator` including any relevant keys and constants
- Update `SkippedCampaignEvaluator` class name to `SkippedCampaignCreationEvaluator` to align with string ID `skipped-campaign-creation`

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Confirm the `paid-orders` notification (originally `sold-10-items`) continues to work as expected.
2. Confirm the `not-onboarded` notification (originally `not-onboarded-90-days`) continues to work as expected.
3. Confirm the `skipped-campaign-creation` notification continues to work as expected.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
