### PR TITLE
GOOWOO-958: Replace enhanced conversions checkbox with a toggle

### DIFF
--- a/js/src/pages/settings/enhanced-conversions/setup-enhanced-conversions.js
+++ b/js/src/pages/settings/enhanced-conversions/setup-enhanced-conversions.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl } from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { useCallback, useState } from '@wordpress/element';
 
 /**
@@ -104,7 +104,7 @@ const SetupEnhancedConversions = () => {
 			{ loaded && (
 				<Section.Card>
 					<Section.Card.Body>
-						<CheckboxControl
+						<ToggleControl
 							label={ __(
 								'Send Enhanced Conversions data to Google Ads',
 								'google-listings-and-ads'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-958/replace-enhanced-conversions-checkbox-with-toggle-control

Replace enhanced conversions checkbox with a toggle

### Screenshots:

<img width="1194" height="436" alt="image" src="https://github.com/user-attachments/assets/b0ead693-ce8e-4774-a39b-04236edf2b41" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Go to the plugin Settings page.
2. Confirm the "Send Enhanced Conversions data to Google Ads" is not a toggle.
3. Checking/unchecking the toggle should apply the settings accordingly.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Convert enhanced conversions checkbox in Settings into a toggle
