### PR TITLE
Fix: GOOWOO-849: Multi-feed - [AI] One invalid primary currency drops every valid entry for the product

### DIFF
--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -349,7 +349,7 @@ class BatchProductHelper implements Service {
 								__METHOD__
 							);
 
-							continue 2;
+							continue;
 						}
 
 						$primary_currency_input = $this->generate_product_input( $product, $main_feed_label, $primary_currency_label, $this->market_service->get_all_countries(), $mapping_rules, $product_language, $primary_currency );

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -1720,6 +1720,82 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 		$this->assertSame( 'US', $results[1]['country'] );
 	}
 
+	public function test_invalid_primary_currency_skips_only_that_currency_feed() {
+		// A validation failure isolated to one additional primary currency must not discard the
+		// entries already staged for the product (the bare primary feed and any earlier valid
+		// currency), nor stop its secondary markets being generated.
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->set_up_market_service_stubs(
+			[ 'US', 'DE' ],
+			[
+				'primary' => [
+					'country'    => 'US',
+					'feed_label' => 'US',
+					'language'   => 'en',
+					'currency'   => [ get_woocommerce_currency(), 'EUR', 'GBP' ],
+				],
+				'de'      => [
+					'country'    => 'DE',
+					'feed_label' => 'DE',
+					'language'   => [ 'de' ],
+					'currency'   => [ 'EUR' ],
+				],
+			]
+		);
+
+		// Only the primary market's EUR copy fails.
+		$this->validator->expects( $this->any() )
+			->method( 'validate' )
+			->willReturnCallback(
+				function ( WCProductAdapter $adapter ) {
+					if ( 'US-EN-EUR' === $adapter->getFeedLabel() ) {
+						$violations = new ConstraintViolationList();
+						$violations->add( $this->createMock( ConstraintViolation::class ) );
+						return $violations;
+					}
+
+					return [];
+				}
+			);
+		$this->rules_query->expects( $this->any() )->method( 'get_results' )->willReturn( [] );
+
+		$messages = [];
+		$capture  = static function ( $message ) use ( &$messages ) {
+			$messages[] = $message;
+		};
+		add_action( 'woocommerce_gla_debug_message', $capture );
+
+		$labels = array_map(
+			static function ( array $entry ): string {
+				return $entry['input']->get_feed_label();
+			},
+			$this->batch_product_helper->generate_mapi_update_entries( [ $product ] )
+		);
+
+		remove_action( 'woocommerce_gla_debug_message', $capture );
+
+		$this->assertNotContains( 'US-EN-EUR', $labels );
+		$this->assertContains( 'US', $labels );
+		$this->assertContains( 'US-EN-GBP', $labels );
+		$this->assertNotEmpty(
+			array_filter(
+				$labels,
+				static function ( string $label ): bool {
+					return 'DE-' === substr( $label, 0, 3 );
+				}
+			)
+		);
+		$this->assertNotEmpty(
+			array_filter(
+				$messages,
+				static function ( $message ): bool {
+					return false !== strpos( (string) $message, 'EUR primary market feed' );
+				}
+			)
+		);
+	}
+
 	public function test_secondary_market_with_two_currencies_emits_one_entry_per_currency() {
 		$product        = WC_Helper_Product::create_simple_product();
 		$store_currency = get_woocommerce_currency();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-849/multi-feed-ai-one-invalid-primary-currency-drops-every-valid-entry-for

When a product fails validation for one additional primary-market currency, it disappears from every feed in that batch, not just that currency. `BatchProductHelper::generate_mapi_update_entries()` used continue 2 in the primary extra currency loop. At that nesting level it continues the outer product loop, skipping the secondary-market loop and the `array_push( $entries, ...$product_entries )` that flushes the staged entries. 


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
