### PR TITLE
GOOWOO-938: Fold a new market into Primary when its shipping config matches

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -1560,18 +1560,24 @@ export function* fetchMarkets() {
 /**
  * Create a new market.
  *
- * @param {Market} args The market data to create.
- * @return {Object} Action object to receive the markets after creation.
+ * Returns the response body rather than the refreshed markets, since the server decides
+ * whether the country became its own market or joined the primary one, and only the body
+ * says which. The markets are still refetched before returning.
+ *
+ * @param {Market & { shipping?: Object }} args The market data to create, including the
+ *   shipping profile the API compares against the primary market's.
+ * @return {Object} The created market, or the primary market with `merged_into_primary` set.
  * @throws Will throw an error if the request failed.
  */
 export function* createMarket( args ) {
 	try {
-		yield apiFetch( {
+		const response = yield apiFetch( {
 			path: `${ API_NAMESPACE }/mc/markets`,
 			method: 'POST',
 			data: args,
 		} );
-		return yield fetchMarkets();
+		yield fetchMarkets();
+		return response;
 	} catch ( error ) {
 		handleApiError( error );
 		throw error;

--- a/js/src/data/actions.test.js
+++ b/js/src/data/actions.test.js
@@ -1,0 +1,74 @@
+/**
+ * Internal dependencies
+ */
+import { createMarket } from './actions';
+import { API_NAMESPACE } from './constants';
+
+jest.mock( '~/utils/handleError', () => ( {
+	handleApiError: jest.fn(),
+} ) );
+
+describe( 'createMarket', () => {
+	/**
+	 * Drives the generator to completion, feeding the given body back as the POST result.
+	 *
+	 * @param {Object} args Market data.
+	 * @param {Object} body Response body the POST resolves to.
+	 * @return {{ request: Object, returned: any }} The yielded request and the returned value.
+	 */
+	const run = ( args, body ) => {
+		const generator = createMarket( args );
+		const request = generator.next().value;
+
+		// The POST resolves to `body`; the next yield refetches the markets.
+		generator.next( body );
+
+		return { request, returned: generator.next().value };
+	};
+
+	it( 'posts the market data to the markets endpoint', () => {
+		const { request } = run( { country: 'GB' }, {} );
+
+		expect( request.request ).toEqual(
+			expect.objectContaining( {
+				path: `${ API_NAMESPACE }/mc/markets`,
+				method: 'POST',
+				data: { country: 'GB' },
+			} )
+		);
+	} );
+
+	it( 'returns the response body so the caller can tell a fold from a creation', () => {
+		const body = { id: 'primary', merged_into_primary: true };
+
+		expect( run( { country: 'GB' }, body ).returned ).toEqual( body );
+	} );
+
+	it( 'returns the created market when nothing was folded', () => {
+		const body = { id: 'gb', country: 'GB' };
+
+		expect( run( { country: 'GB' }, body ).returned ).toEqual( body );
+	} );
+
+	it( 'refetches the markets before returning', () => {
+		const generator = createMarket( { country: 'GB' } );
+
+		generator.next();
+
+		const refetch = generator.next( {} ).value;
+
+		// fetchMarkets is itself a generator, not the plain response body.
+		expect( typeof refetch.next ).toBe( 'function' );
+		expect( generator.next().done ).toBe( true );
+	} );
+
+	it( 'rethrows so the caller can keep the form open', () => {
+		const generator = createMarket( { country: 'GB' } );
+
+		generator.next();
+
+		expect( () => generator.throw( new Error( 'boom' ) ) ).toThrow(
+			'boom'
+		);
+	} );
+} );

--- a/js/src/pages/markets/components/market-form.js
+++ b/js/src/pages/markets/components/market-form.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useRef, useState } from '@wordpress/element';
 
 /**
@@ -25,6 +25,8 @@ import useSaveShippingTimes from '~/hooks/useSaveShippingTimes';
 import useSettings from '~/hooks/useSettings';
 import useStoreCurrency from '~/hooks/useStoreCurrency';
 import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCountryCodes';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
 import AdaptiveForm from '~/components/adaptive-form';
 import ValidationErrors from '~/components/validation-errors';
 import AppSpinner from '~/components/app-spinner';
@@ -77,6 +79,8 @@ const MarketForm = ( {
 	const [ isSaving, setIsSaving ] = useState( false );
 	const { createMarket, updateMarket, syncSettings, invalidateResolution } =
 		useAppDispatch();
+	const { createNotice } = useDispatchCoreNotices();
+	const countryNameMap = useCountryKeyNameMap();
 	const marketId = initialMarket?.id;
 	const isEditing = Boolean( marketId );
 	const isPrimaryMarket = isEditing && checkIsPrimaryMarket( initialMarket );
@@ -116,6 +120,8 @@ const MarketForm = ( {
 			...data
 		} = values;
 
+		let mergedIntoPrimary = false;
+
 		try {
 			setIsSaving( true );
 
@@ -125,7 +131,23 @@ const MarketForm = ( {
 					isPrimaryMarket ? { ...data, countries } : data
 				);
 			} else {
-				await createMarket( data );
+				// The API compares this against the primary market's own shipping and folds
+				// the country in when they match, rather than storing a market that would
+				// feed identically. Values absent for the store's method are simply not
+				// sent, which the API reads as nothing to compare.
+				const response = await createMarket( {
+					...data,
+					shipping: {
+						flat_rate: values.flat_shipping_rate,
+						free_shipping_threshold: values.offer_free_shipping
+							? values.free_shipping_threshold
+							: null,
+						flat_time: values.flat_shipping_min_time,
+						flat_max_time: values.flat_shipping_max_time,
+					},
+				} );
+
+				mergedIntoPrimary = Boolean( response?.merged_into_primary );
 			}
 
 			// Mirror fieldsByMethod from resolveInitialMarket: FLAT includes
@@ -195,6 +217,25 @@ const MarketForm = ( {
 			// for the affected countries, so the cached list is no longer trustworthy.
 			invalidateResolution( 'getTargetAudience', [] );
 			invalidateResolution( 'getMarkets', [] );
+
+			if ( mergedIntoPrimary ) {
+				createNotice(
+					'success',
+					sprintf(
+						// translators: %s: name of the country that joined the primary market.
+						__(
+							'%s was added to the Primary market, as its configuration matched the existing Primary market settings',
+							'google-listings-and-ads'
+						),
+						countryNameMap[ data.country ] || data.country
+					),
+					{
+						type: 'snackbar',
+						isDismissible: true,
+					}
+				);
+			}
+
 			onSubmit();
 		} catch ( error ) {
 			// Every awaited action has already dispatched its own error

--- a/js/src/pages/markets/components/market-form.test.js
+++ b/js/src/pages/markets/components/market-form.test.js
@@ -17,6 +17,8 @@ import useTargetAudienceFinalCountryCodes from '~/hooks/useTargetAudienceFinalCo
 import useSaveShippingRates from '~/hooks/useSaveShippingRates';
 import useSaveShippingTimes from '~/hooks/useSaveShippingTimes';
 import { useAppDispatch } from '~/data';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import useCountryKeyNameMap from '~/hooks/useCountryKeyNameMap';
 import { handleApiError } from '~/utils/handleError';
 import { SHIPPING_RATE_METHOD } from '~/constants';
 
@@ -33,13 +35,21 @@ jest.mock( '~/data', () => ( {
 jest.mock( '~/utils/handleError', () => ( {
 	handleApiError: jest.fn(),
 } ) );
+jest.mock( '~/hooks/useCountryKeyNameMap' );
 
-const submittedValues = {
+const mockBuildSubmittedValues = () => ( {
 	country: 'US',
 	countries: [ 'US' ],
 	shipping_country_rates: [],
 	shipping_country_times: [],
-};
+	flat_shipping_rate: 5,
+	offer_free_shipping: true,
+	free_shipping_threshold: 50,
+	flat_shipping_min_time: 1,
+	flat_shipping_max_time: 3,
+} );
+
+let mockSubmittedValues = mockBuildSubmittedValues();
 
 // MarketForm renders its fields via AdaptiveForm (and attaches a ref to it);
 // mock it as a forwardRef spy so we can both inspect the `initialValues` it's
@@ -57,7 +67,7 @@ jest.mock( '~/components/adaptive-form', () => {
 			return (
 				<button
 					ref={ ref }
-					onClick={ () => props.onSubmit( submittedValues ) }
+					onClick={ () => props.onSubmit( mockSubmittedValues ) }
 				>
 					Submit
 				</button>
@@ -187,6 +197,7 @@ describe( 'MarketForm handleSubmit', () => {
 	const updateMarket = jest.fn();
 	const syncSettings = jest.fn();
 	const invalidateResolution = jest.fn();
+	const createNotice = jest.fn();
 
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -225,6 +236,9 @@ describe( 'MarketForm handleSubmit', () => {
 			targetAudience: { main_target_country: 'US' },
 			loaded: true,
 		} );
+		useDispatchCoreNotices.mockReturnValue( { createNotice } );
+		useCountryKeyNameMap.mockReturnValue( { US: 'United States (US)' } );
+		mockSubmittedValues = mockBuildSubmittedValues();
 	} );
 
 	test( 'invalidates both getTargetAudience and getMarkets after a successful save, since saving shipping rates/times changes what the markets list reports', async () => {
@@ -245,6 +259,102 @@ describe( 'MarketForm handleSubmit', () => {
 		);
 		expect( invalidateResolution ).toHaveBeenCalledWith( 'getMarkets', [] );
 		expect( onSubmit ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'sends the market shipping profile so the API can compare it against Primary', async () => {
+		const user = userEvent.setup();
+
+		useSettings.mockReturnValue( {
+			settings: {
+				shipping_rate: SHIPPING_RATE_METHOD.FLAT,
+				shipping_time: 'flat',
+			},
+		} );
+
+		render( <MarketForm onSubmit={ jest.fn() } /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		expect( createMarket ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				shipping: {
+					flat_rate: 5,
+					free_shipping_threshold: 50,
+					flat_time: 1,
+					flat_max_time: 3,
+				},
+			} )
+		);
+	} );
+
+	test( 'sends a null free shipping threshold when the market offers none', async () => {
+		const user = userEvent.setup();
+
+		useSettings.mockReturnValue( {
+			settings: {
+				shipping_rate: SHIPPING_RATE_METHOD.FLAT,
+				shipping_time: 'flat',
+			},
+		} );
+		mockSubmittedValues.offer_free_shipping = false;
+
+		render( <MarketForm onSubmit={ jest.fn() } /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		expect( createMarket ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				shipping: expect.objectContaining( {
+					free_shipping_threshold: null,
+				} ),
+			} )
+		);
+	} );
+
+	test( 'shows a snackbar naming the country when it is folded into Primary', async () => {
+		const user = userEvent.setup();
+		const onSubmit = jest.fn();
+
+		createMarket.mockResolvedValue( { merged_into_primary: true } );
+
+		render( <MarketForm onSubmit={ onSubmit } /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		expect( createNotice ).toHaveBeenCalledWith(
+			'success',
+			'United States (US) was added to the Primary market, as its configuration matched the existing Primary market settings',
+			{ type: 'snackbar', isDismissible: true }
+		);
+		expect( onSubmit ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'shows no snackbar when the market is created in its own right', async () => {
+		const user = userEvent.setup();
+
+		createMarket.mockResolvedValue( { id: 'us', country: 'US' } );
+
+		render( <MarketForm onSubmit={ jest.fn() } /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		expect( createNotice ).not.toHaveBeenCalled();
+	} );
+
+	test( 'shows no snackbar when editing an existing market', async () => {
+		const user = userEvent.setup();
+
+		render(
+			<MarketForm
+				initialMarket={ { id: 'gb', country: 'GB' } }
+				onSubmit={ jest.fn() }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Submit' } ) );
+
+		expect( createMarket ).not.toHaveBeenCalled();
+		expect( createNotice ).not.toHaveBeenCalled();
 	} );
 
 	test( 'does not invalidate getMarkets or call onSubmit when syncSettings fails', async () => {

--- a/src/API/Site/Controllers/MerchantCenter/MarketsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/MarketsController.php
@@ -196,10 +196,28 @@ class MarketsController extends BaseController {
 				);
 			}
 
+			$shipping = $request->get_param( 'shipping' );
+
 			try {
-				$this->market_service->add_market( $id, $config );
+				$merged = $this->market_service->add_market_or_merge_into_primary(
+					$id,
+					$config,
+					is_array( $shipping ) ? $shipping : null
+				);
 			} catch ( InvalidValue $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], 400 );
+			}
+
+			if ( $merged ) {
+				// No market was created, so this returns the primary market the country joined.
+				// The flag is set after the schema pass so it stays off every other market
+				// response, where it would have no meaning.
+				$response = $this->prepare_item_for_response( $this->market_service->get_primary_market(), $request );
+				$data     = $response->get_data();
+
+				$data['merged_into_primary'] = true;
+
+				return new Response( $data, 200 );
 			}
 
 			$created       = $this->market_service->get_market( $id );
@@ -331,7 +349,10 @@ class MarketsController extends BaseController {
 		$schema = $this->get_schema_properties();
 
 		return [
-			'country' => array_merge( $schema['country'], [ 'required' => true ] ),
+			'country'  => array_merge( $schema['country'], [ 'required' => true ] ),
+			// Compared against the primary market's, and not persisted here: the rates and
+			// times are written through their own endpoints either way.
+			'shipping' => $schema['shipping'],
 		];
 	}
 

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -538,6 +538,197 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	}
 
 	/**
+	 * Adds a market, or folds its country into the primary market when the submitted shipping
+	 * is what the primary already applies there.
+	 *
+	 * A market whose shipping matches the primary's carries no information the primary does not
+	 * already hold, so storing it would split one feed into two identical ones.
+	 *
+	 * @param string     $id       The market ID.
+	 * @param array      $config   The market configuration.
+	 * @param array|null $shipping The submitted shipping configuration, or null when the request
+	 *                             carried none, in which case there is nothing to compare.
+	 *
+	 * @return bool True when the country was folded into the primary market and no market was stored.
+	 *
+	 * @throws InvalidValue When $id is 'primary' or $config is invalid.
+	 */
+	public function add_market_or_merge_into_primary( string $id, array $config, ?array $shipping = null ): bool {
+		if ( 'primary' === $id ) {
+			throw new InvalidValue(
+				sprintf( 'The market ID "%s" is reserved and cannot be added.', $id )
+			);
+		}
+
+		$country = (string) ( $config['country'] ?? '' );
+
+		if (
+			'' === $country
+			|| null === $shipping
+			|| ! $this->carries_only_the_primary_locale( $config )
+			|| ! $this->shipping_matches_primary( $shipping )
+		) {
+			$this->add_market( $id, $config );
+
+			return false;
+		}
+
+		$this->merge_country_into_primary( $country );
+
+		return true;
+	}
+
+	/**
+	 * Whether a market config asks for nothing the primary market does not already give it.
+	 *
+	 * Shipping is not the only thing a market carries. A market wanting its own currency, or a
+	 * fixed rate to produce one, is asking for a feed the primary cannot serve, however alike
+	 * the shipping looks, and folding it would drop what the merchant asked for.
+	 *
+	 * @param array $config The market configuration.
+	 *
+	 * @return bool
+	 */
+	private function carries_only_the_primary_locale( array $config ): bool {
+		if ( isset( $config['exchange_rate'] ) ) {
+			return false;
+		}
+
+		$primary = $this->get_primary_market();
+
+		foreach ( [ 'language', 'currency' ] as $key ) {
+			if ( ! isset( $config[ $key ] ) ) {
+				continue;
+			}
+
+			if ( ! is_array( $config[ $key ] ) ) {
+				return false;
+			}
+
+			$submitted = $config[ $key ];
+			$theirs    = is_array( $primary[ $key ] ?? null ) ? $primary[ $key ] : [];
+
+			sort( $submitted );
+			sort( $theirs );
+
+			if ( $submitted !== $theirs ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether a submitted shipping configuration is the one the primary market already applies.
+	 *
+	 * The comparison is against the primary market's own profile, which is the one keyed to the
+	 * store's main target country and the one the Markets screen shows for Primary. A store that
+	 * sets a different rate per country therefore keeps creating separate markets, which is the
+	 * intended reading of "the Primary market's current effective shipping configuration".
+	 *
+	 * @param array $shipping The submitted shipping configuration.
+	 *
+	 * @return bool
+	 */
+	private function shipping_matches_primary( array $shipping ): bool {
+		$primary = $this->get_market_shipping( $this->target_audience->get_main_target_country() );
+
+		// Only a flat rate and a flat delivery window are stored per country. Any other method
+		// leaves nothing country-specific to compare, so the market stays separate rather than
+		// every country folding on a global setting they cannot help but share. That holds for
+		// an automatic rate with a flat window too: the window alone is a thin basis for
+		// discarding a market the merchant asked for.
+		if ( 'flat' !== $primary['rate_type'] || 'flat' !== $primary['time_type'] ) {
+			return false;
+		}
+
+		// The method types are global, so a payload that states a different one is describing
+		// a market this store cannot have. Absent is the normal case and says nothing.
+		foreach ( [ 'rate_type', 'time_type' ] as $key ) {
+			if ( array_key_exists( $key, $shipping ) && $shipping[ $key ] !== $primary[ $key ] ) {
+				return false;
+			}
+		}
+
+		$families = [
+			[ 'flat_rate', 'free_shipping_threshold' ],
+			[ 'flat_time', 'flat_max_time' ],
+		];
+
+		// Each half is adopted from its own primary row, so each has to exist. A half the
+		// primary holds nothing for cannot be matched, and adopting it would strip the
+		// country's own row rather than align it.
+		foreach ( $families as $family ) {
+			if ( [] === array_filter( array_intersect_key( $primary, array_flip( $family ) ), 'is_numeric' ) ) {
+				return false;
+			}
+		}
+
+		foreach ( array_merge( ...$families ) as $key ) {
+			// An absent value is not an equal one: a partial payload says nothing about the
+			// field, and folding on it would discard a difference the merchant never stated.
+			if ( ! array_key_exists( $key, $shipping ) ) {
+				return false;
+			}
+
+			if ( ! $this->shipping_values_match( $shipping[ $key ], $primary[ $key ] ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Compares one shipping value against the primary's.
+	 *
+	 * Null is a value here, not a zero: "no free shipping threshold" and "free over 0" are
+	 * different offers, so they must not compare equal.
+	 *
+	 * @param mixed      $submitted The submitted value.
+	 * @param float|null $primary   The primary market's value.
+	 *
+	 * @return bool
+	 */
+	private function shipping_values_match( $submitted, $primary ): bool {
+		if ( null === $submitted || null === $primary ) {
+			return null === $submitted && null === $primary;
+		}
+
+		if ( ! is_numeric( $submitted ) ) {
+			return false;
+		}
+
+		return abs( (float) $submitted - (float) $primary ) < 0.0001;
+	}
+
+	/**
+	 * Adds a country to the primary market, giving it the primary's shipping rows and the same
+	 * job scheduling a stored market entering the primary feed already triggers.
+	 *
+	 * @param string $country ISO 3166-1 alpha-2 country code.
+	 */
+	private function merge_country_into_primary( string $country ): void {
+		// The country's own rows are overwritten rather than merely filled in: it may already
+		// carry rows that disagree with the primary's, and folding asserts they are the same
+		// shipping. Leaving them would sync values the caller was told it was merging away.
+		$this->adopt_primary_rate_for_country( $country );
+		$this->adopt_primary_time_for_country( $country );
+		$this->restore_country_to_target_audience( $country );
+
+		if ( $this->global_shipping_is_syncable() ) {
+			$this->schedule_shipping_sync();
+		}
+
+		$this->job_repository->get( UpdateAllProducts::class )->schedule();
+
+		// The primary market gained a country and its shipping rows, the same change a PUT
+		// against it reports, so it is announced the same way.
+		$this->fire_market_updated_action( 'primary' );
+	}
+
+	/**
 	 * Updates values of an existing market.
 	 *
 	 * When $id is 'primary', writes fan out to the underlying settings stores

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -220,10 +220,12 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'de' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -255,6 +257,122 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'flat', $data['shipping_rate'] );
 	}
 
+	public function test_post_market_returns_200_and_the_primary_market_when_the_country_is_folded_in(): void {
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
+		$this->market_service->method( 'get_market' )->willReturn( null );
+		$this->market_service->method( 'get_primary_market' )->willReturn( self::PRIMARY_MARKET );
+
+		$this->market_service->expects( $this->once() )
+			->method( 'add_market_or_merge_into_primary' )
+			->with(
+				'gb',
+				$this->callback(
+					function ( $config ) {
+						return 'GB' === $config['country'];
+					}
+				),
+				$this->callback(
+					function ( $shipping ) {
+						return 5.0 === $shipping['flat_rate'] && 3 === $shipping['flat_max_time'];
+					}
+				)
+			)
+			->willReturn( true );
+
+		$response = $this->do_request(
+			self::ROUTE_MARKETS,
+			'POST',
+			[
+				'country'  => 'GB',
+				'shipping' => [
+					'flat_rate'               => 5.0,
+					'free_shipping_threshold' => 50.0,
+					'flat_time'               => 1,
+					'flat_max_time'           => 3,
+				],
+			]
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertTrue( $data['merged_into_primary'] );
+		$this->assertSame( 'primary', $data['id'] );
+		$this->assertNull( $data['country'] );
+	}
+
+	public function test_post_market_still_returns_201_when_the_shipping_does_not_match(): void {
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
+
+		$created = false;
+
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
+			->willReturnCallback(
+				function () use ( &$created ) {
+					$created = true;
+
+					return false;
+				}
+			);
+
+		$this->market_service->method( 'get_market' )
+			->willReturnCallback(
+				function ( string $id ) use ( &$created ) {
+					if ( 'gb' === $id && $created ) {
+						return self::SECONDARY_MARKET;
+					}
+					return null;
+				}
+			);
+
+		$response = $this->do_request(
+			self::ROUTE_MARKETS,
+			'POST',
+			[
+				'country'  => 'GB',
+				'shipping' => [
+					'flat_rate'               => 9.99,
+					'free_shipping_threshold' => null,
+					'flat_time'               => 2,
+					'flat_max_time'           => 6,
+				],
+			]
+		);
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertArrayNotHasKey( 'merged_into_primary', $response->get_data() );
+	}
+
+	public function test_post_market_forwards_a_null_shipping_when_none_was_submitted(): void {
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
+
+		$this->market_service->expects( $this->once() )
+			->method( 'add_market_or_merge_into_primary' )
+			->with( 'gb', $this->anything(), null )
+			->willReturn( false );
+
+		$created = false;
+		$this->market_service->method( 'get_market' )
+			->willReturnCallback(
+				function () use ( &$created ) {
+					$was    = $created;
+					$created = true;
+					return $was ? self::SECONDARY_MARKET : null;
+				}
+			);
+
+		$this->do_request( self::ROUTE_MARKETS, 'POST', [ 'country' => 'GB' ] );
+	}
+
+	public function test_get_markets_carries_no_merged_flag(): void {
+		$response = $this->do_request( self::ROUTE_MARKETS );
+
+		foreach ( $response->get_data() as $market ) {
+			$this->assertArrayNotHasKey( 'merged_into_primary', $market );
+		}
+	}
+
 	public function test_post_market_returns_400_missing_required_field(): void {
 		$response = $this->do_request(
 			self::ROUTE_MARKETS,
@@ -282,7 +400,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->with(
 				'gb',
 				$this->callback(
@@ -296,6 +414,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -325,7 +445,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->with(
 				'gb',
 				$this->callback(
@@ -339,6 +459,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -371,7 +493,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->market_service->method( 'get_market' )
 			->willReturn( null );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->willThrowException( InvalidValue::is_empty( 'country' ) );
 
 		$response = $this->do_request(
@@ -701,10 +823,12 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'jp' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -738,7 +862,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnOnConsecutiveCalls( null, [] );
 
 		$this->market_service->expects( $this->once() )
-			->method( 'add_market' )
+			->method( 'add_market_or_merge_into_primary' )
 			->with(
 				$this->anything(),
 				$this->callback(
@@ -873,10 +997,12 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'ch' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -918,10 +1044,12 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'ch' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -957,7 +1085,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->with( 'GB' )
 			->willReturn( 'gb' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->with(
 				'gb',
 				$this->callback(
@@ -970,6 +1098,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -1000,7 +1130,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 	 * @param string $country
 	 */
 	public function test_post_market_returns_400_for_a_country_that_is_not_an_alpha_2_code( string $country ): void {
-		$this->market_service->expects( $this->never() )->method( 'add_market' );
+		$this->market_service->expects( $this->never() )->method( 'add_market_or_merge_into_primary' );
 
 		$response = $this->do_request(
 			self::ROUTE_MARKETS,
@@ -1028,10 +1158,12 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$created = false;
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -1077,7 +1209,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
 
-		$this->market_service->method( 'add_market' )
+		$this->market_service->method( 'add_market_or_merge_into_primary' )
 			->with(
 				'gb',
 				$this->callback(
@@ -1089,6 +1221,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 
@@ -1159,7 +1293,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'de' );
 
 		$this->market_service->expects( $this->once() )
-			->method( 'add_market' )
+			->method( 'add_market_or_merge_into_primary' )
 			->with(
 				'de',
 				$this->callback(
@@ -1172,6 +1306,8 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			->willReturnCallback(
 				function () use ( &$created ) {
 					$created = true;
+
+					return false;
 				}
 			);
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -356,7 +356,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		$this->market_service->method( 'get_market' )
 			->willReturnCallback(
 				function () use ( &$created ) {
-					$was    = $created;
+					$was     = $created;
 					$created = true;
 					return $was ? self::SECONDARY_MARKET : null;
 				}
@@ -1143,14 +1143,14 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 	public function provide_invalid_countries(): array {
 		return [
-			'multi word'      => [ 'United Kingdom' ],
-			'punctuation'     => [ '###' ],
-			'whitespace'      => [ '   ' ],
-			'leading dash'    => [ '-GB' ],
-			'lowercase'       => [ 'gb' ],
-			'three letters'   => [ 'GBR' ],
-			'one letter'      => [ 'G' ],
-			'empty'           => [ '' ],
+			'multi word'    => [ 'United Kingdom' ],
+			'punctuation'   => [ '###' ],
+			'whitespace'    => [ '   ' ],
+			'leading dash'  => [ '-GB' ],
+			'lowercase'     => [ 'gb' ],
+			'three letters' => [ 'GBR' ],
+			'one letter'    => [ 'G' ],
+			'empty'         => [ '' ],
 		];
 	}
 

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -312,7 +312,10 @@ class MarketServiceTest extends UnitTest {
 		$this->set_up_options_get(
 			[
 				OptionsInterface::MERCHANT_CENTER => [],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'all', 'countries' => [] ],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'all',
+					'countries' => [],
+				],
 				OptionsInterface::MARKETS         => [
 					'gr' => [
 						'country'    => 'GR',
@@ -1506,7 +1509,10 @@ class MarketServiceTest extends UnitTest {
 					'shipping_rate' => $rate_type,
 					'shipping_time' => $time_type,
 				],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
 				OptionsInterface::MARKETS         => [],
 			]
 		);
@@ -1631,18 +1637,25 @@ class MarketServiceTest extends UnitTest {
 
 	public function provide_shipping_that_differs_from_primary(): array {
 		return [
-			'dearer rate'              => [ $this->primary_shipping_payload( [ 'flat_rate' => 9.99 ] ) ],
-			'free rate'                => [ $this->primary_shipping_payload( [ 'flat_rate' => 0 ] ) ],
-			'no rate at all'           => [ $this->primary_shipping_payload( [ 'flat_rate' => null ] ) ],
-			'higher threshold'         => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 75.0 ] ) ],
+			'dearer rate'            => [ $this->primary_shipping_payload( [ 'flat_rate' => 9.99 ] ) ],
+			'free rate'              => [ $this->primary_shipping_payload( [ 'flat_rate' => 0 ] ) ],
+			'no rate at all'         => [ $this->primary_shipping_payload( [ 'flat_rate' => null ] ) ],
+			'higher threshold'       => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 75.0 ] ) ],
 			// Not the same offer as "free over 50", and not the same as "free over nothing".
-			'no threshold'             => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => null ] ) ],
-			'threshold of zero'        => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 0 ] ) ],
-			'slower minimum'           => [ $this->primary_shipping_payload( [ 'flat_time' => 2 ] ) ],
-			'slower maximum'           => [ $this->primary_shipping_payload( [ 'flat_max_time' => 5 ] ) ],
-			'no delivery window'       => [ $this->primary_shipping_payload( [ 'flat_time' => null, 'flat_max_time' => null ] ) ],
-			'a rate type of its own'   => [ $this->primary_shipping_payload( [ 'rate_type' => 'automatic' ] ) ],
-			'a time type of its own'   => [ $this->primary_shipping_payload( [ 'time_type' => 'manual' ] ) ],
+			'no threshold'           => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => null ] ) ],
+			'threshold of zero'      => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 0 ] ) ],
+			'slower minimum'         => [ $this->primary_shipping_payload( [ 'flat_time' => 2 ] ) ],
+			'slower maximum'         => [ $this->primary_shipping_payload( [ 'flat_max_time' => 5 ] ) ],
+			'no delivery window'     => [
+				$this->primary_shipping_payload(
+					[
+						'flat_time'     => null,
+						'flat_max_time' => null,
+					]
+				),
+			],
+			'a rate type of its own' => [ $this->primary_shipping_payload( [ 'rate_type' => 'automatic' ] ) ],
+			'a time type of its own' => [ $this->primary_shipping_payload( [ 'time_type' => 'manual' ] ) ],
 		];
 	}
 
@@ -1719,8 +1732,14 @@ class MarketServiceTest extends UnitTest {
 	private function set_up_primary_without_free_shipping(): void {
 		$this->set_up_options_get_with_tracking(
 			[
-				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
 				OptionsInterface::MARKETS         => [],
 			]
 		);
@@ -1736,7 +1755,15 @@ class MarketServiceTest extends UnitTest {
 			]
 		);
 		$this->shipping_time_query->method( 'get_all_shipping_times' )
-			->willReturn( [ 'US' => [ 'country_code' => 'US', 'time' => 1, 'max_time' => 3 ] ] );
+			->willReturn(
+				[
+					'US' => [
+						'country_code' => 'US',
+						'time'         => 1,
+						'max_time'     => 3,
+					],
+				]
+			);
 		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
 		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
 	}
@@ -1800,10 +1827,10 @@ class MarketServiceTest extends UnitTest {
 
 	public function provide_configs_that_ask_for_more_than_primary_gives(): array {
 		return [
-			'a currency of its own'    => [ [ 'currency' => [ 'JPY' ] ] ],
-			'an extra currency'        => [ [ 'currency' => [ get_woocommerce_currency(), 'JPY' ] ] ],
-			'a language of its own'    => [ [ 'language' => [ 'cy' ] ] ],
-			'a fixed exchange rate'    => [ [ 'exchange_rate' => 1.25 ] ],
+			'a currency of its own' => [ [ 'currency' => [ 'JPY' ] ] ],
+			'an extra currency'     => [ [ 'currency' => [ get_woocommerce_currency(), 'JPY' ] ] ],
+			'a language of its own' => [ [ 'language' => [ 'cy' ] ] ],
+			'a fixed exchange rate' => [ [ 'exchange_rate' => 1.25 ] ],
 		];
 	}
 
@@ -1827,8 +1854,14 @@ class MarketServiceTest extends UnitTest {
 	public function test_add_market_or_merge_overwrites_the_country_rows_it_folds_onto_primary(): void {
 		$this->set_up_options_get_with_tracking(
 			[
-				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
 				OptionsInterface::MARKETS         => [],
 			]
 		);
@@ -1845,19 +1878,49 @@ class MarketServiceTest extends UnitTest {
 			]
 		);
 		$this->shipping_time_query->method( 'get_all_shipping_times' )
-			->willReturn( [ 'US' => [ 'country_code' => 'US', 'time' => 1, 'max_time' => 3 ] ] );
+			->willReturn(
+				[
+					'US' => [
+						'country_code' => 'US',
+						'time'         => 1,
+						'max_time'     => 3,
+					],
+				]
+			);
 
 		// The country already carries rows of its own that disagree with the primary's.
 		$this->shipping_rate_query->method( 'get_results' )->willReturn(
 			[
-				[ 'id' => 1, 'country' => 'US', 'currency' => 'USD', 'rate' => '5.00', 'options' => [] ],
-				[ 'id' => 2, 'country' => 'GB', 'currency' => 'GBP', 'rate' => '99.00', 'options' => [] ],
+				[
+					'id'       => 1,
+					'country'  => 'US',
+					'currency' => 'USD',
+					'rate'     => '5.00',
+					'options'  => [],
+				],
+				[
+					'id'       => 2,
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => '99.00',
+					'options'  => [],
+				],
 			]
 		);
 		$this->shipping_time_query->method( 'get_results' )->willReturn(
 			[
-				[ 'id' => 1, 'country' => 'US', 'time' => 1, 'max_time' => 3 ],
-				[ 'id' => 2, 'country' => 'GB', 'time' => 9, 'max_time' => 9 ],
+				[
+					'id'       => 1,
+					'country'  => 'US',
+					'time'     => 1,
+					'max_time' => 3,
+				],
+				[
+					'id'       => 2,
+					'country'  => 'GB',
+					'time'     => 9,
+					'max_time' => 9,
+				],
 			]
 		);
 
@@ -1895,8 +1958,14 @@ class MarketServiceTest extends UnitTest {
 	public function test_add_market_or_merge_does_not_fold_onto_a_primary_that_holds_no_values(): void {
 		$this->set_up_options_get_with_tracking(
 			[
-				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
 				OptionsInterface::MARKETS         => [],
 			]
 		);
@@ -1904,10 +1973,25 @@ class MarketServiceTest extends UnitTest {
 		$this->set_up_primary_market_dependencies( 'US', [ 'US' ], [] );
 		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [] );
 		$this->shipping_rate_query->method( 'get_results' )->willReturn(
-			[ [ 'id' => 2, 'country' => 'GB', 'currency' => 'GBP', 'rate' => '9.00', 'options' => [] ] ]
+			[
+				[
+					'id'       => 2,
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => '9.00',
+					'options'  => [],
+				],
+			]
 		);
 		$this->shipping_time_query->method( 'get_results' )->willReturn(
-			[ [ 'id' => 2, 'country' => 'GB', 'time' => 2, 'max_time' => 4 ] ]
+			[
+				[
+					'id'       => 2,
+					'country'  => 'GB',
+					'time'     => 2,
+					'max_time' => 4,
+				],
+			]
 		);
 
 		// Matching nulls against nulls is not a match, and adopting from an absent primary row
@@ -1933,20 +2017,49 @@ class MarketServiceTest extends UnitTest {
 	public function test_add_market_or_merge_does_not_fold_when_the_primary_lacks_one_half(): void {
 		$this->set_up_options_get_with_tracking(
 			[
-				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => [ 'US' ],
+				],
 				OptionsInterface::MARKETS         => [],
 			]
 		);
 		// The primary has a delivery window but no rate row of its own.
 		$this->set_up_primary_market_dependencies( 'US', [ 'US' ], [] );
 		$this->shipping_time_query->method( 'get_all_shipping_times' )
-			->willReturn( [ 'US' => [ 'country_code' => 'US', 'time' => 1, 'max_time' => 3 ] ] );
+			->willReturn(
+				[
+					'US' => [
+						'country_code' => 'US',
+						'time'         => 1,
+						'max_time'     => 3,
+					],
+				]
+			);
 		$this->shipping_rate_query->method( 'get_results' )->willReturn(
-			[ [ 'id' => 2, 'country' => 'GB', 'currency' => 'GBP', 'rate' => '9.00', 'options' => [] ] ]
+			[
+				[
+					'id'       => 2,
+					'country'  => 'GB',
+					'currency' => 'GBP',
+					'rate'     => '9.00',
+					'options'  => [],
+				],
+			]
 		);
 		$this->shipping_time_query->method( 'get_results' )->willReturn(
-			[ [ 'id' => 1, 'country' => 'US', 'time' => 1, 'max_time' => 3 ] ]
+			[
+				[
+					'id'       => 1,
+					'country'  => 'US',
+					'time'     => 1,
+					'max_time' => 3,
+				],
+			]
 		);
 
 		// Folding would adopt an absent primary rate, which deletes the country's own row.
@@ -2073,7 +2186,10 @@ class MarketServiceTest extends UnitTest {
 		$this->set_up_options_get(
 			[
 				OptionsInterface::MARKETS         => [],
-				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'all', 'countries' => [] ],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'all',
+					'countries' => [],
+				],
 			]
 		);
 		// The stored list is empty in this mode; the resolved audience is what covers GB.
@@ -2738,7 +2854,7 @@ class MarketServiceTest extends UnitTest {
 	}
 
 	/**
-	 * update_market() on an unknown id creates the market. There are no prior entries to
+	 * Calling update_market() on an unknown id creates the market. There are no prior entries to
 	 * orphan, so the id-derived base label must not be mistaken for a previous state.
 	 */
 	public function test_update_market_does_not_schedule_cleanup_for_a_market_that_did_not_exist(): void {

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -1493,6 +1493,532 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( [ 'EUR', 'GBP' ], $this->market_service->get_market_currencies_for_language( $market, 'de' ) );
 	}
 
+	/**
+	 * Seeds a flat store whose primary country ships at 5.00, free over 50, in 1 to 3 days.
+	 *
+	 * @param string $rate_type
+	 * @param string $time_type
+	 */
+	private function set_up_primary_shipping_profile( string $rate_type = 'flat', string $time_type = 'flat' ): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => $rate_type,
+					'shipping_time' => $time_type,
+				],
+				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies(
+			'US',
+			[ 'US' ],
+			[
+				'US' => [
+					'country_code'            => 'US',
+					'currency'                => 'USD',
+					'rate'                    => '5.00',
+					'free_shipping_threshold' => 50.0,
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )
+			->willReturn(
+				[
+					'US' => [
+						'country_code' => 'US',
+						'time'         => 1,
+						'max_time'     => 3,
+					],
+				]
+			);
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+	}
+
+	/**
+	 * The shipping the primary market applies to its own country.
+	 *
+	 * @param array $overrides
+	 *
+	 * @return array
+	 */
+	private function primary_shipping_payload( array $overrides = [] ): array {
+		return array_merge(
+			[
+				'flat_rate'               => 5.0,
+				'free_shipping_threshold' => 50.0,
+				'flat_time'               => 1,
+				'flat_max_time'           => 3,
+			],
+			$overrides
+		);
+	}
+
+	private function secondary_config(): array {
+		return [
+			'country'  => 'GB',
+			'language' => [ 'en' ],
+			'currency' => [ get_woocommerce_currency() ],
+		];
+	}
+
+	public function test_add_market_or_merge_folds_the_country_into_primary_when_shipping_matches(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertTrue( $merged );
+		$this->assertSame( [ 'US', 'GB' ], $this->options->get( OptionsInterface::TARGET_AUDIENCE )['countries'] );
+		$this->assertSame( [], $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_schedules_the_primary_entry_jobs_when_folding(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$this->update_all_products_job->expects( $this->once() )->method( 'schedule' );
+		$this->shipping_settings_job->expects( $this->once() )->method( 'schedule' );
+
+		$this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			$this->primary_shipping_payload()
+		);
+	}
+
+	public function test_add_market_or_merge_does_not_fire_the_market_added_hook_when_folding(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$fired = false;
+		add_action(
+			'woocommerce_gla_market_added',
+			function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		$this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertFalse( $fired );
+	}
+
+	/**
+	 * @dataProvider provide_shipping_that_differs_from_primary
+	 *
+	 * @param array $shipping
+	 */
+	public function test_add_market_or_merge_stores_a_market_when_the_shipping_differs( array $shipping ): void {
+		$this->set_up_primary_shipping_profile();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary( 'gb', $this->secondary_config(), $shipping );
+
+		$this->assertFalse( $merged );
+
+		$stored = $this->options->get( OptionsInterface::MARKETS );
+
+		$this->assertArrayHasKey( 'gb', $stored );
+		$this->assertSame( 'GB', $stored['gb']['country'] );
+		$this->assertNotContains( 'GB', $this->options->get( OptionsInterface::TARGET_AUDIENCE )['countries'] );
+	}
+
+	public function provide_shipping_that_differs_from_primary(): array {
+		return [
+			'dearer rate'              => [ $this->primary_shipping_payload( [ 'flat_rate' => 9.99 ] ) ],
+			'free rate'                => [ $this->primary_shipping_payload( [ 'flat_rate' => 0 ] ) ],
+			'no rate at all'           => [ $this->primary_shipping_payload( [ 'flat_rate' => null ] ) ],
+			'higher threshold'         => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 75.0 ] ) ],
+			// Not the same offer as "free over 50", and not the same as "free over nothing".
+			'no threshold'             => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => null ] ) ],
+			'threshold of zero'        => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 0 ] ) ],
+			'slower minimum'           => [ $this->primary_shipping_payload( [ 'flat_time' => 2 ] ) ],
+			'slower maximum'           => [ $this->primary_shipping_payload( [ 'flat_max_time' => 5 ] ) ],
+			'no delivery window'       => [ $this->primary_shipping_payload( [ 'flat_time' => null, 'flat_max_time' => null ] ) ],
+			'a rate type of its own'   => [ $this->primary_shipping_payload( [ 'rate_type' => 'automatic' ] ) ],
+			'a time type of its own'   => [ $this->primary_shipping_payload( [ 'time_type' => 'manual' ] ) ],
+		];
+	}
+
+	/**
+	 * @dataProvider provide_modes_without_a_per_country_profile
+	 *
+	 * @param string $rate_type
+	 * @param string $time_type
+	 */
+	public function test_add_market_or_merge_stores_a_market_when_the_mode_has_no_per_country_profile( string $rate_type, string $time_type ): void {
+		$this->set_up_primary_shipping_profile( $rate_type, $time_type );
+
+		// Identical values: only the mode stops this folding.
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertFalse( $merged );
+		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function provide_modes_without_a_per_country_profile(): array {
+		return [
+			'automatic rates' => [ 'automatic', 'flat' ],
+			'manual rates'    => [ 'manual', 'flat' ],
+			'manual times'    => [ 'flat', 'manual' ],
+			'manual both'     => [ 'manual', 'manual' ],
+		];
+	}
+
+	public function test_add_market_or_merge_stores_a_market_when_no_shipping_was_submitted(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary( 'gb', $this->secondary_config(), null );
+
+		$this->assertFalse( $merged );
+		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_stores_a_market_when_the_payload_omits_a_value(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$partial = $this->primary_shipping_payload();
+		unset( $partial['flat_max_time'] );
+
+		$merged = $this->market_service->add_market_or_merge_into_primary( 'gb', $this->secondary_config(), $partial );
+
+		$this->assertFalse( $merged );
+		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_accepts_numeric_strings_as_equal(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			[
+				'flat_rate'               => '5.00',
+				'free_shipping_threshold' => '50',
+				'flat_time'               => '1',
+				'flat_max_time'           => '3',
+			]
+		);
+
+		$this->assertTrue( $merged );
+	}
+
+	/**
+	 * Seeds a flat store whose primary country charges 5.00 with no free shipping at all.
+	 */
+	private function set_up_primary_without_free_shipping(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
+				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies(
+			'US',
+			[ 'US' ],
+			[
+				'US' => [
+					'country_code' => 'US',
+					'currency'     => 'USD',
+					'rate'         => '5.00',
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )
+			->willReturn( [ 'US' => [ 'country_code' => 'US', 'time' => 1, 'max_time' => 3 ] ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn( [] );
+		$this->shipping_time_query->method( 'get_results' )->willReturn( [] );
+	}
+
+	public function test_add_market_or_merge_folds_when_neither_market_offers_free_shipping(): void {
+		$this->set_up_primary_without_free_shipping();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			[
+				'flat_rate'               => 5.0,
+				'free_shipping_threshold' => null,
+				'flat_time'               => 1,
+				'flat_max_time'           => 3,
+			]
+		);
+
+		$this->assertTrue( $merged );
+		$this->assertSame( [], $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_treats_free_over_zero_as_a_different_offer_from_none(): void {
+		$this->set_up_primary_without_free_shipping();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			[
+				'flat_rate'               => 5.0,
+				'free_shipping_threshold' => 0,
+				'flat_time'               => 1,
+				'flat_max_time'           => 3,
+			]
+		);
+
+		$this->assertFalse( $merged );
+		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	/**
+	 * @dataProvider provide_configs_that_ask_for_more_than_primary_gives
+	 *
+	 * @param array $extra
+	 */
+	public function test_add_market_or_merge_stores_a_market_when_it_asks_for_its_own_locale( array $extra ): void {
+		$this->set_up_primary_shipping_profile();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			array_merge( $this->secondary_config(), $extra ),
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertFalse( $merged );
+
+		$stored = $this->options->get( OptionsInterface::MARKETS );
+
+		$this->assertArrayHasKey( 'gb', $stored );
+	}
+
+	public function provide_configs_that_ask_for_more_than_primary_gives(): array {
+		return [
+			'a currency of its own'    => [ [ 'currency' => [ 'JPY' ] ] ],
+			'an extra currency'        => [ [ 'currency' => [ get_woocommerce_currency(), 'JPY' ] ] ],
+			'a language of its own'    => [ [ 'language' => [ 'cy' ] ] ],
+			'a fixed exchange rate'    => [ [ 'exchange_rate' => 1.25 ] ],
+		];
+	}
+
+	public function test_add_market_or_merge_folds_when_the_locale_only_restates_the_primary(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			[
+				'country'  => 'GB',
+				'language' => [ substr( get_locale(), 0, 2 ) ],
+				'currency' => [ get_woocommerce_currency() ],
+			],
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertTrue( $merged );
+		$this->assertSame( [], $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_overwrites_the_country_rows_it_folds_onto_primary(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
+				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies(
+			'US',
+			[ 'US' ],
+			[
+				'US' => [
+					'country_code'            => 'US',
+					'currency'                => 'USD',
+					'rate'                    => '5.00',
+					'free_shipping_threshold' => 50.0,
+				],
+			]
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )
+			->willReturn( [ 'US' => [ 'country_code' => 'US', 'time' => 1, 'max_time' => 3 ] ] );
+
+		// The country already carries rows of its own that disagree with the primary's.
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[
+				[ 'id' => 1, 'country' => 'US', 'currency' => 'USD', 'rate' => '5.00', 'options' => [] ],
+				[ 'id' => 2, 'country' => 'GB', 'currency' => 'GBP', 'rate' => '99.00', 'options' => [] ],
+			]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn(
+			[
+				[ 'id' => 1, 'country' => 'US', 'time' => 1, 'max_time' => 3 ],
+				[ 'id' => 2, 'country' => 'GB', 'time' => 9, 'max_time' => 9 ],
+			]
+		);
+
+		// Folding says the country ships as the primary does, so its rows are made to say so.
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				$this->callback(
+					function ( $data ) {
+						return 'GB' === $data['country'] && '5.00' === (string) $data['rate'];
+					}
+				),
+				[ 'id' => 2 ]
+			);
+		$this->shipping_time_query->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				$this->callback(
+					function ( $data ) {
+						return 'GB' === $data['country'] && 1 === (int) $data['time'] && 3 === (int) $data['max_time'];
+					}
+				),
+				[ 'id' => 2 ]
+			);
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertTrue( $merged );
+	}
+
+	public function test_add_market_or_merge_does_not_fold_onto_a_primary_that_holds_no_values(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
+				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		// The main target country has no rows, so the primary reports nulls throughout.
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ], [] );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturn( [] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[ [ 'id' => 2, 'country' => 'GB', 'currency' => 'GBP', 'rate' => '9.00', 'options' => [] ] ]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn(
+			[ [ 'id' => 2, 'country' => 'GB', 'time' => 2, 'max_time' => 4 ] ]
+		);
+
+		// Matching nulls against nulls is not a match, and adopting from an absent primary row
+		// would delete the country's own rows instead of aligning them.
+		$this->shipping_rate_query->expects( $this->never() )->method( 'delete' );
+		$this->shipping_time_query->expects( $this->never() )->method( 'delete' );
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			[
+				'flat_rate'               => null,
+				'free_shipping_threshold' => null,
+				'flat_time'               => null,
+				'flat_max_time'           => null,
+			]
+		);
+
+		$this->assertFalse( $merged );
+		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_does_not_fold_when_the_primary_lacks_one_half(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [ 'shipping_rate' => 'flat', 'shipping_time' => 'flat' ],
+				OptionsInterface::TARGET_AUDIENCE => [ 'location' => 'selected', 'countries' => [ 'US' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		// The primary has a delivery window but no rate row of its own.
+		$this->set_up_primary_market_dependencies( 'US', [ 'US' ], [] );
+		$this->shipping_time_query->method( 'get_all_shipping_times' )
+			->willReturn( [ 'US' => [ 'country_code' => 'US', 'time' => 1, 'max_time' => 3 ] ] );
+		$this->shipping_rate_query->method( 'get_results' )->willReturn(
+			[ [ 'id' => 2, 'country' => 'GB', 'currency' => 'GBP', 'rate' => '9.00', 'options' => [] ] ]
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturn(
+			[ [ 'id' => 1, 'country' => 'US', 'time' => 1, 'max_time' => 3 ] ]
+		);
+
+		// Folding would adopt an absent primary rate, which deletes the country's own row.
+		$this->shipping_rate_query->expects( $this->never() )->method( 'delete' );
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			[
+				'flat_rate'               => null,
+				'free_shipping_threshold' => null,
+				'flat_time'               => 1,
+				'flat_max_time'           => 3,
+			]
+		);
+
+		$this->assertFalse( $merged );
+		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_announces_the_fold_as_a_primary_update(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$fired = [];
+		add_action(
+			'woocommerce_gla_market_updated',
+			function ( $id ) use ( &$fired ) {
+				$fired[] = $id;
+			}
+		);
+
+		$this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertSame( [ 'primary' ], $fired );
+	}
+
+	public function test_add_market_or_merge_still_rejects_a_zero_exchange_rate(): void {
+		$this->set_up_primary_shipping_profile();
+
+		// A zero rate is a value the create path refuses, not an absent one to fold past.
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			array_merge( $this->secondary_config(), [ 'exchange_rate' => 0 ] ),
+			$this->primary_shipping_payload()
+		);
+	}
+
+	public function test_add_market_or_merge_folding_is_idempotent_for_a_country_already_in_primary(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$this->market_service->add_market_or_merge_into_primary( 'gb', $this->secondary_config(), $this->primary_shipping_payload() );
+		$merged = $this->market_service->add_market_or_merge_into_primary( 'gb', $this->secondary_config(), $this->primary_shipping_payload() );
+
+		$this->assertTrue( $merged );
+		$this->assertSame( [ 'US', 'GB' ], $this->options->get( OptionsInterface::TARGET_AUDIENCE )['countries'] );
+		$this->assertSame( [], $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function test_add_market_or_merge_throws_for_the_reserved_primary_id(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->add_market_or_merge_into_primary( 'primary', $this->secondary_config(), $this->primary_shipping_payload() );
+	}
+
 	public function test_add_market_persists_and_removes_country_from_target_audience(): void {
 		$config = [
 			'country'    => 'GB',

--- a/tests/e2e/specs/markets/markets-non-multilingual.test.js
+++ b/tests/e2e/specs/markets/markets-non-multilingual.test.js
@@ -496,6 +496,79 @@ test.describe( 'Markets – non-multilingual store', () => {
 			await expect( addModal ).not.toBeVisible();
 		} );
 
+		// Runs before the fold test on purpose: this block is serial on one page, and a
+		// snackbar lingers, so asserting its absence afterwards would pass either way.
+		test( 'a market created in its own right shows no fold snackbar', async () => {
+			await marketsPage.fulfillCreateMarket( {
+				id: 'ca',
+				label: 'Canada',
+				country: 'CA',
+			} );
+			await marketsPage.fulfillMarkets( [
+				PRIMARY_MARKET,
+				SECONDARY_MARKET,
+				{ id: 'ca', label: 'Canada', country: 'CA' },
+			] );
+
+			await marketsPage.getHeaderAddMarketButton().click();
+			const addModal = marketsPage.getAddMarketModal();
+			await expect( addModal ).toBeVisible();
+
+			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+
+			await addModal
+				.getByRole( 'button', { name: 'Add market' } )
+				.click();
+
+			await expect( addModal ).not.toBeVisible();
+
+			await expect(
+				page.getByText(
+					'was added to the Primary market, as its configuration matched the existing Primary market settings'
+				)
+			).toBeHidden();
+		} );
+
+		test( 'a market whose shipping matches Primary is folded into it, with a snackbar', async () => {
+			// A matching shipping profile is answered with the primary market and the merge
+			// flag rather than a created market.
+			await marketsPage.fulfillCreateMarket( {
+				...PRIMARY_MARKET,
+				countries: [ 'US', 'CA' ],
+				merged_into_primary: true,
+			} );
+			// Canada joined the primary market, so the refreshed list gives it no row.
+			await marketsPage.fulfillMarkets( [
+				{ ...PRIMARY_MARKET, countries: [ 'US', 'CA' ] },
+				SECONDARY_MARKET,
+			] );
+
+			await marketsPage.getHeaderAddMarketButton().click();
+			const addModal = marketsPage.getAddMarketModal();
+			await expect( addModal ).toBeVisible();
+
+			await addModal.getByLabel( 'Market' ).selectOption( 'CA' );
+
+			await addModal
+				.getByRole( 'button', { name: 'Add market' } )
+				.click();
+
+			await expect( addModal ).not.toBeVisible();
+
+			await expect(
+				page.locator( '.components-snackbar__content' ).last()
+			).toContainText(
+				'was added to the Primary market, as its configuration matched the existing Primary market settings'
+			);
+
+			await marketsPage.waitForMarketsTable();
+
+			// Canada is covered by Primary, so the refreshed list gives it no row of its own.
+			await expect(
+				page.getByRole( 'row', { name: /^Canada/ } )
+			).toBeHidden();
+		} );
+
 		test( 'API error shows snackbar and keeps Add modal open', async () => {
 			await marketsPage.fulfillCreateMarket(
 				{ message: 'Internal server error' },


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-938/fold-a-new-market-into-primary-when-its-shipping-config-matches

A market whose shipping is what Primary already applies splits one feed into two identical
ones. `POST /mc/markets` now compares the submitted shipping profile against Primary's and,
when they match, adds the country to Primary's target audience instead of storing a market,
answering `200` with `merged_into_primary: true` and a snackbar naming the country.

The decision lives in `MarketService::add_market_or_merge_into_primary()`, the non-matching
branch is unchanged. A fold aligns the country's rate and time rows with Primary's, and is
refused when the market wants its own language, currency or exchange rate, or when Primary
has no rate or time row of its own to match.

**Two open calls:** the comparison anchors on Primary's own profile (AC1), so per-country-rate
stores keep creating separate markets, and only flat rate plus flat window can fold (AC3),
though automatic plus flat window arguably qualifies under AC6. Both documented in code.
Recommend treating automatic-mode folding as a follow-up.

**Backward compatibility:** `POST /mc/markets` gains a `shipping` request property (compared,
never persisted) and may return `200` where callers previously always got `201`, with a
`merged_into_primary` field kept out of the schema so no other response carries it. A fold
fires the existing `woocommerce_gla_market_updated( 'primary', … )`.




### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Setup: both shipping rate and times set to flat/estimated; Primary needs 2+ countries sharing
the same rate and times. (Add Market only offers countries already in Primary.)

1. Add market → pick a country → change nothing → Add market.
   No new row, Primary's count unchanged, snackbar: "[Country] was added to the Primary
   market, as its configuration matched the existing Primary market settings" (country name,
   not code).

2. Same again but change the rate first. New row for that country, Primary's count drops by
   one, no snackbar. Repeat changing only the free shipping threshold, then only the window.

3. Switch the rate to automatic (or times to manual), add a market identical to Primary.
   Separate market every time, no snackbar.

4. Multi-currency stores only: identical shipping, different currency. Separate market,
   currency preserved.


Editing an existing market saves as before with no snackbar, deleting is unchanged.
With the rate set to manual the Markets screen behaves as before.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
