### PR TITLE
GOOWOO-986: Use Learn how instead of 'Find out how'

### DIFF
--- a/js/src/pages/settings/google-customer-reviews/google-customer-reviews-settings.js
+++ b/js/src/pages/settings/google-customer-reviews/google-customer-reviews-settings.js
@@ -30,7 +30,7 @@ import {
 import './google-customer-reviews-settings.scss';
 
 /**
- * Triggered when the "Find out how" button is clicked.
+ * Triggered when the "Learn how" button is clicked.
  *
  * @event gla_reviews_settings_gcr_enrollment_help_click
  */
@@ -215,7 +215,7 @@ const GoogleCustomerReviewsSettings = () => {
 									} }
 								>
 									{ __(
-										'Find out how',
+										'Learn how',
 										'google-listings-and-ads'
 									) }
 								</AppButton>

--- a/js/src/pages/settings/google-customer-reviews/google-customer-reviews-settings.test.js
+++ b/js/src/pages/settings/google-customer-reviews/google-customer-reviews-settings.test.js
@@ -270,7 +270,7 @@ describe( 'GoogleCustomerReviewsSettings', () => {
 
 		render( <GoogleCustomerReviewsSettings /> );
 
-		expect( screen.getByText( /Find out how/i ) ).toHaveAttribute(
+		expect( screen.getByText( /Learn how/i ) ).toHaveAttribute(
 			'href',
 			GCR_ENROLLMENT_HELP_URL
 		);
@@ -285,7 +285,7 @@ describe( 'GoogleCustomerReviewsSettings', () => {
 		render( <GoogleCustomerReviewsSettings /> );
 
 		const gcrNotice = screen
-			.getByText( /Find out how/i )
+			.getByText( /Learn how/i )
 			.closest( '.components-notice' );
 		fireEvent.click(
 			gcrNotice.querySelector( '.components-notice__dismiss' )
@@ -307,7 +307,7 @@ describe( 'GoogleCustomerReviewsSettings', () => {
 
 		render( <GoogleCustomerReviewsSettings /> );
 
-		expect( screen.queryByText( /Find out how/i ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /Learn how/i ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the badge widget toggle unchecked when the setting is disabled', () => {

--- a/js/src/pages/settings/index.test.js
+++ b/js/src/pages/settings/index.test.js
@@ -47,7 +47,7 @@ jest.mock( '~/components/contact-information', () => ( {
 } ) );
 jest.mock( './setup-tax-rate', () => () => null );
 jest.mock( './shipping-rate-settings', () => () => null );
-jest.mock( './linked-accounts', () => () => null );
+jest.mock( './accounts', () => () => null );
 jest.mock( './reconnect-wpcom-account', () => () => null );
 jest.mock( './reconnect-google-account', () => () => null );
 jest.mock( './edit-store-address', () => () => null );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #GOOWOO-986.

Updates the Google Customer Reviews settings button copy from "Find out how" to "Learn how" per final confirmed copy changes. Also updates the co-located test file and the JSDoc comment describing the click event so both stay in sync with the new copy.


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to Google for WooCommerce > Settings > Google Customer Reviews.
2. Trigger the info notice that shows the enrollment help button (until it's been dismissed).
3. Confirm the button reads "Learn how" and still links to the GCR enrollment help URL.
4. Run `npm run test:js -- google-customer-reviews-settings.test.js` and confirm all tests pass.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>