### PR TITLE
GOOWOO-869: Re-sync marketing notifications after settings save

### DIFF
--- a/js/src/data/resolvers.js
+++ b/js/src/data/resolvers.js
@@ -890,5 +890,11 @@ export function* getNotifications() {
 }
 
 getNotifications.shouldInvalidate = ( action ) => {
-	return action.type === TYPES.DISMISS_NOTIFICATION;
+	// Some notifications' visibility (e.g. the GCR "collect reviews"/"badge
+	// widget" prompts) is gated on settings values, so a settings save can
+	// change which notifications the endpoint returns.
+	return (
+		action.type === TYPES.DISMISS_NOTIFICATION ||
+		action.type === TYPES.SAVE_SETTINGS
+	);
 };

--- a/js/src/notifications-system/index.js
+++ b/js/src/notifications-system/index.js
@@ -70,27 +70,22 @@ function createNotificationComponent( id, triggeredAt ) {
 
 const MARKETING_OVERVIEW_PATH = '/marketing';
 
-let hasInitialized = false;
-
 /**
  * Initializes the notifications system by fetching notifications from the GLA store
  * and registering them in the marketing notifications store.
  *
- * Guarded to run at most once per page session, since `registerNotificationsInMarketingSlot`
- * appends to the store with no id-based dedup.
+ * Runs on every visit to the Marketing Overview page (not just the first one per
+ * page load), so notifications whose visibility depends on settings changed
+ * elsewhere (e.g. the GCR "collect reviews"/"badge widget" toggles) reflect the
+ * latest state without requiring a full page reload. `resolveSelect` only hits
+ * the network when `getNotifications`'s resolution has actually been invalidated
+ * (e.g. by a settings save), so repeat visits are otherwise a cheap no-op, and
+ * `registerNotificationsInMarketingSlot` replaces the full set rather than
+ * appending, so re-running this is safe to call repeatedly.
  */
 async function initNotifications() {
-	if ( hasInitialized ) {
-		return;
-	}
-	hasInitialized = true;
-
 	const glaNotifications =
 		await resolveSelect( STORE_KEY ).getNotifications();
-
-	if ( ! glaNotifications.length ) {
-		return;
-	}
 
 	const notifications = glaNotifications.map( ( { id, triggered_at } ) => {
 		return {

--- a/js/src/notifications-system/index.test.js
+++ b/js/src/notifications-system/index.test.js
@@ -1,0 +1,173 @@
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY } from '~/data/constants';
+
+jest.mock( '@woocommerce/navigation', () => ( {
+	getPath: jest.fn(),
+	getHistory: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	resolveSelect: jest.fn(),
+} ) );
+
+jest.mock( '~/notifications-system/woo-marketing-notifications-slot', () => ( {
+	registerNotificationsInMarketingSlot: jest.fn(),
+	useDismissNotificationFromMarketingSlot: jest.fn(),
+} ) );
+
+// `./notification` and `./useNotificationsSystemMap` are only used inside a
+// notification component's render closure, never while fetching/registering
+// notifications — mock them out so importing `./index` doesn't drag in the
+// unrelated `@wordpress/components` tree (and its own `@wordpress/data` use).
+jest.mock( './notification', () => () => null );
+jest.mock( './useNotificationsSystemMap', () => () => ( {} ) );
+
+// `~/utils/tracks` pulls in the whole `~/data` store (and, through it, the
+// real `@wordpress/data`) just to provide `recordGlaEvent`, which is only
+// used inside a dismissed-notification's click handler — irrelevant here.
+jest.mock( '~/utils/tracks', () => ( {
+	recordGlaEvent: jest.fn(),
+	CONTEXT_MARKETING_OVERVIEW: 'marketing-overview',
+} ) );
+
+const flushPromises = () =>
+	new Promise( ( resolve ) => setImmediate( resolve ) );
+
+/**
+ * `./index` self-initializes on import — it fetches/registers notifications
+ * for the current SPA route and subscribes to future navigations — so each
+ * test needs its own fresh module instance rather than a shared one. Setting
+ * up the mocks and requiring `./index` inside the same `isolateModules` call
+ * keeps them all in the same sandboxed registry, so the mock references
+ * returned here are the exact ones `./index` calls internally.
+ */
+function bootstrap( { path, notifications = [] } ) {
+	let deps;
+
+	jest.isolateModules( () => {
+		const { getPath, getHistory } = require( '@woocommerce/navigation' );
+		const { resolveSelect } = require( '@wordpress/data' );
+		const {
+			registerNotificationsInMarketingSlot,
+		} = require( '~/notifications-system/woo-marketing-notifications-slot' );
+
+		const getNotifications = jest.fn().mockResolvedValue( notifications );
+		const listen = jest.fn();
+
+		getPath.mockReturnValue( path );
+		getHistory.mockReturnValue( { listen } );
+		resolveSelect.mockReturnValue( { getNotifications } );
+
+		require( './index' );
+
+		deps = {
+			getPath,
+			getHistory,
+			resolveSelect,
+			registerNotificationsInMarketingSlot,
+			getNotifications,
+			listen,
+		};
+	} );
+
+	return deps;
+}
+
+describe( 'notifications-system bootstrap', () => {
+	it( 'fetches and registers notifications when the current SPA route is Marketing overview', async () => {
+		const {
+			resolveSelect,
+			getNotifications,
+			registerNotificationsInMarketingSlot,
+		} = bootstrap( {
+			path: '/marketing',
+			notifications: [ { id: 'gcr-badge-widget', triggered_at: 123 } ],
+		} );
+
+		await flushPromises();
+
+		expect( resolveSelect ).toHaveBeenCalledWith( STORE_KEY );
+		expect( getNotifications ).toHaveBeenCalledTimes( 1 );
+		expect( registerNotificationsInMarketingSlot ).toHaveBeenCalledWith( [
+			expect.objectContaining( {
+				id: 'gcr-badge-widget',
+				triggered_at: 123,
+				component: expect.any( Function ),
+			} ),
+		] );
+	} );
+
+	it( 'does not fetch or register notifications when the current route is not Marketing overview', async () => {
+		const { resolveSelect, registerNotificationsInMarketingSlot } =
+			bootstrap( { path: '/settings' } );
+
+		await flushPromises();
+
+		expect( resolveSelect ).not.toHaveBeenCalled();
+		expect( registerNotificationsInMarketingSlot ).not.toHaveBeenCalled();
+	} );
+
+	it( 'registers an empty list, clearing any stale notifications, when the fetch resolves with none', async () => {
+		const { registerNotificationsInMarketingSlot } = bootstrap( {
+			path: '/marketing',
+			notifications: [],
+		} );
+
+		await flushPromises();
+
+		expect( registerNotificationsInMarketingSlot ).toHaveBeenCalledWith(
+			[]
+		);
+	} );
+
+	it( 're-syncs on every subsequent visit to Marketing overview, not just the first', async () => {
+		const {
+			getPath,
+			resolveSelect,
+			registerNotificationsInMarketingSlot,
+			listen,
+		} = bootstrap( { path: '/marketing' } );
+
+		await flushPromises();
+		expect( resolveSelect ).toHaveBeenCalledTimes( 1 );
+		expect( registerNotificationsInMarketingSlot ).toHaveBeenCalledTimes(
+			1
+		);
+
+		const onNavigate = listen.mock.calls[ 0 ][ 0 ];
+		getPath.mockReturnValue( '/marketing' );
+		onNavigate();
+		await flushPromises();
+
+		expect( resolveSelect ).toHaveBeenCalledTimes( 2 );
+		expect( registerNotificationsInMarketingSlot ).toHaveBeenCalledTimes(
+			2
+		);
+	} );
+
+	it( 'does not fetch or register on SPA navigation to a page other than Marketing overview', async () => {
+		const {
+			getPath,
+			resolveSelect,
+			registerNotificationsInMarketingSlot,
+			listen,
+		} = bootstrap( { path: '/marketing' } );
+
+		await flushPromises();
+		expect( registerNotificationsInMarketingSlot ).toHaveBeenCalledTimes(
+			1
+		);
+
+		const onNavigate = listen.mock.calls[ 0 ][ 0 ];
+		getPath.mockReturnValue( '/settings' );
+		onNavigate();
+		await flushPromises();
+
+		expect( resolveSelect ).toHaveBeenCalledTimes( 1 );
+		expect( registerNotificationsInMarketingSlot ).toHaveBeenCalledTimes(
+			1
+		);
+	} );
+} );

--- a/js/src/notifications-system/woo-marketing-notifications-slot/data/reducer.js
+++ b/js/src/notifications-system/woo-marketing-notifications-slot/data/reducer.js
@@ -5,8 +5,11 @@ import TYPES from './action-types';
 
 export default function reducer( state = [], action ) {
 	switch ( action.type ) {
+		// Replaces the full set rather than appending, since the caller always
+		// registers the complete, current list of notifications it should be
+		// showing (re-fetched from the server) rather than a delta.
 		case TYPES.REGISTER_NOTIFICATIONS:
-			return [ ...state, ...action.notifications ];
+			return action.notifications;
 
 		case TYPES.DISMISS_NOTIFICATION:
 			return state.filter(

--- a/js/src/notifications-system/woo-marketing-notifications-slot/data/reducer.test.js
+++ b/js/src/notifications-system/woo-marketing-notifications-slot/data/reducer.test.js
@@ -1,0 +1,55 @@
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import TYPES from './action-types';
+
+describe( 'reducer', () => {
+	describe( 'REGISTER_NOTIFICATIONS', () => {
+		it( 'replaces the existing state rather than appending to it', () => {
+			const state = [ { id: 'stale-notification', triggered_at: 1 } ];
+			const notifications = [
+				{ id: 'fresh-notification', triggered_at: 2 },
+			];
+
+			const newState = reducer( state, {
+				type: TYPES.REGISTER_NOTIFICATIONS,
+				notifications,
+			} );
+
+			expect( newState ).toBe( notifications );
+			expect( newState ).toEqual( [
+				{ id: 'fresh-notification', triggered_at: 2 },
+			] );
+		} );
+
+		it( 'clears previously registered notifications when given an empty list', () => {
+			const state = [ { id: 'stale-notification', triggered_at: 1 } ];
+
+			const newState = reducer( state, {
+				type: TYPES.REGISTER_NOTIFICATIONS,
+				notifications: [],
+			} );
+
+			expect( newState ).toEqual( [] );
+		} );
+	} );
+
+	describe( 'DISMISS_NOTIFICATION', () => {
+		it( 'removes only the notification matching the given id', () => {
+			const state = [
+				{ id: 'keep-me', triggered_at: 1 },
+				{ id: 'dismiss-me', triggered_at: 2 },
+			];
+
+			const newState = reducer( state, {
+				type: TYPES.DISMISS_NOTIFICATION,
+				id: 'dismiss-me',
+			} );
+
+			expect( newState ).toEqual( [
+				{ id: 'keep-me', triggered_at: 1 },
+			] );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Settings changes (e.g. toggling GCR review collection or the badge widget) never updated the Overview notifications until a full page reload. Notifications were fetched and registered at most once per page load, and a settings save never invalidated the cached `/notifications` response, so a merchant who enabled/disabled a setting kept seeing stale (or missing) notifications on the Marketing Overview page until they hard-refreshed.

This re-syncs notifications on every SPA visit to Marketing Overview instead of just the first one, invalidates the `getNotifications` resolution on `SAVE_SETTINGS` (in addition to the existing `DISMISS_NOTIFICATION` invalidation), and makes registration replace the full notification set instead of appending to it, so repeat syncs stay idempotent and correctly clear notifications that no longer apply.

Also adds test coverage for the reducer's replace-vs-append behavior and for the bootstrap module's route-gated fetch/register/re-sync logic.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Connect a Merchant Center account and confirm the "Collect reviews after purchase" and "Google store widget" notifications appear on the Marketing Overview page.
2. Without reloading the page, go to Marketing > Settings and enable "Collect reviews after purchase" (or the badge widget), then use the WooCommerce Admin's in-app navigation (not a browser reload) back to Marketing Overview.
3. Confirm the corresponding notification disappears without a full page reload.
4. Repeat step 2 in reverse (disable a setting) and confirm the notification reappears on the next SPA visit to Marketing Overview, again without reloading.
5. Dismiss a notification, navigate away and back to Marketing Overview a couple of times, and confirm the dismissed notification does not reappear (regression check for the existing dismiss-invalidation behavior).
6. Run `npm run test:js -- js/src/notifications-system` and confirm all tests pass.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>