### PR TITLE
Fix unbounded coupon scan in CouponsNotSyncedEvaluator

### DIFF
--- a/src/Notification/Evaluators/CouponsNotSyncedEvaluator.php
+++ b/src/Notification/Evaluators/CouponsNotSyncedEvaluator.php
@@ -146,7 +146,7 @@ class CouponsNotSyncedEvaluator implements InvalidatableNotificationEvaluatorInt
 	 * @return bool
 	 */
 	protected function has_supported_coupon(): bool {
-		$total_pages = $this->get_coupon_pages();
+		$total_pages = $this->get_coupon_page_count();
 
 		for ( $page = 1; $page <= $total_pages; $page++ ) {
 			$coupon_post_ids = $this->get_coupon_post_ids( $page );
@@ -164,9 +164,14 @@ class CouponsNotSyncedEvaluator implements InvalidatableNotificationEvaluatorInt
 	/**
 	 * Number of pages of published coupons to scan.
 	 *
+	 * The count comes from wp_count_posts(), which reads cached post counts. If the
+	 * cache lags the database, the last partial page may be undercounted and a
+	 * supported coupon on it missed; the result self-heals once the count cache is
+	 * refreshed and the evaluator cache is invalidated (see get_invalidation_hooks()).
+	 *
 	 * @return int
 	 */
-	protected function get_coupon_pages(): int {
+	protected function get_coupon_page_count(): int {
 		$counts = wp_count_posts( 'shop_coupon' );
 		$total  = isset( $counts->publish ) ? (int) $counts->publish : 0;
 

--- a/src/Notification/Evaluators/CouponsNotSyncedEvaluator.php
+++ b/src/Notification/Evaluators/CouponsNotSyncedEvaluator.php
@@ -139,32 +139,45 @@ class CouponsNotSyncedEvaluator implements InvalidatableNotificationEvaluatorInt
 	 * Whether the merchant has at least one coupon that is supported for syncing.
 	 *
 	 * Pages through published coupons and returns true as soon as a supported one
-	 * is found (see CouponSyncer::is_coupon_supported()).
+	 * is found (see CouponSyncer::is_coupon_supported()). The number of pages is
+	 * computed up front so the loop is always bounded — pagination uses a stable
+	 * ID ordering so pages never overlap or skip candidates.
 	 *
 	 * @return bool
 	 */
 	protected function has_supported_coupon(): bool {
-		$page = 1;
+		$total_pages = $this->get_coupon_pages();
 
-		while ( true ) {
+		for ( $page = 1; $page <= $total_pages; $page++ ) {
 			$coupon_post_ids = $this->get_coupon_post_ids( $page );
-
-			if ( empty( $coupon_post_ids ) ) {
-				return false;
-			}
 
 			foreach ( $coupon_post_ids as $post_id ) {
 				if ( CouponSyncer::is_coupon_supported( $this->create_coupon( $post_id ) ) ) {
 					return true;
 				}
 			}
-
-			++$page;
 		}
+
+		return false;
+	}
+
+	/**
+	 * Number of pages of published coupons to scan.
+	 *
+	 * @return int
+	 */
+	protected function get_coupon_pages(): int {
+		$counts = wp_count_posts( 'shop_coupon' );
+		$total  = isset( $counts->publish ) ? (int) $counts->publish : 0;
+
+		return (int) ceil( $total / self::COUPONS_PER_PAGE );
 	}
 
 	/**
 	 * Get a page of published coupon post IDs.
+	 *
+	 * Ordered by ID ascending so pagination is deterministic: pages return the
+	 * same IDs in the same order on every query, with no overlaps or gaps.
 	 *
 	 * @param int $page Page number for paginated queries.
 	 *
@@ -177,6 +190,8 @@ class CouponsNotSyncedEvaluator implements InvalidatableNotificationEvaluatorInt
 				'post_status'    => 'publish',
 				'posts_per_page' => self::COUPONS_PER_PAGE,
 				'paged'          => $page,
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
 				'fields'         => 'ids',
 			]
 		);

--- a/tests/Unit/Notification/Evaluators/CouponsNotSyncedEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/CouponsNotSyncedEvaluatorTest.php
@@ -169,6 +169,26 @@ class CouponsNotSyncedEvaluatorTest extends UnitTest {
 		$this->assertFalse( $evaluator->should_show() );
 	}
 
+	public function test_scan_spans_all_reported_pages_to_find_a_supported_coupon() {
+		// Two full pages exist and the page count reports both. The only supported coupon
+		// lives on page 2, so the scan must page past page 1 to reach it.
+		$evaluator = $this->create_evaluator(
+			true,
+			false,
+			[
+				1 => [ 1 ],
+				2 => [ 2 ],
+			],
+			[
+				1 => $this->create_coupon( 1, true, [] ),
+				2 => $this->create_coupon( 2, false, [] ),
+			],
+			2
+		);
+
+		$this->assertTrue( $evaluator->should_show() );
+	}
+
 	public function test_cache_hit_skips_query() {
 		$evaluator = $this->create_evaluator( true, false, [ 1 => [ 1 ] ], [] );
 		$this->login_as_administrator();
@@ -200,12 +220,12 @@ class CouponsNotSyncedEvaluatorTest extends UnitTest {
 
 		$evaluator = $this->getMockBuilder( CouponsNotSyncedEvaluator::class )
 			->setConstructorArgs( [ $merchant_center, $target_audience ] )
-			->onlyMethods( [ 'has_synced_coupon', 'get_coupon_pages', 'get_coupon_post_ids', 'create_coupon' ] )
+			->onlyMethods( [ 'has_synced_coupon', 'get_coupon_page_count', 'get_coupon_post_ids', 'create_coupon' ] )
 			->getMock();
 
 		$evaluator->method( 'has_synced_coupon' )->willReturn( $has_synced );
 
-		$evaluator->method( 'get_coupon_pages' )->willReturn( $total_pages ?? count( $post_ids_by_page ) );
+		$evaluator->method( 'get_coupon_page_count' )->willReturn( $total_pages ?? count( $post_ids_by_page ) );
 
 		$evaluator->method( 'get_coupon_post_ids' )
 			->willReturnCallback(

--- a/tests/Unit/Notification/Evaluators/CouponsNotSyncedEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/CouponsNotSyncedEvaluatorTest.php
@@ -146,6 +146,29 @@ class CouponsNotSyncedEvaluatorTest extends UnitTest {
 		$this->assertFalse( $evaluator->should_show() );
 	}
 
+	public function test_scan_is_bounded_to_the_computed_page_count() {
+		// A supported coupon lives on page 2, but only 1 page is reported. The scan must
+		// stay bounded by the page count and never page past it, so the coupon on the
+		// unreported page is not reached (guards against the previous unbounded loop).
+		$supported_coupon = $this->create_coupon( 2, false, [] );
+
+		$evaluator = $this->create_evaluator(
+			true,
+			false,
+			[
+				1 => [ 1 ],
+				2 => [ 2 ],
+			],
+			[
+				1 => $this->create_coupon( 1, true, [] ),
+				2 => $supported_coupon,
+			],
+			1
+		);
+
+		$this->assertFalse( $evaluator->should_show() );
+	}
+
 	public function test_cache_hit_skips_query() {
 		$evaluator = $this->create_evaluator( true, false, [ 1 => [ 1 ] ], [] );
 		$this->login_as_administrator();
@@ -164,10 +187,11 @@ class CouponsNotSyncedEvaluatorTest extends UnitTest {
 	 * @param bool                  $has_synced       Whether at least one coupon is already synced to Google.
 	 * @param array<int, int[]>     $post_ids_by_page Coupon post IDs returned per page.
 	 * @param array<int, WC_Coupon> $coupons_by_id    Coupon objects keyed by post ID.
+	 * @param int|null              $total_pages      Page count to report; defaults to the number of pages provided.
 	 *
 	 * @return CouponsNotSyncedEvaluator|MockObject
 	 */
-	private function create_evaluator( bool $supported_market, bool $has_synced, array $post_ids_by_page, array $coupons_by_id ): CouponsNotSyncedEvaluator {
+	private function create_evaluator( bool $supported_market, bool $has_synced, array $post_ids_by_page, array $coupons_by_id, ?int $total_pages = null ): CouponsNotSyncedEvaluator {
 		$merchant_center = $this->createMock( MerchantCenterService::class );
 		$target_audience = $this->createMock( TargetAudience::class );
 
@@ -176,10 +200,12 @@ class CouponsNotSyncedEvaluatorTest extends UnitTest {
 
 		$evaluator = $this->getMockBuilder( CouponsNotSyncedEvaluator::class )
 			->setConstructorArgs( [ $merchant_center, $target_audience ] )
-			->onlyMethods( [ 'has_synced_coupon', 'get_coupon_post_ids', 'create_coupon' ] )
+			->onlyMethods( [ 'has_synced_coupon', 'get_coupon_pages', 'get_coupon_post_ids', 'create_coupon' ] )
 			->getMock();
 
 		$evaluator->method( 'has_synced_coupon' )->willReturn( $has_synced );
+
+		$evaluator->method( 'get_coupon_pages' )->willReturn( $total_pages ?? count( $post_ids_by_page ) );
 
 		$evaluator->method( 'get_coupon_post_ids' )
 			->willReturnCallback(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes GOOWOO-829.

`CouponsNotSyncedEvaluator::has_supported_coupon()` paged through published coupons in a `while ( true )` loop that only stopped once it hit an empty page, building a `WC_Coupon` for every candidate along the way. On a catalog with no supported coupon, it scanned the entire coupon catalog every time.

- Replace the `while ( true )` with a bounded `for` loop. The page count is computed up front from `wp_count_posts( 'shop_coupon' )->publish`, so the scan can never run past the known number of pages.
- Order the coupon query by `ID ASC` so pagination is deterministic: pages return the same IDs in the same order on every query, with no overlaps or gaps between pages.
- Extract the page-count calculation into `get_coupon_page_count()`, and document that the `wp_count_posts()` cache can lag the database and undercount the last partial page (self-healing once the count cache and the evaluator cache are invalidated).

### Screenshots:

_N/A — no visible UI change._

### Detailed test instructions:

1. On a store whose target market supports coupon channel visibility, with no coupons synced to Google, create 50+ published coupons where at least one is supported (not virtual, no email restriction, not exclude-sale-items).
2. Trigger the notification evaluation and confirm the "coupons not synced" notification still fires.
3. Delete/edit so that only unsupported coupons remain and confirm the notification does not fire, and evaluation completes without looping.
4. Confirm the evaluator returns the same result across repeated runs (stable pagination).
5. Run the unit tests: `composer test-unit -- --filter CouponsNotSyncedEvaluatorTest` (13 tests pass).

### Additional details:

Unit tests updated to stub `get_coupon_page_count()` and added:

- `test_scan_is_bounded_to_the_computed_page_count` — guards the bound.
- `test_scan_spans_all_reported_pages_to_find_a_supported_coupon` — verifies a supported coupon on a later page is still found.

### Changelog entry

> Fix - Prevent the coupons-not-synced notification evaluator from scanning the entire coupon catalog by bounding the paged scan and ordering it deterministically.