### PR TITLE
GOOWOO-964 Secondary Market Store Shipping Rate Fix

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/SettingsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsController.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Merch
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseOptionsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
@@ -25,14 +26,21 @@ class SettingsController extends BaseOptionsController {
 	protected $shipping_zone;
 
 	/**
+	 * @var MarketService
+	 */
+	protected $market_service;
+
+	/**
 	 * SettingsController constructor.
 	 *
-	 * @param RESTServer   $server
-	 * @param ShippingZone $shipping_zone
+	 * @param RESTServer    $server
+	 * @param ShippingZone  $shipping_zone
+	 * @param MarketService $market_service
 	 */
-	public function __construct( RESTServer $server, ShippingZone $shipping_zone ) {
+	public function __construct( RESTServer $server, ShippingZone $shipping_zone, MarketService $market_service ) {
 		parent::__construct( $server );
-		$this->shipping_zone = $shipping_zone;
+		$this->shipping_zone  = $shipping_zone;
+		$this->market_service = $market_service;
 	}
 
 	/**
@@ -89,6 +97,11 @@ class SettingsController extends BaseOptionsController {
 				$options = [];
 			}
 
+			$previous_shipping = [
+				'shipping_rate' => $options['shipping_rate'] ?? null,
+				'shipping_time' => $options['shipping_time'] ?? null,
+			];
+
 			foreach ( $schema as $key => $property ) {
 				if ( ! in_array( 'edit', $property['context'] ?? [], true ) ) {
 					continue;
@@ -97,6 +110,17 @@ class SettingsController extends BaseOptionsController {
 			}
 
 			$this->options->update( OptionsInterface::MERCHANT_CENTER, $options );
+
+			// The global shipping method is what every market's Merchant Center shipping service is
+			// generated from, but this save path never told MarketService, so a mode switch here
+			// used not to reach Google at all. Only trigger the resync when the method actually
+			// changed, to avoid scheduling a job on unrelated settings saves.
+			$shipping_method_changed = $previous_shipping['shipping_rate'] !== ( $options['shipping_rate'] ?? null )
+				|| $previous_shipping['shipping_time'] !== ( $options['shipping_time'] ?? null );
+
+			if ( $shipping_method_changed ) {
+				$this->market_service->handle_global_shipping_method_change();
+			}
 
 			return [
 				'status'  => 'success',

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -126,7 +126,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 	 * @return void
 	 */
 	public function register(): void {
-		$this->share( SettingsController::class, ShippingZone::class );
+		$this->share( SettingsController::class, ShippingZone::class, MarketService::class );
 		$this->share( ConnectionController::class );
 		$this->share( AdsAccountController::class, AdsAccountService::class );
 		$this->share( AdsCampaignController::class, AdsCampaign::class );

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -590,15 +590,12 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 		$shipping = $config['shipping'] ?? null;
 		unset( $config['shipping'] );
 
-		$mc_settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
-
-		if ( ! isset( $config['shipping_rate'] ) ) {
-			$config['shipping_rate'] = $mc_settings['shipping_rate'] ?? 'flat';
-		}
-
-		if ( ! isset( $config['shipping_time'] ) ) {
-			$config['shipping_time'] = $mc_settings['shipping_time'] ?? 'flat';
-		}
+		// The shipping method (shipping_rate/shipping_time) is a single global setting, not a
+		// per-market one, so it is never stored on the market — a stored copy only drifts from
+		// the global value. Every read derives it live from the global method (see get_markets()
+		// and get_shipping_sync_countries()). Dropped here in case a caller submits it, mirroring
+		// update_market()'s handling of the same fields.
+		unset( $config['shipping_rate'], $config['shipping_time'] );
 
 		// The market form omits the language and currency fields for some
 		// shipping methods and for stores without a multilingual integration,
@@ -1677,13 +1674,14 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	public function get_shipping_sync_countries(): array {
 		$countries = $this->target_audience->get_target_countries();
 
-		foreach ( $this->get_participating_secondary_markets() as $market ) {
-			if ( 'manual' === ( $market['shipping_rate'] ?? null ) ) {
-				continue;
-			}
-
-			if ( ! empty( $market['country'] ) ) {
-				$countries[] = $market['country'];
+		// The shipping method is a single global setting, so it decides this for every secondary
+		// market at once — never a per-market stored value, which could be stale. A manual method
+		// means no secondary market receives a Merchant Center shipping service.
+		if ( 'manual' !== ( $this->global_shipping_method()['shipping_rate'] ?? null ) ) {
+			foreach ( $this->get_participating_secondary_markets() as $market ) {
+				if ( ! empty( $market['country'] ) ) {
+					$countries[] = $market['country'];
+				}
 			}
 		}
 
@@ -1801,6 +1799,23 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	 */
 	private function schedule_shipping_sync(): void {
 		$this->job_repository->get( UpdateShippingSettings::class )->schedule();
+	}
+
+	/**
+	 * Reacts to the global shipping method changing on the Settings page.
+	 *
+	 * Every market's Merchant Center shipping service is generated from that single global method,
+	 * so a change has to be pushed to Google. The Settings-page save is the one shipping-method
+	 * mutation that happens outside this service, and it never scheduled a resync; this schedules
+	 * the same shipping-settings sync the in-service mutations (add/delete market) already do,
+	 * gated the same way.
+	 *
+	 * Call it after the global method is persisted, only when it actually changed.
+	 */
+	public function handle_global_shipping_method_change(): void {
+		if ( $this->global_shipping_is_syncable() ) {
+			$this->schedule_shipping_sync();
+		}
 	}
 
 	/**

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -3,6 +3,7 @@
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\MerchantCenter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\SettingsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Shipping\ShippingZone;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
@@ -21,6 +22,9 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 	/** @var MockObject|ShippingZone $shipping_zone */
 	protected $shipping_zone;
 
+	/** @var MockObject|MarketService $market_service */
+	protected $market_service;
+
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
@@ -29,9 +33,10 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->shipping_zone = $this->createMock( ShippingZone::class );
-		$this->options       = $this->createMock( OptionsInterface::class );
-		$this->controller    = new SettingsController( $this->server, $this->shipping_zone );
+		$this->shipping_zone  = $this->createMock( ShippingZone::class );
+		$this->market_service = $this->createMock( MarketService::class );
+		$this->options        = $this->createMock( OptionsInterface::class );
+		$this->controller     = new SettingsController( $this->server, $this->shipping_zone, $this->market_service );
 		$this->controller->set_options_object( $this->options );
 		$this->controller->register();
 	}
@@ -82,6 +87,54 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'success', $response->get_data()['status'] );
+	}
+
+	public function test_edit_settings_changing_the_shipping_method_triggers_a_market_resync() {
+		$this->options->method( 'get' )->willReturn(
+			[
+				'shipping_rate' => 'flat',
+				'shipping_time' => 'flat',
+				'tax_rate'      => 'destination',
+			]
+		);
+
+		// The global shipping method changed (flat -> automatic), so markets must be resynced.
+		$this->market_service->expects( $this->once() )
+			->method( 'handle_global_shipping_method_change' );
+
+		$response = $this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'shipping_rate' => 'automatic',
+			]
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_edit_settings_without_a_shipping_method_change_does_not_trigger_a_market_resync() {
+		$this->options->method( 'get' )->willReturn(
+			[
+				'shipping_rate' => 'flat',
+				'shipping_time' => 'flat',
+				'tax_rate'      => 'destination',
+			]
+		);
+
+		// Only the tax rate changed; the shipping method is unchanged, so no resync is scheduled.
+		$this->market_service->expects( $this->never() )
+			->method( 'handle_global_shipping_method_change' );
+
+		$response = $this->do_request(
+			self::ROUTE,
+			'POST',
+			[
+				'tax_rate' => 'origin',
+			]
+		);
+
+		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	public function test_default_tax_rate_settings() {

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -2260,8 +2260,9 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( [ 'en' ], $stored_gb['language'] );
 		$this->assertSame( [ 'GBP' ], $stored_gb['currency'] );
 		$this->assertSame( 'GB', $stored_gb['feed_label'] );
-		$this->assertSame( 'flat', $stored_gb['shipping_rate'] );
-		$this->assertSame( 'flat', $stored_gb['shipping_time'] );
+		// The shipping method is global, never stored on the market (a stored copy only drifts).
+		$this->assertArrayNotHasKey( 'shipping_rate', $stored_gb );
+		$this->assertArrayNotHasKey( 'shipping_time', $stored_gb );
 
 		$this->assertArrayHasKey( OptionsInterface::TARGET_AUDIENCE, $update_calls );
 		$this->assertSame( [ 'US', 'CA' ], $update_calls[ OptionsInterface::TARGET_AUDIENCE ]['countries'] );
@@ -4405,61 +4406,13 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( [ 'FR' ], $result['fr']['countries'] );
 	}
 
-	public function test_add_market_defaults_shipping_mode_from_mc_settings_when_omitted(): void {
-		$mc_settings = [
-			'shipping_rate' => 'automatic',
-			'shipping_time' => 'manual',
-		];
-
-		$ta = [
-			'location'  => 'selected',
-			'countries' => [ 'US' ],
-		];
-
-		$this->set_up_options_get(
-			[
-				OptionsInterface::MARKETS         => [],
-				OptionsInterface::MERCHANT_CENTER => $mc_settings,
-				OptionsInterface::TARGET_AUDIENCE => $ta,
-			]
-		);
-
-		$update_calls = [];
-		$this->options->method( 'update' )
-			->willReturnCallback(
-				function ( $key, $value ) use ( &$update_calls ) {
-					$update_calls[ $key ] = $value;
-					return true;
-				}
-			);
-
-		$this->market_service->add_market(
-			'jp',
-			[
-				'country'    => 'JP',
-				'language'   => [ 'ja' ],
-				'currency'   => [ 'JPY' ],
-				'feed_label' => 'JP',
-			]
-		);
-
-		$stored_jp = $update_calls[ OptionsInterface::MARKETS ]['jp'];
-		$this->assertSame( 'automatic', $stored_jp['shipping_rate'] );
-		$this->assertSame( 'manual', $stored_jp['shipping_time'] );
-	}
-
 	/**
-	 * An explicit shipping_rate/shipping_time in the add request is still persisted
-	 * as the stored snapshot. This is storage-only: the snapshot no longer drives any
-	 * decision (get_markets() overwrites it with the global method on read, and the
-	 * sync gate reads the global setting), but the write itself is preserved.
+	 * The shipping method is a single global setting, never a per-market one, so add_market()
+	 * must not store shipping_rate/shipping_time on the market — not even when a caller submits
+	 * them — because a stored copy only drifts from the global value. Every read derives the
+	 * method live from the global setting instead.
 	 */
-	public function test_add_market_explicit_shipping_mode_takes_precedence_over_mc_settings(): void {
-		$mc_settings = [
-			'shipping_rate' => 'automatic',
-			'shipping_time' => 'automatic',
-		];
-
+	public function test_add_market_never_stores_the_shipping_method(): void {
 		$ta = [
 			'location'  => 'selected',
 			'countries' => [ 'US' ],
@@ -4468,7 +4421,10 @@ class MarketServiceTest extends UnitTest {
 		$this->set_up_options_get(
 			[
 				OptionsInterface::MARKETS         => [],
-				OptionsInterface::MERCHANT_CENTER => $mc_settings,
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
 				OptionsInterface::TARGET_AUDIENCE => $ta,
 			]
 		);
@@ -4489,14 +4445,15 @@ class MarketServiceTest extends UnitTest {
 				'language'      => [ 'ja' ],
 				'currency'      => [ 'JPY' ],
 				'feed_label'    => 'JP',
-				'shipping_rate' => 'flat',
-				'shipping_time' => 'flat',
+				// Even submitted explicitly, these must not be persisted on the market.
+				'shipping_rate' => 'manual',
+				'shipping_time' => 'manual',
 			]
 		);
 
 		$stored_jp = $update_calls[ OptionsInterface::MARKETS ]['jp'];
-		$this->assertSame( 'flat', $stored_jp['shipping_rate'] );
-		$this->assertSame( 'flat', $stored_jp['shipping_time'] );
+		$this->assertArrayNotHasKey( 'shipping_rate', $stored_jp );
+		$this->assertArrayNotHasKey( 'shipping_time', $stored_jp );
 	}
 
 	public function test_has_multilingual_support_returns_false(): void {
@@ -5700,16 +5657,24 @@ class MarketServiceTest extends UnitTest {
 		$this->assertSame( [ 'US' ], $this->market_service->get_feed_labels_for_language( 'en' ) );
 	}
 
-	public function test_get_shipping_sync_countries_includes_non_manual_secondary_markets(): void {
+	public function test_get_shipping_sync_countries_uses_the_global_method_not_a_stale_per_market_value(): void {
+		// Regression: the shipping method is a single global setting, so a secondary market's own
+		// stored shipping_rate must be ignored. Here the global is automatic while both markets
+		// carry a stale `manual` snapshot; both countries must still be included. (Before the fix,
+		// a market whose snapshot said `manual` was wrongly skipped and never synced.)
 		$this->set_up_options_get(
 			[
-				OptionsInterface::MARKETS => [
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+				OptionsInterface::MARKETS         => [
 					'fr' => [
 						'country'       => 'FR',
 						'language'      => [ 'fr' ],
 						'currency'      => [ 'EUR' ],
 						'feed_label'    => 'FR',
-						'shipping_rate' => 'automatic',
+						'shipping_rate' => 'manual',
 					],
 					'de' => [
 						'country'       => 'DE',
@@ -5724,11 +5689,69 @@ class MarketServiceTest extends UnitTest {
 		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'CA' ] );
 		$this->wpml->method( 'can_convert_currency' )->willReturn( true );
 
-		// Manual markets are excluded — their shipping is managed outside the plugin.
 		$this->assertSame(
-			[ 'US', 'CA', 'FR' ],
+			[ 'US', 'CA', 'FR', 'DE' ],
 			$this->market_service->get_shipping_sync_countries()
 		);
+	}
+
+	public function test_get_shipping_sync_countries_excludes_all_secondary_markets_when_global_is_manual(): void {
+		// The global method is manual, so no secondary market gets a Merchant Center shipping
+		// service — regardless of any non-manual value stored on the market.
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'manual',
+					'shipping_time' => 'manual',
+				],
+				OptionsInterface::MARKETS         => [
+					'fr' => [
+						'country'       => 'FR',
+						'language'      => [ 'fr' ],
+						'currency'      => [ 'EUR' ],
+						'feed_label'    => 'FR',
+						'shipping_rate' => 'automatic',
+					],
+				],
+			]
+		);
+		$this->target_audience->method( 'get_target_countries' )->willReturn( [ 'US', 'CA' ] );
+		$this->wpml->method( 'can_convert_currency' )->willReturn( true );
+
+		$this->assertSame(
+			[ 'US', 'CA' ],
+			$this->market_service->get_shipping_sync_countries()
+		);
+	}
+
+	public function test_handle_global_shipping_method_change_schedules_the_shipping_sync_when_syncable(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'automatic',
+					'shipping_time' => 'flat',
+				],
+			]
+		);
+
+		$this->shipping_settings_job->expects( $this->once() )->method( 'schedule' );
+
+		$this->market_service->handle_global_shipping_method_change();
+	}
+
+	public function test_handle_global_shipping_method_change_does_not_schedule_when_global_is_manual(): void {
+		$this->set_up_options_get(
+			[
+				OptionsInterface::MERCHANT_CENTER => [
+					'shipping_rate' => 'manual',
+					'shipping_time' => 'manual',
+				],
+			]
+		);
+
+		$this->shipping_settings_job->expects( $this->never() )->method( 'schedule' );
+
+		$this->market_service->handle_global_shipping_method_change();
 	}
 
 	public function test_get_shipping_sync_countries_deduplicates_countries(): void {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

**Problem**
Every secondary market stored its own shipping_rate/shipping_time in gla_markets, snapshotted at creation. These are supposed to always mirror the single global setting (gla_merchant_center), but nothing kept them in sync — the guarantee was only enforced at read time, one call site at a time. So a market's stored method drifted from the global forever, no matter how often the merchant changed it.

**Root cause**
The shipping method (flat/automatic/manual) is a single global setting, not per-market, the only genuinely per-country data is the flat rate/time values, which live in the shipping tables. The stored per-market copy was a leftover from an earlier design where each market owned its method (it used to be in the POST payload); that design was dropped, but the storage was never cleaned up and got papered over with read-time patches instead.

**Fix**
add_market() no longer stores shipping_rate/shipping_time (mirrors update_market, which already unset them).
get_shipping_sync_countries() now reads the global method instead of the raw stored value — the last consumer that wasn't already using the live value.

New SettingsController → MarketService::handle_global_shipping_method_change() cascade: saving a changed global shipping method on the Settings page now schedules the shipping-settings sync, so a mode switch there finally reaches Merchant Center.


Closes https://linear.app/a8c/issue/GOOWOO-964/secondary-markets-stored-shipping-rateshipping-time-drift-from-the

### Screenshots:

### Detailed test instructions:

**Setup**: a store connected to Merchant Center with at least one secondary market (e.g. France) plus a couple of primary countries.

**1. Global method reaches every market**
Set the global shipping method on Settings → Shipping to Automatic (or Flat), save.
Open Marketing → Google for WooCommerce → Markets. Every market (primary and secondary) should show the same method you just saved — none stuck on an old value.
Switch the global method (e.g. Flat → Automatic), save, reload Markets. All markets reflect the new method immediately.

**2. No stale per-market value breaks sync**
With the global method set to Automatic, confirm a secondary market like France syncs to Merchant Center (its country gets a shipping service; products target it). Before this fix, a market that had drifted to "manual" internally was silently skipped and never synced.

Quick check via WP-CLI if you want to see storage directly: wp option get gla_markets --format=json - newly created/edited markets should have no shipping_rate/shipping_time keys at all (the method is derived from the global setting now).

**3. Settings save triggers a resync**
Change the global shipping method on the Settings page and save.
Under WooCommerce → Status → Scheduled Actions, a shipping-settings sync job should be scheduled (search for the GLA shipping sync action). Saving Settings without changing the shipping method (e.g. only the tax rate) should NOT schedule it.

**4. Manual global method**
Set the global method to Manual, save. No secondary market should get an auto-generated MC shipping service (shipping is managed manually in Merchant Center).

**Expected**: markets always show the current global method with no drift; France (and any market) syncs whenever the global method is non-manual; changing the method on Settings schedules a resync.