### PR TITLE
Remove dead google-manager flow from the connection test page

### DIFF
--- a/src/ConnectionTest.php
+++ b/src/ConnectionTest.php
@@ -127,10 +127,6 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 			$this->response .= 'Google Account connected successfully.';
 		}
 
-		if ( ! empty( $_GET['google-manager'] ) && 'connected' === $_GET['google-manager'] ) {
-			$this->response .= 'Successfully connected a Google Manager account.';
-		}
-
 		if ( ! empty( $_GET['google'] ) && 'failed' === $_GET['google'] ) {
 			$this->response .= 'Failed to connect to Google.';
 		}
@@ -893,41 +889,6 @@ class ConnectionTest implements ContainerAwareInterface, Service, Registerable {
 			}
 
 			$this->response .= wp_remote_retrieve_body( $response );
-		}
-
-		if ( 'wcs-google-manager' === $_GET['action'] && check_admin_referer( 'wcs-google-manager' ) ) {
-			if ( empty( $_GET['manager_id'] ) ) {
-				$this->response .= 'Manager ID must be set';
-				return;
-			}
-
-			$id   = absint( $_GET['manager_id'] );
-			$url  = trailingslashit( $this->get_connect_server_url() ) . 'google/connection/google-manager';
-			$args = [
-				'headers' => [ 'Authorization' => $this->get_auth_header() ],
-				'body'    => [
-					'returnUrl' => admin_url( 'admin.php?page=connection-test-admin-page' ),
-					'managerId' => $id,
-					'countries' => 'US,CA',
-				],
-			];
-
-			$this->response = 'POST ' . $url . "\n" . var_export( $args, true ) . "\n";
-
-			$response = wp_remote_post( $url, $args );
-			if ( is_wp_error( $response ) ) {
-				$this->response .= $response->get_error_message();
-				return;
-			}
-
-			$this->response .= wp_remote_retrieve_body( $response );
-
-			$json = json_decode( wp_remote_retrieve_body( $response ), true );
-
-			if ( $json && isset( $json['oauthUrl'] ) ) {
-				wp_redirect( $json['oauthUrl'] ); // phpcs:ignore WordPress.Security.SafeRedirect
-				exit;
-			}
 		}
 
 		if ( 'wcs-google-ads-setup' === $_GET['action'] && check_admin_referer( 'wcs-google-ads-setup' ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Connection Test debug page still carried a legacy flow that connected a Google Manager (MCC) account through the WCS site-facing endpoint `google/connection/google-manager`. This flow is dead code:

- WCS rejects manager connections on that endpoint with `400 Manager connections are not allowed.`, so the handler can never receive the `oauthUrl` it expects to redirect to.
- No UI element triggers the `wcs-google-manager` action. The action string appears nowhere else in the plugin, so the handler is reachable only by hand-crafting a nonce URL.

This PR removes the action handler and the `google-manager=connected` success message that only this flow could produce. Removing the dead code also cuts unnecessary noise, which lowers the cognitive load when changing related code.

### Detailed test instructions:

1. Visit `wp-admin/admin.php?page=connection-test-admin-page` and confirm the Connection Test page still loads.
2. Confirm the **Connect Google Account** debug action (`google/connection/google-mc`) on the page still works.

### Changelog entry