### PR TITLE
Fix GOOWOO-255: recalculate body margin when a layout is detached

### DIFF
--- a/js/src/hooks/useLayout.js
+++ b/js/src/hooks/useLayout.js
@@ -40,6 +40,23 @@ export default function useLayout( layoutName ) {
 		bodyClassList.add( ...classNames );
 		return () => {
 			bodyClassList.remove( ...classNames );
+
+			/**
+			 * WooCommerce Admin sets `#wpbody`'s inline `margin-top` from
+			 * `.woocommerce-layout__header`'s `clientHeight`. Both layouts above
+			 * hide that header, so while one is applied the measurement is `0`
+			 * and `#wpbody` loses its margin.
+			 *
+			 * Detaching the layout makes the header visible again, but core does
+			 * not re-measure on its own, so the stale `margin-top: 0px` remains
+			 * and the header overlaps the page content. Core does recalculate on
+			 * window resize — which is why resizing by a single pixel has been
+			 * the manual workaround — so dispatch one here and let core measure
+			 * the now-visible header itself.
+			 *
+			 * Ref: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/admin/client/header/shared.tsx
+			 */
+			window.dispatchEvent( new Event( 'resize' ) );
 		};
 	}, [ layoutName ] );
 }

--- a/js/src/hooks/useLayout.test.js
+++ b/js/src/hooks/useLayout.test.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useLayout from './useLayout';
+
+describe( 'useLayout', () => {
+	afterEach( () => {
+		document.body.className = '';
+	} );
+
+	it( 'should attach the layout classes when mounting and detach them when unmounting', () => {
+		const { unmount } = renderHook( () => useLayout( 'full-content' ) );
+
+		expect( document.body.classList.contains( 'gla-full-content' ) ).toBe(
+			true
+		);
+
+		unmount();
+
+		expect( document.body.classList.contains( 'gla-full-content' ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'should not detach classes that were already applied before mounting', () => {
+		document.body.classList.add( 'gla-full-content' );
+
+		const { unmount } = renderHook( () => useLayout( 'full-content' ) );
+		unmount();
+
+		expect( document.body.classList.contains( 'gla-full-content' ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'should do nothing for an unknown layout name', () => {
+		const { unmount } = renderHook( () => useLayout( 'not-a-layout' ) );
+
+		expect( document.body.className ).toBe( '' );
+
+		unmount();
+	} );
+
+	/**
+	 * WooCommerce Admin sets `#wpbody`'s inline `margin-top` from the header's
+	 * `clientHeight`. While a layout that hides the header is applied, that
+	 * measurement is 0, and the stale value survives after the layout is
+	 * detached — leaving the header overlapping page content (GOOWOO-255).
+	 *
+	 * Core recalculates on window resize, so the cleanup must dispatch one to
+	 * let core re-measure the now-visible header.
+	 */
+	describe.each( [ 'full-page', 'full-content' ] )(
+		'when the %s layout is detached',
+		( layoutName ) => {
+			it( 'should dispatch a resize event so the body margin is recalculated', () => {
+				const onResize = jest.fn();
+				window.addEventListener( 'resize', onResize );
+
+				const { unmount } = renderHook( () => useLayout( layoutName ) );
+
+				expect( onResize ).not.toHaveBeenCalled();
+
+				unmount();
+
+				expect( onResize ).toHaveBeenCalledTimes( 1 );
+
+				window.removeEventListener( 'resize', onResize );
+			} );
+		}
+	);
+
+	it( 'should not dispatch a resize event for an unknown layout name', () => {
+		const onResize = jest.fn();
+		window.addEventListener( 'resize', onResize );
+
+		const { unmount } = renderHook( () => useLayout( 'not-a-layout' ) );
+		unmount();
+
+		expect( onResize ).not.toHaveBeenCalled();
+
+		window.removeEventListener( 'resize', onResize );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes [GOOWOO-255](https://linear.app/a8c/issue/GOOWOO-255/header-settings-tabs-overlapped-by-woocommerce-layout-header).

This picks up the thread from #3301. That PR had been waiting a while and the Linear issue was heading toward being closed either way, so I took a run at the global approach @asvinb asked for there. Very happy to hand this back, close it in favour of an updated #3301, or adjust anything, @AlejandroPerezMartin, this is your issue first and I don't want to step on it.

Credit where it's due: @asvinb  [analysis on the Linear issue](https://linear.app/a8c/issue/GOOWOO-255/header-settings-tabs-overlapped-by-woocommerce-layout-header) identified the mechanism precisely, and the review note on #3301 about the problem not being Settings-specific is exactly what shaped this patch. Both saved a lot of digging.

**The problem.** WooCommerce Admin sets `#wpbody`'s inline `margin-top` from `.woocommerce-layout__header`'s `clientHeight` ([`shared.tsx`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/admin/client/header/shared.tsx)). Both of our `useLayout` layouts hide that header, so while one is applied the measurement is `0` and `#wpbody` loses its margin. Detaching the layout makes the header visible again, but core never re-measures — so a stale `margin-top: 0px` survives and the header overlaps page content. That is also why resizing the window by a single pixel has been the manual workaround: core recalculates on `resize`.

**Why this approach.** The fix goes in `useLayout`'s cleanup, so it covers every page that applies a layout rather than one page at a time, and it delegates the measurement back to core instead of hardcoding a height. Concretely, that picks up `create-paid-ads-campaign` and `edit-paid-ads-campaign` alongside the store-address screen — they share the same `full-content` layout and show the same overlap, which is what makes the hook the natural place for it.

**On the `min-height` idea** — worth recording so nobody spends time on it again, because it looks like it should work. A `display: none` element generates no box, so `clientHeight` is `0` no matter what `min-height` it carries. That's consistent with what happened in Reddit for WooCommerce, where it shipped ([#24](https://github.com/woocommerce/reddit-for-woocommerce/pull/24)) and was reverted 11 days later ([#34](https://github.com/woocommerce/reddit-for-woocommerce/pull/34)), and with the "does not work as expected" note here.

**Trade-offs, flagged up front so they're easy to push back on:**

- `window.dispatchEvent( new Event( 'resize' ) )` triggers *every* `resize` listener on the page, not only core's. This is the same thing that happens when a merchant resizes the window, so it should be safe, but it is a broader effect than a targeted style write.
- Core debounces `updateBodyMargin` by 200ms, so the correction is not instantaneous. That is a large improvement on a margin that previously stayed wrong indefinitely, but there is a brief window before it settles.

**Backward compatibility:** none. `useLayout` is an internal React hook under `js/src/hooks/`. This touches no `woocommerce_gla_` hook, no `wc/gla` REST route, no public PHP symbol, and no `glaData` property.

### Screenshots:

**Before**: tab strip pushed up under the header, labels clipped:

<img width="2012" height="649" alt="before" src="https://github.com/user-attachments/assets/7c4bc335-29ab-40b3-ad01-549d5b9b09e3" />


**After**: tab strip correctly cleared of the header:

<img width="4014" height="1494" alt="after" src="https://github.com/user-attachments/assets/717a8150-0df9-4927-b8ce-80740edd21ad" />


The vertical difference between the two is ~60px, matching `.woocommerce-layout__header`'s height — i.e. exactly the difference between `margin-top: 0px` and `margin-top: 60px`.

### Detailed test instructions:

**Environment:** WordPress with WooCommerce and Google for WooCommerce active, onboarding completed. Requires a browser (the defect is layout-only).

**Preconditions:** you are logged in as an administrator and on the Google for WooCommerce **Settings** tab.

1. Go to **Marketing → Google for WooCommerce → Settings**.
2. In **Contact information**, click **Edit** on the store address. This mounts the `full-content` layout, which hides the WooCommerce header.
3. Click the **"<"** back button to return to Settings.
4. Repeat steps 2–3, this time clicking **Update store address** before navigating back.
5. **Expected:** the settings tab strip (Dashboard / Reports / Product Feed / …) stays fully visible and is never overlapped or clipped by the WooCommerce header.
6. **Before this change** the tabs slide up under the header on roughly 7 of 10 attempts; resizing the window by 1px corrects it.

**Also verify the two pages #3301 did not cover**, which use the same layout — repeat the navigate-in-then-back pattern and confirm no overlap on return:

- **Create paid ads campaign** (`create-paid-ads-campaign`)
- **Edit paid ads campaign** (`edit-paid-ads-campaign`)

**Regression check:** confirm the full-page onboarding flow (`/google/start`) still renders with the header hidden while you are inside it, and that leaving it lands on a correctly spaced page.

### Additional details:

Unit tests added in `js/src/hooks/useLayout.test.js` (6 cases): two assert the `resize` dispatch on cleanup for both `full-page` and `full-content`, and four pin the existing class attach/detach behaviour so it cannot regress. Verified failing before the change (2 failed / 4 passed) and passing after (6/6).

On the full JS suite, `js/src/hooks/useHasRecentAdSpend.test.js` fails (3 tests) — this reproduces on clean `develop` with this change stashed, so it is pre-existing and unrelated. Two further suites (`app-input-number-control`, `connect-existing-account`) fail intermittently under full-suite parallel load and pass in isolation both with and without this change.

### Changelog entry

> Fix - Google for WooCommerce settings tabs are no longer hidden behind the WooCommerce header after editing your store address or a paid ads campaign.
