### PR TITLE
Fix: Resolve autoload collisions resulting in undefined `trigger_deprecation()` errors

### DIFF
--- a/bin/prefix-vendor-namespace.php
+++ b/bin/prefix-vendor-namespace.php
@@ -76,6 +76,14 @@ $packages = [
 		'package'   => 'guzzlehttp',
 		'strict'    => false,
 	],
+	[
+		// No namespace to prefix; this package only ships a global function. Listing it here
+		// moves its file autoload into our own composer.json so its identifier is unique to
+		// this plugin, preventing other plugins bundling the same package from colliding with it.
+		'namespace' => 'Symfony\\DeprecationContracts',
+		'package'   => 'symfony/deprecation-contracts',
+		'strict'    => true,
+	],
 ];
 
 $vendor_dir       = dirname( __DIR__ ) . '/vendor';

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
 			"Automattic\\WooCommerce\\GoogleListingsAndAds\\Util\\": "bin/"
 		},
 		"files": [
-			"vendor/guzzlehttp/guzzle/src/functions_include.php"
+			"vendor/guzzlehttp/guzzle/src/functions_include.php",
+			"vendor/symfony/deprecation-contracts/function.php"
 		]
 	},
 	"autoload-dev": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes GOOWOO-842.

Complements #3654, which added a runtime fallback in `Autoloader.php`. This PR addresses the underlying cause so the fallback is no longer load-bearing.

**Root cause:** Composer keys `"files"`-type autoloads (globally-required helper files, as opposed to PSR-4 classes) by a hash of `{package name}:{relative path}` — not by file content. `symfony/deprecation-contracts` is a transitive dependency of `guzzlehttp/psr7` that ships one such file, defining the global `trigger_deprecation()` helper. Because the hash is based only on package identity, any other WordPress plugin that also bundles this same package computes the identical identifier we do.

Composer de-duplicates these file autoloads process-wide: whichever plugin's autoloader runs first "claims" that identifier, and every other plugin's copy is silently skipped, even if the contents differ. If another active plugin's build tooling has altered its own bundled copy (e.g. renaming the function internally) and its autoloader happens to run first, our copy — the one that defines the real `trigger_deprecation()` — never loads. `guzzlehttp/psr7` then calls an undefined function and every wp-admin page fatals.

**Fix:** move this file's autoload registration out of the shared, package-identity-keyed slot and into our own `composer.json`'s root `autoload.files`. Root-level file autoloads are keyed by the *root package's own name* (`woocommerce/google-listings-and-ads`), which is unique to this plugin and can't collide with anything another plugin declares. This is the same pattern already applied to `guzzlehttp/guzzle`'s `functions_include.php` (see the existing entry in `composer.json`) — we're just extending an established, working mechanism to a dependency that was missed.

Two files change:
- `composer.json` — add `vendor/symfony/deprecation-contracts/function.php` to `autoload.files`.
- `bin/prefix-vendor-namespace.php` — register `symfony/deprecation-contracts` in `$packages` so the existing `update_autoloads()` step strips the now-redundant package-level registration out of `vendor/composer/installed.json` on every `composer install`/`update`.

No change to `composer.lock` (autoload config isn't part of its content-hash) and no change to the vendored function itself — we're not renaming anything, just fixing where Composer looks for it.

### Detailed test instructions:

1. `composer install` from a clean `vendor/` and confirm the install-scripts chain (`prefix-vendor-namespace.php`, `composer dump-autoload`) completes without error.
2. Confirm `vendor/composer/installed.json`'s `symfony/deprecation-contracts` package now has an empty `autoload.files` array (registration moved to root).
3. Confirm `vendor/composer/autoload_static.php` registers `symfony/deprecation-contracts/function.php` under a hash derived from our own package name, rather than the shared package-identity hash it used before.
4. Reproduce the original collision directly, without needing a second conflicting plugin installed. Save the script below as `bin/verify-deprecation-contracts-autoload.php` and run `php bin/verify-deprecation-contracts-autoload.php` from the plugin root:

   ```php
   #!/usr/bin/env php
   <?php
   /**
    * Reduced test case for GOOWOO-842.
    *
    * Composer keys "files" autoloads by a hash of the package name and relative path, not by
    * file content. If another plugin also bundles symfony/deprecation-contracts, it computes the
    * same hash we do, and whichever autoloader runs first "claims" it — silently skipping every
    * other copy, including ours, even if that other copy defines something different.
    *
    * This script simulates that collision directly, without needing a second plugin installed:
    * it pre-marks the shared, package-identity-keyed hash as already loaded, then confirms our
    * own copy of trigger_deprecation() still becomes available. Run standalone, no WordPress or
    * WooCommerce required:
    *
    *   php bin/verify-deprecation-contracts-autoload.php
    */

   declare( strict_types=1 );

   // phpcs:disable WordPress.Security.EscapeOutput
   // phpcs:disable WordPress.WP.AlternativeFunctions

   // The identifier Composer would use if this file were still registered under the shared
   // third-party package name instead of our own root package name.
   $shared_identifier = md5( 'symfony/deprecation-contracts:function.php' );

   // Simulate another plugin's autoloader claiming that identifier before ours runs.
   $GLOBALS['__composer_autoload_files'][ $shared_identifier ] = true;

   require dirname( __DIR__ ) . '/vendor/autoload.php';

   if ( function_exists( 'trigger_deprecation' ) ) {
       echo "PASS: trigger_deprecation() is defined after a simulated autoload collision.\n";
       exit( 0 );
   }

   echo "FAIL: trigger_deprecation() is undefined after a simulated autoload collision.\n";
   echo "vendor/symfony/deprecation-contracts/function.php is still registered under the shared\n";
   echo "package-identity hash instead of our own root-package hash. See GOOWOO-842.\n";
   exit( 1 );
   ```

   Expect `PASS` and exit code `0` on this branch. Checked out against the pre-fix code (e.g. the released 3.8.1 tag), the same script prints `FAIL` and exits `1` — reproducing the undefined-function condition without needing a conflicting plugin like Amelia Booking installed.

5. `./vendor/bin/phpcs` on the changed files; `composer validate`.

### Changelog entry

> Fix - Resolve autoload collisions resulting in undefined `trigger_deprecation()` errors.
