### PR TITLE
Fix notifications E2E tests.

### DIFF
--- a/tests/e2e/specs/dashboard/notification-badge.test.js
+++ b/tests/e2e/specs/dashboard/notification-badge.test.js
@@ -55,25 +55,25 @@ test.describe( 'Notification Badge', () => {
 			const badge = page
 				.getByRole( 'link', { name: 'Marketing' } )
 				.locator( 'span.update-plugins' )
-				.filter( { hasText: '1' } );
+				.filter( { hasText: '2' } );
 
 			await expect( badge ).toBeVisible();
 		} );
 
 		test( 'In Google for WooCommerce sub-menu when Marketing menu is expanded', async () => {
 			const badge = dashboardPage.page
-				.getByRole( 'link', { name: 'Google for WooCommerce' } )
+				.getByRole( 'link', { name: 'Overview' } )
 				.locator( 'span.update-plugins' )
-				.filter( { hasText: '1' } );
+				.filter( { hasText: '2' } );
 
 			await expect( badge ).toBeVisible();
 		} );
 
 		test( 'On Marketing menu when switched to Analytics menu', async () => {
 			const badge = dashboardPage.page
-				.getByRole( 'link', { name: 'Google for WooCommerce' } )
+				.getByRole( 'link', { name: 'Overview' } )
 				.locator( 'span.update-plugins' )
-				.filter( { hasText: '1' } );
+				.filter( { hasText: '2' } );
 
 			await expect( badge ).toBeVisible();
 
@@ -84,7 +84,7 @@ test.describe( 'Notification Badge', () => {
 			const badgeMoved = dashboardPage.page
 				.getByRole( 'link', { name: 'Marketing' } )
 				.locator( 'span.update-plugins' )
-				.filter( { hasText: '1' } );
+				.filter( { hasText: '2' } );
 
 			await expect( badgeMoved ).toBeVisible();
 		} );
@@ -103,7 +103,7 @@ test.describe( 'Notification Badge', () => {
 			const badge = page
 				.getByRole( 'link', { name: 'Marketing' } )
 				.locator( 'span.update-plugins' )
-				.filter( { hasText: '1' } );
+				.filter( { hasText: '2' } );
 
 			await expect( badge ).not.toBeVisible();
 		} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The E2E tests for the notification badge were failing because the expected number of notifications was hardcoded to '1' which is no longer the expectation. The submenu badge was also moved to the Overview link, but this was not reflected in the tests. This commit updates the tests to expect '2' notifications and checks for the badge on the Overview link instead of the Marketing link.

### Additional details

Screenshots from the failing tests that this fixes:

<img width="1280" height="720" alt="test-failed-2" src="https://github.com/user-attachments/assets/c74b28ac-967e-40af-853c-e2fa31cac43f" />

<img width="1280" height="720" alt="test-failed-3" src="https://github.com/user-attachments/assets/9727243b-eb37-48a7-8e2b-0cafc39f61e5" />


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
