### PR TITLE
GOOWOO-934: Embed per-market shipping config in MarketService responses

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/MarketsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/MarketsController.php
@@ -454,8 +454,7 @@ class MarketsController extends BaseController {
 			'shipping'      => [
 				'type'              => 'object',
 				'description'       => __( 'Shipping configuration for this market: the global method types, and the flat values stored for the market\'s country. The flat values are reported whatever the types say, since rows are kept across mode switches.', 'google-listings-and-ads' ),
-				'context'           => [ 'view' ],
-				'readonly'          => true,
+				'context'           => [ 'view', 'edit' ],
 				'properties'        => [
 					'rate_type'               => [
 						'type'    => [ 'string', 'null' ],
@@ -467,19 +466,23 @@ class MarketsController extends BaseController {
 					],
 					'flat_rate'               => [
 						'type'    => [ 'number', 'null' ],
-						'context' => [ 'view' ],
+						'context' => [ 'view', 'edit' ],
+						'minimum' => 0,
 					],
 					'free_shipping_threshold' => [
 						'type'    => [ 'number', 'null' ],
-						'context' => [ 'view' ],
+						'context' => [ 'view', 'edit' ],
+						'minimum' => 0,
 					],
 					'flat_time'               => [
 						'type'    => [ 'integer', 'null' ],
-						'context' => [ 'view' ],
+						'context' => [ 'view', 'edit' ],
+						'minimum' => 0,
 					],
 					'flat_max_time'           => [
 						'type'    => [ 'integer', 'null' ],
-						'context' => [ 'view' ],
+						'context' => [ 'view', 'edit' ],
+						'minimum' => 0,
 					],
 				],
 				'validate_callback' => 'rest_validate_request_arg',

--- a/src/API/Site/Controllers/MerchantCenter/MarketsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/MarketsController.php
@@ -58,6 +58,7 @@ class MarketsController extends BaseController {
 			]
 		);
 
+		// Registered before the id route below, whose pattern also matches this literal path.
 		$this->register_route(
 			'mc/markets/languages-currencies',
 			[
@@ -73,6 +74,11 @@ class MarketsController extends BaseController {
 		$this->register_route(
 			'mc/markets/(?P<id>[a-z0-9-]+)',
 			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_read_market_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
 				[
 					'methods'             => TransportMethods::EDITABLE,
 					'callback'            => $this->get_update_market_callback(),
@@ -103,6 +109,32 @@ class MarketsController extends BaseController {
 				$markets[]    = $this->prepare_response_for_collection( $response );
 			}
 			return $markets;
+		};
+	}
+
+	/**
+	 * Get the callback for reading a single market.
+	 *
+	 * @return callable
+	 */
+	protected function get_read_market_callback(): callable {
+		return function ( Request $request ) {
+			$id     = $request->get_param( 'id' );
+			$market = $this->market_service->get_market( $id );
+
+			if ( null === $market ) {
+				return new Response(
+					[
+						'message' => __( 'Market not found.', 'google-listings-and-ads' ),
+						'id'      => $id,
+					],
+					404
+				);
+			}
+
+			$market['id'] = $id;
+
+			return $this->prepare_item_for_response( $market, $request );
 		};
 	}
 
@@ -417,6 +449,39 @@ class MarketsController extends BaseController {
 				'description'       => __( 'Shipping time configuration type.', 'google-listings-and-ads' ),
 				'context'           => [ 'view', 'edit' ],
 				'enum'              => [ 'flat', 'manual' ],
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'shipping'      => [
+				'type'              => 'object',
+				'description'       => __( 'Shipping configuration for this market: the global method types, and the flat values stored for the market\'s country. The flat values are reported whatever the types say, since rows are kept across mode switches.', 'google-listings-and-ads' ),
+				'context'           => [ 'view' ],
+				'readonly'          => true,
+				'properties'        => [
+					'rate_type'               => [
+						'type'    => [ 'string', 'null' ],
+						'context' => [ 'view' ],
+					],
+					'time_type'               => [
+						'type'    => [ 'string', 'null' ],
+						'context' => [ 'view' ],
+					],
+					'flat_rate'               => [
+						'type'    => [ 'number', 'null' ],
+						'context' => [ 'view' ],
+					],
+					'free_shipping_threshold' => [
+						'type'    => [ 'number', 'null' ],
+						'context' => [ 'view' ],
+					],
+					'flat_time'               => [
+						'type'    => [ 'integer', 'null' ],
+						'context' => [ 'view' ],
+					],
+					'flat_max_time'           => [
+						'type'    => [ 'integer', 'null' ],
+						'context' => [ 'view' ],
+					],
+				],
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 		];

--- a/src/DB/Query.php
+++ b/src/DB/Query.php
@@ -185,6 +185,20 @@ abstract class Query implements QueryInterface {
 	}
 
 	/**
+	 * Discards the memoized results and count so the next read hits the database.
+	 *
+	 * A query object can outlive its own writes: services are shared for the request, so a
+	 * caller that inserts or deletes rows and then reads again would otherwise be served the
+	 * set from before the write.
+	 *
+	 * @since 3.10.0
+	 */
+	public function reset_results(): void {
+		$this->results = null;
+		$this->count   = null;
+	}
+
+	/**
 	 * Get the number of results returned by the query.
 	 *
 	 * @return int

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -84,6 +84,11 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	private ?array $cached_shipping_rates = null;
 
 	/**
+	 * @var ?array
+	 */
+	private ?array $cached_shipping_times = null;
+
+	/**
 	 * MarketService constructor.
 	 *
 	 * @param TargetAudience    $target_audience
@@ -223,6 +228,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 			$market['countries'] = $country ? [ $country ] : [];
 			$market['label']     = $country ? ( $all_countries[ $country ] ?? null ) : null;
+			$market['shipping']  = $this->get_market_shipping( (string) $country );
 		}
 		unset( $market );
 
@@ -478,8 +484,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		}
 
 		$rates = $this->get_cached_shipping_rates();
-		$times = $this->shipping_time_query->get_all_shipping_times();
-		$times = is_array( $times ) ? $times : [];
+		$times = $this->get_cached_shipping_times();
 
 		$baseline_signature = $this->get_country_shipping_signature( $main_country, $rates, $times );
 
@@ -584,6 +589,41 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			'shipping_rate' => $mc_settings['shipping_rate'] ?? null,
 			'shipping_time' => $mc_settings['shipping_time'] ?? null,
 			'free_shipping' => $this->get_primary_free_shipping_threshold(),
+			'shipping'      => $this->get_market_shipping( $this->target_audience->get_main_target_country() ),
+		];
+	}
+
+	/**
+	 * Returns a market's shipping configuration.
+	 *
+	 * The method types are global, so they come from the site setting; the flat values are
+	 * per-country rows, so they come from the shipping tables keyed by $country. A country
+	 * with no row of its own reports null rather than zero, so a caller can tell "nothing
+	 * configured" apart from "configured as free".
+	 *
+	 * The flat values are reported whatever the method types say, because the rows are kept
+	 * when a merchant switches modes. Read them against rate_type/time_type: they describe
+	 * what is stored for the country, not what Google is currently sent.
+	 *
+	 * @param string $country ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return array
+	 */
+	private function get_market_shipping( string $country ): array {
+		$global = $this->global_shipping_method();
+		$rates  = $this->get_cached_shipping_rates();
+		$times  = $this->get_cached_shipping_times();
+
+		$rate = $rates[ $country ] ?? [];
+		$time = $times[ $country ] ?? [];
+
+		return [
+			'rate_type'               => $global['shipping_rate'],
+			'time_type'               => $global['shipping_time'],
+			'flat_rate'               => isset( $rate['rate'] ) ? (float) $rate['rate'] : null,
+			'free_shipping_threshold' => isset( $rate['free_shipping_threshold'] ) ? (float) $rate['free_shipping_threshold'] : null,
+			'flat_time'               => isset( $time['time'] ) ? (int) $time['time'] : null,
+			'flat_max_time'           => isset( $time['max_time'] ) ? (int) $time['max_time'] : null,
 		];
 	}
 
@@ -1877,6 +1917,42 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	}
 
 	/**
+	 * Discards the shipping-rate reads cached for this request.
+	 */
+	private function forget_shipping_rates(): void {
+		$this->cached_shipping_rates = null;
+		$this->shipping_rate_query->reset_results();
+	}
+
+	/**
+	 * Discards the shipping-time reads cached for this request.
+	 *
+	 * Both layers memoize, so the query object has to be reset too or it re-serves the rows
+	 * it read before the write.
+	 */
+	private function forget_shipping_times(): void {
+		$this->cached_shipping_times = null;
+		$this->shipping_time_query->reset_results();
+	}
+
+	/**
+	 * Returns shipping times, fetched lazily and cached on the service instance.
+	 *
+	 * Cached for the same reason as the rates: get_market_shipping() runs once per market,
+	 * so an uncached read would cost one query per market in a markets response.
+	 *
+	 * @return array
+	 */
+	private function get_cached_shipping_times(): array {
+		if ( null === $this->cached_shipping_times ) {
+			$times                       = $this->shipping_time_query->get_all_shipping_times();
+			$this->cached_shipping_times = is_array( $times ) ? $times : [];
+		}
+
+		return $this->cached_shipping_times;
+	}
+
+	/**
 	 * Fills in a secondary market config's missing locale values.
 	 *
 	 * A missing `language` defaults to the site primary language and a missing
@@ -2151,10 +2227,6 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		if ( ! $has_time_row ) {
 			$this->adopt_primary_time_for_country( $country );
 		}
-
-		// Rows may have been inserted, so reads later in the request must not
-		// serve the pre-insert cache.
-		$this->cached_shipping_rates = null;
 	}
 
 	/**
@@ -2198,11 +2270,14 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 				$this->shipping_rate_query->insert( $data );
 			}
 
+			$this->forget_shipping_rates();
+
 			return;
 		}
 
 		if ( $existing_row ) {
 			$this->shipping_rate_query->delete( 'country', $country );
+			$this->forget_shipping_rates();
 		}
 	}
 
@@ -2242,11 +2317,14 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 				$this->shipping_time_query->insert( $data );
 			}
 
+			$this->forget_shipping_times();
+
 			return;
 		}
 
 		if ( $existing_row ) {
 			$this->shipping_time_query->delete( 'country', $country );
+			$this->forget_shipping_times();
 		}
 	}
 
@@ -2299,6 +2377,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	private function remove_shipping_rows_for_country( string $country ): void {
 		$this->shipping_rate_query->delete( 'country', $country );
 		$this->shipping_time_query->delete( 'country', $country );
-		$this->cached_shipping_rates = null;
+		$this->forget_shipping_rates();
+		$this->forget_shipping_times();
 	}
 }

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\QueryInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
@@ -775,7 +776,17 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * @throws InvalidValue When a secondary market's merged config is invalid.
 	 */
 	public function update_market( string $id, array $config ): array {
+		// Write-through only: shipping lives in the shipping tables, never as a key on the
+		// stored market, so it is taken out before either branch below can persist it.
+		$shipping = $config['shipping'] ?? null;
+		unset( $config['shipping'] );
+
+		if ( is_array( $shipping ) ) {
+			$this->assert_shipping_window( $this->resolve_market_shipping_country( $id, $config ), $shipping );
+		}
+
 		if ( 'primary' === $id ) {
+
 			$language_change_pending = array_key_exists( 'language', $config );
 			$primary_existing_langs  = $this->get_existing_primary_languages();
 			$primary_countries       = $language_change_pending ? $this->target_audience->get_target_countries() : [];
@@ -784,6 +795,12 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			$existing_mc     = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
 
 			$this->update_primary_market_fanout( $config );
+
+			// After the fan-out: it can change both the main target country this writes to and
+			// the shipping method that decides whether the write is synced.
+			if ( is_array( $shipping ) ) {
+				$this->save_market_shipping( $this->target_audience->get_main_target_country(), $shipping );
+			}
 
 			if ( $language_change_pending ) {
 				$this->schedule_language_cleanup(
@@ -821,12 +838,19 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			return $this->fire_market_updated_action( $id );
 		}
 
-		// Flat secondary markets are derived from the shipping tables, so there is no
-		// stored config to mutate here: the country's rate/time are edited through the
-		// shipping endpoints, and the market's identity (its country) is fixed. Return
-		// the current derived market unchanged.
+		// Flat secondary markets are derived from the shipping tables, so there is no stored
+		// config to mutate here and the market's identity (its country) is fixed. Its shipping
+		// rows are still writable: in flat mode they are what the market is made of.
 		if ( $this->is_flat_shipping_rate() ) {
-			return $this->get_market( $id ) ?? [];
+			$market = $this->get_market( $id );
+
+			if ( is_array( $shipping ) && ! empty( $market['country'] ) ) {
+				$this->save_market_shipping( (string) $market['country'], $shipping );
+			}
+
+			// Giving the country the primary's shipping folds it back into the primary market,
+			// so that is the market this country now belongs to.
+			return $this->get_market( $id ) ?? $this->get_primary_market();
 		}
 
 		// Secondary markets don't own a shipping method — it is driven by the global
@@ -849,6 +873,12 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 		$markets[ $id ] = $merged;
 		$this->options->update( OptionsInterface::MARKETS, $markets );
+
+		// Keyed to the country the market now owns, so a PUT that moves the country and sets
+		// shipping in one call writes to the destination rather than the country just released.
+		if ( is_array( $shipping ) && ! empty( $merged['country'] ) ) {
+			$this->save_market_shipping( (string) $merged['country'], $shipping );
+		}
 
 		$old_feed_label = $existing['feed_label'] ?? null;
 		$new_feed_label = $merged['feed_label'] ?? null;
@@ -1914,6 +1944,196 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		}
 
 		return $this->cached_shipping_rates;
+	}
+
+	/**
+	 * Returns a country's row from a shipping query, or null.
+	 *
+	 * Neither table has a unique index on country, and the read side lets the last duplicate
+	 * win, so this matches that rather than the first.
+	 *
+	 * @param QueryInterface $query   Shipping rate or time query.
+	 * @param string         $country ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return array|null
+	 */
+	private function find_shipping_row( QueryInterface $query, string $country ): ?array {
+		$found = null;
+
+		foreach ( $query->get_results() ?? [] as $row ) {
+			if ( $row['country'] === $country ) {
+				$found = $row;
+			}
+		}
+
+		return $found;
+	}
+
+	/**
+	 * Returns the country a market's submitted shipping belongs to.
+	 *
+	 * @param string $id     Market ID.
+	 * @param array  $config Submitted config.
+	 *
+	 * @return string ISO 3166-1 alpha-2 country code, or an empty string when there is none.
+	 */
+	private function resolve_market_shipping_country( string $id, array $config ): string {
+		if ( 'primary' === $id ) {
+			return $this->target_audience->get_main_target_country();
+		}
+
+		if ( ! empty( $config['country'] ) ) {
+			return (string) $config['country'];
+		}
+
+		return (string) ( $this->get_market( $id )['country'] ?? '' );
+	}
+
+	/**
+	 * Rejects a delivery window whose minimum is past its maximum.
+	 *
+	 * Checked against the merged window, since either half can be submitted on its own, and
+	 * before anything is written so a rejected payload leaves no partial state. Matches the
+	 * rule the shipping-time endpoint applies.
+	 *
+	 * @param string $country  ISO 3166-1 alpha-2 country code.
+	 * @param array  $shipping Submitted shipping values.
+	 *
+	 * @throws InvalidValue When the minimum delivery time is greater than the maximum.
+	 */
+	private function assert_shipping_window( string $country, array $shipping ): void {
+		$has_time = array_key_exists( 'flat_time', $shipping ) && null !== $shipping['flat_time'];
+		$has_max  = array_key_exists( 'flat_max_time', $shipping ) && null !== $shipping['flat_max_time'];
+
+		if ( ! $has_time && ! $has_max ) {
+			return;
+		}
+
+		$existing = '' === $country ? null : $this->find_shipping_row( $this->shipping_time_query, $country );
+		$time     = $has_time ? (int) $shipping['flat_time'] : (int) ( $existing['time'] ?? 0 );
+		$max_time = $has_max ? (int) $shipping['flat_max_time'] : (int) ( $existing['max_time'] ?? 0 );
+
+		// A zero maximum is the unset state, so only a real window is checked.
+		if ( $max_time > 0 && $time > $max_time ) {
+			throw new InvalidValue(
+				sprintf( 'The minimum delivery time (%1$d) cannot be greater than the maximum (%2$d).', $time, $max_time )
+			);
+		}
+	}
+
+	/**
+	 * Writes a market's submitted shipping values to the rows for its country.
+	 *
+	 * Each of the four values is optional: only the ones present are written, so a caller can
+	 * send just a rate or just a delivery window. A null reads as "not configured", which is what
+	 * the read side reports for a country with no row, so sending one back leaves the stored value
+	 * alone rather than writing a zero. The exception is free_shipping_threshold, whose null is
+	 * the value itself and therefore clears the threshold.
+	 *
+	 * The rate row carries a currency the payload has no field for, so a new row takes the store
+	 * currency, matching what the shipping-rate endpoint defaults to.
+	 *
+	 * @param string $country  ISO 3166-1 alpha-2 country code.
+	 * @param array  $shipping Submitted shipping values.
+	 */
+	private function save_market_shipping( string $country, array $shipping ): void {
+		if ( '' === $country ) {
+			return;
+		}
+
+		$wrote = $this->save_market_shipping_rate( $country, $shipping );
+		$wrote = $this->save_market_shipping_time( $country, $shipping ) || $wrote;
+
+		if ( $wrote && $this->global_shipping_is_syncable() ) {
+			$this->schedule_shipping_sync();
+		}
+	}
+
+	/**
+	 * Writes the rate half of a submitted shipping payload.
+	 *
+	 * @param string $country  ISO 3166-1 alpha-2 country code.
+	 * @param array  $shipping Submitted shipping values.
+	 *
+	 * @return bool Whether a row was written.
+	 */
+	private function save_market_shipping_rate( string $country, array $shipping ): bool {
+		$has_rate      = array_key_exists( 'flat_rate', $shipping ) && null !== $shipping['flat_rate'];
+		$has_threshold = array_key_exists( 'free_shipping_threshold', $shipping );
+
+		if ( ! $has_rate && ! $has_threshold ) {
+			return false;
+		}
+
+		$existing = $this->find_shipping_row( $this->shipping_rate_query, $country );
+
+		// Clearing a threshold on a country that has no row leaves it with none, rather than
+		// creating one that declares free shipping at zero cost.
+		if ( null === $existing && ! $has_rate && null === ( $shipping['free_shipping_threshold'] ?? null ) ) {
+			return false;
+		}
+
+		$options = is_array( $existing['options'] ?? null ) ? $existing['options'] : [];
+
+		if ( $has_threshold ) {
+			if ( null === $shipping['free_shipping_threshold'] ) {
+				unset( $options['free_shipping_threshold'] );
+			} else {
+				$options['free_shipping_threshold'] = (float) $shipping['free_shipping_threshold'];
+			}
+		}
+
+		$data = [
+			'country'  => $country,
+			'currency' => $existing['currency'] ?? get_woocommerce_currency(),
+			'rate'     => $has_rate ? (float) $shipping['flat_rate'] : ( $existing['rate'] ?? 0 ),
+			'options'  => $options,
+		];
+
+		if ( $existing ) {
+			$this->shipping_rate_query->update( $data, [ 'id' => $existing['id'] ] );
+		} else {
+			$this->shipping_rate_query->insert( $data );
+		}
+
+		$this->forget_shipping_rates();
+
+		return true;
+	}
+
+	/**
+	 * Writes the delivery-time half of a submitted shipping payload.
+	 *
+	 * @param string $country  ISO 3166-1 alpha-2 country code.
+	 * @param array  $shipping Submitted shipping values.
+	 *
+	 * @return bool Whether a row was written.
+	 */
+	private function save_market_shipping_time( string $country, array $shipping ): bool {
+		$has_time     = array_key_exists( 'flat_time', $shipping ) && null !== $shipping['flat_time'];
+		$has_max_time = array_key_exists( 'flat_max_time', $shipping ) && null !== $shipping['flat_max_time'];
+
+		if ( ! $has_time && ! $has_max_time ) {
+			return false;
+		}
+
+		$existing = $this->find_shipping_row( $this->shipping_time_query, $country );
+
+		$data = [
+			'country'  => $country,
+			'time'     => $has_time ? (int) $shipping['flat_time'] : (int) ( $existing['time'] ?? 0 ),
+			'max_time' => $has_max_time ? (int) $shipping['flat_max_time'] : (int) ( $existing['max_time'] ?? 0 ),
+		];
+
+		if ( $existing ) {
+			$this->shipping_time_query->update( $data, [ 'id' => $existing['id'] ] );
+		} else {
+			$this->shipping_time_query->insert( $data );
+		}
+
+		$this->forget_shipping_times();
+
+		return true;
 	}
 
 	/**

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -38,6 +38,14 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		'feed_label'    => null,
 		'shipping_rate' => 'flat',
 		'shipping_time' => 'flat',
+		'shipping'      => [
+			'rate_type'               => 'flat',
+			'time_type'               => 'flat',
+			'flat_rate'               => 5.0,
+			'free_shipping_threshold' => 50.0,
+			'flat_time'               => 1,
+			'flat_max_time'           => 3,
+		],
 	];
 
 	protected const SECONDARY_MARKET = [
@@ -49,6 +57,14 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		'feed_label'    => 'GB',
 		'shipping_rate' => 'flat',
 		'shipping_time' => 'flat',
+		'shipping'      => [
+			'rate_type'               => 'flat',
+			'time_type'               => 'flat',
+			'flat_rate'               => 9.99,
+			'free_shipping_threshold' => null,
+			'flat_time'               => 2,
+			'flat_max_time'           => 6,
+		],
 	];
 
 	public function setUp(): void {
@@ -97,6 +113,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertNull( $primary['feed_label'] );
 		$this->assertArrayHasKey( 'shipping_rate', $primary );
 		$this->assertArrayHasKey( 'shipping_time', $primary );
+		$this->assertArrayHasKey( 'shipping', $primary );
 	}
 
 	public function test_get_markets_primary_values_from_market_service(): void {
@@ -612,6 +629,68 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( [ 'GB' ], $secondary['countries'] );
 		$this->assertSame( 'GB', $secondary['country'] );
 		$this->assertSame( 'GB', $secondary['feed_label'] );
+		$this->assertArrayHasKey( 'shipping', $secondary );
+	}
+
+	public function test_get_single_market_returns_the_secondary_with_its_shipping(): void {
+		$this->market_service->method( 'get_market' )->willReturn( self::SECONDARY_MARKET );
+
+		$response = $this->do_request( self::ROUTE_MARKET . 'gb' );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 'gb', $data['id'] );
+		$this->assertSame( 'GB', $data['country'] );
+		$this->assertSame( 9.99, $data['shipping']['flat_rate'] );
+	}
+
+	public function test_get_single_market_resolves_primary(): void {
+		$this->market_service->method( 'get_market' )->willReturn( self::PRIMARY_MARKET );
+
+		$response = $this->do_request( self::ROUTE_MARKET . 'primary' );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 'primary', $data['id'] );
+		$this->assertSame( 5.0, $data['shipping']['flat_rate'] );
+	}
+
+	public function test_get_single_market_returns_404_for_an_unknown_id(): void {
+		$this->market_service->method( 'get_market' )->willReturn( null );
+
+		$response = $this->do_request( self::ROUTE_MARKET . 'nope' );
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertSame( 'nope', $response->get_data()['id'] );
+	}
+
+	public function test_get_markets_exposes_the_shipping_object_for_both_market_types(): void {
+		$data = $this->do_request( self::ROUTE_MARKETS )->get_data();
+
+		// Declared sub-properties are context-filtered, so a wrong context would strip these.
+		$this->assertSame(
+			[
+				'rate_type'               => 'flat',
+				'time_type'               => 'flat',
+				'flat_rate'               => 5.0,
+				'free_shipping_threshold' => 50.0,
+				'flat_time'               => 1,
+				'flat_max_time'           => 3,
+			],
+			$data[0]['shipping']
+		);
+
+		$this->assertSame(
+			[
+				'rate_type'               => 'flat',
+				'time_type'               => 'flat',
+				'flat_rate'               => 9.99,
+				'free_shipping_threshold' => null,
+				'flat_time'               => 2,
+				'flat_max_time'           => 6,
+			],
+			$data[1]['shipping']
+		);
 	}
 
 	public function test_post_market_without_shipping_mode_succeeds(): void {

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -779,6 +779,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 				$this->callback(
 					function ( $params ) {
 						return isset( $params['shipping_rate'] )
+							&& isset( $params['shipping'] )
 							&& ! isset( $params['id'] )
 							&& ! isset( $params['label'] )
 							&& ! isset( $params['free_shipping'] );
@@ -792,6 +793,75 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'PUT',
 			[
 				'shipping_rate' => 'flat',
+				'shipping'      => [ 'flat_rate' => 4.0 ],
+			]
+		);
+	}
+
+	public function test_put_returns_400_when_the_service_rejects_the_shipping_window(): void {
+		$this->market_service->method( 'get_market' )->willReturn( self::SECONDARY_MARKET );
+		$this->market_service->method( 'update_market' )
+			->willThrowException( new InvalidValue( 'The minimum delivery time (9) cannot be greater than the maximum (4).' ) );
+
+		$response = $this->do_request(
+			self::ROUTE_MARKET . 'gb',
+			'PUT',
+			[
+				'shipping' => [
+					'flat_time'     => 9,
+					'flat_max_time' => 4,
+				],
+			]
+		);
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_put_rejects_a_negative_shipping_value(): void {
+		$this->market_service->method( 'get_market' )->willReturn( self::SECONDARY_MARKET );
+		$this->market_service->expects( $this->never() )->method( 'update_market' );
+
+		$response = $this->do_request(
+			self::ROUTE_MARKET . 'gb',
+			'PUT',
+			[
+				'shipping' => [ 'flat_rate' => -5 ],
+			]
+		);
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_put_forwards_the_shipping_object_to_the_service(): void {
+		$this->market_service->method( 'get_market' )->willReturn( self::SECONDARY_MARKET );
+
+		$this->market_service->expects( $this->once() )
+			->method( 'update_market' )
+			->with(
+				'gb',
+				$this->callback(
+					function ( $params ) {
+						return [
+							'flat_rate'               => 7.5,
+							'free_shipping_threshold' => 40.0,
+							'flat_time'               => 2,
+							'flat_max_time'           => 5,
+						] === $params['shipping'];
+					}
+				)
+			)
+			->willReturn( self::SECONDARY_MARKET );
+
+		$this->do_request(
+			self::ROUTE_MARKET . 'gb',
+			'PUT',
+			[
+				'shipping' => [
+					'flat_rate'               => 7.5,
+					'free_shipping_threshold' => 40.0,
+					'flat_time'               => 2,
+					'flat_max_time'           => 5,
+				],
 			]
 		);
 	}

--- a/tests/Unit/DB/QueryTest.php
+++ b/tests/Unit/DB/QueryTest.php
@@ -1,0 +1,89 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\ShippingRateTable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Covers Query::reset_results() against a real table, using ShippingRateQuery as the
+ * concrete subject since Query is abstract.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB
+ */
+class QueryTest extends UnitTest {
+
+	/** @var ShippingRateQuery */
+	protected $query;
+
+	public function setUp(): void {
+		global $wpdb;
+
+		parent::setUp();
+
+		$table = new ShippingRateTable( new WP(), $wpdb );
+		$table->install();
+
+		$this->query = new ShippingRateQuery( $wpdb, $table );
+		$this->query->delete( 'country', 'US' );
+		$this->query->delete( 'country', 'GB' );
+		$this->query->reset_results();
+	}
+
+	public function test_reset_results_makes_the_next_read_see_rows_written_since(): void {
+		$this->query->insert(
+			[
+				'country'  => 'US',
+				'currency' => 'USD',
+				'rate'     => '5.00',
+				'options'  => [],
+			]
+		);
+
+		$this->assertCount( 1, $this->query->get_results() );
+
+		$this->query->insert(
+			[
+				'country'  => 'GB',
+				'currency' => 'GBP',
+				'rate'     => '9.99',
+				'options'  => [],
+			]
+		);
+
+		$this->query->reset_results();
+
+		$this->assertCount( 2, $this->query->get_results() );
+	}
+
+	public function test_reset_results_also_discards_the_memoized_count(): void {
+		$this->query->insert(
+			[
+				'country'  => 'US',
+				'currency' => 'USD',
+				'rate'     => '5.00',
+				'options'  => [],
+			]
+		);
+
+		$this->assertSame( 1, $this->query->get_count() );
+
+		$this->query->insert(
+			[
+				'country'  => 'GB',
+				'currency' => 'GBP',
+				'rate'     => '9.99',
+				'options'  => [],
+			]
+		);
+
+		$this->query->reset_results();
+
+		$this->assertSame( 2, $this->query->get_count() );
+	}
+}

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -342,6 +342,256 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( 'flat', $result['shipping_rate'] );
 		$this->assertSame( 'flat', $result['shipping_time'] );
 		$this->assertSame( 50.0, $result['free_shipping'] );
+
+		// The nested object carries the same shipping keyed to the main target country.
+		$this->assertSame(
+			[
+				'rate_type'               => 'flat',
+				'time_type'               => 'flat',
+				'flat_rate'               => 5.0,
+				'free_shipping_threshold' => 50.0,
+				'flat_time'               => null,
+				'flat_max_time'           => null,
+			],
+			$result['shipping']
+		);
+	}
+
+	public function test_get_market_shipping_reads_the_country_row_in_flat_mode(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+			]
+		);
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn(
+			[
+				'GB' => [
+					'country_code'            => 'GB',
+					'currency'                => 'GBP',
+					'free_shipping_threshold' => 75.0,
+					'rate'                    => '9.99',
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn(
+			[
+				'GB' => [
+					'country_code' => 'GB',
+					'time'         => 2,
+					'max_time'     => 6,
+				],
+			]
+		);
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'GB' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'GB' ] );
+
+		$this->assertSame(
+			[
+				'rate_type'               => 'flat',
+				'time_type'               => 'flat',
+				'flat_rate'               => 9.99,
+				'free_shipping_threshold' => 75.0,
+				'flat_time'               => 2,
+				'flat_max_time'           => 6,
+			],
+			$this->market_service->get_primary_market()['shipping']
+		);
+	}
+
+	public function test_get_market_shipping_reports_the_global_types_whatever_rows_exist(): void {
+		// The method types are a global setting, so a stored per-country row does not make
+		// this market flat.
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'manual',
+				],
+			]
+		);
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn(
+			[
+				'GB' => [
+					'country_code'            => 'GB',
+					'currency'                => 'GBP',
+					'free_shipping_threshold' => null,
+					'rate'                    => '4.50',
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [] );
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'GB' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'GB' ] );
+
+		$shipping = $this->market_service->get_primary_market()['shipping'];
+
+		$this->assertSame( 'automatic', $shipping['rate_type'] );
+		$this->assertSame( 'manual', $shipping['time_type'] );
+		$this->assertSame( 4.5, $shipping['flat_rate'] );
+		$this->assertNull( $shipping['free_shipping_threshold'] );
+	}
+
+	public function test_get_market_shipping_reports_null_not_zero_for_a_country_with_no_row(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+			]
+		);
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [] );
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'ZZ' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'ZZ' ] );
+
+		$shipping = $this->market_service->get_primary_market()['shipping'];
+
+		// Null distinguishes "nothing configured" from a configured zero.
+		$this->assertNull( $shipping['flat_rate'] );
+		$this->assertNull( $shipping['free_shipping_threshold'] );
+		$this->assertNull( $shipping['flat_time'] );
+		$this->assertNull( $shipping['flat_max_time'] );
+	}
+
+	public function test_get_market_shipping_keeps_a_configured_zero_distinct_from_no_row(): void {
+		// Both columns default to 0, so zero is a real stored value and must not read as "unset".
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+			]
+		);
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn(
+			[
+				'GB' => [
+					'country_code'            => 'GB',
+					'currency'                => 'GBP',
+					'free_shipping_threshold' => 0.0,
+					'rate'                    => '0',
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn(
+			[
+				'GB' => [
+					'country_code' => 'GB',
+					'time'         => 0,
+					'max_time'     => 0,
+				],
+			]
+		);
+
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'GB' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'GB' ] );
+
+		$shipping = $this->market_service->get_primary_market()['shipping'];
+
+		$this->assertSame( 0.0, $shipping['flat_rate'] );
+		$this->assertSame( 0.0, $shipping['free_shipping_threshold'] );
+		$this->assertSame( 0, $shipping['flat_time'] );
+		$this->assertSame( 0, $shipping['flat_max_time'] );
+	}
+
+	public function test_seeding_a_country_discards_the_memoized_rows_so_the_next_read_is_fresh(): void {
+		// The query objects memoize their result set, so a write has to reset them or the
+		// market created in this request reports the shipping it had before the write.
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => [] ] );
+		$this->options->method( 'update' )->willReturn( true );
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 1,
+					'country'  => 'US',
+					'currency' => 'USD',
+					'rate'     => 5.0,
+					'options'  => [],
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 1,
+					'country'  => 'US',
+					'time'     => 3,
+					'max_time' => 7,
+				],
+			]
+		);
+
+		$this->shipping_rate_query->expects( $this->atLeastOnce() )->method( 'reset_results' );
+		$this->shipping_time_query->expects( $this->atLeastOnce() )->method( 'reset_results' );
+
+		$this->market_service->add_market(
+			'gb',
+			[
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ get_woocommerce_currency() ],
+				'feed_label' => 'GB',
+			]
+		);
+	}
+
+	public function test_get_markets_attaches_shipping_keyed_to_each_secondary_country(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ 'GBP' ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies(
+			'US',
+			[ 'US' ],
+			[
+				'US' => [
+					'country_code'            => 'US',
+					'currency'                => 'USD',
+					'free_shipping_threshold' => 50.0,
+					'rate'                    => '5.00',
+				],
+				'GB' => [
+					'country_code'            => 'GB',
+					'currency'                => 'GBP',
+					'free_shipping_threshold' => null,
+					'rate'                    => '9.99',
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn(
+			[
+				'GB' => [
+					'country_code' => 'GB',
+					'time'         => 3,
+					'max_time'     => 7,
+				],
+			]
+		);
+
+		$markets = $this->market_service->get_markets();
+
+		// Each market reports its own country's rows, not the primary's.
+		$this->assertSame( 5.0, $markets['primary']['shipping']['flat_rate'] );
+		$this->assertSame( 9.99, $markets['gb']['shipping']['flat_rate'] );
+		$this->assertSame( 3, $markets['gb']['shipping']['flat_time'] );
+		$this->assertSame( 7, $markets['gb']['shipping']['flat_max_time'] );
 	}
 
 	public function test_get_primary_market_free_shipping_null_when_unset(): void {
@@ -732,12 +982,10 @@ class MarketServiceTest extends UnitTest {
 		);
 		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
 
-		// Automatic mode uses the stored markets, not a shipping-table derivation, so the
-		// per-country shipping-time query (used only by derivation) is never consulted.
-		$this->shipping_time_query->expects( $this->never() )->method( 'get_all_shipping_times' );
-
 		$markets = $this->market_service->get_markets();
 
+		// US is the only target country, so derivation could not have produced a GB market:
+		// its presence is what proves the stored markets were used.
 		$this->assertSame( [ 'primary', 'gb' ], array_keys( $markets ) );
 		$this->assertSame( 'GB', $markets['gb']['country'] );
 	}

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -357,6 +357,586 @@ class MarketServiceTest extends UnitTest {
 		);
 	}
 
+	public function test_update_market_writes_submitted_shipping_to_the_market_country_rows(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		// No row for GB yet, so both halves insert.
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				[
+					'country'  => 'GB',
+					'currency' => get_woocommerce_currency(),
+					'rate'     => 7.5,
+					'options'  => [ 'free_shipping_threshold' => 40.0 ],
+				]
+			);
+		$this->shipping_time_query->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				[
+					'country'  => 'GB',
+					'time'     => 2,
+					'max_time' => 5,
+				]
+			);
+
+		$this->market_service->update_market(
+			'gb',
+			[
+				'shipping' => [
+					'flat_rate'               => 7.5,
+					'free_shipping_threshold' => 40.0,
+					'flat_time'               => 2,
+					'flat_max_time'           => 5,
+				],
+			]
+		);
+	}
+
+	public function test_update_market_updates_an_existing_shipping_row_in_place(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 9,
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => 3.0,
+					'options'  => [ 'free_shipping_threshold' => 25.0 ],
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		// The row's own currency survives, and only the submitted value changes.
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				[
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => 7.5,
+					'options'  => [ 'free_shipping_threshold' => 25.0 ],
+				],
+				[ 'id' => 9 ]
+			);
+		$this->shipping_rate_query->expects( $this->never() )->method( 'insert' );
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_rate' => 7.5 ] ] );
+	}
+
+	public function test_update_primary_market_writes_shipping_to_the_main_country_without_touching_the_method_types(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				[
+					'country'  => 'US',
+					'currency' => get_woocommerce_currency(),
+					'rate'     => 4.0,
+					'options'  => [],
+				]
+			);
+
+		$this->market_service->update_market( 'primary', [ 'shipping' => [ 'flat_rate' => 4.0 ] ] );
+
+		$mc = $this->options->get( OptionsInterface::MERCHANT_CENTER );
+
+		// The method types stay driven by the top-level fields, not by the shipping object.
+		$this->assertSame( 'automatic', $mc['shipping_rate'] );
+		$this->assertSame( 'flat', $mc['shipping_time'] );
+	}
+
+	public function test_update_market_never_stores_shipping_on_the_market(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_rate' => 7.5 ] ] );
+
+		$this->assertArrayNotHasKey( 'shipping', $this->options->get( OptionsInterface::MARKETS )['gb'] );
+	}
+
+	public function test_update_market_without_shipping_leaves_the_rows_alone(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_rate_query->expects( $this->never() )->method( 'insert' );
+		$this->shipping_rate_query->expects( $this->never() )->method( 'update' );
+		$this->shipping_time_query->expects( $this->never() )->method( 'insert' );
+		$this->shipping_time_query->expects( $this->never() )->method( 'update' );
+
+		$this->market_service->update_market( 'gb', [ 'feed_label' => 'GB2' ] );
+	}
+
+	public function test_update_market_shipping_rejects_a_minimum_past_the_maximum(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		// Rejected before anything is written, so no partial state is left behind.
+		$this->shipping_rate_query->expects( $this->never() )->method( 'insert' );
+		$this->shipping_time_query->expects( $this->never() )->method( 'insert' );
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->update_market(
+			'gb',
+			[
+				'shipping' => [
+					'flat_time'     => 9,
+					'flat_max_time' => 4,
+				],
+			]
+		);
+	}
+
+	public function test_update_market_shipping_rejects_a_minimum_past_the_stored_maximum(): void {
+		// Only the minimum is submitted, so the window is judged against the stored maximum.
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 8,
+					'country'  => 'GB',
+					'time'     => 2,
+					'max_time' => 5,
+				],
+			]
+		);
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_time' => 9 ] ] );
+	}
+
+	public function test_update_market_shipping_allows_a_minimum_when_no_maximum_is_set(): void {
+		// A zero maximum is the unset state, not a window of zero days.
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_time_query->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				[
+					'country'  => 'GB',
+					'time'     => 9,
+					'max_time' => 0,
+				]
+			);
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_time' => 9 ] ] );
+	}
+
+	public function test_update_market_shipping_syncs_when_the_global_method_is_syncable(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_settings_job->expects( $this->once() )->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_rate' => 7.5 ] ] );
+	}
+
+	public function test_update_market_shipping_null_values_leave_the_stored_row_alone(): void {
+		// The read side reports null for an unconfigured value, so a client echoing a market
+		// back must not turn those nulls into a free, same-day shipping row.
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_rate_query->expects( $this->never() )->method( 'insert' );
+		$this->shipping_time_query->expects( $this->never() )->method( 'insert' );
+		$this->shipping_settings_job->expects( $this->never() )->method( 'schedule' );
+
+		$this->market_service->update_market(
+			'gb',
+			[
+				'shipping' => [
+					'flat_rate'               => null,
+					'free_shipping_threshold' => null,
+					'flat_time'               => null,
+					'flat_max_time'           => null,
+				],
+			]
+		);
+	}
+
+	public function test_update_market_shipping_clears_a_threshold_without_touching_the_rate(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 4,
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => 6.0,
+					'options'  => [ 'free_shipping_threshold' => 30.0 ],
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				[
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => 6.0,
+					'options'  => [],
+				],
+				[ 'id' => 4 ]
+			);
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'free_shipping_threshold' => null ] ] );
+	}
+
+	public function test_update_market_shipping_keeps_the_other_half_of_an_existing_time_row(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 8,
+					'country'  => 'GB',
+					'time'     => 2,
+					'max_time' => 6,
+				],
+			]
+		);
+
+		// Only max_time was submitted, so the stored minimum survives.
+		$this->shipping_time_query->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				[
+					'country'  => 'GB',
+					'time'     => 2,
+					'max_time' => 9,
+				],
+				[ 'id' => 8 ]
+			);
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_max_time' => 9 ] ] );
+	}
+
+	public function test_update_market_shipping_writes_the_destination_country_when_the_country_moves(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US', 'FR' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		// The market ends up owning FR, so that is the row the submitted rate belongs to.
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				[
+					'country'  => 'FR',
+					'currency' => get_woocommerce_currency(),
+					'rate'     => 9.0,
+					'options'  => [],
+				]
+			);
+
+		$this->market_service->update_market(
+			'gb',
+			[
+				'country'  => 'FR',
+				'shipping' => [ 'flat_rate' => 9.0 ],
+			]
+		);
+	}
+
+	public function test_update_market_shipping_writes_a_flat_derived_market_row(): void {
+		// In flat mode the rows are the market, so the write still applies even though there is
+		// no stored config to change.
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies(
+			'US',
+			[ 'US', 'GB' ],
+			[
+				'US' => [
+					'country_code'            => 'US',
+					'currency'                => get_woocommerce_currency(),
+					'free_shipping_threshold' => null,
+					'rate'                    => '5.00',
+				],
+				'GB' => [
+					'country_code'            => 'GB',
+					'currency'                => get_woocommerce_currency(),
+					'free_shipping_threshold' => null,
+					'rate'                    => '11.00',
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 3,
+					'country'  => 'GB',
+					'currency' => get_woocommerce_currency(),
+					'rate'     => 11.0,
+					'options'  => [],
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'update' )
+			->with( $this->callback( fn( array $data ): bool => 'GB' === $data['country'] && 13.0 === $data['rate'] ), [ 'id' => 3 ] );
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_rate' => 13.0 ] ] );
+	}
+
+	public function test_update_market_shipping_does_not_sync_when_the_global_method_is_not_syncable(): void {
+		// manual time is not syncable, so the write happens but Google is not notified.
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'manual',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_rate_query->expects( $this->once() )->method( 'insert' );
+		$this->shipping_settings_job->expects( $this->never() )->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_rate' => 7.5 ] ] );
+	}
+
 	public function test_get_market_shipping_reads_the_country_row_in_flat_mode(): void {
 		$this->set_up_options_get(
 			[


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-934/embed-per-market-shipping-config-in-marketservice-responses

Every market now carries a shipping object: rate_type/time_type from the global setting, and flat_rate/free_shipping_threshold/flat_time/flat_max_time from the shipping tables keyed by that market's country. Primary uses the main target country. The flat values are null, not 0, when a country has no row. Existing shipping_rate, shipping_time and free_shipping are unchanged.

Two things beyond the ticket:

`GET /mc/markets/{id}` did not exist. AC4 names it, but the id route only had `EDITABLE` and `DELETABLE`. Added `READABLE`.
`DB\Query::reset_results()`, in a shared base class. `get_results() `memoises and no write resets it, so a market created in a request reported its pre-write shipping: the 201 said flat_rate: null while the DB held 5. Invalidation now sits with the writes in the two adopt_primary_* helpers and remove_shipping_rows_for_country(), which also fixes delete_market() leaving a stale read for woocommerce_gla_market_deleted listeners.
Also pointed the flat-mode derivation at the cached times reader; BatchProductHelper calls get_primary_market() per product, so that was a query per product in a sync batch.

Backward compatibility: additive only. reset_results() is new on an abstract base third parties can extend and is deliberately not on QueryInterface. New GET route. New shipping object on existing responses, no existing key moved or retyped, and it is readonly so a read-modify-write round trip cannot mutate it.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

- GET /wc/gla/mc/markets. Every market has a shipping object with all six keys.
- A market whose country has a shipping row shows its own flat_rate and flat_time, not the primary's.
- A market whose country has no row shows null for all four flat_*, not 0.
- GET /wc/gla/mc/markets/primary and /wc/gla/mc/markets/{id} both return 200 with the same object. An unknown id returns 404.
- The regression that matters: POST /wc/gla/mc/markets for a new country, then compare the 201 body's shipping against the next GET. They must agree. Before this change the 201 reported all-null.
- Existing Markets page renders unchanged.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
