### PR TITLE
GOOWOO-938: Fold into primary regardless of shipping mode

### DIFF
--- a/js/src/pages/markets/components/market-form.js
+++ b/js/src/pages/markets/components/market-form.js
@@ -165,7 +165,6 @@ const MarketForm = ( {
 			// Saving shipping above changes what the markets list reports for the
 			// affected countries, so the cached list is no longer trustworthy.
 			invalidateResolution( 'getTargetAudience', [] );
-			invalidateResolution( 'getMarkets', [] );
 
 			if ( mergedIntoPrimary ) {
 				createNotice(

--- a/js/src/pages/markets/components/market-form.test.js
+++ b/js/src/pages/markets/components/market-form.test.js
@@ -93,7 +93,7 @@ describe( 'MarketForm handleSubmit', () => {
 		};
 	} );
 
-	test( 'invalidates both getTargetAudience and getMarkets after a successful save, since saving shipping changes what the markets list reports', async () => {
+	test( 'invalidates getTargetAudience after a successful save, since saving shipping changes what the target audience reports', async () => {
 		const user = userEvent.setup();
 		const onSubmit = jest.fn();
 
@@ -109,7 +109,10 @@ describe( 'MarketForm handleSubmit', () => {
 			'getTargetAudience',
 			[]
 		);
-		expect( invalidateResolution ).toHaveBeenCalledWith( 'getMarkets', [] );
+		// getMarkets needs no separate invalidation: createMarket()/updateMarket() already
+		// refetch and dispatch RECEIVE_MARKETS directly (see actions.js), so the resolver's
+		// cache is never stale to begin with.
+		expect( invalidateResolution ).toHaveBeenCalledTimes( 1 );
 		expect( onSubmit ).toHaveBeenCalledTimes( 1 );
 	} );
 

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -660,7 +660,9 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * @param string     $id       The market ID.
 	 * @param array      $config   The market configuration.
 	 * @param array|null $shipping The submitted shipping configuration, or null when the request
-	 *                             carried none, in which case there is nothing to compare.
+	 *                             carried none. Absence is not itself a mismatch: a store whose
+	 *                             mode stores nothing comparable per country (manual rate and
+	 *                             manual time) has nothing to submit, and still folds on locale.
 	 *
 	 * @return bool True when the country was folded into the primary market and no market was stored.
 	 *
@@ -677,9 +679,8 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 		if (
 			'' === $country
-			|| null === $shipping
 			|| ! $this->carries_only_the_primary_locale( $config )
-			|| ! $this->shipping_matches_primary( $shipping )
+			|| ! $this->shipping_matches_primary( $shipping ?? [] )
 		) {
 			$this->add_market( $id, $config );
 
@@ -697,6 +698,12 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * Shipping is not the only thing a market carries. A market wanting its own currency, or a
 	 * fixed rate to produce one, is asking for a feed the primary cannot serve, however alike
 	 * the shipping looks, and folding it would drop what the merchant asked for.
+	 *
+	 * Checked the same way regardless of shipping mode: a currency picked for a flat-rate
+	 * market is as real a per-market currency assignment (and changes what currency the feed
+	 * uses for that country on a multi-currency store) as one picked under automatic or manual.
+	 * Flat rate's form simply has no `language` field, so that half is naturally absent and
+	 * skipped below rather than needing a mode-specific carve-out.
 	 *
 	 * @param array $config The market configuration.
 	 *
@@ -716,6 +723,12 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 
 			if ( ! is_array( $config[ $key ] ) ) {
 				return false;
+			}
+
+			if ( [] === $config[ $key ] ) {
+				// An empty array is indistinguishable from a disabled/unused control — not a
+				// real request for no language/currency, so it carries no signal to compare.
+				continue;
 			}
 
 			$submitted = $config[ $key ];
@@ -740,6 +753,16 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 * sets a different rate per country therefore keeps creating separate markets, which is the
 	 * intended reading of "the Primary market's current effective shipping configuration".
 	 *
+	 * Applies uniformly across shipping modes (flat, automatic, manual): rate_type/time_type are
+	 * not a per-market choice, they are the store's global shipping settings (the same
+	 * MERCHANT_CENTER-backed values the settings REST endpoint reports), so every market already
+	 * runs on whichever one the store has. Only 'flat' stores a per-country row, and each axis is
+	 * independent: an automatic rate stores nothing for the rate family regardless of the time
+	 * setting, and a manual rate or time stores nothing for whichever axis it's set on. A flat
+	 * time paired with an automatic rate, for instance, still has a real per-country row to
+	 * compare for that axis. What the submitted payload itself states for rate_type/time_type is
+	 * ignored: it cannot diverge from the global setting and is not trusted as a signal either way.
+	 *
 	 * @param array $shipping The submitted shipping configuration.
 	 *
 	 * @return bool
@@ -747,46 +770,34 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	private function shipping_matches_primary( array $shipping ): bool {
 		$primary = $this->get_market_shipping( $this->target_audience->get_main_target_country() );
 
-		// Only a flat rate and a flat delivery window are stored per country. Any other method
-		// leaves nothing country-specific to compare, so the market stays separate rather than
-		// every country folding on a global setting they cannot help but share. That holds for
-		// an automatic rate with a flat window too: the window alone is a thin basis for
-		// discarding a market the merchant asked for.
-		if ( 'flat' !== $primary['rate_type'] || 'flat' !== $primary['time_type'] ) {
-			return false;
+		$families = [];
+
+		if ( 'flat' === $primary['rate_type'] ) {
+			$families[] = [ 'flat_rate', 'free_shipping_threshold' ];
 		}
 
-		// The method types are global, so a payload that states a different one is describing
-		// a market this store cannot have. Absent is the normal case and says nothing.
-		foreach ( [ 'rate_type', 'time_type' ] as $key ) {
-			if ( array_key_exists( $key, $shipping ) && $shipping[ $key ] !== $primary[ $key ] ) {
-				return false;
-			}
+		if ( 'flat' === $primary['time_type'] ) {
+			$families[] = [ 'flat_time', 'flat_max_time' ];
 		}
 
-		$families = [
-			[ 'flat_rate', 'free_shipping_threshold' ],
-			[ 'flat_time', 'flat_max_time' ],
-		];
-
-		// Each half is adopted from its own primary row, so each has to exist. A half the
-		// primary holds nothing for cannot be matched, and adopting it would strip the
-		// country's own row rather than align it.
 		foreach ( $families as $family ) {
+			// Each half is adopted from its own primary row, so each has to exist. A half the
+			// primary holds nothing for cannot be matched, and adopting it would strip the
+			// country's own row rather than align it.
 			if ( [] === array_filter( array_intersect_key( $primary, array_flip( $family ) ), 'is_numeric' ) ) {
 				return false;
 			}
-		}
 
-		foreach ( array_merge( ...$families ) as $key ) {
-			// An absent value is not an equal one: a partial payload says nothing about the
-			// field, and folding on it would discard a difference the merchant never stated.
-			if ( ! array_key_exists( $key, $shipping ) ) {
-				return false;
-			}
+			foreach ( $family as $key ) {
+				// An absent value is not an equal one: a partial payload says nothing about the
+				// field, and folding on it would discard a difference the merchant never stated.
+				if ( ! array_key_exists( $key, $shipping ) ) {
+					return false;
+				}
 
-			if ( ! $this->shipping_values_match( $shipping[ $key ], $primary[ $key ] ) ) {
-				return false;
+				if ( ! $this->shipping_values_match( $shipping[ $key ], $primary[ $key ] ) ) {
+					return false;
+				}
 			}
 		}
 

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -1727,16 +1727,16 @@ class MarketServiceTest extends UnitTest {
 
 	public function provide_shipping_that_differs_from_primary(): array {
 		return [
-			'dearer rate'            => [ $this->primary_shipping_payload( [ 'flat_rate' => 9.99 ] ) ],
-			'free rate'              => [ $this->primary_shipping_payload( [ 'flat_rate' => 0 ] ) ],
-			'no rate at all'         => [ $this->primary_shipping_payload( [ 'flat_rate' => null ] ) ],
-			'higher threshold'       => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 75.0 ] ) ],
+			'dearer rate'        => [ $this->primary_shipping_payload( [ 'flat_rate' => 9.99 ] ) ],
+			'free rate'          => [ $this->primary_shipping_payload( [ 'flat_rate' => 0 ] ) ],
+			'no rate at all'     => [ $this->primary_shipping_payload( [ 'flat_rate' => null ] ) ],
+			'higher threshold'   => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 75.0 ] ) ],
 			// Not the same offer as "free over 50", and not the same as "free over nothing".
-			'no threshold'           => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => null ] ) ],
-			'threshold of zero'      => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 0 ] ) ],
-			'slower minimum'         => [ $this->primary_shipping_payload( [ 'flat_time' => 2 ] ) ],
-			'slower maximum'         => [ $this->primary_shipping_payload( [ 'flat_max_time' => 5 ] ) ],
-			'no delivery window'     => [
+			'no threshold'       => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => null ] ) ],
+			'threshold of zero'  => [ $this->primary_shipping_payload( [ 'free_shipping_threshold' => 0 ] ) ],
+			'slower minimum'     => [ $this->primary_shipping_payload( [ 'flat_time' => 2 ] ) ],
+			'slower maximum'     => [ $this->primary_shipping_payload( [ 'flat_max_time' => 5 ] ) ],
+			'no delivery window' => [
 				$this->primary_shipping_payload(
 					[
 						'flat_time'     => null,
@@ -1748,7 +1748,7 @@ class MarketServiceTest extends UnitTest {
 	}
 
 	/**
-	 * rate_type/time_type are the store's global shipping settings, not a per-market choice, so
+	 * Rate_type/time_type are the store's global shipping settings, not a per-market choice, so
 	 * folding applies the same way whichever mode the store runs — 'flat' is simply the one mode
 	 * with a per-country row left to compare.
 	 *
@@ -1774,11 +1774,11 @@ class MarketServiceTest extends UnitTest {
 
 	public function provide_shipping_modes(): array {
 		return [
-			'automatic rate, flat time'    => [ 'automatic', 'flat' ],
-			'flat rate, manual time'       => [ 'flat', 'manual' ],
-			'automatic rate, manual time'  => [ 'automatic', 'manual' ],
-			'manual rate, flat time'       => [ 'manual', 'flat' ],
-			'manual rate, manual time'     => [ 'manual', 'manual' ],
+			'automatic rate, flat time'   => [ 'automatic', 'flat' ],
+			'flat rate, manual time'      => [ 'flat', 'manual' ],
+			'automatic rate, manual time' => [ 'automatic', 'manual' ],
+			'manual rate, flat time'      => [ 'manual', 'flat' ],
+			'manual rate, manual time'    => [ 'manual', 'manual' ],
 		];
 	}
 

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -1744,37 +1744,71 @@ class MarketServiceTest extends UnitTest {
 					]
 				),
 			],
-			'a rate type of its own' => [ $this->primary_shipping_payload( [ 'rate_type' => 'automatic' ] ) ],
-			'a time type of its own' => [ $this->primary_shipping_payload( [ 'time_type' => 'manual' ] ) ],
 		];
 	}
 
 	/**
-	 * @dataProvider provide_modes_without_a_per_country_profile
+	 * rate_type/time_type are the store's global shipping settings, not a per-market choice, so
+	 * folding applies the same way whichever mode the store runs — 'flat' is simply the one mode
+	 * with a per-country row left to compare.
+	 *
+	 * @dataProvider provide_shipping_modes
 	 *
 	 * @param string $rate_type
 	 * @param string $time_type
 	 */
-	public function test_add_market_or_merge_stores_a_market_when_the_mode_has_no_per_country_profile( string $rate_type, string $time_type ): void {
+	public function test_add_market_or_merge_folds_regardless_of_shipping_mode( string $rate_type, string $time_type ): void {
 		$this->set_up_primary_shipping_profile( $rate_type, $time_type );
 
-		// Identical values: only the mode stops this folding.
+		// Identical values throughout: the mode alone must not stop this folding.
 		$merged = $this->market_service->add_market_or_merge_into_primary(
 			'gb',
 			$this->secondary_config(),
 			$this->primary_shipping_payload()
 		);
 
+		$this->assertTrue( $merged );
+		$this->assertContains( 'GB', $this->options->get( OptionsInterface::TARGET_AUDIENCE )['countries'] );
+		$this->assertArrayNotHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	public function provide_shipping_modes(): array {
+		return [
+			'automatic rate, flat time'    => [ 'automatic', 'flat' ],
+			'flat rate, manual time'       => [ 'flat', 'manual' ],
+			'automatic rate, manual time'  => [ 'automatic', 'manual' ],
+			'manual rate, flat time'       => [ 'manual', 'flat' ],
+			'manual rate, manual time'     => [ 'manual', 'manual' ],
+		];
+	}
+
+	/**
+	 * Only the piece a mode actually stores per-country is comparable; a mismatch there must
+	 * still block the fold even when the mode is not 'flat' on both sides.
+	 *
+	 * @dataProvider provide_mismatched_values_by_mode
+	 *
+	 * @param string $rate_type
+	 * @param string $time_type
+	 * @param array  $overrides
+	 */
+	public function test_add_market_or_merge_stores_a_market_when_the_comparable_value_differs( string $rate_type, string $time_type, array $overrides ): void {
+		$this->set_up_primary_shipping_profile( $rate_type, $time_type );
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			$this->secondary_config(),
+			$this->primary_shipping_payload( $overrides )
+		);
+
 		$this->assertFalse( $merged );
 		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
 	}
 
-	public function provide_modes_without_a_per_country_profile(): array {
+	public function provide_mismatched_values_by_mode(): array {
 		return [
-			'automatic rates' => [ 'automatic', 'flat' ],
-			'manual rates'    => [ 'manual', 'flat' ],
-			'manual times'    => [ 'flat', 'manual' ],
-			'manual both'     => [ 'manual', 'manual' ],
+			'automatic rate, slower window' => [ 'automatic', 'flat', [ 'flat_time' => 2 ] ],
+			'manual time, dearer flat rate' => [ 'flat', 'manual', [ 'flat_rate' => 9.99 ] ],
 		];
 	}
 
@@ -1782,6 +1816,42 @@ class MarketServiceTest extends UnitTest {
 		$this->set_up_primary_shipping_profile();
 
 		$merged = $this->market_service->add_market_or_merge_into_primary( 'gb', $this->secondary_config(), null );
+
+		$this->assertFalse( $merged );
+		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	/**
+	 * Manual rate and manual time store nothing comparable per country, so there is nothing a
+	 * caller could submit to compare — the absence of a shipping payload must not itself block
+	 * the fold when the locale (language/currency) already matches the primary's.
+	 */
+	public function test_add_market_or_merge_folds_on_locale_alone_when_nothing_is_comparable(): void {
+		$this->set_up_primary_shipping_profile( 'manual', 'manual' );
+
+		$merged = $this->market_service->add_market_or_merge_into_primary( 'gb', $this->secondary_config(), null );
+
+		$this->assertTrue( $merged );
+		$this->assertContains( 'GB', $this->options->get( OptionsInterface::TARGET_AUDIENCE )['countries'] );
+		$this->assertArrayNotHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	/**
+	 * Even with nothing shipping-comparable, a market asking for its own locale is still asking
+	 * for a feed the primary cannot serve, and must still be refused the fold.
+	 *
+	 * @dataProvider provide_configs_that_ask_for_more_than_primary_gives
+	 *
+	 * @param array $extra
+	 */
+	public function test_add_market_or_merge_stores_a_market_when_locale_differs_and_nothing_is_comparable( array $extra ): void {
+		$this->set_up_primary_shipping_profile( 'manual', 'manual' );
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			array_merge( $this->secondary_config(), $extra ),
+			null
+		);
 
 		$this->assertFalse( $merged );
 		$this->assertArrayHasKey( 'gb', $this->options->get( OptionsInterface::MARKETS ) );
@@ -1895,6 +1965,10 @@ class MarketServiceTest extends UnitTest {
 	}
 
 	/**
+	 * The locale check applies the same way regardless of shipping mode — a market asking for
+	 * its own currency, an extra currency, its own language, or a fixed exchange rate is asking
+	 * for a feed the primary cannot serve, however alike the shipping looks.
+	 *
 	 * @dataProvider provide_configs_that_ask_for_more_than_primary_gives
 	 *
 	 * @param array $extra
@@ -1934,6 +2008,24 @@ class MarketServiceTest extends UnitTest {
 				'language' => [ substr( get_locale(), 0, 2 ) ],
 				'currency' => [ get_woocommerce_currency() ],
 			],
+			$this->primary_shipping_payload()
+		);
+
+		$this->assertTrue( $merged );
+		$this->assertSame( [], $this->options->get( OptionsInterface::MARKETS ) );
+	}
+
+	/**
+	 * The FE submits `currency: []` for flat-rate mode even on non-multilingual stores (the
+	 * currency control is disabled there and never fires onChange), and submits nothing for
+	 * `language` at all in that mode. Neither should read as "asks for its own locale".
+	 */
+	public function test_add_market_or_merge_folds_when_the_locale_field_is_an_empty_array(): void {
+		$this->set_up_primary_shipping_profile();
+
+		$merged = $this->market_service->add_market_or_merge_into_primary(
+			'gb',
+			array_merge( $this->secondary_config(), [ 'currency' => [] ] ),
 			$this->primary_shipping_payload()
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-938/fold-a-new-market-into-primary-when-its-shipping-config-matches

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Same as https://github.com/woocommerce/google-listings-and-ads/pull/3705 but this should work across different shipping mode and on multilingual/non multilingual stores.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
