### PR TITLE
Clear secondary markets on Merchant Center disconnect (GOOWOO-860)

### DIFF
--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -42,6 +42,7 @@ defined( 'ABSPATH' ) || exit;
  * - AdsAccountState
  * - JobRepository
  * - Merchant
+ * - MarketService
  * - MerchantCenterService
  * - MerchantIssueTable
  * - MerchantStatuses
@@ -280,10 +281,10 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		$this->options->delete( OptionsInterface::MERCHANT_ACCOUNT_STATE );
 		$this->options->delete( OptionsInterface::MERCHANT_CENTER );
 		$this->options->delete( OptionsInterface::SITE_VERIFICATION );
-		$this->options->delete( OptionsInterface::TARGET_AUDIENCE );
 		$this->options->delete( OptionsInterface::MERCHANT_ID );
 		$this->options->delete( OptionsInterface::CLAIMED_URL_HASH );
 
+		$this->container->get( MarketService::class )->reset_markets();
 		$this->container->get( MerchantStatuses::class )->delete();
 
 		$this->container->get( MerchantIssueTable::class )->truncate();

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -334,6 +334,27 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	}
 
 	/**
+	 * Clears every market: the primary market's target audience and all
+	 * stored secondary markets.
+	 *
+	 * Used when Merchant Center is disconnected, so no market configuration
+	 * survives to collide with markets configured during a later onboarding —
+	 * secondary markets are otherwise never cleared on disconnect, and can
+	 * reappear as duplicates of a freshly chosen primary market once the
+	 * merchant reconnects.
+	 *
+	 * The MERCHANT_CENTER option (which also carries the primary market's
+	 * shipping method, language and currency) is deleted separately by the
+	 * caller: it holds settings beyond markets, so its lifecycle belongs to
+	 * whichever disconnect flow owns Merchant Center state, not to this
+	 * service.
+	 */
+	public function reset_markets(): void {
+		$this->options->delete( OptionsInterface::TARGET_AUDIENCE );
+		$this->options->delete( OptionsInterface::MARKETS );
+	}
+
+	/**
 	 * Returns the current secondary markets, choosing the source by shipping mode.
 	 *
 	 * Flat-rate markets are not persisted: a country becomes its own secondary market

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseD
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\CleanupSyncedProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\AccountService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\AdsAccountState;
@@ -61,6 +62,9 @@ class AccountServiceTest extends UnitTest {
 
 	/** @var MockObject|MerchantIssueTable $issue_table */
 	protected $issue_table;
+
+	/** @var MockObject|MarketService $market_service */
+	protected $market_service;
 
 	/** @var MockObject|MerchantStatuses $merchant_statuses */
 	protected $merchant_statuses;
@@ -135,6 +139,7 @@ class AccountServiceTest extends UnitTest {
 		$this->homepage_service             = $this->createMock( MapiAccountHomepageService::class );
 		$this->mc_service                   = $this->createMock( MerchantCenterService::class );
 		$this->issue_table                  = $this->createMock( MerchantIssueTable::class );
+		$this->market_service               = $this->createMock( MarketService::class );
 		$this->merchant_statuses            = $this->createMock( MerchantStatuses::class );
 		$this->middleware                   = $this->createMock( Middleware::class );
 		$this->site_verification            = $this->createMock( SiteVerification::class );
@@ -154,6 +159,7 @@ class AccountServiceTest extends UnitTest {
 		$this->container->addShared( MapiAccountHomepageService::class, $this->homepage_service );
 		$this->container->addShared( MerchantCenterService::class, $this->mc_service );
 		$this->container->addShared( MerchantIssueTable::class, $this->issue_table );
+		$this->container->addShared( MarketService::class, $this->market_service );
 		$this->container->addShared( MerchantStatuses::class, $this->merchant_statuses );
 		$this->container->addShared( Middleware::class, $this->middleware );
 		$this->container->addShared( SiteVerification::class, $this->site_verification );
@@ -898,7 +904,7 @@ class AccountServiceTest extends UnitTest {
 	}
 
 	public function test_disconnect() {
-		$this->options->expects( $this->exactly( 9 ) )
+		$this->options->expects( $this->exactly( 8 ) )
 			->method( 'delete' )
 			->withConsecutive(
 				[ OptionsInterface::CONTACT_INFO_SETUP ],
@@ -907,11 +913,11 @@ class AccountServiceTest extends UnitTest {
 				[ OptionsInterface::MERCHANT_ACCOUNT_STATE ],
 				[ OptionsInterface::MERCHANT_CENTER ],
 				[ OptionsInterface::SITE_VERIFICATION ],
-				[ OptionsInterface::TARGET_AUDIENCE ],
 				[ OptionsInterface::MERCHANT_ID ],
 				[ OptionsInterface::CLAIMED_URL_HASH ]
 			);
 
+		$this->market_service->expects( $this->once() )->method( 'reset_markets' );
 		$this->merchant_statuses->expects( $this->once() )->method( 'delete' );
 		$this->issue_table->expects( $this->once() )->method( 'truncate' );
 		$this->rate_table->expects( $this->once() )->method( 'truncate' );

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -285,6 +285,17 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( [ 'US', 'CA' ], $result['primary']['countries'] );
 	}
 
+	public function test_reset_markets_deletes_target_audience_and_markets_options(): void {
+		$this->options->expects( $this->exactly( 2 ) )
+			->method( 'delete' )
+			->withConsecutive(
+				[ OptionsInterface::TARGET_AUDIENCE ],
+				[ OptionsInterface::MARKETS ]
+			);
+
+		$this->market_service->reset_markets();
+	}
+
 	public function test_get_primary_market_country_and_feed_label_are_null(): void {
 		$this->set_up_options_get( [ OptionsInterface::MERCHANT_CENTER => [] ] );
 		$this->set_up_primary_market_dependencies(


### PR DESCRIPTION
## Summary
- Disconnecting Merchant Center deleted the primary market (`target_audience`) but never cleared secondary markets (`markets` option), so a country previously configured as a secondary market could survive disconnect and reappear as a duplicate of a freshly configured primary market on the next onboarding.
- Adds `MarketService::reset_markets()`, which clears both `target_audience` and `markets`, and updates `AccountService::disconnect()` to call it instead of deleting `target_audience` directly — keeping market CRUD centralized in `MarketService` per its existing "centralises all CRUD logic for managing markets" docblock, rather than `AccountService` reaching into raw options.
- `MERCHANT_CENTER` option deletion stays in `AccountService::disconnect()` since it carries settings beyond markets (site verification state, etc.) and its lifecycle belongs to the Merchant Center disconnect flow, not `MarketService`.
- Deliberately does **not** schedule `CleanupOrphanedMarketProductsJob` for stale feed labels from the cleared markets: `AccountService::disconnect()` already schedules `CleanupSyncedProducts`, which marks all synced products as unsynced, so per-feed-label cleanup would be redundant here.

Linear: GOOWOO-860

## Test plan
- [x] `MarketServiceTest::test_reset_markets_deletes_target_audience_and_markets_options` (new)
- [x] `AccountServiceTest::test_disconnect` (updated to assert `MarketService::reset_markets()` is called instead of a raw `target_audience` delete)
- [x] Manual: configure a primary + secondary market, disconnect from WooCommerce.com/Merchant Center/Google Ads, re-onboard with a primary market that includes the old secondary market's country — confirm it only appears once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)