### PR TITLE
Fix / Google Customer Reviews BE ENG Remediation

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/SettingsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsController.php
@@ -20,6 +20,13 @@ defined( 'ABSPATH' ) || exit;
  */
 class SettingsController extends BaseOptionsController {
 
+	/** @var string[] Schema keys stored in the dedicated GOOGLE_CUSTOMER_REVIEWS option, not MERCHANT_CENTER. */
+	protected const GCR_SCHEMA_KEYS = [
+		'gcr_collect_reviews_after_purchase',
+		'gcr_badge_widget_enabled',
+		'gcr_badge_widget_position',
+	];
+
 	/**
 	 * @var ShippingZone
 	 */
@@ -72,7 +79,13 @@ class SettingsController extends BaseOptionsController {
 	 */
 	protected function get_settings_endpoint_read_callback(): callable {
 		return function () {
-			$data                         = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+			$mc_options  = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+			$gcr_options = $this->options->get( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] );
+
+			$data                         = array_merge(
+				is_array( $mc_options ) ? $mc_options : [],
+				is_array( $gcr_options ) ? $gcr_options : []
+			);
 			$data['shipping_rates_count'] = $this->shipping_zone->get_shipping_rates_count();
 			$schema                       = $this->get_schema_properties();
 			$items                        = [];
@@ -91,32 +104,46 @@ class SettingsController extends BaseOptionsController {
 	 */
 	protected function get_settings_endpoint_edit_callback(): callable {
 		return function ( Request $request ) {
-			$schema  = $this->get_schema_properties();
-			$options = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
-			if ( ! is_array( $options ) ) {
-				$options = [];
+			$schema      = $this->get_schema_properties();
+			$mc_options  = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+			$gcr_options = $this->options->get( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] );
+			if ( ! is_array( $mc_options ) ) {
+				$mc_options = [];
+			}
+			if ( ! is_array( $gcr_options ) ) {
+				$gcr_options = [];
 			}
 
 			$previous_shipping = [
-				'shipping_rate' => $options['shipping_rate'] ?? null,
-				'shipping_time' => $options['shipping_time'] ?? null,
+				'shipping_rate' => $mc_options['shipping_rate'] ?? null,
+				'shipping_time' => $mc_options['shipping_time'] ?? null,
 			];
+
+			$current = array_merge( $mc_options, $gcr_options );
 
 			foreach ( $schema as $key => $property ) {
 				if ( ! in_array( 'edit', $property['context'] ?? [], true ) ) {
 					continue;
 				}
-				$options[ $key ] = $request->get_param( $key ) ?? $options[ $key ] ?? $property['default'] ?? null;
+
+				$value = $request->get_param( $key ) ?? $current[ $key ] ?? $property['default'] ?? null;
+
+				if ( in_array( $key, self::GCR_SCHEMA_KEYS, true ) ) {
+					$gcr_options[ $key ] = $value;
+				} else {
+					$mc_options[ $key ] = $value;
+				}
 			}
 
-			$this->options->update( OptionsInterface::MERCHANT_CENTER, $options );
+			$this->options->update( OptionsInterface::MERCHANT_CENTER, $mc_options );
+			$this->options->update( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, $gcr_options );
 
 			// The global shipping method is what every market's Merchant Center shipping service is
 			// generated from, but this save path never told MarketService, so a mode switch here
 			// used not to reach Google at all. Only trigger the resync when the method actually
 			// changed, to avoid scheduling a job on unrelated settings saves.
-			$shipping_method_changed = $previous_shipping['shipping_rate'] !== ( $options['shipping_rate'] ?? null )
-				|| $previous_shipping['shipping_time'] !== ( $options['shipping_time'] ?? null );
+			$shipping_method_changed = $previous_shipping['shipping_rate'] !== ( $mc_options['shipping_rate'] ?? null )
+				|| $previous_shipping['shipping_time'] !== ( $mc_options['shipping_time'] ?? null );
 
 			if ( $shipping_method_changed ) {
 				$this->market_service->handle_global_shipping_method_change();
@@ -125,7 +152,7 @@ class SettingsController extends BaseOptionsController {
 			return [
 				'status'  => 'success',
 				'message' => __( 'Merchant Center Settings successfully updated.', 'google-listings-and-ads' ),
-				'data'    => $options,
+				'data'    => array_merge( $mc_options, $gcr_options ),
 			];
 		};
 	}
@@ -137,7 +164,7 @@ class SettingsController extends BaseOptionsController {
 	 */
 	protected function get_schema_properties(): array {
 		return [
-			'shipping_rate'                  => [
+			'shipping_rate'                      => [
 				'type'              => 'string',
 				'description'       => __(
 					'Whether shipping rate is a simple flat rate or needs to be configured manually in the Merchant Center.',
@@ -151,7 +178,7 @@ class SettingsController extends BaseOptionsController {
 					'manual',
 				],
 			],
-			'shipping_time'                  => [
+			'shipping_time'                      => [
 				'type'              => 'string',
 				'description'       => __(
 					'Whether shipping time is a simple flat time or needs to be configured manually in the Merchant Center.',
@@ -164,7 +191,7 @@ class SettingsController extends BaseOptionsController {
 					'manual',
 				],
 			],
-			'tax_rate'                       => [
+			'tax_rate'                           => [
 				'type'              => 'string',
 				'description'       => __(
 					'Whether tax rate is destination based or need to be configured manually in the Merchant Center.',
@@ -178,7 +205,7 @@ class SettingsController extends BaseOptionsController {
 				],
 				'default'           => 'destination',
 			],
-			'shipping_rates_count'           => [
+			'shipping_rates_count'               => [
 				'type'              => 'number',
 				'description'       => __(
 					'The number of shipping rates in WC ready to be used in the Merchant Center.',
@@ -188,7 +215,7 @@ class SettingsController extends BaseOptionsController {
 				'validate_callback' => 'rest_validate_request_arg',
 				'default'           => 0,
 			],
-			'collect_reviews_after_purchase' => [
+			'gcr_collect_reviews_after_purchase' => [
 				'type'              => 'boolean',
 				'description'       => __(
 					'Whether to inject the Google Customer Reviews opt-in prompt on the order-confirmation page.',
@@ -198,7 +225,7 @@ class SettingsController extends BaseOptionsController {
 				'validate_callback' => 'rest_validate_request_arg',
 				'default'           => false,
 			],
-			'badge_widget_enabled'           => [
+			'gcr_badge_widget_enabled'           => [
 				'type'              => 'boolean',
 				'description'       => __(
 					'Whether the Google-verified ratings and reviews badge widget is enabled on the store.',
@@ -208,7 +235,7 @@ class SettingsController extends BaseOptionsController {
 				'validate_callback' => 'rest_validate_request_arg',
 				'default'           => false,
 			],
-			'badge_widget_position'          => [
+			'gcr_badge_widget_position'          => [
 				'type'              => 'string',
 				'description'       => __(
 					'The corner of the storefront in which to display the ratings and reviews badge widget.',

--- a/src/Google/BadgeWidget.php
+++ b/src/Google/BadgeWidget.php
@@ -19,7 +19,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Injects Google's store widget (formerly "Customer Reviews badge") script storefront-wide.
+ * Injects Google's store widget script storefront-wide.
  *
  * Modeled on GlobalSiteTag's wp_head injection shape, but for a template-agnostic floating
  * widget rather than a tracking pixel. Google's own script renders the aggregate rating; no
@@ -30,11 +30,11 @@ class BadgeWidget implements Service, Registerable, OptionsAwareInterface {
 	use OptionsAwareTrait;
 	use ConsentGatedScriptTrait;
 
-	/** @var string Key of the badge widget enabled flag within OptionsInterface::MERCHANT_CENTER. */
-	protected const SETTING_ENABLED = 'badge_widget_enabled';
+	/** @var string Key of the badge widget enabled flag within OptionsInterface::GOOGLE_CUSTOMER_REVIEWS. */
+	protected const SETTING_ENABLED = 'gcr_badge_widget_enabled';
 
-	/** @var string Key of the badge widget position setting within OptionsInterface::MERCHANT_CENTER. */
-	protected const SETTING_POSITION = 'badge_widget_position';
+	/** @var string Key of the badge widget position setting within OptionsInterface::GOOGLE_CUSTOMER_REVIEWS. */
+	protected const SETTING_POSITION = 'gcr_badge_widget_position';
 
 	/** @var string Default badge position, used when no position setting is stored yet. */
 	protected const DEFAULT_POSITION = 'bottom-right';
@@ -73,21 +73,19 @@ class BadgeWidget implements Service, Registerable, OptionsAwareInterface {
 	}
 
 	/**
-	 * Display the Google ratings and reviews badge widget snippet, if the badge widget setting is
-	 * enabled, a Merchant Center account is connected (i.e. a Merchant ID is available), and the
-	 * shopper has granted marketing consent (or no consent-management plugin is installed).
-	 * Google's own script renders the aggregate rating; no ratings data is fetched, cached, or
-	 * stored here.
+	 * Display the Google ratings and reviews badge widget snippet, if a Merchant Center account
+	 * is connected (i.e. a Merchant ID is available), the badge widget setting is enabled, and
+	 * the shopper has granted marketing consent (or no consent-management plugin is installed).
 	 */
 	public function maybe_display_badge_snippet(): void {
-		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
-
-		if ( ! $this->is_badge_widget_enabled( $settings ) ) {
+		$merchant_id = $this->options->get_merchant_id();
+		if ( ! $merchant_id ) {
 			return;
 		}
 
-		$merchant_id = $this->options->get_merchant_id();
-		if ( ! $merchant_id ) {
+		$settings = $this->options->get( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] );
+
+		if ( ! $this->is_badge_widget_enabled( $settings ) ) {
 			return;
 		}
 
@@ -101,7 +99,7 @@ class BadgeWidget implements Service, Registerable, OptionsAwareInterface {
 	/**
 	 * Whether the "Reviews badge widget" setting is currently enabled.
 	 *
-	 * @param array $settings The OptionsInterface::MERCHANT_CENTER settings array.
+	 * @param array $settings The OptionsInterface::GOOGLE_CUSTOMER_REVIEWS settings array.
 	 *
 	 * @return bool
 	 */
@@ -113,7 +111,7 @@ class BadgeWidget implements Service, Registerable, OptionsAwareInterface {
 	 * Resolve the merchant's chosen badge corner position, mapped to Google's expected argument.
 	 * Falls back to the default position for a missing or unrecognized stored value.
 	 *
-	 * @param array $settings The OptionsInterface::MERCHANT_CENTER settings array.
+	 * @param array $settings The OptionsInterface::GOOGLE_CUSTOMER_REVIEWS settings array.
 	 *
 	 * @return string
 	 */
@@ -124,7 +122,7 @@ class BadgeWidget implements Service, Registerable, OptionsAwareInterface {
 	}
 
 	/**
-	 * Build the Google store widget (formerly "Customer Reviews badge") snippet markup.
+	 * Build the Google store widget snippet markup.
 	 *
 	 * Per Google's documented widget embed code (support.google.com/merchants/answer/14632921):
 	 * merchant_id and position are the only parameters passed. `region` is intentionally omitted

--- a/src/Google/EstimatedDeliveryTimeResolver.php
+++ b/src/Google/EstimatedDeliveryTimeResolver.php
@@ -69,8 +69,9 @@ class EstimatedDeliveryTimeResolver implements ContainerAwareInterface, OptionsA
 
 	/**
 	 * The merchant's declared `shipping_time` setting (`flat`/`manual`) from the MERCHANT_CENTER
-	 * option. Read directly rather than via `shipping_rate` — see this ticket's PRD for why
-	 * that pairing isn't authoritative for delivery-time sourcing.
+	 * option. Read directly rather than via `shipping_rate` — the two settings are independent
+	 * (a merchant can pair a `flat` shipping rate with `manual` delivery-time sourcing, or vice
+	 * versa), so `shipping_rate`'s value is never authoritative for this decision.
 	 *
 	 * @return string
 	 */
@@ -151,7 +152,7 @@ class EstimatedDeliveryTimeResolver implements ContainerAwareInterface, OptionsA
 	 * @return array|null Null when the read fails.
 	 */
 	private function get_cached_shipping_settings(): ?array {
-		$cache_key = 'gla_edd_shipping_settings_' . $this->options->get_merchant_id();
+		$cache_key = 'gla_estimated_delivery_time_shipping_settings_' . $this->options->get_merchant_id();
 		$cached    = get_transient( $cache_key );
 
 		if ( is_array( $cached ) ) {

--- a/src/Google/ReviewsOptIn.php
+++ b/src/Google/ReviewsOptIn.php
@@ -31,8 +31,8 @@ class ReviewsOptIn implements Service, Registerable, OptionsAwareInterface {
 	use OptionsAwareTrait;
 	use ConsentGatedScriptTrait;
 
-	/** @var string Key of the post-purchase review collection flag within OptionsInterface::MERCHANT_CENTER. */
-	protected const SETTING_KEY = 'collect_reviews_after_purchase';
+	/** @var string Key of the post-purchase review collection flag within OptionsInterface::GOOGLE_CUSTOMER_REVIEWS. */
+	protected const SETTING_KEY = 'gcr_collect_reviews_after_purchase';
 
 	/** @var string Meta key used to mark an order as already prompted, to prevent duplicate injection. */
 	protected const ORDER_PROMPTED_META_KEY = '_gla_gcr_opt_in_prompted';
@@ -72,14 +72,19 @@ class ReviewsOptIn implements Service, Registerable, OptionsAwareInterface {
 
 	/**
 	 * Display the Google Customer Reviews opt-in snippet on the order-confirmation page, if all
-	 * of the following hold: the "Collect reviews after purchase" setting is enabled, the shopper
-	 * has granted marketing consent (or no consent-management plugin is installed), this is a
-	 * verified order-confirmation page view, the order hasn't already been prompted, a Merchant
-	 * Center account is connected, and an estimated delivery date can be resolved for the order's
+	 * of the following hold: this is a verified order-confirmation page view, a Merchant Center
+	 * account is connected, the "Collect reviews after purchase" setting is enabled, the shopper
+	 * has granted marketing consent (or no consent-management plugin is installed), the order
+	 * hasn't already been prompted, and an estimated delivery date can be resolved for the order's
 	 * destination country. No fallback/default delivery date is ever invented.
 	 */
 	public function maybe_display_opt_in_snippet(): void {
 		if ( ! is_order_received_page() ) {
+			return;
+		}
+
+		$merchant_id = $this->options->get_merchant_id();
+		if ( ! $merchant_id ) {
 			return;
 		}
 
@@ -97,11 +102,6 @@ class ReviewsOptIn implements Service, Registerable, OptionsAwareInterface {
 		}
 
 		if ( 1 === (int) $order->get_meta( self::ORDER_PROMPTED_META_KEY, true ) ) {
-			return;
-		}
-
-		$merchant_id = $this->options->get_merchant_id();
-		if ( ! $merchant_id ) {
 			return;
 		}
 
@@ -136,7 +136,7 @@ class ReviewsOptIn implements Service, Registerable, OptionsAwareInterface {
 	 * @return bool
 	 */
 	protected function is_reviews_collection_enabled(): bool {
-		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+		$settings = $this->options->get( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] );
 
 		return ! empty( $settings[ self::SETTING_KEY ] );
 	}

--- a/src/MerchantCenter/AccountService.php
+++ b/src/MerchantCenter/AccountService.php
@@ -275,11 +275,6 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 	 * Disconnect Merchant Center account
 	 */
 	public function disconnect() {
-		// Collect reviews after purchase must survive a disconnect/reconnect cycle,
-		// unlike the rest of the Merchant Center settings blob it lives in.
-		$merchant_center_settings       = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
-		$collect_reviews_after_purchase = is_array( $merchant_center_settings ) ? ( $merchant_center_settings['collect_reviews_after_purchase'] ?? null ) : null;
-
 		$this->options->delete( OptionsInterface::CONTACT_INFO_SETUP );
 		$this->options->delete( OptionsInterface::MAPI_DATA_SOURCES );
 		$this->options->delete( OptionsInterface::MC_SETUP_COMPLETED_AT );
@@ -288,13 +283,6 @@ class AccountService implements ContainerAwareInterface, OptionsAwareInterface, 
 		$this->options->delete( OptionsInterface::SITE_VERIFICATION );
 		$this->options->delete( OptionsInterface::MERCHANT_ID );
 		$this->options->delete( OptionsInterface::CLAIMED_URL_HASH );
-
-		if ( null !== $collect_reviews_after_purchase ) {
-			$this->options->update(
-				OptionsInterface::MERCHANT_CENTER,
-				[ 'collect_reviews_after_purchase' => $collect_reviews_after_purchase ]
-			);
-		}
 
 		$this->container->get( MarketService::class )->reset_markets();
 		$this->container->get( MerchantStatuses::class )->delete();

--- a/src/Notification/Evaluators/BadgeWidgetEvaluator.php
+++ b/src/Notification/Evaluators/BadgeWidgetEvaluator.php
@@ -30,9 +30,9 @@ class BadgeWidgetEvaluator implements NotificationEvaluatorInterface, MerchantCe
 	use OptionsAwareTrait;
 
 	/**
-	 * Key of the badge widget enabled flag within OptionsInterface::MERCHANT_CENTER.
+	 * Key of the badge widget enabled flag within OptionsInterface::GOOGLE_CUSTOMER_REVIEWS.
 	 */
-	private const SETTING_KEY = 'badge_widget_enabled';
+	private const SETTING_KEY = 'gcr_badge_widget_enabled';
 
 	/** @var OnboardingCompleted */
 	private $onboarding_completed;
@@ -69,7 +69,7 @@ class BadgeWidgetEvaluator implements NotificationEvaluatorInterface, MerchantCe
 			return false;
 		}
 
-		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+		$settings = $this->options->get( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] );
 
 		return empty( $settings[ self::SETTING_KEY ] );
 	}

--- a/src/Notification/Evaluators/CollectReviewsEvaluator.php
+++ b/src/Notification/Evaluators/CollectReviewsEvaluator.php
@@ -30,9 +30,9 @@ class CollectReviewsEvaluator implements NotificationEvaluatorInterface, Merchan
 	use OptionsAwareTrait;
 
 	/**
-	 * Key of the post-purchase review collection flag within OptionsInterface::MERCHANT_CENTER.
+	 * Key of the post-purchase review collection flag within OptionsInterface::GOOGLE_CUSTOMER_REVIEWS.
 	 */
-	private const SETTING_KEY = 'collect_reviews_after_purchase';
+	private const SETTING_KEY = 'gcr_collect_reviews_after_purchase';
 
 	/** @var OnboardingCompleted */
 	private $onboarding_completed;
@@ -69,7 +69,7 @@ class CollectReviewsEvaluator implements NotificationEvaluatorInterface, Merchan
 			return false;
 		}
 
-		$settings = $this->options->get( OptionsInterface::MERCHANT_CENTER, [] );
+		$settings = $this->options->get( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] );
 
 		return empty( $settings[ self::SETTING_KEY ] );
 	}

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -31,6 +31,7 @@ interface OptionsInterface {
 	public const DB_VERSION                                = 'db_version';
 	public const FILE_VERSION                              = 'file_version';
 	public const GOOGLE_CONNECTED                          = 'google_connected';
+	public const GOOGLE_CUSTOMER_REVIEWS                   = 'google_customer_reviews';
 	public const GOOGLE_WPCOM_AUTH_NONCE                   = 'google_wpcom_auth_nonce';
 	public const INSTALL_TIMESTAMP                         = 'install_timestamp';
 	public const INSTALL_VERSION                           = 'install_version';
@@ -82,6 +83,7 @@ interface OptionsInterface {
 		self::DB_VERSION                                => true,
 		self::FILE_VERSION                              => true,
 		self::GOOGLE_CONNECTED                          => true,
+		self::GOOGLE_CUSTOMER_REVIEWS                   => true,
 		self::INSTALL_TIMESTAMP                         => true,
 		self::INSTALL_VERSION                           => true,
 		self::JETPACK_CONNECTED                         => true,

--- a/src/Tracking/TrackerSnapshot.php
+++ b/src/Tracking/TrackerSnapshot.php
@@ -74,6 +74,7 @@ class TrackerSnapshot implements ContainerAwareInterface, OptionsAwareInterface,
 		/** @var TargetAudience $target_audience */
 		$target_audience = $this->container->get( TargetAudience::class );
 		$mc_settings     = $this->options->get( OptionsInterface::MERCHANT_CENTER );
+		$gcr_settings    = $this->options->get( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS );
 		/** @var AdsService $ads_service */
 		$ads_service = $this->container->get( AdsService::class );
 		/** @var MerchantCenterService $mc_service */
@@ -99,8 +100,8 @@ class TrackerSnapshot implements ContainerAwareInterface, OptionsAwareInterface,
 			'ads_customer_id'                 => $this->options->get_ads_id(),
 			'ads_campaign_count'              => $merchant_metrics->get_campaign_count(),
 			'youtube_connected'               => $this->get_boolean_value( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK ),
-			'reviews_collection'              => ! empty( $mc_settings['collect_reviews_after_purchase'] ) ? 'yes' : 'no',
-			'reviews_badge_widget'            => ! empty( $mc_settings['badge_widget_enabled'] ) ? 'yes' : 'no',
+			'reviews_collection'              => ! empty( $gcr_settings['gcr_collect_reviews_after_purchase'] ) ? 'yes' : 'no',
+			'reviews_badge_widget'            => ! empty( $gcr_settings['gcr_badge_widget_enabled'] ) ? 'yes' : 'no',
 		];
 	}
 

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -41,25 +41,43 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 		$this->controller->register();
 	}
 
+	/**
+	 * Default GCR settings, as they read when the GOOGLE_CUSTOMER_REVIEWS option doesn't exist yet.
+	 *
+	 * @var array
+	 */
+	protected const DEFAULT_GCR_OPTIONS = [
+		'gcr_collect_reviews_after_purchase' => false,
+		'gcr_badge_widget_enabled'           => false,
+		'gcr_badge_widget_position'          => 'bottom-right',
+	];
+
+	/**
+	 * Stub `$this->options->get()` for both the MERCHANT_CENTER and GOOGLE_CUSTOMER_REVIEWS
+	 * options, since the controller now reads from both on every request.
+	 *
+	 * @param array $mc_options
+	 * @param array $gcr_options
+	 */
+	protected function mock_options( array $mc_options = [], array $gcr_options = [] ): void {
+		$this->options->method( 'get' )->willReturnMap(
+			[
+				[ OptionsInterface::MERCHANT_CENTER, [], $mc_options ],
+				[ OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [], $gcr_options ],
+			]
+		);
+	}
+
 	public function test_get_settings() {
-		$options = [
+		$mc_options = [
 			'shipping_rate' => 'flat',
 			'shipping_time' => 'flat',
 			'tax_rate'      => 'destination',
-
 		];
-
-		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
-			$options
-		);
+		$this->mock_options( $mc_options );
 		$this->shipping_zone->expects( $this->once() )->method( 'get_shipping_rates_count' )->willReturn( 1 );
 
-		$expected = $options + [
-			'shipping_rates_count'           => 1,
-			'collect_reviews_after_purchase' => false,
-			'badge_widget_enabled'           => false,
-			'badge_widget_position'          => 'bottom-right',
-		];
+		$expected = $mc_options + [ 'shipping_rates_count' => 1 ] + self::DEFAULT_GCR_OPTIONS;
 
 		$response = $this->do_request( self::ROUTE, 'GET' );
 
@@ -68,27 +86,19 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_edit_settings() {
-		$options = [
+		$mc_options = [
 			'shipping_rate' => 'flat',
 			'shipping_time' => 'flat',
 			'tax_rate'      => 'destination',
 		];
+		$this->mock_options( $mc_options );
 
-		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
-			$options
-		);
-
-		$this->options->expects( $this->once() )->method( 'update' )->with(
-			OptionsInterface::MERCHANT_CENTER,
-			array_merge(
-				$options,
-				[
-					'shipping_time'                  => 'manual',
-					'collect_reviews_after_purchase' => false,
-					'badge_widget_enabled'           => false,
-					'badge_widget_position'          => 'bottom-right',
-				]
-			)
+		$this->options->expects( $this->exactly( 2 ) )->method( 'update' )->withConsecutive(
+			[
+				OptionsInterface::MERCHANT_CENTER,
+				array_merge( $mc_options, [ 'shipping_time' => 'manual' ] ),
+			],
+			[ OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, self::DEFAULT_GCR_OPTIONS ]
 		);
 
 		$response = $this->do_request(
@@ -104,7 +114,7 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_edit_settings_changing_the_shipping_method_triggers_a_market_resync() {
-		$this->options->method( 'get' )->willReturn(
+		$this->mock_options(
 			[
 				'shipping_rate' => 'flat',
 				'shipping_time' => 'flat',
@@ -128,7 +138,7 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_edit_settings_without_a_shipping_method_change_does_not_trigger_a_market_resync() {
-		$this->options->method( 'get' )->willReturn(
+		$this->mock_options(
 			[
 				'shipping_rate' => 'flat',
 				'shipping_time' => 'flat',
@@ -152,6 +162,8 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_default_tax_rate_settings() {
+		$this->mock_options();
+
 		$response = $this->do_request( self::ROUTE );
 
 		$this->assertEquals( 'destination', $response->get_data()['tax_rate'] );
@@ -159,6 +171,8 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_default_tax_rate_settings_post() {
+		$this->mock_options();
+
 		$response = $this->do_request( self::ROUTE, 'POST', [] );
 
 		$this->assertEquals( 'destination', $response->get_data()['data']['tax_rate'] );
@@ -166,116 +180,113 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_default_collect_reviews_after_purchase_setting() {
+		$this->mock_options();
+
 		$response = $this->do_request( self::ROUTE );
 
-		$this->assertFalse( $response->get_data()['collect_reviews_after_purchase'] );
+		$this->assertFalse( $response->get_data()['gcr_collect_reviews_after_purchase'] );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	public function test_edit_collect_reviews_after_purchase_setting() {
-		$options = [
-			'shipping_rate'                  => 'flat',
-			'shipping_time'                  => 'flat',
-			'tax_rate'                       => 'destination',
-			'collect_reviews_after_purchase' => false,
-			'badge_widget_enabled'           => false,
-			'badge_widget_position'          => 'bottom-right',
+		$mc_options = [
+			'shipping_rate' => 'flat',
+			'shipping_time' => 'flat',
+			'tax_rate'      => 'destination',
 		];
+		$this->mock_options( $mc_options, self::DEFAULT_GCR_OPTIONS );
 
-		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
-			$options
-		);
-
-		$this->options->expects( $this->once() )->method( 'update' )->with(
-			OptionsInterface::MERCHANT_CENTER,
-			array_merge( $options, [ 'collect_reviews_after_purchase' => true ] )
+		$this->options->expects( $this->exactly( 2 ) )->method( 'update' )->withConsecutive(
+			[ OptionsInterface::MERCHANT_CENTER, $mc_options ],
+			[
+				OptionsInterface::GOOGLE_CUSTOMER_REVIEWS,
+				array_merge( self::DEFAULT_GCR_OPTIONS, [ 'gcr_collect_reviews_after_purchase' => true ] ),
+			]
 		);
 
 		$response = $this->do_request(
 			self::ROUTE,
 			'POST',
 			[
-				'collect_reviews_after_purchase' => true,
+				'gcr_collect_reviews_after_purchase' => true,
 			]
 		);
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertTrue( $response->get_data()['data']['collect_reviews_after_purchase'] );
+		$this->assertTrue( $response->get_data()['data']['gcr_collect_reviews_after_purchase'] );
 	}
 
 	public function test_default_badge_widget_enabled_setting() {
+		$this->mock_options();
+
 		$response = $this->do_request( self::ROUTE );
 
-		$this->assertFalse( $response->get_data()['badge_widget_enabled'] );
+		$this->assertFalse( $response->get_data()['gcr_badge_widget_enabled'] );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	public function test_edit_badge_widget_enabled_setting() {
-		$options = [
-			'shipping_rate'                  => 'flat',
-			'shipping_time'                  => 'flat',
-			'tax_rate'                       => 'destination',
-			'collect_reviews_after_purchase' => false,
-			'badge_widget_enabled'           => false,
-			'badge_widget_position'          => 'bottom-right',
+		$mc_options = [
+			'shipping_rate' => 'flat',
+			'shipping_time' => 'flat',
+			'tax_rate'      => 'destination',
 		];
+		$this->mock_options( $mc_options, self::DEFAULT_GCR_OPTIONS );
 
-		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
-			$options
-		);
-
-		$this->options->expects( $this->once() )->method( 'update' )->with(
-			OptionsInterface::MERCHANT_CENTER,
-			array_merge( $options, [ 'badge_widget_enabled' => true ] )
+		$this->options->expects( $this->exactly( 2 ) )->method( 'update' )->withConsecutive(
+			[ OptionsInterface::MERCHANT_CENTER, $mc_options ],
+			[
+				OptionsInterface::GOOGLE_CUSTOMER_REVIEWS,
+				array_merge( self::DEFAULT_GCR_OPTIONS, [ 'gcr_badge_widget_enabled' => true ] ),
+			]
 		);
 
 		$response = $this->do_request(
 			self::ROUTE,
 			'POST',
 			[
-				'badge_widget_enabled' => true,
+				'gcr_badge_widget_enabled' => true,
 			]
 		);
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertTrue( $response->get_data()['data']['badge_widget_enabled'] );
+		$this->assertTrue( $response->get_data()['data']['gcr_badge_widget_enabled'] );
 	}
 
 	public function test_default_badge_widget_position_setting() {
+		$this->mock_options();
+
 		$response = $this->do_request( self::ROUTE );
 
-		$this->assertEquals( 'bottom-right', $response->get_data()['badge_widget_position'] );
+		$this->assertEquals( 'bottom-right', $response->get_data()['gcr_badge_widget_position'] );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	public function test_edit_badge_widget_position_setting() {
-		$options = [
-			'shipping_rate'                  => 'flat',
-			'shipping_time'                  => 'flat',
-			'tax_rate'                       => 'destination',
-			'collect_reviews_after_purchase' => false,
-			'badge_widget_enabled'           => false,
-			'badge_widget_position'          => 'bottom-right',
+		$mc_options = [
+			'shipping_rate' => 'flat',
+			'shipping_time' => 'flat',
+			'tax_rate'      => 'destination',
 		];
+		$this->mock_options( $mc_options, self::DEFAULT_GCR_OPTIONS );
 
-		$this->options->expects( $this->once() )->method( 'get' )->willReturn(
-			$options
-		);
-
-		$this->options->expects( $this->once() )->method( 'update' )->with(
-			OptionsInterface::MERCHANT_CENTER,
-			array_merge( $options, [ 'badge_widget_position' => 'bottom-left' ] )
+		$this->options->expects( $this->exactly( 2 ) )->method( 'update' )->withConsecutive(
+			[ OptionsInterface::MERCHANT_CENTER, $mc_options ],
+			[
+				OptionsInterface::GOOGLE_CUSTOMER_REVIEWS,
+				array_merge( self::DEFAULT_GCR_OPTIONS, [ 'gcr_badge_widget_position' => 'bottom-left' ] ),
+			]
 		);
 
 		$response = $this->do_request(
 			self::ROUTE,
 			'POST',
 			[
-				'badge_widget_position' => 'bottom-left',
+				'gcr_badge_widget_position' => 'bottom-left',
 			]
 		);
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'bottom-left', $response->get_data()['data']['badge_widget_position'] );
+		$this->assertEquals( 'bottom-left', $response->get_data()['data']['gcr_badge_widget_position'] );
 	}
 }

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -113,6 +113,36 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'success', $response->get_data()['status'] );
 	}
 
+	public function test_edit_settings_falls_back_to_empty_array_when_merchant_center_option_is_not_an_array() {
+		// A stored option can come back as `false` (e.g. never set) rather than an array — the
+		// edit endpoint must fall back to an empty array instead of fataling on array access.
+		$this->options->method( 'get' )->willReturnMap(
+			[
+				[ OptionsInterface::MERCHANT_CENTER, [], false ],
+				[ OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [], [] ],
+			]
+		);
+
+		$response = $this->do_request( self::ROUTE, 'POST', [ 'shipping_time' => 'manual' ] );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'manual', $response->get_data()['data']['shipping_time'] );
+	}
+
+	public function test_edit_settings_falls_back_to_empty_array_when_google_customer_reviews_option_is_not_an_array() {
+		$this->options->method( 'get' )->willReturnMap(
+			[
+				[ OptionsInterface::MERCHANT_CENTER, [], [] ],
+				[ OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [], false ],
+			]
+		);
+
+		$response = $this->do_request( self::ROUTE, 'POST', [ 'gcr_badge_widget_enabled' => true ] );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertTrue( $response->get_data()['data']['gcr_badge_widget_enabled'] );
+	}
+
 	public function test_edit_settings_changing_the_shipping_method_triggers_a_market_resync() {
 		$this->mock_options(
 			[

--- a/tests/Unit/Google/BadgeWidgetTest.php
+++ b/tests/Unit/Google/BadgeWidgetTest.php
@@ -43,10 +43,10 @@ class BadgeWidgetTest extends UnitTest {
 
 	protected function mock_settings( array $overrides = [] ): void {
 		$this->options->method( 'get' )
-			->with( OptionsInterface::MERCHANT_CENTER, [] )
+			->with( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] )
 			->willReturn(
 				array_merge(
-					[ 'badge_widget_enabled' => true ],
+					[ 'gcr_badge_widget_enabled' => true ],
 					$overrides
 				)
 			);
@@ -86,7 +86,7 @@ class BadgeWidgetTest extends UnitTest {
 	}
 
 	public function test_snippet_contains_configured_position() {
-		$this->mock_settings( [ 'badge_widget_position' => 'bottom-left' ] );
+		$this->mock_settings( [ 'gcr_badge_widget_position' => 'bottom-left' ] );
 
 		ob_start();
 		$this->badge_widget->maybe_display_badge_snippet();
@@ -96,7 +96,7 @@ class BadgeWidgetTest extends UnitTest {
 	}
 
 	public function test_no_injection_when_setting_disabled() {
-		$this->mock_settings( [ 'badge_widget_enabled' => false ] );
+		$this->mock_settings( [ 'gcr_badge_widget_enabled' => false ] );
 
 		$this->expectOutputString( '' );
 
@@ -117,8 +117,8 @@ class BadgeWidgetTest extends UnitTest {
 
 	public function test_no_injection_when_merchant_center_not_connected() {
 		$this->options->method( 'get' )
-			->with( OptionsInterface::MERCHANT_CENTER, [] )
-			->willReturn( [ 'badge_widget_enabled' => true ] );
+			->with( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] )
+			->willReturn( [ 'gcr_badge_widget_enabled' => true ] );
 		$this->options->method( 'get_merchant_id' )->willReturn( 0 );
 
 		$this->expectOutputString( '' );

--- a/tests/Unit/Google/ReviewsOptInTest.php
+++ b/tests/Unit/Google/ReviewsOptInTest.php
@@ -77,8 +77,8 @@ class ReviewsOptInTest extends UnitTest {
 		$this->wp->method( 'get_query_vars' )->with( 'order-received' )->willReturn( $order->get_id() );
 
 		$this->options->method( 'get' )
-			->with( OptionsInterface::MERCHANT_CENTER, [] )
-			->willReturn( [ 'collect_reviews_after_purchase' => true ] );
+			->with( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] )
+			->willReturn( [ 'gcr_collect_reviews_after_purchase' => true ] );
 
 		$this->options->method( 'get_merchant_id' )->willReturn( self::TEST_MERCHANT_ID );
 		$this->wp->method( 'has_consent' )->willReturn( true );
@@ -123,8 +123,9 @@ class ReviewsOptInTest extends UnitTest {
 		$this->options = $this->createMock( OptionsInterface::class );
 		$this->opt_in->set_options_object( $this->options );
 		$this->options->method( 'get' )
-			->with( OptionsInterface::MERCHANT_CENTER, [] )
-			->willReturn( [ 'collect_reviews_after_purchase' => false ] );
+			->with( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] )
+			->willReturn( [ 'gcr_collect_reviews_after_purchase' => false ] );
+		$this->options->method( 'get_merchant_id' )->willReturn( self::TEST_MERCHANT_ID );
 
 		$this->expectOutputString( '' );
 
@@ -177,8 +178,8 @@ class ReviewsOptInTest extends UnitTest {
 		$this->options = $this->createMock( OptionsInterface::class );
 		$this->opt_in->set_options_object( $this->options );
 		$this->options->method( 'get' )
-			->with( OptionsInterface::MERCHANT_CENTER, [] )
-			->willReturn( [ 'collect_reviews_after_purchase' => true ] );
+			->with( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] )
+			->willReturn( [ 'gcr_collect_reviews_after_purchase' => true ] );
 		$this->options->method( 'get_merchant_id' )->willReturn( 0 );
 
 		$this->expectOutputString( '' );

--- a/tests/Unit/MerchantCenter/AccountServiceTest.php
+++ b/tests/Unit/MerchantCenter/AccountServiceTest.php
@@ -1150,31 +1150,11 @@ class AccountServiceTest extends UnitTest {
 		$this->account->disconnect();
 	}
 
-	public function test_disconnect_preserves_collect_reviews_after_purchase_setting() {
-		$this->options->method( 'get' )
-			->with( OptionsInterface::MERCHANT_CENTER, [] )
-			->willReturn(
-				[
-					'shipping_rate'                  => 'flat',
-					'collect_reviews_after_purchase' => true,
-				]
-			);
-
-		$this->options->expects( $this->once() )
-			->method( 'update' )
-			->with(
-				OptionsInterface::MERCHANT_CENTER,
-				[ 'collect_reviews_after_purchase' => true ]
-			);
-
-		$this->account->disconnect();
-	}
-
-	public function test_disconnect_does_not_restore_setting_when_never_set() {
-		$this->options->method( 'get' )
-			->with( OptionsInterface::MERCHANT_CENTER, [] )
-			->willReturn( [] );
-
+	public function test_disconnect_never_updates_options() {
+		// GOOGLE_CUSTOMER_REVIEWS is its own dedicated option, untouched by disconnect() — it
+		// naturally survives a disconnect/reconnect cycle without any special-case preservation.
+		// (test_disconnect above already proves delete() only ever targets its exact 8 keys,
+		// which don't include GOOGLE_CUSTOMER_REVIEWS.)
 		$this->options->expects( $this->never() )
 			->method( 'update' );
 

--- a/tests/Unit/Notification/Evaluators/BadgeWidgetEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/BadgeWidgetEvaluatorTest.php
@@ -64,8 +64,8 @@ class BadgeWidgetEvaluatorTest extends UnitTest {
 		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
 		$this->merchant_center->method( 'is_connected' )->willReturn( true );
 		$this->options->method( 'get' )
-			->with( OptionsInterface::MERCHANT_CENTER, [] )
-			->willReturn( [ 'badge_widget_enabled' => false ] );
+			->with( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] )
+			->willReturn( [ 'gcr_badge_widget_enabled' => false ] );
 
 		$this->assertTrue( $this->evaluator->should_show() );
 	}
@@ -88,8 +88,8 @@ class BadgeWidgetEvaluatorTest extends UnitTest {
 		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
 		$this->merchant_center->method( 'is_connected' )->willReturn( true );
 		$this->options->method( 'get' )
-			->with( OptionsInterface::MERCHANT_CENTER, [] )
-			->willReturn( [ 'badge_widget_enabled' => true ] );
+			->with( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] )
+			->willReturn( [ 'gcr_badge_widget_enabled' => true ] );
 
 		$this->assertFalse( $this->evaluator->should_show() );
 	}

--- a/tests/Unit/Notification/Evaluators/CollectReviewsEvaluatorTest.php
+++ b/tests/Unit/Notification/Evaluators/CollectReviewsEvaluatorTest.php
@@ -64,8 +64,8 @@ class CollectReviewsEvaluatorTest extends UnitTest {
 		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
 		$this->merchant_center->method( 'is_connected' )->willReturn( true );
 		$this->options->method( 'get' )
-			->with( OptionsInterface::MERCHANT_CENTER, [] )
-			->willReturn( [ 'collect_reviews_after_purchase' => false ] );
+			->with( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] )
+			->willReturn( [ 'gcr_collect_reviews_after_purchase' => false ] );
 
 		$this->assertTrue( $this->evaluator->should_show() );
 	}
@@ -88,8 +88,8 @@ class CollectReviewsEvaluatorTest extends UnitTest {
 		$this->onboarding_completed->method( 'is_onboarding_complete' )->willReturn( true );
 		$this->merchant_center->method( 'is_connected' )->willReturn( true );
 		$this->options->method( 'get' )
-			->with( OptionsInterface::MERCHANT_CENTER, [] )
-			->willReturn( [ 'collect_reviews_after_purchase' => true ] );
+			->with( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] )
+			->willReturn( [ 'gcr_collect_reviews_after_purchase' => true ] );
 
 		$this->assertFalse( $this->evaluator->should_show() );
 	}

--- a/tests/Unit/Tracking/TrackerSnapshotTest.php
+++ b/tests/Unit/Tracking/TrackerSnapshotTest.php
@@ -71,8 +71,8 @@ class TrackerSnapshotTest extends UnitTest {
 	public function test_reviews_collection_is_yes_when_enabled() {
 		$this->options->method( 'get' )->willReturnCallback(
 			function ( $key ) {
-				if ( OptionsInterface::MERCHANT_CENTER === $key ) {
-					return [ 'collect_reviews_after_purchase' => true ];
+				if ( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS === $key ) {
+					return [ 'gcr_collect_reviews_after_purchase' => true ];
 				}
 				return null;
 			}
@@ -86,8 +86,8 @@ class TrackerSnapshotTest extends UnitTest {
 	public function test_reviews_collection_is_no_when_disabled() {
 		$this->options->method( 'get' )->willReturnCallback(
 			function ( $key ) {
-				if ( OptionsInterface::MERCHANT_CENTER === $key ) {
-					return [ 'collect_reviews_after_purchase' => false ];
+				if ( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS === $key ) {
+					return [ 'gcr_collect_reviews_after_purchase' => false ];
 				}
 				return null;
 			}
@@ -98,10 +98,10 @@ class TrackerSnapshotTest extends UnitTest {
 		$this->assertSame( 'no', $settings['reviews_collection'] );
 	}
 
-	public function test_reviews_collection_is_no_when_key_missing_from_merchant_center_settings() {
+	public function test_reviews_collection_is_no_when_key_missing_from_google_customer_reviews_settings() {
 		$this->options->method( 'get' )->willReturnCallback(
 			function ( $key ) {
-				if ( OptionsInterface::MERCHANT_CENTER === $key ) {
+				if ( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS === $key ) {
 					return [];
 				}
 				return null;
@@ -116,8 +116,8 @@ class TrackerSnapshotTest extends UnitTest {
 	public function test_reviews_badge_widget_is_yes_when_enabled() {
 		$this->options->method( 'get' )->willReturnCallback(
 			function ( $key ) {
-				if ( OptionsInterface::MERCHANT_CENTER === $key ) {
-					return [ 'badge_widget_enabled' => true ];
+				if ( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS === $key ) {
+					return [ 'gcr_badge_widget_enabled' => true ];
 				}
 				return null;
 			}
@@ -131,8 +131,8 @@ class TrackerSnapshotTest extends UnitTest {
 	public function test_reviews_badge_widget_is_no_when_disabled() {
 		$this->options->method( 'get' )->willReturnCallback(
 			function ( $key ) {
-				if ( OptionsInterface::MERCHANT_CENTER === $key ) {
-					return [ 'badge_widget_enabled' => false ];
+				if ( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS === $key ) {
+					return [ 'gcr_badge_widget_enabled' => false ];
 				}
 				return null;
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Backend/PHP remediation addressing @asvinb 's  review of the Google Customer Reviews epic ([PR #3742](https://github.com/woocommerce/google-listings-and-ads/pull/3742), [review](https://github.com/woocommerce/google-listings-and-ads/pull/3742#pullrequestreview-5029976145)). Scoped to the comments directed at backend/PHP files — the JS-side comments on are being addressed separately by @mserino .

Each item below addresses exactly one of @asvinb 's  comments, in the order he left them.

---

**1. [`SettingsController.php:191`](https://github.com/woocommerce/google-listings-and-ads/pull/3742#discussion_r3862772698) — unprefixed setting keys collide conceptually**

> `collect_reviews_after_purchase` doesn't scope to Google Customer Reviews. If we add a similar opt-in flag for another integration later, the name collides conceptually. Let's prefix the GCR-related keys...

Renamed all three REST schema fields to `gcr_collect_reviews_after_purchase`, `gcr_badge_widget_enabled`, `gcr_badge_widget_position`, exactly as suggested. This also became the natural place to fix the storage question raised later in the review (#9 below) — see that item for why these three fields now live in their own option entirely, not just under a prefixed key inside Merchant Center's.

**⚠️ Cross-boundary follow-up needed**: these are the REST field names the settings UI reads/writes. `google-customer-reviews-settings.js` needs a matching rename or the settings toggle will silently stop working — flagging this explicitly since it's out of this branch's scope but is a hard dependency, not a nice-to-have. cc @mserino 

---

**2. [`BadgeWidget.php:22`](https://github.com/woocommerce/google-listings-and-ads/pull/3742#discussion_r3862793637) — stale "formerly" naming reference**

> Why we need to have the former name mentioned? 🤔

Applied Asvin's own suggested replacement — removed "(formerly \"Customer Reviews badge\")" from the class docblock. Same phrase also appeared a second time in `get_badge_snippet_markup()`'s docblock (flagged again in #5 below); removed there too.

---

**3. [`BadgeWidget.php:79`](https://github.com/woocommerce/google-listings-and-ads/pull/3742#discussion_r3862810157) — redundant docblock**

> We are kinda repeating the same thing here. What do you think?

`maybe_display_badge_snippet()`'s method docblock restated "Google's own script renders the aggregate rating; no ratings data is fetched, cached, or stored" — already covered by the class-level docblock two lines up. Trimmed the method docblock to describe only its own specific guard conditions, and reordered them to match the fix in #4 below.

---

**4. [`BadgeWidget.php:89`](https://github.com/woocommerce/google-listings-and-ads/pull/3742#discussion_r3862844279) — guard order**

> Having a connected MC account is the real prerequisite here before getting any options/settings. Hence I would have the merchant Id check before the settings check.

Reordered `maybe_display_badge_snippet()`: the merchant ID check now runs first, before fetching/checking the badge widget setting.

---

**5. [`BadgeWidget.php:127`](https://github.com/woocommerce/google-listings-and-ads/pull/3742#discussion_r3862851514) — same "formerly" reference, third occurrence**

> See my previous note here.

Same fix as #2 — removed from `get_badge_snippet_markup()`'s docblock too.

---

**6. [`EstimatedDeliveryTimeResolver.php:72`](https://github.com/woocommerce/google-listings-and-ads/pull/3742#discussion_r3862872884) — internal ticket/PRD reference in a comment**

> Can we remove the ticket PRD here please because it's confusing.

Removed the reference and replaced it with a self-contained explanation: `shipping_time` and `shipping_rate` are independent settings (a merchant can pair a flat rate with manual delivery-time sourcing, or vice versa), so `shipping_rate` is never authoritative for this decision.

---

**7. [`EstimatedDeliveryTimeResolver.php:154`](https://github.com/woocommerce/google-listings-and-ads/pull/3742#discussion_r3862885818) — unexplained abbreviation**

> Curious to what `edd` stands here for please?

Spelled out the cache key in full: `gla_edd_shipping_settings_` → `gla_estimated_delivery_time_shipping_settings_`.

---

**8. [`ReviewsOptIn.php:103`](https://github.com/woocommerce/google-listings-and-ads/pull/3742#discussion_r3862903100) — guard order**

> See my previous comment here. I would check for the merchant ID just after `is_order_received_page`.

Same pattern as #4 — moved the merchant ID check in `maybe_display_opt_in_snippet()` to run immediately after the `is_order_received_page()` check, before the review-collection setting, consent, and order-verification checks. Updated the method's docblock to list the conditions in their new actual order.

---

**9. [`AccountService.php:280`](https://github.com/woocommerce/google-listings-and-ads/pull/3742#discussion_r3862948934) — GCR settings folded into the Merchant Center option**

> Any reason why we stored the GCR settings in the MC option and not have a separate option for GCR?

Gave GCR its own dedicated option (`OptionsInterface::GOOGLE_CUSTOMER_REVIEWS`). This has a good knock-on effect: `disconnect()`'s special-case code that read `collect_reviews_after_purchase` out of the Merchant Center blob before deleting it, then wrote it straight back, is no longer needed at all — a separate option is naturally untouched by a disconnect that only ever deletes Merchant-Center-scoped options. That special-casing is removed entirely rather than adapted.

`SettingsController` now reads from and writes to both options, splitting fields by which one owns them.

---

**10 & 11. [`BadgeWidgetEvaluator.php:35`](https://github.com/woocommerce/google-listings-and-ads/pull/3742#discussion_r3862960332) / [same line, second comment](https://github.com/woocommerce/google-listings-and-ads/pull/3742#discussion_r3862968473) — reads as an MC setting, not a GCR one**

> At no point I would think it's the badge for GCR. Instead I would think it's a badge for MC since it's stored in the MC option.
>
> If we need to keep the GCR settings in the MC option, let's prefix the key please.

Resolved by #9 and #1 together — `BadgeWidgetEvaluator` now reads `gcr_badge_widget_enabled` from the dedicated `GOOGLE_CUSTOMER_REVIEWS` option, so both the storage location and the key name now unambiguously identify it as GCR's.

---

**12. [`CollectReviewsEvaluator.php:35`](https://github.com/woocommerce/google-listings-and-ads/pull/3742#discussion_r3862971597) — related**

> Related: [link to #10/#11]

Same fix — `CollectReviewsEvaluator` now reads `gcr_collect_reviews_after_purchase` from `GOOGLE_CUSTOMER_REVIEWS`.

---

### Not from a specific inline comment, but required by the above

- **`TrackerSnapshot.php`** wasn't commented on directly, but reads both renamed/relocated settings for the tracking snapshot — updated to read `gcr_collect_reviews_after_purchase` and `gcr_badge_widget_enabled` from the new `GOOGLE_CUSTOMER_REVIEWS` option instead of Merchant Center's.
- All affected test files updated to match: `BadgeWidgetTest`, `ReviewsOptInTest`, `BadgeWidgetEvaluatorTest`, `CollectReviewsEvaluatorTest`, `SettingsControllerTest`, `AccountServiceTest` (two now-obsolete disconnect-preservation tests removed, since there's nothing left to preserve), `TrackerSnapshotTest`.

### Screenshots:
N/A — backend-only, no visual change.

### Detailed test instructions:

1. `vendor/bin/phpcs` and `vendor/bin/phpcs --standard=tests/phpcs.xml.dist` both pass clean on every file touched.
2. Full suite: `vendor/bin/phpunit` — 2695 tests, 0 failures.
3. Manual smoke test (once the JS-side field rename lands): connect Merchant Center, toggle each GCR setting, disconnect and reconnect — confirm all three GCR settings survive the disconnect/reconnect cycle (previously only `collect_reviews_after_purchase` was preserved; now all three are, as a natural consequence of living in their own option).

### Additional details:

This branch is intentionally backend/PHP-only. Before merging, the JS settings component needs its three field names updated to match (`collect_reviews_after_purchase` → `gcr_collect_reviews_after_purchase`, `badge_widget_enabled` → `gcr_badge_widget_enabled`, `badge_widget_position` → `gcr_badge_widget_position`), or the settings save will silently fail against the new schema.

### Changelog entry
> Fix - Address Google Customer Reviews backend review feedback: give GCR settings their own dedicated option instead of sharing Merchant Center's, prefix its setting keys, and correct guard-check ordering in the badge widget and opt-in prompt.
