### PR TITLE
fix: prevent notification evaluators from fataling wp-admin with no Ads account connected

### DIFF
--- a/src/API/Google/AdsCampaign.php
+++ b/src/API/Google/AdsCampaign.php
@@ -133,6 +133,13 @@ class AdsCampaign implements ContainerAwareInterface, OptionsAwareInterface {
 	 * @throws ExceptionWithResponseData When an ApiException is caught.
 	 */
 	public function get_campaigns( bool $exclude_removed = true, bool $fetch_criterion = true, array $args = [] ): array {
+		// No Ads account connected means no campaigns; AdsCampaignQuery::set_client() requires
+		// a non-zero Ads ID and throws InvalidProperty otherwise, which callers don't expect
+		// from this method (its documented @throws is ExceptionWithResponseData).
+		if ( ! $this->options->get_ads_id() ) {
+			return [];
+		}
+
 		try {
 			$query = ( new AdsCampaignQuery() )->set_client( $this->client, $this->options->get_ads_id() );
 

--- a/tests/Unit/API/Google/AdsCampaignTest.php
+++ b/tests/Unit/API/Google/AdsCampaignTest.php
@@ -107,6 +107,14 @@ class AdsCampaignTest extends UnitTest {
 		$this->assertEquals( [], $this->campaign->get_campaigns() );
 	}
 
+	public function test_get_campaigns_no_ads_id_returns_empty_list_without_throwing() {
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_ads_id' )->willReturn( 0 );
+		$this->campaign->set_options_object( $this->options );
+
+		$this->assertEquals( [], $this->campaign->get_campaigns() );
+	}
+
 	public function test_get_campaigns() {
 		$campaign_criterion_data = [
 			[


### PR DESCRIPTION
## Summary

`AdsCampaign::get_campaigns()` calls `AdsCampaignQuery::set_client( $this->client, $this->options->get_ads_id() )`, which throws `InvalidProperty` when the Ads ID is empty — not the `ExceptionWithResponseData` this method documents (`@throws`) and that its callers actually catch.

This is reachable through a normal, supported onboarding path: skipping paid campaign creation (`saved-ads-only-setup-stepper`'s `handleSetupPaidAdsSkipped` → `completeAdsSetup()`) marks Ads setup complete (`ADS_SETUP_COMPLETED_AT`) without ever setting a real Ads ID. Any merchant who does this is left with `is_setup_complete() === true` and `get_ads_id() === 0`.

`PausedCampaignEvaluator` and `CampaignNoSalesEvaluator` both gate only on `is_setup_complete()` before calling `get_campaigns()`, and only catch `ExceptionWithResponseData` — so once their cached result (from `CachedNotificationEvaluatorTrait`, cached up to an hour) expires and they re-evaluate fresh, the uncaught `InvalidProperty` exception propagates out through `NotificationService::get_notifications()`, `NotificationManager::notifications_count()`, and the `apply_filters()` call inside `display_aggregated_notification_pill()` — which runs on the global `admin_menu` hook. The result is WordPress's "critical error" page on **every** wp-admin page load, not just a GLA page, persisting until the transient is cleared or a real Ads account is connected (since the failed evaluation is never cached, so it re-throws on every subsequent load).

## Fix

Guard `get_campaigns()` itself: no Ads account connected means no campaigns, matching what it already returns for a connected account with zero campaigns. This fixes all current (and future) callers in one place, rather than patching each evaluator individually.

## Test plan

- [x] Added `test_get_campaigns_no_ads_id_returns_empty_list_without_throwing` to `AdsCampaignTest`
- [ ] CI PHPUnit run is green

This PR is marked draft — opening it mainly to run the full CI suite; happy to un-draft once that's green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)