### PR TITLE
Compatibility testing with WordPress 7.1 RC

### DIFF
--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -7,8 +7,8 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
- * Requires at least: 6.8
- * Tested up to: 7.0
+ * Requires at least: 6.9
+ * Tested up to: 7.1
  * Requires PHP: 7.4
  * Requires PHP Architecture: 64 bits
  * Requires Plugins: woocommerce

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Google for WooCommerce ===
 Contributors: automattic, google, woocommerce
 Tags: woocommerce, google, product feed, ads, listings
-Requires at least: 6.6
-Tested up to: 7.0
+Requires at least: 6.9
+Tested up to: 7.1
 Requires PHP: 7.4
 Requires PHP Architecture: 64 Bits
 Stable tag: 3.9.0


### PR DESCRIPTION
### Changes proposed in this Pull Request:



Confirms plugin compatibility with WordPress 7.1 (final release scheduled for August 19, 2026) and updates the plugin's declared version support accordingly:

- Bump `Tested up to` from `7.0` to `7.1` in `google-listings-and-ads.php` and `readme.txt`.
- Bump `Requires at least` from `6.8`/`6.6` to `6.9` in `google-listings-and-ads.php` and `readme.txt` (reconciling a previous mismatch between the two files).

No functional/code changes — this is a version-header-only update after manually verifying the plugin against WordPress 7.1 RC.


Closes  https://linear.app/a8c/issue/GOOWOO-919/compatibility-testing-with-wordpress-71-rc

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Install/update to WordPress 7.1 (RC1 or later).
2. Activate Google for WooCommerce and confirm no PHP warnings/notices appear on activation.
3. Run through core flows (onboarding, product sync, Merchant Center connection) and confirm no regressions on WP 7.1.



### Changelog entry

> Dev - Bump WordPress "tested up to" version 7.1.
> Dev - Bump WordPress "requires at least" version 6.9.
