### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set Labels
-        uses: woocommerce/grow/branch-label@actions-v2
+        uses: woocommerce/grow/branch-label@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,15 +20,15 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
@@ -69,13 +69,13 @@ jobs:
 
       - name: Publish dev build to GitHub
         if: ${{ github.event_name == 'push' && github.ref_name == 'develop' }}
-        uses: woocommerce/grow/publish-extension-dev-build@actions-v2
+        uses: woocommerce/grow/publish-extension-dev-build@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           extension-asset-path: google-listings-and-ads.zip
 
       - name: Publish build artifact
         if: ${{ ! ( github.event_name == 'push' && github.ref_name == 'develop' ) }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: google-listings-and-ads.zip
           path: ${{ github.workspace }}/google-listings-and-ads.zip

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -25,7 +25,7 @@ jobs:
       RELEASE_BRANCH: ${{ inputs.release_branch != '' && inputs.release_branch || format('release/{0}', inputs.version) }}
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ env.RELEASE_BRANCH }}
           token: ${{ secrets.ORG_DEPLOY_SECRET }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       # Checkout the private action repository
       - name: Checkout woo-product-deploy action
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: woocommerce/woo-product-deploy
           ref: trunk
@@ -69,7 +69,7 @@ jobs:
           fi
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: google-listings-and-ads.zip
           path: ${{ github.workspace }}/google-listings-and-ads.zip

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,15 +26,15 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           install-deps: "no"
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"
@@ -72,7 +72,7 @@ jobs:
 
       - name: Archive e2e failure screenshots
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
             name: e2e-screenshots
             path: tests/e2e/test-results/report/**/*.png

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -32,7 +32,7 @@ jobs:
       changelog_block: ${{ steps.generate.outputs.changelog_block }}
     steps:
       - name: Checkout release branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ env.RELEASE_BRANCH }}
           token: ${{ secrets.ORG_DEPLOY_SECRET }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Generate changelog from merged PRs
         id: generate
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           VERSION: ${{ inputs.version }}
           RELEASE_BRANCH: ${{ env.RELEASE_BRANCH }}
@@ -176,7 +176,7 @@ jobs:
       - name: Prepend changelog entry to changelog.txt
         env:
           CHANGELOG_BLOCK: ${{ steps.generate.outputs.changelog_block }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -191,7 +191,7 @@ jobs:
       - name: Insert changelog entry into readme.txt
         env:
           CHANGELOG_BLOCK: ${{ steps.generate.outputs.changelog_block }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -28,15 +28,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/eslint-annotation@actions-v2
+        uses: woocommerce/grow/eslint-annotation@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
 
       - name: Lint JavaScript and annotate linting errors
         run: npm run lint:js -- --quiet --format ./eslintFormatter.cjs
@@ -46,15 +46,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           node-version-file: ".nvmrc"
 
       - name: Prepare annotation formatter
-        uses: woocommerce/grow/stylelint-annotation@actions-v2
+        uses: woocommerce/grow/stylelint-annotation@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
 
       - name: Lint CSS and annotate linting errors
         run: npm run lint:css -- --custom-formatter ./stylelintFormatter.cjs

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -29,10 +29,10 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           node-version-file: ".nvmrc"
 

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           tools: cs2pr
 

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # Checks out a branch instead of a commit in detached HEAD state
           ref: ${{ github.head_ref }}
@@ -26,7 +26,7 @@ jobs:
         # This generates the documentation string. The `id` property is used to reference the output in the next step.
       - name: Generate hook documentation
         id: generate-hook-docs
-        uses: woocommerce/grow/hook-documentation@actions-v2
+        uses: woocommerce/grow/hook-documentation@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           source-directories: src/,views/,google-listings-and-ads.php,uninstall.php
 

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -44,12 +44,12 @@ jobs:
     steps:
       - name: Get Release versions from WordPress
         id: wp
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           slug: wordpress
       - name: Get Release versions from WooCommerce
         id: wc
-        uses: woocommerce/grow/get-plugin-releases@actions-v2
+        uses: woocommerce/grow/get-plugin-releases@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           source: github
           slug: woocommerce/woocommerce
@@ -81,20 +81,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - if: matrix.wc-versions == needs.GetMatrix.outputs.latest-wc-version && matrix.php == 8.2
         name: Set condition to generate coverage report (only on latest versions)
         run: echo "generate_coverage=true" >> $GITHUB_ENV
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           php-version: "${{ matrix.php }}"
           coverage: "${{ env.generate_coverage == 'true' && 'xdebug' || 'none' }}"
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v2
+        uses: woocommerce/grow/prepare-mysql@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
 
       - name: Install svn (used for installing WP versions)
         run: sudo apt-get -y install subversion
@@ -129,15 +129,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@actions-v2
+        uses: woocommerce/grow/prepare-php@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           php-version: "${{ inputs.php-version }}"
 
       - name: Prepare MySQL
-        uses: woocommerce/grow/prepare-mysql@actions-v2
+        uses: woocommerce/grow/prepare-mysql@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
 
       - name: Install svn (used for installing WP versions)
         run: sudo apt-get -y install subversion

--- a/.github/workflows/post-release-merge.yml
+++ b/.github/workflows/post-release-merge.yml
@@ -18,7 +18,7 @@ jobs:
   MergeTrunkDevelopPR:
     runs-on: ubuntu-latest
     steps:
-      - uses: woocommerce/grow/merge-trunk-develop-pr@actions-v2
+      - uses: woocommerce/grow/merge-trunk-develop-pr@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
 
   delete-simulate-release-branch:
     name: Delete simulate release branch
@@ -32,7 +32,7 @@ jobs:
       contents: write
     steps:
       - name: Delete branch
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;

--- a/.github/workflows/prepare-release--deprecated.yml
+++ b/.github/workflows/prepare-release--deprecated.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Create branch & PR
-        uses: woocommerce/grow/prepare-extension-release@actions-v2
+        uses: woocommerce/grow/prepare-extension-release@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           version: ${{ github.event.inputs.version }}
           type: ${{ github.event.inputs.type }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Checkout source branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.source_branch }}
           token: ${{ secrets.ORG_DEPLOY_SECRET }}
@@ -102,7 +102,7 @@ jobs:
       contents: read
     steps:
       - name: Create Pull Request
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           VERSION: ${{ inputs.version }}
           SOURCE_BRANCH: ${{ inputs.source_branch }}

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -58,12 +58,12 @@ jobs:
     needs: build
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: google-listings-and-ads.zip
       - name: Run QIT Tests
         # Update it with more stable path once merged.
-        uses: woocommerce/grow/run-qit-extension@actions-v2
+        uses: woocommerce/grow/run-qit-extension@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           qit-partner-user: ${{ secrets.QIT_PARTNER_USER }}
           qit-partner-secret: ${{ secrets.QIT_PARTNER_SECRET }}

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: develop
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@actions-v2
+        uses: woocommerce/grow/prepare-node@68794d4270fbfb19bb0bb76d6cebc8dd18f7d133 # actions-v2
         with:
           node-version-file: ".nvmrc"
 


### PR DESCRIPTION
## Changes proposed in this pull request

Pin every third-party GitHub Action used by this repository to a full 40-character commit SHA. The prior human-readable tag or branch is retained in an inline comment so future updates remain understandable.

The WooCommerce organization intends to enforce full-length commit SHA pinning for Actions at the organization level. Landing this change first avoids disrupting this repository when enforcement is enabled. Immutable action revisions reduce the risk that a moved or compromised upstream tag can be used for a CI/CD supply-chain exploit.

## How to test

- Confirm each external `uses:` reference ends in a 40-character commit SHA.
- Confirm the prior version or branch appears in the inline comment.
- Parse all changed workflow and action metadata files as YAML.
- Re-run the repository audit and confirm it reports zero unpinned external action references.

## Changelog

No changelog entry is needed because this only hardens CI configuration and does not change the shipped product.

_Drafted with AI assistance._
