### PR TITLE
GOOWOO-853 Merchant Center Cleanup and Product Re-sync

### DIFF
--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -370,6 +370,12 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * otherwise folded into the primary market), then the stale entries are cleared. The stored
 	 * language/currency is intentionally dropped — flat rate carries none. Idempotent: a no-op
 	 * once there are no stored markets.
+	 *
+	 * The removal mirrors the flat branch of delete_market(): a store may have synced products to
+	 * Merchant Center under the removed markets' feed labels (e.g. GB-EN-GBP), so the same follow-up
+	 * jobs are scheduled — CleanupOrphanedMarketProductsJob to drop the now-stale offers under those
+	 * labels, UpdateAllProducts so the restored countries re-sync under their current flat feed
+	 * labels, and the shipping settings sync when the global method is syncable.
 	 */
 	private function reconcile_orphaned_stored_markets(): void {
 		$stored = $this->get_stored_secondary_markets();
@@ -377,13 +383,42 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			return;
 		}
 
+		// Capture every removed market's feed label variants before the Markets option is cleared,
+		// so the cleanup job can target the offers still sitting under those labels in Merchant Center.
+		$orphaned_feed_labels = [];
+
 		foreach ( $stored as $market ) {
 			if ( ! empty( $market['country'] ) ) {
 				$this->restore_country_to_target_audience( (string) $market['country'] );
 			}
+
+			$feed_label = $market['feed_label'] ?? null;
+			if ( $feed_label ) {
+				$orphaned_feed_labels = array_merge(
+					$orphaned_feed_labels,
+					$this->get_market_feed_label_variants(
+						(string) $feed_label,
+						is_array( $market['language'] ?? null ) ? $market['language'] : [],
+						$this->get_market_currencies( $market )
+					)
+				);
+			}
 		}
 
 		$this->options->update( OptionsInterface::MARKETS, [] );
+
+		if ( ! empty( $orphaned_feed_labels ) ) {
+			$this->job_repository->get( CleanupOrphanedMarketProductsJob::class )
+				->schedule( [ 'feed_labels' => array_values( array_unique( $orphaned_feed_labels ) ) ] );
+		}
+
+		// The shipping method is global; when the flat global rate is syncable the restored
+		// countries' shipping services are regenerated in Merchant Center.
+		if ( $this->global_shipping_is_syncable() ) {
+			$this->schedule_shipping_sync();
+		}
+
+		$this->job_repository->get( UpdateAllProducts::class )->schedule();
 	}
 
 	/**

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -385,7 +385,8 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 		// Capture every removed market's feed label variants before the Markets option is cleared,
 		// so the cleanup job can target the offers still sitting under those labels in Merchant Center.
-		$orphaned_feed_labels = [];
+		// One group per market, flattened once after the loop.
+		$label_variant_groups = [];
 
 		foreach ( $stored as $market ) {
 			if ( ! empty( $market['country'] ) ) {
@@ -394,22 +395,21 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 			$feed_label = $market['feed_label'] ?? null;
 			if ( $feed_label ) {
-				$orphaned_feed_labels = array_merge(
-					$orphaned_feed_labels,
-					$this->get_market_feed_label_variants(
-						(string) $feed_label,
-						is_array( $market['language'] ?? null ) ? $market['language'] : [],
-						$this->get_market_currencies( $market )
-					)
+				$label_variant_groups[] = $this->get_market_feed_label_variants(
+					(string) $feed_label,
+					is_array( $market['language'] ?? null ) ? $market['language'] : [],
+					$this->get_market_currencies( $market )
 				);
 			}
 		}
+
+		$orphaned_feed_labels = array_values( array_unique( array_merge( [], ...$label_variant_groups ) ) );
 
 		$this->options->update( OptionsInterface::MARKETS, [] );
 
 		if ( ! empty( $orphaned_feed_labels ) ) {
 			$this->job_repository->get( CleanupOrphanedMarketProductsJob::class )
-				->schedule( [ 'feed_labels' => array_values( array_unique( $orphaned_feed_labels ) ) ] );
+				->schedule( [ 'feed_labels' => $orphaned_feed_labels ] );
 		}
 
 		// The shipping method is global; when the flat global rate is syncable the restored
@@ -418,7 +418,14 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			$this->schedule_shipping_sync();
 		}
 
+		// Always resync: the restored countries need their products (re)submitted under the
+		// current flat feed labels regardless of whether any old labels needed cleaning up.
 		$this->job_repository->get( UpdateAllProducts::class )->schedule();
+
+		// Deliberately no woocommerce_gla_market_deleted here: that action is for a user
+		// deleting a single market via delete_market(). This is a system-driven bulk fold of
+		// orphaned entries back into the flat model on read, not a user action, so firing a
+		// per-market "deleted" event (and re-entering its listeners) would be misleading.
 	}
 
 	/**

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -835,6 +835,50 @@ class MarketServiceTest extends UnitTest {
 		$this->market_service->get_markets();
 	}
 
+	public function test_flat_mode_reconciliation_cleans_up_variants_of_every_stored_market(): void {
+		// Two stored markets with distinct labels/languages/currencies: the single cleanup job must
+		// receive the accumulated feed label variants from both, not just one.
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ 'GBP' ],
+						'feed_label' => 'GB',
+					],
+					'de' => [
+						'country'    => 'DE',
+						'language'   => [ 'de' ],
+						'currency'   => [ 'EUR' ],
+						'feed_label' => 'DE',
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
+			]
+		);
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US' ] );
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->wc->method( 'get_countries' )->willReturn( [] );
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn( [ 'US' => [ 'rate' => '5' ] ] );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [ 'US' => [ 'time' => '2' ] ] );
+		$this->options->method( 'update' )->willReturn( true );
+
+		// Both markets' variants, in stored order: GB (base + EN/GBP) then DE (base + DE/EUR).
+		$this->cleanup_job->expects( $this->once() )
+			->method( 'schedule' )
+			->with( [ 'feed_labels' => [ 'GB', 'GB-EN-GBP', 'DE', 'DE-DE-EUR' ] ] );
+
+		$this->market_service->get_markets();
+	}
+
 	public function test_flat_mode_reconciliation_with_no_stored_markets_performs_no_writes_or_jobs(): void {
 		// With nothing stored the read path must stay a pure read: no option writes, no jobs.
 		$this->set_up_options_get(

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -788,6 +788,82 @@ class MarketServiceTest extends UnitTest {
 		$this->assertContains( 'GB', $updates[ OptionsInterface::TARGET_AUDIENCE ]['countries'] );
 	}
 
+	public function test_flat_mode_reconciliation_schedules_cleanup_update_and_shipping_sync(): void {
+		// A store that synced products under the stored markets' feed labels and then switched to
+		// flat is left with stale MC offers under those labels. Reconciliation must clean them up,
+		// resync the restored countries, and refresh shipping — mirroring delete_market()'s flat path.
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ 'GBP' ],
+						'feed_label' => 'GB',
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
+			]
+		);
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US' ] );
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->wc->method( 'get_countries' )->willReturn( [] );
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn( [ 'US' => [ 'rate' => '5' ] ] );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [ 'US' => [ 'time' => '2' ] ] );
+		$this->options->method( 'update' )->willReturn( true );
+
+		// Cleanup targets the removed market's feed label variants, captured before the option clear.
+		$this->cleanup_job->expects( $this->once() )
+			->method( 'schedule' )
+			->with( [ 'feed_labels' => [ 'GB', 'GB-EN-GBP' ] ] );
+
+		// The restored country must be re-synced under its current flat feed label.
+		$this->update_all_products_job->expects( $this->once() )
+			->method( 'schedule' );
+
+		// Global shipping method is flat/flat (syncable) → a shipping settings sync is scheduled.
+		$this->shipping_settings_job->expects( $this->once() )
+			->method( 'schedule' );
+
+		$this->market_service->get_markets();
+	}
+
+	public function test_flat_mode_reconciliation_with_no_stored_markets_performs_no_writes_or_jobs(): void {
+		// With nothing stored the read path must stay a pure read: no option writes, no jobs.
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
+			]
+		);
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US' ] );
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->wc->method( 'get_countries' )->willReturn( [] );
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [] );
+
+		$this->options->expects( $this->never() )->method( 'update' );
+		$this->cleanup_job->expects( $this->never() )->method( 'schedule' );
+		$this->update_all_products_job->expects( $this->never() )->method( 'schedule' );
+		$this->shipping_settings_job->expects( $this->never() )->method( 'schedule' );
+
+		$this->market_service->get_markets();
+	}
+
 	public function test_add_market_records_was_in_primary_false_when_country_was_not_targeted(): void {
 		$config = [
 			'country'    => 'DE',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This change makes the reconciliation mirror what `delete_market()` already does on the flat path. Before clearing the Markets option, it captures every removed market's feed-label variants, then schedules:

- CleanupOrphanedMarketProductsJob to remove the stale offers under those labels,
- UpdateAllProducts so the restored countries resync under their current flat labels,
- the shipping settings sync (when the global method is syncable).

When there are no stored markets, nothing changes, the read path stays a pure read with no writes or jobs.

Closes https://linear.app/a8c/issue/GOOWOO-853/schedule-merchant-centre-cleanup-and-product-resync-when-flat-mode

### Screenshots:

### Detailed test instructions:

**Goal**: Switching a store with saved markets to flat rate cleans up the old feed-label offers and triggers a resync.

**Setup**
1. Use a store connected to Merchant Center with WPML/WCML active.
2. Set the global shipping rate to automatic or manual.
3. Create a secondary market (e.g. GB, language EN, currency GBP, feed label ends up like GB-EN-GBP).
4. Let products sync, and confirm in Merchant Center that offers exist under that market's feed label.

**Test**
5. Switch the global shipping rate to flat.
6. Load the Marketing → Google for WooCommerce → Settings/Markets page

**Expected**
- The GB market disappears from the Markets page, and GB is back in the primary market's targeted countries.
- Under WooCommerce → Status → Scheduled Actions, you see freshly scheduled actions: the orphaned-market cleanup, an update-all-products run, and (since flat is syncable) a shipping settings sync.
- After those jobs run, the stale GB-EN-GBP offers are gone from Merchant Center, and GB's products are resynced under the current flat feed label.

**Additionally**
7. On a store already in flat mode with no saved markets, load the Markets page again. Nothing should be scheduled and no settings should change — it's just a read.

**Note**: you can watch the scheduled jobs under WooCommerce → Status → Scheduled Actions (search for the GLA cleanup / update-products / shipping actions), or trigger them immediately with WP-CLI (`wp action-scheduler run`) if you don't want to wait.