### PR TITLE
fix(markets): correct primary market countries and shipping rate/time

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { apiFetch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
@@ -13,6 +14,7 @@ import {
 	API_NAMESPACE,
 	REQUEST_ACTIONS,
 	EMPTY_ASSET_ENTITY_GROUP,
+	STORE_KEY,
 } from './constants';
 import { EU_POLITICAL_ADVERTISING_DECLARATION_REQUIRED_ERROR_CODE } from '~/constants';
 import { handleApiError } from '~/utils/handleError';
@@ -359,6 +361,21 @@ export function* saveSettings( settings ) {
 		method: 'POST',
 		data: settings,
 	} );
+
+	// The markets and target audience are derived server-side from settings
+	// such as the shipping rate method, so they can no longer be trusted.
+	yield controls.dispatch(
+		STORE_KEY,
+		'invalidateResolution',
+		'getMarkets',
+		[]
+	);
+	yield controls.dispatch(
+		STORE_KEY,
+		'invalidateResolution',
+		'getTargetAudience',
+		[]
+	);
 
 	return {
 		type: TYPES.SAVE_SETTINGS,

--- a/js/src/data/test/saveSettings.test.js
+++ b/js/src/data/test/saveSettings.test.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { resolveSelect, select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useAppDispatch, STORE_KEY } from '~/data';
+
+jest.mock( '@wordpress/api-fetch', () => {
+	const impl = jest.fn().mockName( '@wordpress/api-fetch' );
+	impl.use = jest.fn().mockName( 'apiFetch.use' );
+	return impl;
+} );
+
+describe( 'saveSettings', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		apiFetch.mockImplementation( ( { path } ) => {
+			if ( path === '/wc/gla/mc/markets' ) {
+				return Promise.resolve( [] );
+			}
+			if ( path === '/wc/gla/mc/target_audience' ) {
+				return Promise.resolve( { locations: [], location: 'all' } );
+			}
+			return Promise.resolve( {} );
+		} );
+	} );
+
+	it( 'invalidates the markets and target audience resolutions after saving', async () => {
+		// Resolve markets and target audience once, so their resolution
+		// state is populated before saving settings.
+		await resolveSelect( STORE_KEY ).getMarkets();
+		await resolveSelect( STORE_KEY ).getTargetAudience();
+
+		expect(
+			select( STORE_KEY ).hasFinishedResolution( 'getMarkets', [] )
+		).toBe( true );
+		expect(
+			select( STORE_KEY ).hasFinishedResolution( 'getTargetAudience', [] )
+		).toBe( true );
+
+		const { result } = renderHook( () => useAppDispatch() );
+
+		await result.current.saveSettings( { shipping_rate: 'automatic' } );
+
+		expect(
+			select( STORE_KEY ).hasFinishedResolution( 'getMarkets', [] )
+		).toBe( false );
+		expect(
+			select( STORE_KEY ).hasFinishedResolution( 'getTargetAudience', [] )
+		).toBe( false );
+	} );
+} );

--- a/js/src/pages/markets/components/edit-market-modal/index.js
+++ b/js/src/pages/markets/components/edit-market-modal/index.js
@@ -14,7 +14,6 @@ import isPrimaryMarket from '../../utils/isPrimaryMarket';
 import './index.scss';
 
 /**
- * @typedef {import('~/data/actions').TargetAudienceData } TargetAudienceData
  * @typedef {import('~/data/actions').CountryCode} CountryCode
  */
 
@@ -22,11 +21,13 @@ import './index.scss';
  * Modal component for editing an existing market.
  *
  * @param {Object} props
- * @param {{ id: string, label: string }} props.market The market being edited.
- * @param {TargetAudienceData} props.targetAudience Target audience value data to initialize the form with.
+ * @param {{ id: string, label: string }} props.market The market being edited. Its `countries`
+ *                                                      (for the primary market) is already the
+ *                                                      backend-filtered list from `mc/markets`
+ *                                                      and must be used as-is.
  * @param {() => void} props.onRequestClose Called when the user closes the modal.
  */
-const EditMarketModal = ( { market, targetAudience, onRequestClose } ) => {
+const EditMarketModal = ( { market, onRequestClose } ) => {
 	const appModalTitle = isPrimaryMarket( market )
 		? __( 'Edit primary market', 'google-listings-and-ads' )
 		: sprintf(
@@ -35,24 +36,13 @@ const EditMarketModal = ( { market, targetAudience, onRequestClose } ) => {
 				market.label
 		  );
 
-	// `targetAudience.countries` is the authoritative list for the primary
-	// market and may have been refreshed since `market` was read. Only override
-	// for the primary — secondary markets carry their own single-country
-	// `countries` array that must not be replaced with the primary's audience.
-	const initialMarket = isPrimaryMarket( market )
-		? { ...market, countries: targetAudience.countries }
-		: market;
-
 	return (
 		<AppModal
 			title={ appModalTitle }
 			onRequestClose={ onRequestClose }
 			className="gla-edit-market-modal"
 		>
-			<MarketForm
-				initialMarket={ initialMarket }
-				onSubmit={ onRequestClose }
-			>
+			<MarketForm initialMarket={ market } onSubmit={ onRequestClose }>
 				<MarketFields />
 				<ModalFooter onCancel={ onRequestClose } />
 			</MarketForm>

--- a/js/src/pages/markets/components/edit-market-modal/index.test.js
+++ b/js/src/pages/markets/components/edit-market-modal/index.test.js
@@ -29,7 +29,6 @@ jest.mock( '~/components/adaptive-form', () => ( {
 } ) );
 
 const market = { id: 'primary', label: 'Primary Market' };
-const targetAudience = { countries: [ 'US' ] };
 
 describe( 'EditMarketModal', () => {
 	beforeEach( () => {
@@ -46,11 +45,7 @@ describe( 'EditMarketModal', () => {
 
 	test( 'renders the title for the primary market', () => {
 		render(
-			<EditMarketModal
-				market={ market }
-				targetAudience={ targetAudience }
-				onRequestClose={ () => {} }
-			/>
+			<EditMarketModal market={ market } onRequestClose={ () => {} } />
 		);
 
 		expect(
@@ -67,7 +62,6 @@ describe( 'EditMarketModal', () => {
 					country: 'BE',
 					countries: [ 'BE' ],
 				} }
-				targetAudience={ targetAudience }
 				onRequestClose={ () => {} }
 			/>
 		);
@@ -82,11 +76,7 @@ describe( 'EditMarketModal', () => {
 		MarketFormMock.mockImplementationOnce( () => <AppSpinner /> );
 
 		render(
-			<EditMarketModal
-				market={ market }
-				targetAudience={ targetAudience }
-				onRequestClose={ () => {} }
-			/>
+			<EditMarketModal market={ market } onRequestClose={ () => {} } />
 		);
 
 		expect(
@@ -95,11 +85,14 @@ describe( 'EditMarketModal', () => {
 		expect( screen.getByRole( 'status' ) ).toBeInTheDocument();
 	} );
 
-	test( 'forwards target-audience countries as initialMarket.countries for the primary market', () => {
+	test( 'forwards the primary market countries from `market` unchanged (no target-audience override)', () => {
 		render(
 			<EditMarketModal
-				market={ { id: 'primary', label: 'Primary Market' } }
-				targetAudience={ { countries: [ 'US', 'CA', 'MX' ] } }
+				market={ {
+					id: 'primary',
+					label: 'Primary Market',
+					countries: [ 'US', 'CA' ],
+				} }
 				onRequestClose={ () => {} }
 			/>
 		);
@@ -108,14 +101,14 @@ describe( 'EditMarketModal', () => {
 			expect.objectContaining( {
 				initialMarket: expect.objectContaining( {
 					id: 'primary',
-					countries: [ 'US', 'CA', 'MX' ],
+					countries: [ 'US', 'CA' ],
 				} ),
 			} ),
 			expect.anything()
 		);
 	} );
 
-	test( 'preserves the secondary market countries (does not override with primary audience)', () => {
+	test( 'preserves the secondary market countries', () => {
 		render(
 			<EditMarketModal
 				market={ {
@@ -124,7 +117,6 @@ describe( 'EditMarketModal', () => {
 					country: 'FR',
 					countries: [ 'FR' ],
 				} }
-				targetAudience={ { countries: [ 'US', 'CA', 'MX' ] } }
 				onRequestClose={ () => {} }
 			/>
 		);
@@ -145,11 +137,7 @@ describe( 'EditMarketModal', () => {
 		const user = userEvent.setup();
 		const onCancel = jest.fn();
 		render(
-			<EditMarketModal
-				market={ market }
-				targetAudience={ targetAudience }
-				onRequestClose={ onCancel }
-			/>
+			<EditMarketModal market={ market } onRequestClose={ onCancel } />
 		);
 
 		// `getByRole('button', { name: 'Cancel' })` matches both the

--- a/js/src/pages/markets/components/market-data-views/index.js
+++ b/js/src/pages/markets/components/market-data-views/index.js
@@ -3,13 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
-import { Spinner } from '@wordpress/components';
 import { Icon, edit, trash } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 import useMarketDataViewsConfig from '../../hooks/useMarketDataViewsConfig';
 import EditMarketModal from '../edit-market-modal';
 import DeleteMarketModal from '../delete-market-modal';
@@ -35,7 +33,6 @@ const MarketDataViews = () => {
 	const [ view, setView ] = useState( DEFAULT_VIEW );
 	const [ editingMarket, setEditingMarket ] = useState( null );
 	const [ deletingMarket, setDeletingMarket ] = useState( null );
-	const { targetAudience, loaded } = useTargetAudienceFinalCountryCodes();
 
 	// `view.fields` is the list of visible columns; it must track the field set
 	// returned by `useMarketDataViewsConfig`, which varies per scenario.
@@ -60,15 +57,9 @@ const MarketDataViews = () => {
 			{
 				id: 'edit',
 				label: __( 'Edit', 'google-listings-and-ads' ),
-				icon: loaded ? (
-					<Icon icon={ edit } width={ 24 } height={ 24 } />
-				) : (
-					<Spinner />
-				),
+				icon: <Icon icon={ edit } width={ 24 } height={ 24 } />,
 				isPrimary: true,
-				callback: loaded
-					? ( [ market ] ) => setEditingMarket( market )
-					: () => {},
+				callback: ( [ market ] ) => setEditingMarket( market ),
 			},
 			{
 				id: 'delete',
@@ -79,7 +70,7 @@ const MarketDataViews = () => {
 				callback: ( [ market ] ) => setDeletingMarket( market ),
 			},
 		],
-		[ loaded ]
+		[]
 	);
 
 	return (
@@ -100,7 +91,6 @@ const MarketDataViews = () => {
 				<EditMarketModal
 					market={ editingMarket }
 					onRequestClose={ () => setEditingMarket( null ) }
-					targetAudience={ targetAudience }
 				/>
 			) }
 

--- a/js/src/pages/markets/components/market-data-views/index.test.js
+++ b/js/src/pages/markets/components/market-data-views/index.test.js
@@ -15,12 +15,14 @@ import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
 import useSettings from '~/hooks/useSettings';
 import useShippingRates from '~/hooks/useShippingRates';
 import useShippingTimes from '~/hooks/useShippingTimes';
+import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 
 jest.mock( '../../hooks/useMarkets' );
 jest.mock( '~/hooks/useCountryKeyNameMap' );
 jest.mock( '~/hooks/useSettings' );
 jest.mock( '~/hooks/useShippingRates' );
 jest.mock( '~/hooks/useShippingTimes' );
+jest.mock( '~/hooks/useTargetAudienceFinalCountryCodes' );
 
 jest.mock( '../edit-market-modal', () =>
 	jest.fn( ( { market, onRequestClose } ) => (
@@ -155,6 +157,10 @@ beforeEach( () => {
 		data: [],
 		hasFinishedResolution: true,
 	} );
+	useTargetAudienceFinalCountryCodes.mockReturnValue( {
+		targetAudience: {},
+		loaded: true,
+	} );
 } );
 
 afterEach( () => {
@@ -163,6 +169,7 @@ afterEach( () => {
 	useCountryKeyNameMap.mockReset();
 	useShippingRates.mockReset();
 	useShippingTimes.mockReset();
+	useTargetAudienceFinalCountryCodes.mockReset();
 	delete window.glaData.isMultiLingualStore;
 	delete window.wp;
 } );

--- a/js/src/pages/markets/components/market-form.js
+++ b/js/src/pages/markets/components/market-form.js
@@ -24,6 +24,7 @@ import useSaveShippingRates from '~/hooks/useSaveShippingRates';
 import useSaveShippingTimes from '~/hooks/useSaveShippingTimes';
 import useSettings from '~/hooks/useSettings';
 import useStoreCurrency from '~/hooks/useStoreCurrency';
+import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 import AdaptiveForm from '~/components/adaptive-form';
 import ValidationErrors from '~/components/validation-errors';
 import AppSpinner from '~/components/app-spinner';
@@ -69,6 +70,7 @@ const MarketForm = ( {
 		hasFinishedResolution: hasResolvedShippingTimes,
 		data: shippingTimes,
 	} = useShippingTimes();
+	const { targetAudience } = useTargetAudienceFinalCountryCodes();
 	const { saveShippingRates } = useSaveShippingRates();
 	const { saveShippingTimes } = useSaveShippingTimes();
 	const [ isSaving, setIsSaving ] = useState( false );
@@ -375,27 +377,36 @@ const MarketForm = ( {
 		/*
 		 * For the primary market, all countries share the same shipping settings,
 		 * so the form shows a single set of fields rather than per-country rows.
-		 * We seed those fields from the first stored rate/time entry as a
-		 * representative value — any row would give the same result since they
-		 * are kept in sync whenever the user saves. The same entry is also used
-		 * as the starting point when adding a new secondary market.
+		 * We seed those fields from the main target country's stored rate/time
+		 * row — countries can carry distinct per-country rates/times that are
+		 * surfaced as their own secondary markets (see MarketService::
+		 * get_derived_flat_secondary_markets()), so only the main country's row
+		 * is guaranteed to represent the primary market. Falls back to the first
+		 * row when adding a brand new market, before a main country is known.
 		 */
 		if ( isPrimaryMarket || ! isEditing ) {
-			const firstShippingRate = shippingRates?.[ 0 ];
-			const firstShippingTime = shippingTimes?.[ 0 ];
+			const mainCountry = targetAudience?.main_target_country;
+			const mainShippingRate =
+				shippingRates?.find(
+					( rate ) => rate.country === mainCountry
+				) ?? shippingRates?.[ 0 ];
+			const mainShippingTime =
+				shippingTimes?.find(
+					( time ) => time.countryCode === mainCountry
+				) ?? shippingTimes?.[ 0 ];
 			updatedMarket = {
 				...updatedMarket,
-				...( firstShippingRate && {
-					flat_shipping_rate: firstShippingRate.rate,
+				...( mainShippingRate && {
+					flat_shipping_rate: mainShippingRate.rate,
 					offer_free_shipping:
-						firstShippingRate.options?.free_shipping_threshold > 0,
+						mainShippingRate.options?.free_shipping_threshold > 0,
 					free_shipping_threshold:
-						firstShippingRate.options?.free_shipping_threshold ??
+						mainShippingRate.options?.free_shipping_threshold ??
 						undefined,
 				} ),
-				...( firstShippingTime && {
-					flat_shipping_min_time: firstShippingTime.time,
-					flat_shipping_max_time: firstShippingTime.maxTime,
+				...( mainShippingTime && {
+					flat_shipping_min_time: mainShippingTime.time,
+					flat_shipping_max_time: mainShippingTime.maxTime,
 				} ),
 			};
 		}

--- a/js/src/pages/markets/components/market-form.js
+++ b/js/src/pages/markets/components/market-form.js
@@ -70,7 +70,8 @@ const MarketForm = ( {
 		hasFinishedResolution: hasResolvedShippingTimes,
 		data: shippingTimes,
 	} = useShippingTimes();
-	const { targetAudience } = useTargetAudienceFinalCountryCodes();
+	const { targetAudience, loaded: hasResolvedTargetAudience } =
+		useTargetAudienceFinalCountryCodes();
 	const { saveShippingRates } = useSaveShippingRates();
 	const { saveShippingTimes } = useSaveShippingTimes();
 	const [ isSaving, setIsSaving ] = useState( false );
@@ -81,7 +82,10 @@ const MarketForm = ( {
 	const isPrimaryMarket = isEditing && checkIsPrimaryMarket( initialMarket );
 
 	const isLoading =
-		! hasResolvedShippingRates || ! hasResolvedShippingTimes || ! settings;
+		! hasResolvedShippingRates ||
+		! hasResolvedShippingTimes ||
+		! hasResolvedTargetAudience ||
+		! settings;
 
 	if ( isLoading ) {
 		return <AppSpinner />;

--- a/js/src/pages/markets/components/market-form.test.js
+++ b/js/src/pages/markets/components/market-form.test.js
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import MarketForm from './market-form';
+import useShippingRates from '~/hooks/useShippingRates';
+import useShippingTimes from '~/hooks/useShippingTimes';
+import useSettings from '~/hooks/useSettings';
+import useStoreCurrency from '~/hooks/useStoreCurrency';
+import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
+import useSaveShippingRates from '~/hooks/useSaveShippingRates';
+import useSaveShippingTimes from '~/hooks/useSaveShippingTimes';
+import { useAppDispatch } from '~/data';
+
+jest.mock( '~/hooks/useShippingRates' );
+jest.mock( '~/hooks/useShippingTimes' );
+jest.mock( '~/hooks/useSettings' );
+jest.mock( '~/hooks/useStoreCurrency' );
+jest.mock( '~/hooks/useTargetAudienceFinalCountryCodes' );
+jest.mock( '~/hooks/useSaveShippingRates' );
+jest.mock( '~/hooks/useSaveShippingTimes' );
+jest.mock( '~/data', () => ( {
+	useAppDispatch: jest.fn(),
+} ) );
+
+// MarketForm renders its fields via AdaptiveForm (and attaches a ref to it);
+// mock it as a forwardRef spy so we can inspect the `initialValues` it's given
+// without needing a real form context or triggering a "function components
+// cannot be given refs" warning.
+const mockAdaptiveForm = jest.fn( () => null );
+jest.mock( '~/components/adaptive-form', () => {
+	const { forwardRef } = jest.requireActual( '@wordpress/element' );
+	return forwardRef( ( props, ref ) => mockAdaptiveForm( props, ref ) );
+} );
+
+const PRIMARY_MARKET = { id: 'primary', label: 'Primary Market' };
+
+describe( 'MarketForm', () => {
+	beforeEach( () => {
+		mockAdaptiveForm.mockClear();
+		useSettings.mockReturnValue( {
+			settings: { shipping_rate: 'flat', shipping_time: 'flat' },
+		} );
+		useStoreCurrency.mockReturnValue( { code: 'USD' } );
+		useSaveShippingRates.mockReturnValue( {
+			saveShippingRates: jest.fn(),
+		} );
+		useSaveShippingTimes.mockReturnValue( {
+			saveShippingTimes: jest.fn(),
+		} );
+		useAppDispatch.mockReturnValue( {
+			createMarket: jest.fn(),
+			updateMarket: jest.fn(),
+			syncSettings: jest.fn(),
+			invalidateResolution: jest.fn(),
+		} );
+	} );
+
+	test( 'seeds the primary market rate/time from the main target country, not the alphabetically-first row', () => {
+		// CA sorts before US, but US is the store's main target country and
+		// carries a different rate — the bug picked CA's row instead.
+		useShippingRates.mockReturnValue( {
+			data: [
+				{ country: 'CA', rate: 5, options: {} },
+				{ country: 'US', rate: 3, options: {} },
+			],
+			hasFinishedResolution: true,
+		} );
+		useShippingTimes.mockReturnValue( {
+			data: [
+				{ countryCode: 'CA', time: 7, maxTime: 14 },
+				{ countryCode: 'US', time: 1, maxTime: 3 },
+			],
+			hasFinishedResolution: true,
+		} );
+		useTargetAudienceFinalCountryCodes.mockReturnValue( {
+			targetAudience: { main_target_country: 'US' },
+		} );
+
+		render(
+			<MarketForm
+				initialMarket={ {
+					...PRIMARY_MARKET,
+					countries: [ 'CA', 'US' ],
+				} }
+				onSubmit={ () => {} }
+			/>
+		);
+
+		const { initialValues } = mockAdaptiveForm.mock.calls[ 0 ][ 0 ];
+		expect( initialValues.flat_shipping_rate ).toBe( 3 );
+		expect( initialValues.flat_shipping_min_time ).toBe( 1 );
+		expect( initialValues.flat_shipping_max_time ).toBe( 3 );
+	} );
+
+	test( 'falls back to the first shipping rate/time row when no main target country is known', () => {
+		useShippingRates.mockReturnValue( {
+			data: [ { country: 'CA', rate: 5, options: {} } ],
+			hasFinishedResolution: true,
+		} );
+		useShippingTimes.mockReturnValue( {
+			data: [ { countryCode: 'CA', time: 7, maxTime: 14 } ],
+			hasFinishedResolution: true,
+		} );
+		useTargetAudienceFinalCountryCodes.mockReturnValue( {
+			targetAudience: {},
+		} );
+
+		render(
+			<MarketForm
+				initialMarket={ { ...PRIMARY_MARKET, countries: [ 'CA' ] } }
+				onSubmit={ () => {} }
+			/>
+		);
+
+		const { initialValues } = mockAdaptiveForm.mock.calls[ 0 ][ 0 ];
+		expect( initialValues.flat_shipping_rate ).toBe( 5 );
+		expect( initialValues.flat_shipping_min_time ).toBe( 7 );
+	} );
+} );

--- a/js/src/pages/markets/components/market-form.test.js
+++ b/js/src/pages/markets/components/market-form.test.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -79,6 +80,7 @@ describe( 'MarketForm', () => {
 		} );
 		useTargetAudienceFinalCountryCodes.mockReturnValue( {
 			targetAudience: { main_target_country: 'US' },
+			loaded: true,
 		} );
 
 		render(
@@ -108,6 +110,7 @@ describe( 'MarketForm', () => {
 		} );
 		useTargetAudienceFinalCountryCodes.mockReturnValue( {
 			targetAudience: {},
+			loaded: true,
 		} );
 
 		render(
@@ -120,5 +123,33 @@ describe( 'MarketForm', () => {
 		const { initialValues } = mockAdaptiveForm.mock.calls[ 0 ][ 0 ];
 		expect( initialValues.flat_shipping_rate ).toBe( 5 );
 		expect( initialValues.flat_shipping_min_time ).toBe( 7 );
+	} );
+
+	test( 'renders AppSpinner instead of seeding the form while target audience has not resolved', () => {
+		// If the form seeded its rate/time fields before target audience
+		// resolves, main_target_country would be undefined and it would
+		// silently fall back to the (possibly wrong) first row.
+		useShippingRates.mockReturnValue( {
+			data: [ { country: 'CA', rate: 5, options: {} } ],
+			hasFinishedResolution: true,
+		} );
+		useShippingTimes.mockReturnValue( {
+			data: [ { countryCode: 'CA', time: 7, maxTime: 14 } ],
+			hasFinishedResolution: true,
+		} );
+		useTargetAudienceFinalCountryCodes.mockReturnValue( {
+			targetAudience: {},
+			loaded: false,
+		} );
+
+		render(
+			<MarketForm
+				initialMarket={ { ...PRIMARY_MARKET, countries: [ 'CA' ] } }
+				onSubmit={ () => {} }
+			/>
+		);
+
+		expect( screen.getByRole( 'status' ) ).toBeInTheDocument();
+		expect( mockAdaptiveForm ).not.toHaveBeenCalled();
 	} );
 } );

--- a/js/src/pages/markets/hooks/useMarketDataViewsConfig.js
+++ b/js/src/pages/markets/hooks/useMarketDataViewsConfig.js
@@ -446,13 +446,15 @@ const useMarketDataViewsConfig = () => {
 		useShippingRates();
 	const { data: shippingTimesData, hasFinishedResolution: hasResolvedTimes } =
 		useShippingTimes();
-	const { targetAudience } = useTargetAudienceFinalCountryCodes();
+	const { targetAudience, loaded: hasResolvedTargetAudience } =
+		useTargetAudienceFinalCountryCodes();
 	const mainTargetCountry = targetAudience?.main_target_country;
 
 	const hasFinishedResolution =
 		hasResolvedMarkets &&
 		hasResolvedRates &&
 		hasResolvedTimes &&
+		hasResolvedTargetAudience &&
 		!! settings;
 
 	if ( ! hasFinishedResolution ) {

--- a/js/src/pages/markets/hooks/useMarketDataViewsConfig.js
+++ b/js/src/pages/markets/hooks/useMarketDataViewsConfig.js
@@ -11,6 +11,7 @@ import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
 import useSettings from '~/hooks/useSettings';
 import useShippingRates from '~/hooks/useShippingRates';
 import useShippingTimes from '~/hooks/useShippingTimes';
+import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 import useMarkets from './useMarkets';
 import ShippingRateCell from '../components/market-data-views/shipping-rate-cell';
 import LanguageCell from '../components/market-data-views/language-cell';
@@ -231,9 +232,15 @@ const buildManualConfig = ( { markets } ) => {
  * @param {Market[]} options.markets All markets from useMarkets.
  * @param {Object.<string,RateRow>} options.ratesByCountry Country-keyed map of shipping rate rows.
  * @param {Object.<string,TimeRow>} options.timesByCountry Country-keyed map of shipping time rows.
+ * @param {?string} options.mainTargetCountry The store's main target country.
  * @return {DataViewsConfig} DataViews fields and pre-formatted rows.
  */
-const buildFlatConfig = ( { markets, ratesByCountry, timesByCountry } ) => {
+const buildFlatConfig = ( {
+	markets,
+	ratesByCountry,
+	timesByCountry,
+	mainTargetCountry,
+} ) => {
 	const fields = [
 		ALL_FIELDS.market,
 		ALL_FIELDS.shippingRate,
@@ -243,9 +250,11 @@ const buildFlatConfig = ( { markets, ratesByCountry, timesByCountry } ) => {
 
 	const data = markets.map( ( market ) => {
 		let country = market.country;
-		if ( isPrimaryMarket( market ) && market.countries.length > 0 ) {
-			// Primary's country is null by API contract — use the first targeted country for rate/time lookups.
-			country = market.countries[ 0 ];
+		if ( isPrimaryMarket( market ) ) {
+			// Primary's country is null by API contract — use the main target
+			// country (countries can carry distinct per-country rates/times
+			// surfaced as their own secondary markets) for rate/time lookups.
+			country = mainTargetCountry ?? market.countries?.[ 0 ] ?? null;
 		}
 
 		const rateRow = ratesByCountry[ country ];
@@ -288,9 +297,14 @@ const buildFlatConfig = ( { markets, ratesByCountry, timesByCountry } ) => {
  * @param {Object} options
  * @param {Market[]} options.markets All markets from useMarkets.
  * @param {Object.<string,TimeRow>} options.timesByCountry Country-keyed map of shipping time rows.
+ * @param {?string} options.mainTargetCountry The store's main target country.
  * @return {DataViewsConfig} DataViews fields and pre-formatted rows.
  */
-const buildAutomaticConfig = ( { markets, timesByCountry } ) => {
+const buildAutomaticConfig = ( {
+	markets,
+	timesByCountry,
+	mainTargetCountry,
+} ) => {
 	const fields = glaData.isMultiLingualStore
 		? [
 				ALL_FIELDS.market,
@@ -302,9 +316,10 @@ const buildAutomaticConfig = ( { markets, timesByCountry } ) => {
 
 	const data = markets.map( ( market ) => {
 		let country = market.country;
-		if ( isPrimaryMarket( market ) && market.countries?.length > 0 ) {
-			// Primary's country is null by API contract — use the first targeted country for time lookups.
-			country = market.countries[ 0 ];
+		if ( isPrimaryMarket( market ) ) {
+			// Primary's country is null by API contract — use the main target
+			// country (falling back to the first targeted country) for time lookups.
+			country = mainTargetCountry ?? market.countries?.[ 0 ] ?? null;
 		}
 
 		const row = {
@@ -343,15 +358,23 @@ const buildAutomaticConfig = ( { markets, timesByCountry } ) => {
  * @param {Market[]} options.markets All markets from useMarkets.
  * @param {Object.<string,string>} options.countryNames Mapping of country code to country name from useCountryKeyNameMap.
  * @param {Object.<string,TimeRow>} options.timesByCountry Country-keyed map of shipping time rows.
+ * @param {?string} options.mainTargetCountry The store's main target country.
  * @return {DataViewsConfig} DataViews fields and pre-formatted rows.
  */
-const buildDefaultConfig = ( { markets, countryNames, timesByCountry } ) => {
+const buildDefaultConfig = ( {
+	markets,
+	countryNames,
+	timesByCountry,
+	mainTargetCountry,
+} ) => {
 	const fields = [ ALL_FIELDS.market, ALL_FIELDS.shippingTime ];
 
 	const data = markets.map( ( market ) => {
 		let country = market.country;
-		if ( isPrimaryMarket( market ) && market.countries?.length > 0 ) {
-			country = market.countries[ 0 ];
+		if ( isPrimaryMarket( market ) ) {
+			// Primary's country is null by API contract — use the main target
+			// country (falling back to the first targeted country) for time lookups.
+			country = mainTargetCountry ?? market.countries?.[ 0 ] ?? null;
 		}
 
 		const marketCell = isPrimaryMarket( market )
@@ -423,6 +446,8 @@ const useMarketDataViewsConfig = () => {
 		useShippingRates();
 	const { data: shippingTimesData, hasFinishedResolution: hasResolvedTimes } =
 		useShippingTimes();
+	const { targetAudience } = useTargetAudienceFinalCountryCodes();
+	const mainTargetCountry = targetAudience?.main_target_country;
 
 	const hasFinishedResolution =
 		hasResolvedMarkets &&
@@ -456,6 +481,7 @@ const useMarketDataViewsConfig = () => {
 		const { fields, data } = buildAutomaticConfig( {
 			markets,
 			timesByCountry,
+			mainTargetCountry,
 		} );
 		return {
 			fields,
@@ -472,6 +498,7 @@ const useMarketDataViewsConfig = () => {
 			markets,
 			ratesByCountry,
 			timesByCountry,
+			mainTargetCountry,
 		} );
 		return {
 			fields,
@@ -484,6 +511,7 @@ const useMarketDataViewsConfig = () => {
 		markets,
 		countryNames,
 		timesByCountry,
+		mainTargetCountry,
 	} );
 	return {
 		fields,

--- a/js/src/pages/markets/hooks/useMarketDataViewsConfig.test.js
+++ b/js/src/pages/markets/hooks/useMarketDataViewsConfig.test.js
@@ -138,6 +138,7 @@ const setMocks = ( {
 	} );
 	useTargetAudienceFinalCountryCodes.mockReturnValue( {
 		targetAudience: { main_target_country: mainTargetCountry },
+		loaded: true,
 	} );
 	// `glaData` is captured as a reference to `window.glaData` at module load
 	// (see `js/src/constants.js`), so mutate in place rather than replacing the
@@ -812,6 +813,39 @@ describe( 'useMarketDataViewsConfig', () => {
 			} );
 			useTargetAudienceFinalCountryCodes.mockReturnValue( {
 				targetAudience: {},
+				loaded: true,
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+
+			expect( result.current.fields ).toEqual( [] );
+			expect( result.current.data ).toEqual( [] );
+			expect( result.current.hasFinishedResolution ).toBe( false );
+		} );
+
+		test( 'returns empty fields and data when everything else is resolved but target audience is not', () => {
+			// If hasFinishedResolution ignored target audience, a row could
+			// render with an unresolved main_target_country and briefly show
+			// the wrong (first-row) rate/time for the primary market.
+			useMarkets.mockReturnValue( {
+				data: [ PRIMARY_MARKET ],
+				hasFinishedResolution: true,
+			} );
+			useCountryKeyNameMap.mockReturnValue( {} );
+			useSettings.mockReturnValue( {
+				settings: { shipping_rate: 'flat' },
+			} );
+			useShippingRates.mockReturnValue( {
+				data: [],
+				hasFinishedResolution: true,
+			} );
+			useShippingTimes.mockReturnValue( {
+				data: [],
+				hasFinishedResolution: true,
+			} );
+			useTargetAudienceFinalCountryCodes.mockReturnValue( {
+				targetAudience: {},
+				loaded: false,
 			} );
 
 			const { result } = renderHook( () => useMarketDataViewsConfig() );

--- a/js/src/pages/markets/hooks/useMarketDataViewsConfig.test.js
+++ b/js/src/pages/markets/hooks/useMarketDataViewsConfig.test.js
@@ -12,11 +12,13 @@ import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
 import useSettings from '~/hooks/useSettings';
 import useShippingRates from '~/hooks/useShippingRates';
 import useShippingTimes from '~/hooks/useShippingTimes';
+import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 jest.mock( './useMarkets' );
 jest.mock( '~/hooks/useCountryKeyNameMap' );
 jest.mock( '~/hooks/useSettings' );
 jest.mock( '~/hooks/useShippingRates' );
 jest.mock( '~/hooks/useShippingTimes' );
+jest.mock( '~/hooks/useTargetAudienceFinalCountryCodes' );
 
 const SHIPPING_RATES = [
 	{ id: 1, country: 'US', currency: 'USD', rate: 10, options: {} },
@@ -116,6 +118,7 @@ const setMocks = ( {
 	shippingRate = primary.shipping_rate,
 	shippingRates = [],
 	shippingTimes = [],
+	mainTargetCountry,
 } = {} ) => {
 	useMarkets.mockReturnValue( {
 		data: markets,
@@ -133,6 +136,9 @@ const setMocks = ( {
 		data: shippingTimes,
 		hasFinishedResolution: true,
 	} );
+	useTargetAudienceFinalCountryCodes.mockReturnValue( {
+		targetAudience: { main_target_country: mainTargetCountry },
+	} );
 	// `glaData` is captured as a reference to `window.glaData` at module load
 	// (see `js/src/constants.js`), so mutate in place rather than replacing the
 	// object — replacing would leave the original reference stale.
@@ -143,6 +149,7 @@ describe( 'useMarketDataViewsConfig', () => {
 	afterEach( () => {
 		useMarkets.mockReset();
 		useCountryKeyNameMap.mockReset();
+		useTargetAudienceFinalCountryCodes.mockReset();
 		useSettings.mockReset();
 		useShippingRates.mockReset();
 		useShippingTimes.mockReset();
@@ -322,6 +329,37 @@ describe( 'useMarketDataViewsConfig', () => {
 			expect( secondary.shipping_time_config ).toMatchObject( {
 				time: 5,
 				maxTime: 7,
+			} );
+		} );
+
+		test( 'uses the main target country, not the alphabetically-first row, for the primary market rate/time lookup', () => {
+			setMocks( {
+				primary: PRIMARY_MARKET_FLAT,
+				markets: [ PRIMARY_MARKET_FLAT ],
+				shippingRates: [
+					{ country: 'CA', currency: 'CAD', rate: 15, options: {} },
+					{ country: 'US', currency: 'USD', rate: 3, options: {} },
+				],
+				shippingTimes: [
+					{ countryCode: 'CA', time: 7, maxTime: 14 },
+					{ countryCode: 'US', time: 1, maxTime: 3 },
+				],
+				mainTargetCountry: 'US',
+			} );
+
+			const { result } = renderHook( () => useMarketDataViewsConfig() );
+
+			expect(
+				result.current.data[ 0 ].shipping_rate_config
+			).toMatchObject( {
+				rate: 3,
+				currency: 'USD',
+			} );
+			expect(
+				result.current.data[ 0 ].shipping_time_config
+			).toMatchObject( {
+				time: 1,
+				maxTime: 3,
 			} );
 		} );
 
@@ -746,6 +784,9 @@ describe( 'useMarketDataViewsConfig', () => {
 				data: [],
 				hasFinishedResolution: false,
 			} );
+			useTargetAudienceFinalCountryCodes.mockReturnValue( {
+				targetAudience: {},
+			} );
 
 			const { result } = renderHook( () => useMarketDataViewsConfig() );
 
@@ -768,6 +809,9 @@ describe( 'useMarketDataViewsConfig', () => {
 			useShippingTimes.mockReturnValue( {
 				data: [],
 				hasFinishedResolution: true,
+			} );
+			useTargetAudienceFinalCountryCodes.mockReturnValue( {
+				targetAudience: {},
 			} );
 
 			const { result } = renderHook( () => useMarketDataViewsConfig() );

--- a/src/API/Site/Controllers/MerchantCenter/TargetAudienceController.php
+++ b/src/API/Site/Controllers/MerchantCenter/TargetAudienceController.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\CountryCode
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ISO3166AwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -52,20 +53,27 @@ class TargetAudienceController extends BaseOptionsController implements ISO3166A
 	protected $google_helper;
 
 	/**
+	 * @var TargetAudience
+	 */
+	protected $target_audience;
+
+	/**
 	 * TargetAudienceController constructor.
 	 *
-	 * @param RESTServer   $server
-	 * @param WP           $wp
-	 * @param WC           $wc
-	 * @param ShippingZone $shipping_zone
-	 * @param GoogleHelper $google_helper
+	 * @param RESTServer     $server
+	 * @param WP             $wp
+	 * @param WC             $wc
+	 * @param ShippingZone   $shipping_zone
+	 * @param GoogleHelper   $google_helper
+	 * @param TargetAudience $target_audience
 	 */
-	public function __construct( RESTServer $server, WP $wp, WC $wc, ShippingZone $shipping_zone, GoogleHelper $google_helper ) {
+	public function __construct( RESTServer $server, WP $wp, WC $wc, ShippingZone $shipping_zone, GoogleHelper $google_helper, TargetAudience $target_audience ) {
 		parent::__construct( $server );
-		$this->wp            = $wp;
-		$this->wc            = $wc;
-		$this->shipping_zone = $shipping_zone;
-		$this->google_helper = $google_helper;
+		$this->wp              = $wp;
+		$this->wc              = $wc;
+		$this->shipping_zone   = $shipping_zone;
+		$this->google_helper   = $google_helper;
+		$this->target_audience = $target_audience;
 	}
 
 	/**
@@ -193,6 +201,18 @@ class TargetAudienceController extends BaseOptionsController implements ISO3166A
 					return Locale::getPrimaryLanguage( $locale );
 				}
 				return strtolower( explode( '_', $locale )[0] );
+			},
+		];
+
+		$fields['main_target_country'] = [
+			'schema'       => [
+				'type'        => 'string',
+				'description' => __( 'The main target country (the store base country if it is targeted, otherwise the first target country). Used as the reference country for the primary market\'s shipping settings.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+			],
+			'get_callback' => function () {
+				return $this->target_audience->get_main_target_country();
 			},
 		];
 

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -152,7 +152,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( ShippingRateSuggestionsController::class, ShippingSuggestionService::class );
 		$this->share( ShippingTimeBatchController::class );
 		$this->share( ShippingTimeController::class );
-		$this->share( TargetAudienceController::class, WP::class, WC::class, ShippingZone::class, GoogleHelper::class );
+		$this->share( TargetAudienceController::class, WP::class, WC::class, ShippingZone::class, GoogleHelper::class, TargetAudience::class );
 		$this->share( SupportedCountriesController::class, WC::class, GoogleHelper::class );
 		$this->share( SettingsSyncController::class, Settings::class );
 		$this->share( DisconnectController::class );

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -1704,8 +1704,21 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		}
 
 		if ( array_key_exists( 'countries', $config ) ) {
+			$countries = $config['countries'];
+
+			if ( $this->is_flat_shipping_rate() ) {
+				// The submitted primary market countries are already filtered to exclude
+				// flat-derived secondary markets (see get_primary_market_countries()). Merge
+				// those back in so saving the primary market doesn't drop them from the
+				// target audience — which would delete their derived secondary markets too,
+				// since get_derived_flat_secondary_markets() only considers countries still
+				// present in the target audience.
+				$secondary_countries = array_column( $this->get_derived_flat_secondary_markets(), 'country' );
+				$countries           = array_values( array_unique( array_merge( $countries, $secondary_countries ) ) );
+			}
+
 			$target_audience              = $this->options->get( OptionsInterface::TARGET_AUDIENCE, [] );
-			$target_audience['countries'] = $config['countries'];
+			$target_audience['countries'] = $countries;
 			$this->options->update( OptionsInterface::TARGET_AUDIENCE, $target_audience );
 		}
 	}

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/TargetAudienceControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/TargetAudienceControllerTest.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\TargetAudienceController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
@@ -38,6 +39,9 @@ class TargetAudienceControllerTest extends RESTControllerUnitTest {
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
+	/** @var MockObject|TargetAudience $target_audience */
+	protected $target_audience;
+
 	/** @var TargetAudienceController $controller */
 	protected $controller;
 
@@ -49,14 +53,15 @@ class TargetAudienceControllerTest extends RESTControllerUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->wp            = $this->createMock( WP::class );
-		$this->wc            = $this->createMock( WC::class );
-		$this->shipping_zone = $this->createMock( ShippingZone::class );
-		$this->iso_provider  = $this->createMock( ISO3166DataProvider::class );
-		$this->google_helper = $this->createMock( GoogleHelper::class );
-		$this->options       = $this->createMock( OptionsInterface::class );
+		$this->wp              = $this->createMock( WP::class );
+		$this->wc              = $this->createMock( WC::class );
+		$this->shipping_zone   = $this->createMock( ShippingZone::class );
+		$this->iso_provider    = $this->createMock( ISO3166DataProvider::class );
+		$this->google_helper   = $this->createMock( GoogleHelper::class );
+		$this->options         = $this->createMock( OptionsInterface::class );
+		$this->target_audience = $this->createMock( TargetAudience::class );
 
-		$this->controller = new TargetAudienceController( $this->server, $this->wp, $this->wc, $this->shipping_zone, $this->google_helper );
+		$this->controller = new TargetAudienceController( $this->server, $this->wp, $this->wc, $this->shipping_zone, $this->google_helper, $this->target_audience );
 
 		$this->controller->set_iso3166_provider( $this->iso_provider );
 		$this->controller->set_options_object( $this->options );
@@ -77,6 +82,21 @@ class TargetAudienceControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertArrayHasKey( 'language_code', $response->get_data() );
 		$this->assertEquals( 'en', $response->get_data()['language_code'] );
+	}
+
+	/**
+	 * Test that GET target audience response includes main_target_country from TargetAudience.
+	 */
+	public function test_get_target_audience_includes_main_target_country() {
+		$this->wp->method( 'get_locale' )->willReturn( 'en_US' );
+		$this->options->method( 'get' )->willReturn( [] );
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+
+		$response = $this->do_request( self::ROUTE_TARGET_AUDIENCE, 'GET' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'main_target_country', $response->get_data() );
+		$this->assertEquals( 'US', $response->get_data()['main_target_country'] );
 	}
 
 	/**

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -1054,6 +1054,67 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( [ 'US', 'CA' ], $update_calls[ OptionsInterface::TARGET_AUDIENCE ]['countries'] );
 	}
 
+	public function test_update_market_primary_flat_mode_reintroduces_derived_secondary_countries(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'US', 'CA', 'MX' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'CA', 'MX' ] );
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn(
+			[
+				'US' => [
+					'free_shipping_threshold' => 50.0,
+					'rate'                    => '5',
+				],
+				'MX' => [
+					'free_shipping_threshold' => 20.0,
+					'rate'                    => '15',
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn(
+			[
+				'US' => [
+					'time'     => '3',
+					'max_time' => '5',
+				],
+				'MX' => [
+					'time'     => '7',
+					'max_time' => '14',
+				],
+			]
+		);
+
+		$update_calls = [];
+		$this->options->method( 'update' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$update_calls ) {
+					$update_calls[ $key ] = $value;
+					return true;
+				}
+			);
+
+		// Mirrors what the frontend now submits: the primary market's already-filtered
+		// countries (MX excluded, since it's surfaced as its own derived secondary market).
+		$this->market_service->update_market(
+			'primary',
+			[ 'countries' => [ 'US', 'CA' ] ]
+		);
+
+		$this->assertArrayHasKey( OptionsInterface::TARGET_AUDIENCE, $update_calls );
+		$this->assertSame(
+			[ 'US', 'CA', 'MX' ],
+			$update_calls[ OptionsInterface::TARGET_AUDIENCE ]['countries']
+		);
+	}
+
 	public function test_update_market_primary_returns_composed_market(): void {
 		$this->set_up_options_get(
 			[


### PR DESCRIPTION
## Summary

Fixes [GOOWOO-871](https://linear.app/a8c/issue/GOOWOO-871/multi-feeds-duplicate-market-entries) — duplicate market entries / incorrect Primary market country count on stores with multiple target countries that have different shipping settings.

- `EditMarketModal` was overriding the primary market's already-correct `market.countries` (from `mc/markets`, which the backend already diffs against derived secondary markets in `MarketService::get_primary_market_countries()`) with the raw, unfiltered target-audience country list. On flat-rate stores where per-country shipping differences derive their own secondary markets, this reintroduced those countries into the Primary market's edit view/count, and re-persisted the polluted list back into `TARGET_AUDIENCE` on save.
- Removed the now-unnecessary `useTargetAudienceFinalCountryCodes` usage in `MarketDataViews`, whose only purpose was gating the Edit action on that same data dependency.
- Updated `edit-market-modal` tests to reflect the corrected behavior.
- Follow-up: saving the primary market now submits its already-filtered `countries` list, which was being written straight back to `TARGET_AUDIENCE` and would silently drop the flat-derived secondary countries from the target audience entirely. `MarketService::update_primary_market_fanout()` now merges those countries back in before persisting.

Git archaeology on the original override is in the linked ticket/PR discussion if useful — it predates the `mc/markets` endpoint entirely and was never revisited once markets got their own authoritative `countries` field.

### Additional bug found during testing: primary market showed the wrong shipping rate/time

While verifying the fix above, editing the primary market on a flat-rate store with per-country shipping differences could show the **wrong** rate/time — e.g. a stale $5 instead of the actual $3 configured for the store's main country.

- Root cause: `MarketForm`'s `resolveInitialMarket()` seeded the primary market's single rate/time fields from `shippingRates[0]` / `shippingTimes[0]`. Those arrays are returned by the backend sorted alphabetically by country code, so "the primary market's rate" was really just whichever target country happened to sort first — not necessarily the store's actual main country. Once a country's shipping rate differs enough to be split into its own derived secondary market (exactly the GOOWOO-871 scenario), that country's rate could outrank the real main country's alphabetically and get shown instead.
- This is a pre-existing bug, not a regression introduced by this PR — it predates the Markets feature's `mc/markets` endpoint and was only exposed here because multi-feeds is what makes per-country shipping rates diverge in the first place. The same "first row" assumption also existed in three spots in `useMarketDataViewsConfig.js` used to build the table's rate/time cells.
- Fix: exposed the store's main target country — via `TargetAudience::get_main_target_country()`, a value already used server-side for exactly this purpose (e.g. `MarketService::get_main_feed_label()`, and the flat-rate secondary-market derivation this PR touches) but never surfaced to the frontend — as a new read-only `main_target_country` field on `mc/target_audience`. `market-form.js` and `useMarketDataViewsConfig.js` now use it to pick the correct rate/time row, falling back to the first row only when no main country is known yet (e.g. adding a brand-new market).

## Test plan

- [x] `edit-market-modal`, `market-data-views`, `market-form`, and `useMarketDataViewsConfig` Test suites pass
- [x] New `TargetAudienceControllerTest` coverage for the `main_target_country` field passes
- [ ] Manually verify: on a flat-rate store with 3+ target countries where one has a different shipping rate/time, confirm the auto-derived secondary market's country no longer appears in the Primary market's edit modal or count
- [ ] Confirm saving the Primary market after this fix no longer re-adds derived-secondary countries to target audience
- [ ] Manually verify: editing the Primary market shows the correct shipping rate/time (the store's main country's, not an arbitrary one) even when other target countries have differing rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
