### PR TITLE
GOOWOO-936: Remove feed_label as a stored/writable market field

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -1560,18 +1560,24 @@ export function* fetchMarkets() {
 /**
  * Create a new market.
  *
- * @param {Market} args The market data to create.
- * @return {Object} Action object to receive the markets after creation.
+ * Returns the response body rather than the refreshed markets, since the server decides
+ * whether the country became its own market or joined the primary one, and only the body
+ * says which. The markets are still refetched before returning.
+ *
+ * @param {Market & { shipping?: Object }} args The market data to create, including the
+ *   shipping profile the API compares against the primary market's.
+ * @return {Object} The created market, or the primary market with `merged_into_primary` set.
  * @throws Will throw an error if the request failed.
  */
 export function* createMarket( args ) {
 	try {
-		yield apiFetch( {
+		const response = yield apiFetch( {
 			path: `${ API_NAMESPACE }/mc/markets`,
 			method: 'POST',
 			data: args,
 		} );
-		return yield fetchMarkets();
+		yield fetchMarkets();
+		return response;
 	} catch ( error ) {
 		handleApiError( error );
 		throw error;

--- a/js/src/data/actions.test.js
+++ b/js/src/data/actions.test.js
@@ -1,0 +1,74 @@
+/**
+ * Internal dependencies
+ */
+import { createMarket } from './actions';
+import { API_NAMESPACE } from './constants';
+
+jest.mock( '~/utils/handleError', () => ( {
+	handleApiError: jest.fn(),
+} ) );
+
+describe( 'createMarket', () => {
+	/**
+	 * Drives the generator to completion, feeding the given body back as the POST result.
+	 *
+	 * @param {Object} args Market data.
+	 * @param {Object} body Response body the POST resolves to.
+	 * @return {{ request: Object, returned: any }} The yielded request and the returned value.
+	 */
+	const run = ( args, body ) => {
+		const generator = createMarket( args );
+		const request = generator.next().value;
+
+		// The POST resolves to `body`; the next yield refetches the markets.
+		generator.next( body );
+
+		return { request, returned: generator.next().value };
+	};
+
+	it( 'posts the market data to the markets endpoint', () => {
+		const { request } = run( { country: 'GB' }, {} );
+
+		expect( request.request ).toEqual(
+			expect.objectContaining( {
+				path: `${ API_NAMESPACE }/mc/markets`,
+				method: 'POST',
+				data: { country: 'GB' },
+			} )
+		);
+	} );
+
+	it( 'returns the response body so the caller can tell a fold from a creation', () => {
+		const body = { id: 'primary', merged_into_primary: true };
+
+		expect( run( { country: 'GB' }, body ).returned ).toEqual( body );
+	} );
+
+	it( 'returns the created market when nothing was folded', () => {
+		const body = { id: 'gb', country: 'GB' };
+
+		expect( run( { country: 'GB' }, body ).returned ).toEqual( body );
+	} );
+
+	it( 'refetches the markets before returning', () => {
+		const generator = createMarket( { country: 'GB' } );
+
+		generator.next();
+
+		const refetch = generator.next( {} ).value;
+
+		// fetchMarkets is itself a generator, not the plain response body.
+		expect( typeof refetch.next ).toBe( 'function' );
+		expect( generator.next().done ).toBe( true );
+	} );
+
+	it( 'rethrows so the caller can keep the form open', () => {
+		const generator = createMarket( { country: 'GB' } );
+
+		generator.next();
+
+		expect( () => generator.throw( new Error( 'boom' ) ) ).toThrow(
+			'boom'
+		);
+	} );
+} );

--- a/js/src/pages/markets/components/market-form.js
+++ b/js/src/pages/markets/components/market-form.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useRef, useState } from '@wordpress/element';
 
 /**
@@ -25,6 +25,8 @@ import useSaveShippingTimes from '~/hooks/useSaveShippingTimes';
 import useSettings from '~/hooks/useSettings';
 import useStoreCurrency from '~/hooks/useStoreCurrency';
 import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
 import AdaptiveForm from '~/components/adaptive-form';
 import ValidationErrors from '~/components/validation-errors';
 import AppSpinner from '~/components/app-spinner';
@@ -77,6 +79,8 @@ const MarketForm = ( {
 	const [ isSaving, setIsSaving ] = useState( false );
 	const { createMarket, updateMarket, syncSettings, invalidateResolution } =
 		useAppDispatch();
+	const { createNotice } = useDispatchCoreNotices();
+	const countryNameMap = useCountryKeyNameMap();
 	const marketId = initialMarket?.id;
 	const isEditing = Boolean( marketId );
 	const isPrimaryMarket = isEditing && checkIsPrimaryMarket( initialMarket );
@@ -116,6 +120,8 @@ const MarketForm = ( {
 			...data
 		} = values;
 
+		let mergedIntoPrimary = false;
+
 		try {
 			setIsSaving( true );
 
@@ -125,7 +131,23 @@ const MarketForm = ( {
 					isPrimaryMarket ? { ...data, countries } : data
 				);
 			} else {
-				await createMarket( data );
+				// The API compares this against the primary market's own shipping and folds
+				// the country in when they match, rather than storing a market that would
+				// feed identically. Values absent for the store's method are simply not
+				// sent, which the API reads as nothing to compare.
+				const response = await createMarket( {
+					...data,
+					shipping: {
+						flat_rate: values.flat_shipping_rate,
+						free_shipping_threshold: values.offer_free_shipping
+							? values.free_shipping_threshold
+							: null,
+						flat_time: values.flat_shipping_min_time,
+						flat_max_time: values.flat_shipping_max_time,
+					},
+				} );
+
+				mergedIntoPrimary = Boolean( response?.merged_into_primary );
 			}
 
 			// Mirror fieldsByMethod from resolveInitialMarket: FLAT includes
@@ -195,6 +217,25 @@ const MarketForm = ( {
 			// for the affected countries, so the cached list is no longer trustworthy.
 			invalidateResolution( 'getTargetAudience', [] );
 			invalidateResolution( 'getMarkets', [] );
+
+			if ( mergedIntoPrimary ) {
+				createNotice(
+					'success',
+					sprintf(
+						// translators: %s: name of the country that joined the primary market.
+						__(
+							'%s was added to the Primary market, as its configuration matched the existing Primary market settings',
+							'google-listings-and-ads'
+						),
+						countryNameMap[ data.country ] || data.country
+					),
+					{
+						type: 'snackbar',
+						isDismissible: true,
+					}
+				);
+			}
+
 			onSubmit();
 		} catch ( error ) {
 			// Every awaited action has already dispatched its own error

--- a/js/src/pages/markets/components/market-form.test.js
+++ b/js/src/pages/markets/components/market-form.test.js
@@ -17,6 +17,8 @@ import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCo
 import useSaveShippingRates from '~/hooks/useSaveShippingRates';
 import useSaveShippingTimes from '~/hooks/useSaveShippingTimes';
 import { useAppDispatch } from '~/data';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
 import { handleApiError } from '~/utils/handleError';
 import { SHIPPING_RATE_METHOD } from '~/constants';
 
@@ -33,13 +35,21 @@ jest.mock( '~/data', () => ( {
 jest.mock( '~/utils/handleError', () => ( {
 	handleApiError: jest.fn(),
 } ) );
+jest.mock( '~/hooks/useCountryKeyNameMap' );
 
-const submittedValues = {
+const mockBuildSubmittedValues = () => ( {
 	country: 'US',
 	countries: [ 'US' ],
 	shipping_country_rates: [],
 	shipping_country_times: [],
-};
+	flat_shipping_rate: 5,
+	offer_free_shipping: true,
+	free_shipping_threshold: 50,
+	flat_shipping_min_time: 1,
+	flat_shipping_max_time: 3,
+} );
+
+let mockSubmittedValues = mockBuildSubmittedValues();
 
 // MarketForm renders its fields via AdaptiveForm (and attaches a ref to it);
 // mock it as a forwardRef spy so we can both inspect the `initialValues` it's
@@ -57,7 +67,7 @@ jest.mock( '~/components/adaptive-form', () => {
 			return (
 				<button
 					ref={ ref }
-					onClick={ () => props.onSubmit( submittedValues ) }
+					onClick={ () => props.onSubmit( mockSubmittedValues ) }
 				>
 					Submit
 				</button>
@@ -187,6 +197,7 @@ describe( 'MarketForm handleSubmit', () => {
 	const updateMarket = jest.fn();
 	const syncSettings = jest.fn();
 	const invalidateResolution = jest.fn();
+	const createNotice = jest.fn();
 
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -225,6 +236,9 @@ describe( 'MarketForm handleSubmit', () => {
 			targetAudience: { main_target_country: 'US' },
 			loaded: true,
 		} );
+		useDispatchCoreNotices.mockReturnValue( { createNotice } );
+		useCountryKeyNameMap.mockReturnValue( { US: 'United States (US)' } );
+		mockSubmittedValues = mockBuildSubmittedValues();
 	} );
 
 	test( 'invalidates both getTargetAudience and getMarkets after a successful save, since saving shipping rates/times changes what the markets list reports', async () => {
@@ -245,6 +259,102 @@ describe( 'MarketForm handleSubmit', () => {
 		);
 		expect( invalidateResolution ).toHaveBeenCalledWith( 'getMarkets', [] );
 		expect( onSubmit ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'sends the market shipping profile so the API can compare it against Primary', async () => {
+		const user = userEvent.setup();
+
+		useSettings.mockReturnValue( {
+			settings: {
+				shipping_rate: SHIPPING_RATE_METHOD.FLAT,
+				shipping_time: 'flat',
+			},
+		} );
+
+		render( <MarketForm onSubmit={ jest.fn() } /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		expect( createMarket ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				shipping: {
+					flat_rate: 5,
+					free_shipping_threshold: 50,
+					flat_time: 1,
+					flat_max_time: 3,
+				},
+			} )
+		);
+	} );
+
+	test( 'sends a null free shipping threshold when the market offers none', async () => {
+		const user = userEvent.setup();
+
+		useSettings.mockReturnValue( {
+			settings: {
+				shipping_rate: SHIPPING_RATE_METHOD.FLAT,
+				shipping_time: 'flat',
+			},
+		} );
+		mockSubmittedValues.offer_free_shipping = false;
+
+		render( <MarketForm onSubmit={ jest.fn() } /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		expect( createMarket ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				shipping: expect.objectContaining( {
+					free_shipping_threshold: null,
+				} ),
+			} )
+		);
+	} );
+
+	test( 'shows a snackbar naming the country when it is folded into Primary', async () => {
+		const user = userEvent.setup();
+		const onSubmit = jest.fn();
+
+		createMarket.mockResolvedValue( { merged_into_primary: true } );
+
+		render( <MarketForm onSubmit={ onSubmit } /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		expect( createNotice ).toHaveBeenCalledWith(
+			'success',
+			'United States (US) was added to the Primary market, as its configuration matched the existing Primary market settings',
+			{ type: 'snackbar', isDismissible: true }
+		);
+		expect( onSubmit ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'shows no snackbar when the market is created in its own right', async () => {
+		const user = userEvent.setup();
+
+		createMarket.mockResolvedValue( { id: 'us', country: 'US' } );
+
+		render( <MarketForm onSubmit={ jest.fn() } /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		expect( createNotice ).not.toHaveBeenCalled();
+	} );
+
+	test( 'shows no snackbar when editing an existing market', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<MarketForm
+				initialMarket={ { id: 'gb', country: 'GB' } }
+				onSubmit={ jest.fn() }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		expect( createMarket ).not.toHaveBeenCalled();
+		expect( createNotice ).not.toHaveBeenCalled();
 	} );
 
 	test( 'does not invalidate getMarkets or call onSubmit when syncSettings fails', async () => {

--- a/src/API/Site/Controllers/MerchantCenter/MarketsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/MarketsController.php
@@ -162,8 +162,7 @@ class MarketsController extends BaseController {
 	protected function get_create_market_callback(): callable {
 		return function ( Request $request ) {
 			$config = [
-				'country'    => $request->get_param( 'country' ),
-				'feed_label' => $request->get_param( 'feed_label' ) ?? $request->get_param( 'country' ),
+				'country' => $request->get_param( 'country' ),
 			];
 
 			if ( null !== $request->get_param( 'language' ) ) {
@@ -179,7 +178,7 @@ class MarketsController extends BaseController {
 			}
 
 			try {
-				$id = $this->market_service->generate_market_id( $config['feed_label'] );
+				$id = $this->market_service->generate_market_id( $config['country'] );
 			} catch ( InvalidValue $e ) {
 				return new Response(
 					[ 'message' => __( 'Cannot create a market with a reserved ID.', 'google-listings-and-ads' ) ],
@@ -206,7 +205,10 @@ class MarketsController extends BaseController {
 			$created       = $this->market_service->get_market( $id );
 			$created['id'] = $id;
 
-			return new Response( $created, 201 );
+			$response = $this->prepare_item_for_response( $created, $request );
+			$response->set_status( 201 );
+
+			return $response;
 		};
 	}
 
@@ -240,7 +242,9 @@ class MarketsController extends BaseController {
 				return new Response( [ 'message' => $e->getMessage() ], 400 );
 			}
 
-			return new Response( $updated );
+			$updated['id'] = $id;
+
+			return $this->prepare_item_for_response( $updated, $request );
 		};
 	}
 
@@ -409,6 +413,10 @@ class MarketsController extends BaseController {
 				'type'              => 'string',
 				'description'       => __( 'Primary country code in ISO 3166-1 alpha-2 format. Null for the primary market.', 'google-listings-and-ads' ),
 				'context'           => [ 'view', 'edit' ],
+				// The market id is derived from this and the shipping tables store it in a
+				// two-character column, so anything else is persisted before the row insert
+				// rejects it, and a value that sanitises to an empty id is unaddressable.
+				'pattern'           => '^[A-Z]{2}$',
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 			'language'      => [
@@ -428,12 +436,6 @@ class MarketsController extends BaseController {
 			'exchange_rate' => [
 				'type'              => 'number',
 				'description'       => __( 'Fixed exchange rate applied to store prices for this market: units of market currency per unit of store currency. Lets a secondary market use a currency the site cannot otherwise produce. Ignored for the primary market.', 'google-listings-and-ads' ),
-				'context'           => [ 'view', 'edit' ],
-				'validate_callback' => 'rest_validate_request_arg',
-			],
-			'feed_label'    => [
-				'type'              => 'string',
-				'description'       => __( 'Google feed label. Null for the primary market.', 'google-listings-and-ads' ),
 				'context'           => [ 'view', 'edit' ],
 				'validate_callback' => 'rest_validate_request_arg',
 			],

--- a/src/API/Site/Controllers/MerchantCenter/MarketsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/MarketsController.php
@@ -196,10 +196,28 @@ class MarketsController extends BaseController {
 				);
 			}
 
+			$shipping = $request->get_param( 'shipping' );
+
 			try {
-				$this->market_service->add_market( $id, $config );
+				$merged = $this->market_service->add_market_or_merge_into_primary(
+					$id,
+					$config,
+					is_array( $shipping ) ? $shipping : null
+				);
 			} catch ( InvalidValue $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], 400 );
+			}
+
+			if ( $merged ) {
+				// No market was created, so this returns the primary market the country joined.
+				// The flag is set after the schema pass so it stays off every other market
+				// response, where it would have no meaning.
+				$response = $this->prepare_item_for_response( $this->market_service->get_primary_market(), $request );
+				$data     = $response->get_data();
+
+				$data['merged_into_primary'] = true;
+
+				return new Response( $data, 200 );
 			}
 
 			$created       = $this->market_service->get_market( $id );
@@ -331,7 +349,10 @@ class MarketsController extends BaseController {
 		$schema = $this->get_schema_properties();
 
 		return [
-			'country' => array_merge( $schema['country'], [ 'required' => true ] ),
+			'country'  => array_merge( $schema['country'], [ 'required' => true ] ),
+			// Compared against the primary market's, and not persisted here: the rates and
+			// times are written through their own endpoints either way.
+			'shipping' => $schema['shipping'],
 		];
 	}
 

--- a/src/Jobs/CleanupOrphanedMarketProductsJob.php
+++ b/src/Jobs/CleanupOrphanedMarketProductsJob.php
@@ -19,9 +19,9 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class CleanupOrphanedMarketProductsJob
  *
- * Deletes Merchant Center entries that belong to a removed or renamed market.
- * Scheduled by MarketService when a market is deleted or its `feed_label`
- * changes; carries every `google_ids` key the market's entries can be stored
+ * Deletes Merchant Center entries that belong to a removed or reconfigured market.
+ * Scheduled by MarketService when a market is deleted or the labels it derives
+ * change; carries every `google_ids` key the market's entries can be stored
  * under (its base feed label plus each per-language variant) so the orphaned
  * entries can be removed before the next product sync writes new ones.
  *

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -41,15 +41,6 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	use OptionsAwareTrait;
 
 	/**
-	 * Google Content API constraint on `feedLabel`: up to 20 characters,
-	 * uppercase letters, digits and dashes only. Stored labels are capped at
-	 * 13 characters so a derived per-language label (a dash plus a two-letter
-	 * language code plus a dash plus a three-letter currency code) stays
-	 * within the 20-character limit.
-	 */
-	private const FEED_LABEL_PATTERN = '/^[A-Z0-9-]{1,13}$/';
-
-	/**
 	 * @var TargetAudience
 	 */
 	protected TargetAudience $target_audience;
@@ -398,7 +389,6 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			'country'       => null,
 			'language'      => is_array( $mc_settings['language'] ?? null ) ? $mc_settings['language'] : $default_language,
 			'currency'      => is_array( $mc_settings['currency'] ?? null ) ? $mc_settings['currency'] : $default_currency,
-			'feed_label'    => null,
 			'shipping_rate' => $mc_settings['shipping_rate'] ?? null,
 			'shipping_time' => $mc_settings['shipping_time'] ?? null,
 			'free_shipping' => $this->get_primary_free_shipping_threshold(),
@@ -454,23 +444,23 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	}
 
 	/**
-	 * Generates a market ID from a feed label.
+	 * Generates a market ID from the country the market targets.
 	 *
 	 * Centralises the ID-generation rule so any code path that creates a market
 	 * (REST controller, batch import, migration, CLI) produces consistent IDs.
 	 *
-	 * @param string $feed_label The market's feed label.
+	 * @param string $country The market's country code.
 	 *
 	 * @return string The sanitised market ID.
 	 *
 	 * @throws InvalidValue When the generated ID equals the reserved 'primary' key.
 	 */
-	public function generate_market_id( string $feed_label ): string {
-		$id = sanitize_title( $feed_label );
+	public function generate_market_id( string $country ): string {
+		$id = sanitize_title( $country );
 
 		if ( 'primary' === $id ) {
 			throw new InvalidValue(
-				sprintf( 'The feed label "%s" generates the reserved market ID "primary".', $feed_label )
+				sprintf( 'The value "%s" generates the reserved market ID "primary".', $country )
 			);
 		}
 
@@ -652,22 +642,21 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			$this->save_market_shipping( (string) $merged['country'], $shipping );
 		}
 
-		$old_feed_label = $existing['feed_label'] ?? null;
-		$new_feed_label = $merged['feed_label'] ?? null;
+		$base_feed_label = strtoupper( $id );
 
-		// The derived labels carry the market language and currency, so a
-		// feed_label rename, a currency change, and a language removal all
-		// leave entries orphaned under labels that are no longer derived.
-		$old_labels = $old_feed_label ? $this->get_market_derived_feed_labels( $old_feed_label, $existing ) : [];
-		$new_labels = $new_feed_label ? $this->get_market_derived_feed_labels( $new_feed_label, $merged ) : [];
+		// The derived labels carry the market language and currency, so a currency
+		// change and a language removal leave entries orphaned under labels that are
+		// no longer derived. The base label is fixed by the id, so it cannot change.
+		$old_labels = [] !== $existing ? $this->get_market_derived_feed_labels( $base_feed_label, $existing ) : [];
+		$new_labels = $this->get_market_derived_feed_labels( $base_feed_label, $merged );
 
-		if ( $old_feed_label && array_diff( $old_labels, $new_labels ) !== [] ) {
+		if ( [] !== $existing && array_diff( $old_labels, $new_labels ) !== [] ) {
 			// Clean every key the market's entries may sit under except the
 			// labels that remain current, including pre-language-scheme keys.
 			$orphaned = array_values(
 				array_diff(
 					$this->get_market_feed_label_variants(
-						$old_feed_label,
+						$base_feed_label,
 						is_array( $existing['language'] ?? null ) ? $existing['language'] : [],
 						$this->get_market_currencies( $existing )
 					),
@@ -700,7 +689,6 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		$merged_rate   = isset( $merged['exchange_rate'] ) ? (float) $merged['exchange_rate'] : null;
 
 		$resync_needed = ( $existing['country'] ?? null ) !== ( $merged['country'] ?? null )
-			|| ( $existing['feed_label'] ?? null ) !== ( $merged['feed_label'] ?? null )
 			|| array_diff( $existing_language, $merged_language ) !== []
 			|| array_diff( $merged_language, $existing_language ) !== []
 			|| array_diff( $existing_currency, $merged_currency ) !== []
@@ -900,7 +888,6 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 		$deleted_config = $markets[ $id ];
 		$country        = $deleted_config['country'] ?? null;
-		$feed_label     = $deleted_config['feed_label'] ?? null;
 
 		unset( $markets[ $id ] );
 		$this->options->update( OptionsInterface::MARKETS, $markets );
@@ -915,18 +902,16 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			}
 		}
 
-		if ( $feed_label ) {
-			$this->job_repository->get( CleanupOrphanedMarketProductsJob::class )
-				->schedule(
-					[
-						'feed_labels' => $this->get_market_feed_label_variants(
-							$feed_label,
-							is_array( $deleted_config['language'] ?? null ) ? $deleted_config['language'] : [],
-							$this->get_market_currencies( $deleted_config )
-						),
-					]
-				);
-		}
+		$this->job_repository->get( CleanupOrphanedMarketProductsJob::class )
+			->schedule(
+				[
+					'feed_labels' => $this->get_market_feed_label_variants(
+						strtoupper( $id ),
+						is_array( $deleted_config['language'] ?? null ) ? $deleted_config['language'] : [],
+						$this->get_market_currencies( $deleted_config )
+					),
+				]
+			);
 
 		// The shipping method is global. Deleting a market whose stored snapshot said
 		// `manual` while the global rate is flat/automatic must still notify Google,
@@ -977,7 +962,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * Returns the feed label to use for a secondary market's product entries.
 	 *
 	 * A Merchant Center feed is one language-currency pair (PRD), so the
-	 * stored feed label gets the uppercase two-letter language code and the
+	 * base feed label gets the uppercase two-letter language code and the
 	 * uppercase ISO 4217 currency code appended, e.g. "BE-FR-EUR". A market
 	 * configured with several languages produces one label per language.
 	 *
@@ -987,7 +972,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * An empty base label returns an empty string, so callers do not need
 	 * their own empty-label branch.
 	 *
-	 * @param string $base_feed_label The market's stored feed label.
+	 * @param string $base_feed_label The market's base feed label.
 	 * @param string $language        Language code in short ("fr") or locale
 	 *                                ("fr_FR") form. Empty falls back to the
 	 *                                site primary language.
@@ -1192,9 +1177,9 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			}
 		}
 
-		foreach ( $this->get_participating_secondary_markets() as $market ) {
+		foreach ( $this->get_participating_secondary_markets() as $id => $market ) {
 			$market          = $this->apply_site_locale_when_not_multilingual( $market );
-			$base_feed_label = (string) ( $market['feed_label'] ?? '' );
+			$base_feed_label = strtoupper( (string) $id );
 			$languages       = is_array( $market['language'] ?? null ) ? $market['language'] : [];
 
 			if ( empty( $languages ) ) {
@@ -1229,7 +1214,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * verbatim, are still found and cleaned up. The intermediate currency-only scheme is not
 	 * covered: it never shipped, so its keys cannot exist outside intermediate builds.
 	 *
-	 * @param string   $feed_label The market's stored feed label.
+	 * @param string   $feed_label The market's base feed label.
 	 * @param array    $languages  The market's configured language codes. An
 	 *                             empty list contributes the site-language label.
 	 * @param string[] $currencies The market's configured currency codes. An
@@ -1259,7 +1244,7 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * language-currency label per configured language per configured currency
 	 * (the site-language labels when no languages are configured).
 	 *
-	 * @param string $feed_label The market's stored feed label.
+	 * @param string $feed_label The market's base feed label.
 	 * @param array  $market     The market config the languages and currencies come from.
 	 *
 	 * @return string[]
@@ -1929,14 +1914,8 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * @throws InvalidValue When a required key is missing or invalid.
 	 */
 	private function validate_secondary_market_config( array $config, bool $validate_currency_source = true ): void {
-		foreach ( [ 'country', 'feed_label' ] as $key ) {
-			if ( empty( $config[ $key ] ) || ! is_string( $config[ $key ] ) ) {
-				throw InvalidValue::is_empty( $key );
-			}
-		}
-
-		if ( ! preg_match( self::FEED_LABEL_PATTERN, $config['feed_label'] ) ) {
-			throw InvalidValue::does_not_match_pattern( 'feed_label', self::FEED_LABEL_PATTERN, $config['feed_label'] );
+		if ( empty( $config['country'] ) || ! is_string( $config['country'] ) ) {
+			throw InvalidValue::is_empty( 'country' );
 		}
 
 		foreach ( [ 'language', 'currency' ] as $key ) {

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -538,6 +538,197 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	}
 
 	/**
+	 * Adds a market, or folds its country into the primary market when the submitted shipping
+	 * is what the primary already applies there.
+	 *
+	 * A market whose shipping matches the primary's carries no information the primary does not
+	 * already hold, so storing it would split one feed into two identical ones.
+	 *
+	 * @param string     $id       The market ID.
+	 * @param array      $config   The market configuration.
+	 * @param array|null $shipping The submitted shipping configuration, or null when the request
+	 *                             carried none, in which case there is nothing to compare.
+	 *
+	 * @return bool True when the country was folded into the primary market and no market was stored.
+	 *
+	 * @throws InvalidValue When $id is 'primary' or $config is invalid.
+	 */
+	public function add_market_or_merge_into_primary( string $id, array $config, ?array $shipping = null ): bool {
+		if ( 'primary' === $id ) {
+			throw new InvalidValue(
+				sprintf( 'The market ID "%s" is reserved and cannot be added.', $id )
+			);
+		}
+
+		$country = (string) ( $config['country'] ?? '' );
+
+		if (
+			'' === $country
+			|| null === $shipping
+			|| ! $this->carries_only_the_primary_locale( $config )
+			|| ! $this->shipping_matches_primary( $shipping )
+		) {
+			$this->add_market( $id, $config );
+
+			return false;
+		}
+
+		$this->merge_country_into_primary( $country );
+
+		return true;
+	}
+
+	/**
+	 * Whether a market config asks for nothing the primary market does not already give it.
+	 *
+	 * Shipping is not the only thing a market carries. A market wanting its own currency, or a
+	 * fixed rate to produce one, is asking for a feed the primary cannot serve, however alike
+	 * the shipping looks, and folding it would drop what the merchant asked for.
+	 *
+	 * @param array $config The market configuration.
+	 *
+	 * @return bool
+	 */
+	private function carries_only_the_primary_locale( array $config ): bool {
+		if ( isset( $config['exchange_rate'] ) ) {
+			return false;
+		}
+
+		$primary = $this->get_primary_market();
+
+		foreach ( [ 'language', 'currency' ] as $key ) {
+			if ( ! isset( $config[ $key ] ) ) {
+				continue;
+			}
+
+			if ( ! is_array( $config[ $key ] ) ) {
+				return false;
+			}
+
+			$submitted = $config[ $key ];
+			$theirs    = is_array( $primary[ $key ] ?? null ) ? $primary[ $key ] : [];
+
+			sort( $submitted );
+			sort( $theirs );
+
+			if ( $submitted !== $theirs ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether a submitted shipping configuration is the one the primary market already applies.
+	 *
+	 * The comparison is against the primary market's own profile, which is the one keyed to the
+	 * store's main target country and the one the Markets screen shows for Primary. A store that
+	 * sets a different rate per country therefore keeps creating separate markets, which is the
+	 * intended reading of "the Primary market's current effective shipping configuration".
+	 *
+	 * @param array $shipping The submitted shipping configuration.
+	 *
+	 * @return bool
+	 */
+	private function shipping_matches_primary( array $shipping ): bool {
+		$primary = $this->get_market_shipping( $this->target_audience->get_main_target_country() );
+
+		// Only a flat rate and a flat delivery window are stored per country. Any other method
+		// leaves nothing country-specific to compare, so the market stays separate rather than
+		// every country folding on a global setting they cannot help but share. That holds for
+		// an automatic rate with a flat window too: the window alone is a thin basis for
+		// discarding a market the merchant asked for.
+		if ( 'flat' !== $primary['rate_type'] || 'flat' !== $primary['time_type'] ) {
+			return false;
+		}
+
+		// The method types are global, so a payload that states a different one is describing
+		// a market this store cannot have. Absent is the normal case and says nothing.
+		foreach ( [ 'rate_type', 'time_type' ] as $key ) {
+			if ( array_key_exists( $key, $shipping ) && $shipping[ $key ] !== $primary[ $key ] ) {
+				return false;
+			}
+		}
+
+		$families = [
+			[ 'flat_rate', 'free_shipping_threshold' ],
+			[ 'flat_time', 'flat_max_time' ],
+		];
+
+		// Each half is adopted from its own primary row, so each has to exist. A half the
+		// primary holds nothing for cannot be matched, and adopting it would strip the
+		// country's own row rather than align it.
+		foreach ( $families as $family ) {
+			if ( [] === array_filter( array_intersect_key( $primary, array_flip( $family ) ), 'is_numeric' ) ) {
+				return false;
+			}
+		}
+
+		foreach ( array_merge( ...$families ) as $key ) {
+			// An absent value is not an equal one: a partial payload says nothing about the
+			// field, and folding on it would discard a difference the merchant never stated.
+			if ( ! array_key_exists( $key, $shipping ) ) {
+				return false;
+			}
+
+			if ( ! $this->shipping_values_match( $shipping[ $key ], $primary[ $key ] ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Compares one shipping value against the primary's.
+	 *
+	 * Null is a value here, not a zero: "no free shipping threshold" and "free over 0" are
+	 * different offers, so they must not compare equal.
+	 *
+	 * @param mixed      $submitted The submitted value.
+	 * @param float|null $primary   The primary market's value.
+	 *
+	 * @return bool
+	 */
+	private function shipping_values_match( $submitted, $primary ): bool {
+		if ( null === $submitted || null === $primary ) {
+			return null === $submitted && null === $primary;
+		}
+
+		if ( ! is_numeric( $submitted ) ) {
+			return false;
+		}
+
+		return abs( (float) $submitted - (float) $primary ) < 0.0001;
+	}
+
+	/**
+	 * Adds a country to the primary market, giving it the primary's shipping rows and the same
+	 * job scheduling a stored market entering the primary feed already triggers.
+	 *
+	 * @param string $country ISO 3166-1 alpha-2 country code.
+	 */
+	private function merge_country_into_primary( string $country ): void {
+		// The country's own rows are overwritten rather than merely filled in: it may already
+		// carry rows that disagree with the primary's, and folding asserts they are the same
+		// shipping. Leaving them would sync values the caller was told it was merging away.
+		$this->adopt_primary_rate_for_country( $country );
+		$this->adopt_primary_time_for_country( $country );
+		$this->restore_country_to_target_audience( $country );
+
+		if ( $this->global_shipping_is_syncable() ) {
+			$this->schedule_shipping_sync();
+		}
+
+		$this->job_repository->get( UpdateAllProducts::class )->schedule();
+
+		// The primary market gained a country and its shipping rows, the same change a PUT
+		// against it reports, so it is announced the same way.
+		$this->fire_market_updated_action( 'primary' );
+	}
+
+	/**
 	 * Updates values of an existing market.
 	 *
 	 * When $id is 'primary', writes fan out to the underlying settings stores

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -283,8 +283,8 @@ class BatchProductHelper implements Service {
 				$primary_market = $this->market_service->get_primary_market();
 
 				if ( $this->product_matches_market( $product_language, $primary_market, $wpml_active ) ) {
-					// The primary market never stores scalar country/feed_label values
-					// (it is multi-country); its feed label is the main target country,
+					// The primary market never stores a scalar country (it is multi-country);
+					// its feed label is the main target country,
 					// kept bare for every language so existing entries keep their
 					// Merchant Center identity.
 					$main_feed_label = $this->market_service->get_main_feed_label();
@@ -448,7 +448,7 @@ class BatchProductHelper implements Service {
 				continue;
 			}
 
-			$market_feed_label = $this->market_service->get_market_feed_label( $market['feed_label'], $market_language, $market_currency );
+			$market_feed_label = $this->market_service->get_market_feed_label( strtoupper( $market_id ), $market_language, $market_currency );
 
 			// Store-currency entries need no conversion, so they carry no currency override and
 			// price exactly as a single-currency market's entries always have.

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -220,10 +220,12 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'de' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -255,6 +257,122 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'flat', $data['shipping_rate'] );
 	}
 
+	public function test_post_market_returns_200_and_the_primary_market_when_the_country_is_folded_in(): void {
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
+		$this->market_service->method( 'get_market' )->willReturn( null );
+		$this->market_service->method( 'get_primary_market' )->willReturn( self::PRIMARY_MARKET );
+
+		$this->market_service->expects( $this->once() )
+			->method( 'add_market_or_merge_into_primary' )
+			->with(
+				'gb',
+				$this->callback(
+					function ( $config ) {
+						return 'GB' === $config['country'];
+					}
+				),
+				$this->callback(
+					function ( $shipping ) {
+						return 5.0 === $shipping['flat_rate'] && 3 === $shipping['flat_max_time'];
+					}
+				)
+			)
+			->willReturn( true );
+
+		$response = $this->do_request(
+			self::ROUTE_MARKETS,
+			'POST',
+			[
+				'country'  => 'GB',
+				'shipping' => [
+					'flat_rate'               => 5.0,
+					'free_shipping_threshold' => 50.0,
+					'flat_time'               => 1,
+					'flat_max_time'           => 3,
+				],
+			]
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertTrue( $data['merged_into_primary'] );
+		$this->assertSame( 'primary', $data['id'] );
+		$this->assertNull( $data['country'] );
+	}
+
+	public function test_post_market_still_returns_201_when_the_shipping_does_not_match(): void {
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
+
+		$created = false;
+
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
+			->willReturnCallback(
+				function () use ( &$created ) {
+					$created = true;
+
+					return false;
+				}
+			);
+
+		$this->market_service->method( 'get_market' )
+			->willReturnCallback(
+				function ( string $id ) use ( &$created ) {
+					if ( 'gb' === $id && $created ) {
+						return self::SECONDARY_MARKET;
+					}
+					return null;
+				}
+			);
+
+		$response = $this->do_request(
+			self::ROUTE_MARKETS,
+			'POST',
+			[
+				'country'  => 'GB',
+				'shipping' => [
+					'flat_rate'               => 9.99,
+					'free_shipping_threshold' => null,
+					'flat_time'               => 2,
+					'flat_max_time'           => 6,
+				],
+			]
+		);
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertArrayNotHasKey( 'merged_into_primary', $response->get_data() );
+	}
+
+	public function test_post_market_forwards_a_null_shipping_when_none_was_submitted(): void {
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
+
+		$this->market_service->expects( $this->once() )
+			->method( 'add_market_or_merge_into_primary' )
+			->with( 'gb', $this->anything(), null )
+			->willReturn( false );
+
+		$created = false;
+		$this->market_service->method( 'get_market' )
+			->willReturnCallback(
+				function () use ( &$created ) {
+					$was    = $created;
+					$created = true;
+					return $was ? self::SECONDARY_MARKET : null;
+				}
+			);
+
+		$this->do_request( self::ROUTE_MARKETS, 'POST', [ 'country' => 'GB' ] );
+	}
+
+	public function test_get_markets_carries_no_merged_flag(): void {
+		$response = $this->do_request( self::ROUTE_MARKETS );
+
+		foreach ( $response->get_data() as $market ) {
+			$this->assertArrayNotHasKey( 'merged_into_primary', $market );
+		}
+	}
+
 	public function test_post_market_returns_400_missing_required_field(): void {
 		$response = $this->do_request(
 			self::ROUTE_MARKETS,
@@ -282,7 +400,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->with(
 				'gb',
 				$this->callback(
@@ -296,6 +414,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -325,7 +445,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->with(
 				'gb',
 				$this->callback(
@@ -339,6 +459,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -371,7 +493,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->market_service->method( 'get_market' )
 			->willReturn( null );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->willThrowException( InvalidValue::is_empty( 'country' ) );
 
 		$response = $this->do_request(
@@ -701,10 +823,12 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'jp' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -738,7 +862,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnOnConsecutiveCalls( null, [] );
 
 		$this->market_service->expects( $this->once() )
-			->method( 'add_market' )
+			->method( 'add_market_or_merge_into_primary' )
 			->with(
 				$this->anything(),
 				$this->callback(
@@ -873,10 +997,12 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'ch' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -918,10 +1044,12 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'ch' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -957,7 +1085,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->with( 'GB' )
 			->willReturn( 'gb' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->with(
 				'gb',
 				$this->callback(
@@ -970,6 +1098,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -1000,7 +1130,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 	 * @param string $country
 	 */
 	public function test_post_market_returns_400_for_a_country_that_is_not_an_alpha_2_code( string $country ): void {
-		$this->market_service->expects( $this->never() )->method( 'add_market' );
+		$this->market_service->expects( $this->never() )->method( 'add_market_or_merge_into_primary' );
 
 		$response = $this->do_request(
 			self::ROUTE_MARKETS,
@@ -1028,10 +1158,12 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$created = false;
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -1077,7 +1209,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->with(
 				'gb',
 				$this->callback(
@@ -1089,6 +1221,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -1159,7 +1293,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'de' );
 
 		$this->market_service->expects( $this->once() )
-			->method( 'add_market' )
+			->method( 'add_market_or_merge_into_primary' )
 			->with(
 				'de',
 				$this->callback(
@@ -1172,6 +1306,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -356,7 +356,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->market_service->method( 'get_market' )
 			->willReturnCallback(
 				function () use ( &$created ) {
-					$was    = $created;
+					$was     = $created;
 					$created = true;
 					return $was ? self::SECONDARY_MARKET : null;
 				}
@@ -1143,14 +1143,14 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 	public function provide_invalid_countries(): array {
 		return [
-			'multi word'      => [ 'United Kingdom' ],
-			'punctuation'     => [ '###' ],
-			'whitespace'      => [ '   ' ],
-			'leading dash'    => [ '-GB' ],
-			'lowercase'       => [ 'gb' ],
-			'three letters'   => [ 'GBR' ],
-			'one letter'      => [ 'G' ],
-			'empty'           => [ '' ],
+			'multi word'    => [ 'United Kingdom' ],
+			'punctuation'   => [ '###' ],
+			'whitespace'    => [ '   ' ],
+			'leading dash'  => [ '-GB' ],
+			'lowercase'     => [ 'gb' ],
+			'three letters' => [ 'GBR' ],
+			'one letter'    => [ 'G' ],
+			'empty'         => [ '' ],
 		];
 	}
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -1013,14 +1013,14 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 	public function provide_invalid_countries(): array {
 		return [
-			'multi word'      => [ 'United Kingdom' ],
-			'punctuation'     => [ '###' ],
-			'whitespace'      => [ '   ' ],
-			'leading dash'    => [ '-GB' ],
-			'lowercase'       => [ 'gb' ],
-			'three letters'   => [ 'GBR' ],
-			'one letter'      => [ 'G' ],
-			'empty'           => [ '' ],
+			'multi word'    => [ 'United Kingdom' ],
+			'punctuation'   => [ '###' ],
+			'whitespace'    => [ '   ' ],
+			'leading dash'  => [ '-GB' ],
+			'lowercase'     => [ 'gb' ],
+			'three letters' => [ 'GBR' ],
+			'one letter'    => [ 'G' ],
+			'empty'         => [ '' ],
 		];
 	}
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -35,7 +35,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		'country'       => null,
 		'language'      => [ 'en' ],
 		'currency'      => [ 'USD' ],
-		'feed_label'    => null,
 		'shipping_rate' => 'flat',
 		'shipping_time' => 'flat',
 		'shipping'      => [
@@ -54,7 +53,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		'countries'     => [ 'GB' ],
 		'language'      => [ 'en' ],
 		'currency'      => [ 'GBP' ],
-		'feed_label'    => 'GB',
 		'shipping_rate' => 'flat',
 		'shipping_time' => 'flat',
 		'shipping'      => [
@@ -108,9 +106,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertArrayHasKey( 'label', $primary );
 		$this->assertArrayHasKey( 'countries', $primary );
 		$this->assertArrayHasKey( 'country', $primary );
-		$this->assertArrayHasKey( 'feed_label', $primary );
+		$this->assertArrayNotHasKey( 'feed_label', $primary );
 		$this->assertNull( $primary['country'] );
-		$this->assertNull( $primary['feed_label'] );
 		$this->assertArrayHasKey( 'shipping_rate', $primary );
 		$this->assertArrayHasKey( 'shipping_time', $primary );
 		$this->assertArrayHasKey( 'shipping', $primary );
@@ -124,7 +121,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'Primary Market', $primary['label'] );
 		$this->assertEquals( [ 'US' ], $primary['countries'] );
 		$this->assertNull( $primary['country'] );
-		$this->assertNull( $primary['feed_label'] );
+		$this->assertArrayNotHasKey( 'feed_label', $primary );
 		$this->assertEquals( 'flat', $primary['shipping_rate'] );
 		$this->assertEquals( 'flat', $primary['shipping_time'] );
 	}
@@ -214,7 +211,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'country'       => 'DE',
 			'language'      => [ 'de' ],
 			'currency'      => [ 'EUR' ],
-			'feed_label'    => 'DE',
 			'shipping_rate' => 'flat',
 			'shipping_time' => 'flat',
 			'free_shipping' => null,
@@ -256,7 +252,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'de', $data['id'] );
 		$this->assertEquals( 'DE', $data['country'] );
 		$this->assertEquals( [ 'EUR' ], $data['currency'] );
-		$this->assertEquals( 'DE', $data['feed_label'] );
 		$this->assertEquals( 'flat', $data['shipping_rate'] );
 	}
 
@@ -278,7 +273,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'country'       => 'GB',
 			'language'      => [ 'en' ],
 			'currency'      => [ 'USD' ],
-			'feed_label'    => 'GB',
 			'shipping_rate' => 'flat',
 			'shipping_time' => 'flat',
 			'free_shipping' => null,
@@ -628,7 +622,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'United Kingdom (UK)', $secondary['label'] );
 		$this->assertEquals( [ 'GB' ], $secondary['countries'] );
 		$this->assertSame( 'GB', $secondary['country'] );
-		$this->assertSame( 'GB', $secondary['feed_label'] );
+		$this->assertArrayNotHasKey( 'feed_label', $secondary );
 		$this->assertArrayHasKey( 'shipping', $secondary );
 	}
 
@@ -698,7 +692,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'country'       => 'JP',
 			'language'      => [ 'ja' ],
 			'currency'      => [ 'JPY' ],
-			'feed_label'    => 'JP',
 			'shipping_rate' => 'flat',
 			'shipping_time' => 'flat',
 			'free_shipping' => null,
@@ -871,7 +864,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'country'       => 'CH',
 			'language'      => [ 'de', 'fr', 'it' ],
 			'currency'      => [ 'CHF' ],
-			'feed_label'    => 'CH',
 			'shipping_rate' => 'flat',
 			'shipping_time' => 'flat',
 			'free_shipping' => null,
@@ -917,7 +909,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'country'       => 'CH',
 			'language'      => [ 'de' ],
 			'currency'      => [ 'CHF', 'EUR' ],
-			'feed_label'    => 'CH',
 			'shipping_rate' => 'flat',
 			'shipping_time' => 'flat',
 			'free_shipping' => null,
@@ -958,68 +949,13 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( [ 'CHF', 'EUR' ], $response->get_data()['currency'] );
 	}
 
-	public function test_post_market_uses_client_supplied_feed_label(): void {
-		$created_market = [
-			'country'       => 'GB',
-			'language'      => [ 'en' ],
-			'currency'      => [ 'GBP' ],
-			'feed_label'    => 'GB-EN',
-			'shipping_rate' => 'flat',
-			'shipping_time' => 'flat',
-			'free_shipping' => null,
-		];
-
+	public function test_post_market_with_only_country_derives_the_id_from_it(): void {
 		$created = false;
 
-		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb-en' );
-
-		$this->market_service->method( 'add_market' )
-			->with(
-				'gb-en',
-				$this->callback(
-					function ( $config ) {
-						return 'GB' === $config['country']
-							&& 'GB-EN' === $config['feed_label'];
-					}
-				)
-			)
-			->willReturnCallback(
-				function () use ( &$created ) {
-					$created = true;
-				}
-			);
-
-		$this->market_service->method( 'get_market' )
-			->willReturnCallback(
-				function ( string $id ) use ( &$created, $created_market ) {
-					if ( 'gb-en' === $id && $created ) {
-						return $created_market;
-					}
-					return null;
-				}
-			);
-
-		$response = $this->do_request(
-			self::ROUTE_MARKETS,
-			'POST',
-			[
-				'country'    => 'GB',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => 'GB-EN',
-			]
-		);
-
-		$this->assertEquals( 201, $response->get_status() );
-		$data = $response->get_data();
-		$this->assertEquals( 'gb-en', $data['id'] );
-		$this->assertEquals( 'GB-EN', $data['feed_label'] );
-	}
-
-	public function test_post_market_falls_back_to_country_when_feed_label_absent(): void {
-		$created = false;
-
-		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
+		$this->market_service->expects( $this->once() )
+			->method( 'generate_market_id' )
+			->with( 'GB' )
+			->willReturn( 'gb' );
 
 		$this->market_service->method( 'add_market' )
 			->with(
@@ -1027,7 +963,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 				$this->callback(
 					function ( $config ) {
 						return 'GB' === $config['country']
-							&& 'GB' === $config['feed_label'];
+							&& ! array_key_exists( 'feed_label', $config );
 					}
 				)
 			)
@@ -1041,10 +977,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnCallback(
 				function ( string $id ) use ( &$created ) {
 					if ( 'gb' === $id && $created ) {
-						return [
-							'country'    => 'GB',
-							'feed_label' => 'GB',
-						];
+						return [ 'country' => 'GB' ];
 					}
 					return null;
 				}
@@ -1061,13 +994,112 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 201, $response->get_status() );
 	}
 
-	public function test_post_market_returns_400_when_feed_label_pattern_invalid(): void {
+	/**
+	 * @dataProvider provide_invalid_countries
+	 *
+	 * @param string $country
+	 */
+	public function test_post_market_returns_400_for_a_country_that_is_not_an_alpha_2_code( string $country ): void {
+		$this->market_service->expects( $this->never() )->method( 'add_market' );
+
+		$response = $this->do_request(
+			self::ROUTE_MARKETS,
+			'POST',
+			[ 'country' => $country ]
+		);
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function provide_invalid_countries(): array {
+		return [
+			'multi word'      => [ 'United Kingdom' ],
+			'punctuation'     => [ '###' ],
+			'whitespace'      => [ '   ' ],
+			'leading dash'    => [ '-GB' ],
+			'lowercase'       => [ 'gb' ],
+			'three letters'   => [ 'GBR' ],
+			'one letter'      => [ 'G' ],
+			'empty'           => [ '' ],
+		];
+	}
+
+	public function test_post_market_response_drops_a_leftover_feed_label(): void {
+		$created = false;
+
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
+		$this->market_service->method( 'add_market' )
+			->willReturnCallback(
+				function () use ( &$created ) {
+					$created = true;
+				}
+			);
+
+		// A market stored with the leftover key still present.
 		$this->market_service->method( 'get_market' )
-			->willReturn( null );
+			->willReturnCallback(
+				function ( string $id ) use ( &$created ) {
+					if ( 'gb' === $id && $created ) {
+						return array_merge( self::SECONDARY_MARKET, [ 'feed_label' => 'GB-STALE' ] );
+					}
+					return null;
+				}
+			);
+
+		$response = $this->do_request( self::ROUTE_MARKETS, 'POST', [ 'country' => 'GB' ] );
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertArrayNotHasKey( 'feed_label', $response->get_data() );
+		$this->assertSame( 'gb', $response->get_data()['id'] );
+	}
+
+	public function test_put_response_drops_a_leftover_feed_label(): void {
+		$this->market_service->method( 'get_market' )
+			->with( 'gb' )
+			->willReturn( self::SECONDARY_MARKET );
+
+		$this->market_service->method( 'update_market' )
+			->willReturn( array_merge( self::SECONDARY_MARKET, [ 'feed_label' => 'GB-STALE' ] ) );
+
+		$response = $this->do_request(
+			self::ROUTE_MARKET . 'gb',
+			'PUT',
+			[ 'currency' => [ 'GBP' ] ]
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayNotHasKey( 'feed_label', $response->get_data() );
+		$this->assertSame( 'gb', $response->get_data()['id'] );
+	}
+
+	public function test_post_market_ignores_a_submitted_feed_label(): void {
+		$created = false;
+
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
 
 		$this->market_service->method( 'add_market' )
-			->willThrowException(
-				InvalidValue::does_not_match_pattern( 'feed_label', '/^[A-Z0-9-]{1,20}$/', 'gb-en' )
+			->with(
+				'gb',
+				$this->callback(
+					function ( $config ) {
+						return ! array_key_exists( 'feed_label', $config );
+					}
+				)
+			)
+			->willReturnCallback(
+				function () use ( &$created ) {
+					$created = true;
+				}
+			);
+
+		$this->market_service->method( 'get_market' )
+			->willReturnCallback(
+				function ( string $id ) use ( &$created ) {
+					if ( 'gb' === $id && $created ) {
+						return [ 'country' => 'GB' ];
+					}
+					return null;
+				}
 			);
 
 		$response = $this->do_request(
@@ -1075,18 +1107,14 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'POST',
 			[
 				'country'    => 'GB',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => 'gb-en',
+				'feed_label' => 'GB-EN',
 			]
 		);
 
-		$this->assertEquals( 400, $response->get_status() );
-		$this->assertStringContainsString( 'feed_label', $response->get_data()['message'] );
-		$this->assertStringContainsString( 'gb-en', $response->get_data()['message'] );
+		$this->assertEquals( 201, $response->get_status() );
 	}
 
-	public function test_put_passes_feed_label_through(): void {
+	public function test_put_does_not_pass_a_submitted_feed_label_through(): void {
 		$this->market_service->method( 'get_market' )
 			->with( 'gb' )
 			->willReturn( self::SECONDARY_MARKET );
@@ -1097,20 +1125,18 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 				'gb',
 				$this->callback(
 					function ( $params ) {
-						return isset( $params['feed_label'] )
-							&& 'GB-EN' === $params['feed_label'];
+						return ! array_key_exists( 'feed_label', $params );
 					}
 				)
 			)
-			->willReturn(
-				array_merge( self::SECONDARY_MARKET, [ 'feed_label' => 'GB-EN' ] )
-			);
+			->willReturn( self::SECONDARY_MARKET );
 
 		$response = $this->do_request(
 			self::ROUTE_MARKET . 'gb',
 			'PUT',
 			[
 				'feed_label' => 'GB-EN',
+				'currency'   => [ 'GBP' ],
 			]
 		);
 
@@ -1123,7 +1149,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'language'      => [ 'de' ],
 			'currency'      => [ 'EUR' ],
 			'exchange_rate' => 0.92,
-			'feed_label'    => 'DE',
 			'shipping_rate' => 'flat',
 			'shipping_time' => 'flat',
 			'free_shipping' => null,

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -312,7 +312,10 @@ class MarketServiceTest extends UnitTest {
 		$this->set_up_options_get(
 			[
 				OptionsInterface::MERCHANT_CENTER => [],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'all', 'countries' => [] ],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'all',
+					'countries' => [],
+				],
 				OptionsInterface::MARKETS         => [
 					'gr' => [
 						'country'    => 'GR',
@@ -1547,7 +1550,10 @@ class MarketServiceTest extends UnitTest {
 		$this->set_up_options_get(
 			[
 				OptionsInterface::MARKETS         => [],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'all', 'countries' => [] ],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'all',
+					'countries' => [],
+				],
 			]
 		);
 		// The stored list is empty in this mode; the resolved audience is what covers GB.
@@ -2212,7 +2218,7 @@ class MarketServiceTest extends UnitTest {
 	}
 
 	/**
-	 * update_market() on an unknown id creates the market. There are no prior entries to
+	 * Calling update_market() on an unknown id creates the market. There are no prior entries to
 	 * orphan, so the id-derived base label must not be mistaken for a previous state.
 	 */
 	public function test_update_market_does_not_schedule_cleanup_for_a_market_that_did_not_exist(): void {

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -312,7 +312,10 @@ class MarketServiceTest extends UnitTest {
 		$this->set_up_options_get(
 			[
 				OptionsInterface::MERCHANT_CENTER => [],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'all', 'countries' => [] ],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'all',
+					'countries' => [],
+				],
 				OptionsInterface::MARKETS         => [
 					'gr' => [
 						'country'    => 'GR',
@@ -1506,7 +1509,10 @@ class MarketServiceTest extends UnitTest {
 					'shipping_rate' => $rate_type,
 					'shipping_time' => $time_type,
 				],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
 				OptionsInterface::MARKETS         => [],
 			]
 		);
@@ -1631,18 +1637,25 @@ class MarketServiceTest extends UnitTest {
 
 	public function provide_shipping_that_differs_from_primary(): array {
 		return [
-			'dearer rate'              => [ $this->primary_shipping_payload( [ 'flat_rate' => 9.99 ] ) ],
-			'free rate'                => [ $this->primary_shipping_payload( [ 'flat_rate' => 0 ] ) ],
-			'no rate at all'           => [ $this->primary_shipping_payload( [ 'flat_rate' => null ] ) ],
-			'higher threshold'         => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 75.0 ] ) ],
+			'dearer rate'            => [ $this->primary_shipping_payload( [ 'flat_rate' => 9.99 ] ) ],
+			'free rate'              => [ $this->primary_shipping_payload( [ 'flat_rate' => 0 ] ) ],
+			'no rate at all'         => [ $this->primary_shipping_payload( [ 'flat_rate' => null ] ) ],
+			'higher threshold'       => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 75.0 ] ) ],
 			// Not the same offer as "free over 50", and not the same as "free over nothing".
-			'no threshold'             => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => null ] ) ],
-			'threshold of zero'        => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 0 ] ) ],
-			'slower minimum'           => [ $this->primary_shipping_payload( [ 'flat_time' => 2 ] ) ],
-			'slower maximum'           => [ $this->primary_shipping_payload( [ 'flat_max_time' => 5 ] ) ],
-			'no delivery window'       => [ $this->primary_shipping_payload( [ 'flat_time' => null, 'flat_max_time' => null ] ) ],
-			'a rate type of its own'   => [ $this->primary_shipping_payload( [ 'rate_type' => 'automatic' ] ) ],
-			'a time type of its own'   => [ $this->primary_shipping_payload( [ 'time_type' => 'manual' ] ) ],
+			'no threshold'           => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => null ] ) ],
+			'threshold of zero'      => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 0 ] ) ],
+			'slower minimum'         => [ $this->primary_shipping_payload( [ 'flat_time' => 2 ] ) ],
+			'slower maximum'         => [ $this->primary_shipping_payload( [ 'flat_max_time' => 5 ] ) ],
+			'no delivery window'     => [
+				$this->primary_shipping_payload(
+					[
+						'flat_time'     => null,
+						'flat_max_time' => null,
+					]
+				),
+			],
+			'a rate type of its own' => [ $this->primary_shipping_payload( [ 'rate_type' => 'automatic' ] ) ],
+			'a time type of its own' => [ $this->primary_shipping_payload( [ 'time_type' => 'manual' ] ) ],
 		];
 	}
 
@@ -1719,8 +1732,14 @@ class MarketServiceTest extends UnitTest {
 	private function set_up_primary_without_free_shipping(): void {
 		$this->set_up_options_get_with_tracking(
 			[
-				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
 				OptionsInterface::MARKETS         => [],
 			]
 		);
@@ -1736,7 +1755,15 @@ class MarketServiceTest extends UnitTest {
 			]
 		);
 		$this->shipping_time_query->method( 'get_all_shipping_times' )
-			->willReturn( [ 'US' => [ 'country_code' => 'US', 'time' => 1, 'max_time' => 3 ] ] );
+			->willReturn(
+				[
+					'US' => [
+						'country_code' => 'US',
+						'time'         => 1,
+						'max_time'     => 3,
+					],
+				]
+			);
 		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
 		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
 	}
@@ -1800,10 +1827,10 @@ class MarketServiceTest extends UnitTest {
 
 	public function provide_configs_that_ask_for_more_than_primary_gives(): array {
 		return [
-			'a currency of its own'    => [ [ 'currency' => [ 'JPY' ] ] ],
-			'an extra currency'        => [ [ 'currency' => [ get_woocommerce_currency(), 'JPY' ] ] ],
-			'a language of its own'    => [ [ 'language' => [ 'cy' ] ] ],
-			'a fixed exchange rate'    => [ [ 'exchange_rate' => 1.25 ] ],
+			'a currency of its own' => [ [ 'currency' => [ 'JPY' ] ] ],
+			'an extra currency'     => [ [ 'currency' => [ get_woocommerce_currency(), 'JPY' ] ] ],
+			'a language of its own' => [ [ 'language' => [ 'cy' ] ] ],
+			'a fixed exchange rate' => [ [ 'exchange_rate' => 1.25 ] ],
 		];
 	}
 
@@ -1827,8 +1854,14 @@ class MarketServiceTest extends UnitTest {
 	public function test_add_market_or_merge_overwrites_the_country_rows_it_folds_onto_primary(): void {
 		$this->set_up_options_get_with_tracking(
 			[
-				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
 				OptionsInterface::MARKETS         => [],
 			]
 		);
@@ -1845,19 +1878,49 @@ class MarketServiceTest extends UnitTest {
 			]
 		);
 		$this->shipping_time_query->method( 'get_all_shipping_times' )
-			->willReturn( [ 'US' => [ 'country_code' => 'US', 'time' => 1, 'max_time' => 3 ] ] );
+			->willReturn(
+				[
+					'US' => [
+						'country_code' => 'US',
+						'time'         => 1,
+						'max_time'     => 3,
+					],
+				]
+			);
 
 		// The country already carries rows of its own that disagree with the primary's.
 		$this->shipping_rate_query->method( 'get_results' )->willReturn(
 			[
-				[ 'id' => 1, 'country' => 'US', 'currency' => 'USD', 'rate' => '5.00', 'options' => [] ],
-				[ 'id' => 2, 'country' => 'GB', 'currency' => 'GBP', 'rate' => '99.00', 'options' => [] ],
+				[
+					'id'       => 1,
+					'country'  => 'US',
+					'currency' => 'USD',
+					'rate'     => '5.00',
+					'options'  => [],
+				],
+				[
+					'id'       => 2,
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => '99.00',
+					'options'  => [],
+				],
 			]
 		);
 		$this->shipping_time_query->method( 'get_results' )->willReturn(
 			[
-				[ 'id' => 1, 'country' => 'US', 'time' => 1, 'max_time' => 3 ],
-				[ 'id' => 2, 'country' => 'GB', 'time' => 9, 'max_time' => 9 ],
+				[
+					'id'       => 1,
+					'country'  => 'US',
+					'time'     => 1,
+					'max_time' => 3,
+				],
+				[
+					'id'       => 2,
+					'country'  => 'GB',
+					'time'     => 9,
+					'max_time' => 9,
+				],
 			]
 		);
 
@@ -1895,8 +1958,14 @@ class MarketServiceTest extends UnitTest {
 	public function test_add_market_or_merge_does_not_fold_onto_a_primary_that_holds_no_values(): void {
 		$this->set_up_options_get_with_tracking(
 			[
-				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
 				OptionsInterface::MARKETS         => [],
 			]
 		);
@@ -1904,10 +1973,25 @@ class MarketServiceTest extends UnitTest {
 		$this->set_up_primary_market_dependencies( 'US', [ 'US' ], [] );
 		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [] );
 		$this->shipping_rate_query->method( 'get_results' )->willReturn(
-			[ [ 'id' => 2, 'country' => 'GB', 'currency' => 'GBP', 'rate' => '9.00', 'options' => [] ] ]
+			[
+				[
+					'id'       => 2,
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => '9.00',
+					'options'  => [],
+				],
+			]
 		);
 		$this->shipping_time_query->method( 'get_results' )->willReturn(
-			[ [ 'id' => 2, 'country' => 'GB', 'time' => 2, 'max_time' => 4 ] ]
+			[
+				[
+					'id'       => 2,
+					'country'  => 'GB',
+					'time'     => 2,
+					'max_time' => 4,
+				],
+			]
 		);
 
 		// Matching nulls against nulls is not a match, and adopting from an absent primary row
@@ -1933,20 +2017,49 @@ class MarketServiceTest extends UnitTest {
 	public function test_add_market_or_merge_does_not_fold_when_the_primary_lacks_one_half(): void {
 		$this->set_up_options_get_with_tracking(
 			[
-				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
 				OptionsInterface::MARKETS         => [],
 			]
 		);
 		// The primary has a delivery window but no rate row of its own.
 		$this->set_up_primary_market_dependencies( 'US', [ 'US' ], [] );
 		$this->shipping_time_query->method( 'get_all_shipping_times' )
-			->willReturn( [ 'US' => [ 'country_code' => 'US', 'time' => 1, 'max_time' => 3 ] ] );
+			->willReturn(
+				[
+					'US' => [
+						'country_code' => 'US',
+						'time'         => 1,
+						'max_time'     => 3,
+					],
+				]
+			);
 		$this->shipping_rate_query->method( 'get_results' )->willReturn(
-			[ [ 'id' => 2, 'country' => 'GB', 'currency' => 'GBP', 'rate' => '9.00', 'options' => [] ] ]
+			[
+				[
+					'id'       => 2,
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => '9.00',
+					'options'  => [],
+				],
+			]
 		);
 		$this->shipping_time_query->method( 'get_results' )->willReturn(
-			[ [ 'id' => 1, 'country' => 'US', 'time' => 1, 'max_time' => 3 ] ]
+			[
+				[
+					'id'       => 1,
+					'country'  => 'US',
+					'time'     => 1,
+					'max_time' => 3,
+				],
+			]
 		);
 
 		// Folding would adopt an absent primary rate, which deletes the country's own row.
@@ -2073,7 +2186,10 @@ class MarketServiceTest extends UnitTest {
 		$this->set_up_options_get(
 			[
 				OptionsInterface::MARKETS         => [],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'all', 'countries' => [] ],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'all',
+					'countries' => [],
+				],
 			]
 		);
 		// The stored list is empty in this mode; the resolved audience is what covers GB.
@@ -2738,7 +2854,7 @@ class MarketServiceTest extends UnitTest {
 	}
 
 	/**
-	 * update_market() on an unknown id creates the market. There are no prior entries to
+	 * Calling update_market() on an unknown id creates the market. There are no prior entries to
 	 * orphan, so the id-derived base label must not be mistaken for a previous state.
 	 */
 	public function test_update_market_does_not_schedule_cleanup_for_a_market_that_did_not_exist(): void {

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -1493,6 +1493,532 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( [ 'EUR', 'GBP' ], $this->market_service->get_market_currencies_for_language( $market, 'de' ) );
 	}
 
+	/**
+	 * Seeds a flat store whose primary country ships at 5.00, free over 50, in 1 to 3 days.
+	 *
+	 * @param string $rate_type
+	 * @param string $time_type
+	 */
+	private function set_up_primary_shipping_profile( string $rate_type = 'flat', string $time_type = 'flat' ): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => $rate_type,
+					'shipping_time' => $time_type,
+				],
+				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies(
+			'US',
+			[ 'US' ],
+			[
+				'US' => [
+					'country_code'            => 'US',
+					'currency'                => 'USD',
+					'rate'                    => '5.00',
+					'free_shipping_threshold' => 50.0,
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )
+			->willReturn(
+				[
+					'US' => [
+						'country_code' => 'US',
+						'time'         => 1,
+						'max_time'     => 3,
+					],
+				]
+			);
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+	}
+
+	/**
+	 * The shipping the primary market applies to its own country.
+	 *
+	 * @param array $overrides
+	 *
+	 * @return array
+	 */
+	private function primary_shipping_payload( array $overrides = [] ): array {
+		return array_merge(
+			[
+				'flat_rate'               => 5.0,
+				'free_shipping_threshold' => 50.0,
+				'flat_time'               => 1,
+				'flat_max_time'           => 3,
+			],
+			$overrides
+		);
+	}
+
+	private function secondary_config(): array {
+		return [
+			'country'  => 'GB',
+			'language' => [ 'en' ],
+			'currency' => [ get_woocommerce_currency() ],
+		];
+	}
+
+	public function test_add_market_or_merge_folds_the_country_into_primary_when_shipping_matches(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertTrue( $merged );
+		$this->assertSame( [ 'US', 'GB' ], $this->options->get( OptionsInterface::TARGET_AUDIENCE )['countries'] );
+		$this->assertSame( [], $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_schedules_the_primary_entry_jobs_when_folding(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$this->update_all_products_job->expects( $this->once() )->method( 'schedule' );
+		$this->shipping_settings_job->expects( $this->once() )->method( 'schedule' );
+
+		$this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			$this->primary_shipping_payload()
+		);
+	}
+
+	public function test_add_market_or_merge_does_not_fire_the_market_added_hook_when_folding(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$fired = false;
+		add_action(
+			'woocommerce_gla_market_added',
+			function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		$this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertFalse( $fired );
+	}
+
+	/**
+	 * @dataProvider provide_shipping_that_differs_from_primary
+	 *
+	 * @param array $shipping
+	 */
+	public function test_add_market_or_merge_stores_a_market_when_the_shipping_differs( array $shipping ): void {
+		$this->set_up_primary_shipping_profile();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary( 'gb', $this->secondary_config(), $shipping );
+
+		$this->assertFalse( $merged );
+
+		$stored = $this->options->get( OptionsInterface::MARKETS );
+
+		$this->assertArrayHasKey( 'gb', $stored );
+		$this->assertSame( 'GB', $stored['gb']['country'] );
+		$this->assertNotContains( 'GB', $this->options->get( OptionsInterface::TARGET_AUDIENCE )['countries'] );
+	}
+
+	public function provide_shipping_that_differs_from_primary(): array {
+		return [
+			'dearer rate'              => [ $this->primary_shipping_payload( [ 'flat_rate' => 9.99 ] ) ],
+			'free rate'                => [ $this->primary_shipping_payload( [ 'flat_rate' => 0 ] ) ],
+			'no rate at all'           => [ $this->primary_shipping_payload( [ 'flat_rate' => null ] ) ],
+			'higher threshold'         => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 75.0 ] ) ],
+			// Not the same offer as "free over 50", and not the same as "free over nothing".
+			'no threshold'             => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => null ] ) ],
+			'threshold of zero'        => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 0 ] ) ],
+			'slower minimum'           => [ $this->primary_shipping_payload( [ 'flat_time' => 2 ] ) ],
+			'slower maximum'           => [ $this->primary_shipping_payload( [ 'flat_max_time' => 5 ] ) ],
+			'no delivery window'       => [ $this->primary_shipping_payload( [ 'flat_time' => null, 'flat_max_time' => null ] ) ],
+			'a rate type of its own'   => [ $this->primary_shipping_payload( [ 'rate_type' => 'automatic' ] ) ],
+			'a time type of its own'   => [ $this->primary_shipping_payload( [ 'time_type' => 'manual' ] ) ],
+		];
+	}
+
+	/**
+	 * @dataProvider provide_modes_without_a_per_country_profile
+	 *
+	 * @param string $rate_type
+	 * @param string $time_type
+	 */
+	public function test_add_market_or_merge_stores_a_market_when_the_mode_has_no_per_country_profile( string $rate_type, string $time_type ): void {
+		$this->set_up_primary_shipping_profile( $rate_type, $time_type );
+
+		// Identical values: only the mode stops this folding.
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertFalse( $merged );
+		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function provide_modes_without_a_per_country_profile(): array {
+		return [
+			'automatic rates' => [ 'automatic', 'flat' ],
+			'manual rates'    => [ 'manual', 'flat' ],
+			'manual times'    => [ 'flat', 'manual' ],
+			'manual both'     => [ 'manual', 'manual' ],
+		];
+	}
+
+	public function test_add_market_or_merge_stores_a_market_when_no_shipping_was_submitted(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary( 'gb', $this->secondary_config(), null );
+
+		$this->assertFalse( $merged );
+		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_stores_a_market_when_the_payload_omits_a_value(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$partial = $this->primary_shipping_payload();
+		unset( $partial['flat_max_time'] );
+
+		$merged = $this->market_service->add_market_or_merge_into_primary( 'gb', $this->secondary_config(), $partial );
+
+		$this->assertFalse( $merged );
+		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_accepts_numeric_strings_as_equal(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			[
+				'flat_rate'               => '5.00',
+				'free_shipping_threshold' => '50',
+				'flat_time'               => '1',
+				'flat_max_time'           => '3',
+			]
+		);
+
+		$this->assertTrue( $merged );
+	}
+
+	/**
+	 * Seeds a flat store whose primary country charges 5.00 with no free shipping at all.
+	 */
+	private function set_up_primary_without_free_shipping(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
+				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies(
+			'US',
+			[ 'US' ],
+			[
+				'US' => [
+					'country_code' => 'US',
+					'currency'     => 'USD',
+					'rate'         => '5.00',
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )
+			->willReturn( [ 'US' => [ 'country_code' => 'US', 'time' => 1, 'max_time' => 3 ] ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+	}
+
+	public function test_add_market_or_merge_folds_when_neither_market_offers_free_shipping(): void {
+		$this->set_up_primary_without_free_shipping();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			[
+				'flat_rate'               => 5.0,
+				'free_shipping_threshold' => null,
+				'flat_time'               => 1,
+				'flat_max_time'           => 3,
+			]
+		);
+
+		$this->assertTrue( $merged );
+		$this->assertSame( [], $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_treats_free_over_zero_as_a_different_offer_from_none(): void {
+		$this->set_up_primary_without_free_shipping();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			[
+				'flat_rate'               => 5.0,
+				'free_shipping_threshold' => 0,
+				'flat_time'               => 1,
+				'flat_max_time'           => 3,
+			]
+		);
+
+		$this->assertFalse( $merged );
+		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	/**
+	 * @dataProvider provide_configs_that_ask_for_more_than_primary_gives
+	 *
+	 * @param array $extra
+	 */
+	public function test_add_market_or_merge_stores_a_market_when_it_asks_for_its_own_locale( array $extra ): void {
+		$this->set_up_primary_shipping_profile();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			array_merge( $this->secondary_config(), $extra ),
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertFalse( $merged );
+
+		$stored = $this->options->get( OptionsInterface::MARKETS );
+
+		$this->assertArrayHasKey( 'gb', $stored );
+	}
+
+	public function provide_configs_that_ask_for_more_than_primary_gives(): array {
+		return [
+			'a currency of its own'    => [ [ 'currency' => [ 'JPY' ] ] ],
+			'an extra currency'        => [ [ 'currency' => [ get_woocommerce_currency(), 'JPY' ] ] ],
+			'a language of its own'    => [ [ 'language' => [ 'cy' ] ] ],
+			'a fixed exchange rate'    => [ [ 'exchange_rate' => 1.25 ] ],
+		];
+	}
+
+	public function test_add_market_or_merge_folds_when_the_locale_only_restates_the_primary(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			[
+				'country'  => 'GB',
+				'language' => [ substr( get_locale(), 0, 2 ) ],
+				'currency' => [ get_woocommerce_currency() ],
+			],
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertTrue( $merged );
+		$this->assertSame( [], $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_overwrites_the_country_rows_it_folds_onto_primary(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
+				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies(
+			'US',
+			[ 'US' ],
+			[
+				'US' => [
+					'country_code'            => 'US',
+					'currency'                => 'USD',
+					'rate'                    => '5.00',
+					'free_shipping_threshold' => 50.0,
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )
+			->willReturn( [ 'US' => [ 'country_code' => 'US', 'time' => 1, 'max_time' => 3 ] ] );
+
+		// The country already carries rows of its own that disagree with the primary's.
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[
+				[ 'id' => 1, 'country' => 'US', 'currency' => 'USD', 'rate' => '5.00', 'options' => [] ],
+				[ 'id' => 2, 'country' => 'GB', 'currency' => 'GBP', 'rate' => '99.00', 'options' => [] ],
+			]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn(
+			[
+				[ 'id' => 1, 'country' => 'US', 'time' => 1, 'max_time' => 3 ],
+				[ 'id' => 2, 'country' => 'GB', 'time' => 9, 'max_time' => 9 ],
+			]
+		);
+
+		// Folding says the country ships as the primary does, so its rows are made to say so.
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				$this->callback(
+					function ( $data ) {
+						return 'GB' === $data['country'] && '5.00' === (string) $data['rate'];
+					}
+				),
+				[ 'id' => 2 ]
+			);
+		$this->shipping_time_query->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				$this->callback(
+					function ( $data ) {
+						return 'GB' === $data['country'] && 1 === (int) $data['time'] && 3 === (int) $data['max_time'];
+					}
+				),
+				[ 'id' => 2 ]
+			);
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertTrue( $merged );
+	}
+
+	public function test_add_market_or_merge_does_not_fold_onto_a_primary_that_holds_no_values(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
+				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		// The main target country has no rows, so the primary reports nulls throughout.
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ], [] );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[ [ 'id' => 2, 'country' => 'GB', 'currency' => 'GBP', 'rate' => '9.00', 'options' => [] ] ]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn(
+			[ [ 'id' => 2, 'country' => 'GB', 'time' => 2, 'max_time' => 4 ] ]
+		);
+
+		// Matching nulls against nulls is not a match, and adopting from an absent primary row
+		// would delete the country's own rows instead of aligning them.
+		$this->shipping_rate_query->expects( $this->never() )->method( 'delete' );
+		$this->shipping_time_query->expects( $this->never() )->method( 'delete' );
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			[
+				'flat_rate'               => null,
+				'free_shipping_threshold' => null,
+				'flat_time'               => null,
+				'flat_max_time'           => null,
+			]
+		);
+
+		$this->assertFalse( $merged );
+		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_does_not_fold_when_the_primary_lacks_one_half(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
+				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		// The primary has a delivery window but no rate row of its own.
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ], [] );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )
+			->willReturn( [ 'US' => [ 'country_code' => 'US', 'time' => 1, 'max_time' => 3 ] ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[ [ 'id' => 2, 'country' => 'GB', 'currency' => 'GBP', 'rate' => '9.00', 'options' => [] ] ]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn(
+			[ [ 'id' => 1, 'country' => 'US', 'time' => 1, 'max_time' => 3 ] ]
+		);
+
+		// Folding would adopt an absent primary rate, which deletes the country's own row.
+		$this->shipping_rate_query->expects( $this->never() )->method( 'delete' );
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			[
+				'flat_rate'               => null,
+				'free_shipping_threshold' => null,
+				'flat_time'               => 1,
+				'flat_max_time'           => 3,
+			]
+		);
+
+		$this->assertFalse( $merged );
+		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_announces_the_fold_as_a_primary_update(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$fired = [];
+		add_action(
+			'woocommerce_gla_market_updated',
+			function ( $id ) use ( &$fired ) {
+				$fired[] = $id;
+			}
+		);
+
+		$this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertSame( [ 'primary' ], $fired );
+	}
+
+	public function test_add_market_or_merge_still_rejects_a_zero_exchange_rate(): void {
+		$this->set_up_primary_shipping_profile();
+
+		// A zero rate is a value the create path refuses, not an absent one to fold past.
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			array_merge( $this->secondary_config(), [ 'exchange_rate' => 0 ] ),
+			$this->primary_shipping_payload()
+		);
+	}
+
+	public function test_add_market_or_merge_folding_is_idempotent_for_a_country_already_in_primary(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$this->market_service->add_market_or_merge_into_primary( 'gb', $this->secondary_config(), $this->primary_shipping_payload() );
+		$merged = $this->market_service->add_market_or_merge_into_primary( 'gb', $this->secondary_config(), $this->primary_shipping_payload() );
+
+		$this->assertTrue( $merged );
+		$this->assertSame( [ 'US', 'GB' ], $this->options->get( OptionsInterface::TARGET_AUDIENCE )['countries'] );
+		$this->assertSame( [], $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_throws_for_the_reserved_primary_id(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->add_market_or_merge_into_primary( 'primary', $this->secondary_config(), $this->primary_shipping_payload() );
+	}
+
 	public function test_add_market_persists_and_removes_country_from_target_audience(): void {
 		$config = [
 			'country'    => 'GB',

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -222,7 +222,7 @@ class MarketServiceTest extends UnitTest {
 		$this->assertCount( 1, $result );
 		$this->assertArrayHasKey( 'primary', $result );
 		$this->assertNull( $result['primary']['country'] );
-		$this->assertNull( $result['primary']['feed_label'] );
+		$this->assertArrayNotHasKey( 'feed_label', $result['primary'] );
 	}
 
 	public function test_get_markets_strips_stored_primary_key(): void {
@@ -281,7 +281,7 @@ class MarketServiceTest extends UnitTest {
 		$this->assertCount( 1, $primary_ids );
 
 		$this->assertNull( $result['primary']['country'] );
-		$this->assertNull( $result['primary']['feed_label'] );
+		$this->assertArrayNotHasKey( 'feed_label', $result['primary'] );
 		$this->assertSame( [ 'US', 'CA' ], $result['primary']['countries'] );
 	}
 
@@ -343,7 +343,7 @@ class MarketServiceTest extends UnitTest {
 		$this->market_service->reset_markets();
 	}
 
-	public function test_get_primary_market_country_and_feed_label_are_null(): void {
+	public function test_get_primary_market_country_is_null_and_carries_no_feed_label(): void {
 		$this->set_up_options_get( [ OptionsInterface::MERCHANT_CENTER => [] ] );
 		$this->set_up_primary_market_dependencies(
 			'ZW',
@@ -353,7 +353,7 @@ class MarketServiceTest extends UnitTest {
 		$result = $this->market_service->get_primary_market();
 
 		$this->assertNull( $result['country'] );
-		$this->assertNull( $result['feed_label'] );
+		$this->assertArrayNotHasKey( 'feed_label', $result );
 		$this->assertSame( [ 'MU', 'ZW', 'AO', 'CI', 'CM' ], $result['countries'] );
 	}
 
@@ -385,7 +385,7 @@ class MarketServiceTest extends UnitTest {
 		$this->assertNull( $result['country'] );
 		$this->assertSame( [ substr( get_locale(), 0, 2 ) ], $result['language'] );
 		$this->assertSame( [ get_woocommerce_currency() ], $result['currency'] );
-		$this->assertNull( $result['feed_label'] );
+		$this->assertArrayNotHasKey( 'feed_label', $result );
 		$this->assertSame( 'flat', $result['shipping_rate'] );
 		$this->assertSame( 'flat', $result['shipping_time'] );
 		$this->assertSame( 50.0, $result['free_shipping'] );
@@ -596,7 +596,7 @@ class MarketServiceTest extends UnitTest {
 		$this->shipping_time_query->expects( $this->never() )->method( 'insert' );
 		$this->shipping_time_query->expects( $this->never() )->method( 'update' );
 
-		$this->market_service->update_market( 'gb', [ 'feed_label' => 'GB2' ] );
+		$this->market_service->update_market( 'gb', [ 'language' => [ 'en', 'cy' ] ] );
 	}
 
 	public function test_update_market_shipping_rejects_a_minimum_past_the_maximum(): void {
@@ -962,9 +962,12 @@ class MarketServiceTest extends UnitTest {
 		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
 		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
 
-		$this->market_service->update_market( 'gb', [ 'feed_label' => 'GB-NEW' ] );
+		$this->market_service->update_market( 'gb', [ 'language' => [ 'en', 'cy' ] ] );
 
-		$this->assertSame( 'GB-NEW', $this->options->get( OptionsInterface::MARKETS )['gb']['feed_label'] );
+		$stored = $this->options->get( OptionsInterface::MARKETS )['gb'];
+
+		$this->assertSame( [ 'en', 'cy' ], $stored['language'] );
+		$this->assertSame( 'GB', $stored['country'] );
 	}
 
 	public function test_delete_market_in_flat_mode_takes_the_stored_path(): void {
@@ -1367,10 +1370,9 @@ class MarketServiceTest extends UnitTest {
 	public function test_get_market_returns_market_by_id(): void {
 		$stored = [
 			'gb' => [
-				'country'    => 'GB',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => 'GB',
+				'country'  => 'GB',
+				'language' => [ 'en' ],
+				'currency' => [ 'GBP' ],
 			],
 		];
 
@@ -1380,16 +1382,14 @@ class MarketServiceTest extends UnitTest {
 		$result = $this->market_service->get_market( 'gb' );
 
 		$this->assertSame( 'GB', $result['country'] );
-		$this->assertSame( 'GB', $result['feed_label'] );
 	}
 
-	public function test_get_markets_secondary_country_and_feed_label_are_non_null(): void {
+	public function test_get_markets_secondary_country_is_non_null(): void {
 		$stored = [
 			'gb' => [
-				'country'    => 'GB',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => 'GB',
+				'country'  => 'GB',
+				'language' => [ 'en' ],
+				'currency' => [ 'GBP' ],
 			],
 		];
 
@@ -1399,11 +1399,10 @@ class MarketServiceTest extends UnitTest {
 		$result = $this->market_service->get_markets();
 
 		$this->assertNull( $result['primary']['country'] );
-		$this->assertNull( $result['primary']['feed_label'] );
+		$this->assertArrayNotHasKey( 'feed_label', $result['primary'] );
 		$this->assertIsString( $result['gb']['country'] );
-		$this->assertIsString( $result['gb']['feed_label'] );
 		$this->assertSame( 'GB', $result['gb']['country'] );
-		$this->assertSame( 'GB', $result['gb']['feed_label'] );
+		$this->assertArrayNotHasKey( 'feed_label', $result['gb'] );
 	}
 
 	public function test_get_market_returns_primary_for_primary_id(): void {
@@ -1414,7 +1413,7 @@ class MarketServiceTest extends UnitTest {
 
 		$this->assertSame( 'primary', $result['id'] );
 		$this->assertNull( $result['country'] );
-		$this->assertNull( $result['feed_label'] );
+		$this->assertArrayNotHasKey( 'feed_label', $result );
 	}
 
 	public function test_get_market_returns_null_for_unknown_id(): void {
@@ -2212,28 +2211,24 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( 'GB', $result['country'] );
 	}
 
-	public function test_update_market_schedules_cleanup_when_feed_label_changes(): void {
-		$existing = [
-			'gb' => [
-				'country'    => 'GB',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => 'GB',
-			],
-		];
-
-		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
+	/**
+	 * update_market() on an unknown id creates the market. There are no prior entries to
+	 * orphan, so the id-derived base label must not be mistaken for a previous state.
+	 */
+	public function test_update_market_does_not_schedule_cleanup_for_a_market_that_did_not_exist(): void {
+		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => [] ] );
 		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
 
-		$this->cleanup_job->expects( $this->once() )
-			->method( 'schedule' )
-			->with( [ 'feed_labels' => [ 'GB', 'GB-EN-GBP' ] ] );
+		$this->cleanup_job->expects( $this->never() )->method( 'schedule' );
 
-		// feed_label rename alone does not touch country/currency/shipping_rate/shipping_time.
-		$this->shipping_settings_job->expects( $this->never() )
-			->method( 'schedule' );
-
-		$this->market_service->update_market( 'gb', [ 'feed_label' => 'GB-PROMO' ] );
+		$this->market_service->update_market(
+			'gb',
+			[
+				'country'  => 'GB',
+				'language' => [ 'en' ],
+				'currency' => [ 'GBP' ],
+			]
+		);
 	}
 
 	public function test_update_market_schedules_cleanup_when_currency_changes(): void {
@@ -2478,10 +2473,9 @@ class MarketServiceTest extends UnitTest {
 		$this->market_service->add_market(
 			'gb',
 			[
-				'country'    => 'GB',
-				'feed_label' => '',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
+				'country'  => '',
+				'language' => [ 'en' ],
+				'currency' => [ 'GBP' ],
 			]
 		);
 	}
@@ -2541,25 +2535,6 @@ class MarketServiceTest extends UnitTest {
 			'primary',
 			[ 'countries' => [ 'GB', 'US' ] ]
 		);
-	}
-
-	public function test_update_market_secondary_schedules_update_all_products_when_feed_label_differs(): void {
-		$existing = [
-			'gb' => [
-				'country'    => 'GB',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => 'GB',
-			],
-		];
-
-		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
-		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
-
-		$this->update_all_products_job->expects( $this->once() )
-			->method( 'schedule' );
-
-		$this->market_service->update_market( 'gb', [ 'feed_label' => 'GB-PROMO' ] );
 	}
 
 	public function test_update_market_secondary_schedules_update_all_products_when_language_differs(): void {
@@ -2919,7 +2894,7 @@ class MarketServiceTest extends UnitTest {
 		$this->assertArrayNotHasKey( OptionsInterface::TARGET_AUDIENCE, $update_calls );
 	}
 
-	public function test_delete_market_schedules_cleanup_with_feed_label(): void {
+	public function test_delete_market_schedules_cleanup_with_the_id_derived_labels(): void {
 		// Custom language/currency markets are an automatic/manual concept (flat markets
 		// carry no locale of their own), so this exercises the persisted delete path.
 		$existing = [
@@ -2927,7 +2902,7 @@ class MarketServiceTest extends UnitTest {
 				'country'       => 'GB',
 				'language'      => [ 'en' ],
 				'currency'      => [ 'GBP' ],
-				'feed_label'    => 'GB',
+				'feed_label'    => 'GB-STALE',
 				'shipping_rate' => 'automatic',
 				'shipping_time' => 'flat',
 			],
@@ -2968,7 +2943,7 @@ class MarketServiceTest extends UnitTest {
 				'country'       => 'DE',
 				'language'      => [ 'en', 'de' ],
 				'currency'      => [ 'EUR', 'USD' ],
-				'feed_label'    => 'DE',
+				'feed_label'    => 'DE-STALE',
 				'shipping_rate' => 'automatic',
 				'shipping_time' => 'flat',
 			],
@@ -3555,6 +3530,30 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( [ 'US' ], $result );
 	}
 
+	/**
+	 * A market whose stored config carries a leftover feed_label key. The derived labels
+	 * must come from its id, so the stale key cannot re-label its entries.
+	 */
+	public function test_get_all_feed_labels_ignores_a_leftover_feed_label_key(): void {
+		$this->wpml->method( 'is_active' )->willReturn( true );
+
+		$secondary = [
+			'gb' => [
+				'country'    => 'GB',
+				'language'   => [ 'en' ],
+				'currency'   => [ 'GBP' ],
+				'feed_label' => 'GB-PROMO',
+			],
+		];
+
+		$this->set_up_options_get( [ OptionsInterface::MARKETS => $secondary ] );
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
+		$this->wpml->method( 'can_convert_currency' )->willReturn( true );
+
+		$this->assertSame( [ 'US', 'GB-EN-GBP' ], $this->market_service->get_all_feed_labels() );
+		$this->assertSame( [ 'US', 'GB-EN-GBP' ], $this->market_service->get_feed_labels_for_language( 'en' ) );
+	}
+
 	public function test_get_all_feed_labels_includes_secondary_markets(): void {
 		// Stored currencies only drive the derived labels while a multilingual
 		// integration is active; without one the site locale takes over.
@@ -3943,164 +3942,6 @@ class MarketServiceTest extends UnitTest {
 		);
 	}
 
-	/**
-	 * @dataProvider provide_valid_feed_labels
-	 *
-	 * @param string $feed_label
-	 */
-	public function test_add_market_accepts_valid_feed_label( string $feed_label ): void {
-		$this->set_up_options_get(
-			[
-				OptionsInterface::MARKETS         => [],
-				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'GB' ] ],
-			]
-		);
-
-		$persisted = null;
-		$this->options->method( 'update' )
-			->willReturnCallback(
-				function ( $key, $value ) use ( &$persisted ) {
-					if ( OptionsInterface::MARKETS === $key ) {
-						$persisted = $value;
-					}
-					return true;
-				}
-			);
-
-		$this->market_service->add_market(
-			'gb',
-			[
-				'country'    => 'GB',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => $feed_label,
-			]
-		);
-
-		$this->assertSame( $feed_label, $persisted['gb']['feed_label'] );
-	}
-
-	/**
-	 * @dataProvider provide_invalid_feed_labels
-	 *
-	 * @param string $feed_label
-	 */
-	public function test_add_market_rejects_invalid_feed_label( string $feed_label ): void {
-		$this->set_up_options_get( [ OptionsInterface::MARKETS => [] ] );
-
-		$this->expectException( InvalidValue::class );
-
-		$this->market_service->add_market(
-			'gb',
-			[
-				'country'    => 'GB',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => $feed_label,
-			]
-		);
-	}
-
-	/**
-	 * @dataProvider provide_valid_feed_labels
-	 *
-	 * @param string $feed_label
-	 */
-	public function test_update_market_accepts_valid_feed_label( string $feed_label ): void {
-		$existing = [
-			'gb' => [
-				'country'    => 'GB',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => 'GB',
-			],
-		];
-
-		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
-		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
-
-		$result = $this->market_service->update_market( 'gb', [ 'feed_label' => $feed_label ] );
-
-		$this->assertSame( $feed_label, $result['feed_label'] );
-	}
-
-	/**
-	 * @dataProvider provide_invalid_feed_labels
-	 *
-	 * @param string $feed_label
-	 */
-	public function test_update_market_rejects_invalid_feed_label( string $feed_label ): void {
-		$existing = [
-			'gb' => [
-				'country'    => 'GB',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => 'GB',
-			],
-		];
-
-		$this->set_up_options_get( [ OptionsInterface::MARKETS => $existing ] );
-
-		$this->expectException( InvalidValue::class );
-
-		$this->market_service->update_market( 'gb', [ 'feed_label' => $feed_label ] );
-	}
-
-	public function test_feed_label_rejection_message_references_pattern_and_value(): void {
-		$this->set_up_options_get( [ OptionsInterface::MARKETS => [] ] );
-
-		$this->expectException( InvalidValue::class );
-		$this->expectExceptionMessageMatches( '#feed_label.*\[A-Z0-9-\].*"us"#' );
-
-		$this->market_service->add_market(
-			'gb',
-			[
-				'country'    => 'GB',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => 'us',
-			]
-		);
-	}
-
-	public function test_empty_feed_label_still_throws_is_empty_not_pattern(): void {
-		$this->set_up_options_get( [ OptionsInterface::MARKETS => [] ] );
-
-		$this->expectException( InvalidValue::class );
-		$this->expectExceptionMessage( 'The value of feed_label can not be empty.' );
-
-		$this->market_service->add_market(
-			'gb',
-			[
-				'country'    => 'GB',
-				'language'   => [ 'en' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => '',
-			]
-		);
-	}
-
-	public function provide_valid_feed_labels(): array {
-		return [
-			'two-letter uppercase'     => [ 'US' ],
-			'uppercase with dash'      => [ 'GB-EN' ],
-			'alphanumeric'             => [ 'A1' ],
-			'thirteen char max length' => [ 'A1-B2-C3-D4-E' ],
-		];
-	}
-
-	public function provide_invalid_feed_labels(): array {
-		return [
-			'lowercase'      => [ 'us' ],
-			'fourteen chars' => [ 'A1-B2-C3-D4-E5' ],
-			'twenty chars'   => [ 'A1-B2-C3-D4-E5-F6-G7' ],
-			'underscore'     => [ 'GB_EN' ],
-			'period'         => [ 'GB.EN' ],
-			'space'          => [ 'GB EN' ],
-			'at sign'        => [ 'GB@EN' ],
-		];
-	}
-
 	public function test_add_market_persists_array_language_and_currency(): void {
 		$config = [
 			'country'    => 'CH',
@@ -4377,22 +4218,22 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( [ substr( get_locale(), 0, 2 ) ], $result[0]['languages'] );
 	}
 
-	public function test_generate_market_id_sanitises_uppercase_feed_label(): void {
+	public function test_generate_market_id_sanitises_uppercase_country(): void {
 		$this->assertSame( 'gb', $this->market_service->generate_market_id( 'GB' ) );
 	}
 
-	public function test_generate_market_id_converts_multi_word_label_to_slug(): void {
+	public function test_generate_market_id_converts_a_multi_word_value_to_a_slug(): void {
 		$this->assertSame( 'united-kingdom', $this->market_service->generate_market_id( 'United Kingdom' ) );
 	}
 
-	public function test_generate_market_id_throws_when_label_sanitises_to_reserved_primary(): void {
+	public function test_generate_market_id_throws_when_the_value_sanitises_to_reserved_primary(): void {
 		$this->expectException( InvalidValue::class );
 		$this->expectExceptionMessageMatches( '/reserved/' );
 
 		$this->market_service->generate_market_id( 'Primary' );
 	}
 
-	public function test_generate_market_id_throws_when_label_is_already_lowercase_primary(): void {
+	public function test_generate_market_id_throws_when_the_value_is_already_lowercase_primary(): void {
 		$this->expectException( InvalidValue::class );
 		$this->expectExceptionMessageMatches( '/reserved/' );
 
@@ -4657,10 +4498,9 @@ class MarketServiceTest extends UnitTest {
 			$this->market_service->add_market(
 				'gb',
 				[
-					'country'    => 'GB',
-					'feed_label' => '',
-					'language'   => [ 'en' ],
-					'currency'   => [ 'GBP' ],
+					'country'  => '',
+					'language' => [ 'en' ],
+					'currency' => [ 'GBP' ],
 				]
 			);
 		} finally {
@@ -4697,7 +4537,7 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( 1, $fired_count );
 		$this->assertSame( 'primary', $captured_id );
 		$this->assertSame( $result, $captured_market );
-		foreach ( [ 'id', 'label', 'countries', 'country', 'language', 'currency', 'feed_label', 'shipping_rate', 'shipping_time', 'free_shipping' ] as $key ) {
+		foreach ( [ 'id', 'label', 'countries', 'country', 'language', 'currency', 'shipping_rate', 'shipping_time', 'free_shipping' ] as $key ) {
 			$this->assertArrayHasKey( $key, $captured_market );
 		}
 	}
@@ -4764,7 +4604,7 @@ class MarketServiceTest extends UnitTest {
 		$this->expectException( InvalidValue::class );
 
 		try {
-			$this->market_service->update_market( 'gb', [ 'feed_label' => '' ] );
+			$this->market_service->update_market( 'gb', [ 'country' => '' ] );
 		} finally {
 			$this->assertFalse( $fired );
 		}
@@ -4915,31 +4755,30 @@ class MarketServiceTest extends UnitTest {
 		$this->market_service->update_market( 'gb', [ 'language' => [ 'cy', 'en' ] ] );
 	}
 
-	public function test_update_market_secondary_cleanup_uses_old_labels_when_feed_label_also_changes(): void {
+	public function test_update_market_secondary_cleanup_uses_old_labels_when_language_removed(): void {
 		$existing = [
 			'gb' => [
-				'country'    => 'GB',
-				'language'   => [ 'en', 'cy' ],
-				'currency'   => [ 'GBP' ],
-				'feed_label' => 'GB',
+				'country'  => 'GB',
+				'language' => [ 'en', 'cy' ],
+				'currency' => [ 'GBP' ],
 			],
 		];
 
 		$this->set_up_options_get_with_tracking( [ OptionsInterface::MARKETS => $existing ] );
 		$this->set_up_primary_market_dependencies( 'US', [ 'US' ] );
 
+		// The base label and the dropped language's label are orphaned; the label the
+		// market still syncs under is not.
 		$this->cleanup_job->expects( $this->once() )
 			->method( 'schedule' )
-			->with( [ 'feed_labels' => [ 'GB', 'GB-EN-GBP', 'GB-CY-GBP' ] ] );
+			->with( [ 'feed_labels' => [ 'GB', 'GB-CY-GBP' ] ] );
 		$this->language_cleanup_job->expects( $this->never() )->method( 'schedule' );
 
-		$this->market_service->update_market(
-			'gb',
-			[
-				'language'   => [ 'en' ],
-				'feed_label' => 'GB-PROMO',
-			]
-		);
+		// A language change touches neither country nor currency.
+		$this->shipping_settings_job->expects( $this->never() )
+			->method( 'schedule' );
+
+		$this->market_service->update_market( 'gb', [ 'language' => [ 'en' ] ] );
 	}
 
 	public function test_update_market_primary_schedules_language_cleanup_when_language_removed(): void {
@@ -6023,7 +5862,7 @@ class MarketServiceTest extends UnitTest {
 				'country'    => 'AE',
 				'language'   => [ 'en', 'fr' ],
 				'currency'   => [ $store_currency, 'AED' ],
-				'feed_label' => 'AE',
+				'feed_label' => 'AE-STALE',
 			],
 		];
 

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -484,7 +484,7 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 				],
 				'fr'      => [
 					'country'    => 'FR',
-					'feed_label' => 'FR',
+					'feed_label' => 'FR-PROMO',
 					'language'   => [ 'fr', 'en' ],
 				],
 			]
@@ -608,9 +608,9 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 					'feed_label' => 'US',
 					'language'   => [],
 				],
-				'fr-fr'   => [
+				'fr'      => [
 					'country'    => 'FR',
-					'feed_label' => 'FR',
+					'feed_label' => 'FR-PROMO',
 					'language'   => [ 'fr', 'en' ],
 				],
 			]
@@ -647,9 +647,9 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 					'feed_label' => 'US',
 					'language'   => [ 'en' ],
 				],
-				'fr-fr'   => [
+				'fr'      => [
 					'country'    => 'FR',
-					'feed_label' => 'FR',
+					'feed_label' => 'FR-PROMO',
 					'language'   => [ 'fr', 'en' ],
 				],
 			]
@@ -705,7 +705,7 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 					'feed_label' => 'US',
 					'language'   => [],
 				],
-				'fr-fr'   => [
+				'fr'      => [
 					'country'    => 'FR',
 					'feed_label' => 'FR',
 					'language'   => [],
@@ -741,7 +741,7 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 					'feed_label' => 'US',
 					'language'   => [ 'en' ],
 				],
-				'fr-fr'   => [
+				'fr'      => [
 					'country'    => 'FR',
 					'feed_label' => 'FR',
 					'language'   => [ 'fr' ],

--- a/tests/e2e/specs/markets/markets-non-multilingual.test.js
+++ b/tests/e2e/specs/markets/markets-non-multilingual.test.js
@@ -496,6 +496,79 @@ test.describe( 'Markets – non-multilingual store', () => {
 			await expect( addModal ).not.toBeVisible();
 		} );
 
+		// Runs before the fold test on purpose: this block is serial on one page, and a
+		// snackbar lingers, so asserting its absence afterwards would pass either way.
+		test( 'a market created in its own right shows no fold snackbar', async () => {
+			await marketsPage.fulfillCreateMarket( {
+				id: 'ca',
+				label: 'Canada',
+				country: 'CA',
+			} );
+			await marketsPage.fulfillMarkets( [
+				PRIMARY_MARKET,
+				SECONDARY_MARKET,
+				{ id: 'ca', label: 'Canada', country: 'CA' },
+			] );
+
+			await marketsPage.getHeaderAddMarketButton().click();
+			const addModal = marketsPage.getAddMarketModal();
+			await expect( addModal ).toBeVisible();
+
+			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+
+			await addModal
+				.getByRole( 'button', { name: 'Add market' } )
+				.click();
+
+			await expect( addModal ).not.toBeVisible();
+
+			await expect(
+				page.getByText(
+					'was added to the Primary market, as its configuration matched the existing Primary market settings'
+				)
+			).toBeHidden();
+		} );
+
+		test( 'a market whose shipping matches Primary is folded into it, with a snackbar', async () => {
+			// A matching shipping profile is answered with the primary market and the merge
+			// flag rather than a created market.
+			await marketsPage.fulfillCreateMarket( {
+				...PRIMARY_MARKET,
+				countries: [ 'US', 'CA' ],
+				merged_into_primary: true,
+			} );
+			// Canada joined the primary market, so the refreshed list gives it no row.
+			await marketsPage.fulfillMarkets( [
+				{ ...PRIMARY_MARKET, countries: [ 'US', 'CA' ] },
+				SECONDARY_MARKET,
+			] );
+
+			await marketsPage.getHeaderAddMarketButton().click();
+			const addModal = marketsPage.getAddMarketModal();
+			await expect( addModal ).toBeVisible();
+
+			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+
+			await addModal
+				.getByRole( 'button', { name: 'Add market' } )
+				.click();
+
+			await expect( addModal ).not.toBeVisible();
+
+			await expect(
+				page.locator( '.components-snackbar__content' ).last()
+			).toContainText(
+				'was added to the Primary market, as its configuration matched the existing Primary market settings'
+			);
+
+			await marketsPage.waitForMarketsTable();
+
+			// Canada is covered by Primary, so the refreshed list gives it no row of its own.
+			await expect(
+				page.getByRole( 'row', { name: /^Canada/ } )
+			).toBeHidden();
+		} );
+
 		test( 'API error shows snackbar and keeps Add modal open', async () => {
 			await marketsPage.fulfillCreateMarket(
 				{ message: 'Internal server error' },


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-936/remove-feed-label-as-a-storedwritable-market-field


The market `id` becomes the single canonical identifier. `feed_label` always equalled
`strtoupper(id)` by construction, since the create path derived the id via
`sanitize_title(feed_label)` and `FEED_LABEL_PATTERN` forced the label uppercase, so every
consumer now derives the base label from the id.

- Removed from `get_schema_properties()`, which drops it from POST input and, via
  `extract_writable_params()`, from PUT input. Gone from all responses.
- `POST /mc/markets` derives the id from `country`.
- `update_market()`, `delete_market()` and the label enumeration use `strtoupper($id)`.
  `FEED_LABEL_PATTERN` and its validation are removed.
- Markets stored before this change keep an inert `feed_label` key. Their labels come from
  their id, which the key already equalled, so no migration is needed.

### Backward-compatibility impact

`wc/gla` request/response shapes:

1. `feed_label` no longer accepted as input or returned. Our JS never read it.
2. A POST supplying `feed_label` now yields a different id: `sanitize_title(country)` rather
   than `sanitize_title(feed_label)`. Requests sending only `country` are unaffected.
3. `country` is now constrained to `^[A-Z]{2}$`. 3.9.0 enforced this in effect by defaulting
   `feed_label` to `country` and pattern-checking it. Without the constraint, removing that
   pattern let a malformed country persist a market and then 500 on the two-character shipping
   column, leaving an orphan the `[a-z0-9-]+` route cannot address.
4. POST and PUT responses are now schema-filtered like GET, so undeclared keys are no longer
   echoed. This is what stops a legacy market's leftover `feed_label` escaping through PUT.



### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->


Creating a market with only a country selected should work, and editing one should behave
unchanged. A site with markets from before this release should show the same markets with the
same countries and keep syncing to the same Google feeds.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
