### PR TITLE
Fix / GCR Scoped Settings Option Update

### DIFF
--- a/src/API/Site/Controllers/MerchantCenter/SettingsController.php
+++ b/src/API/Site/Controllers/MerchantCenter/SettingsController.php
@@ -136,7 +136,15 @@ class SettingsController extends BaseOptionsController {
 			}
 
 			$this->options->update( OptionsInterface::MERCHANT_CENTER, $mc_options );
-			$this->options->update( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, $gcr_options );
+
+			// Only persist GOOGLE_CUSTOMER_REVIEWS when the request actually touched one of its
+			// keys — otherwise a merchant editing an unrelated Merchant Center setting (e.g.
+			// shipping_rate) would create the option with default values and fire
+			// woocommerce_gla_options_updated_google_customer_reviews for a save that never
+			// touched GCR at all.
+			if ( array_intersect( array_keys( $request->get_params() ), self::GCR_SCHEMA_KEYS ) ) {
+				$this->options->update( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, $gcr_options );
+			}
 
 			// The global shipping method is what every market's Merchant Center shipping service is
 			// generated from, but this save path never told MarketService, so a mode switch here

--- a/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/MerchantCenter/SettingsControllerTest.php
@@ -93,12 +93,12 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 		];
 		$this->mock_options( $mc_options );
 
-		$this->options->expects( $this->exactly( 2 ) )->method( 'update' )->withConsecutive(
-			[
-				OptionsInterface::MERCHANT_CENTER,
-				array_merge( $mc_options, [ 'shipping_time' => 'manual' ] ),
-			],
-			[ OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, self::DEFAULT_GCR_OPTIONS ]
+		// No GCR key is in this request, so only MERCHANT_CENTER should be persisted — see
+		// test_edit_settings_does_not_persist_google_customer_reviews_when_request_has_no_gcr_keys
+		// for the dedicated regression test on that specifically.
+		$this->options->expects( $this->once() )->method( 'update' )->with(
+			OptionsInterface::MERCHANT_CENTER,
+			array_merge( $mc_options, [ 'shipping_time' => 'manual' ] )
 		);
 
 		$response = $this->do_request(
@@ -111,6 +111,27 @@ class SettingsControllerTest extends RESTControllerUnitTest {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'success', $response->get_data()['status'] );
+	}
+
+	public function test_edit_settings_does_not_persist_google_customer_reviews_when_request_has_no_gcr_keys() {
+		// A merchant editing an unrelated Merchant Center setting must not create the
+		// GOOGLE_CUSTOMER_REVIEWS option (with default values) or fire its
+		// woocommerce_gla_options_updated_google_customer_reviews hook for a save that never
+		// touched GCR at all.
+		$this->mock_options(
+			[
+				'shipping_rate' => 'flat',
+				'shipping_time' => 'flat',
+				'tax_rate'      => 'destination',
+			]
+		);
+
+		$this->options->expects( $this->once() )->method( 'update' )
+			->with( OptionsInterface::MERCHANT_CENTER, $this->anything() );
+
+		$response = $this->do_request( self::ROUTE, 'POST', [ 'tax_rate' => 'origin' ] );
+
+		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	public function test_edit_settings_falls_back_to_empty_array_when_merchant_center_option_is_not_an_array() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up fix on top of #3744, from feedback @asvinb spotted after that PR merged.

`SettingsController::get_settings_endpoint_edit_callback()` was writing both `MERCHANT_CENTER` and `GOOGLE_CUSTOMER_REVIEWS` unconditionally on every settings save, regardless of which keys were actually in the request. Concretely: a merchant who has never touched Google Customer Reviews, and just changes `shipping_rate`, would still get a `GOOGLE_CUSTOMER_REVIEWS` option created with default values, and `woocommerce_gla_options_updated_google_customer_reviews` would fire even though nothing GCR-related changed.

This mirrors the existing (already-loose) behavior for `MERCHANT_CENTER`, which is out of scope here — but since #3744 explicitly created `GOOGLE_CUSTOMER_REVIEWS` to give GCR clean semantic isolation, it's worth tightening from day one rather than carrying the same looseness into brand-new code.

**Fix**: only call `$this->options->update( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, ... )` when the request actually contains one of `self::GCR_SCHEMA_KEYS`:

```php
if ( array_intersect( array_keys( $request->get_params() ), self::GCR_SCHEMA_KEYS ) ) {
    $this->options->update( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, $gcr_options );
}
```

`MERCHANT_CENTER`'s own update stays unconditional, matching its existing behavior — not something this fix touches.

### Screenshots:
N/A — backend-only, no visual change.

### Detailed test instructions:

1. Updated `test_edit_settings` — was asserting 2 `update()` calls for an MC-only edit (`shipping_time`), now correctly asserts exactly 1 (`MERCHANT_CENTER` only).
2. Added `test_edit_settings_does_not_persist_google_customer_reviews_when_request_has_no_gcr_keys` — a dedicated regression test naming the exact scenario: editing an unrelated MC setting must not touch `GOOGLE_CUSTOMER_REVIEWS` at all.
3. `vendor/bin/phpcs` and `vendor/bin/phpcs --standard=tests/phpcs.xml.dist` both pass clean.
4. Full suite: `vendor/bin/phpunit` — 2698 tests, 0 failures.

### Additional details:

None.

### Changelog entry
> Fix - Only persist Google Customer Reviews settings when a save actually includes a GCR-related field, instead of unconditionally creating the option on every Merchant Center settings save.
