### PR TITLE
GOOWOO-898 [FE] Analytics overview promo section registration

### DIFF
--- a/js/src/analytics-overview/index.js
+++ b/js/src/analytics-overview/index.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
+import { lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@woocommerce/components';
+
+/**
+ * Dynamically imports the Analytics Overview Promo component.
+ */
+const AnalyticsOverviewPromo = lazy( () =>
+	import(
+		/* webpackChunkName: "analytics-overview-promo" */ '~/components/analytics-overview-promo'
+	)
+);
+
+/**
+ * Lazy-loads and renders the Analytics Overview Promo component, wrapped in a Suspense component.
+ *
+ * @param {Object} props Props core passes down to the Analytics Overview Promo component (path, query, title, controls, etc.).
+ * @return {JSX.Element} The Analytics Overview Promo component, wrapped in a Suspense component.
+ */
+const SectionComponent = ( props ) => (
+	<Suspense fallback={ <Spinner /> }>
+		<AnalyticsOverviewPromo { ...props } />
+	</Suspense>
+);
+
+/*
+ * Registered unconditionally at module-evaluation time so it runs before the lazily-loaded
+ * `customizable-dashboard` chunk applies this filter when a merchant visits
+ * Analytics → Overview.
+ */
+addFilter(
+	'woocommerce_dashboard_default_sections',
+	'woocommerce/google-listings-and-ads/add-analytics-overview-section',
+	( sections ) => [
+		{
+			key: 'google-listings-and-ads-analytics-overview-promo',
+			component: SectionComponent,
+			title: __( 'Analytics Overview Promo', 'google-listings-and-ads' ),
+			icon: 'megaphone',
+			isVisible: true,
+			hiddenBlocks: [],
+		},
+		...sections,
+	]
+);
+
+export default SectionComponent;

--- a/js/src/components/analytics-overview-promo/index.js
+++ b/js/src/components/analytics-overview-promo/index.js
@@ -13,7 +13,7 @@ import './index.scss';
  * `woocommerce_dashboard_default_sections` filter registered in
  * `~/analytics-overview`.
  *
- * @return {JSX.Element} Ananlytics promo component.
+ * @return {JSX.Element} Analytics promo component.
  */
 const AnalyticsOverviewPromo = () => (
 	<div className="gla-analytics-overview-promo">

--- a/js/src/components/analytics-overview-promo/index.js
+++ b/js/src/components/analytics-overview-promo/index.js
@@ -9,11 +9,11 @@ import { __ } from '@wordpress/i18n';
 import './index.scss';
 
 /**
- * Placeholder for the Analytics → Overview dashboard section, mounted by the
+ * Analytics overview promo section for the Analytics → Overview page, mounted by the
  * `woocommerce_dashboard_default_sections` filter registered in
- * `~/analytics-overview`.
+ * `~/filters/analytics-overview-section`.
  *
- * @return {JSX.Element} Analytics promo component.
+ * @return {JSX.Element} Analytics overview promo component.
  */
 const AnalyticsOverviewPromo = () => (
 	<div className="gla-analytics-overview-promo">

--- a/js/src/components/analytics-overview-promo/index.js
+++ b/js/src/components/analytics-overview-promo/index.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './index.scss';
+
+/**
+ * Placeholder for the Analytics → Overview dashboard section, mounted by the
+ * `woocommerce_dashboard_default_sections` filter registered in
+ * `~/analytics-overview`.
+ *
+ * @return {JSX.Element} Ananlytics promo component.
+ */
+const AnalyticsOverviewPromo = () => (
+	<div className="gla-analytics-overview-promo">
+		{ __( 'placeholder', 'google-listings-and-ads' ) }
+	</div>
+);
+
+export default AnalyticsOverviewPromo;

--- a/js/src/components/analytics-overview-promo/index.scss
+++ b/js/src/components/analytics-overview-promo/index.scss
@@ -1,0 +1,3 @@
+.gla-analytics-overview-promo {
+	/* Styles go here */
+}

--- a/js/src/components/analytics-overview-promo/index.test.js
+++ b/js/src/components/analytics-overview-promo/index.test.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import AnalyticsOverviewPromo from './index';
+
+describe( 'AnalyticsOverviewPromo', () => {
+	it( 'renders a placeholder', () => {
+		render( <AnalyticsOverviewPromo /> );
+
+		expect( screen.getByText( 'placeholder' ) ).toBeInTheDocument();
+	} );
+} );

--- a/js/src/filters/analytics-overview-section.js
+++ b/js/src/filters/analytics-overview-section.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import { lazy, Suspense } from '@wordpress/element';
-import { Spinner } from '@woocommerce/components';
 
 /**
  * Dynamically imports the Analytics Overview Promo component.
@@ -22,15 +21,13 @@ const AnalyticsOverviewPromo = lazy( () =>
  * @return {JSX.Element} The Analytics Overview Promo component, wrapped in a Suspense component.
  */
 const SectionComponent = ( props ) => (
-	<Suspense fallback={ <Spinner /> }>
+	<Suspense fallback={ null }>
 		<AnalyticsOverviewPromo { ...props } />
 	</Suspense>
 );
 
-/*
- * Registered unconditionally at module-evaluation time so it runs before the lazily-loaded
- * `customizable-dashboard` chunk applies this filter when a merchant visits
- * Analytics → Overview.
+/**
+ * Adds the Analytics Overview Promo section to the WooCommerce Analytics Overview page.
  */
 addFilter(
 	'woocommerce_dashboard_default_sections',
@@ -42,7 +39,6 @@ addFilter(
 			title: __( 'Analytics Overview Promo', 'google-listings-and-ads' ),
 			icon: 'megaphone',
 			isVisible: true,
-			hiddenBlocks: [],
 		},
 		...sections,
 	]

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -14,7 +14,7 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
 import './css/index.scss';
 import withAdminPageShell from '~/components/withAdminPageShell';
 import './data';
-import './analytics-overview';
+import './filters/analytics-overview-section';
 import { addBaseEventProperties } from '~/utils/tracks';
 import { glaData } from './constants';
 

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -14,6 +14,7 @@ import { getSetting } from '@woocommerce/settings'; // eslint-disable-line impor
 import './css/index.scss';
 import withAdminPageShell from '~/components/withAdminPageShell';
 import './data';
+import './analytics-overview';
 import { addBaseEventProperties } from '~/utils/tracks';
 import { glaData } from './constants';
 

--- a/tests/e2e/specs/analytics-overview/analytics-overview.test.js
+++ b/tests/e2e/specs/analytics-overview/analytics-overview.test.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { expect, test } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import AnalyticsOverviewPage from '../../utils/pages/analytics-overview';
+
+test.use( { storageState: process.env.ADMINSTATE } );
+
+test.describe.configure( { mode: 'serial' } );
+
+/**
+ * @type {import('../../utils/pages/analytics-overview').default} analyticsOverviewPage
+ */
+let analyticsOverviewPage = null;
+
+/**
+ * @type {import('@playwright/test').Page} page
+ */
+let page = null;
+
+test.describe( 'Analytics Overview', () => {
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		analyticsOverviewPage = new AnalyticsOverviewPage( page );
+		await analyticsOverviewPage.goto();
+	} );
+
+	test.afterAll( async () => {
+		await page.close();
+	} );
+
+	test( 'Renders the Analytics Overview promo section', async () => {
+		await expect(
+			analyticsOverviewPage.getAnalyticsOverviewPromoSection()
+		).toBeVisible();
+	} );
+} );

--- a/tests/e2e/utils/pages/analytics-overview.js
+++ b/tests/e2e/utils/pages/analytics-overview.js
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import { LOAD_STATE } from '../constants';
+import MockRequests from '../mock-requests';
+
+/**
+ * Analytics Overview page object class.
+ */
+export default class AnalyticsOverviewPage extends MockRequests {
+	/**
+	 * @param {import('@playwright/test').Page} page
+	 */
+	constructor( page ) {
+		super( page );
+		this.page = page;
+	}
+
+	/**
+	 * Go to the Analytics Overview page.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async goto() {
+		await this.page.goto(
+			'/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Foverview',
+			{ waitUntil: LOAD_STATE.DOM_CONTENT_LOADED }
+		);
+	}
+
+	/**
+	 * Get the Analytics Overview promo section registered by this plugin.
+	 *
+	 * @return {import('@playwright/test').Locator} The Analytics Overview promo section.
+	 */
+	getAnalyticsOverviewPromoSection() {
+		return this.page.locator( '.gla-analytics-overview-promo' );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-898/register-analytics-overview-dashboard-section

Adds placeholder promo component to analytics overview dashboard and e2e tests.


### Screenshots:

<img width="754" height="248" alt="Screenshot 2026-08-12 at 14 10 37" src="https://github.com/user-attachments/assets/648832c2-55d5-45f9-aea1-8313cf88c3a4" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to Analytics > Overview
2. A new placeholder component should be present under the date filters

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
