### PR TITLE
GOOWOO-900 [FE] Merchant-state gating

### DIFF
--- a/js/src/hooks/useGoogleAdsPromoState.js
+++ b/js/src/hooks/useGoogleAdsPromoState.js
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import { getCreateCampaignUrl, getOnboardingUrl } from '~/utils/urls';
+import useGoogleAdsAccountReady from '~/hooks/useGoogleAdsAccountReady';
+import useHasRecentAdSpend from '~/hooks/useHasRecentAdSpend';
+
+/**
+ * @typedef {Object} GoogleAdsPromoState
+ * @property {boolean} isResolving Whether the merchant state is still being determined.
+ * @property {boolean} isEligible  Whether the promo should be shown for the current merchant. `false` while resolving or when the merchant has recent Ads spend.
+ * @property {boolean} isReady     Whether the Google Ads account is ready (connected, claimed, access granted). Drives the CTA/copy state: `false` → "Get started", `true` → "Launch a campaign". `INCOMPLETE` accounts are treated as ready.
+ * @property {string}  ctaUrl      Destination for the CTA: onboarding URL when not ready, campaign-creation URL when ready.
+ */
+
+/**
+ * Merchant-state gating for the Google Ads promo placement.
+ *
+ * This placement is Google Ads only (no Merchant Center), so the
+ * onboarded/not-onboarded split keys off Ads readiness rather than an MC
+ * connection. Merchants with recent Ads spend are suppressed.
+ *
+ * @return {GoogleAdsPromoState} The resolution state, eligibility, readiness, and CTA destination.
+ */
+const useGoogleAdsPromoState = () => {
+	const { isGoogleAdsReady } = useGoogleAdsAccountReady();
+	const { hasAdSpend, hasFinishedResolution: hasResolvedRecentAdSpend } =
+		useHasRecentAdSpend();
+
+	const isResolving = isGoogleAdsReady === null || ! hasResolvedRecentAdSpend;
+	const isReady = isGoogleAdsReady === true;
+	const isEligible = ! isResolving && ! hasAdSpend;
+	const ctaUrl = isReady ? getCreateCampaignUrl() : getOnboardingUrl();
+
+	return {
+		isResolving,
+		isEligible,
+		isReady,
+		ctaUrl,
+	};
+};
+
+export default useGoogleAdsPromoState;

--- a/js/src/hooks/useGoogleAdsPromoState.test.js
+++ b/js/src/hooks/useGoogleAdsPromoState.test.js
@@ -1,0 +1,119 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useGoogleAdsPromoState from '~/hooks/useGoogleAdsPromoState';
+import useGoogleAdsAccountReady from '~/hooks/useGoogleAdsAccountReady';
+import useHasRecentAdSpend from '~/hooks/useHasRecentAdSpend';
+import { getCreateCampaignUrl, getOnboardingUrl } from '~/utils/urls';
+
+jest.mock( '~/hooks/useGoogleAdsAccountReady', () =>
+	jest.fn().mockName( 'useGoogleAdsAccountReady' )
+);
+
+jest.mock( '~/hooks/useHasRecentAdSpend', () =>
+	jest.fn().mockName( 'useHasRecentAdSpend' )
+);
+
+jest.mock( '~/utils/urls', () => ( {
+	getCreateCampaignUrl: jest.fn( () => 'CREATE_CAMPAIGN_URL' ),
+	getOnboardingUrl: jest.fn( () => 'ONBOARDING_URL' ),
+} ) );
+
+describe( 'useGoogleAdsPromoState', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'is not eligible and stays resolving until both signals settle', () => {
+		useGoogleAdsAccountReady.mockReturnValue( { isGoogleAdsReady: null } );
+		useHasRecentAdSpend.mockReturnValue( {
+			hasAdSpend: false,
+			hasFinishedResolution: false,
+		} );
+
+		const { result } = renderHook( () => useGoogleAdsPromoState() );
+
+		expect( result.current.isResolving ).toBe( true );
+		expect( result.current.isEligible ).toBe( false );
+	} );
+
+	test( 'not-onboarded → eligible, not ready, "Get started" onboarding URL', () => {
+		useGoogleAdsAccountReady.mockReturnValue( {
+			isGoogleAdsReady: false,
+		} );
+		useHasRecentAdSpend.mockReturnValue( {
+			hasAdSpend: false,
+			hasFinishedResolution: true,
+		} );
+
+		const { result } = renderHook( () => useGoogleAdsPromoState() );
+
+		expect( result.current ).toEqual( {
+			isResolving: false,
+			isEligible: true,
+			isReady: false,
+			ctaUrl: 'ONBOARDING_URL',
+		} );
+		expect( getOnboardingUrl ).toHaveBeenCalled();
+		expect( getCreateCampaignUrl ).not.toHaveBeenCalled();
+	} );
+
+	test( 'onboarded → eligible, ready, "Launch a campaign" campaign URL', () => {
+		useGoogleAdsAccountReady.mockReturnValue( {
+			isGoogleAdsReady: true,
+		} );
+		useHasRecentAdSpend.mockReturnValue( {
+			hasAdSpend: false,
+			hasFinishedResolution: true,
+		} );
+
+		const { result } = renderHook( () => useGoogleAdsPromoState() );
+
+		expect( result.current ).toEqual( {
+			isResolving: false,
+			isEligible: true,
+			isReady: true,
+			ctaUrl: 'CREATE_CAMPAIGN_URL',
+		} );
+		expect( getCreateCampaignUrl ).toHaveBeenCalled();
+	} );
+
+	// `INCOMPLETE` Ads accounts are folded into `isGoogleAdsReady === true` by
+	// `useGoogleAdsAccountReady`, so at the gating layer they behave as ready
+	// (→ "Launch a campaign"); billing is set during campaign creation.
+	test( 'INCOMPLETE account is treated as ready', () => {
+		useGoogleAdsAccountReady.mockReturnValue( {
+			isGoogleAdsReady: true,
+		} );
+		useHasRecentAdSpend.mockReturnValue( {
+			hasAdSpend: false,
+			hasFinishedResolution: true,
+		} );
+
+		const { result } = renderHook( () => useGoogleAdsPromoState() );
+
+		expect( result.current.isReady ).toBe( true );
+		expect( result.current.isEligible ).toBe( true );
+		expect( result.current.ctaUrl ).toBe( 'CREATE_CAMPAIGN_URL' );
+	} );
+
+	test( 'suppressed when the merchant has recent Ads spend', () => {
+		useGoogleAdsAccountReady.mockReturnValue( {
+			isGoogleAdsReady: true,
+		} );
+		useHasRecentAdSpend.mockReturnValue( {
+			hasAdSpend: true,
+			hasFinishedResolution: true,
+		} );
+
+		const { result } = renderHook( () => useGoogleAdsPromoState() );
+
+		expect( result.current.isResolving ).toBe( false );
+		expect( result.current.isEligible ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes GOOWOO-900. Delivers the merchant-state gating for the Analytics → Overview promo placement. The `Card` component that consumes it lands in GOOWOO-901, and the dashboard section that mounts it lands in GOOWOO-898 (#3689), so nothing renders on this branch yet.

Adds `useGoogleAdsPromoState`, which composes the existing `useGoogleAdsAccountReady` and `useHasRecentAdSpend` hooks to decide whether, and in which state, the placement should show for the current merchant.

- This placement is Google Ads only — there is no Merchant Center dependency. Service-based merchants onboard Ads-only (no MC connection), so the onboarded/not-onboarded split keys off the Ads readiness signal `isGoogleAdsReady` (account connected, claimed, access granted) rather than an MC connection.
- `isEligible` gates visibility: it is `false` while either signal is still resolving, and `false` when the merchant has recent Ads spend (spend > 0 in the last 14 days, from the GLA `programs` report). This is the suppression rule — a merchant already spending on Ads does not see the promo.
- `isReady` drives the CTA and copy state: not ready → "Get started" → `getOnboardingUrl()`; ready → "Launch a campaign" → `getCreateCampaignUrl()`. `INCOMPLETE` Ads accounts need no special-casing — `useGoogleAdsAccountReady` already folds them into `isGoogleAdsReady === true`, and billing is set during campaign creation.
- The hook returns `{ isResolving, isEligible, isReady, ctaUrl }` so the consuming placement can render `null` until the state is known and never flash before we know it should show.

### Screenshots:

_N/A — no visible UI ships in this PR._

### Detailed test instructions:

1. Check out the branch and run `npm run test:js -- useGoogleAdsPromoState` — 5 tests cover the resolving, not-onboarded, onboarded, `INCOMPLETE` (→ ready), and has-ad-spend branches.
2. No UI mounts the hook on this branch (component is GOOWOO-901). To eyeball it, temporarily log its return from an already-mounted placement (e.g. the order-attribution meta box in `js/src/meta-boxes/order-attribution/google-ads-promo.js`), build the JS (`npm start`), and open an order-edit screen:
   - Disconnected Google Ads account → `isReady: false`, `ctaUrl` is the onboarding URL.
   - Connected account (including `INCOMPLETE`, billing not set) → `isReady: true`, `ctaUrl` is the campaign-creation URL.
   - Account with spend > 0 in the last 14 days → `isEligible: false`.
   Revert the probe afterwards.

### Additional details:

Developer-facing hook only; there is no user-facing surface until GOOWOO-901 (component) and GOOWOO-898 (dashboard section) land. `INCOMPLETE` is handled entirely upstream in `useGoogleAdsAccountReady`, so at this gating layer it is indistinguishable from a fully-ready account by design.

### Changelog entry

> Dev - Add the `useGoogleAdsPromoState` hook that gates the Analytics Overview promo placement on merchant state, suppressing it for merchants with recent Google Ads spend.
