### PR TITLE
fix(settings): invalidate markets and target audience after saving settings

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { apiFetch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 
@@ -13,6 +14,7 @@ import {
 	API_NAMESPACE,
 	REQUEST_ACTIONS,
 	EMPTY_ASSET_ENTITY_GROUP,
+	STORE_KEY,
 } from './constants';
 import { EU_POLITICAL_ADVERTISING_DECLARATION_REQUIRED_ERROR_CODE } from '~/constants';
 import { handleApiError } from '~/utils/handleError';
@@ -359,6 +361,21 @@ export function* saveSettings( settings ) {
 		method: 'POST',
 		data: settings,
 	} );
+
+	// The markets and target audience are derived server-side from settings
+	// such as the shipping rate method, so they can no longer be trusted.
+	yield controls.dispatch(
+		STORE_KEY,
+		'invalidateResolution',
+		'getMarkets',
+		[]
+	);
+	yield controls.dispatch(
+		STORE_KEY,
+		'invalidateResolution',
+		'getTargetAudience',
+		[]
+	);
 
 	return {
 		type: TYPES.SAVE_SETTINGS,

--- a/js/src/data/test/saveSettings.test.js
+++ b/js/src/data/test/saveSettings.test.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { resolveSelect, select } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useAppDispatch, STORE_KEY } from '~/data';
+
+jest.mock( '@wordpress/api-fetch', () => {
+	const impl = jest.fn().mockName( '@wordpress/api-fetch' );
+	impl.use = jest.fn().mockName( 'apiFetch.use' );
+	return impl;
+} );
+
+describe( 'saveSettings', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		apiFetch.mockImplementation( ( { path } ) => {
+			if ( path === '/wc/gla/mc/markets' ) {
+				return Promise.resolve( [] );
+			}
+			if ( path === '/wc/gla/mc/target_audience' ) {
+				return Promise.resolve( { locations: [], location: 'all' } );
+			}
+			return Promise.resolve( {} );
+		} );
+	} );
+
+	it( 'invalidates the markets and target audience resolutions after saving', async () => {
+		// Resolve markets and target audience once, so their resolution
+		// state is populated before saving settings.
+		await resolveSelect( STORE_KEY ).getMarkets();
+		await resolveSelect( STORE_KEY ).getTargetAudience();
+
+		expect(
+			select( STORE_KEY ).hasFinishedResolution( 'getMarkets', [] )
+		).toBe( true );
+		expect(
+			select( STORE_KEY ).hasFinishedResolution( 'getTargetAudience', [] )
+		).toBe( true );
+
+		const { result } = renderHook( () => useAppDispatch() );
+
+		await result.current.saveSettings( { shipping_rate: 'automatic' } );
+
+		expect(
+			select( STORE_KEY ).hasFinishedResolution( 'getMarkets', [] )
+		).toBe( false );
+		expect(
+			select( STORE_KEY ).hasFinishedResolution( 'getTargetAudience', [] )
+		).toBe( false );
+	} );
+} );


### PR DESCRIPTION
## Summary
- Changing the shipping rate method from the **Settings tab** calls `saveSettings()`/`syncSettings()`, which update `state.mc.settings` in the WP-data store but never invalidated the `getMarkets`/`getTargetAudience` resolutions.
- Result: navigating (SPA route change, no full reload) to the Markets tab after changing the method in Settings could render a stale market split computed under the *previous* shipping-rate method, until a hard page reload.
- Fix: invalidate `getMarkets` and `getTargetAudience` as part of the `saveSettings` action itself (`js/src/data/actions.js`), using the built-in `dispatch` control from `@wordpress/data`. Colocating this with the action avoids relying on every UI call site remembering to invalidate — which is exactly how this gap was introduced (the Markets tab's own `market-form.js` already invalidates `getTargetAudience` after its saves, but the Settings-tab path never did).

Fixes GOOWOO-879

## Test plan
- [x] Added `js/src/data/test/saveSettings.test.js`, verifying `getMarkets`/`getTargetAudience` resolutions are invalidated after `saveSettings()`.
- [x] `npx wp-scripts test-unit-js js/src/data` — 66 suites / 1087 tests pass.
- [x] `npx wp-scripts test-unit-js js/src/pages/markets js/src/pages/settings` — 146 suites / 1448 tests pass.
- [x] `npx eslint` clean on changed files.
- [x] Manual verification: change shipping rate method in Settings, navigate to Markets tab without a full reload, confirm the market list refetches and reflects the new method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)