### PR TITLE
GOOWOO-825 Fix Issue with Skipped Campaign

### DIFF
--- a/src/Notification/Evaluators/SkippedCampaignCreationEvaluator.php
+++ b/src/Notification/Evaluators/SkippedCampaignCreationEvaluator.php
@@ -147,12 +147,18 @@ class SkippedCampaignCreationEvaluator implements InvalidatableNotificationEvalu
 	}
 
 	/**
-	 * Creating a campaign resolves the "skipped campaign" condition; deleting the last one
-	 * can bring it back.
+	 * The "skipped campaign" state turns on when onboarding finishes (or a service-based
+	 * merchant completes Ads setup) without an enabled campaign, and off when a campaign is
+	 * created — so all three events must bust the cache, or a merchant who just skipped
+	 * campaign creation would not see the notification until the cache expires.
 	 *
 	 * @return string[]
 	 */
 	public function get_invalidation_hooks(): array {
-		return [ 'woocommerce_gla_updated_campaign' ];
+		return [
+			'woocommerce_gla_onboarding_completed',
+			'woocommerce_gla_ads_setup_completed',
+			'woocommerce_gla_updated_campaign',
+		];
 	}
 }

--- a/src/Notification/Evaluators/SkippedCampaignCreationEvaluator.php
+++ b/src/Notification/Evaluators/SkippedCampaignCreationEvaluator.php
@@ -147,16 +147,27 @@ class SkippedCampaignCreationEvaluator implements InvalidatableNotificationEvalu
 	}
 
 	/**
-	 * The "skipped campaign" state turns on when onboarding finishes (or a service-based
-	 * merchant completes Ads setup) without an enabled campaign, and off when a campaign is
-	 * created — so all three events must bust the cache, or a merchant who just skipped
-	 * campaign creation would not see the notification until the cache expires.
+	 * The "skipped campaign" state turns on when onboarding finishes without an enabled
+	 * campaign, and off when a campaign is created — so every event that flips it must bust
+	 * the cache, or a merchant who just skipped campaign creation would keep seeing the stale
+	 * (pre-onboarding) result until the one-hour cache expires.
+	 *
+	 * Onboarding completes through different actions depending on the merchant type:
+	 * - Service-based (ads-only) merchants fire `woocommerce_gla_onboarding_completed`.
+	 * - Retail (shopping) merchants — who reach this notification by skipping campaign
+	 *   creation — complete onboarding by syncing their Merchant Center settings, which fires
+	 *   `woocommerce_gla_mc_settings_sync` (that action is what marks MC setup, and therefore
+	 *   onboarding, complete for them). They never fire `woocommerce_gla_onboarding_completed`.
+	 *
+	 * The state turns off when Ads setup completes (`woocommerce_gla_ads_setup_completed`) or a
+	 * campaign is created/updated (`woocommerce_gla_updated_campaign`).
 	 *
 	 * @return string[]
 	 */
 	public function get_invalidation_hooks(): array {
 		return [
 			'woocommerce_gla_onboarding_completed',
+			'woocommerce_gla_mc_settings_sync',
 			'woocommerce_gla_ads_setup_completed',
 			'woocommerce_gla_updated_campaign',
 		];

--- a/tests/Unit/Notification/Evaluators/SkippedCampaignCreationEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/SkippedCampaignCreationEvaluatorTest.php
@@ -72,6 +72,19 @@ class SkippedCampaignCreationEvaluatorTest extends UnitTest {
 		$this->assertNull( $this->evaluator->get_snooze_duration() );
 	}
 
+	public function test_get_invalidation_hooks_covers_onboarding_ads_setup_and_campaign() {
+		// Finishing onboarding (or completing Ads setup) without a campaign turns the
+		// notification on; creating a campaign turns it off. All three must bust the cache.
+		$this->assertSame(
+			[
+				'woocommerce_gla_onboarding_completed',
+				'woocommerce_gla_ads_setup_completed',
+				'woocommerce_gla_updated_campaign',
+			],
+			$this->evaluator->get_invalidation_hooks()
+		);
+	}
+
 	public function test_should_not_show_when_onboarding_incomplete() {
 		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( false );
 		$this->ads_service->expects( $this->never() )->method( 'is_setup_complete' );

--- a/tests/Unit/Notification/Evaluators/SkippedCampaignCreationEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/SkippedCampaignCreationEvaluatorTest.php
@@ -73,11 +73,15 @@ class SkippedCampaignCreationEvaluatorTest extends UnitTest {
 	}
 
 	public function test_get_invalidation_hooks_covers_onboarding_ads_setup_and_campaign() {
-		// Finishing onboarding (or completing Ads setup) without a campaign turns the
-		// notification on; creating a campaign turns it off. All three must bust the cache.
+		// Finishing onboarding without a campaign turns the notification on; completing Ads
+		// setup or creating a campaign turns it off. Retail (shopping) merchants complete
+		// onboarding via the Merchant Center settings sync (not the onboarding_completed
+		// action), so that hook must be included or a shopping merchant who skips campaign
+		// creation would keep seeing the stale pre-onboarding result until the cache expires.
 		$this->assertSame(
 			[
 				'woocommerce_gla_onboarding_completed',
+				'woocommerce_gla_mc_settings_sync',
 				'woocommerce_gla_ads_setup_completed',
 				'woocommerce_gla_updated_campaign',
 			],


### PR DESCRIPTION
### Changes proposed in this Pull Request:

**Issue**
QA reported that skipping campaign creation during onboarding didn't surface the skipped-campaign-creation notification. Turns out the condition was fine all along - the problem was the cache never getting cleared.

The notification's result is cached site-wide, and each notification lists the hooks that should clear it. This one relied on `woocommerce_gla_onboarding_completed`… but that hook only fires for service-based (ads-only) merchants. A regular shopping merchant who hits "Skip ads creation" finishes onboarding through a different path (`woocommerce_gla_mc_settings_sync`), so none of the listed hooks fired. If the value had already been cached as false earlier in onboarding, it stayed stale until the 1-hour fallback expired - and the notification never appeared.

**Fix**: added `woocommerce_gla_mc_settings_sync` to the invalidation hooks, so the cache clears on the exact event that completes onboarding for shopping merchants.

Closes https://linear.app/a8c/issue/u/notifications-use-generic-names-for-sold10itemsevaluator-and

### Screenshots:
<img width="1280" height="1533" alt="skipped-campaign-notification" src="https://github.com/user-attachments/assets/a3608cd6-28bf-48f5-adab-42cea1a7a45d" />

<img width="680" height="305" alt="skipped-campaign-panel" src="https://github.com/user-attachments/assets/3e5c00f3-a8ef-4f02-9f4d-954f571becfe" />

### Detailed test instructions:

**Goal**: confirm that skipping campaign creation during onboarding shows the "Finish setting up Google Ads" notification.

**Before you start:**
Use a build of fix/GOOWOO-825-update-evaluator-names-and-ids.
Store needs at least one physical product (otherwise it's treated as service-based - different flow).
A Google Ads account with no active campaigns.

**Reset:**
```
wp user meta delete <user-id> gla_notifications_state
wp transient delete gla_notif_skipped-campaign-creation
```
`wp cache flush`   (only if you run an object cache)
Then disconnect all Google accounts so you can onboard fresh.

**Test:**
Run through onboarding. In step 1, connect Google + Merchant Center + Google Ads.
At the campaign step, click "Skip ads creation" (not "Complete setup") and confirm.
Go to Marketing → Overview and refresh.

Expected: under Action required, you see "Finish setting up Google Ads" with the Campaign Setup link.

### Additional details:
Note: this is a follow-up to the notifications caching work (GOOWOO-820); the caching change is what made prompt invalidation necessary, and this closes a gap for the skipped-campaign-creation notification specifically.
