### PR TITLE
GOOWOO-874: Show save/sync feedback for shipping rate method

### DIFF
--- a/js/src/components/shipping-rate-section/shipping-rate-method-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-method-section.js
@@ -23,12 +23,13 @@ import useMCSetup from '~/hooks/useMCSetup';
  *
  * @param {Object} props
  * @param {JSX.Element} props.children Optional children to render below the shipping rate method options.
+ * @param {boolean} [props.disabled] Whether to disable the radio options, e.g. while a save is in progress.
  */
-const ShippingRateMethodSection = ( { children } ) => {
+const ShippingRateMethodSection = ( { children, disabled = false } ) => {
 	const { getInputProps } = useAdaptiveFormContext();
 	const { settings } = useSettings();
 	const { hasFinishedResolution, data: mcSetup } = useMCSetup();
-	const inputProps = getInputProps( 'shipping_rate' );
+	const inputProps = { ...getInputProps( 'shipping_rate' ), disabled };
 	const { isMultiLingualStore } = glaData;
 
 	// Take a one-time snapshot once settings have resolved.

--- a/js/src/components/shipping-rate-section/shipping-rate-method-section.js
+++ b/js/src/components/shipping-rate-section/shipping-rate-method-section.js
@@ -23,7 +23,7 @@ import useMCSetup from '~/hooks/useMCSetup';
  *
  * @param {Object} props
  * @param {JSX.Element} props.children Optional children to render below the shipping rate method options.
- * @param {boolean} [props.disabled] Whether to disable the radio options, e.g. while a save is in progress.
+ * @param {boolean} [props.disabled=false] Whether to disable the radio options, e.g. while a save is in progress.
  */
 const ShippingRateMethodSection = ( { children, disabled = false } ) => {
 	const { getInputProps } = useAdaptiveFormContext();

--- a/js/src/pages/settings/shipping-rate-settings.js
+++ b/js/src/pages/settings/shipping-rate-settings.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,6 +13,7 @@ import Section from '~/components/section';
 import ShippingRateMethodSection from '~/components/shipping-rate-section/shipping-rate-method-section';
 import { SHIPPING_RATE_METHOD, SHIPPING_TIME_METHOD } from '~/constants';
 import useSettings from '~/hooks/useSettings';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 import { handleApiError } from '~/utils/handleError';
 
 /**
@@ -25,6 +26,8 @@ import { handleApiError } from '~/utils/handleError';
  */
 const ShippingRateSettings = () => {
 	const { settings, saveSettings, syncSettings } = useSettings();
+	const { createNotice } = useDispatchCoreNotices();
+	const [ isSaving, setIsSaving ] = useState( false );
 
 	const handleChange = useCallback(
 		async ( change ) => {
@@ -37,6 +40,8 @@ const ShippingRateSettings = () => {
 				newShippingRate === SHIPPING_RATE_METHOD.MANUAL
 					? SHIPPING_TIME_METHOD.MANUAL
 					: SHIPPING_TIME_METHOD.FLAT;
+
+			setIsSaving( true );
 
 			try {
 				await saveSettings( {
@@ -52,6 +57,7 @@ const ShippingRateSettings = () => {
 						'google-listings-and-ads'
 					)
 				);
+				setIsSaving( false );
 				return;
 			}
 
@@ -65,9 +71,20 @@ const ShippingRateSettings = () => {
 						'google-listings-and-ads'
 					)
 				);
+				setIsSaving( false );
+				return;
 			}
+
+			createNotice(
+				'success',
+				__(
+					'Your shipping rate method has been saved and synced to your Google Merchant Center.',
+					'google-listings-and-ads'
+				)
+			);
+			setIsSaving( false );
 		},
-		[ settings, saveSettings, syncSettings ]
+		[ settings, saveSettings, syncSettings, createNotice ]
 	);
 
 	if ( settings === undefined ) {
@@ -87,7 +104,7 @@ const ShippingRateSettings = () => {
 			initialValues={ { shipping_rate: settings.shipping_rate } }
 			onChange={ handleChange }
 		>
-			<ShippingRateMethodSection />
+			<ShippingRateMethodSection disabled={ isSaving } />
 		</AdaptiveForm>
 	);
 };

--- a/js/src/pages/settings/shipping-rate-settings.test.js
+++ b/js/src/pages/settings/shipping-rate-settings.test.js
@@ -1,0 +1,267 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import ShippingRateSettings from './shipping-rate-settings';
+import useSettings from '~/hooks/useSettings';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import { handleApiError } from '~/utils/handleError';
+import { SHIPPING_RATE_METHOD } from '~/constants';
+
+jest.mock( '~/hooks/useSettings' );
+jest.mock( '~/utils/handleError', () => ( {
+	handleApiError: jest.fn(),
+} ) );
+
+// ShippingRateMethodSection relies on `useAdaptiveFormContext`, `useSettings`
+// and `useMCSetup` internals that are irrelevant to this component's own
+// save/notice logic, so stub it to a minimal control surface: a button that
+// triggers a `shipping_rate` change, plus its `disabled` prop rendered as an
+// attribute so tests can assert the in-progress state.
+jest.mock(
+	'~/components/shipping-rate-section/shipping-rate-method-section',
+	() =>
+		( { disabled } ) => (
+			<button disabled={ disabled } data-testid="shipping-rate-option">
+				Manual
+			</button>
+		)
+);
+
+// AdaptiveForm is mocked as a forwardRef spy so the `onChange` handler can be
+// exercised by clicking the stubbed radio button, without needing a real
+// form/context.
+const mockAdaptiveForm = jest.fn();
+jest.mock( '~/components/adaptive-form', () => {
+	const { forwardRef: mockForwardRef } =
+		jest.requireActual( '@wordpress/element' );
+
+	return {
+		__esModule: true,
+		default: mockForwardRef( ( props, ref ) => {
+			mockAdaptiveForm( props, ref );
+			return (
+				<div ref={ ref }>
+					<button
+						onClick={ () =>
+							props.onChange( {
+								name: 'shipping_rate',
+								value: 'manual',
+							} )
+						}
+					>
+						Select manual
+					</button>
+					<button
+						onClick={ () =>
+							props.onChange( {
+								name: 'shipping_rate',
+								value: 'automatic',
+							} )
+						}
+					>
+						Select automatic
+					</button>
+					<button
+						onClick={ () =>
+							props.onChange( {
+								name: 'some_other_field',
+								value: 'anything',
+							} )
+						}
+					>
+						Change other field
+					</button>
+					{ props.children }
+				</div>
+			);
+		} ),
+	};
+} );
+
+describe( 'ShippingRateSettings', () => {
+	let createNotice;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		createNotice = jest.fn();
+		useDispatchCoreNotices.mockReturnValue( { createNotice } );
+	} );
+
+	test( 'shows a success notice only after both save and sync succeed, and re-enables the options', async () => {
+		const saveSettings = jest.fn().mockResolvedValue();
+		const syncSettings = jest.fn().mockResolvedValue();
+		useSettings.mockReturnValue( {
+			settings: { shipping_rate: SHIPPING_RATE_METHOD.AUTOMATIC },
+			saveSettings,
+			syncSettings,
+		} );
+
+		const user = userEvent.setup();
+		render( <ShippingRateSettings /> );
+
+		await user.click( screen.getByText( 'Select manual' ) );
+
+		expect( saveSettings ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				shipping_rate: SHIPPING_RATE_METHOD.MANUAL,
+				shipping_time: 'manual',
+			} )
+		);
+		expect( syncSettings ).toHaveBeenCalledTimes( 1 );
+		expect( createNotice ).toHaveBeenCalledWith(
+			'success',
+			expect.stringContaining( 'has been saved and synced' )
+		);
+		expect( handleApiError ).not.toHaveBeenCalled();
+		expect(
+			screen.getByTestId( 'shipping-rate-option' )
+		).not.toBeDisabled();
+	} );
+
+	test( 'disables the options while the save is in progress', async () => {
+		let resolveSave;
+		const saveSettings = jest.fn(
+			() => new Promise( ( resolve ) => ( resolveSave = resolve ) )
+		);
+		const syncSettings = jest.fn().mockResolvedValue();
+		useSettings.mockReturnValue( {
+			settings: { shipping_rate: SHIPPING_RATE_METHOD.AUTOMATIC },
+			saveSettings,
+			syncSettings,
+		} );
+
+		const user = userEvent.setup();
+		render( <ShippingRateSettings /> );
+
+		await user.click( screen.getByText( 'Select manual' ) );
+
+		expect( screen.getByTestId( 'shipping-rate-option' ) ).toBeDisabled();
+
+		resolveSave();
+
+		await waitFor( () =>
+			expect(
+				screen.getByTestId( 'shipping-rate-option' )
+			).not.toBeDisabled()
+		);
+	} );
+
+	test( 'shows an error notice and skips sync when save fails, without a success notice', async () => {
+		const saveSettings = jest
+			.fn()
+			.mockRejectedValue( new Error( 'save failed' ) );
+		const syncSettings = jest.fn();
+		useSettings.mockReturnValue( {
+			settings: { shipping_rate: SHIPPING_RATE_METHOD.AUTOMATIC },
+			saveSettings,
+			syncSettings,
+		} );
+
+		const user = userEvent.setup();
+		render( <ShippingRateSettings /> );
+
+		await user.click( screen.getByText( 'Select manual' ) );
+
+		expect( handleApiError ).toHaveBeenCalledWith(
+			expect.any( Error ),
+			'There was an error saving the shipping rate method.'
+		);
+		expect( syncSettings ).not.toHaveBeenCalled();
+		expect( createNotice ).not.toHaveBeenCalled();
+		expect(
+			screen.getByTestId( 'shipping-rate-option' )
+		).not.toBeDisabled();
+	} );
+
+	test( 'shows an error notice when sync fails after a successful save, without a success notice', async () => {
+		const saveSettings = jest.fn().mockResolvedValue();
+		const syncSettings = jest
+			.fn()
+			.mockRejectedValue( new Error( 'sync failed' ) );
+		useSettings.mockReturnValue( {
+			settings: { shipping_rate: SHIPPING_RATE_METHOD.AUTOMATIC },
+			saveSettings,
+			syncSettings,
+		} );
+
+		const user = userEvent.setup();
+		render( <ShippingRateSettings /> );
+
+		await user.click( screen.getByText( 'Select manual' ) );
+
+		expect( handleApiError ).toHaveBeenCalledWith(
+			expect.any( Error ),
+			'There was an error synchronizing the shipping rate method to Google Merchant Center.'
+		);
+		expect( createNotice ).not.toHaveBeenCalled();
+		expect(
+			screen.getByTestId( 'shipping-rate-option' )
+		).not.toBeDisabled();
+	} );
+
+	test( 'couples a non-manual shipping rate with the flat shipping time', async () => {
+		const saveSettings = jest.fn().mockResolvedValue();
+		const syncSettings = jest.fn().mockResolvedValue();
+		useSettings.mockReturnValue( {
+			settings: { shipping_rate: SHIPPING_RATE_METHOD.MANUAL },
+			saveSettings,
+			syncSettings,
+		} );
+
+		const user = userEvent.setup();
+		render( <ShippingRateSettings /> );
+
+		await user.click( screen.getByText( 'Select automatic' ) );
+
+		expect( saveSettings ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				shipping_rate: SHIPPING_RATE_METHOD.AUTOMATIC,
+				shipping_time: 'flat',
+			} )
+		);
+	} );
+
+	test( 'ignores changes to fields other than shipping_rate', async () => {
+		const saveSettings = jest.fn().mockResolvedValue();
+		const syncSettings = jest.fn().mockResolvedValue();
+		useSettings.mockReturnValue( {
+			settings: { shipping_rate: SHIPPING_RATE_METHOD.AUTOMATIC },
+			saveSettings,
+			syncSettings,
+		} );
+
+		const user = userEvent.setup();
+		render( <ShippingRateSettings /> );
+
+		await user.click( screen.getByText( 'Change other field' ) );
+
+		expect( saveSettings ).not.toHaveBeenCalled();
+		expect( syncSettings ).not.toHaveBeenCalled();
+		expect( createNotice ).not.toHaveBeenCalled();
+	} );
+
+	test( 'shows a loading spinner while settings have not resolved yet', () => {
+		useSettings.mockReturnValue( { settings: undefined } );
+
+		render( <ShippingRateSettings /> );
+
+		expect( screen.getByRole( 'status' ) ).toBeInTheDocument();
+		expect( mockAdaptiveForm ).not.toHaveBeenCalled();
+	} );
+
+	test( 'renders nothing when settings have resolved without a shipping_rate value', () => {
+		useSettings.mockReturnValue( { settings: {} } );
+
+		const { container } = render( <ShippingRateSettings /> );
+
+		expect( container ).toBeEmptyDOMElement();
+		expect( mockAdaptiveForm ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Disable the radio options and show a success notice only once both saveSettings and syncSettings resolve, so the user gets clear confirmation the change reached Google Merchant Center instead of silent success or an ambiguous in-between state.

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-874/multi-feeds-updating-shipping-settings-does-not-provide-any-user

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

* Setting page
	* Go to Google for WooCommerce → Settings → Shipping rates.
	* Click a different shipping rate option (e.g. switch from Automatic to Manual).
	* Confirm: radio options grey out / become unclickable briefly, then re-enable.
	* Confirm: a snackbar appears saying the shipping rate method was saved and synced.
* Onboarding flow (regression check — no notice expected)
	* Start onboarding (or reset via a fresh test store) and reach the setup step showing shipping rate options.
	* Select each shipping rate option (Automatic / Flat / Manual) in turn.
	* Confirm: no success or error snackbar appears at all during this step — the ticket's notice only fires on the Settings page.
	* Confirm: options are not disabled/greyed out while clicking through onboarding (no isSaving wiring here).
	* Continue through onboarding normally to confirm the step still submits/saves as before.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Show success/error feedback and disable options while saving the shipping rate method in Settings.
