### PR TITLE
fix(markets): fall back to store defaults when WPML has no languages/currencies

### DIFF
--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -1635,7 +1635,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		$currencies = $this->wpml->get_currencies();
 
 		if ( empty( $this->wpml->get_languages() ) ) {
-			$fallback_language_codes = array_column( $this->get_languages(), 'code' );
+			$fallback_language_codes = [ $this->get_default_site_language_code() ];
 
 			foreach ( $currencies as &$currency ) {
 				$currency['languages'] = $fallback_language_codes;

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -1622,10 +1622,26 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * falling back to a single entry for the store's default currency when the
 	 * integration has none configured yet.
 	 *
+	 * WPML ties each currency's `languages` to its own (possibly empty) language
+	 * list, so a currency can come back with no languages even when currencies
+	 * themselves are configured — that leaves it unselectable once the site's
+	 * default language (see get_languages()) is chosen instead. When WPML has no
+	 * languages, every currency is re-pointed at our fallback-aware language list
+	 * so it stays selectable.
+	 *
 	 * @return array<int, array{code: string, symbol: string, languages: string[]}>
 	 */
 	public function get_currencies(): array {
 		$currencies = $this->wpml->get_currencies();
+
+		if ( empty( $this->wpml->get_languages() ) ) {
+			$fallback_language_codes = array_column( $this->get_languages(), 'code' );
+
+			foreach ( $currencies as &$currency ) {
+				$currency['languages'] = $fallback_language_codes;
+			}
+			unset( $currency );
+		}
 
 		if ( ! empty( $currencies ) ) {
 			return $currencies;

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -18,6 +18,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Locale;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -1591,21 +1592,58 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	}
 
 	/**
-	 * Returns the store's active languages from the multilingual integration.
+	 * Returns the store's active languages from the multilingual integration,
+	 * falling back to a single entry for the site's default language when the
+	 * integration has none configured yet.
+	 *
+	 * Without this fallback the Markets edit UI's language dropdown has no
+	 * options to choose from, even though the site default is already what
+	 * newly created markets use (see get_site_primary_language()).
 	 *
 	 * @return array<int, array{code: string, label: string}>
 	 */
 	public function get_languages(): array {
-		return $this->wpml->get_languages();
+		$languages = $this->wpml->get_languages();
+
+		if ( ! empty( $languages ) ) {
+			return $languages;
+		}
+
+		return [
+			[
+				'code'  => $this->get_default_site_language_code(),
+				'label' => $this->get_default_site_language_label(),
+			],
+		];
 	}
 
 	/**
-	 * Returns the store's active currencies from the multilingual integration.
+	 * Returns the store's active currencies from the multilingual integration,
+	 * falling back to a single entry for the store's default currency when the
+	 * integration has none configured yet.
 	 *
-	 * @return array<int, array{code: string, symbol: string}>
+	 * @return array<int, array{code: string, symbol: string, languages: string[]}>
 	 */
 	public function get_currencies(): array {
-		return $this->wpml->get_currencies();
+		$currencies = $this->wpml->get_currencies();
+
+		if ( ! empty( $currencies ) ) {
+			return $currencies;
+		}
+
+		$code = get_woocommerce_currency();
+
+		if ( '' === $code || ! function_exists( 'get_woocommerce_currency_symbol' ) ) {
+			return [];
+		}
+
+		return [
+			[
+				'code'      => $code,
+				'symbol'    => html_entity_decode( get_woocommerce_currency_symbol( $code ), ENT_QUOTES, 'UTF-8' ),
+				'languages' => [ $this->get_default_site_language_code() ],
+			],
+		];
 	}
 
 	/**
@@ -1906,6 +1944,42 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 				throw InvalidValue::not_in_allowed_list( 'currency', $enabled );
 			}
 		}
+	}
+
+	/**
+	 * Returns the site's default language as an ISO 639-1 code, independent of
+	 * any multilingual integration state.
+	 *
+	 * Used to build the fallback language entry in get_languages(); must not
+	 * call get_site_primary_language(), which resolves through get_languages()
+	 * and would recurse.
+	 *
+	 * @return string
+	 */
+	private function get_default_site_language_code(): string {
+		return substr( get_locale(), 0, 2 );
+	}
+
+	/**
+	 * Returns a human-readable label for the site's default language.
+	 *
+	 * @return string
+	 */
+	private function get_default_site_language_label(): string {
+		$locale = get_locale();
+
+		if ( class_exists( Locale::class ) ) {
+			return Locale::getDisplayLanguage( $locale, $locale );
+		}
+
+		// en_US isn't provided by the translations API.
+		if ( 'en_US' === $locale ) {
+			return 'English';
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/translation-install.php';
+
+		return wp_get_available_translations()[ $locale ]['native_name'] ?? $locale;
 	}
 
 	/**

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -3676,10 +3676,14 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( $languages, $this->market_service->get_languages() );
 	}
 
-	public function test_get_languages_returns_empty_when_wpml_not_active(): void {
+	public function test_get_languages_falls_back_to_site_default_when_wpml_returns_none(): void {
 		$this->wpml->method( 'get_languages' )->willReturn( [] );
 
-		$this->assertSame( [], $this->market_service->get_languages() );
+		$result = $this->market_service->get_languages();
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( substr( get_locale(), 0, 2 ), $result[0]['code'] );
+		$this->assertNotSame( '', $result[0]['label'] );
 	}
 
 	public function test_get_currencies_delegates_to_wpml(): void {
@@ -3700,11 +3704,15 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( $currencies, $this->create_service_with_wpml( $wpml )->get_currencies() );
 	}
 
-	public function test_get_currencies_returns_empty_when_wpml_not_active(): void {
+	public function test_get_currencies_falls_back_to_site_default_when_wpml_returns_none(): void {
 		$wpml = $this->createMock( WPML::class );
 		$wpml->method( 'get_currencies' )->willReturn( [] );
 
-		$this->assertSame( [], $this->create_service_with_wpml( $wpml )->get_currencies() );
+		$result = $this->create_service_with_wpml( $wpml )->get_currencies();
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( get_woocommerce_currency(), $result[0]['code'] );
+		$this->assertSame( [ substr( get_locale(), 0, 2 ) ], $result[0]['languages'] );
 	}
 
 	public function test_generate_market_id_sanitises_uppercase_feed_label(): void {

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -3701,7 +3701,14 @@ class MarketServiceTest extends UnitTest {
 		];
 
 		$wpml = $this->createMock( WPML::class );
-		$wpml->method( 'get_languages' )->willReturn( [ [ 'code' => 'en', 'label' => 'English' ] ] );
+		$wpml->method( 'get_languages' )->willReturn(
+			[
+				[
+					'code'  => 'en',
+					'label' => 'English',
+				],
+			]
+		);
 		$wpml->method( 'get_currencies' )->willReturn( $currencies );
 
 		$this->assertSame( $currencies, $this->create_service_with_wpml( $wpml )->get_currencies() );

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -3689,16 +3689,19 @@ class MarketServiceTest extends UnitTest {
 	public function test_get_currencies_delegates_to_wpml(): void {
 		$currencies = [
 			[
-				'code'   => 'USD',
-				'symbol' => '$',
+				'code'      => 'USD',
+				'symbol'    => '$',
+				'languages' => [ 'en' ],
 			],
 			[
-				'code'   => 'EUR',
-				'symbol' => '€',
+				'code'      => 'EUR',
+				'symbol'    => '€',
+				'languages' => [ 'en' ],
 			],
 		];
 
 		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_languages' )->willReturn( [ [ 'code' => 'en', 'label' => 'English' ] ] );
 		$wpml->method( 'get_currencies' )->willReturn( $currencies );
 
 		$this->assertSame( $currencies, $this->create_service_with_wpml( $wpml )->get_currencies() );
@@ -3706,12 +3709,41 @@ class MarketServiceTest extends UnitTest {
 
 	public function test_get_currencies_falls_back_to_site_default_when_wpml_returns_none(): void {
 		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_languages' )->willReturn( [] );
 		$wpml->method( 'get_currencies' )->willReturn( [] );
 
 		$result = $this->create_service_with_wpml( $wpml )->get_currencies();
 
 		$this->assertCount( 1, $result );
 		$this->assertSame( get_woocommerce_currency(), $result[0]['code'] );
+		$this->assertNotSame( '', $result[0]['symbol'] );
+		$this->assertSame( [ substr( get_locale(), 0, 2 ) ], $result[0]['languages'] );
+	}
+
+	public function test_get_currencies_backfills_languages_when_wpml_has_currencies_but_no_languages(): void {
+		// WPML ties each currency's `languages` to its own get_languages(), so a
+		// currency can come back with no languages even though it is itself
+		// configured, if no WPML languages are configured yet. Left unpatched,
+		// this currency would be filtered out of the edit form's currency
+		// dropdown as soon as the fallback language from get_languages() is
+		// selected, reproducing the empty-dropdown bug for a non-empty currency
+		// list.
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_languages' )->willReturn( [] );
+		$wpml->method( 'get_currencies' )->willReturn(
+			[
+				[
+					'code'      => 'USD',
+					'symbol'    => '$',
+					'languages' => [],
+				],
+			]
+		);
+
+		$result = $this->create_service_with_wpml( $wpml )->get_currencies();
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'USD', $result[0]['code'] );
 		$this->assertSame( [ substr( get_locale(), 0, 2 ) ], $result[0]['languages'] );
 	}
 


### PR DESCRIPTION
## Summary

- Fixes [GOOWOO-876](https://linear.app/a8c/issue/GOOWOO-876/multi-feeds-languagecurrency-dropdowns-render-empty-when-there-is-only): the Language/Currency dropdowns in the Market edit form render with **zero options** when WPML/WCML has no languages or currencies configured yet, even though the Markets table and newly created markets already fall back to the site's default language/currency in that situation.
- `MarketService::get_languages()` / `get_currencies()` previously proxied straight to the WPML integration with no fallback. They now fall back to a single entry built from the site's default language (`get_locale()`, with a human-readable label via `Locale::getDisplayLanguage()` when available) and the store's default currency (`get_woocommerce_currency()`), matching the pattern already used elsewhere in the class (`get_site_primary_language()` / `get_site_primary_currency()` / `apply_site_locale_when_not_multilingual()`).
- The fallback currency entry includes `languages` pointing at the fallback language code, so it doesn't get filtered out of the Currency dropdown once the fallback language is selected.

## Test plan

- [ ] Updated unit tests: `test_get_languages_falls_back_to_site_default_when_wpml_returns_none`, `test_get_currencies_falls_back_to_site_default_when_wpml_returns_none` in `tests/Unit/MerchantCenter/MarketServiceTest.php`.
- [ ] On a store with WPML active but no languages/currencies configured, confirm the Market edit form's Language and Currency dropdowns now show the site default as a selectable option instead of rendering empty.
- [ ] Confirm existing multilingual stores with languages/currencies configured are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)