### PR TITLE
Feature / GOOWOO-944 Fix CookieYes Consent Race Condition

### DIFF
--- a/src/Google/ConsentGatedScriptTrait.php
+++ b/src/Google/ConsentGatedScriptTrait.php
@@ -15,8 +15,8 @@ trait ConsentGatedScriptTrait {
 	/**
 	 * Wrap script-loading JavaScript so the browser doesn't fetch the script at all until
 	 * marketing consent is confirmed via the WP Consent API's client-side layer. Fails open
-	 * (loads immediately) when that layer isn't present, matching WP::has_consent()'s own
-	 * fail-open behavior on the PHP side. If consent isn't yet granted, loading is deferred
+	 * (loads immediately) when that layer isn't present at all, matching WP::has_consent()'s
+	 * own fail-open behavior on the PHP side. If consent isn't yet granted, loading is deferred
 	 * until a wp_listen_for_consent_change event grants it, so a shopper who accepts later in
 	 * the same visit doesn't need to reload the page.
 	 *
@@ -32,16 +32,32 @@ trait ConsentGatedScriptTrait {
 	 * enqueued in the footer — checking wp_has_consent immediately would always see it as
 	 * undefined and fail open regardless of the shopper's actual choice.
 	 *
+	 * **A `true` reading at that point is not treated as immediately final.** Confirmed via a
+	 * real headless-browser trace against CookieYes (`cookie-law-info`) + WP Consent API: its
+	 * consent engine is fetched live from `cdn-cookieyes.com`, a cross-origin request, and in
+	 * that trace `wp_has_consent('marketing')` returned `true` at DOMContentLoaded (a default,
+	 * not a confirmed grant) and only corrected itself to `false` ~40ms later, by `window.load`
+	 * — after this method had already fetched the script, which cannot be un-fetched. A same
+	 * consent-plugin, different-CMP trace (GDPR Cookie Compliance, same-origin script) showed no
+	 * such gap — `false` was already stable at DOMContentLoaded. So a `true` reading gets a
+	 * short grace window (`GCL_GRACE_MS`) before being acted on, giving a CMP whose consent
+	 * engine loads asynchronously/cross-origin a chance to correct a stale default first. A
+	 * `false` reading is still acted on immediately — there's no correctness risk in *not*
+	 * loading yet, only in loading too eagerly.
+	 *
 	 * @param string $load_js Raw JavaScript that creates and appends the actual script element.
 	 *
 	 * @return string
 	 */
 	protected function get_consent_gated_script_markup( string $load_js ): string {
 		return sprintf(
-			'<script>(function(){function gclCheck(){function gclLoad(){%1$s}' .
-			'if("function"!==typeof wp_has_consent||wp_has_consent("marketing")){gclLoad();}' .
-			'else{var gclFired=false;document.addEventListener("wp_listen_for_consent_change",function(e){' .
-			'if(!gclFired&&e.detail&&"allow"===e.detail.marketing){gclFired=true;gclLoad();}});}}' .
+			'<script>(function(){var GCL_GRACE_MS=300;function gclCheck(){' .
+			'var gclLoaded=false;function gclLoad(){if(gclLoaded)return;gclLoaded=true;%1$s}' .
+			'if("function"!==typeof wp_has_consent){gclLoad();return;}' .
+			'document.addEventListener("wp_listen_for_consent_change",function(e){' .
+			'if(e.detail&&"allow"===e.detail.marketing){gclLoad();}});' .
+			'if(wp_has_consent("marketing")){setTimeout(function(){' .
+			'if(!gclLoaded&&wp_has_consent("marketing")){gclLoad();}},GCL_GRACE_MS);}}' .
 			'if("loading"===document.readyState){document.addEventListener("DOMContentLoaded",gclCheck);}else{gclCheck();}})();</script>',
 			$load_js
 		);

--- a/src/Google/ConsentGatedScriptTrait.php
+++ b/src/Google/ConsentGatedScriptTrait.php
@@ -13,6 +13,18 @@ defined( 'ABSPATH' ) || exit;
 trait ConsentGatedScriptTrait {
 
 	/**
+	 * Milliseconds a `true` consent reading is given to be corrected before being acted on.
+	 *
+	 * Not a real `const` — traits can't declare constants until PHP 8.2, and this codebase
+	 * still tests against PHP 7.4. A protected static property is the trait-compatible
+	 * equivalent. 300ms comfortably covers the ~40ms correction gap measured against a real
+	 * CookieYes install (see {@see self::get_consent_gated_script_markup()}'s docblock).
+	 *
+	 * @var int
+	 */
+	protected static $consent_grace_period_ms = 300;
+
+	/**
 	 * Wrap script-loading JavaScript so the browser doesn't fetch the script at all until
 	 * marketing consent is confirmed via the WP Consent API's client-side layer. Fails open
 	 * (loads immediately) when that layer isn't present at all, matching WP::has_consent()'s
@@ -40,10 +52,21 @@ trait ConsentGatedScriptTrait {
 	 * — after this method had already fetched the script, which cannot be un-fetched. A same
 	 * consent-plugin, different-CMP trace (GDPR Cookie Compliance, same-origin script) showed no
 	 * such gap — `false` was already stable at DOMContentLoaded. So a `true` reading gets a
-	 * short grace window (`GCL_GRACE_MS`) before being acted on, giving a CMP whose consent
-	 * engine loads asynchronously/cross-origin a chance to correct a stale default first. A
-	 * `false` reading is still acted on immediately — there's no correctness risk in *not*
-	 * loading yet, only in loading too eagerly.
+	 * short grace window ({@see self::$consent_grace_period_ms}) before being acted on, giving
+	 * a CMP whose consent engine loads asynchronously/cross-origin a chance to correct a stale
+	 * default first. A `false` reading is still acted on immediately — there's no correctness
+	 * risk in *not* loading yet, only in loading too eagerly.
+	 *
+	 * **Still no automated coverage of this branching logic, deliberately, not by oversight.**
+	 * Extracting it into a real webpack module would let it run under Jest, but would also
+	 * require `wp_enqueue_script()`-registering it unconditionally on every front-end page —
+	 * reintroducing the exact risk this trait was originally built to avoid instead of
+	 * `GlobalSiteTag`'s existing `wp-consent-api` bundle, which only enqueues when a merchant
+	 * has Ads conversion tracking configured and would silently break this for review-only
+	 * merchants otherwise. No equivalent Jest-testable pattern exists elsewhere in this
+	 * codebase for PHP-templated inline JS either — this would be a new one, not a reuse of an
+	 * existing one. Given that cost, this fix relies on the same real-CMP Playwright trace
+	 * verification described above instead. Revisit if this logic grows further.
 	 *
 	 * @param string $load_js Raw JavaScript that creates and appends the actual script element.
 	 *
@@ -51,15 +74,16 @@ trait ConsentGatedScriptTrait {
 	 */
 	protected function get_consent_gated_script_markup( string $load_js ): string {
 		return sprintf(
-			'<script>(function(){var GCL_GRACE_MS=300;function gclCheck(){' .
+			'<script>(function(){function gclCheck(){' .
 			'var gclLoaded=false;function gclLoad(){if(gclLoaded)return;gclLoaded=true;%1$s}' .
 			'if("function"!==typeof wp_has_consent){gclLoad();return;}' .
 			'document.addEventListener("wp_listen_for_consent_change",function(e){' .
 			'if(e.detail&&"allow"===e.detail.marketing){gclLoad();}});' .
 			'if(wp_has_consent("marketing")){setTimeout(function(){' .
-			'if(!gclLoaded&&wp_has_consent("marketing")){gclLoad();}},GCL_GRACE_MS);}}' .
+			'if(!gclLoaded&&wp_has_consent("marketing")){gclLoad();}},%2$d);}}' .
 			'if("loading"===document.readyState){document.addEventListener("DOMContentLoaded",gclCheck);}else{gclCheck();}})();</script>',
-			$load_js
+			$load_js,
+			static::$consent_grace_period_ms
 		);
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes: [GOOWOO-944](https://linear.app/a8c/issue/GOOWOO-944/add-consent-mode-gating-to-the-gcr-opt-in-prompt-and-badge-widget) (QA follow-up, [comment](https://linear.app/a8c/issue/GOOWOO-944/add-consent-mode-gating-to-the-gcr-opt-in-prompt-and-badge-widget#comment-80d40a85))

> **Requires ENG QA against a real CMP, not a code-read review.** The bug this fixes was a timing race that only shows up when a script's execution order is actually observed live. It was invisible to both `curl`/page-source inspection and to the original manual QA pass. See "Detailed test instructions" below for the exact repro.

QA (@ankitguptaindia ) found that with CookieYes & WP Consent API active and marketing consent explicitly rejected, `merchantwidget.js` (and `platform.js`) still loaded on reload. 

- `wp_has_consent('marketing')` returned **`true`** at `DOMContentLoaded`. This was a stale default, not a confirmed grant and only corrected itself to **`false`** ~40ms later, at `window.load`. By then `get_consent_gated_script_markup()` had already fetched the script, which can't be un-fetched once the element is created and appended.
- The same trace against GDPR Cookie Compliance (the CMP this gate was originally verified against) showed no such gap — `false` was already stable at `DOMContentLoaded`.
- Root cause: CookieYes's actual consent engine is fetched live from `cdn-cookieyes.com`, a cross-origin network request, while GDPR Cookie Compliance's consent-bridge script is enqueued same-origin. The cross-origin fetch simply takes slightly longer than the page needs to reach `DOMContentLoaded`, so our one-time check ran before CookieYes had reported the real answer.

**This isn't unique to CookieYes**: It's a structural risk for any CMP whose consent-reporting script resolves asynchronously or cross-origin, and CookieYes is one of the most widely-installed CMPs for WordPress, so this was not treated as an edge case.

**The fix**: A `false` reading is still acted on immediately (no correctness risk in waiting there). A `true` reading is no longer treated as immediately final, it now gets a short grace window (`ConsentGatedScriptTrait::$consent_grace_period_ms`, 300ms - a documented protected static property, since traits can't declare real `const`s until PHP 8.2 and this repo still tests against 7.4) during which either a `wp_listen_for_consent_change` "allow" event or a live re-check of `wp_has_consent()` can confirm it before the script actually loads. If the reading was genuinely a stale default, the re-check at 300ms sees the corrected value and never fetches. This doesn't rely solely on the CMP correctly firing the change event, the timer-based re-check is an independent safety net.

**Verified live against both CMPs**, not unit tests alone:
- CookieYes, reject > reload: previously fetched incorrectly, now correctly **not fetched**.
- CookieYes, accept > reload: still fetches correctly.
- CookieYes, reject > grant mid-visit (no reload): still fetches live, per the existing AC.
- GDPR Cookie Compliance: no regression, its `false` reading is already stable at `DOMContentLoaded`, so the grace-window path never triggers for it, zero added delay.

**Known trade-off, stated plainly rather than left implied**: This adds up to 300ms of delay before the badge widget / opt-in script loads, specifically in the case where consent reads as granted right at `DOMContentLoaded`. Given both are decorative, non-critical elements (a floating badge, a post-purchase survey prompt), this is a reasonable cost for correctness but it is a real, deliberate change in timing, not a free fix.

**Known automated testing gap, deliberately not addressed here, stated on the record rather than left implied**: The client-side branching logic (`get_consent_gated_script_markup()`'s emitted JS) still has no automated test coverage. This logic has grown past the point this class's own docs originally named as the threshold for extracting it into a real, Jest-testable module, but doing that would mean `wp_enqueue_script()`-registering it unconditionally on every front-end page, reintroducing the exact risk this trait was built to avoid in the first place (unlike `GlobalSiteTag`'s `wp-consent-api` bundle, which only enqueues when Ads conversion tracking is configured). 

No equivalent pattern for testing PHP-templated inline JS exists elsewhere in this codebase either, so this would be new test infrastructure, not reuse of an existing one. Given that cost against the urgency here, this fix relies on the real-CMP Playwright trace verification above instead of new automated coverage. This is documented directly in the trait's own docblock so this isn't a silent gap, and it can be followed up as a tech-debt or equivalent enhancement in future.

### Screenshots:
N/A - Backend/JS timing fix, no visual change.

### Detailed test instructions:

#### Setup
1. Check out `feature/GOOWOO-944-fix-cookieyes-consent-race-condition`.
2. Needs a real storefront reachable over HTTPS (a Cloudflare quick tunnel works for local testing), plus CookieYes (`cookie-law-info`) and the WP Consent API plugin both active and connected (CookieYes requires connecting to their web app to get a real, network-fetched consent engine - the free/unconnected fallback doesn't reproduce this bug).
3. Confirm the badge widget is enabled with a valid Merchant ID (`wp option get gla_merchant_center --format=json` should show `badge_widget_enabled: true`), so `BadgeWidget::maybe_display_badge_snippet()` actually reaches the consent-gated echo.

#### Test 1: CookieYes reject > reload (the actual QA repro)

1. Load the storefront fresh (incognito or a cleared context).
2. On the CookieYes banner, click **Reject All**.
3. Reload the page with DevTools Network tab open, filtered for `merchantwidget.js`.
4. Expect: **no request** for `merchantwidget.js`. Before this fix, it fetched despite rejection.

#### Test 2: CookieYes accept > reload

1. Fresh load, click **Accept All**, reload.
2. Expect: `merchantwidget.js` **is** fetched (confirms the fix didn't break the granted path).

#### Test 3: Grant consent mid-visit, no reload

1. Fresh load, reject consent (script not fetched, per Test 1).
2. Without reloading, grant marketing consent (e.g. via the CMP's preference UI, or directly: `window.wp_set_consent('marketing', 'allow')` in the console).
3. Expect: `merchantwidget.js` fetches immediately, no page refresh needed.

#### Test 4: GDPR Cookie Compliance regression check

1. Deactivate CookieYes, activate GDPR Cookie Compliance.
2. Open Settings on the cookie bar, Save without enabling anything (implicit reject), reload.
3. Expect: `merchantwidget.js` still **not fetched** - same as before this change, no new delay introduced.

#### Test 5: Regression check

1. Run `vendor/bin/phpunit tests/Unit/Google/BadgeWidgetTest.php tests/Unit/Google/ReviewsOptInTest.php` - both should pass unchanged (7 tests).
2. Run the full suite (`vendor/bin/phpunit`) to confirm nothing else was affected.

#### Pass criteria

- CookieYes: reject blocks the script, accept loads it, mid-visit grant loads it without reload - all confirmed.
- GDPR Cookie Compliance: unaffected, no added delay.
- Full PHPUnit suite passes unchanged.

### Additional details:
N/A

### Changelog entry
> Fix - Correct a timing race where a CMP whose consent engine resolves asynchronously could allow the GCR badge widget or opt-in prompt to load despite the shopper denying marketing consent.
