### PR TITLE
GOOWOO-866: Post-purchase opt-in prompt

### DIFF
--- a/src/Google/ReviewsOptIn.php
+++ b/src/Google/ReviewsOptIn.php
@@ -1,0 +1,217 @@
+<?php
+declare( strict_types=1 );
+
+/**
+ * Google Customer Reviews post-purchase opt-in prompt.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds
+ */
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+use WC_Order;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Injects Google's Customer Reviews post-purchase opt-in snippet on the order-confirmation page.
+ *
+ * Modeled on GlobalSiteTag's injection pattern, but hooks the template-agnostic wp_body_open
+ * instead of woocommerce_before_thankyou so the same code path covers both classic and
+ * block-based checkout.
+ */
+class ReviewsOptIn implements Service, Registerable, OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/** @var string Key of the post-purchase review collection flag within OptionsInterface::MERCHANT_CENTER. */
+	protected const SETTING_KEY = 'collect_reviews_after_purchase';
+
+	/** @var string Meta key used to mark an order as already prompted, to prevent duplicate injection. */
+	protected const ORDER_PROMPTED_META_KEY = '_gla_gcr_opt_in_prompted';
+
+	/**
+	 * @var ShippingTimeQuery
+	 */
+	protected $shipping_time_query;
+
+	/**
+	 * @var WP
+	 */
+	protected $wp;
+
+	/**
+	 * ReviewsOptIn constructor.
+	 *
+	 * @param ShippingTimeQuery $shipping_time_query
+	 * @param WP                $wp
+	 */
+	public function __construct( ShippingTimeQuery $shipping_time_query, WP $wp ) {
+		$this->shipping_time_query = $shipping_time_query;
+		$this->wp                  = $wp;
+	}
+
+	/**
+	 * Register the service.
+	 */
+	public function register(): void {
+		add_action(
+			'wp_body_open',
+			function () {
+				$this->maybe_display_opt_in_snippet();
+			}
+		);
+	}
+
+	/**
+	 * Display the Google Customer Reviews opt-in snippet on the order-confirmation page, if all
+	 * of the following hold: the "Collect reviews after purchase" setting is enabled, this is a
+	 * verified order-confirmation page view, the order hasn't already been prompted, a Merchant
+	 * Center account is connected, and an estimated delivery date can be resolved for the order's
+	 * destination country. No fallback/default delivery date is ever invented.
+	 */
+	public function maybe_display_opt_in_snippet(): void {
+		if ( ! $this->is_reviews_collection_enabled() ) {
+			return;
+		}
+
+		if ( ! is_order_received_page() ) {
+			return;
+		}
+
+		$order = $this->get_verified_order();
+		if ( ! $order ) {
+			return;
+		}
+
+		if ( 1 === (int) $order->get_meta( self::ORDER_PROMPTED_META_KEY, true ) ) {
+			return;
+		}
+
+		$merchant_id = $this->options->get_merchant_id();
+		if ( ! $merchant_id ) {
+			return;
+		}
+
+		$delivery_country = $order->get_shipping_country() ?: $order->get_billing_country();
+		if ( ! $delivery_country ) {
+			return;
+		}
+
+		$estimated_delivery_date = $this->get_estimated_delivery_date( $order, $delivery_country );
+		if ( ! $estimated_delivery_date ) {
+			return;
+		}
+
+		// Mark the order as prompted, to avoid double-injection if the confirmation page is reloaded.
+		$order->update_meta_data( self::ORDER_PROMPTED_META_KEY, 1 );
+		$order->save_meta_data();
+
+		$params = [
+			'merchant_id'             => $merchant_id,
+			'order_id'                => (string) $order->get_id(),
+			'email'                   => $order->get_billing_email(),
+			'delivery_country'        => $delivery_country,
+			'estimated_delivery_date' => $estimated_delivery_date,
+		];
+
+		echo $this->get_opt_in_snippet_markup( $params ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/**
+	 * Whether the "Collect reviews after purchase" setting is currently enabled.
+	 *
+	 * @return bool
+	 */
+	protected function is_reviews_collection_enabled(): bool {
+		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
+		return ! empty( $settings[ self::SETTING_KEY ] );
+	}
+
+	/**
+	 * Resolve and validate the order for the current order-confirmation page view.
+	 *
+	 * Mirrors the order-key verification WooCommerce itself performs for both the classic
+	 * thank-you template and the block-based Order Confirmation block, since injecting via
+	 * wp_body_open runs before either of those has had a chance to do it for this request.
+	 *
+	 * @return WC_Order|null
+	 */
+	protected function get_verified_order(): ?WC_Order {
+		$order_id = absint( $this->wp->get_query_vars( 'order-received' ) );
+		if ( ! $order_id ) {
+			return null;
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof WC_Order ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$key = isset( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : '';
+		if ( ! $key || ! $order->key_is_valid( $key ) ) {
+			return null;
+		}
+
+		return $order;
+	}
+
+	/**
+	 * Resolve the estimated delivery date for an order's destination country, from this plugin's
+	 * own "Estimated shipping times" data. Returns null (never a fabricated date) when the country
+	 * has no configured entry.
+	 *
+	 * @param WC_Order $order
+	 * @param string   $delivery_country
+	 *
+	 * @return string|null Delivery date in YYYY-MM-DD format, or null if unresolvable.
+	 */
+	protected function get_estimated_delivery_date( WC_Order $order, string $delivery_country ): ?string {
+		$shipping_times = $this->shipping_time_query->get_all_shipping_times();
+		if ( empty( $shipping_times[ $delivery_country ] ) ) {
+			return null;
+		}
+
+		$date_created = $order->get_date_created();
+		if ( ! $date_created ) {
+			return null;
+		}
+
+		$max_transit_days = (int) $shipping_times[ $delivery_country ]['max_time'];
+
+		$delivery_date = clone $date_created;
+		$delivery_date->modify( "+{$max_transit_days} days" );
+
+		return $delivery_date->format( 'Y-m-d' );
+	}
+
+	/**
+	 * Build the Google Customer Reviews opt-in snippet markup.
+	 *
+	 * Per Google's documented snippet (support.google.com/merchants/answer/14629205): merchant_id,
+	 * order_id, email, delivery_country, and estimated_delivery_date. There is no products/GTIN
+	 * parameter. `opt_in_style` is intentionally omitted to use Google's default.
+	 *
+	 * @param array $params
+	 *
+	 * @return string
+	 */
+	protected function get_opt_in_snippet_markup( array $params ): string {
+		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript -- Google-hosted script, not a local asset.
+		return sprintf(
+			'<script src="https://apis.google.com/js/platform.js?onload=renderOptIn" async defer></script>' .
+			'<script>window.renderOptIn=function(){window.gapi.load("surveyoptin",function(){window.gapi.surveyoptin.render(%s);});};</script>',
+			wp_json_encode( $params )
+		);
+		// phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+	}
+}

--- a/src/Google/ReviewsOptIn.php
+++ b/src/Google/ReviewsOptIn.php
@@ -78,11 +78,11 @@ class ReviewsOptIn implements Service, Registerable, OptionsAwareInterface {
 	 * destination country. No fallback/default delivery date is ever invented.
 	 */
 	public function maybe_display_opt_in_snippet(): void {
-		if ( ! $this->is_reviews_collection_enabled() ) {
+		if ( ! is_order_received_page() ) {
 			return;
 		}
 
-		if ( ! is_order_received_page() ) {
+		if ( ! $this->is_reviews_collection_enabled() ) {
 			return;
 		}
 

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -42,6 +42,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDat
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiPromotionsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\YouTube\Connection as YouTubeConnection;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\RequestReviewStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\ReviewsOptIn;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\SiteVerificationMeta;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\ViewFactory;
@@ -149,6 +150,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		DateTimeUtility::class           => true,
 		EventTracking::class             => true,
 		GlobalSiteTag::class             => true,
+		ReviewsOptIn::class              => true,
 		ISOUtility::class                => true,
 		SiteVerificationEvents::class    => true,
 		OptionsInterface::class          => true,
@@ -283,6 +285,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( RESTControllers::class );
 		$this->share_with_tags( CompleteSetupTask::class );
 		$this->conditionally_share_with_tags( GlobalSiteTag::class, AssetsHandlerInterface::class, GoogleGtagJs::class, ProductHelper::class, WC::class, WP::class );
+		$this->share_with_tags( ReviewsOptIn::class, ShippingTimeQuery::class, WP::class );
 		$this->share_with_tags( SiteVerificationMeta::class );
 		$this->conditionally_share_with_tags( MerchantSetupCompleted::class );
 		$this->conditionally_share_with_tags( AdsSetupCompleted::class );

--- a/tests/Unit/Google/ReviewsOptInTest.php
+++ b/tests/Unit/Google/ReviewsOptInTest.php
@@ -1,0 +1,193 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\ReviewsOptIn;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+use WC_Helper_Order;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ReviewsOptInTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Google
+ */
+class ReviewsOptInTest extends UnitTest {
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var MockObject|ShippingTimeQuery $shipping_time_query */
+	protected $shipping_time_query;
+
+	/** @var MockObject|WP $wp */
+	protected $wp;
+
+	/** @var ReviewsOptIn $opt_in */
+	protected $opt_in;
+
+	protected const TEST_MERCHANT_ID = 12345;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->options             = $this->createMock( OptionsInterface::class );
+		$this->shipping_time_query = $this->createMock( ShippingTimeQuery::class );
+		$this->wp                  = $this->createMock( WP::class );
+
+		$this->opt_in = new ReviewsOptIn( $this->shipping_time_query, $this->wp );
+		$this->opt_in->set_options_object( $this->options );
+
+		unset( $_GET['key'] );
+	}
+
+	/**
+	 * Runs after each test is executed.
+	 */
+	public function tearDown(): void {
+		unset( $_GET['key'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Create a fully-qualified order ready to be prompted, and wire up the mocks so the happy
+	 * path succeeds, unless a test overrides one of them afterwards.
+	 *
+	 * @return \WC_Order
+	 */
+	protected function create_eligible_order() {
+		add_filter( 'woocommerce_is_order_received_page', '__return_true' );
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_shipping_country( 'US' );
+		$order->set_billing_email( 'shopper@example.com' );
+		$order->save();
+
+		$_GET['key'] = $order->get_order_key();
+
+		$this->wp->method( 'get_query_vars' )->with( 'order-received' )->willReturn( $order->get_id() );
+
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [ 'collect_reviews_after_purchase' => true ] );
+
+		$this->options->method( 'get_merchant_id' )->willReturn( self::TEST_MERCHANT_ID );
+
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn(
+			[
+				'US' => [
+					'country_code' => 'US',
+					'time'         => '3',
+					'max_time'     => '5',
+				],
+			]
+		);
+
+		return $order;
+	}
+
+	public function test_injects_snippet_when_enabled_and_delivery_time_available() {
+		$order = $this->create_eligible_order();
+
+		$this->expectOutputRegex( '/surveyoptin\.render/' );
+
+		$this->opt_in->maybe_display_opt_in_snippet();
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertSame( 1, (int) $order->get_meta( '_gla_gcr_opt_in_prompted', true ) );
+	}
+
+	public function test_snippet_contains_expected_parameters_and_omits_opt_in_style() {
+		$order = $this->create_eligible_order();
+
+		ob_start();
+		$this->opt_in->maybe_display_opt_in_snippet();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '"merchant_id":' . self::TEST_MERCHANT_ID, $output );
+		$this->assertStringContainsString( '"order_id":"' . $order->get_id() . '"', $output );
+		$this->assertStringContainsString( '"email":"shopper@example.com"', $output );
+		$this->assertStringContainsString( '"delivery_country":"US"', $output );
+		$this->assertStringContainsString( '"estimated_delivery_date":"', $output );
+		$this->assertStringNotContainsString( 'opt_in_style', $output );
+	}
+
+	public function test_no_injection_when_setting_disabled() {
+		$this->create_eligible_order();
+
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->opt_in->set_options_object( $this->options );
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [ 'collect_reviews_after_purchase' => false ] );
+
+		$this->expectOutputString( '' );
+
+		$this->opt_in->maybe_display_opt_in_snippet();
+	}
+
+	public function test_no_injection_when_not_order_received_page() {
+		$this->create_eligible_order();
+		add_filter( 'woocommerce_is_order_received_page', '__return_false' );
+
+		$this->expectOutputString( '' );
+
+		$this->opt_in->maybe_display_opt_in_snippet();
+	}
+
+	public function test_no_injection_when_order_key_invalid() {
+		$this->create_eligible_order();
+		$_GET['key'] = 'not-the-right-key';
+
+		$this->expectOutputString( '' );
+
+		$this->opt_in->maybe_display_opt_in_snippet();
+	}
+
+	public function test_no_injection_when_already_prompted() {
+		$order = $this->create_eligible_order();
+		$order->update_meta_data( '_gla_gcr_opt_in_prompted', 1 );
+		$order->save_meta_data();
+
+		$this->expectOutputString( '' );
+
+		$this->opt_in->maybe_display_opt_in_snippet();
+	}
+
+	public function test_no_injection_when_merchant_center_not_connected() {
+		$this->create_eligible_order();
+
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->opt_in->set_options_object( $this->options );
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [ 'collect_reviews_after_purchase' => true ] );
+		$this->options->method( 'get_merchant_id' )->willReturn( 0 );
+
+		$this->expectOutputString( '' );
+
+		$this->opt_in->maybe_display_opt_in_snippet();
+	}
+
+	public function test_no_injection_when_destination_country_has_no_shipping_time_entry() {
+		$this->create_eligible_order();
+
+		$this->shipping_time_query = $this->createMock( ShippingTimeQuery::class );
+		$this->opt_in              = new ReviewsOptIn( $this->shipping_time_query, $this->wp );
+		$this->opt_in->set_options_object( $this->options );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [] );
+
+		$this->expectOutputString( '' );
+
+		$this->opt_in->maybe_display_opt_in_snippet();
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes:

- https://linear.app/a8c/issue/GOOWOO-866/post-purchase-opt-in-prompt

Injects Google's Customer Reviews (GCR) post-purchase opt-in snippet on the order-confirmation page, so a shopper who just completed an order can opt in to a later Google review request. The snippet, popup, and follow-up survey/email are entirely Google-hosted — this PR only supplies the data Google's snippet needs and controls whether it fires at all.

- Adds `ReviewsOptIn`, hooked on `wp_body_open` + `is_order_received_page()` — a template-agnostic combination modeled directly on this plugin's own `GlobalSiteTag` injection pattern, not `woocommerce_thankyou`, so classic and block-based (Order Confirmation block) checkout are covered by a single code path with no branching. Verified against WooCommerce core that both checkout types resolve the order via the same `get_query_var('order-received')` + `$_GET['key']` mechanism this class replicates.
- Gated on the "Collect reviews after purchase" setting (`collect_reviews_after_purchase`, from the sibling ticket below) — read live on each page load, so a merchant toggling it off between order placement and confirmation-page load correctly suppresses injection.
- Idempotency guard via `_gla_gcr_opt_in_prompted` order meta, same pattern as `GlobalSiteTag::maybe_display_purchase_event_snippet()`, to prevent duplicate injection on repeat page loads.
- `estimated_delivery_date` is resolved from this plugin's own "Estimated shipping times" data (`ShippingTimeQuery`) for the order's destination country. When no entry exists for that country, injection is skipped entirely for that order — no fallback/default date is ever invented.
- Snippet parameters: `merchant_id`, `order_id`, `email`, `delivery_country`, `estimated_delivery_date`. `opt_in_style` is intentionally left unset to use Google's default (not merchant-configurable in this phase). Verified the parameter set against Google's own published GCR opt-in documentation.

Dependencies:
https://github.com/woocommerce/google-listings-and-ads/pull/3680
https://github.com/woocommerce/google-listings-and-ads/pull/3675
https://github.com/woocommerce/google-listings-and-ads/pull/3676

Out of scope (per ticket): per-product review requests (GCR is store-level only), custom email timing (Google controls this via the estimated delivery date), rendering any WooCommerce page/email for the follow-up survey, and a merchant-facing fallback delivery-estimate setting.

### Screenshots:

<img width="1501" height="971" alt="Screenshot 2026-08-06 at 11 38 04 PM" src="https://github.com/user-attachments/assets/026c7642-c069-42d8-b341-a6a09dd2ff2a" />

### Detailed test instructions:

**Automated coverage** (run first):

1. PHP: `composer test-unit -- --filter ReviewsOptInTest` — covers injection when enabled/disabled, missing shipping-time data (no fallback substituted), the idempotency guard, correct snippet parameters with `opt_in_style` omitted, and the setting being re-checked live at render time.

**Manual verification** (requires a store connected to Merchant Center with the "Collect reviews after purchase" setting available):

1. Add an "Estimated shipping times" entry for a test country (e.g. US) under the plugin's shipping settings.
2. Enable "Collect reviews after purchase".
3. Place a test order shipping to that country and land on the order-confirmation page. Confirm the GCR opt-in script and popup appear (view source for the `apis.google.com/js/platform.js` / `gapi.surveyoptin.render` snippet).
4. Reload the confirmation page — confirm the snippet is not injected a second time.
5. Disable "Collect reviews after purchase" and reload the confirmation page for a *different*, not-yet-prompted order — confirm no snippet is injected.
6. Place an order shipping to a country with no "Estimated shipping times" entry — confirm no snippet is injected for that order.

### Additional details:

### Changelog entry

No changelog entry needed — this PR merges into `feature/google-customer-reviews`, not `develop`/`trunk`. A changelog entry should be added on whichever PR in this stack ultimately merges into `develop`. `changelog: none` label applied here.