### PR TITLE
GOOWOO-916: Add disconnect action to Search Console account card

### DIFF
--- a/js/src/data/actions.js
+++ b/js/src/data/actions.js
@@ -1577,6 +1577,33 @@ export function* disconnectYouTubeAccount() {
 }
 
 /**
+ * Disconnect the connected Google Search Console account.
+ *
+ * @throws Will throw an error if the request failed.
+ */
+export function* disconnectGoogleSearchConsoleAccount() {
+	try {
+		yield apiFetch( {
+			path: `${ API_NAMESPACE }/search-console/connection`,
+			method: 'DELETE',
+		} );
+
+		return {
+			type: TYPES.DISCONNECT_ACCOUNTS_GOOGLE_SEARCH_CONSOLE,
+		};
+	} catch ( error ) {
+		handleApiError(
+			error,
+			__(
+				'Unable to disconnect your Google Search Console account.',
+				'google-listings-and-ads'
+			)
+		);
+		throw error;
+	}
+}
+
+/**
  * Fetch the list of markets.
  *
  * @return {Object} Action object to receive the markets.

--- a/js/src/pages/settings/accounts/google-search-console-account-card/connected-google-search-console-account-card.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/connected-google-search-console-account-card.js
@@ -39,9 +39,13 @@ const getSearchConsolePropertyUrl = ( siteUrl ) =>
  *
  * @param {Object} props Component props.
  * @param {GoogleSearchConsoleAccount} props.account The connected Google Search Console account.
+ * @param {() => void} props.onDisconnect Callback when the user clicks to disconnect the Google Search Console account.
  * @return {JSX.Element} The account card.
  */
-const ConnectedGoogleSearchConsoleAccountCard = ( { account } ) => {
+const ConnectedGoogleSearchConsoleAccountCard = ( {
+	account,
+	onDisconnect,
+} ) => {
 	const siteUrl = account.site_url;
 
 	return (
@@ -61,7 +65,7 @@ const ConnectedGoogleSearchConsoleAccountCard = ( { account } ) => {
 					</AccountCardTextDetail>
 				) : null
 			}
-			indicator={ <ConnectedIndicator /> }
+			indicator={ <ConnectedIndicator onDisconnect={ onDisconnect } /> }
 		>
 			{ account.just_resolved && <ConnectedSuccessNotice /> }
 		</AccountCard>

--- a/js/src/pages/settings/accounts/google-search-console-account-card/connected-indicator.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/connected-indicator.js
@@ -17,12 +17,14 @@ const REPORTS_URL = geReportsUrl();
 
 /**
  * Renders the connected indicator for the Google Search Console account card, including the connected
- * badge and the account actions menu with its "View Organic Search report" action. Disconnect
- * isn't wired up here yet — a sibling ticket attaches its own menu item once it lands.
+ * badge and the account actions menu with its "View Organic Search report" action and its
+ * "Disconnect" action.
  *
+ * @param {Object} props Component props.
+ * @param {() => void} props.onDisconnect Callback when the user clicks to disconnect the Google Search Console account.
  * @return {JSX.Element} The connected indicator for the Google Search Console account card.
  */
-const ConnectedIndicator = () => {
+const ConnectedIndicator = ( { onDisconnect } ) => {
 	return (
 		<Flex>
 			<FlexItem>
@@ -34,6 +36,7 @@ const ConnectedIndicator = () => {
 						'Google Search Console',
 						'google-listings-and-ads'
 					) }
+					onDisconnect={ onDisconnect }
 				>
 					<MenuItem href={ REPORTS_URL }>
 						{ __(

--- a/js/src/pages/settings/accounts/google-search-console-account-card/index.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/index.js
@@ -8,21 +8,27 @@ import ConnectedGoogleSearchConsoleAccountCard from './connected-google-search-c
 import IncompleteGoogleSearchConsoleAccountCard from './incomplete-google-search-console-account-card';
 
 /**
- * Renders the Google Search Console account card, self-contained and driven entirely by the
- * backend-determined connection state (no props): the connected steady state, the not-connected
- * state, and every incomplete connect-flow sub-state, handled by
- * {@link IncompleteGoogleSearchConsoleAccountCard}.
+ * Renders the Google Search Console account card, driven entirely by the backend-determined
+ * connection state: the connected steady state, the not-connected state, and every incomplete
+ * connect-flow sub-state, handled by {@link IncompleteGoogleSearchConsoleAccountCard}.
  *
  * Regardless of entry point (fresh page load, resuming from Accounts, or returning from an
  * OAuth redirect), this always resumes into whichever state the backend currently reports.
  *
+ * @param {Object} props Component props.
+ * @param {() => void} props.onDisconnect Callback when the user clicks to disconnect the Google Search Console account.
  * @return {JSX.Element} The Google Search Console account card.
  */
-const GoogleSearchConsoleAccountCard = () => {
+const GoogleSearchConsoleAccountCard = ( { onDisconnect } ) => {
 	const { account } = useGoogleSearchConsoleAccount();
 
 	if ( account?.status === GOOGLE_SEARCH_CONSOLE_ACCOUNT_STATUS.CONNECTED ) {
-		return <ConnectedGoogleSearchConsoleAccountCard account={ account } />;
+		return (
+			<ConnectedGoogleSearchConsoleAccountCard
+				account={ account }
+				onDisconnect={ onDisconnect }
+			/>
+		);
 	}
 
 	if (

--- a/js/src/pages/settings/accounts/google-search-console-account-card/index.test.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/index.test.js
@@ -78,6 +78,28 @@ describe( 'GoogleSearchConsoleAccountCard', () => {
 		);
 	} );
 
+	it( 'calls onDisconnect when the Disconnect menu item is clicked', async () => {
+		const user = userEvent.setup();
+		const onDisconnect = jest.fn().mockName( 'onDisconnect' );
+
+		mockAccount( { status: CONNECTED } );
+
+		render(
+			<GoogleSearchConsoleAccountCard onDisconnect={ onDisconnect } />
+		);
+
+		await user.click(
+			screen.getByRole( 'button', {
+				name: 'Account actions for Google Search Console',
+			} )
+		);
+		await user.click(
+			screen.getByRole( 'menuitem', { name: 'Disconnect' } )
+		);
+
+		expect( onDisconnect ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'renders a link to the connected property in Google Search Console when the backend sends site_url', () => {
 		mockAccount( { status: CONNECTED, site_url: 'https://example.com/' } );
 

--- a/js/src/pages/settings/accounts/index.js
+++ b/js/src/pages/settings/accounts/index.js
@@ -31,6 +31,7 @@ import useServiceBasedMerchant from '~/hooks/useServiceBasedMerchant';
 import DisconnectModal, {
 	ALL_ACCOUNTS,
 	YOUTUBE_ACCOUNT,
+	SEARCH_CONSOLE_ACCOUNT,
 } from '../disconnect-modal';
 import './index.scss';
 
@@ -38,7 +39,7 @@ import './index.scss';
  * Accounts are disconnected from the Settings > Accounts subtab.
  *
  * @event gla_disconnected_accounts
- * @property {string} context (`all-accounts`|`youtube-account`) - indicate which accounts have been disconnected.
+ * @property {string} context (`all-accounts`|`youtube-account`|`search-console-account`) - indicate which accounts have been disconnected.
  */
 
 /**
@@ -96,6 +97,10 @@ export default function Accounts() {
 
 	const handleDisconnectYouTubeAccount = () => {
 		setOpenedModal( YOUTUBE_ACCOUNT );
+	};
+
+	const handleDisconnectSearchConsoleAccount = () => {
+		setOpenedModal( SEARCH_CONSOLE_ACCOUNT );
 	};
 
 	if ( isLoading ) {
@@ -162,7 +167,9 @@ export default function Accounts() {
 					'google-listings-and-ads'
 				) }
 			>
-				<GoogleSearchConsoleAccountCard />
+				<GoogleSearchConsoleAccountCard
+					onDisconnect={ handleDisconnectSearchConsoleAccount }
+				/>
 			</AccountsGroup>
 
 			<Flex justify="flex-end">

--- a/js/src/pages/settings/accounts/index.test.js
+++ b/js/src/pages/settings/accounts/index.test.js
@@ -18,7 +18,11 @@ import useYouTubeAccount from '~/hooks/useYouTubeAccount';
 import useGoogleSearchConsoleAccount from '~/hooks/useGoogleSearchConsoleAccount';
 import { queueRecordGlaEvent } from '~/utils/tracks';
 import { getGetStartedUrl } from '~/utils/urls';
-import { ALL_ACCOUNTS, YOUTUBE_ACCOUNT } from '../disconnect-modal';
+import {
+	ALL_ACCOUNTS,
+	YOUTUBE_ACCOUNT,
+	SEARCH_CONSOLE_ACCOUNT,
+} from '../disconnect-modal';
 
 jest.mock( '~/hooks/useAdminUrl', () => jest.fn().mockName( 'useAdminUrl' ) );
 jest.mock( '~/hooks/useJetpackAccount', () =>
@@ -87,14 +91,22 @@ jest.mock(
 jest.mock(
 	'./google-search-console-account-card',
 	() =>
-		function MockGoogleSearchConsoleAccountCard() {
-			return <div>Google Search Console account</div>;
+		function MockGoogleSearchConsoleAccountCard( { onDisconnect } ) {
+			return (
+				<div>
+					Google Search Console account
+					<button onClick={ onDisconnect }>
+						Disconnect Google Search Console account
+					</button>
+				</div>
+			);
 		}
 );
 jest.mock( '../disconnect-modal', () => ( {
 	__esModule: true,
 	ALL_ACCOUNTS: 'all-accounts',
 	YOUTUBE_ACCOUNT: 'youtube-account',
+	SEARCH_CONSOLE_ACCOUNT: 'search-console-account',
 	default: function MockDisconnectModal( {
 		disconnectTarget,
 		onDisconnected,
@@ -197,6 +209,27 @@ describe( 'Accounts', () => {
 		expect( queueRecordGlaEvent ).toHaveBeenCalledWith(
 			'gla_disconnected_accounts',
 			{ context: YOUTUBE_ACCOUNT }
+		);
+		expect( window.location.href ).toBe( '' );
+	} );
+
+	it( 'tracks disconnecting the Google Search Console account without redirecting', async () => {
+		const user = userEvent.setup();
+
+		render( <Accounts /> );
+
+		await user.click(
+			screen.getByRole( 'button', {
+				name: 'Disconnect Google Search Console account',
+			} )
+		);
+		await user.click(
+			screen.getByRole( 'button', { name: 'Confirm disconnect' } )
+		);
+
+		expect( queueRecordGlaEvent ).toHaveBeenCalledWith(
+			'gla_disconnected_accounts',
+			{ context: SEARCH_CONSOLE_ACCOUNT }
 		);
 		expect( window.location.href ).toBe( '' );
 	} );

--- a/js/src/pages/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.js
@@ -130,8 +130,8 @@ const disconnectEventsByTarget = {
 };
 
 /**
- * Dispatcher action name to call on confirm, keyed by disconnect target. Targets with no entry
- * here (i.e. the all-accounts/Ads-only bulk actions) fall back to disconnecting Google Ads.
+ * Dispatcher action name to call on confirm, keyed by disconnect target. Any unmapped target
+ * (i.e. the Ads-only bulk action) falls back to disconnecting Google Ads.
  */
 const disconnectActionNameByTarget = {
 	[ ALL_ACCOUNTS ]: 'disconnectAllAccounts',

--- a/js/src/pages/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.js
@@ -13,7 +13,12 @@ import AppButton from '~/components/app-button';
 import WarningIcon from '~/components/warning-icon';
 import { useAppDispatch } from '~/data';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
-import { ALL_ACCOUNTS, ADS_ONLY, YOUTUBE_ACCOUNT } from './constants';
+import {
+	ALL_ACCOUNTS,
+	ADS_ONLY,
+	YOUTUBE_ACCOUNT,
+	SEARCH_CONSOLE_ACCOUNT,
+} from './constants';
 
 const textDict = {
 	[ ALL_ACCOUNTS ]: {
@@ -81,6 +86,47 @@ const textDict = {
 			),
 		],
 	},
+
+	[ SEARCH_CONSOLE_ACCOUNT ]: {
+		title: __(
+			'Disconnect Google Search Console account?',
+			'google-listings-and-ads'
+		),
+		confirmButton: __(
+			'Disconnect Google Search Console account',
+			'google-listings-and-ads'
+		),
+		confirmation: __(
+			'Yes, I want to disconnect my Google Search Console account.',
+			'google-listings-and-ads'
+		),
+		contents: [
+			__(
+				'Your Google Search Console account will be disconnected from your WooCommerce store.',
+				'google-listings-and-ads'
+			),
+			__(
+				'Your organic search data will no longer be available in Reports. You can reconnect at any time.',
+				'google-listings-and-ads'
+			),
+		],
+	},
+};
+
+/**
+ * Tracking event fired when the user confirms disconnecting a specific account, keyed by
+ * disconnect target. Targets with no entry here (e.g. the all-accounts/Ads-only bulk actions)
+ * fire no tracking event.
+ */
+const disconnectEventsByTarget = {
+	[ YOUTUBE_ACCOUNT ]: {
+		eventName: 'gla_youtube_account_disconnect_button_click',
+		eventProps: { context: 'settings-youtube' },
+	},
+	[ SEARCH_CONSOLE_ACCOUNT ]: {
+		eventName: 'gla_search_console_account_disconnect_button_click',
+		eventProps: { context: 'settings-search-console' },
+	},
 };
 
 /**
@@ -91,9 +137,17 @@ const textDict = {
  */
 
 /**
+ * Clicking on the button to disconnect the Google Search Console account.
+ *
+ * @event gla_search_console_account_disconnect_button_click
+ * @property {string} context Indicates from which page the button was clicked. Possible value: 'settings-search-console'.
+ */
+
+/**
  * Renders the disconnect confirmation modal.
  *
  * @fires gla_youtube_account_disconnect_button_click When the user confirms the disconnection of the YouTube account.
+ * @fires gla_search_console_account_disconnect_button_click When the user confirms the disconnection of the Google Search Console account.
  *
  * @param {Object} props Component props.
  * @param {string} props.disconnectTarget Which accounts the modal disconnects.
@@ -116,6 +170,8 @@ export default function ConfirmModal( {
 	let targetTextDict = ALL_ACCOUNTS;
 	if ( disconnectTarget === YOUTUBE_ACCOUNT ) {
 		targetTextDict = YOUTUBE_ACCOUNT;
+	} else if ( disconnectTarget === SEARCH_CONSOLE_ACCOUNT ) {
+		targetTextDict = SEARCH_CONSOLE_ACCOUNT;
 	} else if ( disconnectTarget === ALL_ACCOUNTS && ! hasGoogleMCConnection ) {
 		targetTextDict = ADS_ONLY;
 	}
@@ -123,7 +179,8 @@ export default function ConfirmModal( {
 	const { title, confirmButton, confirmation, contents } =
 		textDict[ targetTextDict ];
 
-	const isYouTubeTarget = disconnectTarget === YOUTUBE_ACCOUNT;
+	const { eventName, eventProps } =
+		disconnectEventsByTarget[ disconnectTarget ] ?? {};
 
 	const handleRequestClose = () => {
 		if ( isDisconnecting ) {
@@ -138,6 +195,8 @@ export default function ConfirmModal( {
 			disconnect = dispatcher.disconnectAllAccounts;
 		} else if ( disconnectTarget === YOUTUBE_ACCOUNT ) {
 			disconnect = dispatcher.disconnectYouTubeAccount;
+		} else if ( disconnectTarget === SEARCH_CONSOLE_ACCOUNT ) {
+			disconnect = dispatcher.disconnectGoogleSearchConsoleAccount;
 		} else {
 			disconnect = dispatcher.disconnectGoogleAdsAccount;
 		}
@@ -182,12 +241,8 @@ export default function ConfirmModal( {
 					isDestructive
 					loading={ isDisconnecting }
 					disabled={ ! isAgreed }
-					eventName={
-						isYouTubeTarget
-							? 'gla_youtube_account_disconnect_button_click'
-							: undefined
-					}
-					eventProps={ { context: 'settings-youtube' } }
+					eventName={ eventName }
+					eventProps={ eventProps }
 					onClick={ handleConfirmClick }
 				>
 					{ confirmButton }

--- a/js/src/pages/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.js
@@ -124,7 +124,7 @@ const disconnectEventsByTarget = {
 		eventProps: { context: 'settings-youtube' },
 	},
 	[ SEARCH_CONSOLE_ACCOUNT ]: {
-		eventName: 'gla_search_console_account_disconnect_button_click',
+		eventName: 'gla_google_search_console_account_disconnect_button_click',
 		eventProps: { context: 'settings-search-console' },
 	},
 };
@@ -149,7 +149,7 @@ const disconnectActionNameByTarget = {
 /**
  * Clicking on the button to disconnect the Google Search Console account.
  *
- * @event gla_search_console_account_disconnect_button_click
+ * @event gla_google_search_console_account_disconnect_button_click
  * @property {string} context Indicates from which page the button was clicked. Possible value: 'settings-search-console'.
  */
 
@@ -157,7 +157,7 @@ const disconnectActionNameByTarget = {
  * Renders the disconnect confirmation modal.
  *
  * @fires gla_youtube_account_disconnect_button_click When the user confirms the disconnection of the YouTube account.
- * @fires gla_search_console_account_disconnect_button_click When the user confirms the disconnection of the Google Search Console account.
+ * @fires gla_google_search_console_account_disconnect_button_click When the user confirms the disconnection of the Google Search Console account.
  *
  * @param {Object} props Component props.
  * @param {string} props.disconnectTarget Which accounts the modal disconnects.

--- a/js/src/pages/settings/disconnect-modal/confirm-modal.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.js
@@ -130,6 +130,16 @@ const disconnectEventsByTarget = {
 };
 
 /**
+ * Dispatcher action name to call on confirm, keyed by disconnect target. Targets with no entry
+ * here (i.e. the all-accounts/Ads-only bulk actions) fall back to disconnecting Google Ads.
+ */
+const disconnectActionNameByTarget = {
+	[ ALL_ACCOUNTS ]: 'disconnectAllAccounts',
+	[ YOUTUBE_ACCOUNT ]: 'disconnectYouTubeAccount',
+	[ SEARCH_CONSOLE_ACCOUNT ]: 'disconnectGoogleSearchConsoleAccount',
+};
+
+/**
  * Clicking on the button to disconnect the YouTube account.
  *
  * @event gla_youtube_account_disconnect_button_click
@@ -190,20 +200,12 @@ export default function ConfirmModal( {
 	};
 
 	const handleConfirmClick = () => {
-		let disconnect;
-		if ( disconnectTarget === ALL_ACCOUNTS ) {
-			disconnect = dispatcher.disconnectAllAccounts;
-		} else if ( disconnectTarget === YOUTUBE_ACCOUNT ) {
-			disconnect = dispatcher.disconnectYouTubeAccount;
-		} else if ( disconnectTarget === SEARCH_CONSOLE_ACCOUNT ) {
-			disconnect = dispatcher.disconnectGoogleSearchConsoleAccount;
-		} else {
-			disconnect = dispatcher.disconnectGoogleAdsAccount;
-		}
-
-		if ( disconnectAction ) {
-			disconnect = disconnectAction;
-		}
+		const disconnect =
+			disconnectAction ??
+			dispatcher[
+				disconnectActionNameByTarget[ disconnectTarget ] ??
+					'disconnectGoogleAdsAccount'
+			];
 
 		setDisconnecting( true );
 		disconnect()

--- a/js/src/pages/settings/disconnect-modal/confirm-modal.test.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.test.js
@@ -174,7 +174,7 @@ describe( 'ConfirmModal', () => {
 
 		expect( recordGlaEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordGlaEvent ).toHaveBeenCalledWith(
-			'gla_search_console_account_disconnect_button_click',
+			'gla_google_search_console_account_disconnect_button_click',
 			{ context: 'settings-search-console' }
 		);
 		expect( disconnectGoogleSearchConsoleAccount ).toHaveBeenCalledTimes(

--- a/js/src/pages/settings/disconnect-modal/confirm-modal.test.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.test.js
@@ -9,7 +9,11 @@ import userEvent from '@testing-library/user-event';
  * Internal dependencies
  */
 import ConfirmModal from './confirm-modal';
-import { ALL_ACCOUNTS, YOUTUBE_ACCOUNT } from './constants';
+import {
+	ALL_ACCOUNTS,
+	YOUTUBE_ACCOUNT,
+	SEARCH_CONSOLE_ACCOUNT,
+} from './constants';
 import { useAppDispatch } from '~/data';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import { recordGlaEvent } from '~/utils/tracks';
@@ -28,6 +32,7 @@ jest.mock( '~/utils/tracks', () => ( {
 describe( 'ConfirmModal', () => {
 	let disconnectAllAccounts;
 	let disconnectYouTubeAccount;
+	let disconnectGoogleSearchConsoleAccount;
 
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -40,10 +45,15 @@ describe( 'ConfirmModal', () => {
 			.fn()
 			.mockName( 'disconnectYouTubeAccount' )
 			.mockResolvedValue();
+		disconnectGoogleSearchConsoleAccount = jest
+			.fn()
+			.mockName( 'disconnectGoogleSearchConsoleAccount' )
+			.mockResolvedValue();
 
 		useAppDispatch.mockReturnValue( {
 			disconnectAllAccounts,
 			disconnectYouTubeAccount,
+			disconnectGoogleSearchConsoleAccount,
 		} );
 		useGoogleMCAccount.mockReturnValue( { hasGoogleMCConnection: true } );
 	} );
@@ -108,5 +118,44 @@ describe( 'ConfirmModal', () => {
 
 		expect( recordGlaEvent ).not.toHaveBeenCalled();
 		expect( disconnectAllAccounts ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'tracks the Google Search Console disconnection only when the modal is confirmed', async () => {
+		const user = userEvent.setup();
+
+		renderModal( SEARCH_CONSOLE_ACCOUNT );
+
+		expect( recordGlaEvent ).not.toHaveBeenCalled();
+
+		await user.click(
+			screen.getByRole( 'checkbox', {
+				name: 'Yes, I want to disconnect my Google Search Console account.',
+			} )
+		);
+		await user.click(
+			screen.getByRole( 'button', {
+				name: 'Disconnect Google Search Console account',
+			} )
+		);
+
+		expect( recordGlaEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordGlaEvent ).toHaveBeenCalledWith(
+			'gla_search_console_account_disconnect_button_click',
+			{ context: 'settings-search-console' }
+		);
+		expect( disconnectGoogleSearchConsoleAccount ).toHaveBeenCalledTimes(
+			1
+		);
+	} );
+
+	it( 'does not track the Google Search Console event when the modal is dismissed', async () => {
+		const user = userEvent.setup();
+
+		renderModal( SEARCH_CONSOLE_ACCOUNT );
+
+		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( recordGlaEvent ).not.toHaveBeenCalled();
+		expect( disconnectGoogleSearchConsoleAccount ).not.toHaveBeenCalled();
 	} );
 } );

--- a/js/src/pages/settings/disconnect-modal/confirm-modal.test.js
+++ b/js/src/pages/settings/disconnect-modal/confirm-modal.test.js
@@ -102,6 +102,40 @@ describe( 'ConfirmModal', () => {
 		expect( disconnectYouTubeAccount ).not.toHaveBeenCalled();
 	} );
 
+	it( 'keeps the modal open and re-enables the button if disconnecting the YouTube account fails', async () => {
+		const user = userEvent.setup();
+		const onDisconnected = jest.fn().mockName( 'onDisconnected' );
+		const onRequestClose = jest.fn().mockName( 'onRequestClose' );
+		disconnectYouTubeAccount.mockRejectedValue(
+			new Error( 'network error' )
+		);
+
+		render(
+			<ConfirmModal
+				disconnectTarget={ YOUTUBE_ACCOUNT }
+				onRequestClose={ onRequestClose }
+				onDisconnected={ onDisconnected }
+			/>
+		);
+
+		await user.click(
+			screen.getByRole( 'checkbox', {
+				name: 'Yes, I want to disconnect my YouTube account.',
+			} )
+		);
+		await user.click(
+			screen.getByRole( 'button', { name: 'Disconnect YouTube account' } )
+		);
+
+		expect(
+			await screen.findByRole( 'button', {
+				name: 'Disconnect YouTube account',
+			} )
+		).toBeEnabled();
+		expect( onDisconnected ).not.toHaveBeenCalled();
+		expect( onRequestClose ).not.toHaveBeenCalled();
+	} );
+
 	it( 'does not track the YouTube event for other disconnect targets', async () => {
 		const user = userEvent.setup();
 
@@ -157,5 +191,41 @@ describe( 'ConfirmModal', () => {
 
 		expect( recordGlaEvent ).not.toHaveBeenCalled();
 		expect( disconnectGoogleSearchConsoleAccount ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps the modal open and re-enables the button if disconnecting the Google Search Console account fails', async () => {
+		const user = userEvent.setup();
+		const onDisconnected = jest.fn().mockName( 'onDisconnected' );
+		const onRequestClose = jest.fn().mockName( 'onRequestClose' );
+		disconnectGoogleSearchConsoleAccount.mockRejectedValue(
+			new Error( 'network error' )
+		);
+
+		render(
+			<ConfirmModal
+				disconnectTarget={ SEARCH_CONSOLE_ACCOUNT }
+				onRequestClose={ onRequestClose }
+				onDisconnected={ onDisconnected }
+			/>
+		);
+
+		await user.click(
+			screen.getByRole( 'checkbox', {
+				name: 'Yes, I want to disconnect my Google Search Console account.',
+			} )
+		);
+		await user.click(
+			screen.getByRole( 'button', {
+				name: 'Disconnect Google Search Console account',
+			} )
+		);
+
+		expect(
+			await screen.findByRole( 'button', {
+				name: 'Disconnect Google Search Console account',
+			} )
+		).toBeEnabled();
+		expect( onDisconnected ).not.toHaveBeenCalled();
+		expect( onRequestClose ).not.toHaveBeenCalled();
 	} );
 } );

--- a/js/src/pages/settings/disconnect-modal/constants.js
+++ b/js/src/pages/settings/disconnect-modal/constants.js
@@ -1,3 +1,4 @@
 export const ALL_ACCOUNTS = 'all-accounts';
 export const ADS_ONLY = 'ads-only';
 export const YOUTUBE_ACCOUNT = 'youtube-account';
+export const SEARCH_CONSOLE_ACCOUNT = 'search-console-account';

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
 			},
 			{
 				"path": "./js/build/woo-marketing-notifications-slot.js",
-				"maxSize": "18.52 kB"
+				"maxSize": "18.55 kB"
 			},
 			{
 				"path": "./js/build/vendors.js",

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -485,14 +485,14 @@ Triggered when datepicker (date ranger picker) is updated,
 - [`ProductsReportFilters`](../../js/src/pages/reports/products/products-report-filters.js#L41)
 - [`ProgramsReportFilters`](../../js/src/pages/reports/programs/programs-report-filters.js#L43)
 
-### [`gla_disconnected_accounts`](../../js/src/pages/settings/accounts/index.js#L37)
+### [`gla_disconnected_accounts`](../../js/src/pages/settings/accounts/index.js#L38)
 Accounts are disconnected from the Settings > Accounts subtab.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
-`context` | `string` | (`all-accounts`\|`youtube-account`) - indicate which accounts have been disconnected.
+`context` | `string` | (`all-accounts`\|`youtube-account`\|`search-console-account`) - indicate which accounts have been disconnected.
 #### Emitters
-- [`exports`](../../js/src/pages/settings/accounts/index.js#L52)
+- [`exports`](../../js/src/pages/settings/accounts/index.js#L53)
 
 ### [`gla_documentation_link_click`](../../js/src/components/app-documentation-link/index.js#L6)
 When a documentation link is clicked.
@@ -795,7 +795,7 @@ Clicking on the button to connect the Google Search Console account.
 #### Emitters
 - [`ConnectGoogleSearchConsoleAccountCard`](../../js/src/pages/settings/accounts/google-search-console-account-card/connect-google-search-console-account-card.js#L32)
 
-### [`gla_google_search_console_connect_button_click`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/indicator.js#L45)
+### [`gla_google_search_console_connect_button_click`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/indicator.js#L36)
 Clicking on the button to (re)connect the Google Search Console account — covers reconnecting after
  expiry, retrying after a failed attempt, and resuming a generic abandoned flow.
 #### Properties
@@ -803,7 +803,7 @@ Clicking on the button to (re)connect the Google Search Console account — cove
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates from which page the button was clicked. Possible value: 'settings-search-console'.
 #### Emitters
-- [`exports`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/indicator.js#L65)
+- [`exports`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/indicator.js#L55)
 
 ### [`gla_google_search_console_property_create_button_click`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.js#L28)
 Clicking on the button to create a new Google Search Console property.
@@ -823,7 +823,7 @@ Clicking on the button to select an existing Google Search Console property.
 #### Emitters
 - [`exports`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.js#L52)
 
-### [`gla_google_search_console_verify_button_click`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/action-needed.js#L13)
+### [`gla_google_search_console_verify_button_click`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/verification.js#L14)
 Clicking on the button to verify the Google Search Console property, either during the normal
  verification step or after re-verification is needed following the "action needed" state.
 #### Properties
@@ -831,18 +831,6 @@ Clicking on the button to verify the Google Search Console property, either duri
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates from which page the button was clicked. Possible value: 'settings-search-console'.
 #### Emitters
-- [`exports`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/action-needed.js#L29)
-- [`exports`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/verification.js#L36)
-
-### [`gla_google_search_console_verify_button_click`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/verification.js#L15)
-Clicking on the button to verify the Google Search Console property, either during the normal
- verification step or after re-verification is needed following the "action needed" state.
-#### Properties
-| name | type | description |
-| ---- | ---- | ----------- |
-`context` | `string` | Indicates from which page the button was clicked. Possible value: 'settings-search-console'.
-#### Emitters
-- [`exports`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/action-needed.js#L29)
 - [`exports`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/verification.js#L36)
 
 ### [`gla_help_click`](../../js/src/components/help-icon-button/index.js#L13)
@@ -1252,6 +1240,15 @@ Event fired when the "Save" button in the EditMarketModal is clicked.
 #### Emitters
 - [`ModalFooter`](../../js/src/pages/markets/components/edit-market-modal/modal-footer.js#L35) when the save button is clicked with context of "edit_market_modal"
 
+### [`gla_search_console_account_disconnect_button_click`](../../js/src/pages/settings/disconnect-modal/confirm-modal.js#L149)
+Clicking on the button to disconnect the Google Search Console account.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Indicates from which page the button was clicked. Possible value: 'settings-search-console'.
+#### Emitters
+- [`exports`](../../js/src/pages/settings/disconnect-modal/confirm-modal.js#L169) When the user confirms the disconnection of the Google Search Console account.
+
 ### [`gla_set_up_merchant_center_click`](../../js/src/pages/settings/accounts/google-merchant-center-account-card/connect-button.js#L12)
 The "Set up Merchant Center" button is clicked from Settings > Accounts.
 #### Properties
@@ -1464,14 +1461,14 @@ Clicking on the button to connect YouTube account.
 #### Emitters
 - [`ConnectYouTubeAccountCard`](../../js/src/pages/settings/accounts/youtube-account-card/connect-youtube-account-card.js#L32)
 
-### [`gla_youtube_account_disconnect_button_click`](../../js/src/pages/settings/disconnect-modal/confirm-modal.js#L86)
+### [`gla_youtube_account_disconnect_button_click`](../../js/src/pages/settings/disconnect-modal/confirm-modal.js#L142)
 Clicking on the button to disconnect the YouTube account.
 #### Properties
 | name | type | description |
 | ---- | ---- | ----------- |
 `context` | `string` | Indicates from which page the button was clicked. Possible value: 'settings-youtube'.
 #### Emitters
-- [`exports`](../../js/src/pages/settings/disconnect-modal/confirm-modal.js#L105) When the user confirms the disconnection of the YouTube account.
+- [`exports`](../../js/src/pages/settings/disconnect-modal/confirm-modal.js#L169) When the user confirms the disconnection of the YouTube account.
 
 ### [`gla_youtube_shopping_tour_close_button_click`](../../js/src/components/tours/youtube-shopping-tour.js#L26)
 When the tour is closed.

--- a/src/Tracking/README.md
+++ b/src/Tracking/README.md
@@ -795,6 +795,15 @@ Clicking on the button to connect the Google Search Console account.
 #### Emitters
 - [`ConnectGoogleSearchConsoleAccountCard`](../../js/src/pages/settings/accounts/google-search-console-account-card/connect-google-search-console-account-card.js#L32)
 
+### [`gla_google_search_console_account_disconnect_button_click`](../../js/src/pages/settings/disconnect-modal/confirm-modal.js#L149)
+Clicking on the button to disconnect the Google Search Console account.
+#### Properties
+| name | type | description |
+| ---- | ---- | ----------- |
+`context` | `string` | Indicates from which page the button was clicked. Possible value: 'settings-search-console'.
+#### Emitters
+- [`exports`](../../js/src/pages/settings/disconnect-modal/confirm-modal.js#L169) When the user confirms the disconnection of the Google Search Console account.
+
 ### [`gla_google_search_console_connect_button_click`](../../js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/indicator.js#L36)
 Clicking on the button to (re)connect the Google Search Console account — covers reconnecting after
  expiry, retrying after a failed attempt, and resuming a generic abandoned flow.
@@ -1239,15 +1248,6 @@ Event fired when the "Save" button in the EditMarketModal is clicked.
 `context` | `string` | The context in which the save button click happened, e.g. "edit_market_modal".
 #### Emitters
 - [`ModalFooter`](../../js/src/pages/markets/components/edit-market-modal/modal-footer.js#L35) when the save button is clicked with context of "edit_market_modal"
-
-### [`gla_search_console_account_disconnect_button_click`](../../js/src/pages/settings/disconnect-modal/confirm-modal.js#L149)
-Clicking on the button to disconnect the Google Search Console account.
-#### Properties
-| name | type | description |
-| ---- | ---- | ----------- |
-`context` | `string` | Indicates from which page the button was clicked. Possible value: 'settings-search-console'.
-#### Emitters
-- [`exports`](../../js/src/pages/settings/disconnect-modal/confirm-modal.js#L169) When the user confirms the disconnection of the Google Search Console account.
 
 ### [`gla_set_up_merchant_center_click`](../../js/src/pages/settings/accounts/google-merchant-center-account-card/connect-button.js#L12)
 The "Set up Merchant Center" button is clicked from Settings > Accounts.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes: [GOOWOO-916](https://linear.app/a8c/issue/GOOWOO-916/connect-search-console-disconnect)

Adds the disconnect action to the connected state of the Search Console account card, following the same per-card disconnect pattern already shipped for YouTube rather than the immediate-fire pattern originally assumed for this ticket (confirmed by live-testing YouTube's actual disconnect flow — it opens a confirmation modal, it doesn't fire immediately).

- `connected-indicator.js` now wires an `onDisconnect` callback into the existing `AccountCardActions` menu (previously stubbed with a "not wired up yet" comment), threaded up through `ConnectedGoogleSearchConsoleAccountCard` and `GoogleSearchConsoleAccountCard`.
- `accounts/index.js` adds a `SEARCH_CONSOLE_ACCOUNT` disconnect target and opens the existing shared `DisconnectModal` on click, mirroring the YouTube target.
- `disconnect-modal/confirm-modal.js` adds the Search Console copy variant and a confirm-time dispatch branch, plus a small `disconnectEventsByTarget` lookup replacing the previous YouTube-only ternary for tracking events.
- `data/actions.js` adds `disconnectGoogleSearchConsoleAccount`, a DELETE to the `search-console/connection` route (already live from GOOWOO-942) mirroring `disconnectYouTubeAccount`. No new action type or reducer case needed — `DISCONNECT_ACCOUNTS_GOOGLE_SEARCH_CONSOLE` and its reducer/resolver invalidation were already scaffolded by the connect-flow work.

### Screenshots:

<!--- Optional --->

### Detailed test instructions:

1. Run `npm run dev` (or `npm start` to watch) to build the JS.
2. Go to Marketing → Google for WooCommerce → Settings → Accounts.
3. If Search Console isn't already connected locally, use a DevTools Local Override on `GET .../wp-json/wc/gla/search-console/connection` to return `{"status":"connected"}`, then reload once.
4. Click the Search Console card's "⋮" actions menu → **Disconnect**. Confirm the modal shows the Search Console-specific title/copy/checkbox, not the YouTube or bulk-disconnect text.
5. Click **Cancel** — confirm no request fires and the card stays connected.
6. Reopen the menu → Disconnect → check the confirmation checkbox → confirm. With any override disabled, confirm a real `DELETE .../wp-json/wc/gla/search-console/connection` fires and the card reverts to the disconnected/Connect state.
7. Run the scoped test suite: `npx wp-scripts test-unit-js --testPathPattern="(disconnect-modal|google-search-console-account-card|settings/accounts/index)"` — 8 suites / 38 tests should pass.

### Additional details:

### Changelog entry

>
