### PR TITLE
fix: prevent wp_login fatal when hook fires with only the username

### DIFF
--- a/src/Notification/NotificationService.php
+++ b/src/Notification/NotificationService.php
@@ -192,12 +192,21 @@ class NotificationService implements ContainerAwareInterface, OptionsAwareInterf
 	/**
 	 * Clear login-scoped dismissals when a user logs in.
 	 *
-	 * @param string  $user_login The user's login name.
-	 * @param WP_User $user         The authenticated user.
+	 * Untyped and defaulted because some plugins/login flows fire `wp_login` with
+	 * only the username (see Integration/JetpackWPCOM.php for the same
+	 * accommodation); strict, required params here would fatal with an
+	 * ArgumentCountError on that call shape.
+	 *
+	 * @param string       $user_login The user's login name.
+	 * @param WP_User|null $user       The authenticated user.
 	 *
 	 * @return void
 	 */
-	public function clear_login_scoped_dismissals( string $user_login, WP_User $user ): void {
+	public function clear_login_scoped_dismissals( $user_login = '', $user = null ): void {
+		if ( ! $user instanceof WP_User ) {
+			return;
+		}
+
 		$state = $this->get_state_for_user( $user->ID );
 
 		if ( empty( $state ) ) {

--- a/tests/Unit/Notification/NotificationServiceTest.php
+++ b/tests/Unit/Notification/NotificationServiceTest.php
@@ -206,6 +206,22 @@ class NotificationServiceTest extends UnitTest {
 		$this->assertEquals( [ 'notification-a' ], $ids );
 	}
 
+	public function test_login_scoped_dismissal_clear_tolerates_missing_user_arg() {
+		$this->set_evaluators(
+			[
+				$this->create_mocked_evaluator( 'notification-a', 10, true, NotificationSnoozeDurations::UNTIL_NEXT_LOGIN ),
+			]
+		);
+
+		$this->service->get_notifications();
+		$this->service->dismiss( 'notification-a' );
+
+		// Some plugins/login flows fire `wp_login` with only the username.
+		$this->service->clear_login_scoped_dismissals( 'some_user_login' );
+
+		$this->assertEquals( [], $this->service->get_notifications() );
+	}
+
 	public function test_login_scoped_clear_does_not_affect_permanent_dismissals() {
 		$this->set_evaluators(
 			[


### PR DESCRIPTION
## Summary
- `NotificationService::clear_login_scoped_dismissals()` was bound to `wp_login` with two required, non-nullable typed params under `declare(strict_types=1)`. WP core always fires `wp_login` with 2 args, but some plugins/login flows (SSO, JWT auth, custom redirect handlers) fire it manually with just the username — a known real-world pattern. That call shape would throw an uncaught `ArgumentCountError` fatal.
- This mirrors the existing accommodation already in the codebase for the same hook: `Integration/JetpackWPCOM.php::store_json_api_authorization_token()` deliberately leaves its `wp_login` params untyped for exactly this reason.
- Fix: give both params defaults and guard with an `instanceof WP_User` check before using `$user`.

## Test plan
- [x] `vendor/bin/phpcs` clean on both changed files
- [x] Added `test_login_scoped_dismissal_clear_tolerates_missing_user_arg` covering the single-arg call shape that previously would have fataled
- [ ] CI PHPUnit run

🤖 Generated with [Claude Code](https://claude.com/claude-code)