### PR TITLE
GOOWOO-872 [FE] Replace markets multi-select with Treeselect

### DIFF
--- a/js/src/pages/markets/components/add-market-button.js
+++ b/js/src/pages/markets/components/add-market-button.js
@@ -10,7 +10,6 @@ import { useState, useCallback } from '@wordpress/element';
 import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
 import useSettings from '~/hooks/useSettings';
 import AppButton from '~/components/app-button';
-import usePrimaryMarketDetails from '../hooks/usePrimaryMarketDetails';
 import AddMarketModal from './add-market-modal';
 
 /**
@@ -22,9 +21,6 @@ import AddMarketModal from './add-market-modal';
 /**
  * Component for the "Add market" button on the markets page, which opens a modal to add a new market.
  *
- * Hidden when the primary market's audience covers only a single country, since
- * markets are derived from the primary market's countries and none remain to add.
- *
  * @fires gla_add_market_button_clicked event when the button is clicked
  */
 const AddMarketButton = () => {
@@ -32,17 +28,9 @@ const AddMarketButton = () => {
 	const { targetAudience, loaded: hasResolvedTargetAudience } =
 		useTargetAudienceFinalCountryCodes();
 	const { settings } = useSettings();
-	const {
-		data: primaryMarket,
-		hasFinishedResolution: hasResolvedPrimaryMarket,
-	} = usePrimaryMarketDetails();
 
 	const handleOpen = useCallback( () => setIsOpen( true ), [] );
 	const handleClose = useCallback( () => setIsOpen( false ), [] );
-
-	if ( ! hasResolvedPrimaryMarket || primaryMarket?.countries?.length <= 1 ) {
-		return null;
-	}
 
 	return (
 		<>

--- a/js/src/pages/markets/components/market-fields/audience-section/market-select-control.js
+++ b/js/src/pages/markets/components/market-fields/audience-section/market-select-control.js
@@ -71,7 +71,7 @@ const MarketSelectControl = () => {
 		[]
 	);
 
-	const { onChange, value: selectedCountry } = getInputProps( 'country' );
+	const { onChange, value } = getInputProps( 'country' );
 
 	const handleChange = ( selectedOption ) => {
 		// TreeSelect renders continent rows as selectable options too (it has no
@@ -121,7 +121,7 @@ const MarketSelectControl = () => {
 				label={ __( 'Market', 'google-listings-and-ads' ) }
 				noOptionLabel={ __( 'Select…', 'google-listings-and-ads' ) }
 				tree={ options }
-				selectedId={ selectedCountry }
+				selectedId={ value }
 				onChange={ handleChange }
 				__next40pxDefaultSize
 			/>

--- a/js/src/pages/markets/components/market-fields/audience-section/market-select-control.js
+++ b/js/src/pages/markets/components/market-fields/audience-section/market-select-control.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { TreeSelect } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { useAdaptiveFormContext } from '~/components/adaptive-form';
 import useAppSelectDispatch from '~/hooks/useAppSelectDispatch';
-import AppSelectControl from '~/components/app-select-control';
 import useMarkets from '../../../hooks/useMarkets';
 import usePrimaryMarketDetails from '../../../hooks/usePrimaryMarketDetails';
 
@@ -20,7 +20,7 @@ import usePrimaryMarketDetails from '../../../hooks/usePrimaryMarketDetails';
  */
 const MarketSelectControl = () => {
 	const {
-		data: { countries },
+		data: { countries, continents },
 		hasFinishedResolution: hasResolvedCountries,
 	} = useAppSelectDispatch( 'getMCCountriesAndContinents' );
 	const {
@@ -40,29 +40,46 @@ const MarketSelectControl = () => {
 		return null;
 	}
 
-	// Exclude countries already assigned to other markets,
-	// as well as the primary market's own countries.
-	// Technically the primary market's countries should be up to date
-	// in the form state, but this ensures the list is correct even if not.
-	const usedCountries = new Set(
-		markets
+	// Exclude countries already assigned to a market: the primary market's own
+	// countries, as well as every secondary market's country.
+	const usedCountries = new Set( [
+		...primaryMarket.countries,
+		...( markets
 			?.filter( ( market ) => market.country )
-			.map( ( market ) => market.country )
+			.map( ( market ) => market.country ) ?? [] ),
+	] );
+
+	const options = Object.entries( continents ).reduce(
+		( acc, [ continentCode, continent ] ) => {
+			const children = continent.countries
+				.filter( ( countryCode ) => ! usedCountries.has( countryCode ) )
+				.map( ( countryCode ) => ( {
+					id: countryCode,
+					name: countries[ countryCode ]?.name || countryCode,
+				} ) );
+
+			if ( children.length ) {
+				acc.push( {
+					id: continentCode,
+					name: continent.name,
+					children,
+				} );
+			}
+
+			return acc;
+		},
+		[]
 	);
 
-	const options = [
-		{ value: '', label: __( 'Select…', 'google-listings-and-ads' ) },
-		...primaryMarket.countries
-			.filter( ( countryCode ) => ! usedCountries.has( countryCode ) )
-			.map( ( countryCode ) => ( {
-				value: countryCode,
-				label: countries[ countryCode ]?.name || countryCode,
-			} ) ),
-	];
-
-	const { onChange, ...inputProps } = getInputProps( 'country' );
+	const { onChange, value: selectedCountry } = getInputProps( 'country' );
 
 	const handleChange = ( selectedOption ) => {
+		// TreeSelect renders continent rows as selectable options too (it has no
+		// per-option disabled support), so ignore anything that isn't a real country.
+		if ( selectedOption && ! countries[ selectedOption ] ) {
+			return;
+		}
+
 		onChange( selectedOption );
 
 		const existingRate = shipping_country_rates?.find(
@@ -98,23 +115,14 @@ const MarketSelectControl = () => {
 		} );
 	};
 
-	const appSelectControlProps = {
-		...inputProps,
-		...( ! inputProps.selected
-			? {
-					autoSelectFirstOption: true,
-					value: undefined,
-			  }
-			: {} ),
-	};
-
 	return (
 		<div>
-			<AppSelectControl
+			<TreeSelect
 				label={ __( 'Market', 'google-listings-and-ads' ) }
-				options={ options }
+				noOptionLabel={ __( 'Select…', 'google-listings-and-ads' ) }
+				tree={ options }
+				selectedId={ selectedCountry }
 				onChange={ handleChange }
-				{ ...appSelectControlProps }
 			/>
 			{ renderRequestedValidation( 'country' ) }
 		</div>

--- a/js/src/pages/markets/components/market-fields/audience-section/market-select-control.js
+++ b/js/src/pages/markets/components/market-fields/audience-section/market-select-control.js
@@ -49,20 +49,19 @@ const MarketSelectControl = () => {
 			.map( ( market ) => market.country ) ?? [] ),
 	] );
 
-	const options = Object.entries( continents ).reduce(
-		( acc, [ continentCode, continent ] ) => {
-			const children = continent.countries
+	const continentGroups = Object.values( continents ).reduce(
+		( acc, continent ) => {
+			const countryOptions = continent.countries
 				.filter( ( countryCode ) => ! usedCountries.has( countryCode ) )
 				.map( ( countryCode ) => ( {
-					id: countryCode,
-					name: countries[ countryCode ]?.name || countryCode,
+					value: countryCode,
+					label: countries[ countryCode ]?.name || countryCode,
 				} ) );
 
-			if ( children.length ) {
+			if ( countryOptions.length ) {
 				acc.push( {
-					id: continentCode,
-					name: continent.name,
-					children,
+					label: continent.name,
+					options: countryOptions,
 				} );
 			}
 
@@ -74,12 +73,6 @@ const MarketSelectControl = () => {
 	const { onChange, value } = getInputProps( 'country' );
 
 	const handleChange = ( selectedOption ) => {
-		// TreeSelect renders continent rows as selectable options too (it has no
-		// per-option disabled support), so ignore anything that isn't a real country.
-		if ( selectedOption && ! countries[ selectedOption ] ) {
-			return;
-		}
-
 		onChange( selectedOption );
 
 		const existingRate = shipping_country_rates?.find(
@@ -119,12 +112,33 @@ const MarketSelectControl = () => {
 		<div>
 			<TreeSelect
 				label={ __( 'Market', 'google-listings-and-ads' ) }
-				noOptionLabel={ __( 'Select…', 'google-listings-and-ads' ) }
-				tree={ options }
-				selectedId={ value }
+				selectedId={ value ?? '' }
 				onChange={ handleChange }
 				__next40pxDefaultSize
-			/>
+			>
+				<option value="">
+					{ __( 'Select…', 'google-listings-and-ads' ) }
+				</option>
+				{ continentGroups.map(
+					( { label, options: countryOptions } ) => (
+						<optgroup key={ label } label={ label }>
+							{ countryOptions.map(
+								( {
+									value: countryCode,
+									label: countryName,
+								} ) => (
+									<option
+										key={ countryCode }
+										value={ countryCode }
+									>
+										{ countryName }
+									</option>
+								)
+							) }
+						</optgroup>
+					)
+				) }
+			</TreeSelect>
 			{ renderRequestedValidation( 'country' ) }
 		</div>
 	);

--- a/js/src/pages/markets/components/market-fields/audience-section/market-select-control.js
+++ b/js/src/pages/markets/components/market-fields/audience-section/market-select-control.js
@@ -123,6 +123,7 @@ const MarketSelectControl = () => {
 				tree={ options }
 				selectedId={ selectedCountry }
 				onChange={ handleChange }
+				__next40pxDefaultSize
 			/>
 			{ renderRequestedValidation( 'country' ) }
 		</div>

--- a/tests/e2e/specs/markets/markets-multilingual.test.js
+++ b/tests/e2e/specs/markets/markets-multilingual.test.js
@@ -365,6 +365,28 @@ test.describe( 'Markets – multilingual store', () => {
 			await marketsPage.goto();
 			await marketsPage.waitForMarketsTable();
 		} );
+
+		test( 'Add modal shows the grouped country select when adding the first market', async () => {
+			await marketsPage.fulfillMarkets( [ PRIMARY_MARKET ] );
+			await marketsPage.goto();
+			await marketsPage.waitForMarketsTable();
+
+			await marketsPage.getHeaderAddMarketButton().click();
+			const addModal = marketsPage.getAddMarketModal();
+			await expect( addModal ).toBeVisible();
+
+			await expect( addModal.getByLabel( 'Market' ) ).toBeVisible();
+
+			await addModal.getByRole( 'button', { name: 'Cancel' } ).click();
+
+			// Restore the two-market fixture for subsequent tests in this file.
+			await marketsPage.fulfillMarkets( [
+				PRIMARY_MARKET,
+				SECONDARY_MARKET,
+			] );
+			await marketsPage.goto();
+			await marketsPage.waitForMarketsTable();
+		} );
 	} );
 
 	test.describe( 'Shipping Rate - Flat', () => {

--- a/tests/e2e/specs/markets/markets-multilingual.test.js
+++ b/tests/e2e/specs/markets/markets-multilingual.test.js
@@ -285,15 +285,15 @@ test.describe( 'Markets – multilingual store', () => {
 
 		test( 'successful save closes the Add modal', async () => {
 			await marketsPage.fulfillCreateMarket( {
-				id: 'ca',
-				label: 'Canada',
+				id: 'de',
+				label: 'Germany',
 			} );
 
 			await marketsPage.getHeaderAddMarketButton().click();
 			const addModal = marketsPage.getAddMarketModal();
 			await expect( addModal ).toBeVisible();
 
-			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+			await addModal.getByLabel( 'Market' ).selectOption( 'DE' );
 
 			await addModal
 				.getByRole( 'button', { name: 'Add market' } )
@@ -312,7 +312,7 @@ test.describe( 'Markets – multilingual store', () => {
 			const addModal = marketsPage.getAddMarketModal();
 			await expect( addModal ).toBeVisible();
 
-			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+			await addModal.getByLabel( 'Market' ).selectOption( 'DE' );
 
 			await addModal
 				.getByRole( 'button', { name: 'Add market' } )
@@ -330,8 +330,8 @@ test.describe( 'Markets – multilingual store', () => {
 		test( 'countries already claimed by another market are excluded from the Add Market select', async () => {
 			// A secondary market for Canada, one of the primary market's own
 			// countries, so both US (claimed by the primary market itself)
-			// and CA (claimed here) are excluded from the Add Market select,
-			// leaving only the placeholder option.
+			// and CA (claimed here) are excluded from the Add Market select.
+			// France and Germany remain unclaimed and stay selectable.
 			const TERTIARY_COUNTRY = {
 				id: 'ca',
 				label: 'Canada',
@@ -350,9 +350,20 @@ test.describe( 'Markets – multilingual store', () => {
 
 			await marketsPage.getHeaderAddMarketButton().click();
 			const addModal = marketsPage.getAddMarketModal();
+			const options = addModal.getByLabel( 'Market' ).locator( 'option' );
 
+			// Placeholder + "Europe" continent header + France + Germany.
+			// North America is omitted entirely since both of its countries
+			// (US, CA) are claimed.
+			await expect( options ).toHaveCount( 4 );
+			await expect( options.filter( { hasText: 'Canada' } ) ).toHaveCount(
+				0
+			);
+			await expect( options.filter( { hasText: 'France' } ) ).toHaveCount(
+				1
+			);
 			await expect(
-				addModal.getByLabel( 'Market' ).locator( 'option' )
+				options.filter( { hasText: 'Germany' } )
 			).toHaveCount( 1 );
 
 			await addModal.getByRole( 'button', { name: 'Cancel' } ).click();
@@ -710,15 +721,15 @@ test.describe( 'Markets – multilingual store', () => {
 
 		test( 'successful save closes the Add modal', async () => {
 			await marketsPage.fulfillCreateMarket( {
-				id: 'ca',
-				label: 'Canada',
+				id: 'de',
+				label: 'Germany',
 			} );
 
 			await marketsPage.getHeaderAddMarketButton().click();
 			const addModal = marketsPage.getAddMarketModal();
 			await expect( addModal ).toBeVisible();
 
-			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+			await addModal.getByLabel( 'Market' ).selectOption( 'DE' );
 
 			await addModal
 				.getByRole( 'button', { name: 'Add market' } )
@@ -737,7 +748,7 @@ test.describe( 'Markets – multilingual store', () => {
 			const addModal = marketsPage.getAddMarketModal();
 			await expect( addModal ).toBeVisible();
 
-			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+			await addModal.getByLabel( 'Market' ).selectOption( 'DE' );
 
 			await addModal
 				.getByRole( 'button', { name: 'Add market' } )
@@ -964,15 +975,15 @@ test.describe( 'Markets – multilingual store', () => {
 
 		test( 'successful save closes the Add modal', async () => {
 			await marketsPage.fulfillCreateMarket( {
-				id: 'ca',
-				label: 'Canada',
+				id: 'de',
+				label: 'Germany',
 			} );
 
 			await marketsPage.getHeaderAddMarketButton().click();
 			const addModal = marketsPage.getAddMarketModal();
 			await expect( addModal ).toBeVisible();
 
-			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+			await addModal.getByLabel( 'Market' ).selectOption( 'DE' );
 
 			await addModal
 				.getByRole( 'button', { name: 'Add market' } )
@@ -991,7 +1002,7 @@ test.describe( 'Markets – multilingual store', () => {
 			const addModal = marketsPage.getAddMarketModal();
 			await expect( addModal ).toBeVisible();
 
-			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+			await addModal.getByLabel( 'Market' ).selectOption( 'DE' );
 
 			await addModal
 				.getByRole( 'button', { name: 'Add market' } )

--- a/tests/e2e/specs/markets/markets-multilingual.test.js
+++ b/tests/e2e/specs/markets/markets-multilingual.test.js
@@ -328,10 +328,8 @@ test.describe( 'Markets – multilingual store', () => {
 		} );
 
 		test( 'countries already claimed by another market are excluded from the Add Market select', async () => {
-			// A secondary market for Canada, one of the primary market's own
-			// countries, so both US (claimed by the primary market itself)
-			// and CA (claimed here) are excluded from the Add Market select.
-			// France and Germany remain unclaimed and stay selectable.
+			// Claims CA in addition to the primary market's US, so both are
+			// excluded from the Add Market select; France and Germany stay selectable.
 			const TERTIARY_COUNTRY = {
 				id: 'ca',
 				label: 'Canada',
@@ -350,12 +348,13 @@ test.describe( 'Markets – multilingual store', () => {
 
 			await marketsPage.getHeaderAddMarketButton().click();
 			const addModal = marketsPage.getAddMarketModal();
-			const options = addModal.getByLabel( 'Market' ).locator( 'option' );
+			const marketSelect = addModal.getByLabel( 'Market' );
+			const options = marketSelect.locator( 'option' );
+			const continentGroups = marketSelect.locator( 'optgroup' );
 
-			// Placeholder + "Europe" continent header + France + Germany.
-			// North America is omitted entirely since both of its countries
-			// (US, CA) are claimed.
-			await expect( options ).toHaveCount( 4 );
+			// Placeholder + France + Germany. North America is omitted since
+			// both its countries (US, CA) are claimed.
+			await expect( options ).toHaveCount( 3 );
 			await expect( options.filter( { hasText: 'Canada' } ) ).toHaveCount(
 				0
 			);
@@ -365,6 +364,12 @@ test.describe( 'Markets – multilingual store', () => {
 			await expect(
 				options.filter( { hasText: 'Germany' } )
 			).toHaveCount( 1 );
+
+			await expect( continentGroups ).toHaveCount( 1 );
+			await expect( continentGroups ).toHaveAttribute(
+				'label',
+				'Europe'
+			);
 
 			await addModal.getByRole( 'button', { name: 'Cancel' } ).click();
 

--- a/tests/e2e/specs/markets/markets-non-multilingual.test.js
+++ b/tests/e2e/specs/markets/markets-non-multilingual.test.js
@@ -479,15 +479,15 @@ test.describe( 'Markets – non-multilingual store', () => {
 
 		test( 'successful save closes the Add modal', async () => {
 			await marketsPage.fulfillCreateMarket( {
-				id: 'ca',
-				label: 'Canada',
+				id: 'de',
+				label: 'Germany',
 			} );
 
 			await marketsPage.getHeaderAddMarketButton().click();
 			const addModal = marketsPage.getAddMarketModal();
 			await expect( addModal ).toBeVisible();
 
-			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+			await addModal.getByLabel( 'Market' ).selectOption( 'DE' );
 
 			await addModal
 				.getByRole( 'button', { name: 'Add market' } )
@@ -506,7 +506,7 @@ test.describe( 'Markets – non-multilingual store', () => {
 			const addModal = marketsPage.getAddMarketModal();
 			await expect( addModal ).toBeVisible();
 
-			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+			await addModal.getByLabel( 'Market' ).selectOption( 'DE' );
 
 			await addModal
 				.getByRole( 'button', { name: 'Add market' } )
@@ -720,15 +720,15 @@ test.describe( 'Markets – non-multilingual store', () => {
 
 		test( 'successful save closes the Add modal', async () => {
 			await marketsPage.fulfillCreateMarket( {
-				id: 'ca',
-				label: 'Canada',
+				id: 'de',
+				label: 'Germany',
 			} );
 
 			await marketsPage.getHeaderAddMarketButton().click();
 			const addModal = marketsPage.getAddMarketModal();
 			await expect( addModal ).toBeVisible();
 
-			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+			await addModal.getByLabel( 'Market' ).selectOption( 'DE' );
 
 			await addModal
 				.getByRole( 'button', { name: 'Add market' } )
@@ -747,7 +747,7 @@ test.describe( 'Markets – non-multilingual store', () => {
 			const addModal = marketsPage.getAddMarketModal();
 			await expect( addModal ).toBeVisible();
 
-			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+			await addModal.getByLabel( 'Market' ).selectOption( 'DE' );
 
 			await addModal
 				.getByRole( 'button', { name: 'Add market' } )

--- a/tests/e2e/utils/pages/markets.js
+++ b/tests/e2e/utils/pages/markets.js
@@ -56,10 +56,13 @@ export const MC_COUNTRIES = {
 		US: { name: 'United States', currency: 'USD' },
 		CA: { name: 'Canada', currency: 'CAD' },
 		FR: { name: 'France', currency: 'EUR' },
+		// Left unclaimed by PRIMARY_MARKET and SECONDARY_MARKET so it remains
+		// selectable in the Add Market select for tests that create a new market.
+		DE: { name: 'Germany', currency: 'EUR' },
 	},
 	continents: {
 		NA: { name: 'North America', countries: [ 'US', 'CA' ] },
-		EU: { name: 'Europe', countries: [ 'FR' ] },
+		EU: { name: 'Europe', countries: [ 'FR', 'DE' ] },
 	},
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-872/multi-feeds-the-add-market-button-is-displayed-conditionally

- Make add market button always visible
- Update Market field within edit market modal to use Treeselect instead and display countries grouped by continent


### Screenshots:

<img width="680" height="582" alt="Screenshot 2026-08-14 at 13 59 03" src="https://github.com/user-attachments/assets/f267cf0f-986c-4b07-8de3-0d9502704e5c" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the plugin Markets tab
2. With only a primary market set up, click "Add market", confirm the button is visible/enabled, and the modal shows the grouped by continent "Market" dropdown (not the multi-select "Audience" field), excluding the primary market's own countries.
3. Add a market, click "Add market" again, confirm that market's country is now excluded too.
4. Confirm the primary market's Edit modal still shows the original multi-select "Audience" picker, unchanged.
5. Check: try selecting a country that's part of the primary market's own audience (e.g. Canada), it should be unavailable. Flag if unexpected, since this is a behaviuor change from before.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Update - Always show the "Add market" button and let it add markets for any Google Merchant Center supported country, not  just the primary market's own
