### PR TITLE
GOOWOO-867: Inject Google reviews badge widget script on storefront

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/SettingsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsController.php
@@ -184,6 +184,20 @@ class SettingsController extends BaseOptionsController {
 				'validate_callback' => 'rest_validate_request_arg',
 				'default'           => false,
 			],
+			'badge_widget_position'          => [
+				'type'              => 'string',
+				'description'       => __(
+					'The corner of the storefront in which to display the ratings and reviews badge widget.',
+					'google-listings-and-ads'
+				),
+				'context'           => [ 'view', 'edit' ],
+				'validate_callback' => 'rest_validate_request_arg',
+				'enum'              => [
+					'bottom-left',
+					'bottom-right',
+				],
+				'default'           => 'bottom-right',
+			],
 		];
 	}
 

--- a/src/Google/BadgeWidget.php
+++ b/src/Google/BadgeWidget.php
@@ -1,0 +1,126 @@
+<?php
+declare( strict_types=1 );
+
+/**
+ * Google ratings and reviews badge widget.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds
+ */
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Injects Google's ratings and reviews badge widget script storefront-wide.
+ *
+ * Modeled on GlobalSiteTag's wp_head injection shape, but for a template-agnostic floating
+ * widget rather than a tracking pixel. Google's own script renders the aggregate rating; no
+ * ratings data is fetched, cached, or stored by this plugin.
+ */
+class BadgeWidget implements Service, Registerable, OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/** @var string Key of the badge widget enabled flag within OptionsInterface::MERCHANT_CENTER. */
+	protected const SETTING_ENABLED = 'badge_widget_enabled';
+
+	/** @var string Key of the badge widget position setting within OptionsInterface::MERCHANT_CENTER. */
+	protected const SETTING_POSITION = 'badge_widget_position';
+
+	/** @var string Default badge position, used when no position setting is stored yet. */
+	protected const DEFAULT_POSITION = 'bottom-right';
+
+	/** @var array Map of accepted position setting values to Google's expected position arguments. */
+	protected const POSITION_MAP = [
+		'bottom-left'  => 'BOTTOM_LEFT',
+		'bottom-right' => 'BOTTOM_RIGHT',
+	];
+
+	/**
+	 * Register the service.
+	 */
+	public function register(): void {
+		add_action(
+			'wp_head',
+			function () {
+				$this->maybe_display_badge_snippet();
+			},
+			999999
+		);
+	}
+
+	/**
+	 * Display the Google ratings and reviews badge widget snippet, if the badge widget setting is
+	 * enabled and a Merchant Center account is connected (i.e. a Merchant ID is available). Google's
+	 * own script renders the aggregate rating; no ratings data is fetched, cached, or stored here.
+	 */
+	public function maybe_display_badge_snippet(): void {
+		if ( ! $this->is_badge_widget_enabled() ) {
+			return;
+		}
+
+		$merchant_id = $this->options->get_merchant_id();
+		if ( ! $merchant_id ) {
+			return;
+		}
+
+		echo $this->get_badge_snippet_markup( $merchant_id, $this->get_badge_position() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/**
+	 * Whether the "Reviews badge widget" setting is currently enabled.
+	 *
+	 * @return bool
+	 */
+	protected function is_badge_widget_enabled(): bool {
+		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
+		return ! empty( $settings[ self::SETTING_ENABLED ] );
+	}
+
+	/**
+	 * Resolve the merchant's chosen badge corner position, mapped to Google's expected argument.
+	 * Falls back to the default position for a missing or unrecognized stored value.
+	 *
+	 * @return string
+	 */
+	protected function get_badge_position(): string {
+		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+		$position = $settings[ self::SETTING_POSITION ] ?? self::DEFAULT_POSITION;
+
+		return self::POSITION_MAP[ $position ] ?? self::POSITION_MAP[ self::DEFAULT_POSITION ];
+	}
+
+	/**
+	 * Build the Google ratings and reviews badge widget snippet markup.
+	 *
+	 * Per Google's documented badge embed code: merchant_id and position are the only parameters.
+	 * Google's script renders the aggregate rating itself; no ratings data is passed or stored.
+	 *
+	 * @param int    $merchant_id
+	 * @param string $position
+	 *
+	 * @return string
+	 */
+	protected function get_badge_snippet_markup( int $merchant_id, string $position ): string {
+		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript -- Google-hosted script, not a local asset.
+		return sprintf(
+			'<script src="https://apis.google.com/js/platform.js?onload=renderBadge" async defer></script>' .
+			'<script>window.renderBadge=function(){var c=document.createElement("div");document.body.appendChild(c);window.gapi.load("ratingbadge",function(){window.gapi.ratingbadge.render(c,%s);});};</script>',
+			wp_json_encode(
+				[
+					'merchant_id' => $merchant_id,
+					'position'    => $position,
+				]
+			)
+		);
+		// phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+	}
+}

--- a/src/Google/BadgeWidget.php
+++ b/src/Google/BadgeWidget.php
@@ -62,7 +62,9 @@ class BadgeWidget implements Service, Registerable, OptionsAwareInterface {
 	 * own script renders the aggregate rating; no ratings data is fetched, cached, or stored here.
 	 */
 	public function maybe_display_badge_snippet(): void {
-		if ( ! $this->is_badge_widget_enabled() ) {
+		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
+		if ( ! $this->is_badge_widget_enabled( $settings ) ) {
 			return;
 		}
 
@@ -71,17 +73,17 @@ class BadgeWidget implements Service, Registerable, OptionsAwareInterface {
 			return;
 		}
 
-		echo $this->get_badge_snippet_markup( $merchant_id, $this->get_badge_position() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo $this->get_badge_snippet_markup( $merchant_id, $this->get_badge_position( $settings ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**
 	 * Whether the "Reviews badge widget" setting is currently enabled.
 	 *
+	 * @param array $settings The OptionsInterface::MERCHANT_CENTER settings array.
+	 *
 	 * @return bool
 	 */
-	protected function is_badge_widget_enabled(): bool {
-		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
-
+	protected function is_badge_widget_enabled( array $settings ): bool {
 		return ! empty( $settings[ self::SETTING_ENABLED ] );
 	}
 
@@ -89,10 +91,11 @@ class BadgeWidget implements Service, Registerable, OptionsAwareInterface {
 	 * Resolve the merchant's chosen badge corner position, mapped to Google's expected argument.
 	 * Falls back to the default position for a missing or unrecognized stored value.
 	 *
+	 * @param array $settings The OptionsInterface::MERCHANT_CENTER settings array.
+	 *
 	 * @return string
 	 */
-	protected function get_badge_position(): string {
-		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+	protected function get_badge_position( array $settings ): string {
 		$position = $settings[ self::SETTING_POSITION ] ?? self::DEFAULT_POSITION;
 
 		return self::POSITION_MAP[ $position ] ?? self::POSITION_MAP[ self::DEFAULT_POSITION ];

--- a/src/Google/BadgeWidget.php
+++ b/src/Google/BadgeWidget.php
@@ -18,7 +18,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Injects Google's ratings and reviews badge widget script storefront-wide.
+ * Injects Google's store widget (formerly "Customer Reviews badge") script storefront-wide.
  *
  * Modeled on GlobalSiteTag's wp_head injection shape, but for a template-agnostic floating
  * widget rather than a tracking pixel. Google's own script renders the aggregate rating; no
@@ -37,10 +37,10 @@ class BadgeWidget implements Service, Registerable, OptionsAwareInterface {
 	/** @var string Default badge position, used when no position setting is stored yet. */
 	protected const DEFAULT_POSITION = 'bottom-right';
 
-	/** @var array Map of accepted position setting values to Google's expected position arguments. */
+	/** @var array Map of accepted position setting values to the store widget's expected position arguments. */
 	protected const POSITION_MAP = [
-		'bottom-left'  => 'BOTTOM_LEFT',
-		'bottom-right' => 'BOTTOM_RIGHT',
+		'bottom-left'  => 'LEFT_BOTTOM',
+		'bottom-right' => 'RIGHT_BOTTOM',
 	];
 
 	/**
@@ -99,10 +99,12 @@ class BadgeWidget implements Service, Registerable, OptionsAwareInterface {
 	}
 
 	/**
-	 * Build the Google ratings and reviews badge widget snippet markup.
+	 * Build the Google store widget (formerly "Customer Reviews badge") snippet markup.
 	 *
-	 * Per Google's documented badge embed code: merchant_id and position are the only parameters.
-	 * Google's script renders the aggregate rating itself; no ratings data is passed or stored.
+	 * Per Google's documented widget embed code (support.google.com/merchants/answer/14632921):
+	 * merchant_id and position are the only parameters passed. `region` is intentionally omitted
+	 * so the widget falls back to Google's own globalization logic to determine it. Google's
+	 * script renders the aggregate rating itself; no ratings data is passed or stored.
 	 *
 	 * @param int    $merchant_id
 	 * @param string $position
@@ -112,8 +114,8 @@ class BadgeWidget implements Service, Registerable, OptionsAwareInterface {
 	protected function get_badge_snippet_markup( int $merchant_id, string $position ): string {
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript -- Google-hosted script, not a local asset.
 		return sprintf(
-			'<script src="https://apis.google.com/js/platform.js?onload=renderBadge" async defer></script>' .
-			'<script>window.renderBadge=function(){var c=document.createElement("div");document.body.appendChild(c);window.gapi.load("ratingbadge",function(){window.gapi.ratingbadge.render(c,%s);});};</script>',
+			'<script id="merchantWidgetScript" src="https://www.gstatic.com/shopping/merchant/merchantwidget.js" defer></script>' .
+			'<script>merchantWidgetScript.addEventListener("load",function(){merchantwidget.start(%s);});</script>',
 			wp_json_encode(
 				[
 					'merchant_id' => $merchant_id,

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -35,6 +35,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\TableManager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Event\ClearProductStatsCache;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\BadgeWidget;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GlobalSiteTag;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelperAwareInterface;
@@ -151,6 +152,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		EventTracking::class             => true,
 		GlobalSiteTag::class             => true,
 		ReviewsOptIn::class              => true,
+		BadgeWidget::class               => true,
 		ISOUtility::class                => true,
 		SiteVerificationEvents::class    => true,
 		OptionsInterface::class          => true,
@@ -286,6 +288,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( CompleteSetupTask::class );
 		$this->conditionally_share_with_tags( GlobalSiteTag::class, AssetsHandlerInterface::class, GoogleGtagJs::class, ProductHelper::class, WC::class, WP::class );
 		$this->share_with_tags( ReviewsOptIn::class, ShippingTimeQuery::class, WP::class );
+		$this->share_with_tags( BadgeWidget::class );
 		$this->share_with_tags( SiteVerificationMeta::class );
 		$this->conditionally_share_with_tags( MerchantSetupCompleted::class );
 		$this->conditionally_share_with_tags( AdsSetupCompleted::class );

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -53,6 +53,7 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 			'shipping_rates_count'           => 1,
 			'collect_reviews_after_purchase' => false,
 			'badge_widget_enabled'           => false,
+			'badge_widget_position'          => 'bottom-right',
 		];
 
 		$response = $this->do_request( self::ROUTE, 'GET' );
@@ -80,6 +81,7 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 					'shipping_time'                  => 'manual',
 					'collect_reviews_after_purchase' => false,
 					'badge_widget_enabled'           => false,
+					'badge_widget_position'          => 'bottom-right',
 				]
 			)
 		);
@@ -124,6 +126,7 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 			'tax_rate'                       => 'destination',
 			'collect_reviews_after_purchase' => false,
 			'badge_widget_enabled'           => false,
+			'badge_widget_position'          => 'bottom-right',
 		];
 
 		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
@@ -161,6 +164,7 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 			'tax_rate'                       => 'destination',
 			'collect_reviews_after_purchase' => false,
 			'badge_widget_enabled'           => false,
+			'badge_widget_position'          => 'bottom-right',
 		];
 
 		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
@@ -182,5 +186,43 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertTrue( $response->get_data()['data']['badge_widget_enabled'] );
+	}
+
+	public function test_default_badge_widget_position_setting() {
+		$response = $this->do_request( self::ROUTE );
+
+		$this->assertEquals( 'bottom-right', $response->get_data()['badge_widget_position'] );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_edit_badge_widget_position_setting() {
+		$options = [
+			'shipping_rate'                  => 'flat',
+			'shipping_time'                  => 'flat',
+			'tax_rate'                       => 'destination',
+			'collect_reviews_after_purchase' => false,
+			'badge_widget_enabled'           => false,
+			'badge_widget_position'          => 'bottom-right',
+		];
+
+		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
+			$options
+		);
+
+		$this->options->expects( $this->once() )->method( 'update' )->with(
+			OptionsInterface::MERCHANT_CENTER,
+			array_merge( $options, [ 'badge_widget_position' => 'bottom-left' ] )
+		);
+
+		$response = $this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'badge_widget_position' => 'bottom-left',
+			]
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'bottom-left', $response->get_data()['data']['badge_widget_position'] );
 	}
 }

--- a/tests/Unit/Google/BadgeWidgetTest.php
+++ b/tests/Unit/Google/BadgeWidgetTest.php
@@ -1,0 +1,99 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\BadgeWidget;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class BadgeWidgetTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Google
+ */
+class BadgeWidgetTest extends UnitTest {
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var BadgeWidget $badge_widget */
+	protected $badge_widget;
+
+	protected const TEST_MERCHANT_ID = 12345;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->options      = $this->createMock( OptionsInterface::class );
+		$this->badge_widget = new BadgeWidget();
+		$this->badge_widget->set_options_object( $this->options );
+	}
+
+	protected function mock_settings( array $overrides = [] ): void {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn(
+				array_merge(
+					[ 'badge_widget_enabled' => true ],
+					$overrides
+				)
+			);
+
+		$this->options->method( 'get_merchant_id' )->willReturn( self::TEST_MERCHANT_ID );
+	}
+
+	public function test_injects_snippet_when_enabled_and_merchant_id_available() {
+		$this->mock_settings();
+
+		$this->expectOutputRegex( '/ratingbadge\.render/' );
+
+		$this->badge_widget->maybe_display_badge_snippet();
+	}
+
+	public function test_snippet_contains_merchant_id_and_default_position() {
+		$this->mock_settings();
+
+		ob_start();
+		$this->badge_widget->maybe_display_badge_snippet();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '"merchant_id":' . self::TEST_MERCHANT_ID, $output );
+		$this->assertStringContainsString( '"position":"BOTTOM_RIGHT"', $output );
+	}
+
+	public function test_snippet_contains_configured_position() {
+		$this->mock_settings( [ 'badge_widget_position' => 'bottom-left' ] );
+
+		ob_start();
+		$this->badge_widget->maybe_display_badge_snippet();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '"position":"BOTTOM_LEFT"', $output );
+	}
+
+	public function test_no_injection_when_setting_disabled() {
+		$this->mock_settings( [ 'badge_widget_enabled' => false ] );
+
+		$this->expectOutputString( '' );
+
+		$this->badge_widget->maybe_display_badge_snippet();
+	}
+
+	public function test_no_injection_when_merchant_center_not_connected() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->willReturn( [ 'badge_widget_enabled' => true ] );
+		$this->options->method( 'get_merchant_id' )->willReturn( 0 );
+
+		$this->expectOutputString( '' );
+
+		$this->badge_widget->maybe_display_badge_snippet();
+	}
+}

--- a/tests/Unit/Google/BadgeWidgetTest.php
+++ b/tests/Unit/Google/BadgeWidgetTest.php
@@ -52,9 +52,19 @@ class BadgeWidgetTest extends UnitTest {
 	public function test_injects_snippet_when_enabled_and_merchant_id_available() {
 		$this->mock_settings();
 
-		$this->expectOutputRegex( '/ratingbadge\.render/' );
+		$this->expectOutputRegex( '/merchantwidget\.start/' );
 
 		$this->badge_widget->maybe_display_badge_snippet();
+	}
+
+	public function test_snippet_loads_the_store_widget_script() {
+		$this->mock_settings();
+
+		ob_start();
+		$this->badge_widget->maybe_display_badge_snippet();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'https://www.gstatic.com/shopping/merchant/merchantwidget.js', $output );
 	}
 
 	public function test_snippet_contains_merchant_id_and_default_position() {
@@ -65,7 +75,7 @@ class BadgeWidgetTest extends UnitTest {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( '"merchant_id":' . self::TEST_MERCHANT_ID, $output );
-		$this->assertStringContainsString( '"position":"BOTTOM_RIGHT"', $output );
+		$this->assertStringContainsString( '"position":"RIGHT_BOTTOM"', $output );
 	}
 
 	public function test_snippet_contains_configured_position() {
@@ -75,7 +85,7 @@ class BadgeWidgetTest extends UnitTest {
 		$this->badge_widget->maybe_display_badge_snippet();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( '"position":"BOTTOM_LEFT"', $output );
+		$this->assertStringContainsString( '"position":"LEFT_BOTTOM"', $output );
 	}
 
 	public function test_no_injection_when_setting_disabled() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes GOOWOO-867.

Adds a small PHP Service class (`BadgeWidget`), modeled on `GlobalSiteTag`'s `wp_head` injection shape, that injects Google's own client-side floating ratings/reviews badge script storefront-wide. Google renders the aggregate rating itself, so no ratings data is fetched, cached, or stored by the plugin.

- Hooks `wp_head` (priority `999999`, same as `GlobalSiteTag`) so it's not tied to any specific page template.
- Only echoes the snippet when `badge_widget_enabled` is true **and** a Merchant ID is available (`Options::get_merchant_id()` is non-zero) — otherwise nothing is output at all.
- Parameterizes the snippet with the Merchant ID and the merchant's chosen `badge_widget_position` (bottom-left/bottom-right), mapped through a fixed whitelist to Google's expected LEFT_BOTTOM/RIGHT_BOTTOM argument, defaulting to bottom-right.
- Adds the `badge_widget_position` key to the `mc/settings` schema (`badge_widget_enabled` already existed from prior scaffolding) so the settings-UI sibling ticket (GOOWOO-868) has both keys to read/write.
- Registered in `CoreServiceProvider` the same way as `GlobalSiteTag`/`ReviewsOptIn`.

Out of scope (left for GOOWOO-868 and future work, per the ticket):
- The settings toggle / position-picker UI.
- Displaying individual review quotes (not exposed by any Google API — only the aggregate badge is).
- Pixel-level badge positioning (only Google's default corner arguments are supported).

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Enable the setting and connect Merchant Center: `POST /wc/gla/mc/settings` with `{"badge_widget_enabled": true}`, on a store with a connected Merchant Center account (so `get_merchant_id()` is non-zero).
2. Load any storefront page (shop, single product, cart) and view source — confirm a `<script id="merchantWidgetScript" src="https://www.gstatic.com/shopping/merchant/merchantwidget.js" defer>` tag and an inline `merchantwidget.start(...)` call appear in `<head>`, with the correct Merchant ID and `"position":"RIGHT_BOTTOM"`.
3. `POST /wc/gla/mc/settings` with `{"badge_widget_position": "bottom-left"}`, reload a storefront page, confirm the snippet now shows `"position":"LEFT_BOTTOM"`.
4. `POST /wc/gla/mc/settings` with `{"badge_widget_enabled": false}`, reload — confirm the script is completely absent from the page source (not merely hidden via CSS).
5. With the setting re-enabled, disconnect Merchant Center (or otherwise force `get_merchant_id()` to `0`), reload — confirm the script is still completely absent.
6. Run `vendor/bin/phpunit --filter "BadgeWidgetTest|SettingsControllerTest"` — all new/updated tests pass.
7. Run `vendor/bin/phpcs` and `vendor/bin/phpcs --standard=tests/phpcs.xml.dist` — no new coding-standard violations.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>