### PR TITLE
GOOWOO-942: Connect Search Console

### DIFF
--- a/src/API/SearchConsole/Connection.php
+++ b/src/API/SearchConsole/Connection.php
@@ -1,0 +1,126 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\SearchConsole;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\ExceptionTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Client\ClientExceptionInterface;
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Connection
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\SearchConsole
+ */
+class Connection implements ContainerAwareInterface {
+
+	use ContainerAwareTrait;
+	use ExceptionTrait;
+
+	/**
+	 * Get the connection URL for performing a connection redirect.
+	 *
+	 * @param string $return_url The return URL.
+	 *
+	 * @return string
+	 * @throws Exception When a ClientException is caught or the response doesn't contain the oauthUrl.
+	 */
+	public function connect( string $return_url ): string {
+		try {
+			/** @var Client $client */
+			$client = $this->container->get( Client::class );
+			$result = $client->post(
+				$this->get_connection_url(),
+				[
+					'body' => wp_json_encode(
+						[
+							'returnUrl' => $return_url,
+						]
+					),
+				]
+			);
+
+			$response = json_decode( $result->getBody()->getContents(), true );
+			if ( 200 === $result->getStatusCode() && ! empty( $response['oauthUrl'] ) ) {
+				return $response['oauthUrl'];
+			}
+
+			do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
+
+			throw new Exception( __( 'Unable to connect Search Console account', 'google-listings-and-ads' ) );
+		} catch ( ClientExceptionInterface $e ) {
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
+
+			throw new Exception( __( 'Unable to connect Search Console account', 'google-listings-and-ads' ) );
+		}
+	}
+
+	/**
+	 * Disconnect from the Search Console account.
+	 *
+	 * @return string
+	 */
+	public function disconnect(): string {
+		try {
+			/** @var Client $client */
+			$client = $this->container->get( Client::class );
+			$result = $client->delete( $this->get_connection_url() );
+
+			return $result->getBody()->getContents();
+		} catch ( ClientExceptionInterface $e ) {
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
+
+			return $e->getMessage();
+		} catch ( Exception $e ) {
+			do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
+
+			return $e->getMessage();
+		}
+	}
+
+	/**
+	 * Get the status of the connection.
+	 *
+	 * @return array
+	 * @throws Exception When a ClientException is caught or the response contains an error.
+	 */
+	public function get_status(): array {
+		try {
+			/** @var Client $client */
+			$client   = $this->container->get( Client::class );
+			$result   = $client->get( $this->get_connection_url() );
+			$response = json_decode( $result->getBody()->getContents(), true );
+
+			if ( 200 === $result->getStatusCode() ) {
+				return $response;
+			}
+
+			do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
+
+			$message = $response['message'] ?? __( 'Invalid response when retrieving status', 'google-listings-and-ads' );
+			throw new Exception( $message, $result->getStatusCode() );
+		} catch ( ClientExceptionInterface $e ) {
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
+
+			throw new Exception( $this->client_exception_message( $e, __( 'Error retrieving status', 'google-listings-and-ads' ) ) );
+		}
+	}
+
+	/**
+	 * Get the Search Console connection URL.
+	 *
+	 * Path pending final confirmation with Woo (GOOWOO-880); follows the
+	 * established one-path-per-integration convention also used by
+	 * `google/connection/youtube` and `google/connection/google-mc`.
+	 *
+	 * @return string
+	 */
+	protected function get_connection_url(): string {
+		return "{$this->container->get( 'connect_server_root' )}google/connection/search-console";
+	}
+}

--- a/src/API/SearchConsole/Connection.php
+++ b/src/API/SearchConsole/Connection.php
@@ -216,8 +216,8 @@ class Connection implements ContainerAwareInterface, MerchantCenterAwareInterfac
 	 *   so this is the initial attempt failing.
 	 *
 	 * STATE_INCOMPLETE and STATE_ACTION_NEEDED are stub branches only; real
-	 * detection depends on the property-selection and verification logic owned
-	 * by the sibling ticket (GOOWOO-943).
+	 * detection depends on property-selection and verification logic that
+	 * lands separately.
 	 *
 	 * @return array
 	 */
@@ -261,8 +261,8 @@ class Connection implements ContainerAwareInterface, MerchantCenterAwareInterfac
 	/**
 	 * Get the Search Console connection URL.
 	 *
-	 * Path pending final confirmation with Woo (GOOWOO-880); follows the
-	 * established one-path-per-integration convention also used by
+	 * Path pending final confirmation with Woo; follows the established
+	 * one-path-per-integration convention also used by
 	 * `google/connection/youtube` and `google/connection/google-mc`.
 	 *
 	 * @return string

--- a/src/API/SearchConsole/Connection.php
+++ b/src/API/SearchConsole/Connection.php
@@ -4,8 +4,12 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\SearchConsole;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\ExceptionTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Client\ClientExceptionInterface;
 use Exception;
@@ -17,10 +21,59 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\SearchConsole
  */
-class Connection implements ContainerAwareInterface {
+class Connection implements ContainerAwareInterface, OptionsAwareInterface {
 
 	use ContainerAwareTrait;
 	use ExceptionTrait;
+	use OptionsAwareTrait;
+
+	/**
+	 * Default shape of the `search_console` option, mirroring Site Verification's
+	 * flat-array shape but with the extra fields this connection needs to track.
+	 *
+	 * @var array
+	 */
+	protected const DEFAULT_CONNECTION_DATA = [
+		'property'      => null,
+		'property_type' => null,
+		'verified'      => SiteVerification::VERIFICATION_STATUS_UNVERIFIED,
+		'state'         => null,
+	];
+
+	/**
+	 * Get the stored Search Console connection data.
+	 *
+	 * @return array
+	 */
+	public function get_connection_data(): array {
+		return $this->options->get( OptionsInterface::SEARCH_CONSOLE, self::DEFAULT_CONNECTION_DATA );
+	}
+
+	/**
+	 * Update the stored Search Console connection data.
+	 *
+	 * Merges the given fields onto the existing stored data (or the defaults, if
+	 * nothing has been stored yet) so callers can update a subset of fields.
+	 *
+	 * @param array $data The connection data fields to update.
+	 *
+	 * @return bool
+	 */
+	public function update_connection_data( array $data ): bool {
+		return $this->options->update(
+			OptionsInterface::SEARCH_CONSOLE,
+			array_merge( $this->get_connection_data(), $data )
+		);
+	}
+
+	/**
+	 * Clear the stored Search Console connection data, returning it to its default state.
+	 *
+	 * @return bool
+	 */
+	public function clear_connection_data(): bool {
+		return $this->options->delete( OptionsInterface::SEARCH_CONSOLE );
+	}
 
 	/**
 	 * Get the connection URL for performing a connection redirect.

--- a/src/API/SearchConsole/Connection.php
+++ b/src/API/SearchConsole/Connection.php
@@ -116,9 +116,15 @@ class Connection implements ContainerAwareInterface, OptionsAwareInterface {
 	/**
 	 * Disconnect from the Search Console account.
 	 *
+	 * Clears the locally stored connection data upfront, even if the remote
+	 * disconnect call below fails, so a merchant who asks to disconnect never
+	 * gets stuck with a stale property or verification state.
+	 *
 	 * @return string
 	 */
 	public function disconnect(): string {
+		$this->clear_connection_data();
+
 		try {
 			/** @var Client $client */
 			$client = $this->container->get( Client::class );

--- a/src/API/SearchConsole/Connection.php
+++ b/src/API/SearchConsole/Connection.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\BadResponseException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Client\ClientExceptionInterface;
 use Exception;
 
@@ -200,7 +201,11 @@ class Connection implements ContainerAwareInterface, MerchantCenterAwareInterfac
 		} catch ( ClientExceptionInterface $e ) {
 			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
 
-			throw new Exception( $this->client_exception_message( $e, __( 'Error retrieving status', 'google-listings-and-ads' ) ) );
+			// A BadResponseException always carries a response and its status code; other
+			// ClientExceptionInterface implementations (e.g. a connection timeout) don't.
+			$status = $e instanceof BadResponseException ? $e->getResponse()->getStatusCode() : 0;
+
+			throw new Exception( $this->client_exception_message( $e, __( 'Error retrieving status', 'google-listings-and-ads' ) ), $status );
 		}
 	}
 

--- a/src/API/SearchConsole/Connection.php
+++ b/src/API/SearchConsole/Connection.php
@@ -49,6 +49,9 @@ class Connection implements ContainerAwareInterface, MerchantCenterAwareInterfac
 	/** @var string The initial connection attempt itself failed. */
 	public const STATE_CONNECTION_FAILED = 'connection-failed';
 
+	/** @var string The remote status check failed transiently (e.g. a 5xx or network error); the persisted state is left untouched. */
+	public const STATE_TRANSIENT_ERROR = 'transient-error';
+
 	/**
 	 * Default shape of the `search_console` option, mirroring Site Verification's
 	 * flat-array shape but with the extra fields this connection needs to track.
@@ -220,6 +223,12 @@ class Connection implements ContainerAwareInterface, MerchantCenterAwareInterfac
 	 * - STATE_CONNECTION_FAILED: the connection never reached STATE_CONNECTED,
 	 *   so this is the initial attempt failing.
 	 *
+	 * Only a 401/403 from the remote status check is treated as an authorization
+	 * failure worth persisting as one of the states above. Any other failure (a
+	 * 5xx, or a network-level failure with no status at all) is reported as
+	 * STATE_TRANSIENT_ERROR without touching the persisted state, so a momentary
+	 * outage can't misdiagnose a healthy connection as needing reconnection.
+	 *
 	 * STATE_INCOMPLETE and STATE_ACTION_NEEDED are stub branches only; real
 	 * detection depends on property-selection and verification logic that
 	 * lands separately.
@@ -232,6 +241,10 @@ class Connection implements ContainerAwareInterface, MerchantCenterAwareInterfac
 		try {
 			$status = $this->get_status();
 		} catch ( Exception $e ) {
+			if ( ! in_array( $e->getCode(), [ 401, 403 ], true ) ) {
+				return [ 'status' => self::STATE_TRANSIENT_ERROR ];
+			}
+
 			$state = self::STATE_CONNECTED === $connection_data['state']
 				? self::STATE_RECONNECT
 				: self::STATE_CONNECTION_FAILED;

--- a/src/API/SearchConsole/Connection.php
+++ b/src/API/SearchConsole/Connection.php
@@ -30,6 +30,24 @@ class Connection implements ContainerAwareInterface, MerchantCenterAwareInterfac
 	use MerchantCenterAwareTrait;
 	use OptionsAwareTrait;
 
+	/** @var string The remote connection is active, but no property has been selected/verified yet. */
+	public const STATE_INCOMPLETE = 'incomplete';
+
+	/** @var string A property was selected but its verification has since been lost. */
+	public const STATE_ACTION_NEEDED = 'action-needed';
+
+	/** @var string A property is selected and verified. */
+	public const STATE_CONNECTED = 'connected';
+
+	/** @var string No connection has ever been established, or it was explicitly disconnected. */
+	public const STATE_DISCONNECTED = 'disconnected';
+
+	/** @var string A previously working connection is no longer authorized. */
+	public const STATE_RECONNECT = 'reconnect';
+
+	/** @var string The initial connection attempt itself failed. */
+	public const STATE_CONNECTION_FAILED = 'connection-failed';
+
 	/**
 	 * Default shape of the `search_console` option, mirroring Site Verification's
 	 * flat-array shape but with the extra fields this connection needs to track.
@@ -184,6 +202,60 @@ class Connection implements ContainerAwareInterface, MerchantCenterAwareInterfac
 
 			throw new Exception( $this->client_exception_message( $e, __( 'Error retrieving status', 'google-listings-and-ads' ) ) );
 		}
+	}
+
+	/**
+	 * Resolve the merchant's current connection state.
+	 *
+	 * Reuses the same remote status check as {@see self::get_status()} but layers
+	 * the locally persisted `state` (this connection's history) on top of it to
+	 * tell apart the states that produce an identical remote error:
+	 * - STATE_RECONNECT: the connection previously reached STATE_CONNECTED and
+	 *   has since become unauthorized (expired).
+	 * - STATE_CONNECTION_FAILED: the connection never reached STATE_CONNECTED,
+	 *   so this is the initial attempt failing.
+	 *
+	 * STATE_INCOMPLETE and STATE_ACTION_NEEDED are stub branches only; real
+	 * detection depends on the property-selection and verification logic owned
+	 * by the sibling ticket (GOOWOO-943).
+	 *
+	 * @return array
+	 */
+	public function get_connection_status(): array {
+		$connection_data = $this->get_connection_data();
+
+		try {
+			$status = $this->get_status();
+		} catch ( Exception $e ) {
+			$state = self::STATE_CONNECTED === $connection_data['state']
+				? self::STATE_RECONNECT
+				: self::STATE_CONNECTION_FAILED;
+
+			$this->update_connection_data( [ 'state' => $state ] );
+
+			return [ 'status' => $state ];
+		}
+
+		if ( self::STATE_CONNECTED !== ( $status['status'] ?? '' ) ) {
+			$this->update_connection_data( [ 'state' => self::STATE_DISCONNECTED ] );
+
+			return array_merge( $status, [ 'status' => self::STATE_DISCONNECTED ] );
+		}
+
+		$is_verified = ! empty( $connection_data['property'] )
+			&& SiteVerification::VERIFICATION_STATUS_VERIFIED === $connection_data['verified'];
+
+		if ( $is_verified ) {
+			$this->update_connection_data( [ 'state' => self::STATE_CONNECTED ] );
+
+			return array_merge( $status, [ 'status' => self::STATE_CONNECTED ] );
+		}
+
+		$state = ! empty( $connection_data['property'] ) ? self::STATE_ACTION_NEEDED : self::STATE_INCOMPLETE;
+
+		$this->update_connection_data( [ 'state' => $state ] );
+
+		return array_merge( $status, [ 'status' => $state ] );
 	}
 
 	/**

--- a/src/API/SearchConsole/Connection.php
+++ b/src/API/SearchConsole/Connection.php
@@ -7,6 +7,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\ExceptionTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -21,10 +23,11 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\SearchConsole
  */
-class Connection implements ContainerAwareInterface, OptionsAwareInterface {
+class Connection implements ContainerAwareInterface, MerchantCenterAwareInterface, OptionsAwareInterface {
 
 	use ContainerAwareTrait;
 	use ExceptionTrait;
+	use MerchantCenterAwareTrait;
 	use OptionsAwareTrait;
 
 	/**
@@ -73,6 +76,19 @@ class Connection implements ContainerAwareInterface, OptionsAwareInterface {
 	 */
 	public function clear_connection_data(): bool {
 		return $this->options->delete( OptionsInterface::SEARCH_CONSOLE );
+	}
+
+	/**
+	 * Whether the Google authorization prompt can be skipped.
+	 *
+	 * The merchant already granted WooCommerce Connect Server's OAuth grant during
+	 * Merchant Center setup, so if they're already connected to Merchant Center
+	 * there's no need to show the prompt again to connect Search Console.
+	 *
+	 * @return bool
+	 */
+	public function should_skip_auth(): bool {
+		return $this->merchant_center->is_connected();
 	}
 
 	/**

--- a/src/API/Site/Controllers/SearchConsole/AccountController.php
+++ b/src/API/Site/Controllers/SearchConsole/AccountController.php
@@ -111,10 +111,10 @@ class AccountController extends BaseController {
 	protected function get_connected_callback(): callable {
 		return function () {
 			try {
-				$status = $this->connection->get_status();
+				$status = $this->connection->get_connection_status();
 
 				return [
-					'status' => $status['status'] ?? 'disconnected',
+					'status' => $status['status'],
 				];
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );

--- a/src/API/Site/Controllers/SearchConsole/AccountController.php
+++ b/src/API/Site/Controllers/SearchConsole/AccountController.php
@@ -74,11 +74,12 @@ class AccountController extends BaseController {
 		return function () {
 			try {
 				return [
-					'url' => $this->connection->connect(
+					'url'       => $this->connection->connect(
 						admin_url(
 							'admin.php?page=wc-admin&path=/google/settings'
 						)
 					),
+					'skip_auth' => $this->connection->should_skip_auth(),
 				];
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
@@ -128,9 +129,15 @@ class AccountController extends BaseController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'url' => [
+			'url'       => [
 				'type'        => 'string',
 				'description' => __( 'The URL for making a connection to Search Console.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+			],
+			'skip_auth' => [
+				'type'        => 'boolean',
+				'description' => __( 'Whether the Google authorization prompt can be skipped, because the merchant is already connected to Merchant Center.', 'google-listings-and-ads' ),
 				'context'     => [ 'view' ],
 				'readonly'    => true,
 			],

--- a/src/API/Site/Controllers/SearchConsole/AccountController.php
+++ b/src/API/Site/Controllers/SearchConsole/AccountController.php
@@ -1,0 +1,150 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\SearchConsole;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\SearchConsole\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AccountController
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\SearchConsole
+ */
+class AccountController extends BaseController {
+
+	/** @var Connection */
+	protected $connection;
+
+	/**
+	 * AccountController constructor.
+	 *
+	 * @param RESTServer $server
+	 * @param Connection $connection
+	 */
+	public function __construct( RESTServer $server, Connection $connection ) {
+		parent::__construct( $server );
+
+		$this->connection = $connection;
+	}
+
+	/**
+	 * Register rest routes with WordPress.
+	 */
+	public function register_routes(): void {
+		$this->register_route(
+			'search-console/connect',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_connect_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+				'schema' => $this->get_api_response_schema_callback(),
+			]
+		);
+		$this->register_route(
+			'search-console/connection',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_connected_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+				[
+					'methods'             => TransportMethods::DELETABLE,
+					'callback'            => $this->get_disconnect_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get the callback function for the connection request.
+	 *
+	 * @return callable
+	 */
+	protected function get_connect_callback(): callable {
+		return function () {
+			try {
+				return [
+					'url' => $this->connection->connect(
+						admin_url(
+							'admin.php?page=wc-admin&path=/google/settings'
+						)
+					),
+				];
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
+		};
+	}
+
+	/**
+	 * Get the callback function for the disconnection request.
+	 *
+	 * @return callable
+	 */
+	protected function get_disconnect_callback(): callable {
+		return function () {
+			$this->connection->disconnect();
+
+			return [
+				'status'  => 'success',
+				'message' => __( 'Successfully disconnected.', 'google-listings-and-ads' ),
+			];
+		};
+	}
+
+	/**
+	 * Get the callback function to determine if Search Console is currently connected.
+	 *
+	 * @return callable
+	 */
+	protected function get_connected_callback(): callable {
+		return function () {
+			try {
+				$status = $this->connection->get_status();
+
+				return [
+					'status' => $status['status'] ?? 'disconnected',
+				];
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
+		};
+	}
+
+	/**
+	 * Get the item schema for the controller.
+	 *
+	 * @return array
+	 */
+	protected function get_schema_properties(): array {
+		return [
+			'url' => [
+				'type'        => 'string',
+				'description' => __( 'The URL for making a connection to Search Console.', 'google-listings-and-ads' ),
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+			],
+		];
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * Used for building the API response schema.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'search_console_account';
+	}
+}

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -40,6 +40,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelperAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiPromotionsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\SearchConsole\Connection as SearchConsoleConnection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\YouTube\Connection as YouTubeConnection;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\RequestReviewStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\SiteVerificationMeta;
@@ -203,6 +204,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		OnboardingCompleted::class       => true,
 		ServiceBasedMerchantState::class => true,
 		ServiceBasedMerchantHooks::class => true,
+		SearchConsoleConnection::class   => true,
 	];
 
 	/**
@@ -289,6 +291,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( AdsAccountService::class, AdsAccountState::class );
 		$this->share_with_tags( MerchantAccountService::class, MerchantAccountState::class );
 		$this->share_with_tags( YouTubeConnection::class );
+		$this->share_with_tags( SearchConsoleConnection::class );
 
 		// Inbox Notes
 		$this->share_with_tags( ContactInformationNote::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -67,8 +67,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCen
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\TargetAudienceController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\PriceBenchmarksController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestAPI\AuthController as RestAPIAuthController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\SearchConsole\AccountController as SearchConsoleAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\YouTube\AccountController as YouTubeAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\OAuthService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\SearchConsole\Connection as SearchConsoleConnection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\YouTube\Connection as YouTubeConnection;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
@@ -175,6 +177,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( AdsSettingsController::class );
 		$this->share( ConnectController::class, Middleware::class, OptionsInterface::class );
 		$this->share( YouTubeAccountController::class, YouTubeConnection::class );
+		$this->share( SearchConsoleAccountController::class, SearchConsoleConnection::class );
 		$this->share( OnboardingController::class );
 		$this->share( MarketsController::class, MarketService::class );
 	}

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -42,6 +42,7 @@ interface OptionsInterface {
 	public const MERCHANT_ID                               = 'merchant_id';
 	public const MARKETS                                   = 'markets';
 	public const REDIRECT_TO_ONBOARDING                    = 'redirect_to_onboarding';
+	public const SEARCH_CONSOLE                            = 'search_console';
 	public const SHIPPING_RATES                            = 'shipping_rates';
 	public const SHIPPING_SYNC_FAILURE                     = 'shipping_sync_failure';
 	public const SHIPPING_TIMES                            = 'shipping_times';
@@ -96,6 +97,7 @@ interface OptionsInterface {
 		self::SHIPPING_SYNC_FAILURE                     => true,
 		self::SHIPPING_TIMES                            => true,
 		self::REDIRECT_TO_ONBOARDING                    => true,
+		self::SEARCH_CONSOLE                            => true,
 		self::SITE_VERIFICATION                         => true,
 		self::SYNCABLE_PRODUCTS_COUNT                   => true,
 		self::SYNCABLE_PRODUCTS_COUNT_INTERMEDIATE_DATA => true,

--- a/tests/Unit/API/SearchConsole/ConnectionTest.php
+++ b/tests/Unit/API/SearchConsole/ConnectionTest.php
@@ -1,0 +1,154 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\SearchConsole;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\SearchConsole\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\RequestException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Handler\MockHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Request;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Response;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ConnectionTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\SearchConsole
+ */
+class ConnectionTest extends UnitTest {
+
+	/** @var Container $container */
+	protected $container;
+
+	/** @var Connection $connection */
+	protected $connection;
+
+	protected const CONNECT_SERVER_ROOT = 'https://wcs.example.com/';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->container = new Container();
+		$this->container->add( 'connect_server_root', self::CONNECT_SERVER_ROOT );
+
+		$this->connection = new Connection();
+		$this->connection->set_container( $this->container );
+	}
+
+	public function test_connect_returns_oauth_url_on_success() {
+		$mock_handler = new MockHandler(
+			[
+				new Response( 200, [], wp_json_encode( [ 'oauthUrl' => 'https://accounts.google.com/oauth' ] ) ),
+			]
+		);
+		$handlers     = HandlerStack::create( $mock_handler );
+		$client       = new Client( [ 'handler' => $handlers ] );
+		$this->container->add( Client::class, $client );
+
+		$url = $this->connection->connect( 'https://example.com/return' );
+
+		$this->assertEquals( 'https://accounts.google.com/oauth', $url );
+	}
+
+	public function test_connect_throws_exception_when_oauth_url_missing() {
+		$mock_handler = new MockHandler(
+			[
+				new Response( 200, [], wp_json_encode( [] ) ),
+			]
+		);
+		$handlers     = HandlerStack::create( $mock_handler );
+		$client       = new Client( [ 'handler' => $handlers ] );
+		$this->container->add( Client::class, $client );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Unable to connect Search Console account' );
+
+		$this->connection->connect( 'https://example.com/return' );
+	}
+
+	public function test_connect_throws_exception_on_client_exception() {
+		$mock_handler = new MockHandler(
+			[
+				new RequestException(
+					'Connection timeout',
+					new Request( 'POST', 'https://example.com' )
+				),
+			]
+		);
+		$handlers     = HandlerStack::create( $mock_handler );
+		$client       = new Client( [ 'handler' => $handlers ] );
+		$this->container->add( Client::class, $client );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Unable to connect Search Console account' );
+
+		$this->connection->connect( 'https://example.com/return' );
+	}
+
+	public function test_disconnect_returns_response_body_on_success() {
+		$mock_handler = new MockHandler(
+			[
+				new Response( 200, [], 'disconnected' ),
+			]
+		);
+		$handlers     = HandlerStack::create( $mock_handler );
+		$client       = new Client( [ 'handler' => $handlers ] );
+		$this->container->add( Client::class, $client );
+
+		$this->assertEquals( 'disconnected', $this->connection->disconnect() );
+	}
+
+	public function test_disconnect_returns_error_message_on_client_exception() {
+		$mock_handler = new MockHandler(
+			[
+				new RequestException(
+					'Connection timeout',
+					new Request( 'DELETE', 'https://example.com' )
+				),
+			]
+		);
+		$handlers     = HandlerStack::create( $mock_handler );
+		$client       = new Client( [ 'handler' => $handlers ] );
+		$this->container->add( Client::class, $client );
+
+		$this->assertStringContainsString( 'Connection timeout', $this->connection->disconnect() );
+	}
+
+	public function test_get_status_returns_decoded_response_on_success() {
+		$mock_handler = new MockHandler(
+			[
+				new Response( 200, [], wp_json_encode( [ 'status' => 'connected' ] ) ),
+			]
+		);
+		$handlers     = HandlerStack::create( $mock_handler );
+		$client       = new Client( [ 'handler' => $handlers ] );
+		$this->container->add( Client::class, $client );
+
+		$this->assertEquals( [ 'status' => 'connected' ], $this->connection->get_status() );
+	}
+
+	public function test_get_status_throws_exception_on_client_exception() {
+		$mock_handler = new MockHandler(
+			[
+				new RequestException(
+					'Connection timeout',
+					new Request( 'GET', 'https://example.com' )
+				),
+			]
+		);
+		$handlers     = HandlerStack::create( $mock_handler );
+		$client       = new Client( [ 'handler' => $handlers ] );
+		$this->container->add( Client::class, $client );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Error retrieving status' );
+
+		$this->connection->get_status();
+	}
+}

--- a/tests/Unit/API/SearchConsole/ConnectionTest.php
+++ b/tests/Unit/API/SearchConsole/ConnectionTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\SearchConso
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\SearchConsole\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
@@ -35,6 +36,9 @@ class ConnectionTest extends UnitTest {
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
+	/** @var MockObject|MerchantCenterService $merchant_center */
+	protected $merchant_center;
+
 	protected const CONNECT_SERVER_ROOT = 'https://wcs.example.com/';
 
 	public function setUp(): void {
@@ -43,11 +47,13 @@ class ConnectionTest extends UnitTest {
 		$this->container = new Container();
 		$this->container->add( 'connect_server_root', self::CONNECT_SERVER_ROOT );
 
-		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options         = $this->createMock( OptionsInterface::class );
+		$this->merchant_center = $this->createMock( MerchantCenterService::class );
 
 		$this->connection = new Connection();
 		$this->connection->set_container( $this->container );
 		$this->connection->set_options_object( $this->options );
+		$this->connection->set_merchant_center_object( $this->merchant_center );
 	}
 
 	public function test_connect_returns_oauth_url_on_success() {
@@ -167,6 +173,22 @@ class ConnectionTest extends UnitTest {
 		$this->expectExceptionMessage( 'Error retrieving status' );
 
 		$this->connection->get_status();
+	}
+
+	public function test_should_skip_auth_returns_true_when_merchant_center_connected() {
+		$this->merchant_center->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( true );
+
+		$this->assertTrue( $this->connection->should_skip_auth() );
+	}
+
+	public function test_should_skip_auth_returns_false_when_merchant_center_not_connected() {
+		$this->merchant_center->expects( $this->once() )
+			->method( 'is_connected' )
+			->willReturn( false );
+
+		$this->assertFalse( $this->connection->should_skip_auth() );
 	}
 
 	public function test_get_connection_data_returns_default_when_nothing_stored() {

--- a/tests/Unit/API/SearchConsole/ConnectionTest.php
+++ b/tests/Unit/API/SearchConsole/ConnectionTest.php
@@ -110,6 +110,10 @@ class ConnectionTest extends UnitTest {
 		$client       = new Client( [ 'handler' => $handlers ] );
 		$this->container->add( Client::class, $client );
 
+		$this->options->expects( $this->once() )
+			->method( 'delete' )
+			->with( OptionsInterface::SEARCH_CONSOLE );
+
 		$this->assertEquals( 'disconnected', $this->connection->disconnect() );
 	}
 
@@ -125,6 +129,10 @@ class ConnectionTest extends UnitTest {
 		$handlers     = HandlerStack::create( $mock_handler );
 		$client       = new Client( [ 'handler' => $handlers ] );
 		$this->container->add( Client::class, $client );
+
+		$this->options->expects( $this->once() )
+			->method( 'delete' )
+			->with( OptionsInterface::SEARCH_CONSOLE );
 
 		$this->assertStringContainsString( 'Connection timeout', $this->connection->disconnect() );
 	}

--- a/tests/Unit/API/SearchConsole/ConnectionTest.php
+++ b/tests/Unit/API/SearchConsole/ConnectionTest.php
@@ -382,6 +382,40 @@ class ConnectionTest extends UnitTest {
 		$this->assertEquals( Connection::STATE_CONNECTION_FAILED, $this->connection->get_connection_status()['status'] );
 	}
 
+	public function test_get_connection_status_returns_transient_error_on_server_error_without_persisting_state() {
+		$this->options->method( 'get' )->willReturn(
+			self::default_connection_data( [ 'state' => Connection::STATE_CONNECTED ] )
+		);
+
+		$mock_handler = new MockHandler(
+			[
+				new BadResponseException( 'Service unavailable', new Request( 'GET', 'https://example.com' ), new Response( 503 ) ),
+			]
+		);
+		$this->container->add( Client::class, new Client( [ 'handler' => HandlerStack::create( $mock_handler ) ] ) );
+
+		$this->options->expects( $this->never() )->method( 'update' );
+
+		$this->assertEquals( Connection::STATE_TRANSIENT_ERROR, $this->connection->get_connection_status()['status'] );
+	}
+
+	public function test_get_connection_status_returns_transient_error_on_network_failure_without_persisting_state() {
+		$this->options->method( 'get' )->willReturn(
+			self::default_connection_data( [ 'state' => Connection::STATE_CONNECTED ] )
+		);
+
+		$mock_handler = new MockHandler(
+			[
+				new RequestException( 'Connection timeout', new Request( 'GET', 'https://example.com' ) ),
+			]
+		);
+		$this->container->add( Client::class, new Client( [ 'handler' => HandlerStack::create( $mock_handler ) ] ) );
+
+		$this->options->expects( $this->never() )->method( 'update' );
+
+		$this->assertEquals( Connection::STATE_TRANSIENT_ERROR, $this->connection->get_connection_status()['status'] );
+	}
+
 	/**
 	 * @param array $overrides Fields to override on top of the default connection data shape.
 	 *

--- a/tests/Unit/API/SearchConsole/ConnectionTest.php
+++ b/tests/Unit/API/SearchConsole/ConnectionTest.php
@@ -262,4 +262,118 @@ class ConnectionTest extends UnitTest {
 
 		$this->assertTrue( $this->connection->clear_connection_data() );
 	}
+
+	public function test_get_connection_status_returns_disconnected_when_remote_status_is_not_connected() {
+		$this->options->method( 'get' )->willReturn( self::default_connection_data() );
+
+		$mock_handler = new MockHandler(
+			[
+				new Response( 200, [], wp_json_encode( [ 'status' => 'disconnected' ] ) ),
+			]
+		);
+		$this->container->add( Client::class, new Client( [ 'handler' => HandlerStack::create( $mock_handler ) ] ) );
+
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::SEARCH_CONSOLE, $this->callback( fn( $data ) => Connection::STATE_DISCONNECTED === $data['state'] ) );
+
+		$this->assertEquals( Connection::STATE_DISCONNECTED, $this->connection->get_connection_status()['status'] );
+	}
+
+	public function test_get_connection_status_returns_connected_when_property_is_verified() {
+		$this->options->method( 'get' )->willReturn(
+			self::default_connection_data(
+				[
+					'property' => 'https://example.com/',
+					'verified' => SiteVerification::VERIFICATION_STATUS_VERIFIED,
+				]
+			)
+		);
+
+		$mock_handler = new MockHandler(
+			[
+				new Response( 200, [], wp_json_encode( [ 'status' => 'connected' ] ) ),
+			]
+		);
+		$this->container->add( Client::class, new Client( [ 'handler' => HandlerStack::create( $mock_handler ) ] ) );
+
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::SEARCH_CONSOLE, $this->callback( fn( $data ) => Connection::STATE_CONNECTED === $data['state'] ) );
+
+		$this->assertEquals( Connection::STATE_CONNECTED, $this->connection->get_connection_status()['status'] );
+	}
+
+	public function test_get_connection_status_returns_incomplete_when_no_property_selected_yet() {
+		$this->options->method( 'get' )->willReturn( self::default_connection_data() );
+
+		$mock_handler = new MockHandler(
+			[
+				new Response( 200, [], wp_json_encode( [ 'status' => 'connected' ] ) ),
+			]
+		);
+		$this->container->add( Client::class, new Client( [ 'handler' => HandlerStack::create( $mock_handler ) ] ) );
+
+		$this->assertEquals( Connection::STATE_INCOMPLETE, $this->connection->get_connection_status()['status'] );
+	}
+
+	public function test_get_connection_status_returns_action_needed_when_property_selected_but_not_verified() {
+		$this->options->method( 'get' )->willReturn(
+			self::default_connection_data( [ 'property' => 'https://example.com/' ] )
+		);
+
+		$mock_handler = new MockHandler(
+			[
+				new Response( 200, [], wp_json_encode( [ 'status' => 'connected' ] ) ),
+			]
+		);
+		$this->container->add( Client::class, new Client( [ 'handler' => HandlerStack::create( $mock_handler ) ] ) );
+
+		$this->assertEquals( Connection::STATE_ACTION_NEEDED, $this->connection->get_connection_status()['status'] );
+	}
+
+	public function test_get_connection_status_returns_reconnect_when_previously_connected_and_now_unauthorized() {
+		$this->options->method( 'get' )->willReturn(
+			self::default_connection_data( [ 'state' => Connection::STATE_CONNECTED ] )
+		);
+
+		$mock_handler = new MockHandler(
+			[
+				new RequestException( 'Unauthorized', new Request( 'GET', 'https://example.com' ) ),
+			]
+		);
+		$this->container->add( Client::class, new Client( [ 'handler' => HandlerStack::create( $mock_handler ) ] ) );
+
+		$this->assertEquals( Connection::STATE_RECONNECT, $this->connection->get_connection_status()['status'] );
+	}
+
+	public function test_get_connection_status_returns_connection_failed_when_never_connected_and_status_errors() {
+		$this->options->method( 'get' )->willReturn( self::default_connection_data() );
+
+		$mock_handler = new MockHandler(
+			[
+				new RequestException( 'Unauthorized', new Request( 'GET', 'https://example.com' ) ),
+			]
+		);
+		$this->container->add( Client::class, new Client( [ 'handler' => HandlerStack::create( $mock_handler ) ] ) );
+
+		$this->assertEquals( Connection::STATE_CONNECTION_FAILED, $this->connection->get_connection_status()['status'] );
+	}
+
+	/**
+	 * @param array $overrides Fields to override on top of the default connection data shape.
+	 *
+	 * @return array
+	 */
+	protected static function default_connection_data( array $overrides = [] ): array {
+		return array_merge(
+			[
+				'property'      => null,
+				'property_type' => null,
+				'verified'      => SiteVerification::VERIFICATION_STATUS_UNVERIFIED,
+				'state'         => null,
+			],
+			$overrides
+		);
+	}
 }

--- a/tests/Unit/API/SearchConsole/ConnectionTest.php
+++ b/tests/Unit/API/SearchConsole/ConnectionTest.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterSer
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\BadResponseException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\RequestException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Handler\MockHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
@@ -171,6 +172,27 @@ class ConnectionTest extends UnitTest {
 
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'Error retrieving status' );
+		$this->expectExceptionCode( 0 );
+
+		$this->connection->get_status();
+	}
+
+	public function test_get_status_preserves_http_status_code_on_bad_response_exception() {
+		$mock_handler = new MockHandler(
+			[
+				new BadResponseException(
+					'Unauthorized',
+					new Request( 'GET', 'https://example.com' ),
+					new Response( 401 )
+				),
+			]
+		);
+		$handlers     = HandlerStack::create( $mock_handler );
+		$client       = new Client( [ 'handler' => $handlers ] );
+		$this->container->add( Client::class, $client );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionCode( 401 );
 
 		$this->connection->get_status();
 	}
@@ -339,7 +361,7 @@ class ConnectionTest extends UnitTest {
 
 		$mock_handler = new MockHandler(
 			[
-				new RequestException( 'Unauthorized', new Request( 'GET', 'https://example.com' ) ),
+				new BadResponseException( 'Unauthorized', new Request( 'GET', 'https://example.com' ), new Response( 401 ) ),
 			]
 		);
 		$this->container->add( Client::class, new Client( [ 'handler' => HandlerStack::create( $mock_handler ) ] ) );
@@ -352,7 +374,7 @@ class ConnectionTest extends UnitTest {
 
 		$mock_handler = new MockHandler(
 			[
-				new RequestException( 'Unauthorized', new Request( 'GET', 'https://example.com' ) ),
+				new BadResponseException( 'Forbidden', new Request( 'GET', 'https://example.com' ), new Response( 403 ) ),
 			]
 		);
 		$this->container->add( Client::class, new Client( [ 'handler' => HandlerStack::create( $mock_handler ) ] ) );

--- a/tests/Unit/API/SearchConsole/ConnectionTest.php
+++ b/tests/Unit/API/SearchConsole/ConnectionTest.php
@@ -3,7 +3,9 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\SearchConsole;
 
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\SiteVerification;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\SearchConsole\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\RequestException;
@@ -13,6 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Request;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Response;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -29,6 +32,9 @@ class ConnectionTest extends UnitTest {
 	/** @var Connection $connection */
 	protected $connection;
 
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
 	protected const CONNECT_SERVER_ROOT = 'https://wcs.example.com/';
 
 	public function setUp(): void {
@@ -37,8 +43,11 @@ class ConnectionTest extends UnitTest {
 		$this->container = new Container();
 		$this->container->add( 'connect_server_root', self::CONNECT_SERVER_ROOT );
 
+		$this->options = $this->createMock( OptionsInterface::class );
+
 		$this->connection = new Connection();
 		$this->connection->set_container( $this->container );
+		$this->connection->set_options_object( $this->options );
 	}
 
 	public function test_connect_returns_oauth_url_on_success() {
@@ -150,5 +159,77 @@ class ConnectionTest extends UnitTest {
 		$this->expectExceptionMessage( 'Error retrieving status' );
 
 		$this->connection->get_status();
+	}
+
+	public function test_get_connection_data_returns_default_when_nothing_stored() {
+		$this->options->expects( $this->once() )
+			->method( 'get' )
+			->with( OptionsInterface::SEARCH_CONSOLE, $this->anything() )
+			->willReturnArgument( 1 );
+
+		$this->assertEquals(
+			[
+				'property'      => null,
+				'property_type' => null,
+				'verified'      => SiteVerification::VERIFICATION_STATUS_UNVERIFIED,
+				'state'         => null,
+			],
+			$this->connection->get_connection_data()
+		);
+	}
+
+	public function test_get_connection_data_returns_stored_value() {
+		$stored = [
+			'property'      => 'https://example.com/',
+			'property_type' => 'url_prefix',
+			'verified'      => SiteVerification::VERIFICATION_STATUS_VERIFIED,
+			'state'         => null,
+		];
+
+		$this->options->expects( $this->once() )
+			->method( 'get' )
+			->with( OptionsInterface::SEARCH_CONSOLE, $this->anything() )
+			->willReturn( $stored );
+
+		$this->assertEquals( $stored, $this->connection->get_connection_data() );
+	}
+
+	public function test_update_connection_data_merges_onto_existing_data() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::SEARCH_CONSOLE, $this->anything() )
+			->willReturn(
+				[
+					'property'      => 'https://example.com/',
+					'property_type' => 'url_prefix',
+					'verified'      => SiteVerification::VERIFICATION_STATUS_UNVERIFIED,
+					'state'         => null,
+				]
+			);
+
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				OptionsInterface::SEARCH_CONSOLE,
+				[
+					'property'      => 'https://example.com/',
+					'property_type' => 'url_prefix',
+					'verified'      => SiteVerification::VERIFICATION_STATUS_VERIFIED,
+					'state'         => null,
+				]
+			)
+			->willReturn( true );
+
+		$this->assertTrue(
+			$this->connection->update_connection_data( [ 'verified' => SiteVerification::VERIFICATION_STATUS_VERIFIED ] )
+		);
+	}
+
+	public function test_clear_connection_data_deletes_the_option() {
+		$this->options->expects( $this->once() )
+			->method( 'delete' )
+			->with( OptionsInterface::SEARCH_CONSOLE )
+			->willReturn( true );
+
+		$this->assertTrue( $this->connection->clear_connection_data() );
 	}
 }

--- a/tests/Unit/API/Site/Controllers/SearchConsole/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/SearchConsole/AccountControllerTest.php
@@ -1,0 +1,115 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\SearchConsole;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\SearchConsole\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\SearchConsole\AccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AccountControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\SearchConsole
+ */
+class AccountControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|Connection $connection */
+	protected $connection;
+
+	/** @var AccountController $controller */
+	protected $controller;
+
+	protected const ROUTE_CONNECT    = '/wc/gla/search-console/connect';
+	protected const ROUTE_CONNECTION = '/wc/gla/search-console/connection';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->connection = $this->createMock( Connection::class );
+		$this->controller = new AccountController( $this->server, $this->connection );
+		$this->controller->register();
+	}
+
+	public function test_connect() {
+		$auth_url = 'https://domain.test?auth=1';
+
+		$this->connection->expects( $this->once() )
+			->method( 'connect' )
+			->willReturn( $auth_url );
+
+		$response = $this->do_request( self::ROUTE_CONNECT, 'GET' );
+
+		$this->assertEquals(
+			[
+				'url' => $auth_url,
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_connect_with_error() {
+		$this->connection->expects( $this->once() )
+			->method( 'connect' )
+			->willThrowException( new Exception( 'error', 400 ) );
+
+		$response = $this->do_request( self::ROUTE_CONNECT, 'GET' );
+
+		$this->assertEquals( [ 'message' => 'error' ], $response->get_data() );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_disconnect() {
+		$this->connection->expects( $this->once() )
+			->method( 'disconnect' );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'DELETE' );
+
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully disconnected.',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_connection_connected() {
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturn( [ 'status' => 'connected' ] );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
+
+		$this->assertEquals( [ 'status' => 'connected' ], $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_connection_disconnected() {
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturn( [ 'status' => 'disconnected' ] );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
+
+		$this->assertEquals( [ 'status' => 'disconnected' ], $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_connection_with_error() {
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willThrowException( new Exception( 'error', 400 ) );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
+
+		$this->assertEquals( [ 'message' => 'error' ], $response->get_data() );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/SearchConsole/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/SearchConsole/AccountControllerTest.php
@@ -42,11 +42,16 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			->method( 'connect' )
 			->willReturn( $auth_url );
 
+		$this->connection->expects( $this->once() )
+			->method( 'should_skip_auth' )
+			->willReturn( false );
+
 		$response = $this->do_request( self::ROUTE_CONNECT, 'GET' );
 
 		$this->assertEquals(
 			[
-				'url' => $auth_url,
+				'url'       => $auth_url,
+				'skip_auth' => false,
 			],
 			$response->get_data()
 		);

--- a/tests/Unit/API/Site/Controllers/SearchConsole/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/SearchConsole/AccountControllerTest.php
@@ -87,29 +87,54 @@ class AccountControllerTest extends RESTControllerUnitTest {
 
 	public function test_connection_connected() {
 		$this->connection->expects( $this->once() )
-			->method( 'get_status' )
-			->willReturn( [ 'status' => 'connected' ] );
+			->method( 'get_connection_status' )
+			->willReturn( [ 'status' => Connection::STATE_CONNECTED ] );
 
 		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
 
-		$this->assertEquals( [ 'status' => 'connected' ], $response->get_data() );
+		$this->assertEquals( [ 'status' => Connection::STATE_CONNECTED ], $response->get_data() );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	public function test_connection_disconnected() {
 		$this->connection->expects( $this->once() )
-			->method( 'get_status' )
-			->willReturn( [ 'status' => 'disconnected' ] );
+			->method( 'get_connection_status' )
+			->willReturn( [ 'status' => Connection::STATE_DISCONNECTED ] );
 
 		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
 
-		$this->assertEquals( [ 'status' => 'disconnected' ], $response->get_data() );
+		$this->assertEquals( [ 'status' => Connection::STATE_DISCONNECTED ], $response->get_data() );
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * @dataProvider provide_connection_states
+	 *
+	 * @param string $state The connection state returned by the resolver.
+	 */
+	public function test_connection_exposes_state( string $state ) {
+		$this->connection->expects( $this->once() )
+			->method( 'get_connection_status' )
+			->willReturn( [ 'status' => $state ] );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
+
+		$this->assertEquals( [ 'status' => $state ], $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function provide_connection_states(): array {
+		return [
+			'incomplete'        => [ Connection::STATE_INCOMPLETE ],
+			'action needed'     => [ Connection::STATE_ACTION_NEEDED ],
+			'reconnect'         => [ Connection::STATE_RECONNECT ],
+			'connection failed' => [ Connection::STATE_CONNECTION_FAILED ],
+		];
 	}
 
 	public function test_connection_with_error() {
 		$this->connection->expects( $this->once() )
-			->method( 'get_status' )
+			->method( 'get_connection_status' )
 			->willThrowException( new Exception( 'error', 400 ) );
 
 		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-942/connect-search-console-foundational-connection-flow

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

#### Setup

1. Check out `feature/GOOWOO-942-connect-search-console` and log into wp-admin as an admin or use with `manage_woocommerce` capability to access REST routes.
2. Open any wp-admin page and use the browser console — `wp.apiFetch` should be loaded with the REST nonce, so no Postman/auth setup needed.
3. Have WP-CLI on hand to inspect/seed options:
  - `wp option get gla_search_console --format=json`
  - `wp option get gla_google_connected / gla_mc_setup_completed_at`

#### Test 1 — Auth-skip check

- Run `wp option update gla_google_connected 0` with WP CLI and then make the following request `wp.apiFetch({path:'/wc/gla/search-console/connect'}).then(console.log)`. The expected response should have `skip_auth: false`.
- Run `wp option update gla_google_connected 1` and `wp option update gla_mc_setup_completed_at $(date +%s)` (fakes Merchant Center as connected — no real Google auth needed), repeat the request above. The response should have `skip_auth: true`.

#### Test 2 — Disconnect clears state

- Update the search console option with some data: `wp option update gla_search_console '{"property":"https://example.com/","property_type":"url_prefix","verified":"yes","state":"connected"}' --format=json`
- Run the connection request `wp.apiFetch({path:'/wc/gla/search-console/connection', method:'DELETE'}).then(console.log)`. The response should contain `{status:"success",...}`.
- Run `wp option get gla_search_console`. The  option should be gone (deleted, reverts to defaults on next read).

#### Test 3 — Four-state resolver

**Updated 2026-09-03 — the reconnect/connection-failed part of this test is no longer forceable the way it's written below.** When this was written, `get_connection_status()` decided reconnect vs. connection-failed purely from the locally stored `state` field, so hand-editing `gla_search_console` was enough to simulate either one. GOOWOO-962 (merged after this PR) moved the connection check to the real shared `google/connection/google-mc` endpoint and added a live `has_webmasters_scope` check on top — reconnect/connection-failed is now only reachable via a genuine 401/403 from that real shared connection, which local option edits can't trigger anymore (confirmed via QA on this ticket, 2026-09-02: editing the option and calling the endpoint now just returns `disconnected` regardless of the seeded `state`).

Forcing a real 401/403 would mean actually revoking or expiring a real Google OAuth grant, which isn't a safe or repeatable manual QA step against a shared test account. Agreed with Joe Grainger (2026-09-03) to treat this as sufficiently covered by the existing unit tests instead, rather than build new mock infrastructure or hold the ticket on it — the underlying detection logic reuses this plugin's existing unauthorized-error/reconnect handling (already proven elsewhere), and the one genuinely new piece (telling reconnect and connection-failed apart via connection history) has direct unit coverage. Manual QA for this test should focus on:

- With the `gla_search_console` option cleared/default (from Test 2), call `wp.apiFetch({path:'/wc/gla/search-console/connection'})`. The response should show `disconnected` (no connection has ever been established, or it was explicitly disconnected).
- The reconnect/connection-failed distinction itself: see the unit tests for the two wired connection-state detections, rather than trying to reproduce it manually here.
- The other two states (only reachable with a genuinely live/connected WCS session — not the focus of this ticket, can be skipped in manual QA):
  - Seed `"property":null + real connected session`. Connection shows as incomplete.
  - Seed `"property":"https://example.com/", "verified":"no" + real connected session`. Connection shows action-needed.
  - Seed `"property":"https://example.com/", "verified":"yes" + real connected session`. Connection shows as connected.

#### Pass criteria

- Each call returns the expected status value and a 200 response.
- `gla_search_console` state field updates to match the resolved status after every `GET` (visible via `wp option get gla_search_console`).
- Disconnect always returns the option to its full default shape.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
