### PR TITLE
fix(markets): refetch markets list after saving shipping rates/times

### DIFF
--- a/js/src/pages/markets/components/market-form.js
+++ b/js/src/pages/markets/components/market-form.js
@@ -185,7 +185,11 @@ const MarketForm = ( {
 				throw error;
 			}
 
+			// Saving shipping rates/times above can change which countries are
+			// split into their own flat-rate derived secondary markets, so the
+			// cached markets list is no longer trustworthy after this point.
 			invalidateResolution( 'getTargetAudience', [] );
+			invalidateResolution( 'getMarkets', [] );
 			onSubmit();
 		} catch ( error ) {
 			// Every awaited action has already dispatched its own error

--- a/js/src/pages/markets/components/market-form.test.js
+++ b/js/src/pages/markets/components/market-form.test.js
@@ -1,0 +1,130 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import MarketForm from './market-form';
+import { useAppDispatch } from '~/data';
+import useShippingRates from '~/hooks/useShippingRates';
+import useShippingTimes from '~/hooks/useShippingTimes';
+import useSaveShippingRates from '~/hooks/useSaveShippingRates';
+import useSaveShippingTimes from '~/hooks/useSaveShippingTimes';
+import useSettings from '~/hooks/useSettings';
+import useStoreCurrency from '~/hooks/useStoreCurrency';
+import { handleApiError } from '~/utils/handleError';
+import { SHIPPING_RATE_METHOD } from '~/constants';
+
+jest.mock( '~/data', () => ( { useAppDispatch: jest.fn() } ) );
+jest.mock( '~/hooks/useShippingRates' );
+jest.mock( '~/hooks/useShippingTimes' );
+jest.mock( '~/hooks/useSaveShippingRates' );
+jest.mock( '~/hooks/useSaveShippingTimes' );
+jest.mock( '~/hooks/useSettings' );
+jest.mock( '~/hooks/useStoreCurrency' );
+jest.mock( '~/utils/handleError', () => ( {
+	handleApiError: jest.fn(),
+} ) );
+
+const submittedValues = {
+	country: 'US',
+	countries: [ 'US' ],
+	shipping_country_rates: [],
+	shipping_country_times: [],
+};
+
+// AdaptiveForm's real submit/validation machinery isn't under test here;
+// stub it down to a button that hands handleSubmit fixed form values.
+jest.mock( '~/components/adaptive-form', () => {
+	const { forwardRef: mockForwardRef } =
+		jest.requireActual( '@wordpress/element' );
+
+	return {
+		__esModule: true,
+		default: mockForwardRef( ( { onSubmit }, ref ) => (
+			<button ref={ ref } onClick={ () => onSubmit( submittedValues ) }>
+				Submit
+			</button>
+		) ),
+	};
+} );
+
+describe( 'MarketForm handleSubmit', () => {
+	const createMarket = jest.fn();
+	const updateMarket = jest.fn();
+	const syncSettings = jest.fn();
+	const invalidateResolution = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		createMarket.mockResolvedValue();
+		updateMarket.mockResolvedValue();
+		syncSettings.mockResolvedValue();
+
+		useAppDispatch.mockReturnValue( {
+			createMarket,
+			updateMarket,
+			syncSettings,
+			invalidateResolution,
+		} );
+		useShippingRates.mockReturnValue( {
+			data: [],
+			hasFinishedResolution: true,
+		} );
+		useShippingTimes.mockReturnValue( {
+			data: [],
+			hasFinishedResolution: true,
+		} );
+		useSaveShippingRates.mockReturnValue( {
+			saveShippingRates: jest.fn(),
+		} );
+		useSaveShippingTimes.mockReturnValue( {
+			saveShippingTimes: jest.fn(),
+		} );
+		useSettings.mockReturnValue( {
+			settings: {
+				shipping_rate: SHIPPING_RATE_METHOD.MANUAL,
+				shipping_time: 'manual',
+			},
+		} );
+		useStoreCurrency.mockReturnValue( { code: 'USD' } );
+	} );
+
+	test( 'invalidates both getTargetAudience and getMarkets after a successful save, since saving shipping rates/times can change which countries are split into their own derived markets', async () => {
+		const user = userEvent.setup();
+		const onSubmit = jest.fn();
+
+		render( <MarketForm onSubmit={ onSubmit } /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		expect( createMarket ).toHaveBeenCalledWith(
+			expect.objectContaining( { country: 'US' } )
+		);
+		expect( syncSettings ).toHaveBeenCalledTimes( 1 );
+		expect( invalidateResolution ).toHaveBeenCalledWith(
+			'getTargetAudience',
+			[]
+		);
+		expect( invalidateResolution ).toHaveBeenCalledWith( 'getMarkets', [] );
+		expect( onSubmit ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'does not invalidate getMarkets or call onSubmit when syncSettings fails', async () => {
+		syncSettings.mockRejectedValue( new Error( 'sync failed' ) );
+		const user = userEvent.setup();
+		const onSubmit = jest.fn();
+
+		render( <MarketForm onSubmit={ onSubmit } /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		expect( handleApiError ).toHaveBeenCalledTimes( 1 );
+		expect( invalidateResolution ).not.toHaveBeenCalled();
+		expect( onSubmit ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
## Summary

Fixes [GOOWOO-873](https://linear.app/a8c/issue/GOOWOO-873/multi-feeds-new-market-appears-only-after-page-refresh) — a newly added/derived market only shows up in the Markets table after a full page refresh.

Stacked on #3662 ([GOOWOO-871](https://linear.app/a8c/issue/GOOWOO-871/multi-feeds-duplicate-market-entries)) since both bugs live in the same "derived flat-rate secondary markets" code path (`market-form.js`, `market-data-views`) — this PR should be retargeted to `develop` once #3662 merges.

### Root cause

In `MarketForm.handleSubmit`:
1. `createMarket()` / `updateMarket()` POST/PUT the market, then internally refetch `mc/markets` — this part already works correctly.
2. `saveShippingRates()` / `saveShippingTimes()` run *after* that refetch. On flat-rate stores, these are what actually change whether a country's shipping diverges from the primary market's baseline, which is what causes the backend (`MarketService::get_derived_flat_secondary_markets()`) to derive a brand-new secondary market.
3. `syncSettings()` runs, then only `invalidateResolution( 'getTargetAudience', [] )` is called — `getMarkets` is never invalidated.

So the one markets refetch happens *before* the mutation that can actually produce a new market, and nothing refreshes it afterward. The stale list sits in the `@wordpress/data` store until a full page load re-runs the `getMarkets` resolver fresh.

### Fix

Add `invalidateResolution( 'getMarkets', [] )` alongside the existing `getTargetAudience` invalidation after a successful save.

## Test plan

- [x] Added `market-form.test.js` covering: successful save invalidates both `getTargetAudience` and `getMarkets`; a `syncSettings` failure invalidates neither and does not call `onSubmit`.
- [x] Full `js/src/pages/markets` Jest suite passes (194/194).
- [x] Lint clean on changed files.
- [ ] Manually verify: on a flat-rate store, add a country with a different shipping rate than the main target country and confirm the derived secondary market appears in the table immediately, without a page refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)