### PR TITLE
Compatibility testing with Woo 11.0

### DIFF
--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -7,7 +7,7 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
- * Requires at least: 6.9
+ * Requires at least: 6.8
  * Tested up to: 7.0
  * Requires PHP: 7.4
  * Requires PHP Architecture: 64 bits

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -7,13 +7,13 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
- * Requires at least: 6.6
+ * Requires at least: 6.9
  * Tested up to: 7.0
  * Requires PHP: 7.4
  * Requires PHP Architecture: 64 bits
  * Requires Plugins: woocommerce
- * WC requires at least: 10.7
- * WC tested up to: 10.9
+ * WC requires at least: 10.8
+ * WC tested up to: 11.0
  * Woo:
  *
  * License: GPLv3
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'WC_GLA_VERSION', '3.8.1' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.4' );
-define( 'WC_GLA_MIN_WC_VER', '10.7' );
+define( 'WC_GLA_MIN_WC_VER', '10.8' );
 
 // Load and initialize the autoloader.
 require_once __DIR__ . '/src/Autoloader.php';

--- a/readme.txt
+++ b/readme.txt
@@ -51,8 +51,8 @@ Once you’re running Google Ads campaigns, the Google tag feature in the extens
 
 = Minimum Requirements =
 
-* WordPress 6.6 or greater
-* WooCommerce 10.7 or greater
+* WordPress 6.9 or greater
+* WooCommerce 10.8 or greater
 * PHP version 7.4 or greater
 * PHP Architecture 64 bits
 * MySQL version 5.6 or greater

--- a/readme.txt
+++ b/readme.txt
@@ -51,7 +51,7 @@ Once you’re running Google Ads campaigns, the Google tag feature in the extens
 
 = Minimum Requirements =
 
-* WordPress 6.9 or greater
+* WordPress 6.8 or greater
 * WooCommerce 10.8 or greater
 * PHP version 7.4 or greater
 * PHP Architecture 64 bits


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Dev - Bump WooCommerce "tested up to" version 11.0.
- Dev - Bump WooCommerce minimum supported version to 10.8.
- Dev - Bump WordPress minimum supported version to 6.9.

Closes  https://linear.app/a8c/issue/GOOWOO-784/compatibility-testing-with-woo-110-beta-1

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR.
2. All tests should be passed.
3. Manually check plugin setup and plugin core functionality.

### Changelog entry
<!--
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WooCommerce "tested up to" version 11.0
> Dev - Bump WooCommerce minimum supported version to 10.8.
> Dev - Bump WordPress minimum supported version to 6.9.

