### PR TITLE
GOOWOO-935: Add shipping write path to MarketService::update_market()

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/MarketsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/MarketsController.php
@@ -454,8 +454,7 @@ class MarketsController extends BaseController {
 			'shipping'      => [
 				'type'              => 'object',
 				'description'       => __( 'Shipping configuration for this market: the global method types, and the flat values stored for the market\'s country. The flat values are reported whatever the types say, since rows are kept across mode switches.', 'google-listings-and-ads' ),
-				'context'           => [ 'view' ],
-				'readonly'          => true,
+				'context'           => [ 'view', 'edit' ],
 				'properties'        => [
 					'rate_type'               => [
 						'type'    => [ 'string', 'null' ],
@@ -467,19 +466,23 @@ class MarketsController extends BaseController {
 					],
 					'flat_rate'               => [
 						'type'    => [ 'number', 'null' ],
-						'context' => [ 'view' ],
+						'context' => [ 'view', 'edit' ],
+						'minimum' => 0,
 					],
 					'free_shipping_threshold' => [
 						'type'    => [ 'number', 'null' ],
-						'context' => [ 'view' ],
+						'context' => [ 'view', 'edit' ],
+						'minimum' => 0,
 					],
 					'flat_time'               => [
 						'type'    => [ 'integer', 'null' ],
-						'context' => [ 'view' ],
+						'context' => [ 'view', 'edit' ],
+						'minimum' => 0,
 					],
 					'flat_max_time'           => [
 						'type'    => [ 'integer', 'null' ],
-						'context' => [ 'view' ],
+						'context' => [ 'view', 'edit' ],
+						'minimum' => 0,
 					],
 				],
 				'validate_callback' => 'rest_validate_request_arg',

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\QueryInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
@@ -775,7 +776,17 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * @throws InvalidValue When a secondary market's merged config is invalid.
 	 */
 	public function update_market( string $id, array $config ): array {
+		// Write-through only: shipping lives in the shipping tables, never as a key on the
+		// stored market, so it is taken out before either branch below can persist it.
+		$shipping = $config['shipping'] ?? null;
+		unset( $config['shipping'] );
+
+		if ( is_array( $shipping ) ) {
+			$this->assert_shipping_window( $this->resolve_market_shipping_country( $id, $config ), $shipping );
+		}
+
 		if ( 'primary' === $id ) {
+
 			$language_change_pending = array_key_exists( 'language', $config );
 			$primary_existing_langs  = $this->get_existing_primary_languages();
 			$primary_countries       = $language_change_pending ? $this->target_audience->get_target_countries() : [];
@@ -784,6 +795,12 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			$existing_mc     = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
 
 			$this->update_primary_market_fanout( $config );
+
+			// After the fan-out: it can change both the main target country this writes to and
+			// the shipping method that decides whether the write is synced.
+			if ( is_array( $shipping ) ) {
+				$this->save_market_shipping( $this->target_audience->get_main_target_country(), $shipping );
+			}
 
 			if ( $language_change_pending ) {
 				$this->schedule_language_cleanup(
@@ -821,12 +838,19 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			return $this->fire_market_updated_action( $id );
 		}
 
-		// Flat secondary markets are derived from the shipping tables, so there is no
-		// stored config to mutate here: the country's rate/time are edited through the
-		// shipping endpoints, and the market's identity (its country) is fixed. Return
-		// the current derived market unchanged.
+		// Flat secondary markets are derived from the shipping tables, so there is no stored
+		// config to mutate here and the market's identity (its country) is fixed. Its shipping
+		// rows are still writable: in flat mode they are what the market is made of.
 		if ( $this->is_flat_shipping_rate() ) {
-			return $this->get_market( $id ) ?? [];
+			$market = $this->get_market( $id );
+
+			if ( is_array( $shipping ) && ! empty( $market['country'] ) ) {
+				$this->save_market_shipping( (string) $market['country'], $shipping );
+			}
+
+			// Giving the country the primary's shipping folds it back into the primary market,
+			// so that is the market this country now belongs to.
+			return $this->get_market( $id ) ?? $this->get_primary_market();
 		}
 
 		// Secondary markets don't own a shipping method — it is driven by the global
@@ -849,6 +873,12 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 		$markets[ $id ] = $merged;
 		$this->options->update( OptionsInterface::MARKETS, $markets );
+
+		// Keyed to the country the market now owns, so a PUT that moves the country and sets
+		// shipping in one call writes to the destination rather than the country just released.
+		if ( is_array( $shipping ) && ! empty( $merged['country'] ) ) {
+			$this->save_market_shipping( (string) $merged['country'], $shipping );
+		}
 
 		$old_feed_label = $existing['feed_label'] ?? null;
 		$new_feed_label = $merged['feed_label'] ?? null;
@@ -1914,6 +1944,196 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		}
 
 		return $this->cached_shipping_rates;
+	}
+
+	/**
+	 * Returns a country's row from a shipping query, or null.
+	 *
+	 * Neither table has a unique index on country, and the read side lets the last duplicate
+	 * win, so this matches that rather than the first.
+	 *
+	 * @param QueryInterface $query   Shipping rate or time query.
+	 * @param string         $country ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return array|null
+	 */
+	private function find_shipping_row( QueryInterface $query, string $country ): ?array {
+		$found = null;
+
+		foreach ( $query->get_results() ?? [] as $row ) {
+			if ( $row['country'] === $country ) {
+				$found = $row;
+			}
+		}
+
+		return $found;
+	}
+
+	/**
+	 * Returns the country a market's submitted shipping belongs to.
+	 *
+	 * @param string $id     Market ID.
+	 * @param array  $config Submitted config.
+	 *
+	 * @return string ISO 3166-1 alpha-2 country code, or an empty string when there is none.
+	 */
+	private function resolve_market_shipping_country( string $id, array $config ): string {
+		if ( 'primary' === $id ) {
+			return $this->target_audience->get_main_target_country();
+		}
+
+		if ( ! empty( $config['country'] ) ) {
+			return (string) $config['country'];
+		}
+
+		return (string) ( $this->get_market( $id )['country'] ?? '' );
+	}
+
+	/**
+	 * Rejects a delivery window whose minimum is past its maximum.
+	 *
+	 * Checked against the merged window, since either half can be submitted on its own, and
+	 * before anything is written so a rejected payload leaves no partial state. Matches the
+	 * rule the shipping-time endpoint applies.
+	 *
+	 * @param string $country  ISO 3166-1 alpha-2 country code.
+	 * @param array  $shipping Submitted shipping values.
+	 *
+	 * @throws InvalidValue When the minimum delivery time is greater than the maximum.
+	 */
+	private function assert_shipping_window( string $country, array $shipping ): void {
+		$has_time = array_key_exists( 'flat_time', $shipping ) && null !== $shipping['flat_time'];
+		$has_max  = array_key_exists( 'flat_max_time', $shipping ) && null !== $shipping['flat_max_time'];
+
+		if ( ! $has_time && ! $has_max ) {
+			return;
+		}
+
+		$existing = '' === $country ? null : $this->find_shipping_row( $this->shipping_time_query, $country );
+		$time     = $has_time ? (int) $shipping['flat_time'] : (int) ( $existing['time'] ?? 0 );
+		$max_time = $has_max ? (int) $shipping['flat_max_time'] : (int) ( $existing['max_time'] ?? 0 );
+
+		// A zero maximum is the unset state, so only a real window is checked.
+		if ( $max_time > 0 && $time > $max_time ) {
+			throw new InvalidValue(
+				sprintf( 'The minimum delivery time (%1$d) cannot be greater than the maximum (%2$d).', $time, $max_time )
+			);
+		}
+	}
+
+	/**
+	 * Writes a market's submitted shipping values to the rows for its country.
+	 *
+	 * Each of the four values is optional: only the ones present are written, so a caller can
+	 * send just a rate or just a delivery window. A null reads as "not configured", which is what
+	 * the read side reports for a country with no row, so sending one back leaves the stored value
+	 * alone rather than writing a zero. The exception is free_shipping_threshold, whose null is
+	 * the value itself and therefore clears the threshold.
+	 *
+	 * The rate row carries a currency the payload has no field for, so a new row takes the store
+	 * currency, matching what the shipping-rate endpoint defaults to.
+	 *
+	 * @param string $country  ISO 3166-1 alpha-2 country code.
+	 * @param array  $shipping Submitted shipping values.
+	 */
+	private function save_market_shipping( string $country, array $shipping ): void {
+		if ( '' === $country ) {
+			return;
+		}
+
+		$wrote = $this->save_market_shipping_rate( $country, $shipping );
+		$wrote = $this->save_market_shipping_time( $country, $shipping ) || $wrote;
+
+		if ( $wrote && $this->global_shipping_is_syncable() ) {
+			$this->schedule_shipping_sync();
+		}
+	}
+
+	/**
+	 * Writes the rate half of a submitted shipping payload.
+	 *
+	 * @param string $country  ISO 3166-1 alpha-2 country code.
+	 * @param array  $shipping Submitted shipping values.
+	 *
+	 * @return bool Whether a row was written.
+	 */
+	private function save_market_shipping_rate( string $country, array $shipping ): bool {
+		$has_rate      = array_key_exists( 'flat_rate', $shipping ) && null !== $shipping['flat_rate'];
+		$has_threshold = array_key_exists( 'free_shipping_threshold', $shipping );
+
+		if ( ! $has_rate && ! $has_threshold ) {
+			return false;
+		}
+
+		$existing = $this->find_shipping_row( $this->shipping_rate_query, $country );
+
+		// Clearing a threshold on a country that has no row leaves it with none, rather than
+		// creating one that declares free shipping at zero cost.
+		if ( null === $existing && ! $has_rate && null === ( $shipping['free_shipping_threshold'] ?? null ) ) {
+			return false;
+		}
+
+		$options = is_array( $existing['options'] ?? null ) ? $existing['options'] : [];
+
+		if ( $has_threshold ) {
+			if ( null === $shipping['free_shipping_threshold'] ) {
+				unset( $options['free_shipping_threshold'] );
+			} else {
+				$options['free_shipping_threshold'] = (float) $shipping['free_shipping_threshold'];
+			}
+		}
+
+		$data = [
+			'country'  => $country,
+			'currency' => $existing['currency'] ?? get_woocommerce_currency(),
+			'rate'     => $has_rate ? (float) $shipping['flat_rate'] : ( $existing['rate'] ?? 0 ),
+			'options'  => $options,
+		];
+
+		if ( $existing ) {
+			$this->shipping_rate_query->update( $data, [ 'id' => $existing['id'] ] );
+		} else {
+			$this->shipping_rate_query->insert( $data );
+		}
+
+		$this->forget_shipping_rates();
+
+		return true;
+	}
+
+	/**
+	 * Writes the delivery-time half of a submitted shipping payload.
+	 *
+	 * @param string $country  ISO 3166-1 alpha-2 country code.
+	 * @param array  $shipping Submitted shipping values.
+	 *
+	 * @return bool Whether a row was written.
+	 */
+	private function save_market_shipping_time( string $country, array $shipping ): bool {
+		$has_time     = array_key_exists( 'flat_time', $shipping ) && null !== $shipping['flat_time'];
+		$has_max_time = array_key_exists( 'flat_max_time', $shipping ) && null !== $shipping['flat_max_time'];
+
+		if ( ! $has_time && ! $has_max_time ) {
+			return false;
+		}
+
+		$existing = $this->find_shipping_row( $this->shipping_time_query, $country );
+
+		$data = [
+			'country'  => $country,
+			'time'     => $has_time ? (int) $shipping['flat_time'] : (int) ( $existing['time'] ?? 0 ),
+			'max_time' => $has_max_time ? (int) $shipping['flat_max_time'] : (int) ( $existing['max_time'] ?? 0 ),
+		];
+
+		if ( $existing ) {
+			$this->shipping_time_query->update( $data, [ 'id' => $existing['id'] ] );
+		} else {
+			$this->shipping_time_query->insert( $data );
+		}
+
+		$this->forget_shipping_times();
+
+		return true;
 	}
 
 	/**

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -779,6 +779,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 				$this->callback(
 					function ( $params ) {
 						return isset( $params['shipping_rate'] )
+							&& isset( $params['shipping'] )
 							&& ! isset( $params['id'] )
 							&& ! isset( $params['label'] )
 							&& ! isset( $params['free_shipping'] );
@@ -792,6 +793,75 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'PUT',
 			[
 				'shipping_rate' => 'flat',
+				'shipping'      => [ 'flat_rate' => 4.0 ],
+			]
+		);
+	}
+
+	public function test_put_returns_400_when_the_service_rejects_the_shipping_window(): void {
+		$this->market_service->method( 'get_market' )->willReturn( self::SECONDARY_MARKET );
+		$this->market_service->method( 'update_market' )
+			->willThrowException( new InvalidValue( 'The minimum delivery time (9) cannot be greater than the maximum (4).' ) );
+
+		$response = $this->do_request(
+			self::ROUTE_MARKET . 'gb',
+			'PUT',
+			[
+				'shipping' => [
+					'flat_time'     => 9,
+					'flat_max_time' => 4,
+				],
+			]
+		);
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_put_rejects_a_negative_shipping_value(): void {
+		$this->market_service->method( 'get_market' )->willReturn( self::SECONDARY_MARKET );
+		$this->market_service->expects( $this->never() )->method( 'update_market' );
+
+		$response = $this->do_request(
+			self::ROUTE_MARKET . 'gb',
+			'PUT',
+			[
+				'shipping' => [ 'flat_rate' => -5 ],
+			]
+		);
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_put_forwards_the_shipping_object_to_the_service(): void {
+		$this->market_service->method( 'get_market' )->willReturn( self::SECONDARY_MARKET );
+
+		$this->market_service->expects( $this->once() )
+			->method( 'update_market' )
+			->with(
+				'gb',
+				$this->callback(
+					function ( $params ) {
+						return [
+							'flat_rate'               => 7.5,
+							'free_shipping_threshold' => 40.0,
+							'flat_time'               => 2,
+							'flat_max_time'           => 5,
+						] === $params['shipping'];
+					}
+				)
+			)
+			->willReturn( self::SECONDARY_MARKET );
+
+		$this->do_request(
+			self::ROUTE_MARKET . 'gb',
+			'PUT',
+			[
+				'shipping' => [
+					'flat_rate'               => 7.5,
+					'free_shipping_threshold' => 40.0,
+					'flat_time'               => 2,
+					'flat_max_time'           => 5,
+				],
 			]
 		);
 	}

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -357,6 +357,586 @@ class MarketServiceTest extends UnitTest {
 		);
 	}
 
+	public function test_update_market_writes_submitted_shipping_to_the_market_country_rows(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		// No row for GB yet, so both halves insert.
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				[
+					'country'  => 'GB',
+					'currency' => get_woocommerce_currency(),
+					'rate'     => 7.5,
+					'options'  => [ 'free_shipping_threshold' => 40.0 ],
+				]
+			);
+		$this->shipping_time_query->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				[
+					'country'  => 'GB',
+					'time'     => 2,
+					'max_time' => 5,
+				]
+			);
+
+		$this->market_service->update_market(
+			'gb',
+			[
+				'shipping' => [
+					'flat_rate'               => 7.5,
+					'free_shipping_threshold' => 40.0,
+					'flat_time'               => 2,
+					'flat_max_time'           => 5,
+				],
+			]
+		);
+	}
+
+	public function test_update_market_updates_an_existing_shipping_row_in_place(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 9,
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => 3.0,
+					'options'  => [ 'free_shipping_threshold' => 25.0 ],
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		// The row's own currency survives, and only the submitted value changes.
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				[
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => 7.5,
+					'options'  => [ 'free_shipping_threshold' => 25.0 ],
+				],
+				[ 'id' => 9 ]
+			);
+		$this->shipping_rate_query->expects( $this->never() )->method( 'insert' );
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_rate' => 7.5 ] ] );
+	}
+
+	public function test_update_primary_market_writes_shipping_to_the_main_country_without_touching_the_method_types(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				[
+					'country'  => 'US',
+					'currency' => get_woocommerce_currency(),
+					'rate'     => 4.0,
+					'options'  => [],
+				]
+			);
+
+		$this->market_service->update_market( 'primary', [ 'shipping' => [ 'flat_rate' => 4.0 ] ] );
+
+		$mc = $this->options->get( OptionsInterface::MERCHANT_CENTER );
+
+		// The method types stay driven by the top-level fields, not by the shipping object.
+		$this->assertSame( 'automatic', $mc['shipping_rate'] );
+		$this->assertSame( 'flat', $mc['shipping_time'] );
+	}
+
+	public function test_update_market_never_stores_shipping_on_the_market(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_rate' => 7.5 ] ] );
+
+		$this->assertArrayNotHasKey( 'shipping', $this->options->get( OptionsInterface::MARKETS )['gb'] );
+	}
+
+	public function test_update_market_without_shipping_leaves_the_rows_alone(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_rate_query->expects( $this->never() )->method( 'insert' );
+		$this->shipping_rate_query->expects( $this->never() )->method( 'update' );
+		$this->shipping_time_query->expects( $this->never() )->method( 'insert' );
+		$this->shipping_time_query->expects( $this->never() )->method( 'update' );
+
+		$this->market_service->update_market( 'gb', [ 'feed_label' => 'GB2' ] );
+	}
+
+	public function test_update_market_shipping_rejects_a_minimum_past_the_maximum(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		// Rejected before anything is written, so no partial state is left behind.
+		$this->shipping_rate_query->expects( $this->never() )->method( 'insert' );
+		$this->shipping_time_query->expects( $this->never() )->method( 'insert' );
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->update_market(
+			'gb',
+			[
+				'shipping' => [
+					'flat_time'     => 9,
+					'flat_max_time' => 4,
+				],
+			]
+		);
+	}
+
+	public function test_update_market_shipping_rejects_a_minimum_past_the_stored_maximum(): void {
+		// Only the minimum is submitted, so the window is judged against the stored maximum.
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 8,
+					'country'  => 'GB',
+					'time'     => 2,
+					'max_time' => 5,
+				],
+			]
+		);
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_time' => 9 ] ] );
+	}
+
+	public function test_update_market_shipping_allows_a_minimum_when_no_maximum_is_set(): void {
+		// A zero maximum is the unset state, not a window of zero days.
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_time_query->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				[
+					'country'  => 'GB',
+					'time'     => 9,
+					'max_time' => 0,
+				]
+			);
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_time' => 9 ] ] );
+	}
+
+	public function test_update_market_shipping_syncs_when_the_global_method_is_syncable(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_settings_job->expects( $this->once() )->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_rate' => 7.5 ] ] );
+	}
+
+	public function test_update_market_shipping_null_values_leave_the_stored_row_alone(): void {
+		// The read side reports null for an unconfigured value, so a client echoing a market
+		// back must not turn those nulls into a free, same-day shipping row.
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_rate_query->expects( $this->never() )->method( 'insert' );
+		$this->shipping_time_query->expects( $this->never() )->method( 'insert' );
+		$this->shipping_settings_job->expects( $this->never() )->method( 'schedule' );
+
+		$this->market_service->update_market(
+			'gb',
+			[
+				'shipping' => [
+					'flat_rate'               => null,
+					'free_shipping_threshold' => null,
+					'flat_time'               => null,
+					'flat_max_time'           => null,
+				],
+			]
+		);
+	}
+
+	public function test_update_market_shipping_clears_a_threshold_without_touching_the_rate(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 4,
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => 6.0,
+					'options'  => [ 'free_shipping_threshold' => 30.0 ],
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				[
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => 6.0,
+					'options'  => [],
+				],
+				[ 'id' => 4 ]
+			);
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'free_shipping_threshold' => null ] ] );
+	}
+
+	public function test_update_market_shipping_keeps_the_other_half_of_an_existing_time_row(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 8,
+					'country'  => 'GB',
+					'time'     => 2,
+					'max_time' => 6,
+				],
+			]
+		);
+
+		// Only max_time was submitted, so the stored minimum survives.
+		$this->shipping_time_query->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				[
+					'country'  => 'GB',
+					'time'     => 2,
+					'max_time' => 9,
+				],
+				[ 'id' => 8 ]
+			);
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_max_time' => 9 ] ] );
+	}
+
+	public function test_update_market_shipping_writes_the_destination_country_when_the_country_moves(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US', 'FR' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		// The market ends up owning FR, so that is the row the submitted rate belongs to.
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'insert' )
+			->with(
+				[
+					'country'  => 'FR',
+					'currency' => get_woocommerce_currency(),
+					'rate'     => 9.0,
+					'options'  => [],
+				]
+			);
+
+		$this->market_service->update_market(
+			'gb',
+			[
+				'country'  => 'FR',
+				'shipping' => [ 'flat_rate' => 9.0 ],
+			]
+		);
+	}
+
+	public function test_update_market_shipping_writes_a_flat_derived_market_row(): void {
+		// In flat mode the rows are the market, so the write still applies even though there is
+		// no stored config to change.
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies(
+			'US',
+			[ 'US', 'GB' ],
+			[
+				'US' => [
+					'country_code'            => 'US',
+					'currency'                => get_woocommerce_currency(),
+					'free_shipping_threshold' => null,
+					'rate'                    => '5.00',
+				],
+				'GB' => [
+					'country_code'            => 'GB',
+					'currency'                => get_woocommerce_currency(),
+					'free_shipping_threshold' => null,
+					'rate'                    => '11.00',
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'       => 3,
+					'country'  => 'GB',
+					'currency' => get_woocommerce_currency(),
+					'rate'     => 11.0,
+					'options'  => [],
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'update' )
+			->with( $this->callback( fn( array $data ): bool => 'GB' === $data['country'] && 13.0 === $data['rate'] ), [ 'id' => 3 ] );
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_rate' => 13.0 ] ] );
+	}
+
+	public function test_update_market_shipping_does_not_sync_when_the_global_method_is_not_syncable(): void {
+		// manual time is not syncable, so the write happens but Google is not notified.
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'manual',
+				],
+				OptionsInterface::MARKETS         => [
+					'gb' => [
+						'country'    => 'GB',
+						'language'   => [ 'en' ],
+						'currency'   => [ get_woocommerce_currency() ],
+						'feed_label' => 'GB',
+					],
+				],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+
+		$this->shipping_rate_query->expects( $this->once() )->method( 'insert' );
+		$this->shipping_settings_job->expects( $this->never() )->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'shipping' => [ 'flat_rate' => 7.5 ] ] );
+	}
+
 	public function test_get_market_shipping_reads_the_country_row_in_flat_mode(): void {
 		$this->set_up_options_get(
 			[


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #https://linear.app/a8c/issue/GOOWOO-935/add-shipping-write-path-to-marketserviceupdate-market

`PUT /mc/markets/{id}` now accepts a shipping object and writes flat_rate, free_shipping_threshold, flat_time and flat_max_time to the shipping tables for that market's country, or the main target country for primary. Write-through only: shipping is never stored on the market, and the next read recomputes it. Inserts if there is no row, updates in place if there is. UpdateShippingSettings is scheduled behind the existing syncable check. Omitting shipping leaves the rows untouched.

Semantics worth knowing:

Each value is independently optional, so a rate-only payload leaves the times and threshold alone.
null means "leave alone", because that is what the read side reports for an unconfigured value. Without this, a client that GETs a market and PUTs it back writes rate 0 and time 0, telling Google free same-day shipping. The exception is free_shipping_threshold, whose null is the value and clears it.
Flat mode is included. The rows are what a flat market is derived from, so the write applies there too. If the new values match the primary's, the country folds back into the primary market and that is what the response returns.
A delivery window whose minimum is past its maximum is rejected with 400, checked against the merged window and before anything is written. minimum: 0 on the four numeric fields matches the dedicated shipping endpoints.
Backward compatibility: additive. shipping changes from read-only to writable; rate_type and time_type stay read-only. No existing field changed behaviour.

Stacked on GOOWOO-934, base should be that branch until it merges. 

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

- Edit the primary market: change the audience countries, shipping rate and delivery times. Save. Reload. Values persist.
- Add a secondary market, set its rate, threshold and times. Save. Reload. Values persist.
- Edit that market's shipping, save, reload.
- Delete it. The country returns to the primary market with working shipping.
- Repeat 1 to 3 with the store's shipping rate set to Flat.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
