### PR TITLE
Fix - Batch the orphaned market/language cleanup jobs instead of loading the whole catalogue

### DIFF
--- a/src/Jobs/AbstractActionSchedulerJob.php
+++ b/src/Jobs/AbstractActionSchedulerJob.php
@@ -54,7 +54,7 @@ abstract class AbstractActionSchedulerJob implements ActionSchedulerJobInterface
 	 * The job name is used to generate the schedule event name.
 	 */
 	public function init(): void {
-		add_action( $this->get_process_item_hook(), [ $this, 'handle_process_items_action' ] );
+		add_action( $this->get_process_item_hook(), [ $this, 'handle_process_items_action' ], 10, 2 );
 	}
 
 	/**
@@ -73,13 +73,14 @@ abstract class AbstractActionSchedulerJob implements ActionSchedulerJobInterface
 	 *
 	 * @hooked gla/jobs/{$job_name}/process_item
 	 *
-	 * @param array $items The job items from the current batch.
+	 * @param array $items   The job items from the current batch.
+	 * @param array $context Optional context carried through from `schedule()`, unrelated to the batch's items.
 	 *
 	 * @throws Exception If an error occurs.
 	 */
-	public function handle_process_items_action( array $items = [] ) {
+	public function handle_process_items_action( array $items = [], array $context = [] ) {
 		$process_hook = $this->get_process_item_hook();
-		$process_args = [ $items ];
+		$process_args = $this->build_hook_args( $items, $context );
 
 		$this->monitor->validate_failure_rate( $this, $process_hook, $process_args );
 		if ( $this->retry_on_timeout ) {
@@ -87,7 +88,7 @@ abstract class AbstractActionSchedulerJob implements ActionSchedulerJobInterface
 		}
 
 		try {
-			$this->process_items( $items );
+			$this->process_items( $items, $context );
 		} catch ( Exception $exception ) {
 			// reschedule on failure
 			$this->action_scheduler->schedule_immediate( $process_hook, $process_args );
@@ -97,6 +98,20 @@ abstract class AbstractActionSchedulerJob implements ActionSchedulerJobInterface
 		}
 
 		$this->monitor->detach_timeout_monitor( $process_hook, $process_args );
+	}
+
+	/**
+	 * Build the args array passed to a scheduled action hook, omitting `$context`
+	 * entirely when empty so jobs that never use it keep their original, simpler
+	 * args shape (and any assertions on it).
+	 *
+	 * @param mixed $primary The hook's primary argument (e.g. items or a batch number).
+	 * @param array $context Optional context carried through `schedule()`.
+	 *
+	 * @return array
+	 */
+	protected function build_hook_args( $primary, array $context ): array {
+		return empty( $context ) ? [ $primary ] : [ $primary, $context ];
 	}
 
 	/**
@@ -135,9 +150,10 @@ abstract class AbstractActionSchedulerJob implements ActionSchedulerJobInterface
 	/**
 	 * Process batch items.
 	 *
-	 * @param array $items A single batch from the get_batch() method.
+	 * @param array $items   A single batch from the get_batch() method.
+	 * @param array $context Optional context carried through from `schedule()`, unrelated to the batch's items.
 	 *
 	 * @throws Exception If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	abstract protected function process_items( array $items );
+	abstract protected function process_items( array $items, array $context = [] );
 }

--- a/src/Jobs/AbstractBatchedActionSchedulerJob.php
+++ b/src/Jobs/AbstractBatchedActionSchedulerJob.php
@@ -27,7 +27,7 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 	 * The job name is used to generate the schedule event name.
 	 */
 	public function init(): void {
-		add_action( $this->get_create_batch_hook(), [ $this, 'handle_create_batch_action' ] );
+		add_action( $this->get_create_batch_hook(), [ $this, 'handle_create_batch_action' ], 10, 2 );
 		parent::init();
 	}
 
@@ -45,10 +45,12 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 	 *
 	 * To minimize the resource use of starting the job the batch creation is handled async.
 	 *
-	 * @param array $args
+	 * @param array $args Optional context carried through every batch of this run (e.g. the
+	 *                    ids identifying what to clean up). Unrelated to the batch's items,
+	 *                    which are always derived by `get_batch()` from the batch number.
 	 */
 	public function schedule( array $args = [] ) {
-		$this->schedule_create_batch_action( 1 );
+		$this->schedule_create_batch_action( 1, $args );
 	}
 
 	/**
@@ -58,33 +60,34 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 	 *
 	 * Schedules an action to run immediately for the items in the batch.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Optional context carried through from `schedule()`.
 	 *
 	 * @throws Exception If an error occurs.
 	 * @throws JobException If the job failure rate is too high.
 	 */
-	public function handle_create_batch_action( int $batch_number ) {
+	public function handle_create_batch_action( int $batch_number, array $context = [] ) {
 		$create_batch_hook = $this->get_create_batch_hook();
-		$create_batch_args = [ $batch_number ];
+		$create_batch_args = $this->build_hook_args( $batch_number, $context );
 
 		$this->monitor->validate_failure_rate( $this, $create_batch_hook, $create_batch_args );
 		if ( $this->retry_on_timeout ) {
 			$this->monitor->attach_timeout_monitor( $create_batch_hook, $create_batch_args );
 		}
 
-		$items = $this->get_batch( $batch_number );
+		$items = $this->get_batch( $batch_number, $context );
 
 		if ( empty( $items ) ) {
 			// if no more items the job is complete
 			$this->handle_complete( $batch_number );
 		} else {
 			// if items, schedule the process action
-			$this->schedule_process_action( $items );
+			$this->schedule_process_action( $items, $context );
 
 			// Add another "create_batch" action to handle unfiltered items.
 			// The last batch created here will be an empty batch, it
 			// will call "handle_complete" to finish the job.
-			$this->schedule_create_batch_action( $batch_number + 1 );
+			$this->schedule_create_batch_action( $batch_number + 1, $context );
 		}
 
 		$this->monitor->detach_timeout_monitor( $create_batch_hook, $create_batch_args );
@@ -118,22 +121,25 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 	/**
 	 * Schedule a new "create batch" action to run immediately.
 	 *
-	 * @param int $batch_number The batch number for the new batch.
+	 * @param int   $batch_number The batch number for the new batch.
+	 * @param array $context      Optional context carried through from `schedule()`.
 	 */
-	protected function schedule_create_batch_action( int $batch_number ) {
-		if ( $this->can_schedule( [ $batch_number ] ) ) {
-			$this->action_scheduler->schedule_immediate( $this->get_create_batch_hook(), [ $batch_number ] );
+	protected function schedule_create_batch_action( int $batch_number, array $context = [] ) {
+		$args = $this->build_hook_args( $batch_number, $context );
+		if ( $this->can_schedule( $args ) ) {
+			$this->action_scheduler->schedule_immediate( $this->get_create_batch_hook(), $args );
 		}
 	}
 
 	/**
 	 * Schedule a new "process" action to run immediately.
 	 *
-	 * @param int[] $items Array of item ids.
+	 * @param int[] $items   Array of item ids.
+	 * @param array $context Optional context carried through from `schedule()`.
 	 */
-	protected function schedule_process_action( array $items ) {
-		if ( ! $this->is_processing( $items ) ) {
-			$this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), [ $items ] );
+	protected function schedule_process_action( array $items, array $context = [] ) {
+		if ( ! $this->is_processing( $items, $context ) ) {
+			$this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), $this->build_hook_args( $items, $context ) );
 		}
 	}
 
@@ -156,11 +162,12 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 	 * The job is considered to be processing if a "process_item" action is currently pending or in-progress.
 	 *
 	 * @param array $items
+	 * @param array $context Optional context carried through from `schedule()`.
 	 *
 	 * @return bool
 	 */
-	protected function is_processing( array $items = [] ): bool {
-		return $this->action_scheduler->has_scheduled_action( $this->get_process_item_hook(), [ $items ] );
+	protected function is_processing( array $items = [], array $context = [] ): bool {
+		return $this->action_scheduler->has_scheduled_action( $this->get_process_item_hook(), $this->build_hook_args( $items, $context ) );
 	}
 
 	/**
@@ -178,11 +185,12 @@ abstract class AbstractBatchedActionSchedulerJob extends AbstractActionScheduler
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Optional context carried through from `schedule()`.
 	 *
 	 * @return array
 	 *
 	 * @throws Exception If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	abstract protected function get_batch( int $batch_number ): array;
+	abstract protected function get_batch( int $batch_number, array $context = [] ): array;
 }

--- a/src/Jobs/BatchedActionSchedulerJobInterface.php
+++ b/src/Jobs/BatchedActionSchedulerJobInterface.php
@@ -19,20 +19,22 @@ interface BatchedActionSchedulerJobInterface extends ActionSchedulerJobInterface
 	 *
 	 * @hooked gla/jobs/{$job_name}/create_batch
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Optional context carried through from `schedule()`.
 	 *
 	 * @throws Exception If an error occurs.
 	 */
-	public function handle_create_batch_action( int $batch_number );
+	public function handle_create_batch_action( int $batch_number, array $context = [] );
 
 	/**
 	 * Handles processing a single batch action hook.
 	 *
 	 * @hooked gla/jobs/{$job_name}/process_item
 	 *
-	 * @param array $items The job items from the current batch.
+	 * @param array $items   The job items from the current batch.
+	 * @param array $context Optional context carried through from `schedule()`.
 	 *
 	 * @throws Exception If an error occurs.
 	 */
-	public function handle_process_items_action( array $items );
+	public function handle_process_items_action( array $items, array $context = [] );
 }

--- a/src/Jobs/CheckUnclaimedIncentive.php
+++ b/src/Jobs/CheckUnclaimedIncentive.php
@@ -86,6 +86,7 @@ class CheckUnclaimedIncentive extends AbstractActionSchedulerJob implements Star
 	 * Process the job.
 	 *
 	 * @param array $items Unused.
+	 * @param array $context Unused.
 	 */
 	public function process_items( array $items, array $context = [] ) {
 		// Only proceed if a previous apply attempt failed.

--- a/src/Jobs/CheckUnclaimedIncentive.php
+++ b/src/Jobs/CheckUnclaimedIncentive.php
@@ -87,7 +87,7 @@ class CheckUnclaimedIncentive extends AbstractActionSchedulerJob implements Star
 	 *
 	 * @param array $items Unused.
 	 */
-	public function process_items( array $items ) {
+	public function process_items( array $items, array $context = [] ) {
 		// Only proceed if a previous apply attempt failed.
 		if ( 'error' !== $this->options->get( OptionsInterface::ADS_INCENTIVE_APPLY_ERROR ) ) {
 			return;

--- a/src/Jobs/CleanupOrphanedLanguageProductsJob.php
+++ b/src/Jobs/CleanupOrphanedLanguageProductsJob.php
@@ -8,6 +8,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -26,9 +28,12 @@ defined( 'ABSPATH' ) || exit;
  * identify a language — the job narrows the deletion to products whose own
  * post language is in the removed set.
  *
+ * Pages through the whole synced catalogue in batches (rather than loading it
+ * all in a single action) since the store's catalogue size is unbounded.
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
-class CleanupOrphanedLanguageProductsJob extends AbstractProductSyncerJob {
+class CleanupOrphanedLanguageProductsJob extends AbstractProductSyncerBatchedJob {
 
 	/**
 	 * @var ProductHelper
@@ -47,7 +52,9 @@ class CleanupOrphanedLanguageProductsJob extends AbstractProductSyncerJob {
 	 * @param ActionSchedulerJobMonitor $monitor
 	 * @param ProductSyncer             $product_syncer
 	 * @param ProductRepository         $product_repository
+	 * @param BatchProductHelper        $batch_product_helper
 	 * @param MerchantCenterService     $merchant_center
+	 * @param MerchantStatuses          $merchant_statuses
 	 * @param ProductHelper             $product_helper
 	 * @param WPML                      $wpml
 	 */
@@ -56,11 +63,13 @@ class CleanupOrphanedLanguageProductsJob extends AbstractProductSyncerJob {
 		ActionSchedulerJobMonitor $monitor,
 		ProductSyncer $product_syncer,
 		ProductRepository $product_repository,
+		BatchProductHelper $batch_product_helper,
 		MerchantCenterService $merchant_center,
+		MerchantStatuses $merchant_statuses,
 		ProductHelper $product_helper,
 		WPML $wpml
 	) {
-		parent::__construct( $action_scheduler, $monitor, $product_syncer, $product_repository, $merchant_center );
+		parent::__construct( $action_scheduler, $monitor, $product_syncer, $product_repository, $batch_product_helper, $merchant_center, $merchant_statuses );
 		$this->product_helper = $product_helper;
 		$this->wpml           = $wpml;
 	}
@@ -97,39 +106,47 @@ class CleanupOrphanedLanguageProductsJob extends AbstractProductSyncerJob {
 			throw InvalidValue::is_empty( 'removed_languages' );
 		}
 
-		$process_args = [
+		parent::schedule(
 			[
 				'keys'              => array_values( $keys ),
 				'removed_languages' => array_values( $removed_languages ),
-			],
-		];
-
-		if ( $this->can_schedule( $process_args ) ) {
-			$this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), $process_args );
-		}
+			]
+		);
 	}
 
 	/**
-	 * Process orphaned entries for products whose language is in the removed set.
+	 * Get a single batch of synced product IDs.
 	 *
-	 * @param array $items Single-element array containing the scheduling args.
+	 * If no items are returned the job will stop.
+	 *
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused by `get_batch()`; the batch is always the next page of
+	 *                            the whole synced catalogue, filtering by language happens per
+	 *                            product in `process_items()`.
+	 *
+	 * @return int[]
+	 */
+	public function get_batch( int $batch_number, array $context = [] ): array {
+		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+	}
+
+	/**
+	 * Process orphaned entries for a single batch of product IDs whose language is in the removed set.
+	 *
+	 * @param int[] $items   A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $context Contains `keys` and `removed_languages`, as passed to `schedule()`.
 	 *
 	 * @throws ProductSyncerException If the Merchant Center delete call fails.
 	 */
-	protected function process_items( array $items ) {
-		$keys    = is_array( $items['keys'] ?? null ) ? $items['keys'] : [];
-		$removed = is_array( $items['removed_languages'] ?? null ) ? $items['removed_languages'] : [];
+	protected function process_items( array $items, array $context = [] ) {
+		$keys    = is_array( $context['keys'] ?? null ) ? $context['keys'] : [];
+		$removed = is_array( $context['removed_languages'] ?? null ) ? $context['removed_languages'] : [];
 
 		if ( empty( $keys ) || empty( $removed ) ) {
 			return;
 		}
 
-		$product_ids = $this->product_repository->find_synced_product_ids();
-		if ( empty( $product_ids ) ) {
-			return;
-		}
-
-		$products        = $this->product_repository->find_by_ids( $product_ids );
+		$products        = $this->product_repository->find_by_ids( $items );
 		$request_entries = [];
 
 		foreach ( $products as $product ) {

--- a/src/Jobs/CleanupOrphanedMarketProductsJob.php
+++ b/src/Jobs/CleanupOrphanedMarketProductsJob.php
@@ -7,6 +7,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerI
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -23,9 +25,12 @@ defined( 'ABSPATH' ) || exit;
  * under (its base feed label plus each per-language variant) so the orphaned
  * entries can be removed before the next product sync writes new ones.
  *
+ * Pages through the whole synced catalogue in batches (rather than loading it
+ * all in a single action) since the store's catalogue size is unbounded.
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
-class CleanupOrphanedMarketProductsJob extends AbstractProductSyncerJob {
+class CleanupOrphanedMarketProductsJob extends AbstractProductSyncerBatchedJob {
 
 	/**
 	 * @var ProductHelper
@@ -39,7 +44,9 @@ class CleanupOrphanedMarketProductsJob extends AbstractProductSyncerJob {
 	 * @param ActionSchedulerJobMonitor $monitor
 	 * @param ProductSyncer             $product_syncer
 	 * @param ProductRepository         $product_repository
+	 * @param BatchProductHelper        $batch_product_helper
 	 * @param MerchantCenterService     $merchant_center
+	 * @param MerchantStatuses          $merchant_statuses
 	 * @param ProductHelper             $product_helper
 	 */
 	public function __construct(
@@ -47,10 +54,12 @@ class CleanupOrphanedMarketProductsJob extends AbstractProductSyncerJob {
 		ActionSchedulerJobMonitor $monitor,
 		ProductSyncer $product_syncer,
 		ProductRepository $product_repository,
+		BatchProductHelper $batch_product_helper,
 		MerchantCenterService $merchant_center,
+		MerchantStatuses $merchant_statuses,
 		ProductHelper $product_helper
 	) {
-		parent::__construct( $action_scheduler, $monitor, $product_syncer, $product_repository, $merchant_center );
+		parent::__construct( $action_scheduler, $monitor, $product_syncer, $product_repository, $batch_product_helper, $merchant_center, $merchant_statuses );
 		$this->product_helper = $product_helper;
 	}
 
@@ -79,34 +88,41 @@ class CleanupOrphanedMarketProductsJob extends AbstractProductSyncerJob {
 			throw InvalidValue::is_empty( 'feed_labels' );
 		}
 
-		$process_args = [ [ 'feed_labels' => array_values( $feed_labels ) ] ];
-
-		if ( $this->can_schedule( $process_args ) ) {
-			$this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), $process_args );
-		}
+		parent::schedule( [ 'feed_labels' => array_values( $feed_labels ) ] );
 	}
 
 	/**
-	 * Process the orphaned market's products.
+	 * Get a single batch of synced product IDs.
 	 *
-	 * @param array $items Single-element array containing the scheduling args.
+	 * If no items are returned the job will stop.
+	 *
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused by `get_batch()`; the batch is always the next page of
+	 *                            the whole synced catalogue, filtering by `feed_labels` happens
+	 *                            per product in `process_items()`.
+	 *
+	 * @return int[]
+	 */
+	public function get_batch( int $batch_number, array $context = [] ): array {
+		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+	}
+
+	/**
+	 * Process the orphaned market's products for a single batch of product IDs.
+	 *
+	 * @param int[] $items   A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $context Contains `feed_labels`, as passed to `schedule()`.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	protected function process_items( array $items ) {
-		$feed_labels = is_array( $items['feed_labels'] ?? null ) ? $items['feed_labels'] : [];
+	protected function process_items( array $items, array $context = [] ) {
+		$feed_labels = is_array( $context['feed_labels'] ?? null ) ? $context['feed_labels'] : [];
 
 		if ( empty( $feed_labels ) ) {
 			return;
 		}
 
-		$product_ids = $this->product_repository->find_synced_product_ids();
-
-		if ( empty( $product_ids ) ) {
-			return;
-		}
-
-		$products        = $this->product_repository->find_by_ids( $product_ids );
+		$products        = $this->product_repository->find_by_ids( $items );
 		$request_entries = [];
 		foreach ( $products as $product ) {
 			$google_ids = $this->product_helper->get_synced_google_product_ids( $product );

--- a/src/Jobs/CleanupProductsJob.php
+++ b/src/Jobs/CleanupProductsJob.php
@@ -31,7 +31,8 @@ class CleanupProductsJob extends AbstractProductSyncerBatchedJob {
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused.
 	 *
 	 * @return array
 	 */
@@ -42,7 +43,8 @@ class CleanupProductsJob extends AbstractProductSyncerBatchedJob {
 	/**
 	 * Process batch items.
 	 *
-	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param int[] $items   A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $context Unused.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/CleanupProductsJob.php
+++ b/src/Jobs/CleanupProductsJob.php
@@ -35,7 +35,7 @@ class CleanupProductsJob extends AbstractProductSyncerBatchedJob {
 	 *
 	 * @return array
 	 */
-	public function get_batch( int $batch_number ): array {
+	public function get_batch( int $batch_number, array $context = [] ): array {
 		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
 	}
 
@@ -46,7 +46,7 @@ class CleanupProductsJob extends AbstractProductSyncerBatchedJob {
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $context = [] ) {
 		$products      = $this->product_repository->find_by_ids( $items );
 		$stale_entries = $this->batch_product_helper->generate_stale_products_delete_entries( $products );
 		$this->product_syncer->delete_mapi_entries( $stale_entries );

--- a/src/Jobs/CleanupSyncedProducts.php
+++ b/src/Jobs/CleanupSyncedProducts.php
@@ -54,7 +54,8 @@ class CleanupSyncedProducts extends AbstractProductSyncerBatchedJob {
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused.
 	 *
 	 * @return int[]
 	 */
@@ -66,7 +67,8 @@ class CleanupSyncedProducts extends AbstractProductSyncerBatchedJob {
 	 * Process batch items.
 	 * Skips processing if the Merchant Center has been connected again.
 	 *
-	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param int[] $items   A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $context Unused.
 	 */
 	protected function process_items( array $items, array $context = [] ) {
 		if ( $this->is_mc_connected() ) {

--- a/src/Jobs/CleanupSyncedProducts.php
+++ b/src/Jobs/CleanupSyncedProducts.php
@@ -58,7 +58,7 @@ class CleanupSyncedProducts extends AbstractProductSyncerBatchedJob {
 	 *
 	 * @return int[]
 	 */
-	public function get_batch( int $batch_number ): array {
+	public function get_batch( int $batch_number, array $context = [] ): array {
 		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
 	}
 
@@ -68,7 +68,7 @@ class CleanupSyncedProducts extends AbstractProductSyncerBatchedJob {
 	 *
 	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $context = [] ) {
 		if ( $this->is_mc_connected() ) {
 			do_action(
 				'woocommerce_gla_debug_message',

--- a/src/Jobs/CreateMerchantReportedConversionReport.php
+++ b/src/Jobs/CreateMerchantReportedConversionReport.php
@@ -109,7 +109,8 @@ class CreateMerchantReportedConversionReport extends AbstractBatchedActionSchedu
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused.
 	 *
 	 * @return int[]
 	 */
@@ -133,7 +134,8 @@ class CreateMerchantReportedConversionReport extends AbstractBatchedActionSchedu
 	 * Handles file state persistence across batches and creates new files
 	 * when the size threshold is exceeded.
 	 *
-	 * @param int[] $items A single batch of WooCommerce Order IDs from the get_batch() method.
+	 * @param int[] $items   A single batch of WooCommerce Order IDs from the get_batch() method.
+	 * @param array $context Unused.
 	 *
 	 * @throws \Exception If an error occurs during CSV creation or writing.
 	 */

--- a/src/Jobs/CreateMerchantReportedConversionReport.php
+++ b/src/Jobs/CreateMerchantReportedConversionReport.php
@@ -113,7 +113,7 @@ class CreateMerchantReportedConversionReport extends AbstractBatchedActionSchedu
 	 *
 	 * @return int[]
 	 */
-	public function get_batch( int $batch_number ): array {
+	public function get_batch( int $batch_number, array $context = [] ): array {
 		// Get the order IDs from the Options.
 		$youtube_cache = $this->options->get( OptionsInterface::YOUTUBE_ORDER_IDS_CACHE, [] );
 		$date          = $this->get_date();
@@ -137,7 +137,7 @@ class CreateMerchantReportedConversionReport extends AbstractBatchedActionSchedu
 	 *
 	 * @throws \Exception If an error occurs during CSV creation or writing.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $context = [] ) {
 		$date = $this->get_date();
 
 		try {

--- a/src/Jobs/CreateYouTubeOrderIdsCache.php
+++ b/src/Jobs/CreateYouTubeOrderIdsCache.php
@@ -94,7 +94,7 @@ class CreateYouTubeOrderIdsCache extends AbstractBatchedActionSchedulerJob imple
 	 *
 	 * @return int[]
 	 */
-	public function get_batch( int $batch_number ): array {
+	public function get_batch( int $batch_number, array $context = [] ): array {
 		return $this->youtube_orders->find_orders( $this->get_date(), $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
 	}
 
@@ -105,7 +105,7 @@ class CreateYouTubeOrderIdsCache extends AbstractBatchedActionSchedulerJob imple
 	 *
 	 * @throws \Exception If an error occurs during caching.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $context = [] ) {
 		try {
 			// Get the date for the orders.
 			$date = $this->get_date();

--- a/src/Jobs/CreateYouTubeOrderIdsCache.php
+++ b/src/Jobs/CreateYouTubeOrderIdsCache.php
@@ -90,7 +90,8 @@ class CreateYouTubeOrderIdsCache extends AbstractBatchedActionSchedulerJob imple
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused.
 	 *
 	 * @return int[]
 	 */
@@ -101,7 +102,8 @@ class CreateYouTubeOrderIdsCache extends AbstractBatchedActionSchedulerJob imple
 	/**
 	 * Process batch items.
 	 *
-	 * @param int[] $items A single batch of WooCommerce Order IDs from the get_batch() method.
+	 * @param int[] $items   A single batch of WooCommerce Order IDs from the get_batch() method.
+	 * @param array $context Unused.
 	 *
 	 * @throws \Exception If an error occurs during caching.
 	 */

--- a/src/Jobs/DeleteAllProducts.php
+++ b/src/Jobs/DeleteAllProducts.php
@@ -34,7 +34,7 @@ class DeleteAllProducts extends AbstractProductSyncerBatchedJob {
 	 *
 	 * @return int[]
 	 */
-	protected function get_batch( int $batch_number ): array {
+	protected function get_batch( int $batch_number, array $context = [] ): array {
 		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
 	}
 
@@ -45,7 +45,7 @@ class DeleteAllProducts extends AbstractProductSyncerBatchedJob {
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $context = [] ) {
 		$products = $this->product_repository->find_by_ids( $items );
 		$this->product_syncer->delete( $products );
 	}

--- a/src/Jobs/DeleteAllProducts.php
+++ b/src/Jobs/DeleteAllProducts.php
@@ -30,7 +30,8 @@ class DeleteAllProducts extends AbstractProductSyncerBatchedJob {
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused.
 	 *
 	 * @return int[]
 	 */
@@ -41,7 +42,8 @@ class DeleteAllProducts extends AbstractProductSyncerBatchedJob {
 	/**
 	 * Process batch items.
 	 *
-	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param int[] $items   A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $context Unused.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/DeleteCoupon.php
+++ b/src/Jobs/DeleteCoupon.php
@@ -32,6 +32,7 @@ class DeleteCoupon extends AbstractCouponSyncerJob implements
 	 * Process an item.
 	 *
 	 * @param array[] $coupon_entries
+	 * @param array   $context Unused.
 	 *
 	 * @throws JobException If no valid coupon data is provided as argument. The exception will be logged by ActionScheduler.
 	 * @throws CouponSyncerException If an error occurs. The exception will be logged by ActionScheduler.

--- a/src/Jobs/DeleteCoupon.php
+++ b/src/Jobs/DeleteCoupon.php
@@ -36,7 +36,7 @@ class DeleteCoupon extends AbstractCouponSyncerJob implements
 	 * @throws JobException If no valid coupon data is provided as argument. The exception will be logged by ActionScheduler.
 	 * @throws CouponSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	public function process_items( array $coupon_entries ) {
+	public function process_items( array $coupon_entries, array $context = [] ) {
 		$wc_coupon_id     = $coupon_entries[0] ?? null;
 		$google_promotion = $coupon_entries[1] ?? null;
 		$google_ids       = $coupon_entries[2] ?? null;

--- a/src/Jobs/DeleteProducts.php
+++ b/src/Jobs/DeleteProducts.php
@@ -32,6 +32,7 @@ class DeleteProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 * Process an item.
 	 *
 	 * @param string[] $product_id_map An array of Google product IDs mapped to WooCommerce product IDs as their key.
+	 * @param array    $context        Unused.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/DeleteProducts.php
+++ b/src/Jobs/DeleteProducts.php
@@ -35,7 +35,7 @@ class DeleteProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	public function process_items( array $product_id_map ) {
+	public function process_items( array $product_id_map, array $context = [] ) {
 		$this->product_syncer->delete_by_id_map( $product_id_map );
 	}
 

--- a/src/Jobs/MigrateGTIN.php
+++ b/src/Jobs/MigrateGTIN.php
@@ -82,7 +82,7 @@ class MigrateGTIN extends AbstractBatchedActionSchedulerJob implements OptionsAw
 	 *
 	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $context = [] ) {
 		// update the product core GTIN using G4W GTIN
 		$products = $this->product_repository->find_by_ids( $items );
 		foreach ( $products as $product ) {
@@ -153,7 +153,7 @@ class MigrateGTIN extends AbstractBatchedActionSchedulerJob implements OptionsAw
 	 *
 	 * @throws Exception If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	protected function get_batch( int $batch_number ): array {
+	protected function get_batch( int $batch_number, array $context = [] ): array {
 		return $this->product_repository->find_all_product_ids( $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
 	}
 

--- a/src/Jobs/MigrateGTIN.php
+++ b/src/Jobs/MigrateGTIN.php
@@ -80,7 +80,8 @@ class MigrateGTIN extends AbstractBatchedActionSchedulerJob implements OptionsAw
 	/**
 	 * Process batch items.
 	 *
-	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param int[] $items   A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $context Unused.
 	 */
 	protected function process_items( array $items, array $context = [] ) {
 		// update the product core GTIN using G4W GTIN
@@ -147,7 +148,8 @@ class MigrateGTIN extends AbstractBatchedActionSchedulerJob implements OptionsAw
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused.
 	 *
 	 * @return array
 	 *

--- a/src/Jobs/ResubmitExpiringProducts.php
+++ b/src/Jobs/ResubmitExpiringProducts.php
@@ -55,7 +55,8 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	 *
 	 * @hooked gla/jobs/resubmit_expiring_products/create_batch
 	 *
-	 * @param int $last_id The highest product ID processed so far (0 on first run).
+	 * @param int   $last_id The highest product ID processed so far (0 on first run).
+	 * @param array $context Unused.
 	 *
 	 * @throws \Exception If an error occurs.
 	 * @throws JobException If the job failure rate is too high.
@@ -86,7 +87,8 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $last_id The cursor: fetch products with ID strictly greater than this value.
+	 * @param int   $last_id The cursor: fetch products with ID strictly greater than this value.
+	 * @param array $context Unused.
 	 *
 	 * @return int[] Array of product IDs ordered ASC.
 	 */
@@ -97,7 +99,8 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	/**
 	 * Process batch items.
 	 *
-	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param int[] $items   A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $context Unused.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/ResubmitExpiringProducts.php
+++ b/src/Jobs/ResubmitExpiringProducts.php
@@ -60,7 +60,7 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	 * @throws \Exception If an error occurs.
 	 * @throws JobException If the job failure rate is too high.
 	 */
-	public function handle_create_batch_action( int $last_id ) {
+	public function handle_create_batch_action( int $last_id, array $context = [] ) {
 		$create_batch_hook = $this->get_create_batch_hook();
 		$create_batch_args = [ $last_id ];
 
@@ -90,7 +90,7 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	 *
 	 * @return int[] Array of product IDs ordered ASC.
 	 */
-	public function get_batch( int $last_id ): array {
+	public function get_batch( int $last_id, array $context = [] ): array {
 		return $this->product_repository->find_expiring_product_ids( $last_id, $this->get_batch_size() );
 	}
 
@@ -101,7 +101,7 @@ class ResubmitExpiringProducts extends AbstractProductSyncerBatchedJob implement
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $context = [] ) {
 		$products = $this->product_repository->find_by_ids( $items );
 
 		$this->product_syncer->update( $products );

--- a/src/Jobs/SyncableProductsBatchedActionSchedulerJobTrait.php
+++ b/src/Jobs/SyncableProductsBatchedActionSchedulerJobTrait.php
@@ -24,7 +24,7 @@ trait SyncableProductsBatchedActionSchedulerJobTrait {
 	 *
 	 * @return WC_Product[]
 	 */
-	public function get_batch( int $batch_number ): array {
+	public function get_batch( int $batch_number, array $context = [] ): array {
 		return $this->get_filtered_batch( $batch_number )->get();
 	}
 
@@ -58,7 +58,7 @@ trait SyncableProductsBatchedActionSchedulerJobTrait {
 	 * @throws Exception If an error occurs.
 	 * @throws JobException If the job failure rate is too high.
 	 */
-	public function handle_create_batch_action( int $batch_number ) {
+	public function handle_create_batch_action( int $batch_number, array $context = [] ) {
 		$create_batch_hook = $this->get_create_batch_hook();
 		$create_batch_args = [ $batch_number ];
 

--- a/src/Jobs/SyncableProductsBatchedActionSchedulerJobTrait.php
+++ b/src/Jobs/SyncableProductsBatchedActionSchedulerJobTrait.php
@@ -20,11 +20,12 @@ trait SyncableProductsBatchedActionSchedulerJobTrait {
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused.
 	 *
 	 * @return WC_Product[]
 	 */
-	public function get_batch( int $batch_number, array $context = [] ): array {
+	public function get_batch( int $batch_number, array $context = [] ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		return $this->get_filtered_batch( $batch_number )->get();
 	}
 
@@ -53,12 +54,13 @@ trait SyncableProductsBatchedActionSchedulerJobTrait {
 	 *
 	 * @since 1.4.0
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused.
 	 *
 	 * @throws Exception If an error occurs.
 	 * @throws JobException If the job failure rate is too high.
 	 */
-	public function handle_create_batch_action( int $batch_number, array $context = [] ) {
+	public function handle_create_batch_action( int $batch_number, array $context = [] ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$create_batch_hook = $this->get_create_batch_hook();
 		$create_batch_args = [ $batch_number ];
 

--- a/src/Jobs/Update/CleanupProductTargetCountriesJob.php
+++ b/src/Jobs/Update/CleanupProductTargetCountriesJob.php
@@ -33,7 +33,8 @@ class CleanupProductTargetCountriesJob extends AbstractProductSyncerBatchedJob {
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused.
 	 *
 	 * @return array
 	 */
@@ -44,7 +45,8 @@ class CleanupProductTargetCountriesJob extends AbstractProductSyncerBatchedJob {
 	/**
 	 * Process batch items.
 	 *
-	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param int[] $items   A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $context Unused.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/Update/CleanupProductTargetCountriesJob.php
+++ b/src/Jobs/Update/CleanupProductTargetCountriesJob.php
@@ -37,7 +37,7 @@ class CleanupProductTargetCountriesJob extends AbstractProductSyncerBatchedJob {
 	 *
 	 * @return array
 	 */
-	public function get_batch( int $batch_number ): array {
+	public function get_batch( int $batch_number, array $context = [] ): array {
 		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
 	}
 
@@ -48,7 +48,7 @@ class CleanupProductTargetCountriesJob extends AbstractProductSyncerBatchedJob {
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $context = [] ) {
 		$products      = $this->product_repository->find_by_ids( $items );
 		$stale_entries = $this->batch_product_helper->generate_stale_countries_delete_entries( $products );
 		$this->product_syncer->delete_mapi_entries( $stale_entries );

--- a/src/Jobs/UpdateAllProducts.php
+++ b/src/Jobs/UpdateAllProducts.php
@@ -37,7 +37,7 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob implements Optio
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $context = [] ) {
 		$products = $this->product_repository->find_by_ids( $items );
 		$this->product_syncer->update( $products );
 	}

--- a/src/Jobs/UpdateAllProducts.php
+++ b/src/Jobs/UpdateAllProducts.php
@@ -33,7 +33,8 @@ class UpdateAllProducts extends AbstractProductSyncerBatchedJob implements Optio
 	/**
 	 * Process batch items.
 	 *
-	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param int[] $items   A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $context Unused.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/UpdateCoupon.php
+++ b/src/Jobs/UpdateCoupon.php
@@ -32,6 +32,7 @@ class UpdateCoupon extends AbstractCouponSyncerJob implements
 	 * Process an item.
 	 *
 	 * @param int[] $coupon_ids
+	 * @param array $context Unused.
 	 *
 	 * @throws CouponSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */

--- a/src/Jobs/UpdateCoupon.php
+++ b/src/Jobs/UpdateCoupon.php
@@ -35,7 +35,7 @@ class UpdateCoupon extends AbstractCouponSyncerJob implements
 	 *
 	 * @throws CouponSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	public function process_items( $coupon_ids ) {
+	public function process_items( $coupon_ids, array $context = [] ) {
 		foreach ( $coupon_ids as $coupon_id ) {
 			$coupon = $this->wc->maybe_get_coupon( $coupon_id );
 			if ( $coupon instanceof WC_Coupon &&

--- a/src/Jobs/UpdateEuPoliticalCampaigns.php
+++ b/src/Jobs/UpdateEuPoliticalCampaigns.php
@@ -94,7 +94,8 @@ class UpdateEuPoliticalCampaigns extends AbstractBatchedActionSchedulerJob imple
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused.
 	 *
 	 * @return int[]
 	 */
@@ -110,7 +111,8 @@ class UpdateEuPoliticalCampaigns extends AbstractBatchedActionSchedulerJob imple
 	/**
 	 * Process batch items.
 	 *
-	 * @param int[] $items A single batch of WooCommerce Order IDs from the get_batch() method.
+	 * @param int[] $items   A single batch of WooCommerce Order IDs from the get_batch() method.
+	 * @param array $context Unused.
 	 *
 	 * @throws \Exception If an error occurs during caching.
 	 */

--- a/src/Jobs/UpdateEuPoliticalCampaigns.php
+++ b/src/Jobs/UpdateEuPoliticalCampaigns.php
@@ -98,7 +98,7 @@ class UpdateEuPoliticalCampaigns extends AbstractBatchedActionSchedulerJob imple
 	 *
 	 * @return int[]
 	 */
-	public function get_batch( int $batch_number ): array {
+	public function get_batch( int $batch_number, array $context = [] ): array {
 		$limit  = $this->get_batch_size();
 		$offset = ( $batch_number - 1 ) * $limit;
 
@@ -114,7 +114,7 @@ class UpdateEuPoliticalCampaigns extends AbstractBatchedActionSchedulerJob imple
 	 *
 	 * @throws \Exception If an error occurs during caching.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $context = [] ) {
 		if ( empty( $items ) ) {
 			return;
 		}

--- a/src/Jobs/UpdateMerchantPriceBenchmarks.php
+++ b/src/Jobs/UpdateMerchantPriceBenchmarks.php
@@ -92,7 +92,8 @@ class UpdateMerchantPriceBenchmarks extends AbstractActionSchedulerJob implement
 	/**
 	 * Process the job.
 	 *
-	 * @param int[] $items An array of job arguments.
+	 * @param int[] $items   An array of job arguments.
+	 * @param array $context Unused.
 	 *
 	 * @throws JobException If the merchant product statuses cannot be retrieved..
 	 */

--- a/src/Jobs/UpdateMerchantPriceBenchmarks.php
+++ b/src/Jobs/UpdateMerchantPriceBenchmarks.php
@@ -96,7 +96,7 @@ class UpdateMerchantPriceBenchmarks extends AbstractActionSchedulerJob implement
 	 *
 	 * @throws JobException If the merchant product statuses cannot be retrieved..
 	 */
-	public function process_items( array $items ) {
+	public function process_items( array $items, array $context = [] ) {
 		try {
 			// Fetch price benchmarks from the API.
 			$this->price_benchmarks->update_price_benchmarks();

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -82,7 +82,7 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 	 *
 	 * @throws JobException If the merchant product statuses cannot be retrieved..
 	 */
-	public function process_items( array $items ) {
+	public function process_items( array $items, array $context = [] ) {
 		try {
 			$next_page_token = $items['next_page_token'] ?? null;
 

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -78,7 +78,8 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 	/**
 	 * Process the job.
 	 *
-	 * @param int[] $items An array of job arguments.
+	 * @param int[] $items   An array of job arguments.
+	 * @param array $context Unused.
 	 *
 	 * @throws JobException If the merchant product statuses cannot be retrieved..
 	 */

--- a/src/Jobs/UpdateProducts.php
+++ b/src/Jobs/UpdateProducts.php
@@ -35,7 +35,7 @@ class UpdateProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 * @throws JobException If invalid or non-existing products are provided. The exception will be logged by ActionScheduler.
 	 */
-	public function process_items( array $product_ids ) {
+	public function process_items( array $product_ids, array $context = [] ) {
 		$args     = [ 'include' => $product_ids ];
 		$products = $this->product_repository->find_sync_ready_products( $args )->get();
 

--- a/src/Jobs/UpdateProducts.php
+++ b/src/Jobs/UpdateProducts.php
@@ -31,6 +31,7 @@ class UpdateProducts extends AbstractProductSyncerJob implements StartOnHookInte
 	 * Process an item.
 	 *
 	 * @param int[] $product_ids An array of WooCommerce product ids.
+	 * @param array $context     Unused.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 * @throws JobException If invalid or non-existing products are provided. The exception will be logged by ActionScheduler.

--- a/src/Jobs/UpdateShippingSettings.php
+++ b/src/Jobs/UpdateShippingSettings.php
@@ -125,7 +125,7 @@ class UpdateShippingSettings extends AbstractActionSchedulerJob implements Optio
 	 *                   stored first so it can be shown in the plugin as a
 	 *                   Merchant Center issue.
 	 */
-	public function process_items( array $items ) {
+	public function process_items( array $items, array $context = [] ) {
 		if ( ! $this->can_sync_shipping() ) {
 			throw new JobException( 'Cannot sync shipping settings. Confirm that the merchant center account is connected and the option to automatically sync the shipping settings is selected.' );
 		}

--- a/src/Jobs/UpdateShippingSettings.php
+++ b/src/Jobs/UpdateShippingSettings.php
@@ -118,7 +118,8 @@ class UpdateShippingSettings extends AbstractActionSchedulerJob implements Optio
 	/**
 	 * Process the job.
 	 *
-	 * @param int[] $items An array of job arguments.
+	 * @param int[] $items   An array of job arguments.
+	 * @param array $context Unused.
 	 *
 	 * @throws JobException If the shipping settings cannot be synced.
 	 * @throws Exception If the shipping settings sync fails. The failure is

--- a/src/Jobs/UpdateSyncableProductsCount.php
+++ b/src/Jobs/UpdateSyncableProductsCount.php
@@ -79,7 +79,7 @@ class UpdateSyncableProductsCount extends AbstractBatchedActionSchedulerJob impl
 	 *
 	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
 	 */
-	protected function process_items( array $items ) {
+	protected function process_items( array $items, array $context = [] ) {
 		$product_ids = $this->options->get( OptionsInterface::SYNCABLE_PRODUCTS_COUNT_INTERMEDIATE_DATA );
 
 		if ( ! is_array( $product_ids ) ) {

--- a/src/Jobs/UpdateSyncableProductsCount.php
+++ b/src/Jobs/UpdateSyncableProductsCount.php
@@ -77,7 +77,8 @@ class UpdateSyncableProductsCount extends AbstractBatchedActionSchedulerJob impl
 	/**
 	 * Process batch items.
 	 *
-	 * @param int[] $items A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param int[] $items   A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $context Unused.
 	 */
 	protected function process_items( array $items, array $context = [] ) {
 		$product_ids = $this->options->get( OptionsInterface::SYNCABLE_PRODUCTS_COUNT_INTERMEDIATE_DATA );

--- a/tests/Unit/Jobs/CleanupOrphanedLanguageProductsJobTest.php
+++ b/tests/Unit/Jobs/CleanupOrphanedLanguageProductsJobTest.php
@@ -12,6 +12,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedLanguageProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -39,8 +41,14 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 	/** @var MockObject|ProductRepository $product_repository */
 	protected $product_repository;
 
+	/** @var MockObject|BatchProductHelper $batch_product_helper */
+	protected $batch_product_helper;
+
 	/** @var MockObject|MerchantCenterService $merchant_center */
 	protected $merchant_center;
+
+	/** @var MockObject|MerchantStatuses $merchant_statuses */
+	protected $merchant_statuses;
 
 	/** @var MockObject|ProductHelper $product_helper */
 	protected $product_helper;
@@ -52,25 +60,31 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 	protected $job;
 
 	protected const JOB_NAME          = 'cleanup_orphaned_language_products_job';
+	protected const CREATE_BATCH_HOOK = 'gla/jobs/' . self::JOB_NAME . '/create_batch';
 	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
+	protected const BATCH_SIZE        = 100;
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->action_scheduler   = $this->createMock( ActionScheduler::class );
-		$this->monitor            = $this->createMock( ActionSchedulerJobMonitor::class );
-		$this->product_syncer     = $this->createMock( ProductSyncer::class );
-		$this->product_repository = $this->createMock( ProductRepository::class );
-		$this->merchant_center    = $this->createMock( MerchantCenterService::class );
-		$this->product_helper     = $this->createMock( ProductHelper::class );
-		$this->wpml               = $this->createMock( WPML::class );
+		$this->action_scheduler     = $this->createMock( ActionScheduler::class );
+		$this->monitor              = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->product_syncer       = $this->createMock( ProductSyncer::class );
+		$this->product_repository   = $this->createMock( ProductRepository::class );
+		$this->batch_product_helper = $this->createMock( BatchProductHelper::class );
+		$this->merchant_center      = $this->createMock( MerchantCenterService::class );
+		$this->merchant_statuses    = $this->createMock( MerchantStatuses::class );
+		$this->product_helper       = $this->createMock( ProductHelper::class );
+		$this->wpml                 = $this->createMock( WPML::class );
 
 		$this->job = new CleanupOrphanedLanguageProductsJob(
 			$this->action_scheduler,
 			$this->monitor,
 			$this->product_syncer,
 			$this->product_repository,
+			$this->batch_product_helper,
 			$this->merchant_center,
+			$this->merchant_statuses,
 			$this->product_helper,
 			$this->wpml
 		);
@@ -112,34 +126,69 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		);
 	}
 
-	public function test_schedule_schedules_immediate_with_payload() {
+	public function test_schedule_schedules_first_batch_with_payload_context() {
 		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
 		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
 
-		$expected_payload = [
-			[
-				'keys'              => [ 'FR-fr' ],
-				'removed_languages' => [ 'fr' ],
-			],
+		$context = [
+			'keys'              => [ 'FR-fr' ],
+			'removed_languages' => [ 'fr' ],
 		];
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )
-			->with( self::PROCESS_ITEM_HOOK, $expected_payload );
+			->with( self::CREATE_BATCH_HOOK, [ 1, $context ] );
 
-		$this->job->schedule(
-			[
-				'keys'              => [ 'FR-fr' ],
-				'removed_languages' => [ 'fr' ],
-			]
-		);
+		$this->job->schedule( $context );
+	}
+
+	public function test_schedule_never_loads_the_full_catalogue_in_one_batch() {
+		$ids = range( 1, self::BATCH_SIZE * 3 );
+
+		$first_batch  = array_slice( $ids, 0, self::BATCH_SIZE );
+		$second_batch = array_slice( $ids, self::BATCH_SIZE, self::BATCH_SIZE );
+		$context      = [
+			'keys'              => [ 'FR-fr' ],
+			'removed_languages' => [ 'fr' ],
+		];
+
+		$this->product_repository->expects( $this->exactly( 3 ) )
+			->method( 'find_synced_product_ids' )
+			->withConsecutive(
+				[ [], self::BATCH_SIZE, 0 ],
+				[ [], self::BATCH_SIZE, self::BATCH_SIZE ],
+				[ [], self::BATCH_SIZE, self::BATCH_SIZE * 2 ]
+			)
+			->will(
+				$this->onConsecutiveCalls(
+					$first_batch,
+					$second_batch,
+					[]
+				)
+			);
+
+		$this->action_scheduler->expects( $this->exactly( 5 ) )
+			->method( 'schedule_immediate' )
+			->withConsecutive(
+				[ self::CREATE_BATCH_HOOK, [ 1, $context ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $first_batch, $context ] ],
+				[ self::CREATE_BATCH_HOOK, [ 2, $context ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $second_batch, $context ] ],
+				[ self::CREATE_BATCH_HOOK, [ 3, $context ] ]
+			);
+
+		$this->job->schedule( $context );
+
+		// Trigger the first two batches; the third comes back empty and stops the job.
+		do_action( self::CREATE_BATCH_HOOK, 1, $context );
+		do_action( self::CREATE_BATCH_HOOK, 2, $context );
+		do_action( self::CREATE_BATCH_HOOK, 3, $context );
 	}
 
 	public function test_process_items_deletes_entry_for_product_in_removed_language() {
 		$product   = WC_Helper_Product::create_simple_product();
 		$google_id = 'online:fr:FR-fr:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 
 		$this->wpml->method( 'get_post_language' )->with( $product->get_id() )->willReturn( 'fr' );
@@ -172,6 +221,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'FR-fr' ],
 				'removed_languages' => [ 'fr' ],
@@ -182,7 +232,6 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 	public function test_process_items_skips_products_whose_language_is_not_in_removed_set() {
 		$product = WC_Helper_Product::create_simple_product();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 
 		$this->wpml->method( 'get_post_language' )->willReturn( 'en' );
@@ -191,6 +240,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'FR-fr' ],
 				'removed_languages' => [ 'fr' ],
@@ -201,7 +251,6 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 	public function test_process_items_skips_products_with_no_entry_under_keys() {
 		$product = WC_Helper_Product::create_simple_product();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 
 		$this->wpml->method( 'get_post_language' )->willReturn( 'fr' );
@@ -214,6 +263,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'FR-fr' ],
 				'removed_languages' => [ 'fr' ],
@@ -225,7 +275,6 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		$product   = WC_Helper_Product::create_simple_product();
 		$google_id = 'online:fr:FR-fr:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 		$this->wpml->method( 'get_post_language' )->willReturn( 'fr' );
 		$this->product_helper->method( 'get_synced_google_product_ids' )->willReturn( [ 'FR-fr' => $google_id ] );
@@ -245,6 +294,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'FR-fr' ],
 				'removed_languages' => [ 'fr' ],
@@ -256,7 +306,6 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		$product   = WC_Helper_Product::create_simple_product();
 		$google_id = 'online:fr:FR-fr:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 		$this->wpml->method( 'get_post_language' )->willReturn( 'fr' );
 		$this->product_helper->method( 'get_synced_google_product_ids' )->willReturn( [ 'FR-fr' => $google_id ] );
@@ -268,6 +317,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'FR-fr' ],
 				'removed_languages' => [ 'fr' ],
@@ -280,7 +330,6 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		$gb_id   = 'online:fr:GB:gla_' . $product->get_id();
 		$us_id   = 'online:fr:US:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 		$this->wpml->method( 'get_post_language' )->willReturn( 'fr' );
 
@@ -318,6 +367,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'GB', 'US' ],
 				'removed_languages' => [ 'fr' ],
@@ -325,13 +375,17 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		);
 	}
 
-	public function test_process_items_returns_early_when_no_synced_products() {
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [] );
+	public function test_process_items_returns_early_when_batch_is_empty() {
+		$this->product_repository->expects( $this->once() )
+			->method( 'find_by_ids' )
+			->with( [] )
+			->willReturn( [] );
 
 		$this->product_syncer->expects( $this->never() )->method( 'delete_by_batch_requests' );
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[],
 			[
 				'keys'              => [ 'GB' ],
 				'removed_languages' => [ 'fr' ],
@@ -339,10 +393,17 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		);
 	}
 
+	public function test_process_items_returns_early_when_context_missing() {
+		$this->product_repository->expects( $this->never() )->method( 'find_by_ids' );
+
+		$this->product_syncer->expects( $this->never() )->method( 'delete_by_batch_requests' );
+
+		do_action( self::PROCESS_ITEM_HOOK, [ 1 ], [] );
+	}
+
 	public function test_process_items_skips_products_with_empty_wpml_language() {
 		$product = WC_Helper_Product::create_simple_product();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 		$this->wpml->method( 'get_post_language' )->willReturn( '' );
 
@@ -350,6 +411,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'GB' ],
 				'removed_languages' => [ 'fr' ],

--- a/tests/Unit/Jobs/CleanupOrphanedLanguageProductsJobTest.php
+++ b/tests/Unit/Jobs/CleanupOrphanedLanguageProductsJobTest.php
@@ -152,6 +152,9 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 			'removed_languages' => [ 'fr' ],
 		];
 
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
+
 		$this->product_repository->expects( $this->exactly( 3 ) )
 			->method( 'find_synced_product_ids' )
 			->withConsecutive(

--- a/tests/Unit/Jobs/CleanupOrphanedMarketProductsJobTest.php
+++ b/tests/Unit/Jobs/CleanupOrphanedMarketProductsJobTest.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedMarketProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -36,8 +38,14 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 	/** @var MockObject|ProductRepository $product_repository */
 	protected $product_repository;
 
+	/** @var MockObject|BatchProductHelper $batch_product_helper */
+	protected $batch_product_helper;
+
 	/** @var MockObject|MerchantCenterService $merchant_center */
 	protected $merchant_center;
+
+	/** @var MockObject|MerchantStatuses $merchant_statuses */
+	protected $merchant_statuses;
 
 	/** @var MockObject|ProductHelper $product_helper */
 	protected $product_helper;
@@ -46,24 +54,30 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 	protected $job;
 
 	protected const JOB_NAME          = 'cleanup_orphaned_market_products_job';
+	protected const CREATE_BATCH_HOOK = 'gla/jobs/' . self::JOB_NAME . '/create_batch';
 	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
+	protected const BATCH_SIZE        = 100;
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->action_scheduler   = $this->createMock( ActionScheduler::class );
-		$this->monitor            = $this->createMock( ActionSchedulerJobMonitor::class );
-		$this->product_syncer     = $this->createMock( ProductSyncer::class );
-		$this->product_repository = $this->createMock( ProductRepository::class );
-		$this->merchant_center    = $this->createMock( MerchantCenterService::class );
-		$this->product_helper     = $this->createMock( ProductHelper::class );
+		$this->action_scheduler     = $this->createMock( ActionScheduler::class );
+		$this->monitor              = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->product_syncer       = $this->createMock( ProductSyncer::class );
+		$this->product_repository   = $this->createMock( ProductRepository::class );
+		$this->batch_product_helper = $this->createMock( BatchProductHelper::class );
+		$this->merchant_center      = $this->createMock( MerchantCenterService::class );
+		$this->merchant_statuses    = $this->createMock( MerchantStatuses::class );
+		$this->product_helper       = $this->createMock( ProductHelper::class );
 
 		$this->job = new CleanupOrphanedMarketProductsJob(
 			$this->action_scheduler,
 			$this->monitor,
 			$this->product_syncer,
 			$this->product_repository,
+			$this->batch_product_helper,
 			$this->merchant_center,
+			$this->merchant_statuses,
 			$this->product_helper
 		);
 
@@ -92,15 +106,57 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 		$this->job->schedule( [ 'feed_labels' => 'GB' ] );
 	}
 
-	public function test_schedule_schedules_immediate_with_feed_labels() {
+	public function test_schedule_schedules_first_batch_with_feed_labels_context() {
 		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
 		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
 
+		$context = [ 'feed_labels' => [ 'GB', 'GB-CY' ] ];
+
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )
-			->with( self::PROCESS_ITEM_HOOK, [ [ 'feed_labels' => [ 'GB', 'GB-CY' ] ] ] );
+			->with( self::CREATE_BATCH_HOOK, [ 1, $context ] );
 
-		$this->job->schedule( [ 'feed_labels' => [ 'GB', 'GB-CY' ] ] );
+		$this->job->schedule( $context );
+	}
+
+	public function test_schedule_never_loads_the_full_catalogue_in_one_batch() {
+		$ids = range( 1, self::BATCH_SIZE * 3 );
+
+		$first_batch  = array_slice( $ids, 0, self::BATCH_SIZE );
+		$second_batch = array_slice( $ids, self::BATCH_SIZE, self::BATCH_SIZE );
+		$context      = [ 'feed_labels' => [ 'GB' ] ];
+
+		$this->product_repository->expects( $this->exactly( 3 ) )
+			->method( 'find_synced_product_ids' )
+			->withConsecutive(
+				[ [], self::BATCH_SIZE, 0 ],
+				[ [], self::BATCH_SIZE, self::BATCH_SIZE ],
+				[ [], self::BATCH_SIZE, self::BATCH_SIZE * 2 ]
+			)
+			->will(
+				$this->onConsecutiveCalls(
+					$first_batch,
+					$second_batch,
+					[]
+				)
+			);
+
+		$this->action_scheduler->expects( $this->exactly( 5 ) )
+			->method( 'schedule_immediate' )
+			->withConsecutive(
+				[ self::CREATE_BATCH_HOOK, [ 1, $context ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $first_batch, $context ] ],
+				[ self::CREATE_BATCH_HOOK, [ 2, $context ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $second_batch, $context ] ],
+				[ self::CREATE_BATCH_HOOK, [ 3, $context ] ]
+			);
+
+		$this->job->schedule( $context );
+
+		// Trigger the first two batches; the third comes back empty and stops the job.
+		do_action( self::CREATE_BATCH_HOOK, 1, $context );
+		do_action( self::CREATE_BATCH_HOOK, 2, $context );
+		do_action( self::CREATE_BATCH_HOOK, 3, $context );
 	}
 
 	public function test_process_items_builds_request_entry_per_product_for_feed_label() {
@@ -108,8 +164,6 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 		$google_id = 'online:en:GB:gla_' . $product->get_id();
 		$other_id  = 'online:en:US:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )
-			->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )
 			->with( [ $product->get_id() ] )
 			->willReturn( [ $product ] );
@@ -140,7 +194,7 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 			)
 			->willReturn( new BatchProductResponse( [], [] ) );
 
-		do_action( self::PROCESS_ITEM_HOOK, [ 'feed_labels' => [ 'GB' ] ] );
+		do_action( self::PROCESS_ITEM_HOOK, [ $product->get_id() ], [ 'feed_labels' => [ 'GB' ] ] );
 	}
 
 	public function test_process_items_builds_request_entries_for_every_given_feed_label() {
@@ -149,8 +203,6 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 		$language_id  = 'online:cy:GB-CY:gla_' . $product->get_id();
 		$unrelated_id = 'online:en:US:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )
-			->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )
 			->willReturn( [ $product ] );
 
@@ -184,15 +236,13 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 			)
 			->willReturn( new BatchProductResponse( [], [] ) );
 
-		do_action( self::PROCESS_ITEM_HOOK, [ 'feed_labels' => [ 'GB', 'GB-CY' ] ] );
+		do_action( self::PROCESS_ITEM_HOOK, [ $product->get_id() ], [ 'feed_labels' => [ 'GB', 'GB-CY' ] ] );
 	}
 
 	public function test_process_items_leaves_local_meta_intact_on_api_failure() {
 		$product   = WC_Helper_Product::create_simple_product();
 		$google_id = 'online:en:GB:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )
-			->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )
 			->willReturn( [ $product ] );
 
@@ -206,14 +256,12 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 		$this->product_helper->expects( $this->never() )
 			->method( 'remove_google_id' );
 
-		do_action( self::PROCESS_ITEM_HOOK, [ 'feed_labels' => [ 'GB' ] ] );
+		do_action( self::PROCESS_ITEM_HOOK, [ $product->get_id() ], [ 'feed_labels' => [ 'GB' ] ] );
 	}
 
 	public function test_process_items_skips_products_with_no_entry_for_feed_label() {
 		$product = WC_Helper_Product::create_simple_product();
 
-		$this->product_repository->method( 'find_synced_product_ids' )
-			->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )
 			->willReturn( [ $product ] );
 
@@ -227,15 +275,28 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 		$this->product_syncer->expects( $this->never() )
 			->method( 'delete_by_batch_requests' );
 
-		do_action( self::PROCESS_ITEM_HOOK, [ 'feed_labels' => [ 'GB' ] ] );
+		do_action( self::PROCESS_ITEM_HOOK, [ $product->get_id() ], [ 'feed_labels' => [ 'GB' ] ] );
 	}
 
-	public function test_process_items_returns_early_when_no_synced_products() {
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [] );
+	public function test_process_items_returns_early_when_batch_is_empty() {
+		$this->product_repository->expects( $this->once() )
+			->method( 'find_by_ids' )
+			->with( [] )
+			->willReturn( [] );
 
 		$this->product_syncer->expects( $this->never() )
 			->method( 'delete_by_batch_requests' );
 
-		do_action( self::PROCESS_ITEM_HOOK, [ 'feed_labels' => [ 'GB' ] ] );
+		do_action( self::PROCESS_ITEM_HOOK, [], [ 'feed_labels' => [ 'GB' ] ] );
+	}
+
+	public function test_process_items_returns_early_when_feed_labels_missing_from_context() {
+		$this->product_repository->expects( $this->never() )
+			->method( 'find_by_ids' );
+
+		$this->product_syncer->expects( $this->never() )
+			->method( 'delete_by_batch_requests' );
+
+		do_action( self::PROCESS_ITEM_HOOK, [ 1 ], [] );
 	}
 }

--- a/tests/Unit/Jobs/CleanupOrphanedMarketProductsJobTest.php
+++ b/tests/Unit/Jobs/CleanupOrphanedMarketProductsJobTest.php
@@ -126,6 +126,9 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 		$second_batch = array_slice( $ids, self::BATCH_SIZE, self::BATCH_SIZE );
 		$context      = [ 'feed_labels' => [ 'GB' ] ];
 
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
+
 		$this->product_repository->expects( $this->exactly( 3 ) )
 			->method( 'find_synced_product_ids' )
 			->withConsecutive(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes GOOWOO-852.

`CleanupOrphanedMarketProductsJob` and `CleanupOrphanedLanguageProductsJob` each loaded the entire synced product catalogue (`find_synced_product_ids()` / `find_by_ids()` with no limit/offset) inside a single unbounded Action Scheduler action. On a large catalogue this risks memory exhaustion or an Action Scheduler timeout — and since the market/language change that scheduled the cleanup has already succeeded and persisted, a failed cleanup run silently leaves orphaned Merchant Center entries behind.

This switches both jobs to the same paged-batching pattern already used by `CleanupProductsJob` and `CleanupSyncedProducts` (`AbstractProductSyncerBatchedJob`, 100 products per batch via Action Scheduler). Since these two jobs need extra per-run context (`feed_labels`, or `keys`/`removed_languages`) that the existing batching base classes had no way to carry through a run, `AbstractActionSchedulerJob` / `AbstractBatchedActionSchedulerJob` / `BatchedActionSchedulerJobInterface` gained an additive, opt-in `$context` parameter threaded through `schedule()` → `create_batch` → `get_batch()` / `process_items()`. It's omitted from the scheduled action's args whenever empty, so every other job on these base classes (`CleanupProductsJob`, `UpdateAllProducts`, `DeleteAllProducts`, `UpdateSyncableProductsCount`, etc.) keeps its exact existing scheduling behavior.

### Detailed test instructions:

1. On a store with a large product catalogue, delete a market (or rename its feed label, or remove a language from a market's accepted set).
2. Confirm the corresponding `cleanup_orphaned_market_products_job` / `cleanup_orphaned_language_products_job` action in Action Scheduler runs to completion via `create_batch`/`process_item` cycles (batches of 100) rather than a single `process_item` action.
3. Confirm the removed/renamed feed label's Merchant Center entries are gone, and other markets'/languages' entries are untouched.
4. `composer test-unit` — `tests/Unit/Jobs/CleanupOrphanedMarketProductsJobTest.php`, `CleanupOrphanedLanguageProductsJobTest.php`, and the other batched-job test suites (`CleanupProductsJobTest`, `CleanupSyncedProductsTest`, `UpdateAllProductsTest`, `DeleteAllProductsTest`, `UpdateSyncableProductsCountTest`) to confirm no regressions from the shared base class change.

### Additional details:

Ran `php -l` on every changed file. Could not run the full PHPUnit suite locally in this sandbox (needs a WP+WooCommerce test environment); relying on CI for that — flagging here in case CI surfaces something the review should double check, particularly the batched-job test suites listed above.

### Changelog entry

> Fix - Cleanup jobs for removed/renamed markets and removed languages now process the synced product catalogue in batches instead of loading it all at once, preventing memory exhaustion or timeouts on large catalogues.