### PR TITLE
Fix: GOOWOO-842: Fatal error called to undefined function trigger_deprecation

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -39,6 +39,8 @@ class Autoloader {
 			return false;
 		}
 
+		self::ensure_deprecation_helper();
+
 		return $autoloader_result;
 	}
 
@@ -70,5 +72,30 @@ class Autoloader {
 				<?php
 			}
 		);
+	}
+
+	/**
+	 * Ensure the Symfony deprecation helper is available.
+	 *
+	 * Composer de-duplicates autoloaded "files" globally. If another plugin ships a
+	 * prefixed copy of symfony/deprecation-contracts, Composer may consider the file
+	 * already loaded even though trigger_deprecation() was never defined. In that
+	 * case, explicitly require our copy.
+	 *
+	 * @return void
+	 */
+	protected static function ensure_deprecation_helper() {
+		if ( function_exists( 'trigger_deprecation' ) ) {
+			return;
+		}
+
+		$file = dirname( __DIR__ ) . '/vendor/symfony/deprecation-contracts/function.php';
+
+		if ( ! is_readable( $file ) ) {
+			return;
+		}
+
+		// Composer may have skipped this file due to another plugin loading a prefixed copy.
+		require_once $file;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-842/fatal-error-in-google-for-woocommerce-381-call-to-undefined-function

### Detailed test instructions:

1. Setup environment to use the 3.8.1 version of the plugin.
2. Install a conflicting plugin (one example found [Amelia Booking](https://wordpress.org/plugins/ameliabooking/))
3. Ensure WordPress debug logging is enabled.
4. Browse the Google for WooCommerce plugin dashboard, this should trigger a API request that results in an error.
5. Check the debug log and look for an error trace resulting in an `PHP Fatal error:  Uncaught Error: Call to undefined function trigger_deprecation() in {project path}/wp-content/plugins/google-listings-and-ads/vendor/guzzlehttp/psr7/src/Request.php(49)` or similar.
6. Update environment to use latest fix in the branch `fix/GOOWOO-842-fatal-error-call-to-undefined-function-trigger-deprecation`
7. Browse the Google for WooCommerce plugin dashboard to trigger additional API request.
8. Confirm that the `PHP Fatal error:  Uncaught Error: Call to undefined function trigger_deprecation()` no longer appears


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
