### PR TITLE
Fix: GOOWOO-848: Multi-feed - [AI] Market writes do not enforce exclusive country ownership

### DIFF
--- a/js/src/pages/markets/components/market-fields/audience-section/audience-select-control.js
+++ b/js/src/pages/markets/components/market-fields/audience-section/audience-select-control.js
@@ -26,14 +26,17 @@ const AudienceSelectControl = () => {
 		adapter: { renderRequestedValidation },
 	} = useAdaptiveFormContext();
 	const { code: storeCurrencyCode } = useStoreCurrency();
-	const { data: markets } = useMarkets();
+	const { data: markets, hasFinishedResolution: hasResolvedMarkets } =
+		useMarkets();
 	const { data: mcCountries, hasFinishedResolution: hasResolvedCountries } =
 		useMCCountries();
 
 	// A country belonging to a secondary market cannot also be in the primary audience, so it
 	// is not offered here. Primary carries no country of its own, so it filters itself out.
+	// Both markets and supported countries have to be resolved first — otherwise a country
+	// another market owns would briefly show as available before markets loads.
 	const countryCodes = useMemo( () => {
-		if ( ! hasResolvedCountries || ! mcCountries ) {
+		if ( ! hasResolvedMarkets || ! hasResolvedCountries || ! mcCountries ) {
 			return undefined;
 		}
 
@@ -46,7 +49,7 @@ const AudienceSelectControl = () => {
 		return Object.keys( mcCountries ).filter(
 			( code ) => ! ownedCountries.has( code )
 		);
-	}, [ markets, mcCountries, hasResolvedCountries ] );
+	}, [ markets, hasResolvedMarkets, mcCountries, hasResolvedCountries ] );
 
 	const {
 		shipping_country_rates: rawRates = [],

--- a/js/src/pages/markets/components/market-fields/audience-section/audience-select-control.js
+++ b/js/src/pages/markets/components/market-fields/audience-section/audience-select-control.js
@@ -2,14 +2,17 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { useAdaptiveFormContext } from '~/components/adaptive-form';
 import useStoreCurrency from '~/hooks/useStoreCurrency';
+import useMCCountries from '~/hooks/useMCCountries';
 import SupportedCountrySelect from '~/components/supported-country-select';
 import isNonFreeShippingRate from '~/utils/isNonFreeShippingRate';
+import useMarkets from '../../../hooks/useMarkets';
 import './audience-select-control.scss';
 
 /**
@@ -23,6 +26,27 @@ const AudienceSelectControl = () => {
 		adapter: { renderRequestedValidation },
 	} = useAdaptiveFormContext();
 	const { code: storeCurrencyCode } = useStoreCurrency();
+	const { data: markets } = useMarkets();
+	const { data: mcCountries, hasFinishedResolution: hasResolvedCountries } =
+		useMCCountries();
+
+	// A country belonging to a secondary market cannot also be in the primary audience, so it
+	// is not offered here. Primary carries no country of its own, so it filters itself out.
+	const countryCodes = useMemo( () => {
+		if ( ! hasResolvedCountries || ! mcCountries ) {
+			return undefined;
+		}
+
+		const ownedCountries = new Set(
+			( markets ?? [] )
+				.filter( ( market ) => market.country )
+				.map( ( market ) => market.country )
+		);
+
+		return Object.keys( mcCountries ).filter(
+			( code ) => ! ownedCountries.has( code )
+		);
+	}, [ markets, mcCountries, hasResolvedCountries ] );
 
 	const {
 		shipping_country_rates: rawRates = [],
@@ -103,6 +127,7 @@ const AudienceSelectControl = () => {
 		<div className="gla-audience-select-control">
 			<SupportedCountrySelect
 				{ ...inputProps }
+				countryCodes={ countryCodes }
 				onChange={ handleChange }
 				help={ __(
 					'Select which countries your store ships to.',

--- a/js/src/pages/markets/components/market-fields/audience-section/audience-select-control.test.js
+++ b/js/src/pages/markets/components/market-fields/audience-section/audience-select-control.test.js
@@ -83,4 +83,16 @@ describe( 'AudienceSelectControl', () => {
 
 		expect( countryCodes ).toBeUndefined();
 	} );
+
+	test( 'leaves the country list undefined until markets resolve', () => {
+		// Resolving with an empty list here would otherwise look identical to "no market owns
+		// any country", which would wrongly offer GB before ownership is known.
+		useMarkets.mockReturnValue( { data: undefined, hasFinishedResolution: false } );
+
+		render( <AudienceSelectControl /> );
+
+		const { countryCodes } = SupportedCountrySelect.mock.calls[ 0 ][ 0 ];
+
+		expect( countryCodes ).toBeUndefined();
+	} );
 } );

--- a/js/src/pages/markets/components/market-fields/audience-section/audience-select-control.test.js
+++ b/js/src/pages/markets/components/market-fields/audience-section/audience-select-control.test.js
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { useAdaptiveFormContext } from '~/components/adaptive-form';
+import useStoreCurrency from '~/hooks/useStoreCurrency';
+import useMCCountries from '~/hooks/useMCCountries';
+import SupportedCountrySelect from '~/components/supported-country-select';
+import useMarkets from '../../../hooks/useMarkets';
+import AudienceSelectControl from './audience-select-control';
+
+jest.mock( '~/components/adaptive-form', () => ( {
+	useAdaptiveFormContext: jest.fn(),
+} ) );
+
+jest.mock( '~/hooks/useStoreCurrency' );
+jest.mock( '~/hooks/useMCCountries' );
+jest.mock( '../../../hooks/useMarkets' );
+
+jest.mock( '~/components/supported-country-select', () =>
+	jest.fn( () => <div data-testid="supported-country-select" /> )
+);
+
+describe( 'AudienceSelectControl', () => {
+	beforeEach( () => {
+		useStoreCurrency.mockReturnValue( { code: 'USD' } );
+		useAdaptiveFormContext.mockReturnValue( {
+			getInputProps: () => ( { value: [], onChange: jest.fn() } ),
+			values: {},
+			setValues: jest.fn(),
+			adapter: { renderRequestedValidation: () => null },
+		} );
+		useMCCountries.mockReturnValue( {
+			data: { US: {}, CA: {}, GB: {} },
+			hasFinishedResolution: true,
+		} );
+		useMarkets.mockReturnValue( { data: [], hasFinishedResolution: true } );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'omits a country that a secondary market owns', () => {
+		useMarkets.mockReturnValue( {
+			data: [
+				{ id: 'primary', country: null },
+				{ id: 'gb', country: 'GB' },
+			],
+			hasFinishedResolution: true,
+		} );
+
+		render( <AudienceSelectControl /> );
+
+		const { countryCodes } = SupportedCountrySelect.mock.calls[ 0 ][ 0 ];
+
+		expect( countryCodes ).toEqual( [ 'US', 'CA' ] );
+	} );
+
+	test( 'offers every supported country when no secondary market owns one', () => {
+		render( <AudienceSelectControl /> );
+
+		const { countryCodes } = SupportedCountrySelect.mock.calls[ 0 ][ 0 ];
+
+		expect( countryCodes ).toEqual( [ 'US', 'CA', 'GB' ] );
+	} );
+
+	test( 'leaves the country list undefined until the supported countries resolve', () => {
+		// Passing an empty array here would render a select with no countries at all.
+		useMCCountries.mockReturnValue( {
+			data: undefined,
+			hasFinishedResolution: false,
+		} );
+
+		render( <AudienceSelectControl /> );
+
+		const { countryCodes } = SupportedCountrySelect.mock.calls[ 0 ][ 0 ];
+
+		expect( countryCodes ).toBeUndefined();
+	} );
+} );

--- a/js/src/pages/markets/components/market-fields/audience-section/audience-select-control.test.js
+++ b/js/src/pages/markets/components/market-fields/audience-section/audience-select-control.test.js
@@ -87,7 +87,10 @@ describe( 'AudienceSelectControl', () => {
 	test( 'leaves the country list undefined until markets resolve', () => {
 		// Resolving with an empty list here would otherwise look identical to "no market owns
 		// any country", which would wrongly offer GB before ownership is known.
-		useMarkets.mockReturnValue( { data: undefined, hasFinishedResolution: false } );
+		useMarkets.mockReturnValue( {
+			data: undefined,
+			hasFinishedResolution: false,
+		} );
 
 		render( <AudienceSelectControl /> );
 

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -516,23 +516,78 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	/**
 	 * Returns the primary market's country list.
 	 *
-	 * In flat mode the countries surfaced as their own secondary markets (those whose
-	 * shipping differs from the main country's) are excluded so they are not listed in
-	 * both the primary feed and their own market. In every other mode the full target
-	 * audience is the primary market.
+	 * A country owned by a secondary market is excluded so it is never listed in both that
+	 * market and the primary feed. The secondary markets are the stored ones, or in flat mode
+	 * the countries whose shipping differs from the main country's.
+	 *
+	 * Filtering on read also keeps the list submittable: TARGET_AUDIENCE is writable outside this
+	 * service, so an overlap it introduces is dropped by saving rather than rejected.
 	 *
 	 * @return string[]
 	 */
 	private function get_primary_market_countries(): array {
 		$target_countries = $this->target_audience->get_target_countries();
 
-		if ( ! $this->is_flat_shipping_rate() ) {
-			return $target_countries;
+		// Read straight from the two sources rather than through get_secondary_markets_source(),
+		// whose flat-mode reconciliation writes options and schedules jobs.
+		$secondary = $this->is_flat_shipping_rate()
+			? $this->get_derived_flat_secondary_markets()
+			: $this->get_stored_secondary_markets();
+
+		return array_values( array_diff( $target_countries, array_column( $secondary, 'country' ) ) );
+	}
+
+	/**
+	 * Returns the ID of the secondary market already owning a country, if any.
+	 *
+	 * A country belongs to exactly one market feed. Market IDs derive from the feed label, not
+	 * the country, so two markets for the same country under different feed labels produce
+	 * different IDs and slip past the ID-based conflict check in the REST controller.
+	 *
+	 * Flat mode owns nothing this way: its markets are derived from the shipping tables on read,
+	 * a country appearing in both is how that mode represents a market rather than a conflict,
+	 * and its stored rows are leftovers that reading the markets list reconciles away. Treating
+	 * those leftovers as owners would reject a country the Markets list does not show.
+	 *
+	 * @param string $country country code.
+	 * @param string $ignore_id Market ID to skip, so a market does not conflict with itself.
+	 *
+	 * @return string|null The owning market ID, or null when the country is unowned.
+	 */
+	private function find_market_owning_country( string $country, string $ignore_id = '' ): ?string {
+		if ( '' === $country || $this->is_flat_shipping_rate() ) {
+			return null;
 		}
 
-		$secondary_countries = array_column( $this->get_derived_flat_secondary_markets(), 'country' );
+		foreach ( $this->get_stored_secondary_markets() as $market_id => $market ) {
+			if ( (string) $market_id === $ignore_id ) {
+				continue;
+			}
 
-		return array_values( array_diff( $target_countries, $secondary_countries ) );
+			if ( $country === ( $market['country'] ?? null ) ) {
+				return (string) $market_id;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Rejects a country that another secondary market already owns.
+	 *
+	 * @param string $country   ISO 3166-1 alpha-2 country code. An empty value is not owned.
+	 * @param string $ignore_id Market ID to skip, so a market does not conflict with itself.
+	 *
+	 * @throws InvalidValue When another market already owns the country.
+	 */
+	private function assert_country_unowned( string $country, string $ignore_id = '' ): void {
+		$owner = $this->find_market_owning_country( $country, $ignore_id );
+
+		if ( null !== $owner ) {
+			throw new InvalidValue(
+				sprintf( 'The country "%1$s" already belongs to the "%2$s" market.', $country, $owner )
+			);
+		}
 	}
 
 	/**
@@ -643,6 +698,8 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 				sprintf( 'The market ID "%s" is reserved and cannot be added.', $id )
 			);
 		}
+
+		$this->assert_country_unowned( (string) ( $config['country'] ?? '' ), $id );
 
 		// Flat markets are derived from the shipping tables, not persisted (see
 		// get_derived_flat_secondary_markets()). Adding one means targeting a new
@@ -807,8 +864,44 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 		$this->validate_secondary_market_config( $merged, $currency_source_touched );
 
+		$old_country = (string) ( $existing['country'] ?? '' );
+		$new_country = (string) ( $merged['country'] ?? '' );
+		$moved       = $new_country !== $old_country;
+
+		if ( $moved ) {
+			$this->assert_country_unowned( $new_country, $id );
+
+			// Recorded against the country the market now owns, so a later delete restores the
+			// right one. Read before the audience is changed below.
+			$merged['was_in_primary'] = '' !== $new_country && $this->is_country_in_target_audience( $new_country );
+		}
+
 		$markets[ $id ] = $merged;
 		$this->options->update( OptionsInterface::MARKETS, $markets );
+
+		if ( $moved ) {
+			// Releasing a country is the same decision delete_market() makes: one the market took
+			// out of the primary feed rejoins it on the primary's shipping, and one the market
+			// introduced stops being targeted rather than landing in a feed nobody put it in.
+			if ( '' !== $old_country ) {
+				$returns_to_primary = ! empty( $existing['was_in_primary'] )
+					|| $this->is_country_in_target_audience( $old_country );
+
+				if ( $returns_to_primary ) {
+					$this->adopt_primary_rate_for_country( $old_country );
+					$this->adopt_primary_time_for_country( $old_country );
+					$this->restore_country_to_target_audience( $old_country );
+				} else {
+					$this->remove_shipping_rows_for_country( $old_country );
+				}
+			}
+
+			// The new country leaves the primary feed, so each country stays in exactly one.
+			if ( '' !== $new_country ) {
+				$this->remove_country_from_target_audience( $new_country );
+				$this->extend_shipping_to_country( $new_country );
+			}
+		}
 
 		$old_feed_label = $existing['feed_label'] ?? null;
 		$new_feed_label = $merged['feed_label'] ?? null;
@@ -1107,7 +1200,14 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		$this->options->update( OptionsInterface::MARKETS, $markets );
 
 		if ( $country ) {
-			if ( ! empty( $deleted_config['was_in_primary'] ) ) {
+			// TARGET_AUDIENCE is writable independently of this service, so the stored flag can
+			// disagree with what the feed currently targets. A country the primary feed targets
+			// returns to it either way; stripping its shipping rows would leave it selling with
+			// no shipping service on the next sync.
+			$returns_to_primary = ! empty( $deleted_config['was_in_primary'] )
+				|| $this->is_country_in_target_audience( $country );
+
+			if ( $returns_to_primary ) {
 				$this->adopt_primary_rate_for_country( $country );
 				$this->adopt_primary_time_for_country( $country );
 				$this->restore_country_to_target_audience( $country );
@@ -1760,6 +1860,13 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		if ( array_key_exists( 'countries', $config ) ) {
 			$countries = $config['countries'];
 
+			// A country owned by a stored secondary market cannot rejoin the primary feed, or it
+			// would be targeted twice. Checked before the flat merge below, which re-adds
+			// flat-derived countries that are computed from this same audience.
+			foreach ( (array) $countries as $country ) {
+				$this->assert_country_unowned( (string) $country );
+			}
+
 			if ( $this->is_flat_shipping_rate() ) {
 				// The submitted primary market countries are already filtered to exclude
 				// flat-derived secondary markets (see get_primary_market_countries()). Merge
@@ -1771,7 +1878,14 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 				$countries           = array_values( array_unique( array_merge( $countries, $secondary_countries ) ) );
 			}
 
-			$target_audience              = $this->options->get( OptionsInterface::TARGET_AUDIENCE, [] );
+			$target_audience = $this->options->get( OptionsInterface::TARGET_AUDIENCE, [] );
+
+			// TargetAudience ignores the stored list while the location is "all", so a submitted
+			// selection only takes effect once the audience is an explicit one.
+			if ( 'all' === strtolower( (string) ( $target_audience['location'] ?? '' ) ) ) {
+				$target_audience['location'] = 'selected';
+			}
+
 			$target_audience['countries'] = $countries;
 			$this->options->update( OptionsInterface::TARGET_AUDIENCE, $target_audience );
 		}
@@ -2092,10 +2206,19 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 *
 	 * Idempotent — no-op if the country is already absent.
 	 *
+	 * An "all countries" audience carries no explicit list, so a country cannot be taken out of
+	 * it without first materialising it into one. Materialising is one-way: the store stops
+	 * picking up countries Merchant Center adds to the supported list later.
+	 *
 	 * @param string $country ISO 3166-1 alpha-2 country code.
 	 */
 	private function remove_country_from_target_audience( string $country ): void {
 		$target_audience = $this->options->get( OptionsInterface::TARGET_AUDIENCE, [] );
+
+		if ( 'all' === strtolower( (string) ( $target_audience['location'] ?? '' ) ) ) {
+			$target_audience['location']  = 'selected';
+			$target_audience['countries'] = $this->target_audience->get_target_countries();
+		}
 
 		if ( empty( $target_audience['countries'] ) || ! is_array( $target_audience['countries'] ) ) {
 			return;
@@ -2260,6 +2383,12 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	private function restore_country_to_target_audience( string $country ): void {
 		$target_audience = $this->options->get( OptionsInterface::TARGET_AUDIENCE, [] );
 
+		// An "all countries" audience already targets it, and appending to the list it does not
+		// read would leave the location and the list saying different things.
+		if ( 'all' === strtolower( (string) ( $target_audience['location'] ?? '' ) ) ) {
+			return;
+		}
+
 		if ( ! isset( $target_audience['countries'] ) || ! is_array( $target_audience['countries'] ) ) {
 			$target_audience['countries'] = [];
 		}
@@ -2271,7 +2400,12 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	}
 
 	/**
-	 * Whether a country is currently in the primary feed's TargetAudience countries list.
+	 * Whether a country is currently targeted by the primary feed.
+	 *
+	 * Resolved through TargetAudience so an "all countries" audience, which stores no explicit
+	 * list, still reports its countries as targeted. Every caller uses this to decide whether a
+	 * country belongs to the primary feed, and a wrong answer strips the shipping rows of a
+	 * country that is still selling.
 	 *
 	 * @param string $country ISO 3166-1 alpha-2 country code.
 	 *
@@ -2279,6 +2413,10 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 */
 	private function is_country_in_target_audience( string $country ): bool {
 		$target_audience = $this->options->get( OptionsInterface::TARGET_AUDIENCE, [] );
+
+		if ( 'all' === strtolower( (string) ( $target_audience['location'] ?? '' ) ) ) {
+			return in_array( $country, $this->target_audience->get_target_countries(), true );
+		}
 
 		return ! empty( $target_audience['countries'] )
 			&& is_array( $target_audience['countries'] )

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -578,14 +578,18 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * @param string $country   ISO 3166-1 alpha-2 country code. An empty value is not owned.
 	 * @param string $ignore_id Market ID to skip, so a market does not conflict with itself.
 	 *
-	 * @throws InvalidValue When another market already owns the country.
+	 * @throws InvalidValue When another market already owns the country, named by its feed label,
+	 *                      or by its ID when no feed label is stored.
 	 */
 	private function assert_country_unowned( string $country, string $ignore_id = '' ): void {
 		$owner = $this->find_market_owning_country( $country, $ignore_id );
 
 		if ( null !== $owner ) {
+			$feed_label  = $this->get_stored_secondary_markets()[ $owner ]['feed_label'] ?? '';
+			$owner_label = ( is_string( $feed_label ) && '' !== $feed_label ) ? $feed_label : $owner;
+
 			throw new InvalidValue(
-				sprintf( 'The country "%1$s" already belongs to the "%2$s" market.', $country, $owner )
+				sprintf( 'The country "%1$s" already belongs to the "%2$s" market.', $country, $owner_label )
 			);
 		}
 	}
@@ -1829,6 +1833,15 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * @throws InvalidValue When `language` or `currency` is present but not an array.
 	 */
 	private function update_primary_market_fanout( array $config ): void {
+		// A country owned by a stored secondary market cannot rejoin the primary feed, or it would
+		// be targeted twice. Checked before anything is written, so a rejection cannot half apply
+		// the update, and before the flat merge below, which re-adds flat-derived countries.
+		if ( array_key_exists( 'countries', $config ) ) {
+			foreach ( (array) $config['countries'] as $country ) {
+				$this->assert_country_unowned( (string) $country );
+			}
+		}
+
 		$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
 		$mc_updated  = false;
 
@@ -1859,13 +1872,6 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 		if ( array_key_exists( 'countries', $config ) ) {
 			$countries = $config['countries'];
-
-			// A country owned by a stored secondary market cannot rejoin the primary feed, or it
-			// would be targeted twice. Checked before the flat merge below, which re-adds
-			// flat-derived countries that are computed from this same audience.
-			foreach ( (array) $countries as $country ) {
-				$this->assert_country_unowned( (string) $country );
-			}
 
 			if ( $this->is_flat_shipping_rate() ) {
 				// The submitted primary market countries are already filtered to exclude

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -5925,6 +5925,116 @@ class MarketServiceTest extends UnitTest {
 		$this->assertTrue( $this->options->get( OptionsInterface::MARKETS )['gb']['was_in_primary'] );
 	}
 
+	public function test_rejected_primary_market_update_writes_nothing(): void {
+		// Ownership is checked before any option is written, so a rejected country selection
+		// cannot leave the Merchant Center settings saved with the audience untouched.
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ 'GBP' ],
+						'feed_label' => 'GB',
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US', 'CA' ],
+				],
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'language'      => [ 'en' ],
+				],
+			]
+		);
+
+		$rejected = false;
+
+		// The call is wrapped rather than declared with expectException() because the assertions
+		// below have to run after it, which they never do once the exception escapes the test.
+		try {
+			$this->market_service->update_market(
+				'primary',
+				[
+					'language'  => [ 'en', 'fr' ],
+					'countries' => [ 'US', 'CA', 'GB' ],
+				]
+			);
+		} catch ( InvalidValue $exception ) {
+			$rejected = true;
+		}
+
+		$this->assertTrue( $rejected, 'GB belongs to the gb market, so the update must be rejected.' );
+
+		$this->assertSame( [ 'en' ], $this->options->get( OptionsInterface::MERCHANT_CENTER )['language'] );
+		$this->assertSame( [ 'US', 'CA' ], $this->options->get( OptionsInterface::TARGET_AUDIENCE )['countries'] );
+	}
+
+	public function test_country_ownership_rejection_names_the_owning_market_feed_label(): void {
+		// A market ID is the sanitised feed label, so naming the ID would report "gb-eur" to a
+		// merchant who entered "GB-EUR".
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [
+					'gb-eur' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ 'EUR' ],
+						'feed_label' => 'GB-EUR',
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'automatic' ],
+			]
+		);
+
+		$this->expectException( InvalidValue::class );
+		$this->expectExceptionMessage( 'The country "GB" already belongs to the "GB-EUR" market.' );
+
+		$this->market_service->add_market(
+			'gb-usd',
+			[
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'USD' ],
+				'feed_label' => 'GB-USD',
+			]
+		);
+	}
+
+	public function test_country_ownership_rejection_falls_back_to_the_market_id(): void {
+		// A market stored before the feed label was required has nothing else to be named by.
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [
+					'gb' => [ 'country' => 'GB' ],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'automatic' ],
+			]
+		);
+
+		$this->expectException( InvalidValue::class );
+		$this->expectExceptionMessage( 'The country "GB" already belongs to the "gb" market.' );
+
+		$this->market_service->add_market(
+			'gb-eur',
+			[
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'EUR' ],
+				'feed_label' => 'GB-EUR',
+			]
+		);
+	}
+
 	/**
 	 * Sets up the options mock to return specific values for different option keys.
 	 *

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -5527,6 +5527,404 @@ class MarketServiceTest extends UnitTest {
 		);
 	}
 
+	public function test_add_market_rejects_country_owned_by_another_market(): void {
+		// Market IDs derive from the feed label, so a second market for the same country under a
+		// different label gets a different ID and passes the controller's ID conflict check.
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ 'GBP' ],
+						'feed_label' => 'GB',
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US', 'CA' ],
+				],
+			]
+		);
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->add_market(
+			'gb-eur',
+			[
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'EUR' ],
+				'feed_label' => 'GB-EUR',
+			]
+		);
+	}
+
+	public function test_update_primary_market_rejects_country_owned_by_secondary(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ 'GBP' ],
+						'feed_label' => 'GB',
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US', 'CA' ],
+				],
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'automatic' ],
+			]
+		);
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->update_market( 'primary', [ 'countries' => [ 'US', 'CA', 'GB' ] ] );
+	}
+
+	public function test_primary_market_countries_exclude_a_country_a_secondary_already_owns(): void {
+		// TARGET_AUDIENCE is writable outside MarketService, so it can hold a country a market
+		// owns. Reading the primary market has to drop it, or saving the form unchanged submits
+		// it back, is rejected, and locks the merchant out of the primary market.
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'CA', 'GB' ] );
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [] );
+
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ 'GBP' ],
+						'feed_label' => 'GB',
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US', 'CA', 'GB' ],
+				],
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'automatic' ],
+			]
+		);
+
+		$countries = $this->market_service->get_primary_market()['countries'];
+
+		$this->assertNotContains( 'GB', $countries );
+		$this->assertSame( [ 'US', 'CA' ], array_values( $countries ) );
+
+		// The filtered list is what the form submits back, and it must save.
+		$this->market_service->update_market( 'primary', [ 'countries' => $countries ] );
+	}
+
+	public function test_flat_mode_stored_leftover_does_not_block_saving_the_primary_market(): void {
+		// A stored market left behind by an earlier mode is an orphan in flat mode, reconciled
+		// away when the markets list is read. It must not count as owning its country, or the
+		// primary market cannot be saved while it sits there.
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [] );
+
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ 'GBP' ],
+						'feed_label' => 'GB',
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US', 'GB' ],
+				],
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat' ],
+			]
+		);
+
+		$this->market_service->update_market( 'primary', [ 'countries' => [ 'US', 'GB' ] ] );
+
+		$this->assertContains( 'GB', $this->options->get( OptionsInterface::TARGET_AUDIENCE )['countries'] );
+	}
+
+	public function test_update_market_country_change_transfers_ownership(): void {
+		// The transfer extends shipping to the new country, which reads the stored rows.
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn( [ 'US' => [ 'rate' => '5' ] ] );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [ 'US' => [ 'time' => 3 ] ] );
+
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'        => 'GB',
+						'language'       => [ 'en' ],
+						'currency'       => [ 'GBP' ],
+						'feed_label'     => 'GB',
+						'was_in_primary' => true,
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US', 'CA' ],
+				],
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'automatic' ],
+			]
+		);
+
+		// MX is not targeted, so the flag has to come out false on the other side of the move.
+		$this->market_service->update_market( 'gb', [ 'country' => 'MX' ] );
+
+		$audience = $this->options->get( OptionsInterface::TARGET_AUDIENCE );
+
+		// The market releases GB back to the feed it came from and takes MX out, so each
+		// country sits in exactly one feed.
+		$this->assertContains( 'GB', $audience['countries'] );
+		$this->assertNotContains( 'MX', $audience['countries'] );
+
+		$stored = $this->options->get( OptionsInterface::MARKETS )['gb'];
+		$this->assertSame( 'MX', $stored['country'] );
+
+		// Seeded true against GB, so a false here can only come from recomputing against MX.
+		$this->assertFalse( $stored['was_in_primary'] );
+	}
+
+	public function test_update_market_country_change_stops_targeting_a_country_the_market_introduced(): void {
+		// GB is targeted only because this market targets it, so releasing it has to stop the
+		// targeting rather than hand it to the primary feed the merchant never put it in.
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn( [ 'US' => [ 'rate' => '5' ] ] );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [ 'US' => [ 'time' => 3 ] ] );
+
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'        => 'GB',
+						'language'       => [ 'en' ],
+						'currency'       => [ 'GBP' ],
+						'feed_label'     => 'GB',
+						'was_in_primary' => false,
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US', 'CA' ],
+				],
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'automatic' ],
+			]
+		);
+
+		$this->market_service->update_market( 'gb', [ 'country' => 'IE' ] );
+
+		$audience = $this->options->get( OptionsInterface::TARGET_AUDIENCE );
+
+		$this->assertNotContains( 'GB', $audience['countries'] );
+	}
+
+	public function test_update_market_country_change_returns_a_borrowed_country_on_primary_shipping(): void {
+		// GB came out of the primary feed, so going back it has to carry the primary's shipping
+		// rather than the rate and delivery time this market gave it.
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn( [ 'US' => [ 'rate' => '5' ] ] );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [ 'US' => [ 'time' => 3 ] ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 1,
+					'country'  => 'US',
+					'currency' => 'USD',
+					'rate'     => '5',
+					'options'  => [],
+				],
+				[
+					'id'       => 2,
+					'country'  => 'GB',
+					'currency' => 'USD',
+					'rate'     => '20',
+					'options'  => [],
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 1,
+					'country'  => 'US',
+					'time'     => 3,
+					'max_time' => 5,
+				],
+				[
+					'id'       => 2,
+					'country'  => 'GB',
+					'time'     => 9,
+					'max_time' => 12,
+				],
+			]
+		);
+
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'        => 'GB',
+						'language'       => [ 'en' ],
+						'currency'       => [ 'GBP' ],
+						'feed_label'     => 'GB',
+						'was_in_primary' => true,
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US', 'CA' ],
+				],
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'automatic' ],
+			]
+		);
+
+		// GB's own rate is overwritten with the primary's, not left at 20.
+		$this->shipping_rate_query->expects( $this->atLeastOnce() )
+			->method( 'update' )
+			->with(
+				$this->callback(
+					function ( array $data ): bool {
+						return 'GB' === $data['country'] && '5' === $data['rate'];
+					}
+				),
+				[ 'id' => 2 ]
+			);
+
+		$this->market_service->update_market( 'gb', [ 'country' => 'IE' ] );
+
+		$audience = $this->options->get( OptionsInterface::TARGET_AUDIENCE );
+
+		$this->assertContains( 'GB', $audience['countries'] );
+	}
+
+	public function test_update_market_rejects_country_owned_by_another_market(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ 'GBP' ],
+						'feed_label' => 'GB',
+					],
+					'ie' => [
+						'country'    => 'IE',
+						'language'   => [ 'en' ],
+						'currency'   => [ 'EUR' ],
+						'feed_label' => 'IE',
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'automatic' ],
+			]
+		);
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->update_market( 'gb', [ 'country' => 'IE' ] );
+	}
+
+	public function test_delete_market_keeps_shipping_when_country_is_still_targeted(): void {
+		// An "all countries" audience stores no explicit list, so markets created before the
+		// membership fix recorded was_in_primary as false for a country that is still targeted.
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'CA', 'GB' ] );
+
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'        => 'GB',
+						'language'       => [ 'en' ],
+						'currency'       => [ 'GBP' ],
+						'feed_label'     => 'GB',
+						'was_in_primary' => false,
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'all' ],
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'automatic' ],
+			]
+		);
+
+		// Stripping the rows would leave GB selling with no shipping service on the next sync.
+		$this->shipping_rate_query->expects( $this->never() )->method( 'delete' );
+		$this->shipping_time_query->expects( $this->never() )->method( 'delete' );
+
+		$this->market_service->delete_market( 'gb' );
+
+		// An "all countries" audience already targets GB, so it stays "all" rather than gaining
+		// a one-country list that contradicts the location.
+		$audience = $this->options->get( OptionsInterface::TARGET_AUDIENCE );
+
+		$this->assertSame( 'all', $audience['location'] );
+		$this->assertArrayNotHasKey( 'countries', $audience );
+	}
+
+	public function test_delete_market_removes_shipping_when_country_was_never_targeted(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'        => 'GB',
+						'language'       => [ 'en' ],
+						'currency'       => [ 'GBP' ],
+						'feed_label'     => 'GB',
+						'was_in_primary' => false,
+					],
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US', 'CA' ],
+				],
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'automatic' ],
+			]
+		);
+
+		$this->shipping_rate_query->expects( $this->once() )->method( 'delete' )->with( 'country', 'GB' );
+		$this->shipping_time_query->expects( $this->once() )->method( 'delete' )->with( 'country', 'GB' );
+
+		$this->market_service->delete_market( 'gb' );
+	}
+
+	public function test_add_market_takes_country_out_of_an_all_countries_audience(): void {
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'CA', 'GB' ] );
+
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MARKETS         => [],
+				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'all' ],
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'automatic' ],
+			]
+		);
+
+		$this->market_service->add_market(
+			'gb',
+			[
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB',
+			]
+		);
+
+		$audience = $this->options->get( OptionsInterface::TARGET_AUDIENCE );
+
+		// "All" carries no list to remove from, so it is materialised before GB is taken out.
+		// Left as "all", GB would stay in the primary feed while also owning its own market.
+		$this->assertSame( 'selected', $audience['location'] );
+		$this->assertNotContains( 'GB', $audience['countries'] );
+		$this->assertContains( 'US', $audience['countries'] );
+
+		$this->assertTrue( $this->options->get( OptionsInterface::MARKETS )['gb']['was_in_primary'] );
+	}
+
 	/**
 	 * Sets up the options mock to return specific values for different option keys.
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-848/multi-feed-ai-market-writes-do-not-enforce-exclusive-country-ownership

A country could end up in two feeds. Ownership was checked when a market was created and nowhere else.

Creating a market, updating the primary market, and changing a market's country all reject a country another market owns.
Reading the primary market filters out owned countries, so a save cannot resubmit an overlap.
Changing a market's country releases the old one the same way delete does: back to primary on the primary's shipping if it came from there, otherwise it stops being targeted.
Delete decides from current ownership, not the stored was_in_primary.
The primary Audience select no longer offers owned countries.
Not enforced in flat mode, where markets are derived from the shipping tables.

Heads up: an "all countries" audience has no explicit list, so removing a country materialises it to "selected". One way, and those stores stop auto-including countries Google adds later.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Setup: Shipping rate set to Automatic or Manual (not Flat), target audience with a few countries, e.g. US, CA, GB.

- Create: add a market for GB. GB disappears from the primary market's country count.
- Duplicate: add another market for GB with a different feed label. Rejected with an error.
- Primary Audience: edit the primary market, open Audience, search GB. Not offered. Search a country no market owns; it is.
- Move: edit the GB market, change its country to CA. CA leaves the primary market, GB comes back to it.
- Delete the market. Its country returns to the primary market and keeps working shipping.
- Also check a store with Audience set to All countries: creating a market converts it to an explicit country list, minus the new market's country. That conversion is expected and one way.
- 
- ### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
