### PR TITLE
[GOOWOO-979] Add Google Ads credits offer text to dashboard

### DIFF
--- a/js/src/pages/dashboard/summary-section/paid-features/index.js
+++ b/js/src/pages/dashboard/summary-section/paid-features/index.js
@@ -10,7 +10,6 @@ import GridiconCheckmark from 'gridicons/dist/checkmark';
  * Internal dependencies
  */
 import { ContentLink } from '~/components/guide-page-content';
-import AppDocumentationLink from '~/components/app-documentation-link';
 import CampaignPreview from '~/components/paid-ads/campaign-preview';
 import AddPaidCampaignButton from '~/components/paid-ads/add-paid-campaign-button';
 import VerticalGapLayout from '~/components/vertical-gap-layout';
@@ -51,30 +50,19 @@ function FeatureList() {
 		},
 		{
 			Icon: GridiconCheckmark,
-			content: (
-				<>
-					{ __(
-						'Get $500 USD or more in Google Ads credits*. New advertiser? Choose between three offers, based on your monthly budget, to jumpstart your first campaign!',
-						'google-listings-and-ads'
-					) }
-					<br />
-					{ createInterpolateElement(
-						__(
-							'* <link>Terms and conditions</link> apply.',
-							'google-listings-and-ads'
-						),
-						{
-							link: (
-								<AppDocumentationLink
-									className="gla-get-started-benefits-card__terms-link"
-									context="get-started"
-									linkId="benefits-card-credit-terms"
-									href="https://ads.google.com/home/terms-and-conditions/incentives/"
-								/>
-							),
-						}
-					) }
-				</>
+			content: createInterpolateElement(
+				__(
+					'Get $500 USD or more in Google Ads credits. New advertiser? Choose between three offers, based on your monthly budget, to jumpstart your first campaign! <link>Terms and conditions</link> apply.',
+					'google-listings-and-ads'
+				),
+				{
+					link: (
+						<ContentLink
+							href="https://ads.google.com/home/terms-and-conditions/incentives/"
+							context="paid-features"
+						/>
+					),
+				}
 			),
 		},
 	];

--- a/js/src/pages/dashboard/summary-section/paid-features/index.js
+++ b/js/src/pages/dashboard/summary-section/paid-features/index.js
@@ -10,6 +10,7 @@ import GridiconCheckmark from 'gridicons/dist/checkmark';
  * Internal dependencies
  */
 import { ContentLink } from '~/components/guide-page-content';
+import AppDocumentationLink from '~/components/app-documentation-link';
 import CampaignPreview from '~/components/paid-ads/campaign-preview';
 import AddPaidCampaignButton from '~/components/paid-ads/add-paid-campaign-button';
 import VerticalGapLayout from '~/components/vertical-gap-layout';
@@ -46,6 +47,34 @@ function FeatureList() {
 						/>
 					),
 				}
+			),
+		},
+		{
+			Icon: GridiconCheckmark,
+			content: (
+				<>
+					{ __(
+						'Get $500 USD or more in Google Ads credits*. New advertiser? Choose between three offers, based on your monthly budget, to jumpstart your first campaign!',
+						'google-listings-and-ads'
+					) }
+					<br />
+					{ createInterpolateElement(
+						__(
+							'* <link>Terms and conditions</link> apply.',
+							'google-listings-and-ads'
+						),
+						{
+							link: (
+								<AppDocumentationLink
+									className="gla-get-started-benefits-card__terms-link"
+									context="get-started"
+									linkId="benefits-card-credit-terms"
+									href="https://ads.google.com/home/terms-and-conditions/incentives/"
+								/>
+							),
+						}
+					) }
+				</>
 			),
 		},
 	];

--- a/tests/e2e/specs/dashboard/paid-features.test.js
+++ b/tests/e2e/specs/dashboard/paid-features.test.js
@@ -53,7 +53,7 @@ test.describe( 'Paid Feature Listing', () => {
 		);
 
 		await expect( dashboardPage.paidFeatures ).toContainText(
-			'Get $500 USD or more in Google Ads credits*. New advertiser? Choose between three offers, based on your monthly budget, to jumpstart your first campaign!'
+			'Get $500 USD or more in Google Ads credits. New advertiser? Choose between three offers, based on your monthly budget, to jumpstart your first campaign!'
 		);
 
 		const termsAndConditionsLink = dashboardPage.paidFeatures.getByRole(

--- a/tests/e2e/specs/dashboard/paid-features.test.js
+++ b/tests/e2e/specs/dashboard/paid-features.test.js
@@ -52,6 +52,20 @@ test.describe( 'Paid Feature Listing', () => {
 			'Reach more customer by advertising your products across Google Ads channels like Search, YouTube and Discover.'
 		);
 
+		await expect( dashboardPage.paidFeatures ).toContainText(
+			'Get $500 USD or more in Google Ads credits*. New advertiser? Choose between three offers, based on your monthly budget, to jumpstart your first campaign!'
+		);
+
+		const termsAndConditionsLink = dashboardPage.paidFeatures.getByRole(
+			'link',
+			{ name: 'Terms and conditions' }
+		);
+		await expect( termsAndConditionsLink ).toBeVisible();
+		await expect( termsAndConditionsLink ).toHaveAttribute(
+			'target',
+			'_blank'
+		);
+
 		await expect( dashboardPage.createCampaignButton ).toBeEnabled();
 		await dashboardPage.mockAdsAccountsResponse( [] );
 		await dashboardPage.createCampaignButton.click();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-979/add-google-ads-credits-offer-text-to-dashboard-featurelist

Adds a Google Ads credits offer text to dashboard's FeatureList.

### Screenshots:

<img width="745" height="477" alt="Screenshot 2026-08-27 at 13 10 25" src="https://github.com/user-attachments/assets/a06ae348-348a-4201-b3fe-7d7ab6340c56" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go through the onboarding flow and in the last step (3) click on "Skip ads creation".
2. Go to the plugin's dashboard.
3. The Google Ads credits offer text should appear as the last item in the Features list component in the dashboard (see screenshot above).

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Google Ads credits offer text to dashboard
