### PR TITLE
GOOWOO-789: Fix snackbar error appearing after disconnecting Google Ads account.

### DIFF
--- a/js/src/hooks/useAdsSettings.js
+++ b/js/src/hooks/useAdsSettings.js
@@ -12,15 +12,17 @@ import useGoogleAdsAccount from './useGoogleAdsAccount';
 const selectorName = 'getAdsSettings';
 
 const useAdsSettings = () => {
-	const { hasGoogleAdsConnection, hasFinishedResolution } =
-		useGoogleAdsAccount();
+	const {
+		hasGoogleAdsConnection,
+		hasFinishedResolution: hasResolvedGoogleAdsAccount,
+	} = useGoogleAdsAccount();
 
 	return useSelect(
 		( select ) => {
 			if ( ! hasGoogleAdsConnection ) {
 				return {
 					adsSettings: null,
-					hasFinishedResolution,
+					hasFinishedResolution: hasResolvedGoogleAdsAccount,
 				};
 			}
 
@@ -34,7 +36,7 @@ const useAdsSettings = () => {
 				),
 			};
 		},
-		[ hasGoogleAdsConnection, hasFinishedResolution ]
+		[ hasGoogleAdsConnection, hasResolvedGoogleAdsAccount ]
 	);
 };
 

--- a/js/src/hooks/useAdsSettings.js
+++ b/js/src/hooks/useAdsSettings.js
@@ -7,21 +7,35 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { STORE_KEY } from '~/data/constants';
+import useGoogleAdsAccount from './useGoogleAdsAccount';
 
 const selectorName = 'getAdsSettings';
 
 const useAdsSettings = () => {
-	return useSelect( ( select ) => {
-		const selector = select( STORE_KEY );
+	const { hasGoogleAdsConnection, hasFinishedResolution } =
+		useGoogleAdsAccount();
 
-		return {
-			adsSettings: selector[ selectorName ](),
-			hasFinishedResolution: selector.hasFinishedResolution(
-				selectorName,
-				[]
-			),
-		};
-	}, [] );
+	return useSelect(
+		( select ) => {
+			if ( ! hasGoogleAdsConnection ) {
+				return {
+					adsSettings: null,
+					hasFinishedResolution,
+				};
+			}
+
+			const selector = select( STORE_KEY );
+
+			return {
+				adsSettings: selector[ selectorName ](),
+				hasFinishedResolution: selector.hasFinishedResolution(
+					selectorName,
+					[]
+				),
+			};
+		},
+		[ hasGoogleAdsConnection, hasFinishedResolution ]
+	);
 };
 
 export default useAdsSettings;

--- a/js/src/hooks/useAdsSettings.test.js
+++ b/js/src/hooks/useAdsSettings.test.js
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { renderHook } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
+import useAdsSettings from '~/hooks/useAdsSettings';
+
+const mockGetAdsSettings = jest.fn().mockName( 'getAdsSettings' );
+const mockHasFinishedResolution = jest.fn().mockName( 'hasFinishedResolution' );
+
+jest.mock( '@wordpress/data', () => ( {
+	__esModule: true,
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '~/hooks/useGoogleAdsAccount', () =>
+	jest.fn().mockName( 'useGoogleAdsAccount' )
+);
+
+describe( 'useAdsSettings', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		useSelect.mockImplementation( ( cb ) =>
+			cb( () => ( {
+				getAdsSettings: mockGetAdsSettings,
+				hasFinishedResolution: mockHasFinishedResolution,
+			} ) )
+		);
+	} );
+
+	test( 'reads and returns the ads settings when a Google Ads account is connected', () => {
+		useGoogleAdsAccount.mockReturnValue( {
+			hasGoogleAdsConnection: true,
+			hasFinishedResolution: false,
+		} );
+		mockGetAdsSettings.mockReturnValue( {
+			ads_has_unclaimed_incentive: true,
+		} );
+		mockHasFinishedResolution.mockReturnValue( true );
+
+		const { result } = renderHook( () => useAdsSettings() );
+
+		expect( mockGetAdsSettings ).toHaveBeenCalled();
+		expect( result.current ).toEqual( {
+			adsSettings: { ads_has_unclaimed_incentive: true },
+			hasFinishedResolution: true,
+		} );
+	} );
+
+	test( 'skips reading ads settings and returns null when there is no connected Google Ads account', () => {
+		useGoogleAdsAccount.mockReturnValue( {
+			hasGoogleAdsConnection: false,
+			hasFinishedResolution: true,
+		} );
+
+		const { result } = renderHook( () => useAdsSettings() );
+
+		expect( mockGetAdsSettings ).not.toHaveBeenCalled();
+		expect( mockHasFinishedResolution ).not.toHaveBeenCalled();
+		expect( result.current ).toEqual( {
+			adsSettings: null,
+			hasFinishedResolution: true,
+		} );
+	} );
+
+	test( 'reflects the Google Ads account resolution state while disconnected state is still resolving', () => {
+		useGoogleAdsAccount.mockReturnValue( {
+			hasGoogleAdsConnection: false,
+			hasFinishedResolution: false,
+		} );
+
+		const { result } = renderHook( () => useAdsSettings() );
+
+		expect( mockGetAdsSettings ).not.toHaveBeenCalled();
+		expect( result.current ).toEqual( {
+			adsSettings: null,
+			hasFinishedResolution: false,
+		} );
+	} );
+} );

--- a/js/src/hooks/useAdsSettings.test.js
+++ b/js/src/hooks/useAdsSettings.test.js
@@ -83,4 +83,21 @@ describe( 'useAdsSettings', () => {
 			hasFinishedResolution: false,
 		} );
 	} );
+
+	test( 'reflects the ads settings resolution state, not the account resolution state, while connected', () => {
+		useGoogleAdsAccount.mockReturnValue( {
+			hasGoogleAdsConnection: true,
+			hasFinishedResolution: true,
+		} );
+		mockGetAdsSettings.mockReturnValue( undefined );
+		mockHasFinishedResolution.mockReturnValue( false );
+
+		const { result } = renderHook( () => useAdsSettings() );
+
+		expect( mockGetAdsSettings ).toHaveBeenCalled();
+		expect( result.current ).toEqual( {
+			adsSettings: undefined,
+			hasFinishedResolution: false,
+		} );
+	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-789/snackbar-error-there-was-an-error-getting-the-ads-settings-shown-when

Fix snackbar error appearing after disconnecting Google Ads account.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go through onboarding flow, connect both Ads and MC accounts
2. Disconnect Ads account only, in Settings
3. Navigate to dashboard → the snackbar error "There was an error getting the ads settings." **should not** appear anymore

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Skip ads settings fetch when no Google Ads account connected
