### PR TITLE
[GOOWOO-854] Make the create-market response reliable in flat shipping mode

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/MarketsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/MarketsController.php
@@ -3,10 +3,11 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter;
 
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
@@ -18,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter
  */
-class MarketsController extends BaseController {
+class MarketsController extends BaseOptionsController {
 
 	/**
 	 * @var MarketService
@@ -146,8 +147,13 @@ class MarketsController extends BaseController {
 				$config['exchange_rate'] = $request->get_param( 'exchange_rate' );
 			}
 
+			// A flat market is derived from its country's shipping rows and always takes its
+			// ID from the country, so generating the ID from a submitted feed label would
+			// return an ID that never matches the market the Markets list shows.
+			$id_source = $this->is_flat_shipping_rate() ? $config['country'] : $config['feed_label'];
+
 			try {
-				$id = $this->market_service->generate_market_id( $config['feed_label'] );
+				$id = $this->market_service->generate_market_id( $id_source );
 			} catch ( InvalidValue $e ) {
 				return new Response(
 					[ 'message' => __( 'Cannot create a market with a reserved ID.', 'google-listings-and-ads' ) ],
@@ -166,16 +172,29 @@ class MarketsController extends BaseController {
 			}
 
 			try {
-				$this->market_service->add_market( $id, $config );
+				// The service returns the market as it will be read back, so the response is
+				// complete even in flat shipping mode, where the market is derived from the
+				// country's shipping rows rather than persisted.
+				$created = $this->market_service->add_market( $id, $config );
 			} catch ( InvalidValue $e ) {
 				return new Response( [ 'message' => $e->getMessage() ], 400 );
 			}
 
-			$created       = $this->market_service->get_market( $id );
-			$created['id'] = $id;
-
 			return new Response( $created, 201 );
 		};
+	}
+
+	/**
+	 * Whether the store-wide shipping rate mode is 'flat'.
+	 *
+	 * Read from the same Merchant Center option the settings endpoint writes.
+	 *
+	 * @return bool
+	 */
+	private function is_flat_shipping_rate(): bool {
+		$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+
+		return is_array( $mc_settings ) && 'flat' === ( $mc_settings['shipping_rate'] ?? null );
 	}
 
 	/**

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -199,34 +199,67 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * @return array[] Keyed by market ID ('primary', then secondary IDs).
 	 */
 	public function get_markets(): array {
-		$secondary = $this->get_secondary_markets_source();
-
-		$all_rates       = $this->get_cached_shipping_rates();
-		$all_countries   = $this->wc->get_countries();
-		$is_flat_mode    = $this->is_flat_shipping_rate();
-		$global_shipping = $this->global_shipping_method();
+		$secondary   = $this->get_secondary_markets_source();
+		$live_values = $this->get_live_market_values();
 
 		foreach ( $secondary as &$market ) {
-			$market  = $this->apply_site_locale_when_not_multilingual( $market );
-			$country = $market['country'] ?? null;
-
-			// Overwrite the stored snapshot with the live global shipping method so
-			// no decision is ever made against a stale per-market copy.
-			$market['shipping_rate'] = $global_shipping['shipping_rate'];
-			$market['shipping_time'] = $global_shipping['shipping_time'];
-
-			// DB rate rows are retained when the merchant switches modes so they
-			// can be restored later, so the read boundary has to gate them.
-			$market['free_shipping'] = ( $is_flat_mode && $country && isset( $all_rates[ $country ]['free_shipping_threshold'] ) )
-				? (float) $all_rates[ $country ]['free_shipping_threshold']
-				: null;
-
-			$market['countries'] = $country ? [ $country ] : [];
-			$market['label']     = $country ? ( $all_countries[ $country ] ?? null ) : null;
+			$market = $this->apply_live_values_to_market( $market, $live_values );
 		}
 		unset( $market );
 
 		return [ 'primary' => $this->get_primary_market() ] + $secondary;
+	}
+
+	/**
+	 * Gathers the store-wide values a market needs to be completed for reading.
+	 *
+	 * These are read fresh rather than taken from a market's stored copy, and read
+	 * once per call so apply_live_values_to_market() can complete one market or every
+	 * market without repeating the same option and table reads. The shipping rates
+	 * are only read in flat mode, the only mode that reports a free shipping
+	 * threshold from them.
+	 *
+	 * @return array{rates: array, countries: array, is_flat_mode: bool, global_shipping: array}
+	 */
+	private function get_live_market_values(): array {
+		$is_flat_mode = $this->is_flat_shipping_rate();
+
+		return [
+			'rates'           => $is_flat_mode ? $this->get_cached_shipping_rates() : [],
+			'countries'       => $this->wc->get_countries(),
+			'is_flat_mode'    => $is_flat_mode,
+			'global_shipping' => $this->global_shipping_method(),
+		];
+	}
+
+	/**
+	 * Completes a secondary market for reading: masked locale, the live shipping
+	 * method, the free shipping threshold, the country list and the label.
+	 *
+	 * @param array $market      The market config.
+	 * @param array $live_values The values from get_live_market_values().
+	 *
+	 * @return array The completed market.
+	 */
+	private function apply_live_values_to_market( array $market, array $live_values ): array {
+		$market  = $this->apply_site_locale_when_not_multilingual( $market );
+		$country = $market['country'] ?? null;
+
+		// Overwrite the stored snapshot with the live global shipping method so
+		// no decision is ever made against a stale per-market copy.
+		$market['shipping_rate'] = $live_values['global_shipping']['shipping_rate'];
+		$market['shipping_time'] = $live_values['global_shipping']['shipping_time'];
+
+		// DB rate rows are retained when the merchant switches modes so they
+		// can be restored later, so the read boundary has to gate them.
+		$market['free_shipping'] = ( $live_values['is_flat_mode'] && $country && isset( $live_values['rates'][ $country ]['free_shipping_threshold'] ) )
+			? (float) $live_values['rates'][ $country ]['free_shipping_threshold']
+			: null;
+
+		$market['countries'] = $country ? [ $country ] : [];
+		$market['label']     = $country ? ( $live_values['countries'][ $country ] ?? null ) : null;
+
+		return $market;
 	}
 
 	/**
@@ -500,17 +533,31 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 				continue;
 			}
 
-			$id = $this->generate_market_id( $country );
-
-			$markets[ $id ] = [
-				'country'    => $country,
-				'feed_label' => strtoupper( $country ),
-				'language'   => [ $this->get_site_primary_language() ],
-				'currency'   => [ $this->get_site_primary_currency() ],
-			];
+			$markets[ $this->generate_market_id( $country ) ] = $this->build_derived_flat_market( $country );
 		}
 
 		return $markets;
+	}
+
+	/**
+	 * Builds the derived market entry for one flat-rate country.
+	 *
+	 * Flat markets have no language or currency of their own (those fields are not
+	 * offered for flat rate) so the site defaults are attached, and the feed label is
+	 * always the country code. Shared with add_market() so a market created through
+	 * the REST API is described exactly as the Markets list will describe it.
+	 *
+	 * @param string $country ISO 3166-1 alpha-2 country code.
+	 *
+	 * @return array
+	 */
+	private function build_derived_flat_market( string $country ): array {
+		return [
+			'country'    => $country,
+			'feed_label' => strtoupper( $country ),
+			'language'   => [ $this->get_site_primary_language() ],
+			'currency'   => [ $this->get_site_primary_currency() ],
+		];
 	}
 
 	/**
@@ -635,9 +682,11 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * @param string $id
 	 * @param array  $config
 	 *
+	 * @return array The created market as it will be read back, including its `id`.
+	 *
 	 * @throws InvalidValue When $id is 'primary' or $config is invalid.
 	 */
-	public function add_market( string $id, array $config ): void {
+	public function add_market( string $id, array $config ): array {
 		if ( 'primary' === $id ) {
 			throw new InvalidValue(
 				sprintf( 'The market ID "%s" is reserved and cannot be added.', $id )
@@ -657,6 +706,16 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			$this->restore_country_to_target_audience( $country );
 			$this->extend_shipping_to_country( $country );
 
+			// Built after the rows are seeded: extend_shipping_to_country() clears the rate
+			// cache, so the market carries the rate, time and free shipping threshold the
+			// country now has. That is the values copied from the primary market when it had
+			// no rows of its own, or its own values when it already had rows that differ.
+			$created       = $this->apply_live_values_to_market(
+				$this->build_derived_flat_market( $country ),
+				$this->get_live_market_values()
+			);
+			$created['id'] = $id;
+
 			if ( $this->global_shipping_is_syncable() ) {
 				$this->schedule_shipping_sync();
 			}
@@ -664,9 +723,9 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 			$this->job_repository->get( UpdateAllProducts::class )->schedule();
 
 			/** This action is documented in this method's persisted-market branch below. */
-			do_action( 'woocommerce_gla_market_added', $id, array_merge( $config, $this->global_shipping_method() ) );
+			do_action( 'woocommerce_gla_market_added', $id, $created );
 
-			return;
+			return $created;
 		}
 
 		$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
@@ -709,14 +768,20 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 		$this->job_repository->get( UpdateAllProducts::class )->schedule();
 
+		$created       = $this->apply_live_values_to_market( $config, $this->get_live_market_values() );
+		$created['id'] = $id;
+
 		/**
 		 * Fires after a secondary market is successfully added.
 		 *
 		 * @param string $id     The market ID.
-		 * @param array  $config The market configuration as persisted. The shipping_rate/shipping_time
-		 *                       reflect the current global shipping method (see get_markets()).
+		 * @param array  $market The created market as it will be read back (see get_markets()),
+		 *                       so the shipping method, language and currency are the ones the
+		 *                       store will actually use rather than the submitted values.
 		 */
-		do_action( 'woocommerce_gla_market_added', $id, array_merge( $config, $this->global_shipping_method() ) );
+		do_action( 'woocommerce_gla_market_added', $id, $created );
+
+		return $created;
 	}
 
 	/**

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/MarketsControllerTest.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\MarketsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -23,6 +24,12 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 
 	/** @var MockObject|MarketService */
 	protected $market_service;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var array The Merchant Center option the controller reads the shipping method from. */
+	protected $merchant_center_settings;
 
 	protected const ROUTE_MARKETS              = '/wc/gla/mc/markets';
 	protected const ROUTE_LANGUAGES_CURRENCIES = '/wc/gla/mc/markets/languages-currencies';
@@ -63,7 +70,26 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			]
 		);
 
+		// The create endpoint reads the store-wide shipping method from this option to decide
+		// how a market ID is derived. Flat rate is the mode that derives the ID from the
+		// country, so tests for that set this to flat before making a request.
+		$this->merchant_center_settings = [
+			'shipping_rate' => 'automatic',
+			'shipping_time' => 'flat',
+		];
+
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get' )
+			->willReturnCallback(
+				function ( $key, $fallback = null ) {
+					return OptionsInterface::MERCHANT_CENTER === $key
+						? $this->merchant_center_settings
+						: $fallback;
+				}
+			);
+
 		$this->controller = new MarketsController( $this->server, $this->market_service );
+		$this->controller->set_options_object( $this->options );
 		$this->controller->register();
 	}
 
@@ -203,26 +229,10 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'free_shipping' => null,
 		];
 
-		$created = false;
-
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'de' );
 
 		$this->market_service->method( 'add_market' )
-			->willReturnCallback(
-				function () use ( &$created ) {
-					$created = true;
-				}
-			);
-
-		$this->market_service->method( 'get_market' )
-			->willReturnCallback(
-				function ( string $id ) use ( &$created, $created_market ) {
-					if ( 'de' === $id && $created ) {
-						return $created_market;
-					}
-					return null;
-				}
-			);
+			->willReturn( $created_market + [ 'id' => 'de' ] );
 
 		$response = $this->do_request(
 			self::ROUTE_MARKETS,
@@ -267,8 +277,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'free_shipping' => null,
 		];
 
-		$created = false;
-
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
 
 		$this->market_service->method( 'add_market' )
@@ -282,21 +290,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 					}
 				)
 			)
-			->willReturnCallback(
-				function () use ( &$created ) {
-					$created = true;
-				}
-			);
-
-		$this->market_service->method( 'get_market' )
-			->willReturnCallback(
-				function ( string $id ) use ( &$created, $created_market ) {
-					if ( 'gb' === $id && $created ) {
-						return $created_market;
-					}
-					return null;
-				}
-			);
+			->willReturn( $created_market + [ 'id' => 'gb' ] );
 
 		$response = $this->do_request(
 			self::ROUTE_MARKETS,
@@ -310,8 +304,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_post_market_with_empty_language_currency_arrays_passes_empty_arrays(): void {
-		$created = false;
-
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
 
 		$this->market_service->method( 'add_market' )
@@ -325,20 +317,11 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 					}
 				)
 			)
-			->willReturnCallback(
-				function () use ( &$created ) {
-					$created = true;
-				}
-			);
-
-		$this->market_service->method( 'get_market' )
-			->willReturnCallback(
-				function ( string $id ) use ( &$created ) {
-					if ( 'gb' === $id && $created ) {
-						return [ 'country' => 'GB' ];
-					}
-					return null;
-				}
+			->willReturn(
+				[
+					'id'      => 'gb',
+					'country' => 'GB',
+				]
 			);
 
 		$response = $this->do_request(
@@ -352,6 +335,124 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 		);
 
 		$this->assertEquals( 201, $response->get_status() );
+	}
+
+	public function test_post_market_flat_mode_derives_id_from_country_not_feed_label(): void {
+		$this->merchant_center_settings = [
+			'shipping_rate' => 'flat',
+			'shipping_time' => 'flat',
+		];
+
+		$id_source = null;
+		$this->market_service->method( 'generate_market_id' )
+			->willReturnCallback(
+				function ( string $source ) use ( &$id_source ) {
+					$id_source = $source;
+					return 'cm';
+				}
+			);
+
+		$this->market_service->method( 'add_market' )->willReturn(
+			[
+				'id'         => 'cm',
+				'country'    => 'CM',
+				'feed_label' => 'CM',
+			]
+		);
+
+		$response = $this->do_request(
+			self::ROUTE_MARKETS,
+			'POST',
+			[
+				'country'    => 'CM',
+				'feed_label' => 'MYLABEL',
+			]
+		);
+
+		// A flat market always takes its ID from the country, so the submitted label cannot
+		// produce an ID that differs from the market the Markets list shows.
+		$this->assertSame( 'CM', $id_source );
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertSame( 'cm', $response->get_data()['id'] );
+		$this->assertSame( 'CM', $response->get_data()['feed_label'] );
+	}
+
+	public function test_post_market_non_flat_mode_derives_id_from_feed_label(): void {
+		$id_source = null;
+		$this->market_service->method( 'generate_market_id' )
+			->willReturnCallback(
+				function ( string $source ) use ( &$id_source ) {
+					$id_source = $source;
+					return 'mylabel';
+				}
+			);
+
+		$this->market_service->method( 'add_market' )->willReturn( [ 'id' => 'mylabel' ] );
+
+		$response = $this->do_request(
+			self::ROUTE_MARKETS,
+			'POST',
+			[
+				'country'    => 'CM',
+				'feed_label' => 'MYLABEL',
+			]
+		);
+
+		$this->assertSame( 'MYLABEL', $id_source );
+		$this->assertEquals( 201, $response->get_status() );
+	}
+
+	public function test_post_market_body_is_the_market_returned_by_the_service(): void {
+		$this->merchant_center_settings = [
+			'shipping_rate' => 'flat',
+			'shipping_time' => 'flat',
+		];
+
+		$created_market = [
+			'id'            => 'cm',
+			'country'       => 'CM',
+			'countries'     => [ 'CM' ],
+			'label'         => 'Cameroon',
+			'language'      => [ 'en' ],
+			'currency'      => [ 'USD' ],
+			'feed_label'    => 'CM',
+			'shipping_rate' => 'flat',
+			'shipping_time' => 'flat',
+			'free_shipping' => 44.0,
+		];
+
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'cm' );
+		$this->market_service->method( 'add_market' )->willReturn( $created_market );
+
+		$response = $this->do_request( self::ROUTE_MARKETS, 'POST', [ 'country' => 'CM' ] );
+
+		// Complete regardless of whether the merchant has saved the country's shipping values,
+		// because the service builds it rather than reading back a market that may not exist yet.
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertSame( $created_market, $response->get_data() );
+	}
+
+	public function test_post_market_flat_mode_country_in_primary_market_returns_201(): void {
+		$this->merchant_center_settings = [
+			'shipping_rate' => 'flat',
+			'shipping_time' => 'flat',
+		];
+
+		// A country that is currently part of the primary market has no market of its own, so
+		// there is nothing to conflict with and it is created and returned as derived.
+		$this->market_service->method( 'generate_market_id' )->willReturn( 'cm' );
+		$this->market_service->method( 'get_market' )->willReturn( null );
+		$this->market_service->method( 'add_market' )->willReturn(
+			[
+				'id'      => 'cm',
+				'country' => 'CM',
+			]
+		);
+
+		$response = $this->do_request( self::ROUTE_MARKETS, 'POST', [ 'country' => 'CM' ] );
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertSame( 'CM', $response->get_data()['country'] );
 	}
 
 	public function test_post_market_returns_400_when_add_market_throws_invalid_value(): void {
@@ -625,26 +726,10 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'free_shipping' => null,
 		];
 
-		$created = false;
-
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'jp' );
 
 		$this->market_service->method( 'add_market' )
-			->willReturnCallback(
-				function () use ( &$created ) {
-					$created = true;
-				}
-			);
-
-		$this->market_service->method( 'get_market' )
-			->willReturnCallback(
-				function ( string $id ) use ( &$created, $created_market ) {
-					if ( 'jp' === $id && $created ) {
-						return $created_market;
-					}
-					return null;
-				}
-			);
+			->willReturn( $created_market + [ 'id' => 'jp' ] );
 
 		$response = $this->do_request(
 			self::ROUTE_MARKETS,
@@ -728,26 +813,10 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'free_shipping' => null,
 		];
 
-		$created = false;
-
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'ch' );
 
 		$this->market_service->method( 'add_market' )
-			->willReturnCallback(
-				function () use ( &$created ) {
-					$created = true;
-				}
-			);
-
-		$this->market_service->method( 'get_market' )
-			->willReturnCallback(
-				function ( string $id ) use ( &$created, $created_market ) {
-					if ( 'ch' === $id && $created ) {
-						return $created_market;
-					}
-					return null;
-				}
-			);
+			->willReturn( $created_market + [ 'id' => 'ch' ] );
 
 		$response = $this->do_request(
 			self::ROUTE_MARKETS,
@@ -774,26 +843,10 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'free_shipping' => null,
 		];
 
-		$created = false;
-
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'ch' );
 
 		$this->market_service->method( 'add_market' )
-			->willReturnCallback(
-				function () use ( &$created ) {
-					$created = true;
-				}
-			);
-
-		$this->market_service->method( 'get_market' )
-			->willReturnCallback(
-				function ( string $id ) use ( &$created, $created_market ) {
-					if ( 'ch' === $id && $created ) {
-						return $created_market;
-					}
-					return null;
-				}
-			);
+			->willReturn( $created_market + [ 'id' => 'ch' ] );
 
 		$response = $this->do_request(
 			self::ROUTE_MARKETS,
@@ -834,21 +887,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 					}
 				)
 			)
-			->willReturnCallback(
-				function () use ( &$created ) {
-					$created = true;
-				}
-			);
-
-		$this->market_service->method( 'get_market' )
-			->willReturnCallback(
-				function ( string $id ) use ( &$created, $created_market ) {
-					if ( 'gb-en' === $id && $created ) {
-						return $created_market;
-					}
-					return null;
-				}
-			);
+			->willReturn( $created_market + [ 'id' => 'gb-en' ] );
 
 		$response = $this->do_request(
 			self::ROUTE_MARKETS,
@@ -868,8 +907,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_post_market_falls_back_to_country_when_feed_label_absent(): void {
-		$created = false;
-
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'gb' );
 
 		$this->market_service->method( 'add_market' )
@@ -882,23 +919,12 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 					}
 				)
 			)
-			->willReturnCallback(
-				function () use ( &$created ) {
-					$created = true;
-				}
-			);
-
-		$this->market_service->method( 'get_market' )
-			->willReturnCallback(
-				function ( string $id ) use ( &$created ) {
-					if ( 'gb' === $id && $created ) {
-						return [
-							'country'    => 'GB',
-							'feed_label' => 'GB',
-						];
-					}
-					return null;
-				}
+			->willReturn(
+				[
+					'id'         => 'gb',
+					'country'    => 'GB',
+					'feed_label' => 'GB',
+				]
 			);
 
 		$response = $this->do_request(
@@ -980,8 +1006,6 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 			'free_shipping' => null,
 		];
 
-		$created = false;
-
 		$this->market_service->method( 'generate_market_id' )->willReturn( 'de' );
 
 		$this->market_service->expects( $this->once() )
@@ -995,21 +1019,7 @@ class MarketsControllerTest extends RESTControllerUnitTest {
 					}
 				)
 			)
-			->willReturnCallback(
-				function () use ( &$created ) {
-					$created = true;
-				}
-			);
-
-		$this->market_service->method( 'get_market' )
-			->willReturnCallback(
-				function ( string $id ) use ( &$created, $created_market ) {
-					if ( 'de' === $id && $created ) {
-						return $created_market;
-					}
-					return null;
-				}
-			);
+			->willReturn( $created_market + [ 'id' => 'de' ] );
 
 		$response = $this->do_request(
 			self::ROUTE_MARKETS,

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -528,6 +528,194 @@ class MarketServiceTest extends UnitTest {
 		$this->assertTrue( $update_calls[ OptionsInterface::MARKETS ]['gb']['was_in_primary'] );
 	}
 
+	public function test_add_market_flat_restores_country_seeds_shipping_and_schedules_jobs(): void {
+		$rate_rows = [
+			[
+				'id'       => 1,
+				'country'  => 'MU',
+				'currency' => 'USD',
+				'rate'     => '77',
+				'options'  => [ 'free_shipping_threshold' => 44.0 ],
+			],
+		];
+		$time_rows = [
+			[
+				'id'       => 1,
+				'country'  => 'MU',
+				'time'     => '7',
+				'max_time' => '14',
+			],
+		];
+
+		$this->set_up_flat_market_dependencies( [ 'MU' ], $rate_rows, $time_rows );
+
+		$target_countries = null;
+		$this->options->method( 'update' )
+			->willReturnCallback(
+				function ( $key, $value ) use ( &$target_countries ) {
+					if ( OptionsInterface::TARGET_AUDIENCE === $key ) {
+						$target_countries = $value['countries'] ?? null;
+					}
+					return true;
+				}
+			);
+
+		$this->update_all_products_job->expects( $this->once() )->method( 'schedule' );
+		$this->shipping_settings_job->expects( $this->once() )->method( 'schedule' );
+
+		$fired_count   = 0;
+		$captured_id   = null;
+		$captured_hook = null;
+		add_action(
+			'woocommerce_gla_market_added',
+			function ( $id, $market ) use ( &$fired_count, &$captured_id, &$captured_hook ) {
+				++$fired_count;
+				$captured_id   = $id;
+				$captured_hook = $market;
+			},
+			10,
+			2
+		);
+
+		$this->market_service->add_market( 'cm', [ 'country' => 'CM' ] );
+
+		// The country joins the target audience: a flat market is derived from a targeted country.
+		$this->assertSame( [ 'MU', 'CM' ], $target_countries );
+
+		// A flat market is never persisted, so its shipping rows are seeded from the primary
+		// market instead, giving the merchant editable values to start from.
+		$this->assertSame(
+			[
+				'country'  => 'CM',
+				'currency' => 'USD',
+				'rate'     => '77',
+				'options'  => [ 'free_shipping_threshold' => 44.0 ],
+			],
+			array_intersect_key( $rate_rows[1], array_flip( [ 'country', 'currency', 'rate', 'options' ] ) )
+		);
+		$this->assertSame(
+			[
+				'country'  => 'CM',
+				'time'     => '7',
+				'max_time' => '14',
+			],
+			array_intersect_key( $time_rows[1], array_flip( [ 'country', 'time', 'max_time' ] ) )
+		);
+
+		// The action reports the derived market, not the submitted config.
+		$this->assertSame( 1, $fired_count );
+		$this->assertSame( 'cm', $captured_id );
+		$this->assertSame( 'cm', $captured_hook['id'] );
+		$this->assertSame( 'CM', $captured_hook['feed_label'] );
+		$this->assertSame( 'flat', $captured_hook['shipping_rate'] );
+	}
+
+	public function test_add_market_flat_returns_full_market_seeded_from_primary(): void {
+		$rate_rows = [
+			[
+				'id'       => 1,
+				'country'  => 'MU',
+				'currency' => 'USD',
+				'rate'     => '77',
+				'options'  => [ 'free_shipping_threshold' => 44.0 ],
+			],
+		];
+		$time_rows = [
+			[
+				'id'       => 1,
+				'country'  => 'MU',
+				'time'     => '7',
+				'max_time' => '14',
+			],
+		];
+
+		$this->set_up_flat_market_dependencies( [ 'MU', 'CM' ], $rate_rows, $time_rows );
+
+		$created = $this->market_service->add_market( 'cm', [ 'country' => 'CM' ] );
+		$primary = $this->market_service->get_primary_market();
+
+		// Complete without the merchant having saved any shipping values of their own,
+		// with the seeded values copied from the primary market.
+		$this->assertSame( 'cm', $created['id'] );
+		$this->assertSame( 'CM', $created['country'] );
+		$this->assertSame( [ 'CM' ], $created['countries'] );
+		$this->assertSame( 'Cameroon', $created['label'] );
+		$this->assertSame( 'CM', $created['feed_label'] );
+		$this->assertSame( 'flat', $created['shipping_rate'] );
+		$this->assertSame( 'flat', $created['shipping_time'] );
+		$this->assertSame( 44.0, $created['free_shipping'] );
+
+		// Flat markets carry no locale of their own, so they use the site defaults.
+		$this->assertSame( $primary['language'], $created['language'] );
+		$this->assertSame( $primary['currency'], $created['currency'] );
+	}
+
+	public function test_add_market_flat_keeps_the_countrys_own_shipping_rows(): void {
+		$rate_rows = [
+			[
+				'id'       => 1,
+				'country'  => 'MU',
+				'currency' => 'USD',
+				'rate'     => '77',
+				'options'  => [ 'free_shipping_threshold' => 44.0 ],
+			],
+			[
+				'id'       => 2,
+				'country'  => 'CM',
+				'currency' => 'USD',
+				'rate'     => '55',
+				'options'  => [ 'free_shipping_threshold' => 10.0 ],
+			],
+		];
+		$time_rows = [
+			[
+				'id'       => 1,
+				'country'  => 'MU',
+				'time'     => '7',
+				'max_time' => '14',
+			],
+			[
+				'id'       => 2,
+				'country'  => 'CM',
+				'time'     => '1',
+				'max_time' => '5',
+			],
+		];
+
+		$this->set_up_flat_market_dependencies( [ 'MU', 'CM' ], $rate_rows, $time_rows );
+
+		// Rows already exist for the country, so they are never written over.
+		$this->shipping_rate_query->expects( $this->never() )->method( 'update' );
+		$this->shipping_time_query->expects( $this->never() )->method( 'update' );
+
+		$created = $this->market_service->add_market( 'cm', [ 'country' => 'CM' ] );
+
+		// The response reports the country's own values, not the primary market's.
+		$this->assertSame( 10.0, $created['free_shipping'] );
+		$this->assertSame( 'CM', $created['feed_label'] );
+
+		// Nothing was seeded on top of the existing rows.
+		$this->assertCount( 2, $rate_rows );
+		$this->assertCount( 2, $time_rows );
+		$this->assertSame( '55', $rate_rows[1]['rate'] );
+		$this->assertSame( '1', $time_rows[1]['time'] );
+	}
+
+	public function test_add_market_flat_throws_when_country_is_empty(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+			]
+		);
+
+		$this->expectException( InvalidValue::class );
+
+		$this->market_service->add_market( 'cm', [ 'country' => '' ] );
+	}
+
 	public function test_flat_derives_country_with_distinct_shipping_as_secondary_market(): void {
 		$this->set_up_options_get(
 			[
@@ -2205,6 +2393,9 @@ class MarketServiceTest extends UnitTest {
 		);
 		$this->options->method( 'update' )->willReturn( true );
 
+		// Flat mode, so the created market is completed from the shipping tables.
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturn( [] );
+
 		$this->cleanup_job->expects( $this->never() )
 			->method( 'schedule' );
 
@@ -3854,7 +4045,17 @@ class MarketServiceTest extends UnitTest {
 	 * makes the count expectation unreliable.
 	 */
 	public function test_shipping_rates_fetched_once_across_multiple_get_markets_calls(): void {
-		$this->set_up_options_get( [ OptionsInterface::MARKETS => [] ] );
+		// Flat rate: the only mode that reads the shipping rates for a market's free
+		// shipping threshold, so the only mode where there is a fetch to cache.
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MARKETS         => [],
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+			]
+		);
 
 		$this->target_audience->method( 'get_main_target_country' )->willReturn( 'US' );
 		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US' ] );
@@ -4048,11 +4249,23 @@ class MarketServiceTest extends UnitTest {
 
 		$this->assertSame( 1, $fired_count );
 		$this->assertSame( 'gb', $captured_id );
-		$this->assertSame( $persisted_markets['gb'], $captured_config );
+
+		// The market was persisted as submitted.
+		$this->assertSame( [ 'GBP' ], $persisted_markets['gb']['currency'] );
+
+		// The action reports the market as it will be read back, so a listener sees the
+		// values the store will use: the live shipping method, the country's list and
+		// label, and the store currency, since without a multilingual integration the
+		// submitted GBP cannot be produced.
+		$this->assertSame( 'gb', $captured_config['id'] );
+		$this->assertSame( 'GB', $captured_config['country'] );
+		$this->assertSame( [ 'GB' ], $captured_config['countries'] );
+		$this->assertSame( 'GB', $captured_config['feed_label'] );
 		$this->assertSame( 'automatic', $captured_config['shipping_rate'] );
 		$this->assertSame( 'automatic', $captured_config['shipping_time'] );
-		$this->assertSame( [ 'en' ], $captured_config['language'] );
-		$this->assertSame( [ 'GBP' ], $captured_config['currency'] );
+		$this->assertSame( [ substr( get_locale(), 0, 2 ) ], $captured_config['language'] );
+		$this->assertSame( [ get_woocommerce_currency() ], $captured_config['currency'] );
+		$this->assertNull( $captured_config['free_shipping'] );
 	}
 
 	public function test_add_market_does_not_fire_market_added_hook_when_id_is_primary(): void {
@@ -5593,5 +5806,95 @@ class MarketServiceTest extends UnitTest {
 			->willReturn( $shipping_rates );
 		$this->wc->method( 'get_countries' )
 			->willReturn( $country_names );
+	}
+
+	/**
+	 * Sets up a flat-rate store whose shipping tables behave like the real ones: rows
+	 * inserted during the call are visible to the reads that follow it.
+	 *
+	 * The first target country is the main one. Both row arrays are taken by reference so
+	 * a test can assert on what the call wrote.
+	 *
+	 * @param string[] $target_countries The target audience countries.
+	 * @param array    $rate_rows        Shipping rate rows, as ShippingRateQuery::get_results() returns them.
+	 * @param array    $time_rows        Shipping time rows, as ShippingTimeQuery::get_results() returns them.
+	 */
+	private function set_up_flat_market_dependencies(
+		array $target_countries,
+		array &$rate_rows,
+		array &$time_rows
+	): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'flat',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::TARGET_AUDIENCE => [
+					'location'  => 'selected',
+					'countries' => $target_countries,
+				],
+			]
+		);
+
+		$this->target_audience->method( 'get_main_target_country' )->willReturn( $target_countries[0] );
+		$this->target_audience->method( 'get_target_countries' )->willReturn( $target_countries );
+		$this->wc->method( 'get_countries' )->willReturn(
+			[
+				'MU' => 'Mauritius',
+				'CM' => 'Cameroon',
+			]
+		);
+
+		$this->shipping_rate_query->method( 'get_results' )->willReturnCallback(
+			function () use ( &$rate_rows ) {
+				return $rate_rows;
+			}
+		);
+		$this->shipping_time_query->method( 'get_results' )->willReturnCallback(
+			function () use ( &$time_rows ) {
+				return $time_rows;
+			}
+		);
+
+		$this->shipping_rate_query->method( 'insert' )->willReturnCallback(
+			function ( array $data ) use ( &$rate_rows ) {
+				$id          = count( $rate_rows ) + 1;
+				$rate_rows[] = $data + [ 'id' => $id ];
+				return $id;
+			}
+		);
+		$this->shipping_time_query->method( 'insert' )->willReturnCallback(
+			function ( array $data ) use ( &$time_rows ) {
+				$id          = count( $time_rows ) + 1;
+				$time_rows[] = $data + [ 'id' => $id ];
+				return $id;
+			}
+		);
+
+		$this->shipping_rate_query->method( 'get_all_shipping_rates' )->willReturnCallback(
+			function () use ( &$rate_rows ) {
+				$rates = [];
+				foreach ( $rate_rows as $row ) {
+					$rates[ $row['country'] ] = [ 'rate' => $row['rate'] ];
+					if ( isset( $row['options']['free_shipping_threshold'] ) ) {
+						$rates[ $row['country'] ]['free_shipping_threshold'] = $row['options']['free_shipping_threshold'];
+					}
+				}
+				return $rates;
+			}
+		);
+		$this->shipping_time_query->method( 'get_all_shipping_times' )->willReturnCallback(
+			function () use ( &$time_rows ) {
+				$times = [];
+				foreach ( $time_rows as $row ) {
+					$times[ $row['country'] ] = [
+						'time'     => $row['time'],
+						'max_time' => $row['max_time'],
+					];
+				}
+				return $times;
+			}
+		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-854/make-the-create-market-response-reliable-in-flat-shipping-mode

### Screenshots:

N/A

### Detailed test instructions:

Before you start you need:
- A WooCommerce store you control, with at least three published, purchasable products.
- Connected Google Merchant Centre account
- At least three countries chosen as your target audience. Your main country is your store's base country if that country is one of the ones you targeted, and otherwise it is the first country in your list. Note which country it is, because several checks below compare against it.
- In the WordPress admin go to Marketing, then Google for WooCommerce, then Settings. In the "Shipping rates" section choose "My shipping settings are simple. I can manually estimate flat shipping rates." The choice saves on its own, so wait for the saving activity to finish.
- Go to Marketing, then Google for WooCommerce, then Markets. You should see a single row, the primary market, listing all the countries you targeted. Note the rate, the delivery times and any free shipping amount shown on that row, because later steps compare against them.

When reporting a problem, include your store's base country, the countries you targeted, and the values you typed in.

**Test 1: create a market with its own shipping values**

1. On the Markets page select "Add market".
2. In the "Market" dropdown choose one of your targeted countries that is not your main country.
3. In "Estimated shipping rates" enter a rate that is different from the one on the primary market row.
4. A free shipping option appears once the rate is above zero. Tick it and enter an amount.
5. In "Estimated shipping times" enter a minimum and a maximum number of days that differ from the primary market row's.
6. Select "Add market".

Expected: the window closes and no error notice appears. The Markets table now has a second row for the country you chose, showing the rate, the delivery times and the free shipping amount you entered. That country is no longer listed on the primary market row.

**Test 2: check the reply the browser receives**

This is the check that proves the fix. Use a targeted country you have not used yet.

1. On the Markets page open your browser's developer tools (F12 in Chrome, Firefox and Edge) and select the "Network" tab. Leave it open.
2. In the filter box inside that tab, type: markets
3. Select "Add market" and fill the form in as you did in test 1, with values that differ from the primary market row, then submit it.
4. In the list of network entries, find the entry named "markets" whose method is POST. Select it, then select its "Response" tab.

Expected: the response describes the whole market, not just an identifier. It should include the country you chose, a feed label which is the country's two letter code in capitals, a language, a currency, a shipping rate, a shipping time, the free shipping amount if you set one, and an identifier which is that same two letter country code in lower case. If the response contains an identifier and nothing else, the fix is not working.

**Test 3: create a market whose shipping matches the primary market**

1. Select "Add market" and choose another targeted country that is not your main country.
2. Enter exactly the same rate, free shipping amount and delivery times as the primary market row shows.
3. Select "Add market".

Expected: no error notice, and no new row appears. The country stays inside the primary market. This is intended behaviour, because a country only becomes a market of its own when its shipping differs from the main country's. What you are checking is that nothing breaks: no duplicate row, no error, and the primary market row still lists that country.

**Test 4: edit and delete**

1. On the row you created in test 1, select the edit action.
2. Change the rate and the delivery times, then save.

Expected: the table row shows your new values.

3. On the same row select the delete action and confirm with "Delete".

Expected: the row disappears, and the country is now in neither the market list nor the primary market row. That is correct: deleting a market of this kind stops the store selling to that country altogether. To sell to it again, edit the primary market and add the country back.

**Test 5: check Google Merchant Centre received it**

1. Create a market again as in test 1.
2. Wait for the synchronising activity to finish, then sign in to your Google Merchant Centre account.
3. Open the shipping settings for your account.

Expected: there is a shipping service for the country you added, carrying the rate and delivery times you entered. Back in the plugin, the Product Feed page shows no new errors for your products.

**Test 6: repeat the create flow with automatic shipping**

1. Go to Settings and in "Shipping rates" choose "Automatically sync my store's shipping settings to Google." Wait for the saving activity to finish.
2. Go to Markets and select "Add market" for one of your targeted countries. Fill in whatever the form asks for, which will include delivery times but no shipping rate, then submit.

Expected: the market is created and appears as its own row. With the developer tools open as in test 2, the reply again describes the whole market rather than just an identifier.

**What cannot be checked from the interface**

Two parts of this change cannot be seen in the admin, and are covered by automated tests instead. The first is the identifier a market receives when something other than the plugin's own screens creates it and sends a label that differs from the country. The second is the set of details handed to other plugins that listen for a market being added. Neither is reachable by clicking through the admin.

### Additional details:

> Fix - Make the create-market response reliable in flat shipping mode