### PR TITLE
GOOWOO-972: Remove countries from the primary market leaves orphan shipping

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/TargetAudienceController.php
+++ b/src/API/Site/Controllers/MerchantCenter/TargetAudienceController.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\CountryCode
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ISO3166AwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
@@ -58,6 +59,11 @@ class TargetAudienceController extends BaseOptionsController implements ISO3166A
 	protected $target_audience;
 
 	/**
+	 * @var MarketService
+	 */
+	protected $market_service;
+
+	/**
 	 * TargetAudienceController constructor.
 	 *
 	 * @param RESTServer     $server
@@ -66,14 +72,16 @@ class TargetAudienceController extends BaseOptionsController implements ISO3166A
 	 * @param ShippingZone   $shipping_zone
 	 * @param GoogleHelper   $google_helper
 	 * @param TargetAudience $target_audience
+	 * @param MarketService  $market_service
 	 */
-	public function __construct( RESTServer $server, WP $wp, WC $wc, ShippingZone $shipping_zone, GoogleHelper $google_helper, TargetAudience $target_audience ) {
+	public function __construct( RESTServer $server, WP $wp, WC $wc, ShippingZone $shipping_zone, GoogleHelper $google_helper, TargetAudience $target_audience, MarketService $market_service ) {
 		parent::__construct( $server );
 		$this->wp              = $wp;
 		$this->wc              = $wc;
 		$this->shipping_zone   = $shipping_zone;
 		$this->google_helper   = $google_helper;
 		$this->target_audience = $target_audience;
+		$this->market_service  = $market_service;
 	}
 
 	/**
@@ -141,8 +149,12 @@ class TargetAudienceController extends BaseOptionsController implements ISO3166A
 	 */
 	protected function get_update_audience_callback(): callable {
 		return function ( Request $request ) {
-			$data = $this->prepare_item_for_database( $request );
+			$data          = $this->prepare_item_for_database( $request );
+			$previous_data = $this->get_target_audience_option();
+
 			$this->update_target_audience_option( $data );
+			$this->remove_shipping_rows_for_dropped_countries( $previous_data, $data );
+
 			$this->prepare_item_for_response( $data, $request );
 
 			return new Response(
@@ -258,6 +270,44 @@ class TargetAudienceController extends BaseOptionsController implements ISO3166A
 	 */
 	protected function update_target_audience_option( array $data ): bool {
 		return $this->options->update( OptionsInterface::TARGET_AUDIENCE, $data );
+	}
+
+	/**
+	 * Cleans up shipping rate/time rows for countries no longer targeted after a save.
+	 *
+	 * Compares the effective target countries before and after the save, not the raw
+	 * "countries" lists, so a switch to location "all" (where every MC-supported country
+	 * becomes targeted regardless of the stored list) is never mistaken for every
+	 * previously selected country being removed.
+	 *
+	 * @param array $previous_data The target audience data before this save.
+	 * @param array $new_data      The target audience data just persisted.
+	 */
+	protected function remove_shipping_rows_for_dropped_countries( array $previous_data, array $new_data ): void {
+		$removed_countries = array_diff(
+			$this->get_effective_target_countries( $previous_data ),
+			$this->get_effective_target_countries( $new_data )
+		);
+
+		foreach ( $removed_countries as $removed_country ) {
+			$this->market_service->remove_shipping_rows_for_country( (string) $removed_country );
+		}
+	}
+
+	/**
+	 * Resolves the countries actually targeted by a given target audience data set,
+	 * mirroring TargetAudience::get_target_countries()'s location handling.
+	 *
+	 * @param array $data Target audience data with 'location' and 'countries' keys.
+	 *
+	 * @return string[]
+	 */
+	protected function get_effective_target_countries( array $data ): array {
+		if ( 'all' === strtolower( (string) ( $data['location'] ?? '' ) ) ) {
+			return $this->google_helper->get_mc_supported_countries();
+		}
+
+		return $data['countries'] ?? [];
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -152,7 +152,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( ShippingRateSuggestionsController::class, ShippingSuggestionService::class );
 		$this->share( ShippingTimeBatchController::class );
 		$this->share( ShippingTimeController::class );
-		$this->share( TargetAudienceController::class, WP::class, WC::class, ShippingZone::class, GoogleHelper::class, TargetAudience::class );
+		$this->share( TargetAudienceController::class, WP::class, WC::class, ShippingZone::class, GoogleHelper::class, TargetAudience::class, MarketService::class );
 		$this->share( SupportedCountriesController::class, WC::class, GoogleHelper::class );
 		$this->share( SettingsSyncController::class, Settings::class );
 		$this->share( DisconnectController::class );

--- a/src/MerchantCenter/MarketService.php
+++ b/src/MerchantCenter/MarketService.php
@@ -919,6 +919,15 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 				$this->schedule_primary_currency_cleanup( $removed_currencies, $primary_existing_langs );
 			}
 
+			// A country dropped from the primary market's target audience here (rather than
+			// claimed by a secondary market, which removes it via remove_country_from_target_audience()
+			// before this diff runs) is no longer targeted by any market, so its shipping rows
+			// would otherwise be left as orphans.
+			$removed_countries = array_diff( $existing_countries, $merged_countries );
+			foreach ( $removed_countries as $removed_country ) {
+				$this->remove_shipping_rows_for_country( (string) $removed_country );
+			}
+
 			$resync_needed = $existing_countries !== $merged_countries
 				|| array_diff( $existing_language, $merged_language ) !== []
 				|| array_diff( $merged_language, $existing_language ) !== []
@@ -2691,15 +2700,21 @@ class MarketService implements Service, OptionsAwareInterface, Registerable {
 	/**
 	 * Removes a country's shipping rate and time rows.
 	 *
-	 * Used when a deleted market's country is not returning to the primary
-	 * market: with no rows and no target audience entry, the country is
-	 * omitted from the next shipping settings payload, and Google deletes its
-	 * shipping service because shippingsettings.update replaces the full
-	 * resource ("any fields that are not provided are deleted").
+	 * Used when a country is no longer targeted by any market — a deleted
+	 * secondary market's country not returning to the primary market, or a
+	 * country dropped from the primary market's target audience entirely:
+	 * with no rows and no target audience entry, the country is omitted from
+	 * the next shipping settings payload, and Google deletes its shipping
+	 * service because shippingsettings.update replaces the full resource
+	 * ("any fields that are not provided are deleted").
+	 *
+	 * Public so callers outside this service (e.g. TargetAudienceController)
+	 * can clean up a country's rows when they remove it from the primary
+	 * market's target audience.
 	 *
 	 * @param string $country ISO 3166-1 alpha-2 country code.
 	 */
-	private function remove_shipping_rows_for_country( string $country ): void {
+	public function remove_shipping_rows_for_country( string $country ): void {
 		$this->shipping_rate_query->delete( 'country', $country );
 		$this->shipping_time_query->delete( 'country', $country );
 		$this->forget_shipping_rates();

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/TargetAudienceControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/TargetAudienceControllerTest.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\MerchantCenter\TargetAudienceController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
@@ -42,6 +43,9 @@ class TargetAudienceControllerTest extends RESTControllerUnitTest {
 	/** @var MockObject|TargetAudience $target_audience */
 	protected $target_audience;
 
+	/** @var MockObject|MarketService $market_service */
+	protected $market_service;
+
 	/** @var TargetAudienceController $controller */
 	protected $controller;
 
@@ -60,8 +64,9 @@ class TargetAudienceControllerTest extends RESTControllerUnitTest {
 		$this->google_helper   = $this->createMock( GoogleHelper::class );
 		$this->options         = $this->createMock( OptionsInterface::class );
 		$this->target_audience = $this->createMock( TargetAudience::class );
+		$this->market_service  = $this->createMock( MarketService::class );
 
-		$this->controller = new TargetAudienceController( $this->server, $this->wp, $this->wc, $this->shipping_zone, $this->google_helper, $this->target_audience );
+		$this->controller = new TargetAudienceController( $this->server, $this->wp, $this->wc, $this->shipping_zone, $this->google_helper, $this->target_audience, $this->market_service );
 
 		$this->controller->set_iso3166_provider( $this->iso_provider );
 		$this->controller->set_options_object( $this->options );
@@ -108,9 +113,12 @@ class TargetAudienceControllerTest extends RESTControllerUnitTest {
 			'countries' => [ 'US', 'GB' ],
 		];
 
+		// No countries dropped, so no shipping rows should be cleaned up.
+		$this->options->method( 'get' )->willReturn( $payload );
 		$this->options->expects( $this->once() )
 			->method( 'update' )
 			->with( OptionsInterface::TARGET_AUDIENCE, $payload );
+		$this->market_service->expects( $this->never() )->method( 'remove_shipping_rows_for_country' );
 
 		$response = $this->do_request( self::ROUTE_TARGET_AUDIENCE, 'POST', $payload );
 
@@ -127,9 +135,65 @@ class TargetAudienceControllerTest extends RESTControllerUnitTest {
 			'countries' => [],
 		];
 
+		$this->options->method( 'get' )->willReturn( $payload );
 		$this->options->expects( $this->once() )
 			->method( 'update' )
 			->with( OptionsInterface::TARGET_AUDIENCE, $payload );
+
+		$response = $this->do_request( self::ROUTE_TARGET_AUDIENCE, 'POST', $payload );
+
+		$this->assertEquals( 'success', $response->get_data()['status'] );
+		$this->assertEquals( 201, $response->get_status() );
+	}
+
+	/**
+	 * Test that removing a country from the target audience deletes its shipping
+	 * rate/time rows, while countries that remain are left untouched.
+	 */
+	public function test_update_target_audience_removes_shipping_rows_for_dropped_countries() {
+		$previous = [
+			'location'  => 'selected',
+			'countries' => [ 'US', 'GB', 'FR' ],
+		];
+		$payload  = [
+			'location'  => 'selected',
+			'countries' => [ 'US', 'GB' ],
+		];
+
+		$this->options->method( 'get' )->willReturn( $previous );
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::TARGET_AUDIENCE, $payload );
+
+		$this->market_service->expects( $this->once() )
+			->method( 'remove_shipping_rows_for_country' )
+			->with( 'FR' );
+
+		$response = $this->do_request( self::ROUTE_TARGET_AUDIENCE, 'POST', $payload );
+
+		$this->assertEquals( 'success', $response->get_data()['status'] );
+		$this->assertEquals( 201, $response->get_status() );
+	}
+
+	/**
+	 * Test that switching the target audience to "all" countries does not treat the
+	 * previously "selected" countries as removed, since they remain targeted.
+	 */
+	public function test_update_target_audience_switching_to_all_does_not_remove_shipping_rows() {
+		$previous = [
+			'location'  => 'selected',
+			'countries' => [ 'US', 'GB' ],
+		];
+		$payload  = [
+			'location'  => 'all',
+			'countries' => [],
+		];
+
+		$this->options->method( 'get' )->willReturn( $previous );
+		$this->options->method( 'update' )->willReturn( true );
+		$this->google_helper->method( 'get_mc_supported_countries' )->willReturn( [ 'US', 'GB', 'FR' ] );
+
+		$this->market_service->expects( $this->never() )->method( 'remove_shipping_rows_for_country' );
 
 		$response = $this->do_request( self::ROUTE_TARGET_AUDIENCE, 'POST', $payload );
 

--- a/tests/Unit/MerchantCenter/MarketServiceTest.php
+++ b/tests/Unit/MerchantCenter/MarketServiceTest.php
@@ -3567,6 +3567,49 @@ class MarketServiceTest extends UnitTest {
 		);
 	}
 
+	public function test_update_market_primary_removes_shipping_rows_for_dropped_countries(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [],
+				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'US', 'CA', 'GB' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US', 'CA', 'GB' ] );
+
+		// CA is dropped; US and GB remain targeted and must be left alone.
+		$this->shipping_rate_query->expects( $this->once() )
+			->method( 'delete' )
+			->with( 'country', 'CA' );
+		$this->shipping_time_query->expects( $this->once() )
+			->method( 'delete' )
+			->with( 'country', 'CA' );
+
+		$this->market_service->update_market(
+			'primary',
+			[ 'countries' => [ 'US', 'GB' ] ]
+		);
+	}
+
+	public function test_update_market_primary_does_not_remove_shipping_rows_when_countries_unchanged(): void {
+		$this->set_up_options_get_with_tracking(
+			[
+				OptionsInterface::MERCHANT_CENTER => [],
+				OptionsInterface::TARGET_AUDIENCE => [ 'countries' => [ 'US', 'GB' ] ],
+				OptionsInterface::MARKETS         => [],
+			]
+		);
+		$this->set_up_primary_market_dependencies( 'US', [ 'US', 'GB' ] );
+
+		$this->shipping_rate_query->expects( $this->never() )->method( 'delete' );
+		$this->shipping_time_query->expects( $this->never() )->method( 'delete' );
+
+		$this->market_service->update_market(
+			'primary',
+			[ 'countries' => [ 'US', 'GB' ] ]
+		);
+	}
+
 	public function test_update_market_secondary_schedules_update_all_products_when_language_differs(): void {
 		$existing = [
 			'gb' => [


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-972/removing-countries-from-the-primary-market-leaves-orphan-shipping

_Replace this with a good description of your changes & reasoning._

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

All changes below are made through the plugin's UI. Verification is done by calling the plugin's own read-only endpoints. `GET /wp-json/wc/gla/mc/shipping/rates` and `GET /wp-json/wc/gla/mc/shipping/times` (while logged in as an admin).

1. Go to the plugin's Markets tab (WooCommerce > Marketing > Google Listings & Ads > Markets).
2. Click Edit on the primary market's row to open the "Edit primary market" modal. In the Audience field, select US, GB, and FR (and configure a flat shipping rate/time, if shown, so each has stored shipping settings). Click Save.
3. Click Add market and create a secondary market for DE, with its own shipping rate/time. Click Add market to save.
4. Call `GET /wc/gla/mc/shipping/rates` and `GET /wc/gla/mc/shipping/times`. Confirm both list US, GB, FR, and DE.
5. Reopen "Edit primary market", deselect FR from the Audience field (leaving US and GB selected), and click Save.
6. Repeat the `GET` calls from step 4 and confirm FR no longer appear in either the `shipping_rates` or `shipping_times` response.
7. In the same responses, confirm US and GB (still in the primary market) and DE (secondary market) are all still present with their original rate/time values.
8. Re-run the GET calls once more (e.g. after saving an unrelated change elsewhere in the plugin). Confirm FR does not reappear in either table, confirming no new shipping rate/time entries are generated for a country once it's removed from the primary market's target audience.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
