### PR TITLE
Add missing Google Merchant supported countries

### DIFF
--- a/src/Google/GoogleHelper.php
+++ b/src/Google/GoogleHelper.php
@@ -124,6 +124,12 @@ class GoogleHelper implements Service {
 			'currency' => 'EUR',
 			'id'       => 2191,
 		],
+		// Cyprus
+		'CY' => [
+			'code'     => 'CY',
+			'currency' => 'EUR',
+			'id'       => 2196,
+		],
 		// Czechia
 		'CZ' => [
 			'code'     => 'CZ',
@@ -159,6 +165,12 @@ class GoogleHelper implements Service {
 			'code'     => 'SV',
 			'currency' => 'USD',
 			'id'       => 2222,
+		],
+		// Estonia
+		'EE' => [
+			'code'     => 'EE',
+			'currency' => 'EUR',
+			'id'       => 2233,
 		],
 		// Ethiopia
 		'ET' => [
@@ -280,11 +292,29 @@ class GoogleHelper implements Service {
 			'currency' => 'KWD',
 			'id'       => 2414,
 		],
+		// Latvia
+		'LV' => [
+			'code'     => 'LV',
+			'currency' => 'EUR',
+			'id'       => 2428,
+		],
 		// Lebanon
 		'LB' => [
 			'code'     => 'LB',
 			'currency' => 'LBP',
 			'id'       => 2422,
+		],
+		// Lithuania
+		'LT' => [
+			'code'     => 'LT',
+			'currency' => 'EUR',
+			'id'       => 2440,
+		],
+		// Luxembourg
+		'LU' => [
+			'code'     => 'LU',
+			'currency' => 'EUR',
+			'id'       => 2442,
 		],
 		// Madagascar
 		'MG' => [
@@ -297,6 +327,12 @@ class GoogleHelper implements Service {
 			'code'     => 'MY',
 			'currency' => 'MYR',
 			'id'       => 2458,
+		],
+		// Malta
+		'MT' => [
+			'code'     => 'MT',
+			'currency' => 'EUR',
+			'id'       => 2470,
 		],
 		// Mauritius
 		'MU' => [
@@ -453,6 +489,12 @@ class GoogleHelper implements Service {
 			'code'     => 'SK',
 			'currency' => 'EUR',
 			'id'       => 2703,
+		],
+		// Slovenia
+		'SI' => [
+			'code'     => 'SI',
+			'currency' => 'EUR',
+			'id'       => 2705,
 		],
 		// South Africa
 		'ZA' => [

--- a/tests/Unit/Google/GoogleHelperTest.php
+++ b/tests/Unit/Google/GoogleHelperTest.php
@@ -49,6 +49,34 @@ class GoogleHelperTest extends UnitTest {
 		$this->assertContains( 'US', $supported );
 	}
 
+	/**
+	 * @dataProvider data_provider_newly_supported_eu_countries
+	 *
+	 * @param string $country_code Country code.
+	 * @param int    $country_id Google location ID.
+	 */
+	public function test_newly_supported_eu_country( string $country_code, int $country_id ) {
+		$supported = $this->google_helper->get_mc_supported_countries_currencies();
+
+		$this->assertArrayHasKey( $country_code, $supported );
+		$this->assertSame( 'EUR', $supported[ $country_code ] );
+		$this->assertTrue( $this->google_helper->is_country_supported( $country_code ) );
+		$this->assertSame( $country_id, $this->google_helper->find_country_id_by_code( $country_code ) );
+		$this->assertSame( $country_code, $this->google_helper->find_country_code_by_id( $country_id ) );
+	}
+
+	public function data_provider_newly_supported_eu_countries(): array {
+		return [
+			'Cyprus'     => [ 'CY', 2196 ],
+			'Estonia'    => [ 'EE', 2233 ],
+			'Latvia'     => [ 'LV', 2428 ],
+			'Lithuania'  => [ 'LT', 2440 ],
+			'Luxembourg' => [ 'LU', 2442 ],
+			'Malta'      => [ 'MT', 2470 ],
+			'Slovenia'   => [ 'SI', 2705 ],
+		];
+	}
+
 	public function test_get_mc_promotion_supported_countries() {
 		$supported = $this->google_helper->get_mc_promotion_supported_countries();
 		$this->assertNotEmpty( $supported );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/GOOWOO-978/supported-countries-missing-7-eueea-countries-si-cy-ee-lv-lt-lu-mt

Adds Cyprus, Estonia, Latvia, Lithuania, Luxembourg, Malta, and Slovenia to `GoogleHelper::SUPPORTED_COUNTRIES`, including their EUR currency and active Google geo target IDs.

The missing entries caused every consumer of the central list to omit or reject these countries, including the Markets selector, country validation, Ads geo mapping, and WooCommerce shipping-zone synchronization. A data-provider test now verifies support, currency, and both directions of the country-code/location-ID mapping for all seven entries.

The compatibility impact is additive: existing helper methods and the supported-countries REST response return seven more entries. No method signatures, hooks, routes, or existing values are changed.

### Screenshots:

Not applicable; this is a backend country-data change.

### Detailed test instructions:

#### Merchant-facing verification

**Environment:** A WordPress test site with WooCommerce and the Google for WooCommerce build from this PR installed and activated. Complete Google for WooCommerce onboarding and connect a Merchant Center account so the Markets page is available.

##### Scenario 1 — The seven countries are available to merchants

**Preconditions:**

1. In WP Admin, go to **Marketing > Google for WooCommerce > Markets**.
2. Find the **Primary Market** row and click **Edit**.
3. In the **Edit primary market** modal, open the **Audience** country selector.

**Action:** Search, one at a time, for **Cyprus, Estonia, Latvia, Lithuania, Luxembourg, Malta, and Slovenia**.

**Validation:**

- Each country appears in the selector and can be selected. Before this change, all seven were missing.
- An existing supported country such as **France** still appears as before.

##### Scenario 2 — A newly supported country can be saved

**Preconditions:**

1. Follow Scenario 1 to open the Primary Market's **Audience** country selector.
2. Make sure **Cyprus** is not already assigned to another market on the test store.

**Action:** Select **Cyprus** and click **Save**.

**Validation:**

- The modal closes without an unsupported-country validation error.
- Reopening the Primary Market shows **Cyprus** still selected in the Audience field.

#### Developer checks

1. Install the Composer and WordPress/WooCommerce test dependencies described in the repository README.
2. Run `vendor/bin/phpunit tests/Unit/Google/GoogleHelperTest.php`.
3. Run `vendor/bin/phpcs src/Google/GoogleHelper.php`.
4. Run `vendor/bin/phpcs --standard=tests/phpcs.xml.dist tests/Unit/Google/GoogleHelperTest.php`.
5. Optionally run the complete suite with `vendor/bin/phpunit`.

Verified locally: 2,645 tests and 7,231 assertions pass.

### Additional details:

- Stores configured for all supported countries will automatically include these seven countries, consistent with the existing behavior of that setting.
- The separate promotions allowlist and regional-shipping support rules are unchanged.
- All seven Google location IDs are active, unique country targets in Google's current geo-target dataset.

### Changelog entry

> Add - Add Cyprus, Estonia, Latvia, Lithuania, Luxembourg, Malta, and Slovenia to the Google Merchant Center supported countries list.
