### PR TITLE
Fix: GOOWOO-850: Multi-feed - [AI] Fixed exchange rates are not available to shipping conversion

### DIFF
--- a/src/API/Google/Settings.php
+++ b/src/API/Google/Settings.php
@@ -160,7 +160,8 @@ class Settings implements ContainerAwareInterface {
 		$wc_proxy = $this->container->get( WC::class );
 		$currency = $wc_proxy->get_woocommerce_currency();
 
-		$country_currency_map = $this->build_country_currency_map();
+		$country_currency_map   = $this->build_country_currency_map();
+		$country_exchange_rates = $this->build_country_exchange_rate_map();
 
 		/** @var WPML $wpml */
 		$wpml = $this->container->get( WPML::class );
@@ -168,26 +169,61 @@ class Settings implements ContainerAwareInterface {
 		if ( $this->should_get_shipping_rates_from_woocommerce() ) {
 			return new WCShippingSettingsAdapter(
 				[
-					'currency'             => $currency,
-					'country_currency_map' => $country_currency_map,
-					'wpml'                 => $wpml,
-					'rates_collections'    => $this->get_shipping_rates_collections_from_woocommerce(),
-					'delivery_times'       => $times,
-					'accountId'            => $this->get_account_id(),
+					'currency'               => $currency,
+					'country_currency_map'   => $country_currency_map,
+					'country_exchange_rates' => $country_exchange_rates,
+					'wpml'                   => $wpml,
+					'rates_collections'      => $this->get_shipping_rates_collections_from_woocommerce(),
+					'delivery_times'         => $times,
+					'accountId'              => $this->get_account_id(),
 				]
 			);
 		}
 
 		return new DBShippingSettingsAdapter(
 			[
-				'currency'             => $currency,
-				'country_currency_map' => $country_currency_map,
-				'wpml'                 => $wpml,
-				'db_rates'             => $this->get_shipping_rates_from_database(),
-				'delivery_times'       => $times,
-				'accountId'            => $this->get_account_id(),
+				'currency'               => $currency,
+				'country_currency_map'   => $country_currency_map,
+				'country_exchange_rates' => $country_exchange_rates,
+				'wpml'                   => $wpml,
+				'db_rates'               => $this->get_shipping_rates_from_database(),
+				'delivery_times'         => $times,
+				'accountId'              => $this->get_account_id(),
 			]
 		);
+	}
+
+	/**
+	 * Map of country code to the market's fixed exchange rate, for markets that configure one.
+	 *
+	 * The REST contract lets a secondary market sync in a currency the site cannot otherwise
+	 * produce, provided it sets a positive rate. Shipping needs the same rate as product prices so
+	 * a market's services are generated in the currency its prices already use.
+	 *
+	 * @return array<string, float>
+	 */
+	protected function build_country_exchange_rate_map(): array {
+		/** @var MarketService $market_service */
+		$market_service = $this->container->get( MarketService::class );
+
+		$map = [];
+
+		foreach ( $market_service->get_participating_markets() as $market_id => $market ) {
+			if ( 'primary' === $market_id || 'manual' === ( $market['shipping_rate'] ?? null ) ) {
+				continue;
+			}
+
+			$country = $market['country'] ?? null;
+			$rate    = isset( $market['exchange_rate'] ) && is_numeric( $market['exchange_rate'] )
+				? (float) $market['exchange_rate']
+				: 0.0;
+
+			if ( $country && $rate > 0 ) {
+				$map[ $country ] = $rate;
+			}
+		}
+
+		return $map;
 	}
 
 	/**

--- a/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php
@@ -52,6 +52,15 @@ abstract class AbstractShippingSettingsAdapter {
 	protected $country_currency_map = [];
 
 	/**
+	 * Optional map of country code => fixed exchange rate, from the market's configured rate.
+	 * Used to convert store-currency amounts when no WPML conversion is available, mirroring how
+	 * product prices treat the same rate.
+	 *
+	 * @var array<string, float>
+	 */
+	protected $country_exchange_rates = [];
+
+	/**
 	 * @var WPML|null WPML integration used to convert amounts for services in
 	 *                a non-store currency.
 	 */
@@ -72,7 +81,11 @@ abstract class AbstractShippingSettingsAdapter {
 		$this->country_currency_map = isset( $properties['country_currency_map'] ) && is_array( $properties['country_currency_map'] )
 			? $properties['country_currency_map']
 			: [];
-		$this->wpml                 = isset( $properties['wpml'] ) && $properties['wpml'] instanceof WPML
+
+		$this->country_exchange_rates = isset( $properties['country_exchange_rates'] ) && is_array( $properties['country_exchange_rates'] )
+			? array_map( 'floatval', $properties['country_exchange_rates'] )
+			: [];
+		$this->wpml                   = isset( $properties['wpml'] ) && $properties['wpml'] instanceof WPML
 			? $properties['wpml']
 			: null;
 
@@ -116,26 +129,32 @@ abstract class AbstractShippingSettingsAdapter {
 	/**
 	 * Converts a store-currency amount into the given service currency.
 	 *
-	 * The store currency needs no conversion and is returned unchanged. Any
-	 * other currency is converted via the WPML integration, returning null
-	 * when no integration was provided or conversion is unavailable, so the
-	 * caller can leave that currency's service out.
+	 * The store currency needs no conversion and is returned unchanged. Any other currency is
+	 * converted via WPML, and when that is unavailable the country's fixed market exchange rate is
+	 * used. Product prices apply that same rate as their own fallback, so a market priced by a fixed
+	 * rate gets its shipping in the currency its prices are already in. Null when neither applies,
+	 * so the caller can leave that currency's service out.
 	 *
 	 * @param float  $amount   Amount in the store currency.
 	 * @param string $currency ISO 4217 currency code of the service.
+	 * @param string $country  Country the service is built for, used to find its fixed rate.
 	 *
 	 * @return float|null
 	 */
-	protected function convert_amount_for_service( float $amount, string $currency ): ?float {
+	protected function convert_amount_for_service( float $amount, string $currency, string $country ): ?float {
 		if ( $currency === $this->currency ) {
 			return $amount;
 		}
 
-		if ( null === $this->wpml ) {
-			return null;
+		$converted = null !== $this->wpml ? $this->wpml->convert_amount( $amount, $currency ) : null;
+
+		if ( null !== $converted ) {
+			return $converted;
 		}
 
-		return $this->wpml->convert_amount( $amount, $currency );
+		$rate = (float) ( $this->country_exchange_rates[ $country ] ?? 0.0 );
+
+		return $rate > 0 ? $amount * $rate : null;
 	}
 
 	/**
@@ -249,6 +268,7 @@ abstract class AbstractShippingSettingsAdapter {
 		unset( $data['currency'] );
 		unset( $data['delivery_times'] );
 		unset( $data['country_currency_map'] );
+		unset( $data['country_exchange_rates'] );
 		unset( $data['wpml'] );
 	}
 

--- a/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/DBShippingSettingsAdapter.php
@@ -88,7 +88,7 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 				: [ $row_currency ];
 
 			foreach ( $service_currencies as $service_currency ) {
-				$service_rate = $this->resolve_row_amount( (float) $rate, $row_currency, $service_currency );
+				$service_rate = $this->resolve_row_amount( (float) $rate, $row_currency, $service_currency, $country );
 
 				if ( null === $service_rate ) {
 					$this->report_country_missing_conversion( $country, $service_currency );
@@ -97,7 +97,7 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 
 				$minimum_order_value = null;
 				if ( isset( $options['free_shipping_threshold'] ) ) {
-					$minimum_order_value = $this->resolve_row_amount( (float) $options['free_shipping_threshold'], $row_currency, $service_currency );
+					$minimum_order_value = $this->resolve_row_amount( (float) $options['free_shipping_threshold'], $row_currency, $service_currency, $country );
 
 					if ( null === $minimum_order_value ) {
 						$this->report_country_missing_conversion( $country, $service_currency );
@@ -131,10 +131,11 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	 * @param float  $amount           Amount as stored on the row.
 	 * @param string $row_currency     Currency the row is stored in.
 	 * @param string $service_currency Currency of the service being built.
+	 * @param string $country          Country the service is built for.
 	 *
 	 * @return float|null
 	 */
-	protected function resolve_row_amount( float $amount, string $row_currency, string $service_currency ): ?float {
+	protected function resolve_row_amount( float $amount, string $row_currency, string $service_currency, string $country ): ?float {
 		if ( $service_currency === $row_currency ) {
 			return $amount;
 		}
@@ -143,7 +144,7 @@ class DBShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 			return null;
 		}
 
-		return $this->convert_amount_for_service( $amount, $service_currency );
+		return $this->convert_amount_for_service( $amount, $service_currency, $country );
 	}
 
 	/**

--- a/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
+++ b/src/Shipping/GoogleAdapter/WCShippingSettingsAdapter.php
@@ -146,7 +146,7 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 		$rate_groups   = [];
 		$shipping_area = $service_collection->get_shipping_area();
 		foreach ( $service_collection->get_rates_grouped_by_shipping_class() as $class => $location_rates ) {
-			$converted_rates = $this->convert_location_rates( $location_rates, $currency );
+			$converted_rates = $this->convert_location_rates( $location_rates, $currency, $country );
 
 			if ( null === $converted_rates ) {
 				$this->report_country_missing_conversion( $country, $currency );
@@ -160,7 +160,7 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 
 		$min_order_amount = $service_collection->get_min_order_amount();
 		if ( $min_order_amount ) {
-			$min_order_amount = $this->convert_amount_for_service( (float) $min_order_amount, $currency );
+			$min_order_amount = $this->convert_amount_for_service( (float) $min_order_amount, $currency, $country );
 
 			if ( null === $min_order_amount ) {
 				$this->report_country_missing_conversion( $country, $currency );
@@ -200,17 +200,18 @@ class WCShippingSettingsAdapter extends AbstractShippingSettingsAdapter {
 	 *
 	 * @param LocationRate[] $location_rates
 	 * @param string         $currency ISO 4217 currency code of the service.
+	 * @param string         $country        Country the service is built for.
 	 *
 	 * @return LocationRate[]|null
 	 */
-	protected function convert_location_rates( array $location_rates, string $currency ): ?array {
+	protected function convert_location_rates( array $location_rates, string $currency, string $country ): ?array {
 		if ( $currency === $this->currency ) {
 			return $location_rates;
 		}
 
 		$converted = [];
 		foreach ( $location_rates as $location_rate ) {
-			$amount = $this->convert_amount_for_service( (float) $location_rate->get_shipping_rate()->get_rate(), $currency );
+			$amount = $this->convert_amount_for_service( (float) $location_rate->get_shipping_rate()->get_rate(), $currency, $country );
 
 			if ( null === $amount ) {
 				return null;

--- a/tests/Unit/API/Google/SettingsTest.php
+++ b/tests/Unit/API/Google/SettingsTest.php
@@ -290,6 +290,69 @@ class SettingsTest extends UnitTest {
 		$this->assertSame( [ 'US' => [ 'USD' ] ], $map );
 	}
 
+	public function test_exchange_rate_map_contains_secondary_markets_with_a_positive_rate(): void {
+		$this->market_service->method( 'get_participating_markets' )->willReturn(
+			[
+				'primary' => [
+					'country'       => 'US',
+					'currency'      => [ 'USD' ],
+					'shipping_rate' => 'flat',
+				],
+				'fr'      => [
+					'country'       => 'FR',
+					'currency'      => [ 'EUR' ],
+					'exchange_rate' => '0.9',
+					'shipping_rate' => 'flat',
+				],
+			]
+		);
+
+		// The primary market never carries a rate, so only the secondary one is mapped.
+		$this->assertSame( [ 'FR' => 0.9 ], $this->invoke( 'build_country_exchange_rate_map' ) );
+	}
+
+	/**
+	 * Markets that cannot use a rate are left out: manual shipping gets no Merchant Center
+	 * service at all, and a missing, zero, negative or non-numeric rate is not a rate.
+	 */
+	public function test_exchange_rate_map_skips_manual_and_non_positive_rates(): void {
+		$this->market_service->method( 'get_participating_markets' )->willReturn(
+			[
+				'manual'      => [
+					'country'       => 'DE',
+					'exchange_rate' => '1.1',
+					'shipping_rate' => 'manual',
+				],
+				'zero'        => [
+					'country'       => 'ES',
+					'exchange_rate' => '0',
+					'shipping_rate' => 'flat',
+				],
+				'negative'    => [
+					'country'       => 'IT',
+					'exchange_rate' => '-1',
+					'shipping_rate' => 'flat',
+				],
+				'not_numeric' => [
+					'country'       => 'NL',
+					'exchange_rate' => 'abc',
+					'shipping_rate' => 'flat',
+				],
+				'absent'      => [
+					'country'       => 'PT',
+					'shipping_rate' => 'flat',
+				],
+				'no_country'  => [
+					'country'       => null,
+					'exchange_rate' => '2.0',
+					'shipping_rate' => 'flat',
+				],
+			]
+		);
+
+		$this->assertSame( [], $this->invoke( 'build_country_exchange_rate_map' ) );
+	}
+
 	/**
 	 * With a non-manual global method every market contributes to the currency map,
 	 * each with its own currency.

--- a/tests/Unit/Shipping/GoogleAdapter/DBShippingSettingsAdapterTest.php
+++ b/tests/Unit/Shipping/GoogleAdapter/DBShippingSettingsAdapterTest.php
@@ -451,6 +451,88 @@ class DBShippingSettingsAdapterTest extends UnitTest {
 		);
 	}
 
+	public function test_fixed_exchange_rate_produces_a_flat_rate_service_without_wpml() {
+		$db_rates = [
+			[
+				'country' => 'FR',
+				'rate'    => 5,
+				// A threshold that fails to convert drops the whole service, so it must use the
+				// fixed rate too.
+				'options' => [ 'free_shipping_threshold' => 200 ],
+			],
+		];
+
+		$settings = new DBShippingSettingsAdapter(
+			[
+				'currency'               => 'USD',
+				'country_currency_map'   => [
+					'FR' => 'EUR',
+				],
+				'country_exchange_rates' => [
+					'FR' => 0.9,
+				],
+				'delivery_times'         => [
+					'FR' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
+				'db_rates'               => $db_rates,
+			]
+		);
+
+		$services = $settings->get_services();
+
+		// The conditional free service the threshold produces, plus the paid one.
+		$this->assertCount( 2, $services );
+		foreach ( $services as $service ) {
+			$this->assertEquals( 'EUR', $service['currencyCode'] );
+		}
+		// The 200 USD threshold is converted at the fixed rate, not passed through unconverted.
+		$this->assertSame( '180000000', $services[0]['minimumOrderValue']['amountMicros'] );
+		// 5 USD at the same rate.
+		$this->assertSame( '4500000', $services[1]['rateGroups'][0]['singleValue']['flatRate']['amountMicros'] );
+	}
+
+	public function test_without_a_fixed_rate_or_wpml_the_service_is_still_left_out_with_an_error() {
+		// Unchanged behaviour: no rate and no conversion means no service, reported by country
+		// and currency so the merchant can act on it.
+		$reported = [];
+		add_action(
+			'woocommerce_gla_error',
+			function ( $message ) use ( &$reported ) {
+				$reported[] = $message;
+			}
+		);
+
+		$settings = new DBShippingSettingsAdapter(
+			[
+				'currency'             => 'USD',
+				'country_currency_map' => [
+					'FR' => 'EUR',
+				],
+				'delivery_times'       => [
+					'FR' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
+				'db_rates'             => [
+					[
+						'country' => 'FR',
+						'rate'    => 5,
+						'options' => [],
+					],
+				],
+			]
+		);
+
+		$this->assertCount( 0, $settings->get_services() );
+		$this->assertNotEmpty( $reported );
+		$this->assertStringContainsString( 'EUR', $reported[0] );
+		$this->assertStringContainsString( 'FR', $reported[0] );
+	}
+
 	public function test_country_currency_map_overrides_per_service_currency() {
 		$db_rates = [
 			[

--- a/tests/Unit/Shipping/GoogleAdapter/WCShippingSettingsAdapterTest.php
+++ b/tests/Unit/Shipping/GoogleAdapter/WCShippingSettingsAdapterTest.php
@@ -549,6 +549,104 @@ class WCShippingSettingsAdapterTest extends UnitTest {
 		$this->assertNotEquals( $by_currency['USD']['serviceName'], $by_currency['AED']['serviceName'] );
 	}
 
+	public function test_fixed_exchange_rate_produces_a_service_without_wpml_conversion() {
+		$ae_rate = new LocationRate( new ShippingLocation( 1, 'AE' ), new ShippingRate( 50 ) );
+
+		$settings = new WCShippingSettingsAdapter(
+			[
+				'currency'               => 'USD',
+				'country_currency_map'   => [
+					'AE' => [ 'AED' ],
+				],
+				'country_exchange_rates' => [
+					'AE' => 3.67,
+				],
+				'rates_collections'      => [
+					new CountryRatesCollection( 'AE', [ $ae_rate ] ),
+				],
+				'delivery_times'         => [
+					'AE' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
+			]
+		);
+
+		$services = $settings->get_services();
+
+		$this->assertCount( 1, $services );
+		$this->assertEquals( 'AED', $services[0]['currencyCode'] );
+		$this->assertSame( '183500000', $services[0]['rateGroups'][0]['singleValue']['flatRate']['amountMicros'] );
+	}
+
+	public function test_fixed_rate_is_used_when_wpml_is_present_but_cannot_convert() {
+		$ae_rate = new LocationRate( new ShippingLocation( 1, 'AE' ), new ShippingRate( 50 ) );
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'convert_amount' )->willReturn( null );
+
+		$settings = new WCShippingSettingsAdapter(
+			[
+				'currency'               => 'USD',
+				'country_currency_map'   => [
+					'AE' => [ 'AED' ],
+				],
+				'country_exchange_rates' => [
+					'AE' => 3.67,
+				],
+				'wpml'                   => $wpml,
+				'rates_collections'      => [
+					new CountryRatesCollection( 'AE', [ $ae_rate ] ),
+				],
+				'delivery_times'         => [
+					'AE' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
+			]
+		);
+
+		$services = $settings->get_services();
+
+		$this->assertCount( 1, $services );
+		$this->assertEquals( 'AED', $services[0]['currencyCode'] );
+		$this->assertSame( '183500000', $services[0]['rateGroups'][0]['singleValue']['flatRate']['amountMicros'] );
+	}
+
+	public function test_wpml_conversion_still_wins_over_the_fixed_rate() {
+		// An unchanged market: WPML is available, so the configured rate is not consulted.
+		$ae_rate = new LocationRate( new ShippingLocation( 1, 'AE' ), new ShippingRate( 50 ) );
+
+		$settings = new WCShippingSettingsAdapter(
+			[
+				'currency'               => 'USD',
+				'country_currency_map'   => [
+					'AE' => [ 'AED' ],
+				],
+				'country_exchange_rates' => [
+					'AE' => 3.67,
+				],
+				'wpml'                   => $this->create_wpml_doubling_converter(),
+				'rates_collections'      => [
+					new CountryRatesCollection( 'AE', [ $ae_rate ] ),
+				],
+				'delivery_times'         => [
+					'AE' => [
+						'time'     => 1,
+						'max_time' => 1,
+					],
+				],
+			]
+		);
+
+		$services = $settings->get_services();
+
+		$this->assertCount( 1, $services );
+		$this->assertEquals( 100.0, $services[0]['rateGroups'][0]['singleValue']['flatRate']['amountMicros'] / 1000000 );
+	}
+
 	public function test_leaves_out_non_store_currency_service_when_conversion_unavailable() {
 		$reported = [];
 		add_action(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-850/multi-feed-ai-fixed-exchange-rates-are-not-available-to-shipping

A secondary market with a fixed exchange_rate can sync its product prices in a non-store currency, but its matching shipping service was silently dropped. build_country_currency_map() passed only currency codes to the adapters, and convert_amount_for_service() could convert only through WPML.

New `Settings::build_country_exchange_rate_map()` passes each market's rate to the adapters as country_exchange_rates. convert_amount_for_service() now tries WPML first and falls back to that rate, mirroring how product prices treat the same rate (same direction, same precedence, same rate > 0 threshold), so a market's shipping lands in the currency its prices already use. $country is threaded through resolve_row_amount() and convert_location_rates().


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
