### PR TITLE
GOOWOO-865: Post-onboarding reviews notifications: content and CTA behavior

### DIFF
--- a/js/src/notifications-system/notification.js
+++ b/js/src/notifications-system/notification.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { dateI18n } from '@wordpress/date';
 import { addQueryArgs } from '@wordpress/url';
 import { CardBody, Flex, FlexBlock, FlexItem } from '@wordpress/components';
@@ -13,9 +13,11 @@ import { closeSmall } from '@wordpress/icons';
  */
 import { glaData } from '~/constants';
 import { useAppDispatch } from '~/data';
+import useSettings from '~/hooks/useSettings';
 import AppButton from '~/components/app-button';
 import NotificationSkeleton from './notification-skeleton';
 import googleLogoURL from '~/images/logo/google-g-logo.svg';
+import { handleApiError } from '~/utils/handleError';
 import {
 	recordGlaEvent,
 	CONTEXT_MARKETING_OVERVIEW,
@@ -45,6 +47,8 @@ function withReferrer( href, notificationId ) {
  * @property {string} children Button label.
  * @property {string} [target] Link target (e.g. '_blank').
  * @property {string} [rel] Link rel attribute.
+ * @property {string} [settingKey] When set, clicking the action first saves this settings
+ *   field as `true` and only navigates to `href` once the save succeeds, instead of just navigating.
  */
 
 /**
@@ -88,6 +92,8 @@ const Notification = ( {
 	isReady,
 } ) => {
 	const { dismissNotification } = useAppDispatch();
+	const { settings, saveSettings } = useSettings();
+	const [ savingActionId, setSavingActionId ] = useState( null );
 
 	useEffect( () => {
 		if ( isReady === false ) {
@@ -118,12 +124,37 @@ const Notification = ( {
 		}
 	};
 
-	const handleCtaClick = ( href ) => {
+	const handleCtaClick = async ( event, action ) => {
+		const { id: actionId, href, settingKey } = action;
+
 		recordGlaEvent( 'gla_notifications_system_notification_cta_clicked', {
 			context: CONTEXT_MARKETING_OVERVIEW,
 			id,
 			href,
 		} );
+
+		if ( ! settingKey ) {
+			return;
+		}
+
+		// This action must save the setting before navigating, so it can't
+		// rely on the anchor's own default navigation.
+		event.preventDefault();
+		setSavingActionId( actionId );
+
+		try {
+			await saveSettings( { ...settings, [ settingKey ]: true } );
+			window.location.assign( withReferrer( href, id ) );
+		} catch ( error ) {
+			handleApiError(
+				error,
+				__(
+					'There was an error updating the setting. Please try again.',
+					'google-listings-and-ads'
+				)
+			);
+			setSavingActionId( null );
+		}
 	};
 
 	return (
@@ -153,14 +184,16 @@ const Notification = ( {
 							{ formattedDate }
 						</span>
 						<FlexBlock>
-							{ actions.map(
-								( {
+							{ actions.map( ( action ) => {
+								const {
 									id: actionId,
 									href,
 									children,
 									target,
 									rel,
-								} ) => (
+								} = action;
+
+								return (
 									<AppButton
 										key={ actionId }
 										className="gla-notification__action"
@@ -168,12 +201,19 @@ const Notification = ( {
 										href={ withReferrer( href, id ) }
 										target={ target }
 										rel={ rel }
-										onClick={ () => handleCtaClick( href ) }
+										loading={ savingActionId === actionId }
+										disabled={
+											savingActionId !== null &&
+											savingActionId !== actionId
+										}
+										onClick={ ( event ) =>
+											handleCtaClick( event, action )
+										}
 									>
 										{ children }
 									</AppButton>
-								)
-							) }
+								);
+							} ) }
 						</FlexBlock>
 					</Flex>
 				</Flex>

--- a/js/src/notifications-system/notification.test.js
+++ b/js/src/notifications-system/notification.test.js
@@ -1,0 +1,213 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Notification from './notification';
+import { useAppDispatch } from '~/data';
+import useSettings from '~/hooks/useSettings';
+import { handleApiError } from '~/utils/handleError';
+import { recordGlaEvent } from '~/utils/tracks';
+
+jest.mock( '~/data', () => ( { useAppDispatch: jest.fn() } ) );
+
+jest.mock( '~/hooks/useSettings', () => jest.fn().mockName( 'useSettings' ) );
+
+jest.mock( '~/utils/handleError', () => ( {
+	handleApiError: jest.fn(),
+} ) );
+
+jest.mock( '~/utils/tracks', () => ( {
+	recordGlaEvent: jest.fn(),
+	CONTEXT_MARKETING_OVERVIEW: 'marketing-overview',
+	REFERRER_TYPE_NOTIFICATION: 'notification',
+} ) );
+
+// Rendered as a `<button>`, not an `<a>` — real anchor navigation isn't
+// implemented in jsdom, and these tests don't assert on the `href` attribute.
+jest.mock(
+	'~/components/app-button',
+	() =>
+		( { href, children, onClick, loading, disabled } ) => (
+			<button
+				data-href={ href }
+				onClick={ onClick }
+				aria-disabled={ disabled }
+				data-loading={ loading ? 'true' : 'false' }
+			>
+				{ children }
+			</button>
+		)
+);
+
+jest.mock( './notification-skeleton', () => () => (
+	<div data-testid="notification-skeleton" />
+) );
+
+const dismissNotification = jest.fn();
+const saveSettings = jest.fn();
+
+const baseProps = {
+	id: 'collect-reviews',
+	title: 'Collect Google reviews after purchase',
+	description: 'Google Reviews provide free social proof.',
+	triggeredAt: 1_700_000_000,
+	onDismiss: jest.fn(),
+};
+
+describe( 'Notification', () => {
+	const originalLocation = window.location;
+	let locationAssignSpy;
+
+	afterAll( () => {
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			value: originalLocation,
+		} );
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		useAppDispatch.mockReturnValue( { dismissNotification } );
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		locationAssignSpy = jest.fn();
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			value: { ...originalLocation, assign: locationAssignSpy },
+		} );
+	} );
+
+	it( 'navigates immediately and only tracks the click for an action with no settingKey', () => {
+		render(
+			<Notification
+				{ ...baseProps }
+				actions={ [
+					{
+						id: 'view-product-issues',
+						href: '/settings',
+						children: 'View Product Issues',
+					},
+				] }
+			/>
+		);
+
+		const link = screen.getByText( 'View Product Issues' );
+		fireEvent.click( link );
+
+		expect( recordGlaEvent ).toHaveBeenCalledWith(
+			'gla_notifications_system_notification_cta_clicked',
+			expect.objectContaining( { id: 'collect-reviews' } )
+		);
+		expect( saveSettings ).not.toHaveBeenCalled();
+		expect( locationAssignSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'saves the setting and then navigates when the action has a settingKey', async () => {
+		saveSettings.mockResolvedValue( {} );
+
+		render(
+			<Notification
+				{ ...baseProps }
+				actions={ [
+					{
+						id: 'enable-reviews-collection',
+						href: '/settings',
+						settingKey: 'collect_reviews_after_purchase',
+						children: 'Enable reviews collection',
+					},
+				] }
+			/>
+		);
+
+		fireEvent.click( screen.getByText( 'Enable reviews collection' ) );
+
+		expect( saveSettings ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				collect_reviews_after_purchase: true,
+			} )
+		);
+
+		await waitFor( () =>
+			expect( locationAssignSpy ).toHaveBeenCalledWith(
+				expect.stringContaining( '/settings' )
+			)
+		);
+	} );
+
+	it( 'does not navigate and shows an error when saving the setting fails', async () => {
+		const error = { message: 'Something went wrong' };
+		saveSettings.mockRejectedValue( error );
+
+		render(
+			<Notification
+				{ ...baseProps }
+				actions={ [
+					{
+						id: 'add-widget',
+						href: '/settings',
+						settingKey: 'badge_widget_enabled',
+						children: 'Add widget',
+					},
+				] }
+			/>
+		);
+
+		fireEvent.click( screen.getByText( 'Add widget' ) );
+
+		await waitFor( () =>
+			expect( handleApiError ).toHaveBeenCalledWith(
+				error,
+				expect.any( String )
+			)
+		);
+
+		expect( locationAssignSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'disables other actions while one settingKey action is saving', async () => {
+		let resolveSave;
+		saveSettings.mockReturnValue(
+			new Promise( ( resolve ) => {
+				resolveSave = resolve;
+			} )
+		);
+
+		render(
+			<Notification
+				{ ...baseProps }
+				actions={ [
+					{
+						id: 'enable-reviews-collection',
+						href: '/settings',
+						settingKey: 'collect_reviews_after_purchase',
+						children: 'Enable reviews collection',
+					},
+					{
+						id: 'learn-more',
+						href: '/learn-more',
+						children: 'Learn more',
+					},
+				] }
+			/>
+		);
+
+		fireEvent.click( screen.getByText( 'Enable reviews collection' ) );
+
+		expect( screen.getByText( 'Learn more' ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+
+		resolveSave( {} );
+		await waitFor( () => expect( locationAssignSpy ).toHaveBeenCalled() );
+	} );
+} );

--- a/js/src/notifications-system/useNotificationsSystemMap.js
+++ b/js/src/notifications-system/useNotificationsSystemMap.js
@@ -211,6 +211,42 @@ const STATIC_MAP = {
 			},
 		],
 	},
+	'collect-reviews': {
+		title: __(
+			'Collect Google reviews after purchase',
+			'google-listings-and-ads'
+		),
+		description: __(
+			'Google Reviews provide free social proof, increased organic visibility, and a boost to advertising performance.',
+			'google-listings-and-ads'
+		),
+		actions: [
+			{
+				id: 'enable-reviews-collection',
+				href: settingsUrl,
+				settingKey: 'collect_reviews_after_purchase',
+				children: __(
+					'Enable reviews collection',
+					'google-listings-and-ads'
+				),
+			},
+		],
+	},
+	'badge-widget': {
+		title: __( 'Add your store rating widget', 'google-listings-and-ads' ),
+		description: __(
+			'Show Google-verified ratings and reviews on your site and boost shopper trust and conversions.',
+			'google-listings-and-ads'
+		),
+		actions: [
+			{
+				id: 'add-widget',
+				href: settingsUrl,
+				settingKey: 'badge_widget_enabled',
+				children: __( 'Add widget', 'google-listings-and-ads' ),
+			},
+		],
+	},
 };
 
 /**

--- a/js/src/notifications-system/useNotificationsSystemMap.js
+++ b/js/src/notifications-system/useNotificationsSystemMap.js
@@ -213,7 +213,7 @@ const STATIC_MAP = {
 	},
 	'collect-reviews': {
 		title: __(
-			'Collect Google reviews after purchase',
+			'Collect Google Reviews after purchase',
 			'google-listings-and-ads'
 		),
 		description: __(

--- a/js/src/notifications-system/useNotificationsSystemMap.test.js
+++ b/js/src/notifications-system/useNotificationsSystemMap.test.js
@@ -25,7 +25,7 @@ describe( 'useNotificationsSystemMap', () => {
 		const { result } = renderHook( () => useNotificationsSystemMap() );
 		const config = result.current[ 'collect-reviews' ];
 
-		expect( config.title ).toBe( 'Collect Google reviews after purchase' );
+		expect( config.title ).toBe( 'Collect Google Reviews after purchase' );
 		expect( config.description ).toBe(
 			'Google Reviews provide free social proof, increased organic visibility, and a boost to advertising performance.'
 		);

--- a/js/src/notifications-system/useNotificationsSystemMap.test.js
+++ b/js/src/notifications-system/useNotificationsSystemMap.test.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useNotificationsSystemMap from './useNotificationsSystemMap';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+
+jest.mock( '~/hooks/useGoogleMCAccount', () =>
+	jest.fn().mockName( 'useGoogleMCAccount' )
+);
+
+describe( 'useNotificationsSystemMap', () => {
+	beforeEach( () => {
+		useGoogleMCAccount.mockReturnValue( {
+			hasGoogleMCConnection: true,
+			hasFinishedResolution: true,
+		} );
+	} );
+
+	it( 'defines the collect-reviews notification content and CTA', () => {
+		const { result } = renderHook( () => useNotificationsSystemMap() );
+		const config = result.current[ 'collect-reviews' ];
+
+		expect( config.title ).toBe( 'Collect Google reviews after purchase' );
+		expect( config.description ).toBe(
+			'Google Reviews provide free social proof, increased organic visibility, and a boost to advertising performance.'
+		);
+		expect( config.actions ).toHaveLength( 1 );
+		expect( config.actions[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				settingKey: 'collect_reviews_after_purchase',
+				children: 'Enable reviews collection',
+			} )
+		);
+	} );
+
+	it( 'defines the badge-widget notification content and CTA', () => {
+		const { result } = renderHook( () => useNotificationsSystemMap() );
+		const config = result.current[ 'badge-widget' ];
+
+		expect( config.title ).toBe( 'Add your store rating widget' );
+		expect( config.description ).toBe(
+			'Show Google-verified ratings and reviews on your site and boost shopper trust and conversions.'
+		);
+		expect( config.actions ).toHaveLength( 1 );
+		expect( config.actions[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				settingKey: 'badge_widget_enabled',
+				children: 'Add widget',
+			} )
+		);
+	} );
+} );

--- a/js/src/pages/settings/index.js
+++ b/js/src/pages/settings/index.js
@@ -23,6 +23,7 @@ import EditStoreAddress from './edit-store-address';
 import MainTabNav from '~/components/main-tab-nav';
 import RebrandingTour from '~/components/tours/rebranding-tour';
 import SetupEnhancedConversions from './enhanced-conversions/setup-enhanced-conversions';
+import { ReviewsSettings } from './reviews';
 import ExperienceRatingBanner from '~/components/experience-rating-banner';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
@@ -118,6 +119,7 @@ const Settings = () => {
 					<ContactInformationPreview />
 					<ShippingRateSettings />
 					<SetupTaxRate />
+					<ReviewsSettings />
 				</>
 			) }
 			<LinkedAccounts />

--- a/js/src/pages/settings/index.test.js
+++ b/js/src/pages/settings/index.test.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Settings from './';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+
+jest.mock( '@woocommerce/navigation', () => ( {
+	...jest.requireActual( '@woocommerce/navigation' ),
+	getQuery: jest.fn().mockReturnValue( {} ),
+} ) );
+
+jest.mock( '~/hooks/useGoogleAccount', () =>
+	jest.fn().mockReturnValue( { google: { active: 'yes' } } )
+);
+
+jest.mock( '~/hooks/useGoogleMCAccount', () => jest.fn() );
+
+jest.mock( '~/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery', () =>
+	jest.fn()
+);
+
+jest.mock( '~/hooks/useTargetAudienceFinalCountryCodes', () =>
+	jest.fn().mockReturnValue( {
+		targetAudience: undefined,
+		getFinalCountries: jest.fn(),
+	} )
+);
+
+jest.mock( '~/data', () => ( {
+	useAppDispatch: jest
+		.fn()
+		.mockReturnValue( { saveTargetAudience: jest.fn() } ),
+} ) );
+
+jest.mock( '~/components/main-tab-nav', () => () => null );
+jest.mock( '~/components/tours/rebranding-tour', () => () => null );
+jest.mock( '~/components/experience-rating-banner', () => () => null );
+jest.mock( '~/components/target-audience-section', () => () => null );
+jest.mock( '~/components/contact-information', () => ( {
+	ContactInformationPreview: () => null,
+} ) );
+jest.mock( './setup-tax-rate', () => () => null );
+jest.mock( './shipping-rate-settings', () => () => null );
+jest.mock( './linked-accounts', () => () => null );
+jest.mock( './reconnect-wpcom-account', () => () => null );
+jest.mock( './reconnect-google-account', () => () => null );
+jest.mock( './edit-store-address', () => () => null );
+jest.mock(
+	'./enhanced-conversions/setup-enhanced-conversions',
+	() => () => null
+);
+jest.mock( './reviews', () => ( {
+	ReviewsSettings: () => <div data-testid="reviews-settings" />,
+} ) );
+
+beforeAll( () => {
+	// Used in the js/src/hooks/useMenuEffect.js dependency.
+	window.wpNavMenuClassChange = jest.fn();
+} );
+
+afterEach( () => {
+	useGoogleMCAccount.mockReset();
+} );
+
+describe( 'Settings page — reviews settings visibility gating', () => {
+	it( 'renders the reviews settings when Merchant Center is connected', () => {
+		useGoogleMCAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			hasGoogleMCConnection: true,
+		} );
+
+		render( <Settings /> );
+
+		expect( screen.getByTestId( 'reviews-settings' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the reviews settings when Merchant Center is not connected', () => {
+		useGoogleMCAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			hasGoogleMCConnection: false,
+		} );
+
+		render( <Settings /> );
+
+		expect(
+			screen.queryByTestId( 'reviews-settings' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the reviews settings while Merchant Center connection is still resolving', () => {
+		useGoogleMCAccount.mockReturnValue( {
+			hasFinishedResolution: false,
+			hasGoogleMCConnection: false,
+		} );
+
+		render( <Settings /> );
+
+		expect(
+			screen.queryByTestId( 'reviews-settings' )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/js/src/pages/settings/reviews/constants.js
+++ b/js/src/pages/settings/reviews/constants.js
@@ -1,0 +1,4 @@
+export const GCR_ENROLLMENT_NOTICE_DISMISSED_KEY =
+	'gla_reviews_gcr_enrollment_notice_dismissed';
+export const GCR_ENROLLMENT_HELP_URL =
+	'https://support.google.com/merchants/answer/14628991?hl=en';

--- a/js/src/pages/settings/reviews/index.js
+++ b/js/src/pages/settings/reviews/index.js
@@ -1,0 +1,1 @@
+export { default as ReviewsSettings } from './reviews-settings';

--- a/js/src/pages/settings/reviews/reviews-settings.js
+++ b/js/src/pages/settings/reviews/reviews-settings.js
@@ -1,0 +1,167 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import { PREFERENCES_STORE_NAMESPACE } from '~/constants';
+import Section from '~/components/section';
+import AppStandaloneToggleControl from '~/components/app-standalone-toggle-control';
+import AppButton from '~/components/app-button';
+import SpinnerCard from '~/components/spinner-card';
+import useSettings from '~/hooks/useSettings';
+import usePreference from '~/hooks/usePreference';
+import { handleApiError } from '~/utils/handleError';
+import {
+	GCR_ENROLLMENT_NOTICE_DISMISSED_KEY,
+	GCR_ENROLLMENT_HELP_URL,
+} from './constants';
+
+/**
+ * Triggered when the "Learn how to enable Google Customer Reviews" button is clicked.
+ *
+ * @event gla_reviews_settings_gcr_enrollment_help_click
+ */
+
+/**
+ * Renders the "Collect reviews after purchase" (Google Customer Reviews) setting.
+ *
+ * Visibility is gated by the parent Settings page rendering this only when
+ * `hasGoogleMCConnection` is true (see FEA-08.1.1 AC-002) — not repeated here.
+ *
+ * The "Estimated shipping times" dependency notice (AC-005) is deferred —
+ * tracked as a follow-up once the Shipping page/route it depends on exists.
+ */
+const ReviewsSettings = () => {
+	const { settings, saveSettings } = useSettings();
+	const [ isSaving, setIsSaving ] = useState( false );
+	const { set: setPreference } = useDispatch( preferencesStore );
+
+	const isGCRNoticeDismissed = usePreference(
+		GCR_ENROLLMENT_NOTICE_DISMISSED_KEY
+	);
+
+	const sectionDescription = (
+		<div>
+			<p>
+				{ __(
+					'Google Reviews provide free social proof, increased organic visibility, and a boost to advertising performance.',
+					'google-listings-and-ads'
+				) }
+			</p>
+			<p>
+				{ __(
+					'Shoppers rely heavily on reviews to navigate consumer skepticism; having a strong Google rating directly drives higher conversion rates and builds trust with new buyers.',
+					'google-listings-and-ads'
+				) }
+			</p>
+		</div>
+	);
+
+	if ( ! settings ) {
+		return (
+			<Section
+				title={ __(
+					'Google Customer Reviews',
+					'google-listings-and-ads'
+				) }
+				description={ sectionDescription }
+			>
+				<SpinnerCard />
+			</Section>
+		);
+	}
+
+	const isEnabled = Boolean( settings.collect_reviews_after_purchase );
+
+	const handleToggle = async () => {
+		setIsSaving( true );
+		try {
+			await saveSettings( {
+				...settings,
+				collect_reviews_after_purchase: ! isEnabled,
+			} );
+		} catch ( error ) {
+			handleApiError(
+				error,
+				__(
+					'There was an error updating the review collection setting.',
+					'google-listings-and-ads'
+				)
+			);
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	const dismissGCRNotice = () => {
+		setPreference(
+			PREFERENCES_STORE_NAMESPACE,
+			GCR_ENROLLMENT_NOTICE_DISMISSED_KEY,
+			true
+		);
+	};
+
+	return (
+		<Section
+			title={ __( 'Google Customer Reviews', 'google-listings-and-ads' ) }
+			description={ sectionDescription }
+		>
+			<Section.Card>
+				<Section.Card.Body>
+					<AppStandaloneToggleControl
+						label={ __(
+							'Collect reviews after purchase',
+							'google-listings-and-ads'
+						) }
+						checked={ isEnabled }
+						disabled={ isSaving }
+						onChange={ handleToggle }
+						help={ __(
+							'Google asks customers on the order confirmation page if they would like to review your store. Customers who opt in receive an email from Google once their order arrives.',
+							'google-listings-and-ads'
+						) }
+					/>
+					{ ! isGCRNoticeDismissed && (
+						<Notice
+							status="info"
+							isDismissible
+							onRemove={ dismissGCRNotice }
+						>
+							<p>
+								{ __(
+									"This setting will only take effect if you're enrolled in the Merchant Center.",
+									'google-listings-and-ads'
+								) }
+							</p>
+							<AppButton
+								variant="primary"
+								href={ GCR_ENROLLMENT_HELP_URL }
+								target="_blank"
+								eventName="gla_reviews_settings_gcr_enrollment_help_click"
+								eventProps={ {
+									context: 'reviews-settings',
+									link_id: 'gcr-enrollment-help',
+									href: GCR_ENROLLMENT_HELP_URL,
+								} }
+							>
+								{ __(
+									'Find out how',
+									'google-listings-and-ads'
+								) }
+							</AppButton>
+						</Notice>
+					) }
+				</Section.Card.Body>
+			</Section.Card>
+		</Section>
+	);
+};
+
+export default ReviewsSettings;

--- a/js/src/pages/settings/reviews/reviews-settings.test.js
+++ b/js/src/pages/settings/reviews/reviews-settings.test.js
@@ -1,0 +1,195 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { useDispatch } from '@wordpress/data';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { PREFERENCES_STORE_NAMESPACE } from '~/constants';
+import {
+	GCR_ENROLLMENT_NOTICE_DISMISSED_KEY,
+	GCR_ENROLLMENT_HELP_URL,
+} from './constants';
+import ReviewsSettings from './reviews-settings';
+import useSettings from '~/hooks/useSettings';
+import usePreference from '~/hooks/usePreference';
+
+jest.mock( '@wordpress/data', () => ( {
+	__esModule: true,
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	ToggleControl: ( { label, checked, onChange, disabled, help } ) => (
+		<div>
+			<label htmlFor="toggle-control-mock">
+				<input
+					id="toggle-control-mock"
+					type="checkbox"
+					aria-label={ label }
+					checked={ checked }
+					disabled={ disabled }
+					onChange={ () => onChange( ! checked ) }
+				/>
+				{ label }
+			</label>
+			{ help && <p>{ help }</p> }
+		</div>
+	),
+	Notice: ( { children, onRemove, isDismissible } ) => (
+		<div className="components-notice" role="status">
+			{ children }
+			{ isDismissible && (
+				<button
+					className="components-notice__dismiss"
+					onClick={ onRemove }
+				>
+					Dismiss
+				</button>
+			) }
+		</div>
+	),
+	Flex: ( { children, ...rest } ) => <div { ...rest }>{ children }</div>,
+	Card: ( { children, ...rest } ) => <div { ...rest }>{ children }</div>,
+	CardBody: ( { children, ...rest } ) => <div { ...rest }>{ children }</div>,
+	CardFooter: ( { children, ...rest } ) => (
+		<div { ...rest }>{ children }</div>
+	),
+} ) );
+
+jest.mock( '~/components/app-button', () => ( { href, children, onClick } ) => (
+	<a href={ href } onClick={ onClick }>
+		{ children }
+	</a>
+) );
+
+jest.mock( '~/components/spinner-card', () => () => (
+	<div data-testid="spinner-card" />
+) );
+
+jest.mock( '~/hooks/useSettings', () => jest.fn().mockName( 'useSettings' ) );
+
+jest.mock( '~/hooks/usePreference', () =>
+	jest.fn().mockName( 'usePreference' )
+);
+
+describe( 'ReviewsSettings', () => {
+	let saveSettings;
+	let setPreference;
+
+	beforeEach( () => {
+		saveSettings = jest.fn().mockResolvedValue( {} );
+		setPreference = jest.fn();
+
+		useDispatch.mockReturnValue( { set: setPreference } );
+		usePreference.mockReturnValue( false );
+	} );
+
+	it( 'renders a loading state until settings resolve', () => {
+		useSettings.mockReturnValue( { settings: undefined, saveSettings } );
+
+		render( <ReviewsSettings /> );
+
+		expect( screen.getByTestId( 'spinner-card' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByLabelText( 'Collect reviews after purchase' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the toggle unchecked when the setting is disabled', () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		expect(
+			screen.getByLabelText( 'Collect reviews after purchase' )
+		).not.toBeChecked();
+	} );
+
+	it( 'renders the toggle checked when the setting is enabled', () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: true },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		expect(
+			screen.getByLabelText( 'Collect reviews after purchase' )
+		).toBeChecked();
+	} );
+
+	it( 'saves the setting with the toggled value on change', async () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+		fireEvent.click(
+			screen.getByLabelText( 'Collect reviews after purchase' )
+		);
+
+		await waitFor( () =>
+			expect( saveSettings ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					collect_reviews_after_purchase: true,
+				} )
+			)
+		);
+	} );
+
+	it( 'renders the GCR-enrollment notice with its link when not dismissed', () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		expect( screen.getByText( /Find out how/i ) ).toHaveAttribute(
+			'href',
+			GCR_ENROLLMENT_HELP_URL
+		);
+	} );
+
+	it( 'dismisses the GCR-enrollment notice', () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		const gcrNotice = screen
+			.getByText( /Find out how/i )
+			.closest( '.components-notice' );
+		fireEvent.click(
+			gcrNotice.querySelector( '.components-notice__dismiss' )
+		);
+
+		expect( setPreference ).toHaveBeenCalledWith(
+			PREFERENCES_STORE_NAMESPACE,
+			GCR_ENROLLMENT_NOTICE_DISMISSED_KEY,
+			true
+		);
+	} );
+
+	it( 'does not render the GCR-enrollment notice once dismissed', () => {
+		usePreference.mockReturnValue( true );
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		expect( screen.queryByText( /Find out how/i ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/src/API/Site/Controllers/MerchantCenter/SettingsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsController.php
@@ -113,7 +113,7 @@ class SettingsController extends BaseOptionsController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'shipping_rate'        => [
+			'shipping_rate'                  => [
 				'type'              => 'string',
 				'description'       => __(
 					'Whether shipping rate is a simple flat rate or needs to be configured manually in the Merchant Center.',
@@ -127,7 +127,7 @@ class SettingsController extends BaseOptionsController {
 					'manual',
 				],
 			],
-			'shipping_time'        => [
+			'shipping_time'                  => [
 				'type'              => 'string',
 				'description'       => __(
 					'Whether shipping time is a simple flat time or needs to be configured manually in the Merchant Center.',
@@ -140,7 +140,7 @@ class SettingsController extends BaseOptionsController {
 					'manual',
 				],
 			],
-			'tax_rate'             => [
+			'tax_rate'                       => [
 				'type'              => 'string',
 				'description'       => __(
 					'Whether tax rate is destination based or need to be configured manually in the Merchant Center.',
@@ -154,7 +154,7 @@ class SettingsController extends BaseOptionsController {
 				],
 				'default'           => 'destination',
 			],
-			'shipping_rates_count' => [
+			'shipping_rates_count'           => [
 				'type'              => 'number',
 				'description'       => __(
 					'The number of shipping rates in WC ready to be used in the Merchant Center.',
@@ -163,6 +163,16 @@ class SettingsController extends BaseOptionsController {
 				'context'           => [ 'view' ],
 				'validate_callback' => 'rest_validate_request_arg',
 				'default'           => 0,
+			],
+			'collect_reviews_after_purchase' => [
+				'type'              => 'boolean',
+				'description'       => __(
+					'Whether to inject the Google Customer Reviews opt-in prompt on the order-confirmation page.',
+					'google-listings-and-ads'
+				),
+				'context'           => [ 'view', 'edit' ],
+				'validate_callback' => 'rest_validate_request_arg',
+				'default'           => false,
 			],
 		];
 	}

--- a/src/API/Site/Controllers/MerchantCenter/SettingsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsController.php
@@ -174,6 +174,16 @@ class SettingsController extends BaseOptionsController {
 				'validate_callback' => 'rest_validate_request_arg',
 				'default'           => false,
 			],
+			'badge_widget_enabled'           => [
+				'type'              => 'boolean',
+				'description'       => __(
+					'Whether the Google-verified ratings and reviews badge widget is enabled on the store.',
+					'google-listings-and-ads'
+				),
+				'context'           => [ 'view', 'edit' ],
+				'validate_callback' => 'rest_validate_request_arg',
+				'default'           => false,
+			],
 		];
 	}
 

--- a/src/Internal/DependencyManagement/NotificationsServiceProvider.php
+++ b/src/Internal/DependencyManagement/NotificationsServiceProvider.php
@@ -10,7 +10,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\AbandonedOnboardingEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\BadgeWidgetEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CampaignNoSalesEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CollectReviewsEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CouponsNotSyncedEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\EnhancedConversionsOffEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\NotOnboardedEvaluator;
@@ -52,7 +54,9 @@ class NotificationsServiceProvider extends AbstractServiceProvider {
 		NotificationService::class               => true,
 		NotificationCacheInvalidator::class      => true,
 		AbandonedOnboardingEvaluator::class      => true,
+		BadgeWidgetEvaluator::class              => true,
 		CampaignNoSalesEvaluator::class          => true,
+		CollectReviewsEvaluator::class           => true,
 		CouponsNotSyncedEvaluator::class         => true,
 		EnhancedConversionsOffEvaluator::class   => true,
 		NotOnboardedEvaluator::class             => true,
@@ -75,6 +79,8 @@ class NotificationsServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( SkippedCampaignCreationEvaluator::class, AdsCampaign::class, OnboardingCompleted::class, ServiceBasedMerchantState::class );
 		$this->share_with_tags( AbandonedOnboardingEvaluator::class, ServiceBasedMerchantState::class, OnboardingCompleted::class );
 		$this->share_with_tags( NotOnboardedEvaluator::class, OnboardingCompleted::class );
+		$this->share_with_tags( CollectReviewsEvaluator::class, OnboardingCompleted::class );
+		$this->share_with_tags( BadgeWidgetEvaluator::class, OnboardingCompleted::class );
 		$this->share_with_tags( EnhancedConversionsOffEvaluator::class );
 		$this->share_with_tags( TrackingOffEvaluator::class );
 		$this->share_with_tags( ProductIssuesEvaluator::class, ServiceBasedMerchantState::class );

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -275,6 +275,11 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 	 * Disconnect Merchant Center account
 	 */
 	public function disconnect() {
+		// Collect reviews after purchase must survive a disconnect/reconnect cycle,
+		// unlike the rest of the Merchant Center settings blob it lives in.
+		$merchant_center_settings       = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+		$collect_reviews_after_purchase = is_array( $merchant_center_settings ) ? ( $merchant_center_settings['collect_reviews_after_purchase'] ?? null ) : null;
+
 		$this->options->delete( OptionsInterface::CONTACT_INFO_SETUP );
 		$this->options->delete( OptionsInterface::MAPI_DATA_SOURCES );
 		$this->options->delete( OptionsInterface::MC_SETUP_COMPLETED_AT );
@@ -283,6 +288,13 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		$this->options->delete( OptionsInterface::SITE_VERIFICATION );
 		$this->options->delete( OptionsInterface::MERCHANT_ID );
 		$this->options->delete( OptionsInterface::CLAIMED_URL_HASH );
+
+		if ( null !== $collect_reviews_after_purchase ) {
+			$this->options->update(
+				OptionsInterface::MERCHANT_CENTER,
+				[ 'collect_reviews_after_purchase' => $collect_reviews_after_purchase ]
+			);
+		}
 
 		$this->container->get( MarketService::class )->reset_markets();
 		$this->container->get( MerchantStatuses::class )->delete();

--- a/src/Notification/Evaluators/BadgeWidgetEvaluator.php
+++ b/src/Notification/Evaluators/BadgeWidgetEvaluator.php
@@ -1,0 +1,94 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class BadgeWidgetEvaluator
+ *
+ * Fires after onboarding completes when the merchant has a connected Merchant Center
+ * account and the Google Customer Reviews badge widget is not yet enabled.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
+ */
+class BadgeWidgetEvaluator implements NotificationEvaluatorInterface, MerchantCenterAwareInterface, OptionsAwareInterface, Service {
+
+	use MerchantCenterAwareTrait;
+	use OptionsAwareTrait;
+
+	/**
+	 * Key of the badge widget enabled flag within OptionsInterface::MERCHANT_CENTER.
+	 */
+	private const SETTING_KEY = 'badge_widget_enabled';
+
+	/** @var OnboardingCompleted */
+	private $onboarding_completed;
+
+	/**
+	 * BadgeWidgetEvaluator constructor.
+	 *
+	 * @param OnboardingCompleted $onboarding_completed
+	 */
+	public function __construct( OnboardingCompleted $onboarding_completed ) {
+		$this->onboarding_completed = $onboarding_completed;
+	}
+
+	/**
+	 * Get the notification's unique ID.
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return 'badge-widget';
+	}
+
+	/**
+	 * Whether the notification's condition is currently met.
+	 *
+	 * @return bool
+	 */
+	public function should_show(): bool {
+		if ( ! $this->onboarding_completed->is_onboarding_complete() ) {
+			return false;
+		}
+
+		if ( ! $this->merchant_center->is_connected() ) {
+			return false;
+		}
+
+		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
+		return empty( $settings[ self::SETTING_KEY ] );
+	}
+
+	/**
+	 * Get the notification's priority.
+	 *
+	 * @return int
+	 */
+	public function get_priority(): int {
+		return NotificationPriorities::BADGE_WIDGET;
+	}
+
+	/**
+	 * Get the snooze duration in seconds for temporary dismissals.
+	 *
+	 * @return int|null
+	 */
+	public function get_snooze_duration(): ?int {
+		return NotificationSnoozeDurations::BADGE_WIDGET;
+	}
+}

--- a/src/Notification/Evaluators/CollectReviewsEvaluator.php
+++ b/src/Notification/Evaluators/CollectReviewsEvaluator.php
@@ -1,0 +1,94 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationEvaluatorInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CollectReviewsEvaluator
+ *
+ * Fires after onboarding completes when the merchant has a connected Merchant Center
+ * account and post-purchase Google review collection is not yet enabled.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators
+ */
+class CollectReviewsEvaluator implements NotificationEvaluatorInterface, MerchantCenterAwareInterface, OptionsAwareInterface, Service {
+
+	use MerchantCenterAwareTrait;
+	use OptionsAwareTrait;
+
+	/**
+	 * Key of the post-purchase review collection flag within OptionsInterface::MERCHANT_CENTER.
+	 */
+	private const SETTING_KEY = 'collect_reviews_after_purchase';
+
+	/** @var OnboardingCompleted */
+	private $onboarding_completed;
+
+	/**
+	 * CollectReviewsEvaluator constructor.
+	 *
+	 * @param OnboardingCompleted $onboarding_completed
+	 */
+	public function __construct( OnboardingCompleted $onboarding_completed ) {
+		$this->onboarding_completed = $onboarding_completed;
+	}
+
+	/**
+	 * Get the notification's unique ID.
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return 'collect-reviews';
+	}
+
+	/**
+	 * Whether the notification's condition is currently met.
+	 *
+	 * @return bool
+	 */
+	public function should_show(): bool {
+		if ( ! $this->onboarding_completed->is_onboarding_complete() ) {
+			return false;
+		}
+
+		if ( ! $this->merchant_center->is_connected() ) {
+			return false;
+		}
+
+		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
+		return empty( $settings[ self::SETTING_KEY ] );
+	}
+
+	/**
+	 * Get the notification's priority.
+	 *
+	 * @return int
+	 */
+	public function get_priority(): int {
+		return NotificationPriorities::COLLECT_REVIEWS;
+	}
+
+	/**
+	 * Get the snooze duration in seconds for temporary dismissals.
+	 *
+	 * @return int|null
+	 */
+	public function get_snooze_duration(): ?int {
+		return NotificationSnoozeDurations::COLLECT_REVIEWS;
+	}
+}

--- a/src/Notification/NotificationPriorities.php
+++ b/src/Notification/NotificationPriorities.php
@@ -27,4 +27,6 @@ class NotificationPriorities {
 	public const PAUSED_CAMPAIGN           = 110;
 	public const CAMPAIGN_NO_SALES         = 120;
 	public const RECOMMENDATIONS_AVAILABLE = 130;
+	public const COLLECT_REVIEWS           = 140;
+	public const BADGE_WIDGET              = 150;
 }

--- a/src/Notification/NotificationSnoozeDurations.php
+++ b/src/Notification/NotificationSnoozeDurations.php
@@ -30,4 +30,6 @@ class NotificationSnoozeDurations {
 	public const PAUSED_CAMPAIGN           = 7 * DAY_IN_SECONDS;
 	public const CAMPAIGN_NO_SALES         = 7 * DAY_IN_SECONDS;
 	public const RECOMMENDATIONS_AVAILABLE = 7 * DAY_IN_SECONDS;
+	public const COLLECT_REVIEWS           = 7 * DAY_IN_SECONDS;
+	public const BADGE_WIDGET              = 7 * DAY_IN_SECONDS;
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -123,6 +123,7 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 			'shipping_time'                  => 'flat',
 			'tax_rate'                       => 'destination',
 			'collect_reviews_after_purchase' => false,
+			'badge_widget_enabled'           => false,
 		];
 
 		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
@@ -155,10 +156,11 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 
 	public function test_edit_badge_widget_enabled_setting() {
 		$options = [
-			'shipping_rate'        => 'flat',
-			'shipping_time'        => 'flat',
-			'tax_rate'             => 'destination',
-			'badge_widget_enabled' => false,
+			'shipping_rate'                  => 'flat',
+			'shipping_time'                  => 'flat',
+			'tax_rate'                       => 'destination',
+			'collect_reviews_after_purchase' => false,
+			'badge_widget_enabled'           => false,
 		];
 
 		$this->options->expects( $this->once() )->method( 'get' )->willReturn(

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -52,6 +52,7 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 		$expected = $options + [
 			'shipping_rates_count'           => 1,
 			'collect_reviews_after_purchase' => false,
+			'badge_widget_enabled'           => false,
 		];
 
 		$response = $this->do_request( self::ROUTE, 'GET' );
@@ -78,6 +79,7 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 				[
 					'shipping_time'                  => 'manual',
 					'collect_reviews_after_purchase' => false,
+					'badge_widget_enabled'           => false,
 				]
 			)
 		);
@@ -142,5 +144,41 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertTrue( $response->get_data()['data']['collect_reviews_after_purchase'] );
+	}
+
+	public function test_default_badge_widget_enabled_setting() {
+		$response = $this->do_request( self::ROUTE );
+
+		$this->assertFalse( $response->get_data()['badge_widget_enabled'] );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_edit_badge_widget_enabled_setting() {
+		$options = [
+			'shipping_rate'        => 'flat',
+			'shipping_time'        => 'flat',
+			'tax_rate'             => 'destination',
+			'badge_widget_enabled' => false,
+		];
+
+		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
+			$options
+		);
+
+		$this->options->expects( $this->once() )->method( 'update' )->with(
+			OptionsInterface::MERCHANT_CENTER,
+			array_merge( $options, [ 'badge_widget_enabled' => true ] )
+		);
+
+		$response = $this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'badge_widget_enabled' => true,
+			]
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()['data']['badge_widget_enabled'] );
 	}
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -50,7 +50,8 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 		$this->shipping_zone->expects( $this->once() )->method( 'get_shipping_rates_count' )->willReturn( 1 );
 
 		$expected = $options + [
-			'shipping_rates_count' => 1,
+			'shipping_rates_count'           => 1,
+			'collect_reviews_after_purchase' => false,
 		];
 
 		$response = $this->do_request( self::ROUTE, 'GET' );
@@ -70,7 +71,16 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 			$options
 		);
 
-		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::MERCHANT_CENTER, array_merge( $options, [ 'shipping_time' => 'manual' ] ) );
+		$this->options->expects( $this->once() )->method( 'update' )->with(
+			OptionsInterface::MERCHANT_CENTER,
+			array_merge(
+				$options,
+				[
+					'shipping_time'                  => 'manual',
+					'collect_reviews_after_purchase' => false,
+				]
+			)
+		);
 
 		$response = $this->do_request(
 			self::ROUTE,
@@ -96,5 +106,41 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 
 		$this->assertEquals( 'destination', $response->get_data()['data']['tax_rate'] );
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_default_collect_reviews_after_purchase_setting() {
+		$response = $this->do_request( self::ROUTE );
+
+		$this->assertFalse( $response->get_data()['collect_reviews_after_purchase'] );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_edit_collect_reviews_after_purchase_setting() {
+		$options = [
+			'shipping_rate'                  => 'flat',
+			'shipping_time'                  => 'flat',
+			'tax_rate'                       => 'destination',
+			'collect_reviews_after_purchase' => false,
+		];
+
+		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
+			$options
+		);
+
+		$this->options->expects( $this->once() )->method( 'update' )->with(
+			OptionsInterface::MERCHANT_CENTER,
+			array_merge( $options, [ 'collect_reviews_after_purchase' => true ] )
+		);
+
+		$response = $this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'collect_reviews_after_purchase' => true,
+			]
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()['data']['collect_reviews_after_purchase'] );
 	}
 }

--- a/tests/Unit/DependencyManagement/CoreServiceProviderTest.php
+++ b/tests/Unit/DependencyManagement/CoreServiceProviderTest.php
@@ -5,7 +5,9 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DependencyManag
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\NotificationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\AbandonedOnboardingEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\BadgeWidgetEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CampaignNoSalesEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CollectReviewsEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CouponsNotSyncedEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\EnhancedConversionsOffEvaluator;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\NotOnboardedEvaluator;
@@ -42,7 +44,9 @@ class CoreServiceProviderTest extends ContainerAwareUnitTest {
 	 */
 	private const EVALUATOR_CLASSES = [
 		AbandonedOnboardingEvaluator::class,
+		BadgeWidgetEvaluator::class,
 		CampaignNoSalesEvaluator::class,
+		CollectReviewsEvaluator::class,
 		CouponsNotSyncedEvaluator::class,
 		EnhancedConversionsOffEvaluator::class,
 		NotOnboardedEvaluator::class,

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -1150,6 +1150,37 @@ class AccountServiceTest extends UnitTest {
 		$this->account->disconnect();
 	}
 
+	public function test_disconnect_preserves_collect_reviews_after_purchase_setting() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn(
+				[
+					'shipping_rate'                  => 'flat',
+					'collect_reviews_after_purchase' => true,
+				]
+			);
+
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				OptionsInterface::MERCHANT_CENTER,
+				[ 'collect_reviews_after_purchase' => true ]
+			);
+
+		$this->account->disconnect();
+	}
+
+	public function test_disconnect_does_not_restore_setting_when_never_set() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [] );
+
+		$this->options->expects( $this->never() )
+			->method( 'update' );
+
+		$this->account->disconnect();
+	}
+
 	public function test_update_wpcom_api_authorization() {
 		$status = 'approved';
 		$nonce  = 'nonce-123';

--- a/tests/Unit/Notification/Evaluators/BadgeWidgetEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/BadgeWidgetEvaluatorTest.php
@@ -1,0 +1,96 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\BadgeWidgetEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class BadgeWidgetEvaluatorTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators
+ */
+class BadgeWidgetEvaluatorTest extends UnitTest {
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|OnboardingCompleted $onboarding_completed */
+	protected $onboarding_completed;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var BadgeWidgetEvaluator $evaluator */
+	protected $evaluator;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->merchant_center      = $this->createMock( MerchantCenterService::class );
+		$this->onboarding_completed = $this->createMock( OnboardingCompleted::class );
+		$this->options              = $this->createMock( OptionsInterface::class );
+
+		$this->evaluator = new BadgeWidgetEvaluator( $this->onboarding_completed );
+		$this->evaluator->set_merchant_center_object( $this->merchant_center );
+		$this->evaluator->set_options_object( $this->options );
+	}
+
+	public function test_get_id() {
+		$this->assertEquals( 'badge-widget', $this->evaluator->get_id() );
+	}
+
+	public function test_get_priority() {
+		$this->assertEquals( NotificationPriorities::BADGE_WIDGET, $this->evaluator->get_priority() );
+	}
+
+	public function test_get_snooze_duration() {
+		$this->assertEquals( NotificationSnoozeDurations::BADGE_WIDGET, $this->evaluator->get_snooze_duration() );
+	}
+
+	public function test_should_show_when_onboarded_connected_and_widget_disabled() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( true );
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [ 'badge_widget_enabled' => false ] );
+
+		$this->assertTrue( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_onboarding_not_complete() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( false );
+		$this->merchant_center->expects( $this->never() )->method( 'is_connected' );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_without_merchant_center_connection() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( false );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_widget_already_enabled() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( true );
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [ 'badge_widget_enabled' => true ] );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+}

--- a/tests/Unit/Notification/Evaluators/CollectReviewsEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/CollectReviewsEvaluatorTest.php
@@ -1,0 +1,96 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\Evaluators\CollectReviewsEvaluator;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationPriorities;
+use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationSnoozeDurations;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OnboardingCompleted;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class CollectReviewsEvaluatorTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notification\Evaluators
+ */
+class CollectReviewsEvaluatorTest extends UnitTest {
+
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
+	/** @var MockObject|OnboardingCompleted $onboarding_completed */
+	protected $onboarding_completed;
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var CollectReviewsEvaluator $evaluator */
+	protected $evaluator;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->merchant_center      = $this->createMock( MerchantCenterService::class );
+		$this->onboarding_completed = $this->createMock( OnboardingCompleted::class );
+		$this->options              = $this->createMock( OptionsInterface::class );
+
+		$this->evaluator = new CollectReviewsEvaluator( $this->onboarding_completed );
+		$this->evaluator->set_merchant_center_object( $this->merchant_center );
+		$this->evaluator->set_options_object( $this->options );
+	}
+
+	public function test_get_id() {
+		$this->assertEquals( 'collect-reviews', $this->evaluator->get_id() );
+	}
+
+	public function test_get_priority() {
+		$this->assertEquals( NotificationPriorities::COLLECT_REVIEWS, $this->evaluator->get_priority() );
+	}
+
+	public function test_get_snooze_duration() {
+		$this->assertEquals( NotificationSnoozeDurations::COLLECT_REVIEWS, $this->evaluator->get_snooze_duration() );
+	}
+
+	public function test_should_show_when_onboarded_connected_and_collection_disabled() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( true );
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [ 'collect_reviews_after_purchase' => false ] );
+
+		$this->assertTrue( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_onboarding_not_complete() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( false );
+		$this->merchant_center->expects( $this->never() )->method( 'is_connected' );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_without_merchant_center_connection() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( false );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+
+	public function test_should_not_show_when_collection_already_enabled() {
+		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_connected' )->willReturn( true );
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [ 'collect_reviews_after_purchase' => true ] );
+
+		$this->assertFalse( $this->evaluator->should_show() );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes:

- https://linear.app/a8c/issue/GOOWOO-865/post-onboarding-reviews-notifications-content-and-cta-behavior

Adds the merchant-facing content and CTA behavior for the two post-onboarding reviews notifications. This assumes the server-side eligibility gating from the sibling ticket (https://linear.app/a8c/issue/GOOWOO-864/post-onboarding-reviews-notifications-server-side-gating, this PR's base branch) — this PR is only about what the merchant sees and what happens when they click it.

- Add `collect-reviews` and `badge-widget` entries to the shared notification content-map (`useNotificationsSystemMap.js`), following the existing pattern for title/body/CTA text.
- Extend the shared `Notification` component's CTA handling with a new `settingKey` action property: when set, clicking the CTA now saves that setting to `true` via the existing settings store slice, then navigates — instead of navigating only, which is all any other notification's CTA does today. Includes its own loading state (CTA shows a spinner and disables its siblings while saving) and failure handling (shows the existing `handleApiError` snackbar and re-enables the button if the save fails).
- Register `badge_widget_enabled` in the Merchant Center settings REST schema so it can be persisted through the existing settings store (`collect_reviews_after_purchase` was already registered in a prior ticket).
- Both CTAs point at Marketing > Google for WooCommerce > Settings and fire the plugin's existing `gla_notifications_system_notification_cta_clicked` tracking event, matching every other notification's convention.

Decision on the two implementation approaches raised in the ticket: went with **(a) extend the shared component to support an async "save, then navigate" action**, rather than **(b) navigate with a query param for the Settings page to read on arrival** — this keeps the behavior self-contained in the Notifications System and doesn't create a dependency on the sibling Settings-page ticket's page-arrival logic.

Dependencies:
https://github.com/woocommerce/google-listings-and-ads/pull/3680
https://github.com/woocommerce/google-listings-and-ads/pull/3675

Out of scope (per ticket): server-side eligibility/visibility logic for either notification (sibling ticket above), and dismissal semantics (inherited from the Notifications System's own contract).

### Screenshots:

<img width="904" height="782" alt="Screenshot 2026-08-06 at 2 08 00 AM" src="https://github.com/user-attachments/assets/a0ec58dc-d507-453d-8703-d0bad17faf0b" />


### Detailed test instructions:

**Automated coverage** (run these first):

1. JS: `npx wp-scripts test-unit-js js/src/notifications-system/useNotificationsSystemMap.test.js js/src/notifications-system/notification.test.js` — covers exact title/body/CTA copy for both notifications, the save-then-navigate success path, the save-failure path (no navigation, error snackbar shown), and sibling actions being disabled while one CTA is saving.
2. PHP: `composer test-unit -- --filter SettingsControllerTest` — covers the `badge_widget_enabled` default/edit round-trip and confirms editing one of the two new settings doesn't drop the other's persisted value.

**Manual verification** (requires a store that has completed onboarding and connected Merchant Center, since eligibility is server-side gated by the sibling ticket's evaluators):

1. On a test store, make sure both `collect_reviews_after_purchase` and `badge_widget_enabled` are off (fresh onboarding, or via WooCommerce > Settings > Google for WooCommerce, or directly: `wp option get merchant_center` / `wp option update merchant_center` to unset those keys).
2. Go to **WooCommerce > Marketing** (the Marketing Overview page where the Notifications System panel renders).
3. Confirm the **"Collect Google reviews after purchase"** notification appears with body "Google Reviews provide free social proof, increased organic visibility, and a boost to advertising performance." and a **"Enable reviews collection"** button.
4. Confirm the **"Add your store rating widget"** notification appears with body "Show Google-verified ratings and reviews on your site and boost shopper trust and conversions." and an **"Add widget"** button.
5. Click **"Enable reviews collection"**. Confirm: the button shows a loading state briefly, you're redirected to Marketing > Google for WooCommerce > Settings, and the "Collect reviews after purchase" setting is now enabled on that page.
6. Go back to the Marketing Overview page and confirm the "Collect Google reviews after purchase" notification no longer appears (its setting is now on).
7. Repeat steps 5–6 for **"Add widget"** / the badge widget setting.
8. Force a save failure (e.g. temporarily block the `mc/settings` REST endpoint, or disconnect network) and click a CTA — confirm the error snackbar appears, the button returns to its normal (non-loading) state, and no navigation occurs.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

No changelog entry needed — this PR merges into `feature/GOOWOO-864-post-onboarding-reviews-notifications-server-side-gating`, not `develop`. A changelog entry should be added on whichever PR in this stack ultimately merges into `develop`. `changelog: none` label applied here.
