### PR TITLE
GOOWOO-864: Post-onboarding reviews notifications: server-side gating

### DIFF
--- a/js/src/pages/settings/index.js
+++ b/js/src/pages/settings/index.js
@@ -23,6 +23,7 @@ import EditStoreAddress from './edit-store-address';
 import MainTabNav from '~/components/main-tab-nav';
 import RebrandingTour from '~/components/tours/rebranding-tour';
 import SetupEnhancedConversions from './enhanced-conversions/setup-enhanced-conversions';
+import { ReviewsSettings } from './reviews';
 import ExperienceRatingBanner from '~/components/experience-rating-banner';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
@@ -118,6 +119,7 @@ const Settings = () => {
 					<ContactInformationPreview />
 					<ShippingRateSettings />
 					<SetupTaxRate />
+					<ReviewsSettings />
 				</>
 			) }
 			<LinkedAccounts />

--- a/js/src/pages/settings/index.test.js
+++ b/js/src/pages/settings/index.test.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Settings from './';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+
+jest.mock( '@woocommerce/navigation', () => ( {
+	...jest.requireActual( '@woocommerce/navigation' ),
+	getQuery: jest.fn().mockReturnValue( {} ),
+} ) );
+
+jest.mock( '~/hooks/useGoogleAccount', () =>
+	jest.fn().mockReturnValue( { google: { active: 'yes' } } )
+);
+
+jest.mock( '~/hooks/useGoogleMCAccount', () => jest.fn() );
+
+jest.mock( '~/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery', () =>
+	jest.fn()
+);
+
+jest.mock( '~/hooks/useTargetAudienceFinalCountryCodes', () =>
+	jest.fn().mockReturnValue( {
+		targetAudience: undefined,
+		getFinalCountries: jest.fn(),
+	} )
+);
+
+jest.mock( '~/data', () => ( {
+	useAppDispatch: jest
+		.fn()
+		.mockReturnValue( { saveTargetAudience: jest.fn() } ),
+} ) );
+
+jest.mock( '~/components/main-tab-nav', () => () => null );
+jest.mock( '~/components/tours/rebranding-tour', () => () => null );
+jest.mock( '~/components/experience-rating-banner', () => () => null );
+jest.mock( '~/components/target-audience-section', () => () => null );
+jest.mock( '~/components/contact-information', () => ( {
+	ContactInformationPreview: () => null,
+} ) );
+jest.mock( './setup-tax-rate', () => () => null );
+jest.mock( './shipping-rate-settings', () => () => null );
+jest.mock( './linked-accounts', () => () => null );
+jest.mock( './reconnect-wpcom-account', () => () => null );
+jest.mock( './reconnect-google-account', () => () => null );
+jest.mock( './edit-store-address', () => () => null );
+jest.mock(
+	'./enhanced-conversions/setup-enhanced-conversions',
+	() => () => null
+);
+jest.mock( './reviews', () => ( {
+	ReviewsSettings: () => <div data-testid="reviews-settings" />,
+} ) );
+
+beforeAll( () => {
+	// Used in the js/src/hooks/useMenuEffect.js dependency.
+	window.wpNavMenuClassChange = jest.fn();
+} );
+
+afterEach( () => {
+	useGoogleMCAccount.mockReset();
+} );
+
+describe( 'Settings page — reviews settings visibility gating', () => {
+	it( 'renders the reviews settings when Merchant Center is connected', () => {
+		useGoogleMCAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			hasGoogleMCConnection: true,
+		} );
+
+		render( <Settings /> );
+
+		expect( screen.getByTestId( 'reviews-settings' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the reviews settings when Merchant Center is not connected', () => {
+		useGoogleMCAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			hasGoogleMCConnection: false,
+		} );
+
+		render( <Settings /> );
+
+		expect(
+			screen.queryByTestId( 'reviews-settings' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the reviews settings while Merchant Center connection is still resolving', () => {
+		useGoogleMCAccount.mockReturnValue( {
+			hasFinishedResolution: false,
+			hasGoogleMCConnection: false,
+		} );
+
+		render( <Settings /> );
+
+		expect(
+			screen.queryByTestId( 'reviews-settings' )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/js/src/pages/settings/reviews/constants.js
+++ b/js/src/pages/settings/reviews/constants.js
@@ -1,0 +1,4 @@
+export const GCR_ENROLLMENT_NOTICE_DISMISSED_KEY =
+	'gla_reviews_gcr_enrollment_notice_dismissed';
+export const GCR_ENROLLMENT_HELP_URL =
+	'https://support.google.com/merchants/answer/14628991?hl=en';

--- a/js/src/pages/settings/reviews/index.js
+++ b/js/src/pages/settings/reviews/index.js
@@ -1,0 +1,1 @@
+export { default as ReviewsSettings } from './reviews-settings';

--- a/js/src/pages/settings/reviews/reviews-settings.js
+++ b/js/src/pages/settings/reviews/reviews-settings.js
@@ -1,0 +1,167 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import { PREFERENCES_STORE_NAMESPACE } from '~/constants';
+import Section from '~/components/section';
+import AppStandaloneToggleControl from '~/components/app-standalone-toggle-control';
+import AppButton from '~/components/app-button';
+import SpinnerCard from '~/components/spinner-card';
+import useSettings from '~/hooks/useSettings';
+import usePreference from '~/hooks/usePreference';
+import { handleApiError } from '~/utils/handleError';
+import {
+	GCR_ENROLLMENT_NOTICE_DISMISSED_KEY,
+	GCR_ENROLLMENT_HELP_URL,
+} from './constants';
+
+/**
+ * Triggered when the "Learn how to enable Google Customer Reviews" button is clicked.
+ *
+ * @event gla_reviews_settings_gcr_enrollment_help_click
+ */
+
+/**
+ * Renders the "Collect reviews after purchase" (Google Customer Reviews) setting.
+ *
+ * Visibility is gated by the parent Settings page rendering this only when
+ * `hasGoogleMCConnection` is true (see FEA-08.1.1 AC-002) — not repeated here.
+ *
+ * The "Estimated shipping times" dependency notice (AC-005) is deferred —
+ * tracked as a follow-up once the Shipping page/route it depends on exists.
+ */
+const ReviewsSettings = () => {
+	const { settings, saveSettings } = useSettings();
+	const [ isSaving, setIsSaving ] = useState( false );
+	const { set: setPreference } = useDispatch( preferencesStore );
+
+	const isGCRNoticeDismissed = usePreference(
+		GCR_ENROLLMENT_NOTICE_DISMISSED_KEY
+	);
+
+	const sectionDescription = (
+		<div>
+			<p>
+				{ __(
+					'Google Reviews provide free social proof, increased organic visibility, and a boost to advertising performance.',
+					'google-listings-and-ads'
+				) }
+			</p>
+			<p>
+				{ __(
+					'Shoppers rely heavily on reviews to navigate consumer skepticism; having a strong Google rating directly drives higher conversion rates and builds trust with new buyers.',
+					'google-listings-and-ads'
+				) }
+			</p>
+		</div>
+	);
+
+	if ( ! settings ) {
+		return (
+			<Section
+				title={ __(
+					'Google Customer Reviews',
+					'google-listings-and-ads'
+				) }
+				description={ sectionDescription }
+			>
+				<SpinnerCard />
+			</Section>
+		);
+	}
+
+	const isEnabled = Boolean( settings.collect_reviews_after_purchase );
+
+	const handleToggle = async () => {
+		setIsSaving( true );
+		try {
+			await saveSettings( {
+				...settings,
+				collect_reviews_after_purchase: ! isEnabled,
+			} );
+		} catch ( error ) {
+			handleApiError(
+				error,
+				__(
+					'There was an error updating the review collection setting.',
+					'google-listings-and-ads'
+				)
+			);
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	const dismissGCRNotice = () => {
+		setPreference(
+			PREFERENCES_STORE_NAMESPACE,
+			GCR_ENROLLMENT_NOTICE_DISMISSED_KEY,
+			true
+		);
+	};
+
+	return (
+		<Section
+			title={ __( 'Google Customer Reviews', 'google-listings-and-ads' ) }
+			description={ sectionDescription }
+		>
+			<Section.Card>
+				<Section.Card.Body>
+					<AppStandaloneToggleControl
+						label={ __(
+							'Collect reviews after purchase',
+							'google-listings-and-ads'
+						) }
+						checked={ isEnabled }
+						disabled={ isSaving }
+						onChange={ handleToggle }
+						help={ __(
+							'Google asks customers on the order confirmation page if they would like to review your store. Customers who opt in receive an email from Google once their order arrives.',
+							'google-listings-and-ads'
+						) }
+					/>
+					{ ! isGCRNoticeDismissed && (
+						<Notice
+							status="info"
+							isDismissible
+							onRemove={ dismissGCRNotice }
+						>
+							<p>
+								{ __(
+									"This setting will only take effect if you're enrolled in the Merchant Center.",
+									'google-listings-and-ads'
+								) }
+							</p>
+							<AppButton
+								variant="primary"
+								href={ GCR_ENROLLMENT_HELP_URL }
+								target="_blank"
+								eventName="gla_reviews_settings_gcr_enrollment_help_click"
+								eventProps={ {
+									context: 'reviews-settings',
+									link_id: 'gcr-enrollment-help',
+									href: GCR_ENROLLMENT_HELP_URL,
+								} }
+							>
+								{ __(
+									'Find out how',
+									'google-listings-and-ads'
+								) }
+							</AppButton>
+						</Notice>
+					) }
+				</Section.Card.Body>
+			</Section.Card>
+		</Section>
+	);
+};
+
+export default ReviewsSettings;

--- a/js/src/pages/settings/reviews/reviews-settings.test.js
+++ b/js/src/pages/settings/reviews/reviews-settings.test.js
@@ -1,0 +1,195 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { useDispatch } from '@wordpress/data';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { PREFERENCES_STORE_NAMESPACE } from '~/constants';
+import {
+	GCR_ENROLLMENT_NOTICE_DISMISSED_KEY,
+	GCR_ENROLLMENT_HELP_URL,
+} from './constants';
+import ReviewsSettings from './reviews-settings';
+import useSettings from '~/hooks/useSettings';
+import usePreference from '~/hooks/usePreference';
+
+jest.mock( '@wordpress/data', () => ( {
+	__esModule: true,
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	ToggleControl: ( { label, checked, onChange, disabled, help } ) => (
+		<div>
+			<label htmlFor="toggle-control-mock">
+				<input
+					id="toggle-control-mock"
+					type="checkbox"
+					aria-label={ label }
+					checked={ checked }
+					disabled={ disabled }
+					onChange={ () => onChange( ! checked ) }
+				/>
+				{ label }
+			</label>
+			{ help && <p>{ help }</p> }
+		</div>
+	),
+	Notice: ( { children, onRemove, isDismissible } ) => (
+		<div className="components-notice" role="status">
+			{ children }
+			{ isDismissible && (
+				<button
+					className="components-notice__dismiss"
+					onClick={ onRemove }
+				>
+					Dismiss
+				</button>
+			) }
+		</div>
+	),
+	Flex: ( { children, ...rest } ) => <div { ...rest }>{ children }</div>,
+	Card: ( { children, ...rest } ) => <div { ...rest }>{ children }</div>,
+	CardBody: ( { children, ...rest } ) => <div { ...rest }>{ children }</div>,
+	CardFooter: ( { children, ...rest } ) => (
+		<div { ...rest }>{ children }</div>
+	),
+} ) );
+
+jest.mock( '~/components/app-button', () => ( { href, children, onClick } ) => (
+	<a href={ href } onClick={ onClick }>
+		{ children }
+	</a>
+) );
+
+jest.mock( '~/components/spinner-card', () => () => (
+	<div data-testid="spinner-card" />
+) );
+
+jest.mock( '~/hooks/useSettings', () => jest.fn().mockName( 'useSettings' ) );
+
+jest.mock( '~/hooks/usePreference', () =>
+	jest.fn().mockName( 'usePreference' )
+);
+
+describe( 'ReviewsSettings', () => {
+	let saveSettings;
+	let setPreference;
+
+	beforeEach( () => {
+		saveSettings = jest.fn().mockResolvedValue( {} );
+		setPreference = jest.fn();
+
+		useDispatch.mockReturnValue( { set: setPreference } );
+		usePreference.mockReturnValue( false );
+	} );
+
+	it( 'renders a loading state until settings resolve', () => {
+		useSettings.mockReturnValue( { settings: undefined, saveSettings } );
+
+		render( <ReviewsSettings /> );
+
+		expect( screen.getByTestId( 'spinner-card' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByLabelText( 'Collect reviews after purchase' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the toggle unchecked when the setting is disabled', () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		expect(
+			screen.getByLabelText( 'Collect reviews after purchase' )
+		).not.toBeChecked();
+	} );
+
+	it( 'renders the toggle checked when the setting is enabled', () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: true },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		expect(
+			screen.getByLabelText( 'Collect reviews after purchase' )
+		).toBeChecked();
+	} );
+
+	it( 'saves the setting with the toggled value on change', async () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+		fireEvent.click(
+			screen.getByLabelText( 'Collect reviews after purchase' )
+		);
+
+		await waitFor( () =>
+			expect( saveSettings ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					collect_reviews_after_purchase: true,
+				} )
+			)
+		);
+	} );
+
+	it( 'renders the GCR-enrollment notice with its link when not dismissed', () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		expect( screen.getByText( /Find out how/i ) ).toHaveAttribute(
+			'href',
+			GCR_ENROLLMENT_HELP_URL
+		);
+	} );
+
+	it( 'dismisses the GCR-enrollment notice', () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		const gcrNotice = screen
+			.getByText( /Find out how/i )
+			.closest( '.components-notice' );
+		fireEvent.click(
+			gcrNotice.querySelector( '.components-notice__dismiss' )
+		);
+
+		expect( setPreference ).toHaveBeenCalledWith(
+			PREFERENCES_STORE_NAMESPACE,
+			GCR_ENROLLMENT_NOTICE_DISMISSED_KEY,
+			true
+		);
+	} );
+
+	it( 'does not render the GCR-enrollment notice once dismissed', () => {
+		usePreference.mockReturnValue( true );
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		expect( screen.queryByText( /Find out how/i ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/src/API/Site/Controllers/MerchantCenter/SettingsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsController.php
@@ -113,7 +113,7 @@ class SettingsController extends BaseOptionsController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'shipping_rate'        => [
+			'shipping_rate'                  => [
 				'type'              => 'string',
 				'description'       => __(
 					'Whether shipping rate is a simple flat rate or needs to be configured manually in the Merchant Center.',
@@ -127,7 +127,7 @@ class SettingsController extends BaseOptionsController {
 					'manual',
 				],
 			],
-			'shipping_time'        => [
+			'shipping_time'                  => [
 				'type'              => 'string',
 				'description'       => __(
 					'Whether shipping time is a simple flat time or needs to be configured manually in the Merchant Center.',
@@ -140,7 +140,7 @@ class SettingsController extends BaseOptionsController {
 					'manual',
 				],
 			],
-			'tax_rate'             => [
+			'tax_rate'                       => [
 				'type'              => 'string',
 				'description'       => __(
 					'Whether tax rate is destination based or need to be configured manually in the Merchant Center.',
@@ -154,7 +154,7 @@ class SettingsController extends BaseOptionsController {
 				],
 				'default'           => 'destination',
 			],
-			'shipping_rates_count' => [
+			'shipping_rates_count'           => [
 				'type'              => 'number',
 				'description'       => __(
 					'The number of shipping rates in WC ready to be used in the Merchant Center.',
@@ -163,6 +163,16 @@ class SettingsController extends BaseOptionsController {
 				'context'           => [ 'view' ],
 				'validate_callback' => 'rest_validate_request_arg',
 				'default'           => 0,
+			],
+			'collect_reviews_after_purchase' => [
+				'type'              => 'boolean',
+				'description'       => __(
+					'Whether to inject the Google Customer Reviews opt-in prompt on the order-confirmation page.',
+					'google-listings-and-ads'
+				),
+				'context'           => [ 'view', 'edit' ],
+				'validate_callback' => 'rest_validate_request_arg',
+				'default'           => false,
 			],
 		];
 	}

--- a/src/Internal/DependencyManagement/NotificationsServiceProvider.php
+++ b/src/Internal/DependencyManagement/NotificationsServiceProvider.php
@@ -10,7 +10,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\AbandonedOnboardingEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\BadgeWidgetEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CampaignNoSalesEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CollectReviewsEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CouponsNotSyncedEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\EnhancedConversionsOffEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\NotOnboardedEvaluator;
@@ -52,7 +54,9 @@ class NotificationsServiceProvider extends AbstractServiceProvider {
 		NotificationService::class               => true,
 		NotificationCacheInvalidator::class      => true,
 		AbandonedOnboardingEvaluator::class      => true,
+		BadgeWidgetEvaluator::class              => true,
 		CampaignNoSalesEvaluator::class          => true,
+		CollectReviewsEvaluator::class           => true,
 		CouponsNotSyncedEvaluator::class         => true,
 		EnhancedConversionsOffEvaluator::class   => true,
 		NotOnboardedEvaluator::class             => true,
@@ -75,6 +79,8 @@ class NotificationsServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( SkippedCampaignCreationEvaluator::class, AdsCampaign::class, OnboardingCompleted::class, ServiceBasedMerchantState::class );
 		$this->share_with_tags( AbandonedOnboardingEvaluator::class, ServiceBasedMerchantState::class, OnboardingCompleted::class );
 		$this->share_with_tags( NotOnboardedEvaluator::class, OnboardingCompleted::class );
+		$this->share_with_tags( CollectReviewsEvaluator::class, OnboardingCompleted::class );
+		$this->share_with_tags( BadgeWidgetEvaluator::class, OnboardingCompleted::class );
 		$this->share_with_tags( EnhancedConversionsOffEvaluator::class );
 		$this->share_with_tags( TrackingOffEvaluator::class );
 		$this->share_with_tags( ProductIssuesEvaluator::class, ServiceBasedMerchantState::class );

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -275,6 +275,11 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 	 * Disconnect Merchant Center account
 	 */
 	public function disconnect() {
+		// Collect reviews after purchase must survive a disconnect/reconnect cycle,
+		// unlike the rest of the Merchant Center settings blob it lives in.
+		$merchant_center_settings       = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+		$collect_reviews_after_purchase = is_array( $merchant_center_settings ) ? ( $merchant_center_settings['collect_reviews_after_purchase'] ?? null ) : null;
+
 		$this->options->delete( OptionsInterface::CONTACT_INFO_SETUP );
 		$this->options->delete( OptionsInterface::MAPI_DATA_SOURCES );
 		$this->options->delete( OptionsInterface::MC_SETUP_COMPLETED_AT );
@@ -283,6 +288,13 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		$this->options->delete( OptionsInterface::SITE_VERIFICATION );
 		$this->options->delete( OptionsInterface::MERCHANT_ID );
 		$this->options->delete( OptionsInterface::CLAIMED_URL_HASH );
+
+		if ( null !== $collect_reviews_after_purchase ) {
+			$this->options->update(
+				OptionsInterface::MERCHANT_CENTER,
+				[ 'collect_reviews_after_purchase' => $collect_reviews_after_purchase ]
+			);
+		}
 
 		$this->container->get( MarketService::class )->reset_markets();
 		$this->container->get( MerchantStatuses::class )->delete();

--- a/src/Notification/Evaluators/BadgeWidgetEvaluator.php
+++ b/src/Notification/Evaluators/BadgeWidgetEvaluator.php
@@ -1,0 +1,94 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class BadgeWidgetEvaluator
+ *
+ * Fires after onboarding completes when the merchant has a connected Merchant Center
+ * account and the Google Customer Reviews badge widget is not yet enabled.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
+ */
+class BadgeWidgetEvaluator implements NotificationEvaluatorInterface, MerchantCenterAwareInterface, OptionsAwareInterface, Service {
+
+	use MerchantCenterAwareTrait;
+	use OptionsAwareTrait;
+
+	/**
+	 * Key of the badge widget enabled flag within OptionsInterface::MERCHANT_CENTER.
+	 */
+	private const SETTING_KEY = 'badge_widget_enabled';
+
+	/** @var OnboardingCompleted */
+	private $onboarding_completed;
+
+	/**
+	 * BadgeWidgetEvaluator constructor.
+	 *
+	 * @param OnboardingCompleted $onboarding_completed
+	 */
+	public function __construct( OnboardingCompleted $onboarding_completed ) {
+		$this->onboarding_completed = $onboarding_completed;
+	}
+
+	/**
+	 * Get the notification's unique ID.
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return 'badge-widget';
+	}
+
+	/**
+	 * Whether the notification's condition is currently met.
+	 *
+	 * @return bool
+	 */
+	public function should_show(): bool {
+		if ( ! $this->onboarding_completed->is_onboarding_complete() ) {
+			return false;
+		}
+
+		if ( ! $this->merchant_center->is_connected() ) {
+			return false;
+		}
+
+		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
+		return empty( $settings[ self::SETTING_KEY ] );
+	}
+
+	/**
+	 * Get the notification's priority.
+	 *
+	 * @return int
+	 */
+	public function get_priority(): int {
+		return NotificationPriorities::BADGE_WIDGET;
+	}
+
+	/**
+	 * Get the snooze duration in seconds for temporary dismissals.
+	 *
+	 * @return int|null
+	 */
+	public function get_snooze_duration(): ?int {
+		return NotificationSnoozeDurations::BADGE_WIDGET;
+	}
+}

--- a/src/Notification/Evaluators/CollectReviewsEvaluator.php
+++ b/src/Notification/Evaluators/CollectReviewsEvaluator.php
@@ -1,0 +1,94 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CollectReviewsEvaluator
+ *
+ * Fires after onboarding completes when the merchant has a connected Merchant Center
+ * account and post-purchase Google review collection is not yet enabled.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
+ */
+class CollectReviewsEvaluator implements NotificationEvaluatorInterface, MerchantCenterAwareInterface, OptionsAwareInterface, Service {
+
+	use MerchantCenterAwareTrait;
+	use OptionsAwareTrait;
+
+	/**
+	 * Key of the post-purchase review collection flag within OptionsInterface::MERCHANT_CENTER.
+	 */
+	private const SETTING_KEY = 'collect_reviews_after_purchase';
+
+	/** @var OnboardingCompleted */
+	private $onboarding_completed;
+
+	/**
+	 * CollectReviewsEvaluator constructor.
+	 *
+	 * @param OnboardingCompleted $onboarding_completed
+	 */
+	public function __construct( OnboardingCompleted $onboarding_completed ) {
+		$this->onboarding_completed = $onboarding_completed;
+	}
+
+	/**
+	 * Get the notification's unique ID.
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return 'collect-reviews';
+	}
+
+	/**
+	 * Whether the notification's condition is currently met.
+	 *
+	 * @return bool
+	 */
+	public function should_show(): bool {
+		if ( ! $this->onboarding_completed->is_onboarding_complete() ) {
+			return false;
+		}
+
+		if ( ! $this->merchant_center->is_connected() ) {
+			return false;
+		}
+
+		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
+		return empty( $settings[ self::SETTING_KEY ] );
+	}
+
+	/**
+	 * Get the notification's priority.
+	 *
+	 * @return int
+	 */
+	public function get_priority(): int {
+		return NotificationPriorities::COLLECT_REVIEWS;
+	}
+
+	/**
+	 * Get the snooze duration in seconds for temporary dismissals.
+	 *
+	 * @return int|null
+	 */
+	public function get_snooze_duration(): ?int {
+		return NotificationSnoozeDurations::COLLECT_REVIEWS;
+	}
+}

--- a/src/Notification/NotificationPriorities.php
+++ b/src/Notification/NotificationPriorities.php
@@ -27,4 +27,6 @@ class NotificationPriorities {
 	public const PAUSED_CAMPAIGN           = 110;
 	public const CAMPAIGN_NO_SALES         = 120;
 	public const RECOMMENDATIONS_AVAILABLE = 130;
+	public const COLLECT_REVIEWS           = 140;
+	public const BADGE_WIDGET              = 150;
 }

--- a/src/Notification/NotificationSnoozeDurations.php
+++ b/src/Notification/NotificationSnoozeDurations.php
@@ -30,4 +30,6 @@ class NotificationSnoozeDurations {
 	public const PAUSED_CAMPAIGN           = 7 * DAY_IN_SECONDS;
 	public const CAMPAIGN_NO_SALES         = 7 * DAY_IN_SECONDS;
 	public const RECOMMENDATIONS_AVAILABLE = 7 * DAY_IN_SECONDS;
+	public const COLLECT_REVIEWS           = 7 * DAY_IN_SECONDS;
+	public const BADGE_WIDGET              = 7 * DAY_IN_SECONDS;
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -50,7 +50,8 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 		$this->shipping_zone->expects( $this->once() )->method( 'get_shipping_rates_count' )->willReturn( 1 );
 
 		$expected = $options + [
-			'shipping_rates_count' => 1,
+			'shipping_rates_count'           => 1,
+			'collect_reviews_after_purchase' => false,
 		];
 
 		$response = $this->do_request( self::ROUTE, 'GET' );
@@ -70,7 +71,16 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 			$options
 		);
 
-		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::MERCHANT_CENTER, array_merge( $options, [ 'shipping_time' => 'manual' ] ) );
+		$this->options->expects( $this->once() )->method( 'update' )->with(
+			OptionsInterface::MERCHANT_CENTER,
+			array_merge(
+				$options,
+				[
+					'shipping_time'                  => 'manual',
+					'collect_reviews_after_purchase' => false,
+				]
+			)
+		);
 
 		$response = $this->do_request(
 			self::ROUTE,
@@ -96,5 +106,41 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 
 		$this->assertEquals( 'destination', $response->get_data()['data']['tax_rate'] );
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_default_collect_reviews_after_purchase_setting() {
+		$response = $this->do_request( self::ROUTE );
+
+		$this->assertFalse( $response->get_data()['collect_reviews_after_purchase'] );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_edit_collect_reviews_after_purchase_setting() {
+		$options = [
+			'shipping_rate'                  => 'flat',
+			'shipping_time'                  => 'flat',
+			'tax_rate'                       => 'destination',
+			'collect_reviews_after_purchase' => false,
+		];
+
+		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
+			$options
+		);
+
+		$this->options->expects( $this->once() )->method( 'update' )->with(
+			OptionsInterface::MERCHANT_CENTER,
+			array_merge( $options, [ 'collect_reviews_after_purchase' => true ] )
+		);
+
+		$response = $this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'collect_reviews_after_purchase' => true,
+			]
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()['data']['collect_reviews_after_purchase'] );
 	}
 }

--- a/tests/Unit/DependencyManagement/CoreServiceProviderTest.php
+++ b/tests/Unit/DependencyManagement/CoreServiceProviderTest.php
@@ -5,7 +5,9 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DependencyManag
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\NotificationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\AbandonedOnboardingEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\BadgeWidgetEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CampaignNoSalesEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CollectReviewsEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CouponsNotSyncedEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\EnhancedConversionsOffEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\NotOnboardedEvaluator;
@@ -42,7 +44,9 @@ class CoreServiceProviderTest extends ContainerAwareUnitTest {
 	 */
 	private const EVALUATOR_CLASSES = [
 		AbandonedOnboardingEvaluator::class,
+		BadgeWidgetEvaluator::class,
 		CampaignNoSalesEvaluator::class,
+		CollectReviewsEvaluator::class,
 		CouponsNotSyncedEvaluator::class,
 		EnhancedConversionsOffEvaluator::class,
 		NotOnboardedEvaluator::class,

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -1150,6 +1150,37 @@ class AccountServiceTest extends UnitTest {
 		$this->account->disconnect();
 	}
 
+	public function test_disconnect_preserves_collect_reviews_after_purchase_setting() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn(
+				[
+					'shipping_rate'                  => 'flat',
+					'collect_reviews_after_purchase' => true,
+				]
+			);
+
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				OptionsInterface::MERCHANT_CENTER,
+				[ 'collect_reviews_after_purchase' => true ]
+			);
+
+		$this->account->disconnect();
+	}
+
+	public function test_disconnect_does_not_restore_setting_when_never_set() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [] );
+
+		$this->options->expects( $this->never() )
+			->method( 'update' );
+
+		$this->account->disconnect();
+	}
+
 	public function test_update_wpcom_api_authorization() {
 		$status = 'approved';
 		$nonce  = 'nonce-123';

--- a/tests/Unit/Notification/Evaluators/BadgeWidgetEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/BadgeWidgetEvaluatorTest.php
@@ -1,0 +1,96 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\BadgeWidgetEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class BadgeWidgetEvaluatorTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators
+ */
+class BadgeWidgetEvaluatorTest extends UnitTest {
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|OnboardingCompleted $onboarding_completed */
+	protected $onboarding_completed;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var BadgeWidgetEvaluator $evaluator */
+	protected $evaluator;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->merchant_center      = $this->createMock( MerchantCenterService::class );
+		$this->onboarding_completed = $this->createMock( OnboardingCompleted::class );
+		$this->options              = $this->createMock( OptionsInterface::class );
+
+		$this->evaluator = new BadgeWidgetEvaluator( $this->onboarding_completed );
+		$this->evaluator->set_merchant_center_object( $this->merchant_center );
+		$this->evaluator->set_options_object( $this->options );
+	}
+
+	public function test_get_id() {
+		$this->assertEquals( 'badge-widget', $this->evaluator->get_id() );
+	}
+
+	public function test_get_priority() {
+		$this->assertEquals( NotificationPriorities::BADGE_WIDGET, $this->evaluator->get_priority() );
+	}
+
+	public function test_get_snooze_duration() {
+		$this->assertEquals( NotificationSnoozeDurations::BADGE_WIDGET, $this->evaluator->get_snooze_duration() );
+	}
+
+	public function test_should_show_when_onboarded_connected_and_widget_disabled() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( true );
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [ 'badge_widget_enabled' => false ] );
+
+		$this->assertTrue( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_onboarding_not_complete() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( false );
+		$this->merchant_center->expects( $this->never() )->method( 'is_connected' );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_without_merchant_center_connection() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( false );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_widget_already_enabled() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( true );
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [ 'badge_widget_enabled' => true ] );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+}

--- a/tests/Unit/Notification/Evaluators/CollectReviewsEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/CollectReviewsEvaluatorTest.php
@@ -1,0 +1,96 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CollectReviewsEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CollectReviewsEvaluatorTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators
+ */
+class CollectReviewsEvaluatorTest extends UnitTest {
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|OnboardingCompleted $onboarding_completed */
+	protected $onboarding_completed;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var CollectReviewsEvaluator $evaluator */
+	protected $evaluator;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->merchant_center      = $this->createMock( MerchantCenterService::class );
+		$this->onboarding_completed = $this->createMock( OnboardingCompleted::class );
+		$this->options              = $this->createMock( OptionsInterface::class );
+
+		$this->evaluator = new CollectReviewsEvaluator( $this->onboarding_completed );
+		$this->evaluator->set_merchant_center_object( $this->merchant_center );
+		$this->evaluator->set_options_object( $this->options );
+	}
+
+	public function test_get_id() {
+		$this->assertEquals( 'collect-reviews', $this->evaluator->get_id() );
+	}
+
+	public function test_get_priority() {
+		$this->assertEquals( NotificationPriorities::COLLECT_REVIEWS, $this->evaluator->get_priority() );
+	}
+
+	public function test_get_snooze_duration() {
+		$this->assertEquals( NotificationSnoozeDurations::COLLECT_REVIEWS, $this->evaluator->get_snooze_duration() );
+	}
+
+	public function test_should_show_when_onboarded_connected_and_collection_disabled() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( true );
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [ 'collect_reviews_after_purchase' => false ] );
+
+		$this->assertTrue( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_onboarding_not_complete() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( false );
+		$this->merchant_center->expects( $this->never() )->method( 'is_connected' );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_without_merchant_center_connection() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( false );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_collection_already_enabled() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( true );
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [ 'collect_reviews_after_purchase' => true ] );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds the server-side visibility gating for the two post-onboarding review notifications (**collect reviews** and **badge widget**). This registers the evaluators only — the front-end content/CTA for each notification is a separate, sibling ticket (GOOWOO-865).

- `CollectReviewsEvaluator` — eligible once onboarding is complete, Merchant Center is connected, and `collect_reviews_after_purchase` is not yet enabled.
- `BadgeWidgetEvaluator` — eligible once onboarding is complete, Merchant Center is connected, and `badge_widget_enabled` is not yet enabled.
- Both are modeled directly on the existing `EnhancedConversionsOffEvaluator` and registered via the same tagged-collection DI pattern in `NotificationsServiceProvider`.
- Adds `COLLECT_REVIEWS`/`BADGE_WIDGET` entries to the shared `NotificationPriorities`/`NotificationSnoozeDurations` constant classes. Final priority/snooze ordering against the 13 existing evaluators is a separate, still-open product decision and not blocking for this PR.

**Depends on #3673 (GOOWOO-863)** — this branch is stacked on `feature/GOOWOO-863-collect-reviews-setting` since `CollectReviewsEvaluator` reads the `collect_reviews_after_purchase` settings key introduced there. Please don't merge before #3673 lands; this PR's base should retarget to `develop` automatically once that happens.

Closes:

- https://linear.app/a8c/issue/GOOWOO-864/post-onboarding-reviews-notifications-server-side-gating

### Screenshots:

Not applicable — this PR is server-side only (visibility-gating logic + tests). There's no UI change; the front-end content for these notifications is scoped to GOOWOO-865.

### Detailed test instructions:

**Automated:**

1. `composer install`
2. `vendor/bin/phpunit --filter 'CollectReviewsEvaluatorTest|BadgeWidgetEvaluatorTest'` — all cases should pass (eligible when all conditions are met; not eligible before onboarding; not eligible without a Merchant Center connection; not eligible once the setting is enabled).
3. `vendor/bin/phpunit --filter CoreServiceProviderTest` — confirms both evaluators resolve from the container alongside the other 13.
4. `vendor/bin/phpcs ./*` and `vendor/bin/phpcs --standard=tests/phpcs.xml.dist` — both should be clean.

**Manual, end-to-end (no FE yet, so verify via the REST endpoint directly):**

1. On a store where onboarding is **not** yet complete, call `GET /wp-json/wc/gla/notifications` as an admin. Confirm neither `collect-reviews` nor `badge-widget` appears in the response.
2. Complete onboarding and connect a Merchant Center account, leaving both `collect_reviews_after_purchase` and the badge-widget setting disabled/unset. Call the same endpoint again — both `collect-reviews` and `badge-widget` should now be present.
3. Update the Merchant Center settings option (`PATCH /wp-json/wc/gla/mc/settings` with `collect_reviews_after_purchase: true`, or directly via the `wc_gla_merchant_center` option) and re-check the endpoint — `collect-reviews` should disappear while `badge-widget` remains (the badge-widget setting itself isn't wired to any UI/schema yet — that's GOOWOO-867 — so it will always show as eligible once onboarded + connected until that ticket lands).
4. Disconnect Merchant Center and confirm both notifications disappear again, regardless of onboarding status.

### Additional details:

N/A

### Changelog entry

Not applicable — this PR merges into `feature/GOOWOO-863-collect-reviews-setting`, not `develop`. A changelog entry (if any) should be added when the combined reviews epic branch merges into `develop`.