### PR TITLE
Fix - Batch the orphaned market/language cleanup jobs via a scoped context class

### DIFF
--- a/src/Jobs/AbstractContextualProductSyncerBatchedJob.php
+++ b/src/Jobs/AbstractContextualProductSyncerBatchedJob.php
@@ -30,12 +30,25 @@ defined( 'ABSPATH' ) || exit;
  * cycle, but threads a `$context` array alongside the cursor and items at
  * every step, so `get_batch()` and `process_items()` can use it.
  *
+ * `handle_create_batch_action()` and `handle_process_items_action()` below
+ * therefore take an extra `$context` parameter beyond what
+ * `BatchedActionSchedulerJobInterface` declares for them. PHP allows this
+ * (an override may add optional parameters), but it means the interface
+ * alone no longer fully describes this class's hook contract.
+ *
+ * @since 3.9.0
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
 abstract class AbstractContextualProductSyncerBatchedJob extends AbstractProductSyncerBatchedJob {
 
 	/**
 	 * Init the batch schedule for the job.
+	 *
+	 * Deliberately does not call `parent::init()`: the parent registers both
+	 * hooks at arity 1 (batch number / items only), and this class's handlers
+	 * need arity 2 to also receive `$context`. Calling both would register
+	 * `handle_create_batch_action()`/`handle_process_items_action()` twice.
 	 */
 	public function init(): void {
 		add_action( $this->get_create_batch_hook(), [ $this, 'handle_create_batch_action' ], 10, 2 );
@@ -74,7 +87,8 @@ abstract class AbstractContextualProductSyncerBatchedJob extends AbstractProduct
 		$items = $this->get_batch( $last_id, $context );
 
 		if ( empty( $items ) ) {
-			// if no more items the job is complete
+			// if no more items the job is complete. Note $last_id is a cursor here, not a batch
+			// count, despite handle_complete()'s inherited "$final_batch_number" parameter name.
 			$this->handle_complete( $last_id );
 		} else {
 			// if items, schedule the process action

--- a/src/Jobs/AbstractContextualProductSyncerBatchedJob.php
+++ b/src/Jobs/AbstractContextualProductSyncerBatchedJob.php
@@ -1,0 +1,164 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
+
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AbstractContextualProductSyncerBatchedJob
+ *
+ * A batched product syncer job whose run needs a fixed piece of context
+ * established when the job is scheduled (e.g. which feed labels or languages
+ * to clean up), carried through every batch of that run.
+ *
+ * `AbstractProductSyncerBatchedJob`'s batches are always context-free (a
+ * plain paginated scan of the whole catalogue), so its `schedule()` drops any
+ * `$args` it's given and its `create_batch`/`process_item` hooks only ever
+ * carry a batch number or an item list. This class re-implements that same
+ * batch cycle, but threads a `$context` array alongside the batch number and
+ * items at every step, so `get_batch()` and `process_items()` can use it.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
+ */
+abstract class AbstractContextualProductSyncerBatchedJob extends AbstractProductSyncerBatchedJob {
+
+	/**
+	 * Init the batch schedule for the job.
+	 */
+	public function init(): void {
+		add_action( $this->get_create_batch_hook(), [ $this, 'handle_create_batch_action' ], 10, 2 );
+		add_action( $this->get_process_item_hook(), [ $this, 'handle_process_items_action' ], 10, 2 );
+	}
+
+	/**
+	 * Enqueue the "create_batch" action provided it doesn't already exist.
+	 *
+	 * @param array $context The run's context, carried through every batch of this run.
+	 */
+	public function schedule( array $context = [] ) {
+		$this->schedule_create_batch_action( 1, $context );
+	}
+
+	/**
+	 * Handles batch creation action hook.
+	 *
+	 * @hooked gla/jobs/{$job_name}/create_batch
+	 *
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      The run's context, as passed to `schedule()`.
+	 *
+	 * @throws Exception If an error occurs.
+	 * @throws JobException If the job failure rate is too high.
+	 */
+	public function handle_create_batch_action( int $batch_number, array $context = [] ) {
+		$create_batch_hook = $this->get_create_batch_hook();
+		$create_batch_args = [ $batch_number, $context ];
+
+		$this->monitor->validate_failure_rate( $this, $create_batch_hook, $create_batch_args );
+		if ( $this->retry_on_timeout ) {
+			$this->monitor->attach_timeout_monitor( $create_batch_hook, $create_batch_args );
+		}
+
+		$items = $this->get_batch( $batch_number, $context );
+
+		if ( empty( $items ) ) {
+			// if no more items the job is complete
+			$this->handle_complete( $batch_number );
+		} else {
+			// if items, schedule the process action
+			$this->schedule_process_action( $items, $context );
+
+			// Add another "create_batch" action to handle unfiltered items.
+			// The last batch created here will be an empty batch, it
+			// will call "handle_complete" to finish the job.
+			$this->schedule_create_batch_action( $batch_number + 1, $context );
+		}
+
+		$this->monitor->detach_timeout_monitor( $create_batch_hook, $create_batch_args );
+	}
+
+	/**
+	 * Handles processing single item action hook.
+	 *
+	 * @hooked gla/jobs/{$job_name}/process_item
+	 *
+	 * @param array $items   The job items from the current batch.
+	 * @param array $context The run's context, as passed to `schedule()`.
+	 *
+	 * @throws Exception If an error occurs.
+	 */
+	public function handle_process_items_action( array $items = [], array $context = [] ) {
+		$process_hook = $this->get_process_item_hook();
+		$process_args = [ $items, $context ];
+
+		$this->monitor->validate_failure_rate( $this, $process_hook, $process_args );
+		if ( $this->retry_on_timeout ) {
+			$this->monitor->attach_timeout_monitor( $process_hook, $process_args );
+		}
+
+		try {
+			$this->process_items( $items, $context );
+		} catch ( Exception $exception ) {
+			// reschedule on failure
+			$this->action_scheduler->schedule_immediate( $process_hook, $process_args );
+
+			// throw the exception again so that it can be logged
+			throw $exception;
+		}
+
+		$this->monitor->detach_timeout_monitor( $process_hook, $process_args );
+	}
+
+	/**
+	 * Schedule a new "create batch" action to run immediately.
+	 *
+	 * @param int   $batch_number The batch number for the new batch.
+	 * @param array $context      The run's context, as passed to `schedule()`.
+	 */
+	protected function schedule_create_batch_action( int $batch_number, array $context = [] ) {
+		$args = [ $batch_number, $context ];
+		if ( $this->can_schedule( $args ) ) {
+			$this->action_scheduler->schedule_immediate( $this->get_create_batch_hook(), $args );
+		}
+	}
+
+	/**
+	 * Schedule a new "process" action to run immediately.
+	 *
+	 * @param array $items   Array of item ids.
+	 * @param array $context The run's context, as passed to `schedule()`.
+	 */
+	protected function schedule_process_action( array $items, array $context = [] ) {
+		$args = [ $items, $context ];
+		if ( ! $this->action_scheduler->has_scheduled_action( $this->get_process_item_hook(), $args ) ) {
+			$this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), $args );
+		}
+	}
+
+	/**
+	 * Get a single batch of items.
+	 *
+	 * If no items are returned the job will stop.
+	 *
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      The run's context, as passed to `schedule()`.
+	 *
+	 * @return array
+	 *
+	 * @throws Exception If an error occurs. The exception will be logged by ActionScheduler.
+	 */
+	abstract protected function get_batch( int $batch_number, array $context = [] ): array;
+
+	/**
+	 * Process batch items.
+	 *
+	 * @param array $items   A single batch from the get_batch() method.
+	 * @param array $context The run's context, as passed to `schedule()`.
+	 *
+	 * @throws Exception If an error occurs. The exception will be logged by ActionScheduler.
+	 */
+	abstract protected function process_items( array $items, array $context = [] );
+}

--- a/src/Jobs/AbstractContextualProductSyncerBatchedJob.php
+++ b/src/Jobs/AbstractContextualProductSyncerBatchedJob.php
@@ -14,12 +14,21 @@ defined( 'ABSPATH' ) || exit;
  * established when the job is scheduled (e.g. which feed labels or languages
  * to clean up), carried through every batch of that run.
  *
- * `AbstractProductSyncerBatchedJob`'s batches are always context-free (a
- * plain paginated scan of the whole catalogue), so its `schedule()` drops any
- * `$args` it's given and its `create_batch`/`process_item` hooks only ever
- * carry a batch number or an item list. This class re-implements that same
- * batch cycle, but threads a `$context` array alongside the batch number and
- * items at every step, so `get_batch()` and `process_items()` can use it.
+ * Uses keyset (cursor) pagination, like `ResubmitExpiringProducts`, rather
+ * than `AbstractProductSyncerBatchedJob`'s OFFSET-based batch numbering: a
+ * batch here is expected to mutate the very rows its own query matched (e.g.
+ * deleting or unsyncing them), which shrinks the result set as the run
+ * progresses. OFFSET-based paging would skip rows whenever that happens,
+ * since each new page still skips a fixed count from the start rather than
+ * resuming after the last row actually seen; a cursor is immune to that
+ * because it only ever asks for rows after the highest ID already handled.
+ *
+ * `AbstractProductSyncerBatchedJob`'s batches are also always context-free (a
+ * plain scan of the whole catalogue), so its `schedule()` drops any `$args`
+ * it's given and its `create_batch`/`process_item` hooks only ever carry a
+ * batch number or an item list. This class re-implements that same batch
+ * cycle, but threads a `$context` array alongside the cursor and items at
+ * every step, so `get_batch()` and `process_items()` can use it.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
@@ -34,12 +43,12 @@ abstract class AbstractContextualProductSyncerBatchedJob extends AbstractProduct
 	}
 
 	/**
-	 * Enqueue the "create_batch" action provided it doesn't already exist.
+	 * Enqueue the "create_batch" action, starting the cursor at 0, provided it doesn't already exist.
 	 *
 	 * @param array $context The run's context, carried through every batch of this run.
 	 */
 	public function schedule( array $context = [] ) {
-		$this->schedule_create_batch_action( 1, $context );
+		$this->schedule_create_batch_action( 0, $context );
 	}
 
 	/**
@@ -47,34 +56,34 @@ abstract class AbstractContextualProductSyncerBatchedJob extends AbstractProduct
 	 *
 	 * @hooked gla/jobs/{$job_name}/create_batch
 	 *
-	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
-	 * @param array $context      The run's context, as passed to `schedule()`.
+	 * @param int   $last_id The cursor: the highest product ID processed so far (0 on first run).
+	 * @param array $context The run's context, as passed to `schedule()`.
 	 *
 	 * @throws Exception If an error occurs.
 	 * @throws JobException If the job failure rate is too high.
 	 */
-	public function handle_create_batch_action( int $batch_number, array $context = [] ) {
+	public function handle_create_batch_action( int $last_id, array $context = [] ) {
 		$create_batch_hook = $this->get_create_batch_hook();
-		$create_batch_args = [ $batch_number, $context ];
+		$create_batch_args = [ $last_id, $context ];
 
 		$this->monitor->validate_failure_rate( $this, $create_batch_hook, $create_batch_args );
 		if ( $this->retry_on_timeout ) {
 			$this->monitor->attach_timeout_monitor( $create_batch_hook, $create_batch_args );
 		}
 
-		$items = $this->get_batch( $batch_number, $context );
+		$items = $this->get_batch( $last_id, $context );
 
 		if ( empty( $items ) ) {
 			// if no more items the job is complete
-			$this->handle_complete( $batch_number );
+			$this->handle_complete( $last_id );
 		} else {
 			// if items, schedule the process action
 			$this->schedule_process_action( $items, $context );
 
-			// Add another "create_batch" action to handle unfiltered items.
-			// The last batch created here will be an empty batch, it
-			// will call "handle_complete" to finish the job.
-			$this->schedule_create_batch_action( $batch_number + 1, $context );
+			// Advance the cursor to the highest ID seen in this batch. The last batch
+			// created here will come back empty, and will call "handle_complete" to
+			// finish the job.
+			$this->schedule_create_batch_action( max( $items ), $context );
 		}
 
 		$this->monitor->detach_timeout_monitor( $create_batch_hook, $create_batch_args );
@@ -115,11 +124,11 @@ abstract class AbstractContextualProductSyncerBatchedJob extends AbstractProduct
 	/**
 	 * Schedule a new "create batch" action to run immediately.
 	 *
-	 * @param int   $batch_number The batch number for the new batch.
-	 * @param array $context      The run's context, as passed to `schedule()`.
+	 * @param int   $last_id The cursor for the new batch.
+	 * @param array $context The run's context, as passed to `schedule()`.
 	 */
-	protected function schedule_create_batch_action( int $batch_number, array $context = [] ) {
-		$args = [ $batch_number, $context ];
+	protected function schedule_create_batch_action( int $last_id, array $context = [] ) {
+		$args = [ $last_id, $context ];
 		if ( $this->can_schedule( $args ) ) {
 			$this->action_scheduler->schedule_immediate( $this->get_create_batch_hook(), $args );
 		}
@@ -143,14 +152,14 @@ abstract class AbstractContextualProductSyncerBatchedJob extends AbstractProduct
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
-	 * @param array $context      The run's context, as passed to `schedule()`.
+	 * @param int   $last_id The cursor: fetch items with ID strictly greater than this value.
+	 * @param array $context The run's context, as passed to `schedule()`.
 	 *
 	 * @return array
 	 *
 	 * @throws Exception If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	abstract protected function get_batch( int $batch_number, array $context = [] ): array;
+	abstract protected function get_batch( int $last_id, array $context = [] ): array;
 
 	/**
 	 * Process batch items.

--- a/src/Jobs/CleanupOrphanedLanguageProductsJob.php
+++ b/src/Jobs/CleanupOrphanedLanguageProductsJob.php
@@ -8,6 +8,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -26,9 +28,12 @@ defined( 'ABSPATH' ) || exit;
  * identify a language — the job narrows the deletion to products whose own
  * post language is in the removed set.
  *
+ * Pages through the whole synced catalogue in batches (rather than loading it
+ * all in a single action) since the store's catalogue size is unbounded.
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
-class CleanupOrphanedLanguageProductsJob extends AbstractProductSyncerJob {
+class CleanupOrphanedLanguageProductsJob extends AbstractContextualProductSyncerBatchedJob {
 
 	/**
 	 * @var ProductHelper
@@ -47,7 +52,9 @@ class CleanupOrphanedLanguageProductsJob extends AbstractProductSyncerJob {
 	 * @param ActionSchedulerJobMonitor $monitor
 	 * @param ProductSyncer             $product_syncer
 	 * @param ProductRepository         $product_repository
+	 * @param BatchProductHelper        $batch_product_helper
 	 * @param MerchantCenterService     $merchant_center
+	 * @param MerchantStatuses          $merchant_statuses
 	 * @param ProductHelper             $product_helper
 	 * @param WPML                      $wpml
 	 */
@@ -56,11 +63,13 @@ class CleanupOrphanedLanguageProductsJob extends AbstractProductSyncerJob {
 		ActionSchedulerJobMonitor $monitor,
 		ProductSyncer $product_syncer,
 		ProductRepository $product_repository,
+		BatchProductHelper $batch_product_helper,
 		MerchantCenterService $merchant_center,
+		MerchantStatuses $merchant_statuses,
 		ProductHelper $product_helper,
 		WPML $wpml
 	) {
-		parent::__construct( $action_scheduler, $monitor, $product_syncer, $product_repository, $merchant_center );
+		parent::__construct( $action_scheduler, $monitor, $product_syncer, $product_repository, $batch_product_helper, $merchant_center, $merchant_statuses );
 		$this->product_helper = $product_helper;
 		$this->wpml           = $wpml;
 	}
@@ -97,39 +106,47 @@ class CleanupOrphanedLanguageProductsJob extends AbstractProductSyncerJob {
 			throw InvalidValue::is_empty( 'removed_languages' );
 		}
 
-		$process_args = [
+		parent::schedule(
 			[
 				'keys'              => array_values( $keys ),
 				'removed_languages' => array_values( $removed_languages ),
-			],
-		];
-
-		if ( $this->can_schedule( $process_args ) ) {
-			$this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), $process_args );
-		}
+			]
+		);
 	}
 
 	/**
-	 * Process orphaned entries for products whose language is in the removed set.
+	 * Get a single batch of synced product IDs.
 	 *
-	 * @param array $items Single-element array containing the scheduling args.
+	 * If no items are returned the job will stop.
+	 *
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused by `get_batch()`; the batch is always the next page of
+	 *                            the whole synced catalogue, filtering by language happens per
+	 *                            product in `process_items()`.
+	 *
+	 * @return int[]
+	 */
+	public function get_batch( int $batch_number, array $context = [] ): array {
+		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+	}
+
+	/**
+	 * Process orphaned entries for a single batch of product IDs whose language is in the removed set.
+	 *
+	 * @param int[] $items   A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $context Contains `keys` and `removed_languages`, as passed to `schedule()`.
 	 *
 	 * @throws ProductSyncerException If the Merchant Center delete call fails.
 	 */
-	protected function process_items( array $items ) {
-		$keys    = is_array( $items['keys'] ?? null ) ? $items['keys'] : [];
-		$removed = is_array( $items['removed_languages'] ?? null ) ? $items['removed_languages'] : [];
+	protected function process_items( array $items, array $context = [] ) {
+		$keys    = is_array( $context['keys'] ?? null ) ? $context['keys'] : [];
+		$removed = is_array( $context['removed_languages'] ?? null ) ? $context['removed_languages'] : [];
 
 		if ( empty( $keys ) || empty( $removed ) ) {
 			return;
 		}
 
-		$product_ids = $this->product_repository->find_synced_product_ids();
-		if ( empty( $product_ids ) ) {
-			return;
-		}
-
-		$products        = $this->product_repository->find_by_ids( $product_ids );
+		$products        = $this->product_repository->find_by_ids( $items );
 		$request_entries = [];
 
 		foreach ( $products as $product ) {

--- a/src/Jobs/CleanupOrphanedLanguageProductsJob.php
+++ b/src/Jobs/CleanupOrphanedLanguageProductsJob.php
@@ -29,7 +29,9 @@ defined( 'ABSPATH' ) || exit;
  * post language is in the removed set.
  *
  * Pages through the whole synced catalogue in batches (rather than loading it
- * all in a single action) since the store's catalogue size is unbounded.
+ * all in a single action) since the store's catalogue size is unbounded, using
+ * cursor pagination since each batch removes some of the very rows the next
+ * page's query would otherwise need to count past.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
@@ -119,15 +121,15 @@ class CleanupOrphanedLanguageProductsJob extends AbstractContextualProductSyncer
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
-	 * @param array $context      Unused by `get_batch()`; the batch is always the next page of
-	 *                            the whole synced catalogue, filtering by language happens per
-	 *                            product in `process_items()`.
+	 * @param int   $last_id The cursor: fetch products with ID strictly greater than this value.
+	 * @param array $context Unused by `get_batch()`; the batch is always the next page of the
+	 *                       whole synced catalogue, filtering by language happens per product
+	 *                       in `process_items()`.
 	 *
 	 * @return int[]
 	 */
-	public function get_batch( int $batch_number, array $context = [] ): array {
-		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+	public function get_batch( int $last_id, array $context = [] ): array {
+		return $this->product_repository->find_synced_product_ids_after_id( $last_id, $this->get_batch_size() );
 	}
 
 	/**

--- a/src/Jobs/CleanupOrphanedLanguageProductsJob.php
+++ b/src/Jobs/CleanupOrphanedLanguageProductsJob.php
@@ -128,7 +128,7 @@ class CleanupOrphanedLanguageProductsJob extends AbstractContextualProductSyncer
 	 *
 	 * @return int[]
 	 */
-	public function get_batch( int $last_id, array $context = [] ): array {
+	protected function get_batch( int $last_id, array $context = [] ): array {
 		return $this->product_repository->find_synced_product_ids_after_id( $last_id, $this->get_batch_size() );
 	}
 

--- a/src/Jobs/CleanupOrphanedMarketProductsJob.php
+++ b/src/Jobs/CleanupOrphanedMarketProductsJob.php
@@ -105,7 +105,7 @@ class CleanupOrphanedMarketProductsJob extends AbstractContextualProductSyncerBa
 	 *
 	 * @return int[]
 	 */
-	public function get_batch( int $last_id, array $context = [] ): array {
+	protected function get_batch( int $last_id, array $context = [] ): array {
 		return $this->product_repository->find_synced_product_ids_after_id( $last_id, $this->get_batch_size() );
 	}
 

--- a/src/Jobs/CleanupOrphanedMarketProductsJob.php
+++ b/src/Jobs/CleanupOrphanedMarketProductsJob.php
@@ -7,6 +7,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerI
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -23,9 +25,12 @@ defined( 'ABSPATH' ) || exit;
  * under (its base feed label plus each per-language variant) so the orphaned
  * entries can be removed before the next product sync writes new ones.
  *
+ * Pages through the whole synced catalogue in batches (rather than loading it
+ * all in a single action) since the store's catalogue size is unbounded.
+ *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
-class CleanupOrphanedMarketProductsJob extends AbstractProductSyncerJob {
+class CleanupOrphanedMarketProductsJob extends AbstractContextualProductSyncerBatchedJob {
 
 	/**
 	 * @var ProductHelper
@@ -39,7 +44,9 @@ class CleanupOrphanedMarketProductsJob extends AbstractProductSyncerJob {
 	 * @param ActionSchedulerJobMonitor $monitor
 	 * @param ProductSyncer             $product_syncer
 	 * @param ProductRepository         $product_repository
+	 * @param BatchProductHelper        $batch_product_helper
 	 * @param MerchantCenterService     $merchant_center
+	 * @param MerchantStatuses          $merchant_statuses
 	 * @param ProductHelper             $product_helper
 	 */
 	public function __construct(
@@ -47,10 +54,12 @@ class CleanupOrphanedMarketProductsJob extends AbstractProductSyncerJob {
 		ActionSchedulerJobMonitor $monitor,
 		ProductSyncer $product_syncer,
 		ProductRepository $product_repository,
+		BatchProductHelper $batch_product_helper,
 		MerchantCenterService $merchant_center,
+		MerchantStatuses $merchant_statuses,
 		ProductHelper $product_helper
 	) {
-		parent::__construct( $action_scheduler, $monitor, $product_syncer, $product_repository, $merchant_center );
+		parent::__construct( $action_scheduler, $monitor, $product_syncer, $product_repository, $batch_product_helper, $merchant_center, $merchant_statuses );
 		$this->product_helper = $product_helper;
 	}
 
@@ -79,34 +88,41 @@ class CleanupOrphanedMarketProductsJob extends AbstractProductSyncerJob {
 			throw InvalidValue::is_empty( 'feed_labels' );
 		}
 
-		$process_args = [ [ 'feed_labels' => array_values( $feed_labels ) ] ];
-
-		if ( $this->can_schedule( $process_args ) ) {
-			$this->action_scheduler->schedule_immediate( $this->get_process_item_hook(), $process_args );
-		}
+		parent::schedule( [ 'feed_labels' => array_values( $feed_labels ) ] );
 	}
 
 	/**
-	 * Process the orphaned market's products.
+	 * Get a single batch of synced product IDs.
 	 *
-	 * @param array $items Single-element array containing the scheduling args.
+	 * If no items are returned the job will stop.
+	 *
+	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
+	 * @param array $context      Unused by `get_batch()`; the batch is always the next page of
+	 *                            the whole synced catalogue, filtering by `feed_labels` happens
+	 *                            per product in `process_items()`.
+	 *
+	 * @return int[]
+	 */
+	public function get_batch( int $batch_number, array $context = [] ): array {
+		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+	}
+
+	/**
+	 * Process the orphaned market's products for a single batch of product IDs.
+	 *
+	 * @param int[] $items   A single batch of WooCommerce product IDs from the get_batch() method.
+	 * @param array $context Contains `feed_labels`, as passed to `schedule()`.
 	 *
 	 * @throws ProductSyncerException If an error occurs. The exception will be logged by ActionScheduler.
 	 */
-	protected function process_items( array $items ) {
-		$feed_labels = is_array( $items['feed_labels'] ?? null ) ? $items['feed_labels'] : [];
+	protected function process_items( array $items, array $context = [] ) {
+		$feed_labels = is_array( $context['feed_labels'] ?? null ) ? $context['feed_labels'] : [];
 
 		if ( empty( $feed_labels ) ) {
 			return;
 		}
 
-		$product_ids = $this->product_repository->find_synced_product_ids();
-
-		if ( empty( $product_ids ) ) {
-			return;
-		}
-
-		$products        = $this->product_repository->find_by_ids( $product_ids );
+		$products        = $this->product_repository->find_by_ids( $items );
 		$request_entries = [];
 		foreach ( $products as $product ) {
 			$google_ids = $this->product_helper->get_synced_google_product_ids( $product );

--- a/src/Jobs/CleanupOrphanedMarketProductsJob.php
+++ b/src/Jobs/CleanupOrphanedMarketProductsJob.php
@@ -26,7 +26,9 @@ defined( 'ABSPATH' ) || exit;
  * entries can be removed before the next product sync writes new ones.
  *
  * Pages through the whole synced catalogue in batches (rather than loading it
- * all in a single action) since the store's catalogue size is unbounded.
+ * all in a single action) since the store's catalogue size is unbounded, using
+ * cursor pagination since each batch removes some of the very rows the next
+ * page's query would otherwise need to count past.
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Jobs
  */
@@ -96,15 +98,15 @@ class CleanupOrphanedMarketProductsJob extends AbstractContextualProductSyncerBa
 	 *
 	 * If no items are returned the job will stop.
 	 *
-	 * @param int   $batch_number The batch number increments for each new batch in the job cycle.
-	 * @param array $context      Unused by `get_batch()`; the batch is always the next page of
-	 *                            the whole synced catalogue, filtering by `feed_labels` happens
-	 *                            per product in `process_items()`.
+	 * @param int   $last_id The cursor: fetch products with ID strictly greater than this value.
+	 * @param array $context Unused by `get_batch()`; the batch is always the next page of the
+	 *                       whole synced catalogue, filtering by `feed_labels` happens per
+	 *                       product in `process_items()`.
 	 *
 	 * @return int[]
 	 */
-	public function get_batch( int $batch_number, array $context = [] ): array {
-		return $this->product_repository->find_synced_product_ids( [], $this->get_batch_size(), $this->get_query_offset( $batch_number ) );
+	public function get_batch( int $last_id, array $context = [] ): array {
+		return $this->product_repository->find_synced_product_ids_after_id( $last_id, $this->get_batch_size() );
 	}
 
 	/**

--- a/src/Product/ProductRepository.php
+++ b/src/Product/ProductRepository.php
@@ -164,6 +164,49 @@ class ProductRepository implements Service {
 	}
 
 	/**
+	 * Find and return an array of WooCommerce product IDs already submitted to Google Merchant
+	 * Center, ordered by ID ascending and starting strictly after the given cursor.
+	 *
+	 * Uses keyset (cursor) pagination like find_expiring_product_ids(), rather than
+	 * find_synced_product_ids()'s OFFSET-based paging. That matters here specifically because a
+	 * caller paging through synced products in order to unsync or delete some of them (a cleanup
+	 * job) shrinks the very result set the query filters on as it goes; OFFSET-based paging would
+	 * silently skip rows whenever earlier batches removed matches, since each new page still skips
+	 * a fixed count from the start rather than resuming after the last row actually seen.
+	 *
+	 * @since 3.9.0
+	 *
+	 * @param int $last_id The last product ID processed in the previous batch (0 to start from the beginning).
+	 * @param int $limit   Maximum number of results to retrieve or -1 for unlimited.
+	 *
+	 * @return int[] Array of WooCommerce product IDs ordered by ID ASC.
+	 */
+	public function find_synced_product_ids_after_id( int $last_id = 0, int $limit = -1 ): array {
+		global $wpdb;
+
+		$args = [
+			'orderby'    => 'ID',
+			'order'      => 'ASC',
+			'meta_query' => $this->get_synced_products_meta_query(),
+		];
+
+		// Add a temporary WHERE clause to implement keyset pagination (ID > $last_id).
+		$cursor_filter = function ( string $where ) use ( $wpdb, $last_id ): string {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			return $where . $wpdb->prepare( " AND {$wpdb->posts}.ID > %d", $last_id );
+		};
+
+		add_filter( 'posts_where', $cursor_filter );
+		try {
+			$results = $this->find_ids( $args, $limit );
+		} finally {
+			remove_filter( 'posts_where', $cursor_filter );
+		}
+
+		return $results;
+	}
+
+	/**
 	 * @return array
 	 */
 	protected function get_synced_products_meta_query(): array {

--- a/tests/Unit/Jobs/CleanupOrphanedLanguageProductsJobTest.php
+++ b/tests/Unit/Jobs/CleanupOrphanedLanguageProductsJobTest.php
@@ -137,16 +137,14 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )
-			->with( self::CREATE_BATCH_HOOK, [ 1, $context ] );
+			->with( self::CREATE_BATCH_HOOK, [ 0, $context ] );
 
 		$this->job->schedule( $context );
 	}
 
 	public function test_schedule_never_loads_the_full_catalogue_in_one_batch() {
-		$ids = range( 1, self::BATCH_SIZE * 3 );
-
-		$first_batch  = array_slice( $ids, 0, self::BATCH_SIZE );
-		$second_batch = array_slice( $ids, self::BATCH_SIZE, self::BATCH_SIZE );
+		$first_batch  = range( 1, self::BATCH_SIZE );
+		$second_batch = range( self::BATCH_SIZE + 1, self::BATCH_SIZE * 2 );
 		$context      = [
 			'keys'              => [ 'FR-fr' ],
 			'removed_languages' => [ 'fr' ],
@@ -156,11 +154,11 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
 
 		$this->product_repository->expects( $this->exactly( 3 ) )
-			->method( 'find_synced_product_ids' )
+			->method( 'find_synced_product_ids_after_id' )
 			->withConsecutive(
-				[ [], self::BATCH_SIZE, 0 ],
-				[ [], self::BATCH_SIZE, self::BATCH_SIZE ],
-				[ [], self::BATCH_SIZE, self::BATCH_SIZE * 2 ]
+				[ 0, self::BATCH_SIZE ],
+				[ max( $first_batch ), self::BATCH_SIZE ],
+				[ max( $second_batch ), self::BATCH_SIZE ]
 			)
 			->will(
 				$this->onConsecutiveCalls(
@@ -173,19 +171,55 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		$this->action_scheduler->expects( $this->exactly( 5 ) )
 			->method( 'schedule_immediate' )
 			->withConsecutive(
-				[ self::CREATE_BATCH_HOOK, [ 1, $context ] ],
+				[ self::CREATE_BATCH_HOOK, [ 0, $context ] ],
 				[ self::PROCESS_ITEM_HOOK, [ $first_batch, $context ] ],
-				[ self::CREATE_BATCH_HOOK, [ 2, $context ] ],
+				[ self::CREATE_BATCH_HOOK, [ max( $first_batch ), $context ] ],
 				[ self::PROCESS_ITEM_HOOK, [ $second_batch, $context ] ],
-				[ self::CREATE_BATCH_HOOK, [ 3, $context ] ]
+				[ self::CREATE_BATCH_HOOK, [ max( $second_batch ), $context ] ]
 			);
 
 		$this->job->schedule( $context );
 
 		// Trigger the first two batches; the third comes back empty and stops the job.
-		do_action( self::CREATE_BATCH_HOOK, 1, $context );
-		do_action( self::CREATE_BATCH_HOOK, 2, $context );
-		do_action( self::CREATE_BATCH_HOOK, 3, $context );
+		do_action( self::CREATE_BATCH_HOOK, 0, $context );
+		do_action( self::CREATE_BATCH_HOOK, max( $first_batch ), $context );
+		do_action( self::CREATE_BATCH_HOOK, max( $second_batch ), $context );
+	}
+
+	public function test_schedule_resumes_by_cursor_when_a_batch_shrinks_the_result_set() {
+		// Simulates deleting entries as they're processed: the first batch's IDs are
+		// removed from the synced set, so the *next* page can't be found by counting a
+		// fixed number of rows from the start — it must resume after the last ID seen.
+		$first_batch  = range( 1, self::BATCH_SIZE );
+		$second_batch = [ self::BATCH_SIZE + 50 ];
+		$context      = [
+			'keys'              => [ 'FR-fr' ],
+			'removed_languages' => [ 'fr' ],
+		];
+
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
+
+		$this->product_repository->expects( $this->exactly( 3 ) )
+			->method( 'find_synced_product_ids_after_id' )
+			->withConsecutive(
+				[ 0, self::BATCH_SIZE ],
+				[ self::BATCH_SIZE, self::BATCH_SIZE ],
+				[ self::BATCH_SIZE + 50, self::BATCH_SIZE ]
+			)
+			->will(
+				$this->onConsecutiveCalls(
+					$first_batch,
+					$second_batch,
+					[]
+				)
+			);
+
+		$this->job->schedule( $context );
+
+		do_action( self::CREATE_BATCH_HOOK, 0, $context );
+		do_action( self::CREATE_BATCH_HOOK, self::BATCH_SIZE, $context );
+		do_action( self::CREATE_BATCH_HOOK, self::BATCH_SIZE + 50, $context );
 	}
 
 	public function test_process_items_deletes_entry_for_product_in_removed_language() {

--- a/tests/Unit/Jobs/CleanupOrphanedLanguageProductsJobTest.php
+++ b/tests/Unit/Jobs/CleanupOrphanedLanguageProductsJobTest.php
@@ -12,6 +12,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedLanguageProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -39,8 +41,14 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 	/** @var MockObject|ProductRepository $product_repository */
 	protected $product_repository;
 
+	/** @var MockObject|BatchProductHelper $batch_product_helper */
+	protected $batch_product_helper;
+
 	/** @var MockObject|MerchantCenterService $merchant_center */
 	protected $merchant_center;
+
+	/** @var MockObject|MerchantStatuses $merchant_statuses */
+	protected $merchant_statuses;
 
 	/** @var MockObject|ProductHelper $product_helper */
 	protected $product_helper;
@@ -52,25 +60,31 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 	protected $job;
 
 	protected const JOB_NAME          = 'cleanup_orphaned_language_products_job';
+	protected const CREATE_BATCH_HOOK = 'gla/jobs/' . self::JOB_NAME . '/create_batch';
 	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
+	protected const BATCH_SIZE        = 100;
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->action_scheduler   = $this->createMock( ActionScheduler::class );
-		$this->monitor            = $this->createMock( ActionSchedulerJobMonitor::class );
-		$this->product_syncer     = $this->createMock( ProductSyncer::class );
-		$this->product_repository = $this->createMock( ProductRepository::class );
-		$this->merchant_center    = $this->createMock( MerchantCenterService::class );
-		$this->product_helper     = $this->createMock( ProductHelper::class );
-		$this->wpml               = $this->createMock( WPML::class );
+		$this->action_scheduler     = $this->createMock( ActionScheduler::class );
+		$this->monitor              = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->product_syncer       = $this->createMock( ProductSyncer::class );
+		$this->product_repository   = $this->createMock( ProductRepository::class );
+		$this->batch_product_helper = $this->createMock( BatchProductHelper::class );
+		$this->merchant_center      = $this->createMock( MerchantCenterService::class );
+		$this->merchant_statuses    = $this->createMock( MerchantStatuses::class );
+		$this->product_helper       = $this->createMock( ProductHelper::class );
+		$this->wpml                 = $this->createMock( WPML::class );
 
 		$this->job = new CleanupOrphanedLanguageProductsJob(
 			$this->action_scheduler,
 			$this->monitor,
 			$this->product_syncer,
 			$this->product_repository,
+			$this->batch_product_helper,
 			$this->merchant_center,
+			$this->merchant_statuses,
 			$this->product_helper,
 			$this->wpml
 		);
@@ -112,34 +126,72 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		);
 	}
 
-	public function test_schedule_schedules_immediate_with_payload() {
+	public function test_schedule_schedules_first_batch_with_payload_context() {
 		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
 		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
 
-		$expected_payload = [
-			[
-				'keys'              => [ 'FR-fr' ],
-				'removed_languages' => [ 'fr' ],
-			],
+		$context = [
+			'keys'              => [ 'FR-fr' ],
+			'removed_languages' => [ 'fr' ],
 		];
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )
-			->with( self::PROCESS_ITEM_HOOK, $expected_payload );
+			->with( self::CREATE_BATCH_HOOK, [ 1, $context ] );
 
-		$this->job->schedule(
-			[
-				'keys'              => [ 'FR-fr' ],
-				'removed_languages' => [ 'fr' ],
-			]
-		);
+		$this->job->schedule( $context );
+	}
+
+	public function test_schedule_never_loads_the_full_catalogue_in_one_batch() {
+		$ids = range( 1, self::BATCH_SIZE * 3 );
+
+		$first_batch  = array_slice( $ids, 0, self::BATCH_SIZE );
+		$second_batch = array_slice( $ids, self::BATCH_SIZE, self::BATCH_SIZE );
+		$context      = [
+			'keys'              => [ 'FR-fr' ],
+			'removed_languages' => [ 'fr' ],
+		];
+
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
+
+		$this->product_repository->expects( $this->exactly( 3 ) )
+			->method( 'find_synced_product_ids' )
+			->withConsecutive(
+				[ [], self::BATCH_SIZE, 0 ],
+				[ [], self::BATCH_SIZE, self::BATCH_SIZE ],
+				[ [], self::BATCH_SIZE, self::BATCH_SIZE * 2 ]
+			)
+			->will(
+				$this->onConsecutiveCalls(
+					$first_batch,
+					$second_batch,
+					[]
+				)
+			);
+
+		$this->action_scheduler->expects( $this->exactly( 5 ) )
+			->method( 'schedule_immediate' )
+			->withConsecutive(
+				[ self::CREATE_BATCH_HOOK, [ 1, $context ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $first_batch, $context ] ],
+				[ self::CREATE_BATCH_HOOK, [ 2, $context ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $second_batch, $context ] ],
+				[ self::CREATE_BATCH_HOOK, [ 3, $context ] ]
+			);
+
+		$this->job->schedule( $context );
+
+		// Trigger the first two batches; the third comes back empty and stops the job.
+		do_action( self::CREATE_BATCH_HOOK, 1, $context );
+		do_action( self::CREATE_BATCH_HOOK, 2, $context );
+		do_action( self::CREATE_BATCH_HOOK, 3, $context );
 	}
 
 	public function test_process_items_deletes_entry_for_product_in_removed_language() {
 		$product   = WC_Helper_Product::create_simple_product();
 		$google_id = 'online:fr:FR-fr:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 
 		$this->wpml->method( 'get_post_language' )->with( $product->get_id() )->willReturn( 'fr' );
@@ -172,6 +224,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'FR-fr' ],
 				'removed_languages' => [ 'fr' ],
@@ -182,7 +235,6 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 	public function test_process_items_skips_products_whose_language_is_not_in_removed_set() {
 		$product = WC_Helper_Product::create_simple_product();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 
 		$this->wpml->method( 'get_post_language' )->willReturn( 'en' );
@@ -191,6 +243,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'FR-fr' ],
 				'removed_languages' => [ 'fr' ],
@@ -201,7 +254,6 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 	public function test_process_items_skips_products_with_no_entry_under_keys() {
 		$product = WC_Helper_Product::create_simple_product();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 
 		$this->wpml->method( 'get_post_language' )->willReturn( 'fr' );
@@ -214,6 +266,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'FR-fr' ],
 				'removed_languages' => [ 'fr' ],
@@ -225,7 +278,6 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		$product   = WC_Helper_Product::create_simple_product();
 		$google_id = 'online:fr:FR-fr:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 		$this->wpml->method( 'get_post_language' )->willReturn( 'fr' );
 		$this->product_helper->method( 'get_synced_google_product_ids' )->willReturn( [ 'FR-fr' => $google_id ] );
@@ -245,6 +297,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'FR-fr' ],
 				'removed_languages' => [ 'fr' ],
@@ -256,7 +309,6 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		$product   = WC_Helper_Product::create_simple_product();
 		$google_id = 'online:fr:FR-fr:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 		$this->wpml->method( 'get_post_language' )->willReturn( 'fr' );
 		$this->product_helper->method( 'get_synced_google_product_ids' )->willReturn( [ 'FR-fr' => $google_id ] );
@@ -268,6 +320,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'FR-fr' ],
 				'removed_languages' => [ 'fr' ],
@@ -280,7 +333,6 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		$gb_id   = 'online:fr:GB:gla_' . $product->get_id();
 		$us_id   = 'online:fr:US:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 		$this->wpml->method( 'get_post_language' )->willReturn( 'fr' );
 
@@ -318,6 +370,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'GB', 'US' ],
 				'removed_languages' => [ 'fr' ],
@@ -325,13 +378,17 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		);
 	}
 
-	public function test_process_items_returns_early_when_no_synced_products() {
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [] );
+	public function test_process_items_returns_early_when_batch_is_empty() {
+		$this->product_repository->expects( $this->once() )
+			->method( 'find_by_ids' )
+			->with( [] )
+			->willReturn( [] );
 
 		$this->product_syncer->expects( $this->never() )->method( 'delete_by_batch_requests' );
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[],
 			[
 				'keys'              => [ 'GB' ],
 				'removed_languages' => [ 'fr' ],
@@ -339,10 +396,17 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 		);
 	}
 
+	public function test_process_items_returns_early_when_context_missing() {
+		$this->product_repository->expects( $this->never() )->method( 'find_by_ids' );
+
+		$this->product_syncer->expects( $this->never() )->method( 'delete_by_batch_requests' );
+
+		do_action( self::PROCESS_ITEM_HOOK, [ 1 ], [] );
+	}
+
 	public function test_process_items_skips_products_with_empty_wpml_language() {
 		$product = WC_Helper_Product::create_simple_product();
 
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )->willReturn( [ $product ] );
 		$this->wpml->method( 'get_post_language' )->willReturn( '' );
 
@@ -350,6 +414,7 @@ class CleanupOrphanedLanguageProductsJobTest extends UnitTest {
 
 		do_action(
 			self::PROCESS_ITEM_HOOK,
+			[ $product->get_id() ],
 			[
 				'keys'              => [ 'GB' ],
 				'removed_languages' => [ 'fr' ],

--- a/tests/Unit/Jobs/CleanupOrphanedMarketProductsJobTest.php
+++ b/tests/Unit/Jobs/CleanupOrphanedMarketProductsJobTest.php
@@ -114,27 +114,25 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )
-			->with( self::CREATE_BATCH_HOOK, [ 1, $context ] );
+			->with( self::CREATE_BATCH_HOOK, [ 0, $context ] );
 
 		$this->job->schedule( $context );
 	}
 
 	public function test_schedule_never_loads_the_full_catalogue_in_one_batch() {
-		$ids = range( 1, self::BATCH_SIZE * 3 );
-
-		$first_batch  = array_slice( $ids, 0, self::BATCH_SIZE );
-		$second_batch = array_slice( $ids, self::BATCH_SIZE, self::BATCH_SIZE );
+		$first_batch  = range( 1, self::BATCH_SIZE );
+		$second_batch = range( self::BATCH_SIZE + 1, self::BATCH_SIZE * 2 );
 		$context      = [ 'feed_labels' => [ 'GB' ] ];
 
 		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
 		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
 
 		$this->product_repository->expects( $this->exactly( 3 ) )
-			->method( 'find_synced_product_ids' )
+			->method( 'find_synced_product_ids_after_id' )
 			->withConsecutive(
-				[ [], self::BATCH_SIZE, 0 ],
-				[ [], self::BATCH_SIZE, self::BATCH_SIZE ],
-				[ [], self::BATCH_SIZE, self::BATCH_SIZE * 2 ]
+				[ 0, self::BATCH_SIZE ],
+				[ max( $first_batch ), self::BATCH_SIZE ],
+				[ max( $second_batch ), self::BATCH_SIZE ]
 			)
 			->will(
 				$this->onConsecutiveCalls(
@@ -147,19 +145,52 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 		$this->action_scheduler->expects( $this->exactly( 5 ) )
 			->method( 'schedule_immediate' )
 			->withConsecutive(
-				[ self::CREATE_BATCH_HOOK, [ 1, $context ] ],
+				[ self::CREATE_BATCH_HOOK, [ 0, $context ] ],
 				[ self::PROCESS_ITEM_HOOK, [ $first_batch, $context ] ],
-				[ self::CREATE_BATCH_HOOK, [ 2, $context ] ],
+				[ self::CREATE_BATCH_HOOK, [ max( $first_batch ), $context ] ],
 				[ self::PROCESS_ITEM_HOOK, [ $second_batch, $context ] ],
-				[ self::CREATE_BATCH_HOOK, [ 3, $context ] ]
+				[ self::CREATE_BATCH_HOOK, [ max( $second_batch ), $context ] ]
 			);
 
 		$this->job->schedule( $context );
 
 		// Trigger the first two batches; the third comes back empty and stops the job.
-		do_action( self::CREATE_BATCH_HOOK, 1, $context );
-		do_action( self::CREATE_BATCH_HOOK, 2, $context );
-		do_action( self::CREATE_BATCH_HOOK, 3, $context );
+		do_action( self::CREATE_BATCH_HOOK, 0, $context );
+		do_action( self::CREATE_BATCH_HOOK, max( $first_batch ), $context );
+		do_action( self::CREATE_BATCH_HOOK, max( $second_batch ), $context );
+	}
+
+	public function test_schedule_resumes_by_cursor_when_a_batch_shrinks_the_result_set() {
+		// Simulates deleting entries as they're processed: the first batch's IDs are
+		// removed from the synced set, so the *next* page can't be found by counting a
+		// fixed number of rows from the start — it must resume after the last ID seen.
+		$first_batch  = range( 1, self::BATCH_SIZE );
+		$second_batch = [ self::BATCH_SIZE + 50 ];
+		$context      = [ 'feed_labels' => [ 'GB' ] ];
+
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
+
+		$this->product_repository->expects( $this->exactly( 3 ) )
+			->method( 'find_synced_product_ids_after_id' )
+			->withConsecutive(
+				[ 0, self::BATCH_SIZE ],
+				[ self::BATCH_SIZE, self::BATCH_SIZE ],
+				[ self::BATCH_SIZE + 50, self::BATCH_SIZE ]
+			)
+			->will(
+				$this->onConsecutiveCalls(
+					$first_batch,
+					$second_batch,
+					[]
+				)
+			);
+
+		$this->job->schedule( $context );
+
+		do_action( self::CREATE_BATCH_HOOK, 0, $context );
+		do_action( self::CREATE_BATCH_HOOK, self::BATCH_SIZE, $context );
+		do_action( self::CREATE_BATCH_HOOK, self::BATCH_SIZE + 50, $context );
 	}
 
 	public function test_process_items_builds_request_entry_per_product_for_feed_label() {

--- a/tests/Unit/Jobs/CleanupOrphanedMarketProductsJobTest.php
+++ b/tests/Unit/Jobs/CleanupOrphanedMarketProductsJobTest.php
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductResponse;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupOrphanedMarketProductsJob;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer;
@@ -36,8 +38,14 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 	/** @var MockObject|ProductRepository $product_repository */
 	protected $product_repository;
 
+	/** @var MockObject|BatchProductHelper $batch_product_helper */
+	protected $batch_product_helper;
+
 	/** @var MockObject|MerchantCenterService $merchant_center */
 	protected $merchant_center;
+
+	/** @var MockObject|MerchantStatuses $merchant_statuses */
+	protected $merchant_statuses;
 
 	/** @var MockObject|ProductHelper $product_helper */
 	protected $product_helper;
@@ -46,24 +54,30 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 	protected $job;
 
 	protected const JOB_NAME          = 'cleanup_orphaned_market_products_job';
+	protected const CREATE_BATCH_HOOK = 'gla/jobs/' . self::JOB_NAME . '/create_batch';
 	protected const PROCESS_ITEM_HOOK = 'gla/jobs/' . self::JOB_NAME . '/process_item';
+	protected const BATCH_SIZE        = 100;
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->action_scheduler   = $this->createMock( ActionScheduler::class );
-		$this->monitor            = $this->createMock( ActionSchedulerJobMonitor::class );
-		$this->product_syncer     = $this->createMock( ProductSyncer::class );
-		$this->product_repository = $this->createMock( ProductRepository::class );
-		$this->merchant_center    = $this->createMock( MerchantCenterService::class );
-		$this->product_helper     = $this->createMock( ProductHelper::class );
+		$this->action_scheduler     = $this->createMock( ActionScheduler::class );
+		$this->monitor              = $this->createMock( ActionSchedulerJobMonitor::class );
+		$this->product_syncer       = $this->createMock( ProductSyncer::class );
+		$this->product_repository   = $this->createMock( ProductRepository::class );
+		$this->batch_product_helper = $this->createMock( BatchProductHelper::class );
+		$this->merchant_center      = $this->createMock( MerchantCenterService::class );
+		$this->merchant_statuses    = $this->createMock( MerchantStatuses::class );
+		$this->product_helper       = $this->createMock( ProductHelper::class );
 
 		$this->job = new CleanupOrphanedMarketProductsJob(
 			$this->action_scheduler,
 			$this->monitor,
 			$this->product_syncer,
 			$this->product_repository,
+			$this->batch_product_helper,
 			$this->merchant_center,
+			$this->merchant_statuses,
 			$this->product_helper
 		);
 
@@ -92,15 +106,60 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 		$this->job->schedule( [ 'feed_labels' => 'GB' ] );
 	}
 
-	public function test_schedule_schedules_immediate_with_feed_labels() {
+	public function test_schedule_schedules_first_batch_with_feed_labels_context() {
 		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
 		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
 
+		$context = [ 'feed_labels' => [ 'GB', 'GB-CY' ] ];
+
 		$this->action_scheduler->expects( $this->once() )
 			->method( 'schedule_immediate' )
-			->with( self::PROCESS_ITEM_HOOK, [ [ 'feed_labels' => [ 'GB', 'GB-CY' ] ] ] );
+			->with( self::CREATE_BATCH_HOOK, [ 1, $context ] );
 
-		$this->job->schedule( [ 'feed_labels' => [ 'GB', 'GB-CY' ] ] );
+		$this->job->schedule( $context );
+	}
+
+	public function test_schedule_never_loads_the_full_catalogue_in_one_batch() {
+		$ids = range( 1, self::BATCH_SIZE * 3 );
+
+		$first_batch  = array_slice( $ids, 0, self::BATCH_SIZE );
+		$second_batch = array_slice( $ids, self::BATCH_SIZE, self::BATCH_SIZE );
+		$context      = [ 'feed_labels' => [ 'GB' ] ];
+
+		$this->action_scheduler->method( 'has_scheduled_action' )->willReturn( false );
+		$this->merchant_center->method( 'is_ready_for_syncing' )->willReturn( true );
+
+		$this->product_repository->expects( $this->exactly( 3 ) )
+			->method( 'find_synced_product_ids' )
+			->withConsecutive(
+				[ [], self::BATCH_SIZE, 0 ],
+				[ [], self::BATCH_SIZE, self::BATCH_SIZE ],
+				[ [], self::BATCH_SIZE, self::BATCH_SIZE * 2 ]
+			)
+			->will(
+				$this->onConsecutiveCalls(
+					$first_batch,
+					$second_batch,
+					[]
+				)
+			);
+
+		$this->action_scheduler->expects( $this->exactly( 5 ) )
+			->method( 'schedule_immediate' )
+			->withConsecutive(
+				[ self::CREATE_BATCH_HOOK, [ 1, $context ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $first_batch, $context ] ],
+				[ self::CREATE_BATCH_HOOK, [ 2, $context ] ],
+				[ self::PROCESS_ITEM_HOOK, [ $second_batch, $context ] ],
+				[ self::CREATE_BATCH_HOOK, [ 3, $context ] ]
+			);
+
+		$this->job->schedule( $context );
+
+		// Trigger the first two batches; the third comes back empty and stops the job.
+		do_action( self::CREATE_BATCH_HOOK, 1, $context );
+		do_action( self::CREATE_BATCH_HOOK, 2, $context );
+		do_action( self::CREATE_BATCH_HOOK, 3, $context );
 	}
 
 	public function test_process_items_builds_request_entry_per_product_for_feed_label() {
@@ -108,8 +167,6 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 		$google_id = 'online:en:GB:gla_' . $product->get_id();
 		$other_id  = 'online:en:US:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )
-			->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )
 			->with( [ $product->get_id() ] )
 			->willReturn( [ $product ] );
@@ -140,7 +197,7 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 			)
 			->willReturn( new BatchProductResponse( [], [] ) );
 
-		do_action( self::PROCESS_ITEM_HOOK, [ 'feed_labels' => [ 'GB' ] ] );
+		do_action( self::PROCESS_ITEM_HOOK, [ $product->get_id() ], [ 'feed_labels' => [ 'GB' ] ] );
 	}
 
 	public function test_process_items_builds_request_entries_for_every_given_feed_label() {
@@ -149,8 +206,6 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 		$language_id  = 'online:cy:GB-CY:gla_' . $product->get_id();
 		$unrelated_id = 'online:en:US:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )
-			->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )
 			->willReturn( [ $product ] );
 
@@ -184,15 +239,13 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 			)
 			->willReturn( new BatchProductResponse( [], [] ) );
 
-		do_action( self::PROCESS_ITEM_HOOK, [ 'feed_labels' => [ 'GB', 'GB-CY' ] ] );
+		do_action( self::PROCESS_ITEM_HOOK, [ $product->get_id() ], [ 'feed_labels' => [ 'GB', 'GB-CY' ] ] );
 	}
 
 	public function test_process_items_leaves_local_meta_intact_on_api_failure() {
 		$product   = WC_Helper_Product::create_simple_product();
 		$google_id = 'online:en:GB:gla_' . $product->get_id();
 
-		$this->product_repository->method( 'find_synced_product_ids' )
-			->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )
 			->willReturn( [ $product ] );
 
@@ -206,14 +259,12 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 		$this->product_helper->expects( $this->never() )
 			->method( 'remove_google_id' );
 
-		do_action( self::PROCESS_ITEM_HOOK, [ 'feed_labels' => [ 'GB' ] ] );
+		do_action( self::PROCESS_ITEM_HOOK, [ $product->get_id() ], [ 'feed_labels' => [ 'GB' ] ] );
 	}
 
 	public function test_process_items_skips_products_with_no_entry_for_feed_label() {
 		$product = WC_Helper_Product::create_simple_product();
 
-		$this->product_repository->method( 'find_synced_product_ids' )
-			->willReturn( [ $product->get_id() ] );
 		$this->product_repository->method( 'find_by_ids' )
 			->willReturn( [ $product ] );
 
@@ -227,15 +278,28 @@ class CleanupOrphanedMarketProductsJobTest extends UnitTest {
 		$this->product_syncer->expects( $this->never() )
 			->method( 'delete_by_batch_requests' );
 
-		do_action( self::PROCESS_ITEM_HOOK, [ 'feed_labels' => [ 'GB' ] ] );
+		do_action( self::PROCESS_ITEM_HOOK, [ $product->get_id() ], [ 'feed_labels' => [ 'GB' ] ] );
 	}
 
-	public function test_process_items_returns_early_when_no_synced_products() {
-		$this->product_repository->method( 'find_synced_product_ids' )->willReturn( [] );
+	public function test_process_items_returns_early_when_batch_is_empty() {
+		$this->product_repository->expects( $this->once() )
+			->method( 'find_by_ids' )
+			->with( [] )
+			->willReturn( [] );
 
 		$this->product_syncer->expects( $this->never() )
 			->method( 'delete_by_batch_requests' );
 
-		do_action( self::PROCESS_ITEM_HOOK, [ 'feed_labels' => [ 'GB' ] ] );
+		do_action( self::PROCESS_ITEM_HOOK, [], [ 'feed_labels' => [ 'GB' ] ] );
+	}
+
+	public function test_process_items_returns_early_when_feed_labels_missing_from_context() {
+		$this->product_repository->expects( $this->never() )
+			->method( 'find_by_ids' );
+
+		$this->product_syncer->expects( $this->never() )
+			->method( 'delete_by_batch_requests' );
+
+		do_action( self::PROCESS_ITEM_HOOK, [ 1 ], [] );
 	}
 }

--- a/tests/Unit/Product/ProductRepositoryTest.php
+++ b/tests/Unit/Product/ProductRepositoryTest.php
@@ -203,6 +203,65 @@ class ProductRepositoryTest extends ContainerAwareUnitTest {
 		);
 	}
 
+	public function test_find_synced_product_ids_after_id() {
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );
+
+		$product_2 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_2, $this->generate_google_product_mock() );
+
+		WC_Helper_Product::create_simple_product();
+
+		$this->assertEquals(
+			[ $product_1->get_id(), $product_2->get_id() ],
+			$this->product_repository->find_synced_product_ids_after_id()
+		);
+	}
+
+	public function test_find_synced_product_ids_after_id_respects_cursor() {
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );
+
+		$product_2 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_2, $this->generate_google_product_mock() );
+
+		// Both products are synced; passing the first ID as cursor should only return the second.
+		$ids = $this->product_repository->find_synced_product_ids_after_id( $product_1->get_id() );
+
+		$this->assertEquals( [ $product_2->get_id() ], $ids );
+	}
+
+	public function test_find_synced_product_ids_after_id_survives_a_shrinking_result_set() {
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_1, $this->generate_google_product_mock() );
+
+		$product_2 = WC_Helper_Product::create_simple_product();
+		$this->product_helper->mark_as_synced( $product_2, $this->generate_google_product_mock() );
+
+		// The first page returns product_1 only (limit 1).
+		$first_page = $this->product_repository->find_synced_product_ids_after_id( 0, 1 );
+		$this->assertEquals( [ $product_1->get_id() ], $first_page );
+
+		// Simulate the batch consumer unsyncing product_1 before the next page is fetched.
+		$this->product_helper->mark_as_unsynced( $product_1 );
+
+		// Resuming from the cursor still finds product_2, even though product_1 no longer
+		// matches the synced filter — an OFFSET-based query would have skipped it instead.
+		$second_page = $this->product_repository->find_synced_product_ids_after_id( max( $first_page ), 1 );
+		$this->assertEquals( [ $product_2->get_id() ], $second_page );
+	}
+
+	public function test_find_synced_product_ids_after_id_respects_limit() {
+		for ( $i = 0; $i < 3; $i++ ) {
+			$p = WC_Helper_Product::create_simple_product();
+			$this->product_helper->mark_as_synced( $p, $this->generate_google_product_mock() );
+		}
+
+		$ids = $this->product_repository->find_synced_product_ids_after_id( 0, 2 );
+
+		$this->assertCount( 2, $ids );
+	}
+
 	public function test_find_sync_ready_products() {
 		// create some products that are not sync ready
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes GOOWOO-852.

Alternative to #3656 — same bug, lighter-touch fix. See that PR for the full problem writeup; this PR fixes it with a much smaller diff.

`CleanupOrphanedMarketProductsJob` and `CleanupOrphanedLanguageProductsJob` each loaded the entire synced product catalogue (`find_synced_product_ids()` / `find_by_ids()` with no limit/offset) inside a single unbounded Action Scheduler action, risking memory exhaustion or a timeout on large catalogues.

This switches both jobs to the same paged-batching pattern used by `CleanupProductsJob` and `CleanupSyncedProducts` (100 products per batch via Action Scheduler), but instead of widening the shared `AbstractActionSchedulerJob` / `AbstractBatchedActionSchedulerJob` base classes to carry per-run context (feed_labels, or keys/removed_languages) through the batch cycle — which forces every other job built on those classes to update its `process_items()`/`get_batch()` signature just to stay compatible with PHP's method-override rules — this introduces one new, self-contained class: `AbstractContextualProductSyncerBatchedJob`, extended only by these two jobs. It re-implements the same `create_batch`/`process_item` cycle, threading a `$context` array through `schedule()` → `create_batch` → `get_batch()`/`process_items()`.

No other job class, the shared base classes, or the batch-job interface are touched. Total diff: 1 new file + the two job classes (repointed to the new parent, bodies otherwise unchanged) + their tests.

### Detailed test instructions:

1. On a store with a large product catalogue, delete a market (or rename its feed label, or remove a language from a market's accepted set).
2. Confirm the corresponding `cleanup_orphaned_market_products_job` / `cleanup_orphaned_language_products_job` action in Action Scheduler runs to completion via `create_batch`/`process_item` cycles (batches of 100) rather than a single `process_item` action.
3. Confirm the removed/renamed feed label's Merchant Center entries are gone, and other markets'/languages' entries are untouched.
4. `composer test-unit` — `tests/Unit/Jobs/CleanupOrphanedMarketProductsJobTest.php` and `CleanupOrphanedLanguageProductsJobTest.php`.

### Additional details:

Verified locally: `php -l` and the project's `phpcs.xml.dist` ruleset are clean on every changed/new file. Also verified, outside the WP test environment, that the full class hierarchy (including all other job classes, untouched) still declares without any PHP "must be compatible" fatals, and exercised the new batch-cycle logic (schedule → create_batch → process_item, paging through a 300-item fake catalogue in batches of 100) against the real source via a standalone PHPUnit harness with a minimal WP-hook shim — both jobs page correctly and never load more than one batch at a time.

### Changelog entry

