### PR TITLE
GOOWOO-955 Channel visibility select alignment

### DIFF
--- a/js/src/meta-boxes/channel-visibility/channel-visibility-settings.js
+++ b/js/src/meta-boxes/channel-visibility/channel-visibility-settings.js
@@ -79,8 +79,8 @@ const ChannelVisibilitySettings = () => {
 		<Flex direction="column" gap={ 4 } className="gla-channel-visibility">
 			<FlexBlock>
 				<Flex gap={ 2 } align="center" justify="flex-start">
-					<FlexBlock>
-						<Flex gap={ 2 } align="center" justify="flex-start">
+					<FlexItem>
+						<Flex gap={ 2 } align="center">
 							<FlexItem>
 								<img
 									className="gla-channel-visibility__logo"
@@ -97,10 +97,10 @@ const ChannelVisibilitySettings = () => {
 								{ __( 'Google', 'google-listings-and-ads' ) }
 							</FlexItem>
 						</Flex>
-					</FlexBlock>
+					</FlexItem>
 
 					{ selectOptions.length > 0 && (
-						<FlexItem>
+						<FlexBlock>
 							<SelectControl
 								name={ fieldId }
 								options={ selectOptions }
@@ -111,7 +111,7 @@ const ChannelVisibilitySettings = () => {
 								disabled={ ! productIsVisible }
 								__nextHasNoMarginBottom
 							/>
-						</FlexItem>
+						</FlexBlock>
 					) }
 				</Flex>
 			</FlexBlock>

--- a/js/src/meta-boxes/channel-visibility/channel-visibility-settings.js
+++ b/js/src/meta-boxes/channel-visibility/channel-visibility-settings.js
@@ -79,8 +79,8 @@ const ChannelVisibilitySettings = () => {
 		<Flex direction="column" gap={ 4 } className="gla-channel-visibility">
 			<FlexBlock>
 				<Flex gap={ 2 } align="center" justify="flex-start">
-					<FlexItem>
-						<Flex gap={ 2 } align="center">
+					<FlexBlock>
+						<Flex gap={ 2 } align="center" justify="flex-start">
 							<FlexItem>
 								<img
 									className="gla-channel-visibility__logo"
@@ -97,10 +97,10 @@ const ChannelVisibilitySettings = () => {
 								{ __( 'Google', 'google-listings-and-ads' ) }
 							</FlexItem>
 						</Flex>
-					</FlexItem>
+					</FlexBlock>
 
 					{ selectOptions.length > 0 && (
-						<FlexBlock>
+						<FlexItem>
 							<SelectControl
 								name={ fieldId }
 								options={ selectOptions }
@@ -111,7 +111,7 @@ const ChannelVisibilitySettings = () => {
 								disabled={ ! productIsVisible }
 								__nextHasNoMarginBottom
 							/>
-						</FlexBlock>
+						</FlexItem>
 					) }
 				</Flex>
 			</FlexBlock>

--- a/js/src/meta-boxes/channel-visibility/channel-visibility-settings.js
+++ b/js/src/meta-boxes/channel-visibility/channel-visibility-settings.js
@@ -80,7 +80,12 @@ const ChannelVisibilitySettings = () => {
 			<FlexBlock>
 				<Flex gap={ 2 } align="center" justify="flex-start">
 					<FlexItem>
-						<Flex gap={ 2 } align="center">
+						<Flex
+							className="gla-channel-visibility__label"
+							align="center"
+							gap={ 2 }
+							justify="flex-start"
+						>
 							<FlexItem>
 								<img
 									className="gla-channel-visibility__logo"

--- a/js/src/meta-boxes/channel-visibility/google-ads-promo.scss
+++ b/js/src/meta-boxes/channel-visibility/google-ads-promo.scss
@@ -1,9 +1,20 @@
+:root {
+	// Single source of truth for the Channel visibility label-column width.
+	// Reddit for WooCommerce's SCSS reads this same property (with a 70px
+	// fallback for when GLA isn't active) so both plugins' rows stay aligned.
+	--gla-channel-visibility-label-width: 70px;
+}
+
 .gla-channel-visibility {
 	padding: $grid-unit-05;
 }
 
 .gla-channel-visibility__logo {
 	display: block;
+}
+
+.gla-channel-visibility__label {
+	min-width: var(--gla-channel-visibility-label-width);
 }
 
 .gla-channel-visibility__title {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-955/apply-channel-visibility-dropdown-alignment-fix-cohabit-mode

Adds css to visually align both Reddit and Google channel visibility settings.


### Screenshots:

<img width="324" height="229" alt="Screenshot 2026-08-18 at 14 01 48" src="https://github.com/user-attachments/assets/9d28e628-320c-4075-aaf5-77038bdf6882" />
<img width="303" height="198" alt="Screenshot 2026-08-18 at 14 02 43" src="https://github.com/user-attachments/assets/081083d6-3721-4805-b013-3075f251c010" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Have both Reddit and Google plugin configured and onboarded
2. Go to a product and in the sidebar both channel visibility settings should be aligned

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Visually align channel visibility settings
