### PR TITLE
Fix disconnected state when WordPress.com token is already revoked

### DIFF
--- a/src/API/WP/OAuthService.php
+++ b/src/API/WP/OAuthService.php
@@ -42,6 +42,8 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 	public const STATUS_DISAPPROVED = 'disapproved';
 	public const STATUS_ERROR       = 'error';
 
+	private const TOKEN_NOT_ASSOCIATED_ERROR_CODE = 'wpcom_partner_token_not_associated';
+
 	public const ALLOWED_STATUSES = [
 		self::STATUS_APPROVED,
 		self::STATUS_DISAPPROVED,
@@ -205,6 +207,11 @@ class OAuthService implements Service, OptionsAwareInterface, Deactivateable, Co
 						'blog_id' => Jetpack_Options::get_option( 'id' ),
 					]
 				);
+
+				if ( self::TOKEN_NOT_ASSOCIATED_ERROR_CODE === ( $data['code'] ?? null ) ) {
+					$this->container->get( AccountService::class )->reset_wpcom_api_authorization_data();
+					return $body;
+				}
 
 				throw new Exception( $message, $status );
 			}

--- a/tests/Unit/API/WP/OAuthServiceTest.php
+++ b/tests/Unit/API/WP/OAuthServiceTest.php
@@ -310,4 +310,36 @@ class OAuthServiceTest extends UnitTest {
 
 		$this->service->revoke_wpcom_api_auth();
 	}
+
+	public function test_revoke_wpcom_api_auth_token_not_associated() {
+		$response_body = wp_json_encode(
+			[
+				'code'    => 'wpcom_partner_token_not_associated',
+				'message' => 'No token found associated with the client ID and user.',
+			]
+		);
+
+		$this->jp->expects( $this->once() )
+			->method( 'remote_request' )
+			->willReturn(
+				[
+					'body'     => $response_body,
+					'response' => [ 'code' => 400 ],
+				]
+			);
+
+		$this->account_service->expects( $this->once() )
+			->method( 'reset_wpcom_api_authorization_data' );
+
+		$this->expect_track_event(
+			'revoke_wpcom_api_authorization',
+			[
+				'status'  => 400,
+				'error'   => 'No token found associated with the client ID and user.',
+				'blog_id' => Jetpack_Options::get_option( 'id' ),
+			]
+		);
+
+		$this->assertSame( $response_body, $this->service->revoke_wpcom_api_auth() );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Addresses [GOOWOO-528](https://linear.app/a8c/issue/GOOWOO-528/brokered-wpcom-token-stuck-in-disconnected-state).

#### Problem

Disconnecting all accounts can leave `gla_wpcom_rest_api_status` stuck at `error` when the brokered WordPress.com token is already absent. The Merchant Center connection is removed, but GLA continues to report the stale WordPress.com authorization state on later requests.

#### Root cause

The WordPress.com revoke endpoint reports an already-absent token with the stable error code `wpcom_partner_token_not_associated`. `OAuthService::revoke_wpcom_api_auth()` treated every non-200 response as a generic failure and threw before calling `reset_wpcom_api_authorization_data()`.

#### Change

Treat only `wpcom_partner_token_not_associated` as an idempotent revoke result. GLA still records the original response, clears its local WordPress.com authorization data, and completes the disconnect. Transport failures and every other WordPress.com error continue to throw.

A regression test covers the already-revoked response and a control test continues to prove that generic 400 responses throw without clearing local data.

### How this was reproduced:

The original behavior was reproduced in a disposable WordPress/WooCommerce/MariaDB environment with Google for WooCommerce 3.7.3. The regression tests ran with PHP 8.4.6, PHPUnit 9.6.34, and WooCommerce 10.9.4. The relevant OAuth implementation is unchanged on the current `develop` branch.

Preconditions:

- `gla_merchant_id=1234`
- `gla_wpcom_rest_api_status=error`
- The WordPress.com user/site pairing has no associated brokered token, so the revoke request returns:

```json
{
  "code": "wpcom_partner_token_not_associated",
  "message": "No token found associated with the client ID and user."
}
```

Observed before the patch:

1. `DELETE /wc/gla/connections` attempted each account disconnect.
2. The WordPress.com revoke step returned `400` and the overall request reported that `/rest-api/authorize` failed.
3. `gla_merchant_id` was removed, but `gla_wpcom_rest_api_status` remained `error`.
4. The connection response remained:

```json
{
  "id": 0,
  "status": "disconnected",
  "wpcom_rest_api_status": "error"
}
```

The regression test failed before the production change with:

```text
Exception: No token found associated with the client ID and user.
Tests: 1, Assertions: 0, Errors: 1.
```

### Detailed test instructions:

Use the repository's configured WordPress PHP unit-test environment. For a first run, follow the repository README:

```bash
composer install
./bin/install-wp-tests.sh wordpress_tests root root localhost
```

1. Run the focused regression:

   ```bash
   vendor/bin/phpunit tests/Unit/API/WP/OAuthServiceTest.php \
     --filter test_revoke_wpcom_api_auth_token_not_associated
   ```

   Expected: `OK (1 test, 4 assertions)`. The known already-absent response returns normally and local WordPress.com authorization data is reset.

2. Run the control case:

   ```bash
   vendor/bin/phpunit tests/Unit/API/WP/OAuthServiceTest.php \
     --filter test_revoke_wpcom_api_auth_status_error
   ```

   Expected: the test passes, confirming an unrelated `400` still throws and does not reset local authorization data.

3. Run the complete OAuth service tests:

   ```bash
   vendor/bin/phpunit tests/Unit/API/WP/OAuthServiceTest.php
   ```

   Expected: `OK (8 tests, 39 assertions)`.

4. Run the related REST authorization controller tests:

   ```bash
   vendor/bin/phpunit tests/Unit/API/Site/Controllers/RestAPI/AuthControllerTest.php
   ```

   Expected: `OK (9 tests, 22 assertions)`.

5. Run coding standards on the changed files:

   ```bash
   vendor/bin/phpcs src/API/WP/OAuthService.php
   vendor/bin/phpcs --standard=tests/phpcs.xml.dist tests/Unit/API/WP/OAuthServiceTest.php
   ```

   Expected: both files pass with no coding-standard violations.

### Test results:

Author-observed local results:

- Focused regression: `1 test, 4 assertions` passed after the patch.
- OAuth service suite: `8 tests, 39 assertions` passed.
- REST authorization controller suite: `9 tests, 22 assertions` passed.
- PHPCS passed for both changed files.
- `git diff --check` passed.

GitHub Actions results:

- Extension bundle build passed.
- PHP coding standards passed.
- PHP unit tests passed on PHP 7.4, 8.2, 8.3, and 8.4 across the configured WordPress/WooCommerce matrix.
- Codecov project and patch checks passed.
- Bundlewatch passed.

### Additional details:

This fixes the sticky client-side authorization state after WordPress.com confirms the token is already absent. It does not repair unrelated server-side Google Merchant Center or Ads brokered-token failures.

Reviewer focus: confirm that the stable error code is narrow enough for idempotent handling and that generic revoke failures retain their existing behavior.

### Changelog entry

> Fix - Clear stale WordPress.com connection state when the brokered token has already been revoked.
