### PR TITLE
GOOWOO-933: Migrate flat-derived markets into stored markets on plugin upgrade

### DIFF
--- a/src/DB/Migration/Migration20260813T1653383133.php
+++ b/src/DB/Migration/Migration20260813T1653383133.php
@@ -1,0 +1,239 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Throwable;
+use wpdb;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Migration20260813T1653383133
+ *
+ * Stores the secondary markets that flat shipping mode used to derive from the shipping
+ * tables. Without this, a merchant's per-country flat setups stop being markets when the
+ * derivation is removed, and the countries silently fold back into the primary feed.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration
+ *
+ * @since 3.10.0
+ */
+class Migration20260813T1653383133 extends AbstractMigration {
+
+	/**
+	 * @var TargetAudience
+	 */
+	protected TargetAudience $target_audience;
+
+	/**
+	 * @var ShippingRateQuery
+	 */
+	protected ShippingRateQuery $shipping_rate_query;
+
+	/**
+	 * @var ShippingTimeQuery
+	 */
+	protected ShippingTimeQuery $shipping_time_query;
+
+	/**
+	 * @var MarketService
+	 */
+	protected MarketService $market_service;
+
+	/**
+	 * @var OptionsInterface
+	 */
+	protected OptionsInterface $options;
+
+	/**
+	 * Migration constructor.
+	 *
+	 * @param wpdb              $wpdb
+	 * @param TargetAudience    $target_audience
+	 * @param ShippingRateQuery $shipping_rate_query
+	 * @param ShippingTimeQuery $shipping_time_query
+	 * @param MarketService     $market_service
+	 * @param OptionsInterface  $options
+	 */
+	public function __construct(
+		wpdb $wpdb,
+		TargetAudience $target_audience,
+		ShippingRateQuery $shipping_rate_query,
+		ShippingTimeQuery $shipping_time_query,
+		MarketService $market_service,
+		OptionsInterface $options
+	) {
+		parent::__construct( $wpdb );
+		$this->target_audience     = $target_audience;
+		$this->shipping_rate_query = $shipping_rate_query;
+		$this->shipping_time_query = $shipping_time_query;
+		$this->market_service      = $market_service;
+		$this->options             = $options;
+	}
+
+	/**
+	 * Returns the version to apply this migration for.
+	 *
+	 * @return string A version number.
+	 */
+	public function get_applicable_version(): string {
+		return '3.10.0';
+	}
+
+	/**
+	 * Apply the migration.
+	 *
+	 * @return void
+	 */
+	public function apply(): void {
+		if ( ! $this->has_convertible_audience() ) {
+			return;
+		}
+
+		$main_country = $this->target_audience->get_main_target_country();
+		$countries    = $this->target_audience->get_target_countries();
+
+		if ( '' === $main_country || count( $countries ) < 2 ) {
+			return;
+		}
+
+		$rates = $this->shipping_rate_query->get_all_shipping_rates();
+		$rates = is_array( $rates ) ? $rates : [];
+		$times = $this->shipping_time_query->get_all_shipping_times();
+		$times = is_array( $times ) ? $times : [];
+
+		$baseline = $this->shipping_signature( $main_country, $rates, $times );
+		$owned    = $this->countries_with_a_market();
+
+		foreach ( $countries as $country ) {
+			if ( $country === $main_country || in_array( $country, $owned, true ) ) {
+				continue;
+			}
+
+			// A country with no row of its own was never its own market: it inherited the
+			// primary's shipping, so it stays part of the primary market.
+			if ( ! isset( $rates[ $country ] ) && ! isset( $times[ $country ] ) ) {
+				continue;
+			}
+
+			if ( $this->shipping_signature( $country, $rates, $times ) === $baseline ) {
+				continue;
+			}
+
+			$this->store_market( (string) $country );
+
+			// A country listed twice would otherwise convert twice, and the second pass would
+			// record that it was never in the primary feed.
+			$owned[] = $country;
+		}
+	}
+
+	/**
+	 * Whether this store can have markets worth converting.
+	 *
+	 * Only a flat rate ever produced them: the other modes keep their markets in the Markets
+	 * option already, and their shipping rows are retained across mode switches, so reading the
+	 * rows there would invent markets the merchant never had.
+	 *
+	 * An "all countries" audience is left alone. The stored country list is ignored in that
+	 * mode, so taking a country out of it does not take it out of the primary feed: the market
+	 * would be listed twice and would record that its country was never in the primary feed.
+	 *
+	 * @return bool
+	 */
+	private function has_convertible_audience(): bool {
+		$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
+		if ( ! is_array( $mc_settings ) || 'flat' !== ( $mc_settings['shipping_rate'] ?? null ) ) {
+			return false;
+		}
+
+		$target_audience = $this->options->get( OptionsInterface::TARGET_AUDIENCE, [] );
+
+		return is_array( $target_audience ) && 'selected' === ( $target_audience['location'] ?? null );
+	}
+
+	/**
+	 * Stores one market for a country, leaving language and currency to the site defaults
+	 * that add_market() applies.
+	 *
+	 * @param string $country ISO 3166-1 alpha-2 country code.
+	 */
+	private function store_market( string $country ): void {
+		$feed_label = strtoupper( $country );
+
+		try {
+			$id = $this->market_service->generate_market_id( $feed_label );
+
+			// The id is derived from the country, but a market for another country can already
+			// be using it, and add_market() would overwrite that market wholesale.
+			if ( null !== $this->market_service->get_market( $id ) ) {
+				return;
+			}
+
+			$this->market_service->add_market(
+				$id,
+				[
+					'country'    => $country,
+					'feed_label' => $feed_label,
+				]
+			);
+		} catch ( Throwable $exception ) {
+			// One unconvertible country must not abort the upgrade: apply() runs from admin_init
+			// and a throw here would leave the version unrecorded, repeating on every page load.
+			do_action( 'woocommerce_gla_exception', $exception, __METHOD__ );
+		}
+	}
+
+	/**
+	 * Returns the countries a stored market already owns, so the migration can run again
+	 * without duplicating or overwriting them.
+	 *
+	 * @return string[]
+	 */
+	private function countries_with_a_market(): array {
+		$countries = [];
+
+		foreach ( $this->market_service->get_markets() as $id => $market ) {
+			if ( 'primary' === $id || empty( $market['country'] ) ) {
+				continue;
+			}
+
+			$countries[] = (string) $market['country'];
+		}
+
+		return $countries;
+	}
+
+	/**
+	 * Builds a comparable signature of a country's stored flat shipping.
+	 *
+	 * Two countries share a market only when their rate, free-shipping threshold and delivery
+	 * window all match, so all four take part in the comparison.
+	 *
+	 * @param string $country ISO 3166-1 alpha-2 country code.
+	 * @param array  $rates   Rates keyed by country.
+	 * @param array  $times   Times keyed by country.
+	 *
+	 * @return string
+	 */
+	private function shipping_signature( string $country, array $rates, array $times ): string {
+		$rate = $rates[ $country ] ?? [];
+		$time = $times[ $country ] ?? [];
+
+		return (string) wp_json_encode(
+			[
+				'rate'          => isset( $rate['rate'] ) ? (string) $rate['rate'] : null,
+				'free_shipping' => $rate['free_shipping_threshold'] ?? null,
+				'time'          => isset( $time['time'] ) ? (string) $time['time'] : null,
+				'max_time'      => isset( $time['max_time'] ) ? (string) $time['max_time'] : null,
+			]
+		);
+	}
+}

--- a/src/DB/Migration/Migration20260813T1653383133.php
+++ b/src/DB/Migration/Migration20260813T1653383133.php
@@ -92,7 +92,7 @@ class Migration20260813T1653383133 extends AbstractMigration {
 	 * @return void
 	 */
 	public function apply(): void {
-		if ( ! $this->has_convertible_audience() ) {
+		if ( ! $this->has_convertible_shipping() ) {
 			return;
 		}
 
@@ -141,22 +141,16 @@ class Migration20260813T1653383133 extends AbstractMigration {
 	 * option already, and their shipping rows are retained across mode switches, so reading the
 	 * rows there would invent markets the merchant never had.
 	 *
-	 * An "all countries" audience is left alone. The stored country list is ignored in that
-	 * mode, so taking a country out of it does not take it out of the primary feed: the market
-	 * would be listed twice and would record that its country was never in the primary feed.
+	 * The audience shape does not matter. A market's country leaves the primary feed because
+	 * the primary country list is computed without the countries markets own, not because it
+	 * was taken out of the stored list, which an "all countries" audience never consults.
 	 *
 	 * @return bool
 	 */
-	private function has_convertible_audience(): bool {
+	private function has_convertible_shipping(): bool {
 		$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
 
-		if ( ! is_array( $mc_settings ) || 'flat' !== ( $mc_settings['shipping_rate'] ?? null ) ) {
-			return false;
-		}
-
-		$target_audience = $this->options->get( OptionsInterface::TARGET_AUDIENCE, [] );
-
-		return is_array( $target_audience ) && 'selected' === ( $target_audience['location'] ?? null );
+		return is_array( $mc_settings ) && 'flat' === ( $mc_settings['shipping_rate'] ?? null );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/DBServiceProvider.php
+++ b/src/Internal/DependencyManagement/DBServiceProvider.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migration20211228T1
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migration20220524T1653383133;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migration20240813T1653383133;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migration20250910T1653383133;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migration20260813T1653383133;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\MigrationVersion141;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migrator;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
@@ -20,6 +21,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantPriceBenchmarksQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\AttributeMappingRulesTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\BudgetRecommendationTable;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
@@ -114,6 +117,7 @@ class DBServiceProvider extends AbstractServiceProvider {
 		$this->share_migration( Migration20231109T1653383133::class, BudgetRecommendationTable::class );
 		$this->share_migration( Migration20240813T1653383133::class, ShippingTimeTable::class );
 		$this->share_migration( Migration20250910T1653383133::class, ActionScheduler::class );
+		$this->share_migration( Migration20260813T1653383133::class, TargetAudience::class, ShippingRateQuery::class, ShippingTimeQuery::class, MarketService::class, OptionsInterface::class );
 		$this->share_with_tags( Migrator::class, MigrationInterface::class );
 	}
 

--- a/tests/Unit/DB/Migration/Migration20260813T1653383133Test.php
+++ b/tests/Unit/DB/Migration/Migration20260813T1653383133Test.php
@@ -1,0 +1,563 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB\Migration;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Migration\Migration20260813T1653383133;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingTimeQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
+use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateShippingSettings;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Migration20260813T1653383133Test
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\DB\Migration
+ */
+class Migration20260813T1653383133Test extends UnitTest {
+
+	/** @var MockObject|TargetAudience */
+	protected $target_audience;
+
+	/** @var MockObject|ShippingRateQuery */
+	protected $shipping_rate_query;
+
+	/** @var MockObject|ShippingTimeQuery */
+	protected $shipping_time_query;
+
+	/** @var MockObject|MarketService */
+	protected $market_service;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var Migration20260813T1653383133 */
+	protected $migration;
+
+	public function setUp(): void {
+		global $wpdb;
+
+		parent::setUp();
+
+		$this->target_audience     = $this->createMock( TargetAudience::class );
+		$this->shipping_rate_query = $this->createMock( ShippingRateQuery::class );
+		$this->shipping_time_query = $this->createMock( ShippingTimeQuery::class );
+		$this->market_service      = $this->createMock( MarketService::class );
+		$this->options             = $this->createMock( OptionsInterface::class );
+
+		// A flat store with an explicit audience, which is the only shape worth converting.
+		$this->set_up_store( 'flat', 'selected' );
+
+		$this->market_service->method( 'generate_market_id' )
+			->willReturnCallback(
+				function ( string $feed_label ): string {
+					return sanitize_title( $feed_label );
+				}
+			);
+
+		$this->migration = new Migration20260813T1653383133(
+			$wpdb,
+			$this->target_audience,
+			$this->shipping_rate_query,
+			$this->shipping_time_query,
+			$this->market_service,
+			$this->options
+		);
+	}
+
+	/**
+	 * Sets the shipping mode and audience shape.
+	 *
+	 * @param string $shipping_rate
+	 * @param string $location
+	 */
+	private function set_up_store( string $shipping_rate, string $location ): void {
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get' )->willReturnCallback(
+			function ( string $key ) use ( $shipping_rate, $location ) {
+				if ( OptionsInterface::MERCHANT_CENTER === $key ) {
+					return [ 'shipping_rate' => $shipping_rate ];
+				}
+
+				if ( OptionsInterface::TARGET_AUDIENCE === $key ) {
+					return [ 'location' => $location ];
+				}
+
+				return [];
+			}
+		);
+
+		$this->rebuild();
+	}
+
+	/**
+	 * Rebuilds the migration against the current mocks.
+	 */
+	private function rebuild(): void {
+		global $wpdb;
+
+		$this->migration = new Migration20260813T1653383133(
+			$wpdb,
+			$this->target_audience,
+			$this->shipping_rate_query,
+			$this->shipping_time_query,
+			$this->market_service,
+			$this->options
+		);
+	}
+
+	/**
+	 * Sets the shipping tables up.
+	 *
+	 * @param array $rates Rates keyed by country.
+	 * @param array $times Times keyed by country.
+	 */
+	private function set_up_shipping( array $rates, array $times = [] ): void {
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn( $rates );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( $times );
+	}
+
+	/**
+	 * Builds a rate row as get_all_shipping_rates() reports it.
+	 *
+	 * @param string     $country
+	 * @param string     $rate
+	 * @param float|null $threshold
+	 *
+	 * @return array
+	 */
+	private function rate( string $country, string $rate, ?float $threshold = null ): array {
+		return [
+			'country_code'            => $country,
+			'currency'                => 'USD',
+			'free_shipping_threshold' => $threshold,
+			'rate'                    => $rate,
+		];
+	}
+
+	public function test_applies_to_the_release_that_removes_the_derived_model(): void {
+		$this->assertSame( '3.10.0', $this->migration->get_applicable_version() );
+	}
+
+	public function test_stores_a_market_for_a_country_whose_rate_differs(): void {
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+		$this->set_up_shipping(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'GB' => $this->rate( 'GB', '12.00' ),
+			]
+		);
+		$this->market_service->method( 'get_markets' )->willReturn( [ 'primary' => [ 'country' => null ] ] );
+
+		// Language and currency are left out: add_market() fills the site defaults.
+		$this->market_service->expects( $this->once() )
+			->method( 'add_market' )
+			->with(
+				'gb',
+				[
+					'country'    => 'GB',
+					'feed_label' => 'GB',
+				]
+			);
+
+		$this->migration->apply();
+	}
+
+	public function test_stores_a_market_when_only_the_delivery_time_differs(): void {
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+		$this->set_up_shipping(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'GB' => $this->rate( 'GB', '5.00' ),
+			],
+			[
+				'US' => [
+					'time'     => 2,
+					'max_time' => 4,
+				],
+				'GB' => [
+					'time'     => 7,
+					'max_time' => 9,
+				],
+			]
+		);
+		$this->market_service->method( 'get_markets' )->willReturn( [] );
+
+		$this->market_service->expects( $this->once() )->method( 'add_market' );
+
+		$this->migration->apply();
+	}
+
+	public function test_stores_a_market_when_only_the_free_shipping_threshold_differs(): void {
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+		$this->set_up_shipping(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'GB' => $this->rate( 'GB', '5.00', 75.0 ),
+			]
+		);
+		$this->market_service->method( 'get_markets' )->willReturn( [] );
+
+		$this->market_service->expects( $this->once() )->method( 'add_market' );
+
+		$this->migration->apply();
+	}
+
+	public function test_stores_a_market_when_only_the_maximum_delivery_time_differs(): void {
+		// Both halves of the window take part, so a shared minimum is not enough to match.
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+		$this->set_up_shipping(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'GB' => $this->rate( 'GB', '5.00' ),
+			],
+			[
+				'US' => [
+					'time'     => 2,
+					'max_time' => 5,
+				],
+				'GB' => [
+					'time'     => 2,
+					'max_time' => 9,
+				],
+			]
+		);
+		$this->market_service->method( 'get_markets' )->willReturn( [] );
+
+		$this->market_service->expects( $this->once() )->method( 'add_market' );
+
+		$this->migration->apply();
+	}
+
+	public function test_stores_a_market_for_a_country_that_only_has_a_time_row(): void {
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+		$this->set_up_shipping(
+			[ 'US' => $this->rate( 'US', '5.00' ) ],
+			[
+				'US' => [
+					'time'     => 2,
+					'max_time' => 4,
+				],
+				'GB' => [
+					'time'     => 8,
+					'max_time' => 10,
+				],
+			]
+		);
+		$this->market_service->method( 'get_markets' )->willReturn( [] );
+
+		$this->market_service->expects( $this->once() )
+			->method( 'add_market' )
+			->with( 'gb', $this->anything() );
+
+		$this->migration->apply();
+	}
+
+	public function test_a_country_listed_twice_is_converted_once(): void {
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB', 'GB' ] );
+		$this->set_up_shipping(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'GB' => $this->rate( 'GB', '12.00' ),
+			]
+		);
+		$this->market_service->method( 'get_markets' )->willReturn( [] );
+
+		$this->market_service->expects( $this->once() )->method( 'add_market' );
+
+		$this->migration->apply();
+	}
+
+	public function test_leaves_a_market_that_already_owns_the_generated_id(): void {
+		// The id comes from the country, but another market can already be using it.
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+		$this->set_up_shipping(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'GB' => $this->rate( 'GB', '12.00' ),
+			]
+		);
+		$this->market_service->method( 'get_markets' )->willReturn( [] );
+		$this->market_service->method( 'get_market' )->willReturn( [ 'country' => 'DE' ] );
+
+		$this->market_service->expects( $this->never() )->method( 'add_market' );
+
+		$this->migration->apply();
+	}
+
+	public function test_leaves_a_country_whose_shipping_matches_the_main_country(): void {
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'CA' ] );
+		$this->set_up_shipping(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'CA' => $this->rate( 'CA', '5.00' ),
+			]
+		);
+		$this->market_service->method( 'get_markets' )->willReturn( [] );
+
+		$this->market_service->expects( $this->never() )->method( 'add_market' );
+
+		$this->migration->apply();
+	}
+
+	public function test_leaves_a_country_with_no_shipping_row_of_its_own(): void {
+		// It inherited the primary's shipping, so it was never its own market.
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'CA' ] );
+		$this->set_up_shipping( [ 'US' => $this->rate( 'US', '5.00' ) ] );
+		$this->market_service->method( 'get_markets' )->willReturn( [] );
+
+		$this->market_service->expects( $this->never() )->method( 'add_market' );
+
+		$this->migration->apply();
+	}
+
+	public function test_skips_a_country_that_already_has_a_stored_market(): void {
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+		$this->set_up_shipping(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'GB' => $this->rate( 'GB', '12.00' ),
+			]
+		);
+		$this->market_service->method( 'get_markets' )->willReturn(
+			[
+				'primary' => [ 'country' => null ],
+				'gb-eur'  => [ 'country' => 'GB' ],
+			]
+		);
+
+		// Matched on country, not id, so a market stored under any id still counts.
+		$this->market_service->expects( $this->never() )->method( 'add_market' );
+
+		$this->migration->apply();
+	}
+
+	public function test_running_twice_stores_the_market_once(): void {
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+		$this->set_up_shipping(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'GB' => $this->rate( 'GB', '12.00' ),
+			]
+		);
+
+		// The second pass sees the market the first pass stored.
+		$stored = [];
+		$this->market_service->method( 'get_markets' )->willReturnCallback(
+			function () use ( &$stored ): array {
+				return $stored;
+			}
+		);
+		$this->market_service->expects( $this->once() )
+			->method( 'add_market' )
+			->willReturnCallback(
+				function ( string $id, array $config ) use ( &$stored ): void {
+					$stored[ $id ] = $config;
+				}
+			);
+
+		$this->migration->apply();
+		$this->migration->apply();
+	}
+
+	public function test_no_op_when_the_store_is_not_on_a_flat_rate(): void {
+		// Rate rows survive a mode switch and delivery times are set independently, so reading
+		// them outside flat mode would invent markets the merchant never had.
+		$this->set_up_store( 'automatic', 'selected' );
+
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+		$this->set_up_shipping(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'GB' => $this->rate( 'GB', '12.00' ),
+			]
+		);
+
+		$this->market_service->expects( $this->never() )->method( 'add_market' );
+
+		$this->migration->apply();
+	}
+
+	public function test_no_op_for_an_all_countries_audience(): void {
+		// Such a store keeps no explicit country list, so a converted market would record that
+		// its country was never in the primary feed.
+		$this->set_up_store( 'flat', 'all' );
+
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+		$this->set_up_shipping(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'GB' => $this->rate( 'GB', '12.00' ),
+			]
+		);
+
+		$this->market_service->expects( $this->never() )->method( 'add_market' );
+
+		$this->migration->apply();
+	}
+
+	public function test_the_stored_market_carries_the_defaults_and_leaves_the_primary_audience(): void {
+		// Everything above mocks MarketService, so nothing proves what add_market() actually
+		// writes. This drives the real service and reads the option back.
+		global $wpdb;
+
+		$stored_options = [
+			OptionsInterface::MERCHANT_CENTER => [
+				'shipping_rate' => 'flat',
+				'shipping_time' => 'flat',
+			],
+			OptionsInterface::TARGET_AUDIENCE => [
+				'location'  => 'selected',
+				'countries' => [ 'US', 'GB' ],
+			],
+			OptionsInterface::MARKETS         => [],
+		];
+
+		$options = $this->createMock( OptionsInterface::class );
+		$options->method( 'get' )->willReturnCallback(
+			function ( string $key, $fallback = null ) use ( &$stored_options ) {
+				return $stored_options[ $key ] ?? $fallback;
+			}
+		);
+		$options->method( 'update' )->willReturnCallback(
+			function ( string $key, $value ) use ( &$stored_options ): bool {
+				$stored_options[ $key ] = $value;
+
+				return true;
+			}
+		);
+
+		$target_audience = $this->createMock( TargetAudience::class );
+		$target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+
+		$rate_query = $this->createMock( ShippingRateQuery::class );
+		$rate_query->method( 'get_all_shipping_rates' )->willReturn(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'GB' => $this->rate( 'GB', '12.00' ),
+			]
+		);
+		$rate_query->method( 'get_results' )->willReturn( [] );
+
+		$time_query = $this->createMock( ShippingTimeQuery::class );
+		$time_query->method( 'get_all_shipping_times' )->willReturn( [] );
+		$time_query->method( 'get_results' )->willReturn( [] );
+
+		$wc = $this->createMock( WC::class );
+		$wc->method( 'get_countries' )->willReturn( [ 'GB' => 'United Kingdom (UK)' ] );
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_currencies_enabled_for_language' )->willReturnCallback(
+			function ( array $currencies ): array {
+				return $currencies;
+			}
+		);
+
+		$job_repository = $this->createMock( JobRepository::class );
+		$job_repository->method( 'get' )->willReturnCallback(
+			function ( $classname ) {
+				switch ( $classname ) {
+					case UpdateAllProducts::class:
+						return $this->createMock( UpdateAllProducts::class );
+					case UpdateShippingSettings::class:
+						return $this->createMock( UpdateShippingSettings::class );
+					default:
+						return null;
+				}
+			}
+		);
+
+		$market_service = new MarketService( $target_audience, $rate_query, $time_query, $wc, $wpml, $job_repository );
+		$market_service->set_options_object( $options );
+
+		$migration = new Migration20260813T1653383133( $wpdb, $target_audience, $rate_query, $time_query, $market_service, $options );
+		$migration->apply();
+
+		$market = $stored_options[ OptionsInterface::MARKETS ]['gb'] ?? null;
+
+		$this->assertNotNull( $market, wp_json_encode( $stored_options[ OptionsInterface::MARKETS ] ) );
+		$this->assertSame( 'GB', $market['country'] );
+		$this->assertSame( 'GB', $market['feed_label'] );
+
+		// AC1: the site defaults land, and the country is recorded as having been in primary.
+		$this->assertSame( [ substr( get_locale(), 0, 2 ) ], $market['language'] );
+		$this->assertSame( [ get_woocommerce_currency() ], $market['currency'] );
+		$this->assertTrue( $market['was_in_primary'] );
+
+		// The converted country leaves the primary feed, so it is not listed twice.
+		$this->assertSame( [ 'US' ], array_values( $stored_options[ OptionsInterface::TARGET_AUDIENCE ]['countries'] ) );
+	}
+
+	public function test_no_op_when_only_one_country_is_targeted(): void {
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US' ] );
+
+		$this->market_service->expects( $this->never() )->method( 'add_market' );
+
+		$this->migration->apply();
+	}
+
+	public function test_no_op_when_there_is_no_main_target_country(): void {
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( '' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+
+		$this->market_service->expects( $this->never() )->method( 'add_market' );
+
+		$this->migration->apply();
+	}
+
+	public function test_one_rejected_country_does_not_stop_the_others(): void {
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB', 'DE' ] );
+		$this->set_up_shipping(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'GB' => $this->rate( 'GB', '12.00' ),
+				'DE' => $this->rate( 'DE', '9.00' ),
+			]
+		);
+		$this->market_service->method( 'get_markets' )->willReturn( [] );
+
+		$seen = [];
+		$this->market_service->expects( $this->exactly( 2 ) )
+			->method( 'add_market' )
+			->willReturnCallback(
+				function ( string $id ) use ( &$seen ): void {
+					$seen[] = $id;
+
+					if ( 'gb' === $id ) {
+						throw new InvalidValue( 'nope' );
+					}
+				}
+			);
+
+		$this->migration->apply();
+
+		$this->assertSame( [ 'gb', 'de' ], $seen );
+	}
+}

--- a/tests/Unit/DB/Migration/Migration20260813T1653383133Test.php
+++ b/tests/Unit/DB/Migration/Migration20260813T1653383133Test.php
@@ -401,9 +401,9 @@ class Migration20260813T1653383133Test extends UnitTest {
 		$this->migration->apply();
 	}
 
-	public function test_no_op_for_an_all_countries_audience(): void {
-		// Such a store keeps no explicit country list, so a converted market would record that
-		// its country was never in the primary feed.
+	public function test_converts_for_an_all_countries_audience(): void {
+		// Such a store keeps no explicit country list. The primary country list is computed
+		// without the countries markets own, so the conversion holds there too.
 		$this->set_up_store( 'flat', 'all' );
 
 		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
@@ -415,7 +415,9 @@ class Migration20260813T1653383133Test extends UnitTest {
 			]
 		);
 
-		$this->market_service->expects( $this->never() )->method( 'add_market' );
+		$this->market_service->expects( $this->once() )
+			->method( 'add_market' )
+			->with( 'gb', $this->callback( fn( $config ) => 'GB' === $config['country'] ) );
 
 		$this->migration->apply();
 	}
@@ -511,6 +513,101 @@ class Migration20260813T1653383133Test extends UnitTest {
 
 		// The converted country leaves the primary feed, so it is not listed twice.
 		$this->assertSame( [ 'US' ], array_values( $stored_options[ OptionsInterface::TARGET_AUDIENCE ]['countries'] ) );
+	}
+
+	public function test_an_all_countries_store_records_the_country_as_having_been_primary(): void {
+		// An all-countries audience keeps no explicit country list, so membership has to come
+		// from the resolved audience. Drives the real service to prove the recorded flag.
+		global $wpdb;
+
+		$stored_options = [
+			OptionsInterface::MERCHANT_CENTER => [
+				'shipping_rate' => 'flat',
+				'shipping_time' => 'flat',
+			],
+			OptionsInterface::TARGET_AUDIENCE => [
+				'location'  => 'all',
+				'countries' => [],
+			],
+			OptionsInterface::MARKETS         => [],
+		];
+
+		$options = $this->createMock( OptionsInterface::class );
+		$options->method( 'get' )->willReturnCallback(
+			function ( string $key, $fallback = null ) use ( &$stored_options ) {
+				return $stored_options[ $key ] ?? $fallback;
+			}
+		);
+		$options->method( 'update' )->willReturnCallback(
+			function ( string $key, $value ) use ( &$stored_options ): bool {
+				$stored_options[ $key ] = $value;
+
+				return true;
+			}
+		);
+
+		$target_audience = $this->createMock( TargetAudience::class );
+		$target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
+		$target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'GB' ] );
+
+		$rate_query = $this->createMock( ShippingRateQuery::class );
+		$rate_query->method( 'get_all_shipping_rates' )->willReturn(
+			[
+				'US' => $this->rate( 'US', '5.00' ),
+				'GB' => $this->rate( 'GB', '12.00' ),
+			]
+		);
+		$rate_query->method( 'get_results' )->willReturn( [] );
+
+		$time_query = $this->createMock( ShippingTimeQuery::class );
+		$time_query->method( 'get_all_shipping_times' )->willReturn( [] );
+		$time_query->method( 'get_results' )->willReturn( [] );
+
+		$wc = $this->createMock( WC::class );
+		$wc->method( 'get_countries' )->willReturn( [ 'GB' => 'United Kingdom (UK)' ] );
+
+		$wpml = $this->createMock( WPML::class );
+		$wpml->method( 'get_currencies_enabled_for_language' )->willReturnCallback(
+			function ( array $currencies ): array {
+				return $currencies;
+			}
+		);
+
+		$job_repository = $this->createMock( JobRepository::class );
+		$job_repository->method( 'get' )->willReturnCallback(
+			function ( $classname ) {
+				switch ( $classname ) {
+					case UpdateAllProducts::class:
+						return $this->createMock( UpdateAllProducts::class );
+					case UpdateShippingSettings::class:
+						return $this->createMock( UpdateShippingSettings::class );
+					default:
+						return null;
+				}
+			}
+		);
+
+		$market_service = new MarketService( $target_audience, $rate_query, $time_query, $wc, $wpml, $job_repository );
+		$market_service->set_options_object( $options );
+
+		$migration = new Migration20260813T1653383133( $wpdb, $target_audience, $rate_query, $time_query, $market_service, $options );
+		$migration->apply();
+
+		$market = $stored_options[ OptionsInterface::MARKETS ]['gb'] ?? null;
+
+		$this->assertNotNull( $market, wp_json_encode( $stored_options[ OptionsInterface::MARKETS ] ) );
+		$this->assertSame( 'GB', $market['country'] );
+		$this->assertSame( 'GB', $market['feed_label'] );
+
+		// AC1: the site defaults land, and the country is recorded as having been in primary.
+		$this->assertSame( [ substr( get_locale(), 0, 2 ) ], $market['language'] );
+		$this->assertSame( [ get_woocommerce_currency() ], $market['currency'] );
+		$this->assertTrue( $market['was_in_primary'] );
+
+		// The stored list is empty in this mode and stays that way; the country leaves the
+		// primary feed because the primary country list excludes what markets own.
+		$this->assertSame( [], $stored_options[ OptionsInterface::TARGET_AUDIENCE ]['countries'] );
+		$this->assertNotContains( 'GB', $market_service->get_primary_market()['countries'] );
 	}
 
 	public function test_no_op_when_only_one_country_is_targeted(): void {

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -312,7 +312,10 @@ class MarketServiceTest extends UnitTest {
 		$this->set_up_options_get(
 			[
 				OptionsInterface::MERCHANT_CENTER => [],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'all', 'countries' => [] ],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'all',
+					'countries' => [],
+				],
 				OptionsInterface::MARKETS         => [
 					'gr' => [
 						'country'    => 'GR',
@@ -1548,7 +1551,10 @@ class MarketServiceTest extends UnitTest {
 		$this->set_up_options_get(
 			[
 				OptionsInterface::MARKETS         => [],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'all', 'countries' => [] ],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'all',
+					'countries' => [],
+				],
 			]
 		);
 		// The stored list is empty in this mode; the resolved audience is what covers GB.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-933/migrate-flat-derived-markets-into-stored-markets-on-plugin-upgrade

Flat shipping mode used to derive secondary markets from the shipping tables. #3699  removes that derivation, so on upgrade a merchant's per-country flat setups would stop being markets and the countries would silently fold back into the primary feed.

This adds a migration that reads the shipping rows once, at 3.10.0, and stores a real market for every country whose flat shipping differs from the primary's. Converted countries are removed from the primary audience, matching what a market created through the API does.

Countries with no shipping row of their own, or with shipping identical to the primary's, were never separate markets and are left in the primary feed. Non-flat stores are skipped: their markets are already stored, and their shipping rows survive mode switches, so reading the rows there would invent markets. Flat stores targeting "All countries" are also skipped, since removing a country from the stored list does not remove it from the primary feed in that mode.

**Note**
get_applicable_version() is 3.10.0 and must match the release that carries #3699


### Screenshots:

N/A


### Detailed test instructions:

## Scenario 1: A store with markets to convert

Set up on the old version:

1. Install and activate Google for WooCommerce 3.9.0.
2. Complete the plugin's onboarding, connecting your Google account and Merchant Centre account. When asked about shipping, choose "My shipping settings are simple. I can manually estimate flat shipping rates.". When asked where you sell, select at least three countries. Finish onboarding.
3. Go to Marketing, Google for WooCommerce, and open the "Markets" tab.
4. Click "Add market", choose a country, enter a shipping rate different from your main market's under "Estimated shipping rates", enter "Estimated shipping times", and add the market.
5. Write down, or screenshot, what the Markets page now shows: the main market's country count, the added country's row, and its shipping rate. Leave the remaining countries alone so they stay inside the main market.
6. Wait for the product sync to finish (the "Product Feed" tab shows progress), then in Google Merchant Centre confirm the shipping rate for the added country is the one you entered.

Upgrade:

7. Go to Plugins, Add New Plugin, Upload Plugin, choose the zip file of the build under test, and confirm replacing the currently installed version when WordPress asks.
8. On the Plugins page, confirm Google for WooCommerce now reports the new version (3.10.0 or higher). If it still says 3.9.0, stop: the conversion cannot run, and the build needs its version number corrected.
9. Open any admin page (the Plugins page itself is fine). The conversion runs quietly during this page load; there is no button and no message.

Check the result:

10. Open the "Markets" tab.
11. Expected: the page matches your note from step 5 exactly. The added country is still its own market with the same shipping rate, the untouched countries are still inside the main market, and the country count is unchanged. Nothing has appeared, disappeared or changed. An upgrade you cannot notice on this page is the pass result.
12. Edit the converted market, change its shipping rate, save, and reload the page.
13. Expected: the new rate is kept. The market now behaves exactly like one created after the upgrade.
14. In Google Merchant Centre, allowing a few minutes, confirm the country's shipping rate is now the value from step 12 and your products are still listed.

## Scenario 2: A flat-shipping store with nothing to convert

1. On a fresh site, install Google for WooCommerce 3.9.0 and complete onboarding as in Scenario 1, but do not add any market: leave every country inside the main market, sharing one rate.
2. Upgrade to the build under test and open an admin page, as in Scenario 1 steps 7 to 9.
3. Expected: the Markets page still shows only the main market with the same countries and rate. No market has been invented by the upgrade.

## Scenario 3: A store not using flat shipping is left alone

1. On a fresh site, install Google for WooCommerce 3.9.0 and complete onboarding, this time choosing "Automatically sync my store's shipping settings to Google." for shipping. Select at least three countries.
2. On the Markets page, click "Add market", choose a country, fill in the fields shown (leave any suggested values as they are), and add the market.
3. Write down, or screenshot, what the Markets page shows.
4. Upgrade to the build under test and open an admin page, as in Scenario 1 steps 7 to 9.
5. Expected: the Markets page matches your note. The market you created is unchanged, and no extra markets have appeared.

### Additional details:

> Update - Migrate flat-derived markets into stored markets on plugin upgrade