### PR TITLE
GOOWOO-863: Add Google Customer Reviews collect-after-purchase setting

### DIFF
--- a/js/src/pages/settings/index.js
+++ b/js/src/pages/settings/index.js
@@ -116,10 +116,10 @@ const Settings = () => {
 			) }
 			{ hasGoogleMCConnection && (
 				<>
+					<ReviewsSettings />
 					<ContactInformationPreview />
 					<ShippingRateSettings />
 					<SetupTaxRate />
-					<ReviewsSettings />
 				</>
 			) }
 			<LinkedAccounts />

--- a/js/src/pages/settings/index.js
+++ b/js/src/pages/settings/index.js
@@ -23,6 +23,7 @@ import EditStoreAddress from './edit-store-address';
 import MainTabNav from '~/components/main-tab-nav';
 import RebrandingTour from '~/components/tours/rebranding-tour';
 import SetupEnhancedConversions from './enhanced-conversions/setup-enhanced-conversions';
+import { ReviewsSettings } from './reviews';
 import ExperienceRatingBanner from '~/components/experience-rating-banner';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
@@ -118,6 +119,7 @@ const Settings = () => {
 					<ContactInformationPreview />
 					<ShippingRateSettings />
 					<SetupTaxRate />
+					<ReviewsSettings />
 				</>
 			) }
 			<LinkedAccounts />

--- a/js/src/pages/settings/index.test.js
+++ b/js/src/pages/settings/index.test.js
@@ -1,0 +1,108 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Settings from './';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+
+jest.mock( '@woocommerce/navigation', () => ( {
+	...jest.requireActual( '@woocommerce/navigation' ),
+	getQuery: jest.fn().mockReturnValue( {} ),
+} ) );
+
+jest.mock( '~/hooks/useGoogleAccount', () =>
+	jest.fn().mockReturnValue( { google: { active: 'yes' } } )
+);
+
+jest.mock( '~/hooks/useGoogleMCAccount', () => jest.fn() );
+
+jest.mock( '~/hooks/useUpdateRestAPIAuthorizeStatusByUrlQuery', () =>
+	jest.fn()
+);
+
+jest.mock( '~/hooks/useTargetAudienceFinalCountryCodes', () =>
+	jest.fn().mockReturnValue( {
+		targetAudience: undefined,
+		getFinalCountries: jest.fn(),
+	} )
+);
+
+jest.mock( '~/data', () => ( {
+	useAppDispatch: jest
+		.fn()
+		.mockReturnValue( { saveTargetAudience: jest.fn() } ),
+} ) );
+
+jest.mock( '~/components/main-tab-nav', () => () => null );
+jest.mock( '~/components/tours/rebranding-tour', () => () => null );
+jest.mock( '~/components/experience-rating-banner', () => () => null );
+jest.mock( '~/components/target-audience-section', () => () => null );
+jest.mock( '~/components/contact-information', () => ( {
+	ContactInformationPreview: () => null,
+} ) );
+jest.mock( './setup-tax-rate', () => () => null );
+jest.mock( './shipping-rate-settings', () => () => null );
+jest.mock( './linked-accounts', () => () => null );
+jest.mock( './reconnect-wpcom-account', () => () => null );
+jest.mock( './reconnect-google-account', () => () => null );
+jest.mock( './edit-store-address', () => () => null );
+jest.mock(
+	'./enhanced-conversions/setup-enhanced-conversions',
+	() => () => null
+);
+jest.mock( './reviews', () => ( {
+	ReviewsSettings: () => <div data-testid="reviews-settings" />,
+} ) );
+
+beforeAll( () => {
+	// Used in the js/src/hooks/useMenuEffect.js dependency.
+	window.wpNavMenuClassChange = jest.fn();
+} );
+
+afterEach( () => {
+	useGoogleMCAccount.mockReset();
+} );
+
+describe( 'Settings page — reviews settings visibility gating', () => {
+	it( 'renders the reviews settings when Merchant Center is connected', () => {
+		useGoogleMCAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			hasGoogleMCConnection: true,
+		} );
+
+		render( <Settings /> );
+
+		expect( screen.getByTestId( 'reviews-settings' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the reviews settings when Merchant Center is not connected', () => {
+		useGoogleMCAccount.mockReturnValue( {
+			hasFinishedResolution: true,
+			hasGoogleMCConnection: false,
+		} );
+
+		render( <Settings /> );
+
+		expect(
+			screen.queryByTestId( 'reviews-settings' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the reviews settings while Merchant Center connection is still resolving', () => {
+		useGoogleMCAccount.mockReturnValue( {
+			hasFinishedResolution: false,
+			hasGoogleMCConnection: false,
+		} );
+
+		render( <Settings /> );
+
+		expect(
+			screen.queryByTestId( 'reviews-settings' )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/js/src/pages/settings/reviews/constants.js
+++ b/js/src/pages/settings/reviews/constants.js
@@ -1,0 +1,4 @@
+export const GCR_ENROLLMENT_NOTICE_DISMISSED_KEY =
+	'gla_reviews_gcr_enrollment_notice_dismissed';
+export const GCR_ENROLLMENT_HELP_URL =
+	'https://support.google.com/merchants/answer/14628991?hl=en';

--- a/js/src/pages/settings/reviews/index.js
+++ b/js/src/pages/settings/reviews/index.js
@@ -1,0 +1,1 @@
+export { default as ReviewsSettings } from './reviews-settings';

--- a/js/src/pages/settings/reviews/reviews-settings.js
+++ b/js/src/pages/settings/reviews/reviews-settings.js
@@ -1,0 +1,167 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import { PREFERENCES_STORE_NAMESPACE } from '~/constants';
+import Section from '~/components/section';
+import AppStandaloneToggleControl from '~/components/app-standalone-toggle-control';
+import AppButton from '~/components/app-button';
+import SpinnerCard from '~/components/spinner-card';
+import useSettings from '~/hooks/useSettings';
+import usePreference from '~/hooks/usePreference';
+import { handleApiError } from '~/utils/handleError';
+import {
+	GCR_ENROLLMENT_NOTICE_DISMISSED_KEY,
+	GCR_ENROLLMENT_HELP_URL,
+} from './constants';
+
+/**
+ * Triggered when the "Learn how to enable Google Customer Reviews" button is clicked.
+ *
+ * @event gla_reviews_settings_gcr_enrollment_help_click
+ */
+
+/**
+ * Renders the "Collect reviews after purchase" (Google Customer Reviews) setting.
+ *
+ * Visibility is gated by the parent Settings page rendering this only when
+ * `hasGoogleMCConnection` is true (see FEA-08.1.1 AC-002) — not repeated here.
+ *
+ * The "Estimated shipping times" dependency notice (AC-005) is deferred —
+ * tracked as a follow-up once the Shipping page/route it depends on exists.
+ */
+const ReviewsSettings = () => {
+	const { settings, saveSettings } = useSettings();
+	const [ isSaving, setIsSaving ] = useState( false );
+	const { set: setPreference } = useDispatch( preferencesStore );
+
+	const isGCRNoticeDismissed = usePreference(
+		GCR_ENROLLMENT_NOTICE_DISMISSED_KEY
+	);
+
+	const sectionDescription = (
+		<div>
+			<p>
+				{ __(
+					'Google Reviews provide free social proof, increased organic visibility, and a boost to advertising performance.',
+					'google-listings-and-ads'
+				) }
+			</p>
+			<p>
+				{ __(
+					'Shoppers rely heavily on reviews to navigate consumer skepticism; having a strong Google rating directly drives higher conversion rates and builds trust with new buyers.',
+					'google-listings-and-ads'
+				) }
+			</p>
+		</div>
+	);
+
+	if ( ! settings ) {
+		return (
+			<Section
+				title={ __(
+					'Google Customer Reviews',
+					'google-listings-and-ads'
+				) }
+				description={ sectionDescription }
+			>
+				<SpinnerCard />
+			</Section>
+		);
+	}
+
+	const isEnabled = Boolean( settings.collect_reviews_after_purchase );
+
+	const handleToggle = async () => {
+		setIsSaving( true );
+		try {
+			await saveSettings( {
+				...settings,
+				collect_reviews_after_purchase: ! isEnabled,
+			} );
+		} catch ( error ) {
+			handleApiError(
+				error,
+				__(
+					'There was an error updating the review collection setting.',
+					'google-listings-and-ads'
+				)
+			);
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	const dismissGCRNotice = () => {
+		setPreference(
+			PREFERENCES_STORE_NAMESPACE,
+			GCR_ENROLLMENT_NOTICE_DISMISSED_KEY,
+			true
+		);
+	};
+
+	return (
+		<Section
+			title={ __( 'Google Customer Reviews', 'google-listings-and-ads' ) }
+			description={ sectionDescription }
+		>
+			<Section.Card>
+				<Section.Card.Body>
+					<AppStandaloneToggleControl
+						label={ __(
+							'Collect reviews after purchase',
+							'google-listings-and-ads'
+						) }
+						checked={ isEnabled }
+						disabled={ isSaving }
+						onChange={ handleToggle }
+						help={ __(
+							'Google asks customers on the order confirmation page if they would like to review your store. Customers who opt in receive an email from Google once their order arrives.',
+							'google-listings-and-ads'
+						) }
+					/>
+					{ ! isGCRNoticeDismissed && (
+						<Notice
+							status="info"
+							isDismissible
+							onRemove={ dismissGCRNotice }
+						>
+							<p>
+								{ __(
+									"This setting will only take effect if you're enrolled in the Merchant Center.",
+									'google-listings-and-ads'
+								) }
+							</p>
+							<AppButton
+								variant="primary"
+								href={ GCR_ENROLLMENT_HELP_URL }
+								target="_blank"
+								eventName="gla_reviews_settings_gcr_enrollment_help_click"
+								eventProps={ {
+									context: 'reviews-settings',
+									link_id: 'gcr-enrollment-help',
+									href: GCR_ENROLLMENT_HELP_URL,
+								} }
+							>
+								{ __(
+									'Find out how',
+									'google-listings-and-ads'
+								) }
+							</AppButton>
+						</Notice>
+					) }
+				</Section.Card.Body>
+			</Section.Card>
+		</Section>
+	);
+};
+
+export default ReviewsSettings;

--- a/js/src/pages/settings/reviews/reviews-settings.js
+++ b/js/src/pages/settings/reviews/reviews-settings.js
@@ -24,7 +24,7 @@ import {
 } from './constants';
 
 /**
- * Triggered when the "Learn how to enable Google Customer Reviews" button is clicked.
+ * Triggered when the "Find out how" button is clicked.
  *
  * @event gla_reviews_settings_gcr_enrollment_help_click
  */

--- a/js/src/pages/settings/reviews/reviews-settings.test.js
+++ b/js/src/pages/settings/reviews/reviews-settings.test.js
@@ -16,6 +16,7 @@ import {
 import ReviewsSettings from './reviews-settings';
 import useSettings from '~/hooks/useSettings';
 import usePreference from '~/hooks/usePreference';
+import { handleApiError } from '~/utils/handleError';
 
 jest.mock( '@wordpress/data', () => ( {
 	__esModule: true,
@@ -76,6 +77,10 @@ jest.mock( '~/hooks/usePreference', () =>
 	jest.fn().mockName( 'usePreference' )
 );
 
+jest.mock( '~/utils/handleError', () => ( {
+	handleApiError: jest.fn(),
+} ) );
+
 describe( 'ReviewsSettings', () => {
 	let saveSettings;
 	let setPreference;
@@ -86,6 +91,7 @@ describe( 'ReviewsSettings', () => {
 
 		useDispatch.mockReturnValue( { set: setPreference } );
 		usePreference.mockReturnValue( false );
+		handleApiError.mockClear();
 	} );
 
 	it( 'renders a loading state until settings resolve', () => {
@@ -143,6 +149,31 @@ describe( 'ReviewsSettings', () => {
 				} )
 			)
 		);
+	} );
+
+	it( 'calls handleApiError and re-enables the toggle when saving fails', async () => {
+		const error = new Error( 'Network error' );
+		saveSettings.mockRejectedValueOnce( error );
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		const toggle = screen.getByLabelText(
+			'Collect reviews after purchase'
+		);
+		fireEvent.click( toggle );
+
+		await waitFor( () =>
+			expect( handleApiError ).toHaveBeenCalledWith(
+				error,
+				'There was an error updating the review collection setting.'
+			)
+		);
+
+		expect( toggle ).not.toBeDisabled();
 	} );
 
 	it( 'renders the GCR-enrollment notice with its link when not dismissed', () => {

--- a/js/src/pages/settings/reviews/reviews-settings.test.js
+++ b/js/src/pages/settings/reviews/reviews-settings.test.js
@@ -1,0 +1,195 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { useDispatch } from '@wordpress/data';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { PREFERENCES_STORE_NAMESPACE } from '~/constants';
+import {
+	GCR_ENROLLMENT_NOTICE_DISMISSED_KEY,
+	GCR_ENROLLMENT_HELP_URL,
+} from './constants';
+import ReviewsSettings from './reviews-settings';
+import useSettings from '~/hooks/useSettings';
+import usePreference from '~/hooks/usePreference';
+
+jest.mock( '@wordpress/data', () => ( {
+	__esModule: true,
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	ToggleControl: ( { label, checked, onChange, disabled, help } ) => (
+		<div>
+			<label htmlFor="toggle-control-mock">
+				<input
+					id="toggle-control-mock"
+					type="checkbox"
+					aria-label={ label }
+					checked={ checked }
+					disabled={ disabled }
+					onChange={ () => onChange( ! checked ) }
+				/>
+				{ label }
+			</label>
+			{ help && <p>{ help }</p> }
+		</div>
+	),
+	Notice: ( { children, onRemove, isDismissible } ) => (
+		<div className="components-notice" role="status">
+			{ children }
+			{ isDismissible && (
+				<button
+					className="components-notice__dismiss"
+					onClick={ onRemove }
+				>
+					Dismiss
+				</button>
+			) }
+		</div>
+	),
+	Flex: ( { children, ...rest } ) => <div { ...rest }>{ children }</div>,
+	Card: ( { children, ...rest } ) => <div { ...rest }>{ children }</div>,
+	CardBody: ( { children, ...rest } ) => <div { ...rest }>{ children }</div>,
+	CardFooter: ( { children, ...rest } ) => (
+		<div { ...rest }>{ children }</div>
+	),
+} ) );
+
+jest.mock( '~/components/app-button', () => ( { href, children, onClick } ) => (
+	<a href={ href } onClick={ onClick }>
+		{ children }
+	</a>
+) );
+
+jest.mock( '~/components/spinner-card', () => () => (
+	<div data-testid="spinner-card" />
+) );
+
+jest.mock( '~/hooks/useSettings', () => jest.fn().mockName( 'useSettings' ) );
+
+jest.mock( '~/hooks/usePreference', () =>
+	jest.fn().mockName( 'usePreference' )
+);
+
+describe( 'ReviewsSettings', () => {
+	let saveSettings;
+	let setPreference;
+
+	beforeEach( () => {
+		saveSettings = jest.fn().mockResolvedValue( {} );
+		setPreference = jest.fn();
+
+		useDispatch.mockReturnValue( { set: setPreference } );
+		usePreference.mockReturnValue( false );
+	} );
+
+	it( 'renders a loading state until settings resolve', () => {
+		useSettings.mockReturnValue( { settings: undefined, saveSettings } );
+
+		render( <ReviewsSettings /> );
+
+		expect( screen.getByTestId( 'spinner-card' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByLabelText( 'Collect reviews after purchase' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the toggle unchecked when the setting is disabled', () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		expect(
+			screen.getByLabelText( 'Collect reviews after purchase' )
+		).not.toBeChecked();
+	} );
+
+	it( 'renders the toggle checked when the setting is enabled', () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: true },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		expect(
+			screen.getByLabelText( 'Collect reviews after purchase' )
+		).toBeChecked();
+	} );
+
+	it( 'saves the setting with the toggled value on change', async () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+		fireEvent.click(
+			screen.getByLabelText( 'Collect reviews after purchase' )
+		);
+
+		await waitFor( () =>
+			expect( saveSettings ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					collect_reviews_after_purchase: true,
+				} )
+			)
+		);
+	} );
+
+	it( 'renders the GCR-enrollment notice with its link when not dismissed', () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		expect( screen.getByText( /Find out how/i ) ).toHaveAttribute(
+			'href',
+			GCR_ENROLLMENT_HELP_URL
+		);
+	} );
+
+	it( 'dismisses the GCR-enrollment notice', () => {
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		const gcrNotice = screen
+			.getByText( /Find out how/i )
+			.closest( '.components-notice' );
+		fireEvent.click(
+			gcrNotice.querySelector( '.components-notice__dismiss' )
+		);
+
+		expect( setPreference ).toHaveBeenCalledWith(
+			PREFERENCES_STORE_NAMESPACE,
+			GCR_ENROLLMENT_NOTICE_DISMISSED_KEY,
+			true
+		);
+	} );
+
+	it( 'does not render the GCR-enrollment notice once dismissed', () => {
+		usePreference.mockReturnValue( true );
+		useSettings.mockReturnValue( {
+			settings: { collect_reviews_after_purchase: false },
+			saveSettings,
+		} );
+
+		render( <ReviewsSettings /> );
+
+		expect( screen.queryByText( /Find out how/i ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/src/API/Site/Controllers/MerchantCenter/SettingsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsController.php
@@ -113,7 +113,7 @@ class SettingsController extends BaseOptionsController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'shipping_rate'        => [
+			'shipping_rate'                  => [
 				'type'              => 'string',
 				'description'       => __(
 					'Whether shipping rate is a simple flat rate or needs to be configured manually in the Merchant Center.',
@@ -127,7 +127,7 @@ class SettingsController extends BaseOptionsController {
 					'manual',
 				],
 			],
-			'shipping_time'        => [
+			'shipping_time'                  => [
 				'type'              => 'string',
 				'description'       => __(
 					'Whether shipping time is a simple flat time or needs to be configured manually in the Merchant Center.',
@@ -140,7 +140,7 @@ class SettingsController extends BaseOptionsController {
 					'manual',
 				],
 			],
-			'tax_rate'             => [
+			'tax_rate'                       => [
 				'type'              => 'string',
 				'description'       => __(
 					'Whether tax rate is destination based or need to be configured manually in the Merchant Center.',
@@ -154,7 +154,7 @@ class SettingsController extends BaseOptionsController {
 				],
 				'default'           => 'destination',
 			],
-			'shipping_rates_count' => [
+			'shipping_rates_count'           => [
 				'type'              => 'number',
 				'description'       => __(
 					'The number of shipping rates in WC ready to be used in the Merchant Center.',
@@ -163,6 +163,16 @@ class SettingsController extends BaseOptionsController {
 				'context'           => [ 'view' ],
 				'validate_callback' => 'rest_validate_request_arg',
 				'default'           => 0,
+			],
+			'collect_reviews_after_purchase' => [
+				'type'              => 'boolean',
+				'description'       => __(
+					'Whether to inject the Google Customer Reviews opt-in prompt on the order-confirmation page.',
+					'google-listings-and-ads'
+				),
+				'context'           => [ 'view', 'edit' ],
+				'validate_callback' => 'rest_validate_request_arg',
+				'default'           => false,
 			],
 		];
 	}

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -275,6 +275,11 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 	 * Disconnect Merchant Center account
 	 */
 	public function disconnect() {
+		// Collect reviews after purchase must survive a disconnect/reconnect cycle,
+		// unlike the rest of the Merchant Center settings blob it lives in.
+		$merchant_center_settings       = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+		$collect_reviews_after_purchase = is_array( $merchant_center_settings ) ? ( $merchant_center_settings['collect_reviews_after_purchase'] ?? null ) : null;
+
 		$this->options->delete( OptionsInterface::CONTACT_INFO_SETUP );
 		$this->options->delete( OptionsInterface::MAPI_DATA_SOURCES );
 		$this->options->delete( OptionsInterface::MC_SETUP_COMPLETED_AT );
@@ -283,6 +288,13 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		$this->options->delete( OptionsInterface::SITE_VERIFICATION );
 		$this->options->delete( OptionsInterface::MERCHANT_ID );
 		$this->options->delete( OptionsInterface::CLAIMED_URL_HASH );
+
+		if ( null !== $collect_reviews_after_purchase ) {
+			$this->options->update(
+				OptionsInterface::MERCHANT_CENTER,
+				[ 'collect_reviews_after_purchase' => $collect_reviews_after_purchase ]
+			);
+		}
 
 		$this->container->get( MarketService::class )->reset_markets();
 		$this->container->get( MerchantStatuses::class )->delete();

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -50,7 +50,8 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 		$this->shipping_zone->expects( $this->once() )->method( 'get_shipping_rates_count' )->willReturn( 1 );
 
 		$expected = $options + [
-			'shipping_rates_count' => 1,
+			'shipping_rates_count'           => 1,
+			'collect_reviews_after_purchase' => false,
 		];
 
 		$response = $this->do_request( self::ROUTE, 'GET' );
@@ -70,7 +71,16 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 			$options
 		);
 
-		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::MERCHANT_CENTER, array_merge( $options, [ 'shipping_time' => 'manual' ] ) );
+		$this->options->expects( $this->once() )->method( 'update' )->with(
+			OptionsInterface::MERCHANT_CENTER,
+			array_merge(
+				$options,
+				[
+					'shipping_time'                  => 'manual',
+					'collect_reviews_after_purchase' => false,
+				]
+			)
+		);
 
 		$response = $this->do_request(
 			self::ROUTE,
@@ -96,5 +106,41 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 
 		$this->assertEquals( 'destination', $response->get_data()['data']['tax_rate'] );
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_default_collect_reviews_after_purchase_setting() {
+		$response = $this->do_request( self::ROUTE );
+
+		$this->assertFalse( $response->get_data()['collect_reviews_after_purchase'] );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_edit_collect_reviews_after_purchase_setting() {
+		$options = [
+			'shipping_rate'                  => 'flat',
+			'shipping_time'                  => 'flat',
+			'tax_rate'                       => 'destination',
+			'collect_reviews_after_purchase' => false,
+		];
+
+		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
+			$options
+		);
+
+		$this->options->expects( $this->once() )->method( 'update' )->with(
+			OptionsInterface::MERCHANT_CENTER,
+			array_merge( $options, [ 'collect_reviews_after_purchase' => true ] )
+		);
+
+		$response = $this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'collect_reviews_after_purchase' => true,
+			]
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()['data']['collect_reviews_after_purchase'] );
 	}
 }

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -1150,6 +1150,37 @@ class AccountServiceTest extends UnitTest {
 		$this->account->disconnect();
 	}
 
+	public function test_disconnect_preserves_collect_reviews_after_purchase_setting() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn(
+				[
+					'shipping_rate'                  => 'flat',
+					'collect_reviews_after_purchase' => true,
+				]
+			);
+
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				OptionsInterface::MERCHANT_CENTER,
+				[ 'collect_reviews_after_purchase' => true ]
+			);
+
+		$this->account->disconnect();
+	}
+
+	public function test_disconnect_does_not_restore_setting_when_never_set() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [] );
+
+		$this->options->expects( $this->never() )
+			->method( 'update' );
+
+		$this->account->disconnect();
+	}
+
 	public function test_update_wpcom_api_authorization() {
 		$status = 'approved';
 		$nonce  = 'nonce-123';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes:

- https://linear.app/a8c/issue/GOOWOO-863

Adds a "Collect reviews after purchase" (Google Customer Reviews) setting to the Merchant Center Settings page:

- New `collect_reviews_after_purchase` boolean added to the Merchant Center settings REST schema (`SettingsController`), defaulting to `false`.
- New `ReviewsSettings` section/card on the Settings page with a toggle, description copy, and a dismissible info notice linking out to Google's Merchant Center enrollment help doc. The notice's dismissed state is persisted via the `wp/preferences` store.
- `AccountService::disconnect()` now preserves the `collect_reviews_after_purchase` value across a Merchant Center disconnect/reconnect cycle, instead of having it wiped along with the rest of the settings blob.

### Screenshots:

<img width="2076" height="692" alt="Screenshot 2026-08-07 at 12 55 08 AM" src="https://github.com/user-attachments/assets/9cc4008e-b1e9-4ac0-8d03-4b3ed02c247f" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

**Toggle behavior**

1. With a Merchant Center account connected, go to **Google for WooCommerce > Settings**.
2. Confirm a new "Google Customer Reviews" section appears with a "Collect reviews after purchase" toggle, off by default.
3. Turn the toggle on. Confirm it saves (no error notice) and stays on after a page refresh.
4. Turn it off and refresh again — confirm it persists as off.
5. Force a save error (e.g. throttle/block the `PUT /wc/gla/mc/settings` request in devtools) and confirm the toggle reverts and an error notice ("There was an error updating the review collection setting.") is shown.

**Enrollment notice**

6. On first load, confirm the info notice ("This setting will only take effect if you're enrolled in the Merchant Center.") is visible with a "Find out how" button linking to `https://support.google.com/merchants/answer/14628991?hl=en` in a new tab.
7. Dismiss the notice and refresh the page — confirm it stays dismissed (persisted via preferences).

**API**

8. `GET /wp-json/wc/gla/mc/settings` — confirm the response includes `collect_reviews_after_purchase`.
9. `PUT /wp-json/wc/gla/mc/settings` with `{ "collect_reviews_after_purchase": true }` — confirm a `200` and the value is persisted.

**Disconnect/reconnect**

10. With the setting turned on, disconnect the Merchant Center account (Settings > disconnect), then reconnect.
11. Confirm `collect_reviews_after_purchase` is still `true` after reconnecting, while other Merchant Center settings (shipping rate, tax rate, etc.) reset to their defaults as expected.

**Automated tests**

12. `composer test:unit -- --filter=SettingsControllerTest`
13. `composer test:unit -- --filter=AccountServiceTest`
14. `npm run test:js -- reviews-settings`
15. `npm run test:js -- settings/index`

### Changelog entry

No changelog entry needed — this targets `feature/google-customer-reviews`, not `develop`.
