### PR TITLE
Fix: E2E tests for Optimize Campaign step in onboarding flow

### DIFF
--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -1491,6 +1491,33 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Fulfills a mock request for the ads settings endpoint.
+	 *
+	 * @param {Object} payload - The mock response payload to be returned.
+	 * @param {number} [status=200] - The HTTP status code to be returned.
+	 * @return {Promise<void>} A promise that resolves when the request is fulfilled.
+	 */
+	async fulfillAdsSettings( payload, status = 200 ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/ads\/settings\b/,
+			payload,
+			status,
+			[ 'GET' ]
+		);
+	}
+
+	/**
+	 * Mocks a request for the ads settings endpoint.
+	 *
+	 * @param {Object} payload - The mock response payload to be returned.
+	 * @param {number} [status=200] - The HTTP status code to be returned.
+	 * @return {Promise<void>} A promise that resolves when the request is mocked.
+	 */
+	async mockAdsSettings( payload, status = 200 ) {
+		await this.fulfillAdsSettings( payload, status );
+	}
+
+	/**
 	 * Fulfills a mock request for the asset groups of a specific campaign.
 	 *
 	 * @param {string|number} campaignId - The ID of the campaign to get asset groups for.

--- a/tests/e2e/utils/pages/onboarding/step-3-optimize-campaign-ads-account-only.js
+++ b/tests/e2e/utils/pages/onboarding/step-3-optimize-campaign-ads-account-only.js
@@ -133,6 +133,11 @@ export default class OptimizeCampaign extends MockRequests {
 	 * @return {Promise<void>}
 	 */
 	async mockOptimizeCampaignRequests() {
+		await this.mockAdsSettings( {
+			enhanced_conversions_enabled: false,
+			ads_has_unclaimed_incentive: false,
+		} );
+
 		await this.mockFinalUrlSuggestions( [
 			{
 				id: 0,

--- a/tests/e2e/utils/pages/onboarding/step-3-optimize-campaign-ads-account-only.js
+++ b/tests/e2e/utils/pages/onboarding/step-3-optimize-campaign-ads-account-only.js
@@ -195,16 +195,69 @@ export default class OptimizeCampaign extends MockRequests {
 		await this.fulfillGenerateTextAssetsRequest( {
 			final_url: 'https://woo.com/shop/',
 			items: [
+				// Headlines
 				{
 					text: 'Latest Deals',
 					type: 'headline',
 				},
 				{
+					text: 'Limited-Time Offers',
+					type: 'headline',
+				},
+				{
+					text: 'New Arrivals In Store',
+					type: 'headline',
+				},
+				{
+					text: 'Top Deals This Week',
+					type: 'headline',
+				},
+				{
+					text: 'Fast Shipping Available',
+					type: 'headline',
+				},
+
+				// Long headlines
+				{
 					text: 'Discover quality products at great prices',
 					type: 'long_headline',
 				},
 				{
+					text: 'Everything you need, delivered fast',
+					type: 'long_headline',
+				},
+				{
+					text: 'Upgrade your everyday shopping experience',
+					type: 'long_headline',
+				},
+				{
+					text: 'Find your next favorite product today',
+					type: 'long_headline',
+				},
+				{
+					text: 'Smart shopping starts right here',
+					type: 'long_headline',
+				},
+
+				// Descriptions
+				{
 					text: 'Browse top picks and enjoy exclusive savings.',
+					type: 'description',
+				},
+				{
+					text: 'Shop trusted products with fast delivery.',
+					type: 'description',
+				},
+				{
+					text: 'Great value items curated just for you.',
+					type: 'description',
+				},
+				{
+					text: 'Simple shopping with reliable service.',
+					type: 'description',
+				},
+				{
+					text: 'Quality products backed by great support.',
 					type: 'description',
 				},
 			],
@@ -227,8 +280,43 @@ export default class OptimizeCampaign extends MockRequests {
 				},
 				{
 					temporary_image_url:
+						'https://placehold.co/400x225?text=Marketing+Image+2',
+					type: 'marketing_image',
+				},
+				{
+					temporary_image_url:
+						'https://placehold.co/400x225?text=Marketing+Image+3',
+					type: 'marketing_image',
+				},
+				{
+					temporary_image_url:
+						'https://placehold.co/400x225?text=Marketing+Image+4',
+					type: 'marketing_image',
+				},
+				{
+					temporary_image_url:
 						'https://placehold.co/200x200?text=Square+Marketing+Image+1',
 					type: 'square_marketing_image',
+				},
+				{
+					temporary_image_url:
+						'https://placehold.co/200x200?text=Square+Marketing+Image+2',
+					type: 'square_marketing_image',
+				},
+				{
+					temporary_image_url:
+						'https://placehold.co/200x200?text=Square+Marketing+Image+3',
+					type: 'square_marketing_image',
+				},
+				{
+					temporary_image_url:
+						'https://placehold.co/200x300?text=Portrait+Marketing+Image+1',
+					type: 'portrait_marketing_image',
+				},
+				{
+					temporary_image_url:
+						'https://placehold.co/200x300?text=Portrait+Marketing+Image+2',
+					type: 'portrait_marketing_image',
 				},
 			],
 		} );

--- a/tests/e2e/utils/pages/onboarding/step-3-optimize-campaign-ads-account-only.js
+++ b/tests/e2e/utils/pages/onboarding/step-3-optimize-campaign-ads-account-only.js
@@ -53,10 +53,16 @@ export default class OptimizeCampaign extends MockRequests {
 	/**
 	 * Get final URL select dropdown.
 	 *
+	 * Scoped to the "Select final URL" search control (`.gla-assets-loader`)
+	 * so it doesn't collide with the unrelated Call to Action select that's
+	 * also rendered on this step.
+	 *
 	 * @return {import('@playwright/test').Locator} Get final URL select dropdown.
 	 */
 	getFinalUrlSelect() {
-		return this.page.getByRole( 'combobox' );
+		return this.page
+			.locator( '.gla-assets-loader' )
+			.getByRole( 'combobox' );
 	}
 
 	/**
@@ -87,9 +93,11 @@ export default class OptimizeCampaign extends MockRequests {
 	async selectUrlOption() {
 		const finalUrlSelect = this.getFinalUrlSelect();
 		await finalUrlSelect.focus();
-		const option = this.page.getByRole( 'option', {
-			name: 'Shop',
-		} );
+		const option = this.page
+			.locator( '.gla-assets-loader' )
+			.getByRole( 'option', {
+				name: 'Shop',
+			} );
 		await option.click();
 
 		const selectButton = this.getSelectButton();

--- a/tests/e2e/utils/pages/onboarding/step-3-optimize-campaign-ads-account-only.js
+++ b/tests/e2e/utils/pages/onboarding/step-3-optimize-campaign-ads-account-only.js
@@ -176,5 +176,56 @@ export default class OptimizeCampaign extends MockRequests {
 				assets: {},
 			},
 		] );
+
+		await this.mockGenerateTextAssetsSuccess();
+		await this.mockGenerateImageAssetsSuccess();
+	}
+
+	/**
+	 * Mock generate text assets success response.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async mockGenerateTextAssetsSuccess() {
+		await this.fulfillGenerateTextAssetsRequest( {
+			final_url: 'https://woo.com/shop/',
+			items: [
+				{
+					text: 'Latest Deals',
+					type: 'headline',
+				},
+				{
+					text: 'Discover quality products at great prices',
+					type: 'long_headline',
+				},
+				{
+					text: 'Browse top picks and enjoy exclusive savings.',
+					type: 'description',
+				},
+			],
+		} );
+	}
+
+	/**
+	 * Mock generate image assets success response.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async mockGenerateImageAssetsSuccess() {
+		await this.fulfillGenerateImageAssetsRequest( {
+			final_url: 'https://woo.com/shop/',
+			items: [
+				{
+					temporary_image_url:
+						'https://placehold.co/400x225?text=Marketing+Image+1',
+					type: 'marketing_image',
+				},
+				{
+					temporary_image_url:
+						'https://placehold.co/200x200?text=Square+Marketing+Image+1',
+					type: 'square_marketing_image',
+				},
+			],
+		} );
 	}
 }

--- a/tests/e2e/utils/pages/optimize-campaign.js
+++ b/tests/e2e/utils/pages/optimize-campaign.js
@@ -14,7 +14,13 @@ export default async function optimizeCampaign(
 		page.getByRole( 'heading', { name: 'Optimize your campaign' } )
 	).toBeVisible();
 
-	await optimizeCampaignPage.selectUrlOption();
+	// For a new (not yet created) campaign, the asset group header
+	// automatically loads homepage assets as soon as this step mounts, so
+	// there's no Final URL picker to interact with manually - just wait for
+	// that auto-load to settle.
+	await expect(
+		optimizeCampaignPage.getSelectDifferentFinalUrlButton()
+	).toBeVisible();
 
 	const createCampaignButton = page.locator(
 		'[data-action="submit-campaign-and-assets"]'


### PR DESCRIPTION
## Summary

Follow-up to #3255 ("Add E2E coverage for campaign creation via dashboard (onboarded users)", GOOWOO-420). That PR added `onboarded-merchant-add-campaign.test.js` on a branch that sat open for ~5.5 months before merging to `develop` on 2026-07-31, so it never actually ran against current `develop` until last week - which is when these failures first showed up in CI.

There's no app-side regression here. The auto-load-homepage-assets behavior in `AssetGroupHeader` (from #3222, merged back in January) has been stable in `develop` the whole time; the new test just modeled an older, manual Final-URL-selection flow that no longer matches how the "Optimize your campaign" step behaves for a brand-new campaign. Four issues, found incrementally as each one exposed the next:

- **Locator collision**: `getFinalUrlSelect()` used an unscoped `getByRole('combobox')`, which could resolve to the unrelated Call to Action `<select>` instead of the Final URL search widget (both expose an accessible combobox role, and the CTA select's "Shop now" option matched the test's "Shop" lookup). Clicking a native `<option>` directly never becomes "visible" in headless Chromium, causing a 2-minute timeout. Scoped both the combobox and option lookups to `.gla-assets-loader`.
- **Missing Gen AI mocks**: once the locator was fixed, the flow progressed further and hit real, unmocked `ads/assets/generate-text` / `ads/assets/generate-images` requests. Added the mocks (mirroring the pattern already used in `create-campaign.js`).
- **Missing ads/settings mock**: `wc/gla/ads/settings` (fetched by `UnclaimedIncentiveNotice`, which rides along on the Dashboard-embedded onboarding page) had no mock helper at all. Added `fulfillAdsSettings`/`mockAdsSettings` to the shared `MockRequests` class.
- **Root cause**: `AssetGroupHeader` automatically fetches homepage assets on mount for any new, not-yet-created campaign (`!isEditing`, no `final_url` yet) - this has been the case since #3222. In this onboarding flow the campaign is always new at this step, so the Final URL picker gets replaced by the "already selected" state before the test's manual click sequence ever runs. Replaced the manual `selectUrlOption()` interaction with a wait for that auto-load to settle, and expanded the Gen AI mocks to the full item counts needed to clear the asset group's minimum requirements (3 headlines, 2 descriptions, etc.).

## Test plan

- [x] `npm run test:e2e -- add-paid-campaigns` passes locally
- [ ] CI E2E run is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
