### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -10,6 +10,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Set Labels
         uses: woocommerce/grow/branch-label@actions-v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
   BuildExtensionBundle:
     name: Build extension bundle
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       FORCE_COLOR: 2
     steps:

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -21,6 +21,7 @@ jobs:
   bump:
     name: Bump version to ${{ inputs.version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       RELEASE_BRANCH: ${{ inputs.release_branch != '' && inputs.release_branch || format('release/{0}', inputs.version) }}
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
 
     steps:
       # Checkout the private action repository

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,6 +22,7 @@ jobs:
   E2ETests:
     name: E2E Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     env:
       FORCE_COLOR: 2
     steps:

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -26,6 +26,7 @@ jobs:
   changelog:
     name: Generate changelog for ${{ inputs.version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       RELEASE_BRANCH: ${{ inputs.release_branch != '' && inputs.release_branch || format('release/{0}', inputs.version) }}
     outputs:

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -26,6 +26,7 @@ jobs:
   JSLintingCheck:
     name: Lint JavaScript
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -44,6 +45,7 @@ jobs:
   CSSLintingCheck:
     name: Lint CSS
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/js-unit-tests.yml
+++ b/.github/workflows/js-unit-tests.yml
@@ -25,6 +25,7 @@ jobs:
   UnitTests:
     name: JavaScript unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       FORCE_COLOR: 2
     steps:

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -25,6 +25,7 @@ jobs:
   phpcs:
     name: PHP coding standards
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/php-hook-documentation.yml
+++ b/.github/workflows/php-hook-documentation.yml
@@ -16,6 +16,7 @@ jobs:
   HookDocumentation:
     name: Hook Documentation Generator
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -37,6 +37,7 @@ jobs:
     if: github.event_name != 'workflow_dispatch'
     name: Get WP and WC version Matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       wp-versions: ${{ steps.wp.outputs.versions }}
       wc-versions: ${{ steps.wc.outputs.versions }}
@@ -59,6 +60,7 @@ jobs:
     name: PHP unit tests - PHP ${{ matrix.php }}, WP ${{ matrix.wp-version || 'latest' }}, WC ${{ matrix.wc-versions || 'latest' }}
     needs: GetMatrix
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       WP_CORE_DIR: "/tmp/wordpress/src"
       WP_TESTS_DIR: "/tmp/wordpress/tests/phpunit"
@@ -123,6 +125,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     name: PHP unit tests (for Release Candidates)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       WP_CORE_DIR: "/tmp/wordpress/src"
       WP_TESTS_DIR: "/tmp/wordpress/tests/phpunit"

--- a/.github/workflows/post-release-merge.yml
+++ b/.github/workflows/post-release-merge.yml
@@ -17,12 +17,14 @@ on:
 jobs:
   MergeTrunkDevelopPR:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: woocommerce/grow/merge-trunk-develop-pr@actions-v2
 
   delete-simulate-release-branch:
     name: Delete simulate release branch
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: |
       github.event.pull_request.merged == false &&
       startsWith(github.event.pull_request.head.ref, 'release/') &&

--- a/.github/workflows/prepare-release--deprecated.yml
+++ b/.github/workflows/prepare-release--deprecated.yml
@@ -25,6 +25,7 @@ jobs:
   PrepareRelease:
     name: Prepare Release
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,6 +26,7 @@ jobs:
   create-branch:
     name: Create release branch
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Validate version format
         run: |
@@ -97,6 +98,7 @@ jobs:
     name: Create Pull Request
     needs: generate-changelog
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       pull-requests: write
       contents: read

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -55,6 +55,7 @@ jobs:
   qit-tests:
     name: Run QIT Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: build
     steps:
       - name: Download artifact

--- a/.github/workflows/update-browserslist-db.yml
+++ b/.github/workflows/update-browserslist-db.yml
@@ -14,6 +14,7 @@ jobs:
   UpdateBrowserslistDB:
     name: Update Browserslist DB
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Add job timeouts so runs fail fast instead of hanging for up to 6 hours.

| Job | Median (30d) | Max (30d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `branch-labels.yml` / SetLabels | 0.10 min | 0.13 min | 5 |
| `build.yml` / BuildExtensionBundle | 4.38 min | 4.87 min | 10 |
| `bump-versions.yml` / bump | 0.10 min | 0.10 min | 5 |
| `deploy.yml` / deploy | 18.09 min | 18.78 min | 25 |
| `e2e-tests.yml` / E2ETests | 16.83 min | 18.03 min | 25 |
| `generate-changelog.yml` / changelog | 0.33 min | 0.33 min | 5 |
| `js-css-linting.yml` / JSLintingCheck | 3.07 min | 3.63 min | 10 |
| `js-css-linting.yml` / CSSLintingCheck | 2.75 min | 3.12 min | 10 |
| `js-unit-tests.yml` / UnitTests | 4.92 min | 5.47 min | 10 |
| `php-coding-standards.yml` / phpcs | 1.35 min | 1.63 min | 5 |
| `php-hook-documentation.yml` / HookDocumentation | 0.13 min | 0.15 min | 5 |
| `php-unit-tests.yml` / GetMatrix | 0.08 min | 0.12 min | 5 |
| `php-unit-tests.yml` / UnitTests (matrix) | 2.70 min | 6.47 min | 10 |
| `php-unit-tests.yml` / ReleaseCandidateUnitTests | no run in 30d (2.03 min older) | no run in 30d (2.37 min older) | 10 |
| `post-release-merge.yml` / MergeTrunkDevelopPR | 0.10 min | 0.10 min | 5 |
| `post-release-merge.yml` / delete-simulate-release-branch | always skipped | always skipped | 5 |
| `prepare-release--deprecated.yml` / PrepareRelease | never run | never run | 5 |
| `prepare-release.yml` / create-branch | 0.12 min | 0.12 min | 5 |
| `prepare-release.yml` / create-pr | 0.08 min | 0.08 min | 5 |
| `run-qit.yml` / qit-tests | never run | never run | 45 |
| `update-browserslist-db.yml` / UpdateBrowserslistDB | no success in 30d (2.85 min failed) | no success in 30d (3.07 min failed) | 10 |

Part of TESTOPS-272
