### PR TITLE
Improve account connection experience for service-based merchants

### DIFF
--- a/js/src/pages/dashboard/index.js
+++ b/js/src/pages/dashboard/index.js
@@ -111,7 +111,7 @@ const Dashboard = () => {
 				<MainTabNav />
 				<RaiseBudgetRecommendationBanner />
 				<RebrandingTour />
-				<YouTubeShoppingTour />
+				{ hasGoogleMCConnection && <YouTubeShoppingTour /> }
 				<div className="gla-dashboard__filter">
 					<AppDateRangeFilterPicker
 						trackEventReportId={ trackEventReportId }

--- a/js/src/pages/settings/accounts/index.js
+++ b/js/src/pages/settings/accounts/index.js
@@ -25,7 +25,6 @@ import useGoogleAccount from '~/hooks/useGoogleAccount';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import useGoogleAdsAccount from '~/hooks/useGoogleAdsAccount';
 import useYouTubeAccount from '~/hooks/useYouTubeAccount';
-import useServiceBasedMerchant from '~/hooks/useServiceBasedMerchant';
 import DisconnectModal, {
 	ALL_ACCOUNTS,
 	YOUTUBE_ACCOUNT,
@@ -49,7 +48,6 @@ import './index.scss';
  */
 export default function Accounts() {
 	const adminUrl = useAdminUrl();
-	const serviceBasedMerchant = useServiceBasedMerchant();
 	const { hasFinishedResolution: hasResolvedJetpackAccount } =
 		useJetpackAccount();
 	const { hasFinishedResolution: hasResolvedGoogleAccount } =
@@ -122,30 +120,25 @@ export default function Accounts() {
 				<CardDivider />
 				<GoogleAccountCard />
 
-				{ ! serviceBasedMerchant && (
-					<>
-						<CardDivider />
-						<GoogleMerchantCenterAccountCard />
-					</>
-				) }
+				<CardDivider />
+				<GoogleMerchantCenterAccountCard />
 
 				<CardDivider />
 				<GoogleAdsAccountCard />
 			</AccountsGroup>
 
-			{ hasGoogleMCConnection && (
-				<AccountsGroup
-					title={ __( 'Grow your reach', 'google-listings-and-ads' ) }
-					description={ __(
-						'Optional. Connect more Google services to your store.',
-						'google-listings-and-ads'
-					) }
-				>
-					<YouTubeAccountCard
-						onDisconnect={ handleDisconnectYouTubeAccount }
-					/>
-				</AccountsGroup>
-			) }
+			<AccountsGroup
+				title={ __( 'Grow your reach', 'google-listings-and-ads' ) }
+				description={ __(
+					'Optional. Connect more Google services to your store.',
+					'google-listings-and-ads'
+				) }
+			>
+				<YouTubeAccountCard
+					disabled={ ! hasGoogleMCConnection }
+					onDisconnect={ handleDisconnectYouTubeAccount }
+				/>
+			</AccountsGroup>
 
 			<Flex justify="flex-end">
 				<AppButton

--- a/js/src/pages/settings/accounts/index.test.js
+++ b/js/src/pages/settings/accounts/index.test.js
@@ -72,9 +72,9 @@ jest.mock(
 jest.mock(
 	'./youtube-account-card',
 	() =>
-		function MockYouTubeAccountCard( { onDisconnect } ) {
+		function MockYouTubeAccountCard( { disabled, onDisconnect } ) {
 			return (
-				<button onClick={ onDisconnect }>
+				<button disabled={ disabled } onClick={ onDisconnect }>
 					Disconnect YouTube account
 				</button>
 			);
@@ -143,7 +143,7 @@ describe( 'Accounts', () => {
 		expect( screen.queryByText( 'WPCom account' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'does not render the YouTube group without a Google Merchant Center connection', () => {
+	it( 'renders a disabled YouTube card without a Google Merchant Center connection', () => {
 		useGoogleMCAccount.mockReturnValue( {
 			hasGoogleMCConnection: false,
 			hasFinishedResolution: true,
@@ -152,10 +152,16 @@ describe( 'Accounts', () => {
 		render( <Accounts /> );
 
 		expect(
-			screen.queryByRole( 'button', {
+			screen.getByRole( 'button', {
 				name: 'Disconnect YouTube account',
 			} )
-		).not.toBeInTheDocument();
+		).toBeDisabled();
+		expect(
+			screen.getByRole( 'heading', { name: 'Grow your reach' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Merchant Center account' )
+		).toBeInTheDocument();
 	} );
 
 	it( 'tracks disconnecting the YouTube account without redirecting', async () => {

--- a/js/src/pages/settings/accounts/merchant-center-account-card/confirm-supported-products-modal.js
+++ b/js/src/pages/settings/accounts/merchant-center-account-card/confirm-supported-products-modal.js
@@ -1,0 +1,133 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { API_NAMESPACE } from '~/data/constants';
+import AppButton from '~/components/app-button';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import AppModal from '~/components/app-modal';
+import useAdminUrl from '~/hooks/useAdminUrl';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import { recordGlaEvent } from '~/utils/tracks';
+import { getAccountsSettingsUrl } from '~/utils/urls';
+import {
+	SUPPORTED_PRODUCTS_CONTEXT,
+	SUPPORTED_PRODUCTS_POLICY_URL,
+} from './constants';
+
+/**
+ * Confirming that the merchant sells products supported by Google.
+ *
+ * @event gla_supported_products_confirmation
+ * @property {string} action (`confirm`|`cancel`|`success`|`error`) Confirmation action.
+ * @property {string} context Page context. Always `settings-merchant-center-supported-products`.
+ */
+
+/**
+ * @param {Object} props Component props.
+ * @param {Function} props.onRequestClose Close callback.
+ * @return {JSX.Element} Confirmation modal.
+ */
+export default function ConfirmSupportedProductsModal( { onRequestClose } ) {
+	const adminUrl = useAdminUrl();
+	const { createNotice } = useDispatchCoreNotices();
+	const [ confirmSupportedProducts, { loading } ] = useApiFetchCallback( {
+		path: `${ API_NAMESPACE }/merchant/supported-products`,
+		method: 'POST',
+		data: { confirmed: true },
+	} );
+
+	const handleCancel = () => {
+		recordGlaEvent( 'gla_supported_products_confirmation', {
+			action: 'cancel',
+			context: SUPPORTED_PRODUCTS_CONTEXT,
+		} );
+		onRequestClose();
+	};
+
+	const handleConfirm = async () => {
+		recordGlaEvent( 'gla_supported_products_confirmation', {
+			action: 'confirm',
+			context: SUPPORTED_PRODUCTS_CONTEXT,
+		} );
+
+		try {
+			await confirmSupportedProducts();
+			recordGlaEvent( 'gla_supported_products_confirmation', {
+				action: 'success',
+				context: SUPPORTED_PRODUCTS_CONTEXT,
+			} );
+			window.location.href = adminUrl + getAccountsSettingsUrl();
+		} catch ( error ) {
+			recordGlaEvent( 'gla_supported_products_confirmation', {
+				action: 'error',
+				context: SUPPORTED_PRODUCTS_CONTEXT,
+			} );
+			createNotice(
+				'error',
+				__(
+					'Unable to enable the Google Merchant Center connection. Please try again.',
+					'google-listings-and-ads'
+				)
+			);
+		}
+	};
+
+	return (
+		<AppModal
+			title={ __(
+				'Confirm supported product types',
+				'google-listings-and-ads'
+			) }
+			buttons={ [
+				<AppButton
+					key="cancel"
+					isTertiary
+					disabled={ loading }
+					onClick={ handleCancel }
+				>
+					{ __( 'Cancel', 'google-listings-and-ads' ) }
+				</AppButton>,
+				<AppButton
+					key="confirm"
+					isPrimary
+					loading={ loading }
+					onClick={ handleConfirm }
+				>
+					{ __( 'Confirm', 'google-listings-and-ads' ) }
+				</AppButton>,
+			] }
+			onRequestClose={ handleCancel }
+		>
+			<p>
+				{ __(
+					"Only confirm if this matches what you sell. If products that don't meet Google's requirements are submitted, Google will disapprove them.",
+					'google-listings-and-ads'
+				) }
+			</p>
+			<p>
+				{ createInterpolateElement(
+					__(
+						'Not sure? <link>See what Google supports</link> before continuing.',
+						'google-listings-and-ads'
+					),
+					{
+						link: (
+							<AppDocumentationLink
+								context={ SUPPORTED_PRODUCTS_CONTEXT }
+								linkId="supported-product-types"
+								href={ SUPPORTED_PRODUCTS_POLICY_URL }
+							/>
+						),
+					}
+				) }
+			</p>
+		</AppModal>
+	);
+}

--- a/js/src/pages/settings/accounts/merchant-center-account-card/confirm-supported-products-modal.js
+++ b/js/src/pages/settings/accounts/merchant-center-account-card/confirm-supported-products-modal.js
@@ -44,6 +44,10 @@ export default function ConfirmSupportedProductsModal( { onRequestClose } ) {
 	} );
 
 	const handleCancel = () => {
+		if ( loading ) {
+			return;
+		}
+
 		recordGlaEvent( 'gla_supported_products_confirmation', {
 			action: 'cancel',
 			context: SUPPORTED_PRODUCTS_CONTEXT,
@@ -103,6 +107,7 @@ export default function ConfirmSupportedProductsModal( { onRequestClose } ) {
 					{ __( 'Confirm', 'google-listings-and-ads' ) }
 				</AppButton>,
 			] }
+			isDismissible={ ! loading }
 			onRequestClose={ handleCancel }
 		>
 			<p>

--- a/js/src/pages/settings/accounts/merchant-center-account-card/confirm-supported-products-modal.test.js
+++ b/js/src/pages/settings/accounts/merchant-center-account-card/confirm-supported-products-modal.test.js
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import ConfirmSupportedProductsModal from './confirm-supported-products-modal';
+import useAdminUrl from '~/hooks/useAdminUrl';
+import useApiFetchCallback from '~/hooks/useApiFetchCallback';
+import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
+import { recordGlaEvent } from '~/utils/tracks';
+import { getAccountsSettingsUrl } from '~/utils/urls';
+
+jest.mock( '~/hooks/useAdminUrl' );
+jest.mock( '~/hooks/useApiFetchCallback' );
+jest.mock( '~/hooks/useDispatchCoreNotices' );
+jest.mock( '~/utils/tracks', () => ( {
+	recordGlaEvent: jest.fn().mockName( 'recordGlaEvent' ),
+} ) );
+jest.mock( '~/utils/urls', () => ( {
+	getAccountsSettingsUrl: jest.fn().mockName( 'getAccountsSettingsUrl' ),
+} ) );
+
+describe( 'ConfirmSupportedProductsModal', () => {
+	const originalLocation = window.location;
+	let confirmSupportedProducts;
+	let createNotice;
+	let onRequestClose;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			value: { href: '' },
+		} );
+
+		confirmSupportedProducts = jest.fn().mockResolvedValue( {
+			confirmed: true,
+			service_based_merchant: false,
+		} );
+		createNotice = jest.fn();
+		onRequestClose = jest.fn();
+
+		useAdminUrl.mockReturnValue( 'https://example.com/wp-admin/' );
+		getAccountsSettingsUrl.mockReturnValue(
+			'admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings&section=accounts'
+		);
+		useApiFetchCallback.mockReturnValue( [
+			confirmSupportedProducts,
+			{ loading: false },
+		] );
+		useDispatchCoreNotices.mockReturnValue( { createNotice } );
+	} );
+
+	afterAll( () => {
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			value: originalLocation,
+		} );
+	} );
+
+	it( 'confirms supported products and reloads the Accounts page', async () => {
+		const user = userEvent.setup();
+		render(
+			<ConfirmSupportedProductsModal onRequestClose={ onRequestClose } />
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Confirm' } ) );
+
+		expect( confirmSupportedProducts ).toHaveBeenCalledTimes( 1 );
+		expect( recordGlaEvent ).toHaveBeenCalledWith(
+			'gla_supported_products_confirmation',
+			{
+				action: 'success',
+				context: 'settings-merchant-center-supported-products',
+			}
+		);
+		expect( window.location.href ).toBe(
+			'https://example.com/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings&section=accounts'
+		);
+	} );
+
+	it( 'closes without confirming', async () => {
+		const user = userEvent.setup();
+		render(
+			<ConfirmSupportedProductsModal onRequestClose={ onRequestClose } />
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( onRequestClose ).toHaveBeenCalledTimes( 1 );
+		expect( confirmSupportedProducts ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows an error notice when confirmation fails', async () => {
+		const user = userEvent.setup();
+		confirmSupportedProducts.mockRejectedValue(
+			new Error( 'Request failed' )
+		);
+		render(
+			<ConfirmSupportedProductsModal onRequestClose={ onRequestClose } />
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Confirm' } ) );
+
+		expect( createNotice ).toHaveBeenCalledWith(
+			'error',
+			'Unable to enable the Google Merchant Center connection. Please try again.'
+		);
+		expect( window.location.href ).toBe( '' );
+	} );
+} );

--- a/js/src/pages/settings/accounts/merchant-center-account-card/connect-button.js
+++ b/js/src/pages/settings/accounts/merchant-center-account-card/connect-button.js
@@ -17,9 +17,8 @@ import { getOnboardingUrl } from '~/utils/urls';
  */
 
 /**
- * Renders the "Connect" button for the Merchant Center account
- * card, shown when the account is not connected but the store now has physical
- * products. Routes to the onboarding flow.
+ * Renders the "Connect" button for the Merchant Center account card when the
+ * account is not connected and the store is eligible for Merchant Center.
  *
  * @fires gla_set_up_merchant_center_click with `{ context: 'settings-linked-accounts' }`
  *

--- a/js/src/pages/settings/accounts/merchant-center-account-card/connect-button.js
+++ b/js/src/pages/settings/accounts/merchant-center-account-card/connect-button.js
@@ -10,14 +10,14 @@ import AppButton from '~/components/app-button';
 import { getOnboardingUrl } from '~/utils/urls';
 
 /**
- * The "Set up Merchant Center" button is clicked from Settings > Accounts.
+ * The Merchant Center "Connect" button is clicked from Settings > Accounts.
  *
  * @event gla_set_up_merchant_center_click
  * @property {string} context The page context. Possible value: 'settings-linked-accounts'.
  */
 
 /**
- * Renders the "Set up Merchant Center" button for the Merchant Center account
+ * Renders the "Connect" button for the Merchant Center account
  * card, shown when the account is not connected but the store now has physical
  * products. Routes to the onboarding flow.
  *
@@ -33,7 +33,7 @@ const ConnectButton = () => {
 			eventProps={ { context: 'settings-linked-accounts' } }
 			isSecondary
 		>
-			{ __( 'Set up Merchant Center', 'google-listings-and-ads' ) }
+			{ __( 'Connect', 'google-listings-and-ads' ) }
 		</AppButton>
 	);
 };

--- a/js/src/pages/settings/accounts/merchant-center-account-card/connect-button.test.js
+++ b/js/src/pages/settings/accounts/merchant-center-account-card/connect-button.test.js
@@ -16,7 +16,7 @@ jest.mock( '~/utils/tracks', () => ( {
 } ) );
 
 describe( 'ConnectButton', () => {
-	it( 'tracks the "Set up Merchant Center" button click', async () => {
+	it( 'tracks the "Connect" button click', async () => {
 		const user = userEvent.setup();
 
 		render( <ConnectButton /> );
@@ -24,7 +24,7 @@ describe( 'ConnectButton', () => {
 		// The button renders as a real anchor; jsdom doesn't implement
 		// navigation, so prevent the click from following the href.
 		const link = screen.getByRole( 'link', {
-			name: 'Set up Merchant Center',
+			name: 'Connect',
 		} );
 		link.addEventListener( 'click', ( event ) => event.preventDefault() );
 

--- a/js/src/pages/settings/accounts/merchant-center-account-card/constants.js
+++ b/js/src/pages/settings/accounts/merchant-center-account-card/constants.js
@@ -1,0 +1,5 @@
+export const SUPPORTED_PRODUCTS_POLICY_URL =
+	'https://support.google.com/merchants/answer/6150006';
+
+export const SUPPORTED_PRODUCTS_CONTEXT =
+	'settings-merchant-center-supported-products';

--- a/js/src/pages/settings/accounts/merchant-center-account-card/index.js
+++ b/js/src/pages/settings/accounts/merchant-center-account-card/index.js
@@ -13,6 +13,8 @@ import ConnectButton from './connect-button';
 import ConnectedBadge from '../connected-badge';
 import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 import useServiceBasedMerchant from '~/hooks/useServiceBasedMerchant';
+import ServiceBasedContent from './service-based-content';
+import './index.scss';
 
 const GOOGLE_MERCHANT_CENTER_OVERVIEW_URL =
 	'https://merchants.google.com/mc/overview?a=';
@@ -38,6 +40,26 @@ const MerchantCenterAccountCard = () => {
 		return null;
 	};
 
+	const getDetail = () => {
+		if ( hasGoogleMCConnection ) {
+			return (
+				<AccountCardTextDetail>
+					<ExternalLink
+						href={ `${ GOOGLE_MERCHANT_CENTER_OVERVIEW_URL }${ googleMCAccount.id }` }
+					>
+						{ googleMCAccount.id }
+					</ExternalLink>
+				</AccountCardTextDetail>
+			);
+		}
+
+		if ( serviceBasedMerchant ) {
+			return <ServiceBasedContent />;
+		}
+
+		return null;
+	};
+
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.GOOGLE_MERCHANT_CENTER }
@@ -45,20 +67,11 @@ const MerchantCenterAccountCard = () => {
 				'Where your product catalog is synced to appear on Google.',
 				'google-listings-and-ads'
 			) }
-			detail={
-				hasGoogleMCConnection ? (
-					<AccountCardTextDetail>
-						<ExternalLink
-							href={ `${ GOOGLE_MERCHANT_CENTER_OVERVIEW_URL }${ googleMCAccount.id }` }
-						>
-							{ googleMCAccount.id }
-						</ExternalLink>
-					</AccountCardTextDetail>
-				) : null
-			}
+			detail={ getDetail() }
 			indicator={ getIndicator() }
 			alignIndicator="top"
 			alignIcon="top"
+			expandedDetail={ serviceBasedMerchant && ! hasGoogleMCConnection }
 		/>
 	);
 };

--- a/js/src/pages/settings/accounts/merchant-center-account-card/index.scss
+++ b/js/src/pages/settings/accounts/merchant-center-account-card/index.scss
@@ -1,0 +1,14 @@
+.gla-merchant-center-account-card__service-based-content {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: $grid-unit-15;
+
+	> p {
+		margin: 0;
+	}
+
+	.components-notice {
+		margin: 0;
+	}
+}

--- a/js/src/pages/settings/accounts/merchant-center-account-card/index.test.js
+++ b/js/src/pages/settings/accounts/merchant-center-account-card/index.test.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import MerchantCenterAccountCard from './index';
+import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
+import useServiceBasedMerchant from '~/hooks/useServiceBasedMerchant';
+
+jest.mock( '~/hooks/useGoogleMCAccount', () =>
+	jest.fn().mockName( 'useGoogleMCAccount' )
+);
+jest.mock( '~/hooks/useServiceBasedMerchant', () =>
+	jest.fn().mockName( 'useServiceBasedMerchant' )
+);
+jest.mock( '~/components/account-card', () => ( {
+	__esModule: true,
+	APPEARANCE: { GOOGLE_MERCHANT_CENTER: 'merchant-center' },
+	default: function MockAccountCard( { detail, indicator, expandedDetail } ) {
+		return (
+			<div data-expanded={ String( expandedDetail ) }>
+				{ indicator }
+				{ detail }
+			</div>
+		);
+	},
+} ) );
+jest.mock(
+	'../account-card-text-detail',
+	() =>
+		( { children } ) =>
+			children
+);
+jest.mock( '../connected-badge', () => () => <div>Connected badge</div> );
+jest.mock( './connect-button', () => () => <div>Connect action</div> );
+jest.mock( './service-based-content', () => () => (
+	<div>Supported products confirmation</div>
+) );
+
+describe( 'MerchantCenterAccountCard', () => {
+	beforeEach( () => {
+		useGoogleMCAccount.mockReturnValue( {
+			googleMCAccount: {},
+			hasGoogleMCConnection: false,
+		} );
+		useServiceBasedMerchant.mockReturnValue( false );
+	} );
+
+	it( 'renders the Connect action for a disconnected supported-products store', () => {
+		render( <MerchantCenterAccountCard /> );
+
+		expect( screen.getByText( 'Connect action' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Supported products confirmation' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the expanded confirmation flow for a service-based store', () => {
+		useServiceBasedMerchant.mockReturnValue( true );
+
+		const { container } = render( <MerchantCenterAccountCard /> );
+
+		expect(
+			screen.getByText( 'Supported products confirmation' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Connect action' )
+		).not.toBeInTheDocument();
+		expect( container.firstChild ).toHaveAttribute(
+			'data-expanded',
+			'true'
+		);
+	} );
+
+	it( 'renders the connected account when Merchant Center is already connected', () => {
+		useGoogleMCAccount.mockReturnValue( {
+			googleMCAccount: { id: 123456 },
+			hasGoogleMCConnection: true,
+		} );
+		useServiceBasedMerchant.mockReturnValue( true );
+
+		const { container } = render( <MerchantCenterAccountCard /> );
+
+		expect( screen.getByText( 'Connected badge' ) ).toBeInTheDocument();
+		expect( screen.getByText( '123456' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Supported products confirmation' )
+		).not.toBeInTheDocument();
+		expect( container.firstChild ).toHaveAttribute(
+			'data-expanded',
+			'false'
+		);
+	} );
+} );

--- a/js/src/pages/settings/accounts/merchant-center-account-card/service-based-content.js
+++ b/js/src/pages/settings/accounts/merchant-center-account-card/service-based-content.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import AppButton from '~/components/app-button';
+import AppDocumentationLink from '~/components/app-documentation-link';
+import { recordGlaEvent } from '~/utils/tracks';
+import ConfirmSupportedProductsModal from './confirm-supported-products-modal';
+import {
+	SUPPORTED_PRODUCTS_CONTEXT,
+	SUPPORTED_PRODUCTS_POLICY_URL,
+} from './constants';
+
+/**
+ * @return {JSX.Element} Service-based merchant explanation and confirmation action.
+ */
+export default function ServiceBasedContent() {
+	const [ isModalOpen, setModalOpen ] = useState( false );
+
+	const handleOpen = () => {
+		recordGlaEvent( 'gla_supported_products_confirmation_button_click', {
+			context: SUPPORTED_PRODUCTS_CONTEXT,
+		} );
+		setModalOpen( true );
+	};
+
+	return (
+		<div className="gla-merchant-center-account-card__service-based-content">
+			{ isModalOpen && (
+				<ConfirmSupportedProductsModal
+					onRequestClose={ () => setModalOpen( false ) }
+				/>
+			) }
+			<Notice isDismissible={ false }>
+				{ createInterpolateElement(
+					__(
+						'The Google Merchant Center connection is not available, as your store sells services or digital products that Google does not support. <link>Read more</link> about unsupported product types.',
+						'google-listings-and-ads'
+					),
+					{
+						link: (
+							<AppDocumentationLink
+								context={ SUPPORTED_PRODUCTS_CONTEXT }
+								linkId="unsupported-product-types"
+								href={ SUPPORTED_PRODUCTS_POLICY_URL }
+							/>
+						),
+					}
+				) }
+			</Notice>
+			<p>
+				{ __(
+					'If the digital products you sell are supported by Google, confirm below to enable the Google Merchant Center connection.',
+					'google-listings-and-ads'
+				) }
+			</p>
+			<AppButton isSecondary onClick={ handleOpen }>
+				{ __(
+					'Confirm that I sell supported products',
+					'google-listings-and-ads'
+				) }
+			</AppButton>
+		</div>
+	);
+}

--- a/js/src/pages/settings/accounts/merchant-center-account-card/service-based-content.test.js
+++ b/js/src/pages/settings/accounts/merchant-center-account-card/service-based-content.test.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Internal dependencies
+ */
+import ServiceBasedContent from './service-based-content';
+import { recordGlaEvent } from '~/utils/tracks';
+
+jest.mock( '~/utils/tracks', () => ( {
+	recordGlaEvent: jest.fn().mockName( 'recordGlaEvent' ),
+} ) );
+jest.mock( './confirm-supported-products-modal', () => ( {
+	__esModule: true,
+	default: function MockConfirmSupportedProductsModal() {
+		return <div>Confirmation modal</div>;
+	},
+} ) );
+
+describe( 'ServiceBasedContent', () => {
+	it( 'shows the written explanation and opens the confirmation modal', async () => {
+		const user = userEvent.setup();
+		render( <ServiceBasedContent /> );
+
+		expect(
+			screen.getAllByText(
+				/The Google Merchant Center connection is not available/
+			)
+		).not.toHaveLength( 0 );
+		expect(
+			screen.getByRole( 'link', { name: /Read more/ } )
+		).toHaveAttribute(
+			'href',
+			'https://support.google.com/merchants/answer/6150006'
+		);
+
+		await user.click(
+			screen.getByRole( 'button', {
+				name: 'Confirm that I sell supported products',
+			} )
+		);
+
+		expect( screen.getByText( 'Confirmation modal' ) ).toBeInTheDocument();
+		expect( recordGlaEvent ).toHaveBeenCalledWith(
+			'gla_supported_products_confirmation_button_click',
+			{
+				context: 'settings-merchant-center-supported-products',
+			}
+		);
+	} );
+} );

--- a/js/src/pages/settings/accounts/youtube-account-card/connect-youtube-account-card.js
+++ b/js/src/pages/settings/accounts/youtube-account-card/connect-youtube-account-card.js
@@ -11,6 +11,7 @@ import { ExternalLink } from '@wordpress/components';
 import { API_NAMESPACE } from '~/data/constants';
 import { recordGlaEvent } from '~/utils/tracks';
 import AppButton from '~/components/app-button';
+import AppTooltip from '~/components/app-tooltip';
 import AccountCard, { APPEARANCE } from '~/components/account-card';
 import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 import useApiFetchCallback from '~/hooks/useApiFetchCallback';
@@ -28,8 +29,11 @@ const TERMS_URL = 'https://www.youtube.com/t/merchant_terms';
 /**
  * @fires gla_youtube_account_connect_button_click
  * @fires gla_documentation_link_click with `{ context: 'settings-connect-youtube-account-card', link_id: 'youtube-merchant-terms' }` and the URL.
+ * @param {Object} props Component props.
+ * @param {boolean} [props.disabled=false] Whether the connection action is disabled.
+ * @return {JSX.Element} YouTube connection card.
  */
-const ConnectYouTubeAccountCard = () => {
+const ConnectYouTubeAccountCard = ( { disabled = false } ) => {
 	const { createNotice } = useDispatchCoreNotices();
 
 	const query = { next_page_name: 'setup-youtube' };
@@ -61,9 +65,24 @@ const ConnectYouTubeAccountCard = () => {
 		} );
 	};
 
+	const connectButton = (
+		<AppButton
+			// Show spinner while the API request is in progress or while the user is being redirected to YouTube for authentication.
+			loading={ loading || !! data }
+			disabled={ disabled }
+			eventName="gla_youtube_account_connect_button_click"
+			eventProps={ { context: 'settings-youtube' } }
+			onClick={ handleConnectClick }
+			isSecondary
+		>
+			{ __( 'Connect', 'google-listings-and-ads' ) }
+		</AppButton>
+	);
+
 	return (
 		<AccountCard
 			appearance={ APPEARANCE.YOUTUBE }
+			disabled={ disabled }
 			description={
 				<div className="gla-connect-youtube-account-card__description">
 					<p>
@@ -81,16 +100,18 @@ const ConnectYouTubeAccountCard = () => {
 				</div>
 			}
 			indicator={
-				<AppButton
-					// Show spinner while the API request is in progress or while the user is being redirected to YouTube for authentication.
-					loading={ loading || !! data }
-					eventName="gla_youtube_account_connect_button_click"
-					eventProps={ { context: 'settings-youtube' } }
-					onClick={ handleConnectClick }
-					isSecondary
-				>
-					{ __( 'Connect', 'google-listings-and-ads' ) }
-				</AppButton>
+				disabled ? (
+					<AppTooltip
+						text={ __(
+							'Connect a Google Merchant Center account before connecting YouTube.',
+							'google-listings-and-ads'
+						) }
+					>
+						{ connectButton }
+					</AppTooltip>
+				) : (
+					connectButton
+				)
 			}
 		/>
 	);

--- a/js/src/pages/settings/accounts/youtube-account-card/connect-youtube-account-card.js
+++ b/js/src/pages/settings/accounts/youtube-account-card/connect-youtube-account-card.js
@@ -11,7 +11,6 @@ import { ExternalLink } from '@wordpress/components';
 import { API_NAMESPACE } from '~/data/constants';
 import { recordGlaEvent } from '~/utils/tracks';
 import AppButton from '~/components/app-button';
-import AppTooltip from '~/components/app-tooltip';
 import AccountCard, { APPEARANCE } from '~/components/account-card';
 import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 import useApiFetchCallback from '~/hooks/useApiFetchCallback';
@@ -83,6 +82,14 @@ const ConnectYouTubeAccountCard = ( { disabled = false } ) => {
 		<AccountCard
 			appearance={ APPEARANCE.YOUTUBE }
 			disabled={ disabled }
+			helper={
+				disabled
+					? __(
+							'Connect a Google Merchant Center account before connecting YouTube.',
+							'google-listings-and-ads'
+					  )
+					: undefined
+			}
 			description={
 				<div className="gla-connect-youtube-account-card__description">
 					<p>
@@ -99,20 +106,7 @@ const ConnectYouTubeAccountCard = ( { disabled = false } ) => {
 					</ExternalLink>
 				</div>
 			}
-			indicator={
-				disabled ? (
-					<AppTooltip
-						text={ __(
-							'Connect a Google Merchant Center account before connecting YouTube.',
-							'google-listings-and-ads'
-						) }
-					>
-						{ connectButton }
-					</AppTooltip>
-				) : (
-					connectButton
-				)
-			}
+			indicator={ connectButton }
 		/>
 	);
 };

--- a/js/src/pages/settings/accounts/youtube-account-card/connect-youtube-account-card.test.js
+++ b/js/src/pages/settings/accounts/youtube-account-card/connect-youtube-account-card.test.js
@@ -68,6 +68,19 @@ describe( 'ConnectYouTubeAccountCard', () => {
 		expect( fetchYouTubeConnect ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'disables the connection when Merchant Center is not connected', async () => {
+		const user = userEvent.setup();
+
+		render( <ConnectYouTubeAccountCard disabled /> );
+
+		const connectButton = screen.getByRole( 'button', { name: 'Connect' } );
+		expect( connectButton ).toBeDisabled();
+
+		await user.click( connectButton );
+
+		expect( fetchYouTubeConnect ).not.toHaveBeenCalled();
+	} );
+
 	it( 'tracks the YouTube Merchant Terms documentation link click', async () => {
 		const user = userEvent.setup();
 

--- a/js/src/pages/settings/accounts/youtube-account-card/connect-youtube-account-card.test.js
+++ b/js/src/pages/settings/accounts/youtube-account-card/connect-youtube-account-card.test.js
@@ -68,17 +68,12 @@ describe( 'ConnectYouTubeAccountCard', () => {
 		expect( fetchYouTubeConnect ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'disables the connection when Merchant Center is not connected', async () => {
-		const user = userEvent.setup();
-
+	it( 'disables the connection when Merchant Center is not connected', () => {
 		render( <ConnectYouTubeAccountCard disabled /> );
 
-		const connectButton = screen.getByRole( 'button', { name: 'Connect' } );
-		expect( connectButton ).toBeDisabled();
-
-		await user.click( connectButton );
-
-		expect( fetchYouTubeConnect ).not.toHaveBeenCalled();
+		expect(
+			screen.getByRole( 'button', { name: 'Connect' } )
+		).toBeDisabled();
 	} );
 
 	it( 'tracks the YouTube Merchant Terms documentation link click', async () => {

--- a/js/src/pages/settings/accounts/youtube-account-card/connect-youtube-account-card.test.js
+++ b/js/src/pages/settings/accounts/youtube-account-card/connect-youtube-account-card.test.js
@@ -74,6 +74,11 @@ describe( 'ConnectYouTubeAccountCard', () => {
 		expect(
 			screen.getByRole( 'button', { name: 'Connect' } )
 		).toBeDisabled();
+		expect(
+			screen.getByText(
+				'Connect a Google Merchant Center account before connecting YouTube.'
+			)
+		).toBeVisible();
 	} );
 
 	it( 'tracks the YouTube Merchant Terms documentation link click', async () => {

--- a/js/src/pages/settings/accounts/youtube-account-card/index.js
+++ b/js/src/pages/settings/accounts/youtube-account-card/index.js
@@ -5,7 +5,6 @@ import { YOUTUBE_ACCOUNT_STATUS } from '~/constants';
 import useYouTubeAccount from '~/hooks/useYouTubeAccount';
 import ConnectedYouTubeAccountCard from './connected-youtube-account-card';
 import ConnectYouTubeAccountCard from './connect-youtube-account-card';
-import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
 
 /**
  * @typedef {Object} YouTubeChannel
@@ -23,16 +22,12 @@ import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
  * Renders the YouTube account card, either connected or connect state.
  * Shows a loading spinner while the account data is being fetched.
  * @param {Object} props Component props.
+ * @param {boolean} [props.disabled=false] Whether connecting YouTube is disabled.
  * @param {() => void} props.onDisconnect Callback when the user clicks to disconnect the YouTube account.
- * @return {JSX.Element|null} The YouTube account card, or null if the Google Merchant Center connection is not present.
+ * @return {JSX.Element} The YouTube account card.
  */
-const YouTubeAccountCard = ( { onDisconnect } ) => {
+const YouTubeAccountCard = ( { disabled = false, onDisconnect } ) => {
 	const { youTubeAccount } = useYouTubeAccount();
-	const { hasGoogleMCConnection } = useGoogleMCAccount();
-
-	if ( ! hasGoogleMCConnection ) {
-		return null;
-	}
 
 	if (
 		[
@@ -48,7 +43,7 @@ const YouTubeAccountCard = ( { onDisconnect } ) => {
 		);
 	}
 
-	return <ConnectYouTubeAccountCard />;
+	return <ConnectYouTubeAccountCard disabled={ disabled } />;
 };
 
 export default YouTubeAccountCard;

--- a/src/API/Site/Controllers/DisconnectController.php
+++ b/src/API/Site/Controllers/DisconnectController.php
@@ -4,6 +4,8 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\ServiceBasedMerchantState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use WP_REST_Request as Request;
 use WP_REST_Response as Response;
 
@@ -17,6 +19,24 @@ defined( 'ABSPATH' ) || exit;
 class DisconnectController extends BaseController {
 
 	use EmptySchemaPropertiesTrait;
+
+	/**
+	 * Service-based merchant state.
+	 *
+	 * @var ServiceBasedMerchantState
+	 */
+	protected ?ServiceBasedMerchantState $service_based_merchant_state;
+
+	/**
+	 * DisconnectController constructor.
+	 *
+	 * @param RESTServer                     $server REST server proxy.
+	 * @param ServiceBasedMerchantState|null $service_based_merchant_state Service-based merchant state.
+	 */
+	public function __construct( RESTServer $server, ?ServiceBasedMerchantState $service_based_merchant_state = null ) {
+		parent::__construct( $server );
+		$this->service_based_merchant_state = $service_based_merchant_state;
+	}
 
 	/**
 	 * Register rest routes with WordPress.
@@ -41,6 +61,10 @@ class DisconnectController extends BaseController {
 	 */
 	protected function get_disconnect_callback(): callable {
 		return function ( Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			if ( null !== $this->service_based_merchant_state ) {
+				$this->service_based_merchant_state->reset_supported_products_confirmation();
+			}
+
 			$endpoints = [
 				'ads/connection',
 				'mc/connection',

--- a/src/API/Site/Controllers/SupportedProductsController.php
+++ b/src/API/Site/Controllers/SupportedProductsController.php
@@ -1,0 +1,93 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\ServiceBasedMerchantState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use WP_REST_Request as Request;
+use WP_REST_Response as Response;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Controller for recording a merchant's supported-products confirmation.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers
+ */
+class SupportedProductsController extends BaseController {
+
+	use EmptySchemaPropertiesTrait;
+
+	/**
+	 * Service-based merchant state.
+	 *
+	 * @var ServiceBasedMerchantState
+	 */
+	protected ServiceBasedMerchantState $service_based_merchant_state;
+
+	/**
+	 * SupportedProductsController constructor.
+	 *
+	 * @param RESTServer                $server REST server proxy.
+	 * @param ServiceBasedMerchantState $service_based_merchant_state Service-based merchant state.
+	 */
+	public function __construct( RESTServer $server, ServiceBasedMerchantState $service_based_merchant_state ) {
+		parent::__construct( $server );
+		$this->service_based_merchant_state = $service_based_merchant_state;
+	}
+
+	/**
+	 * Register REST routes with WordPress.
+	 */
+	public function register_routes(): void {
+		$this->register_route(
+			'merchant/supported-products',
+			[
+				[
+					'methods'             => TransportMethods::CREATABLE,
+					'callback'            => $this->get_confirm_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+					'args'                => [
+						'confirmed' => [
+							'type'              => 'boolean',
+							'enum'              => [ true ],
+							'required'          => true,
+							'validate_callback' => 'rest_validate_request_arg',
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get the callback for confirming supported products.
+	 *
+	 * @return callable
+	 */
+	protected function get_confirm_callback(): callable {
+		return function ( Request $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+			$this->service_based_merchant_state->confirm_supported_products();
+
+			return new Response(
+				[
+					'confirmed'              => true,
+					'service_based_merchant' => false,
+				],
+				200
+			);
+		};
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'supported_products';
+	}
+}

--- a/src/API/Site/Controllers/YouTube/AccountController.php
+++ b/src/API/Site/Controllers/YouTube/AccountController.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Client\ClientExceptionInterface;
 use Exception;
+use WP_REST_Response as Response;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -91,6 +92,18 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 	 */
 	protected function get_connect_callback(): callable {
 		return function () {
+			if ( ! $this->options->get_merchant_id() ) {
+				return new Response(
+					[
+						'message' => __(
+							'A Merchant Center account must be connected before connecting YouTube.',
+							'google-listings-and-ads'
+						),
+					],
+					409
+				);
+			}
+
 			try {
 				return [
 					'url' => $this->connection->connect(

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -34,6 +34,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\Ads\Recomme
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\GTINMigrationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\NotificationController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\OnboardingController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\SupportedProductsController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\TourController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\DisconnectController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\ConnectController;
@@ -88,6 +89,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\TargetAudience;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\PolicyComplianceCheck;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notification\NotificationService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\ServiceBasedMerchantState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\TransientsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\AttributeMapping\AttributeMappingHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
@@ -155,7 +157,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( TargetAudienceController::class, WP::class, WC::class, ShippingZone::class, GoogleHelper::class, TargetAudience::class, MarketService::class );
 		$this->share( SupportedCountriesController::class, WC::class, GoogleHelper::class );
 		$this->share( SettingsSyncController::class, Settings::class );
-		$this->share( DisconnectController::class );
+		$this->share( DisconnectController::class, ServiceBasedMerchantState::class );
 		$this->share( SetupCompleteController::class, MerchantMetrics::class );
 		$this->share( AssetSuggestionsController::class, AdsAssetSuggestionsService::class );
 		$this->share( AssetGenerationController::class, AdsAssetGenerationService::class );
@@ -176,6 +178,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( ConnectController::class, Middleware::class, OptionsInterface::class );
 		$this->share( YouTubeAccountController::class, YouTubeConnection::class );
 		$this->share( OnboardingController::class );
+		$this->share( SupportedProductsController::class, ServiceBasedMerchantState::class );
 		$this->share( MarketsController::class, MarketService::class );
 	}
 

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -62,6 +62,7 @@ interface OptionsInterface {
 	public const NOTIFICATIONS_SITE_STATE                  = 'notifications_site_state';
 	public const WC_INSTALL_TIMESTAMP                      = 'wc_install_timestamp';
 	public const IS_SERVICE_BASED_MERCHANT                 = 'is_service_based_merchant';
+	public const SUPPORTED_PRODUCTS_CONFIRMED              = 'supported_products_confirmed';
 
 	public const VALID_OPTIONS = [
 		self::ADS_ACCOUNT_CURRENCY                      => true,
@@ -114,6 +115,7 @@ interface OptionsInterface {
 		self::NOTIFICATIONS_SITE_STATE                  => true,
 		self::WC_INSTALL_TIMESTAMP                      => true,
 		self::IS_SERVICE_BASED_MERCHANT                 => true,
+		self::SUPPORTED_PRODUCTS_CONFIRMED              => true,
 	];
 
 	public const OPTION_TYPES = [

--- a/src/Options/ServiceBasedMerchantState.php
+++ b/src/Options/ServiceBasedMerchantState.php
@@ -35,6 +35,10 @@ class ServiceBasedMerchantState implements Service, OptionsAwareInterface {
 	 * @return bool True if service-based, false otherwise.
 	 */
 	public function is_service_based_merchant(): bool {
+		if ( $this->has_confirmed_supported_products() ) {
+			return false;
+		}
+
 		$option_value = $this->options->get( OptionsInterface::IS_SERVICE_BASED_MERCHANT );
 
 		// If option is null, calculate it now.
@@ -45,6 +49,36 @@ class ServiceBasedMerchantState implements Service, OptionsAwareInterface {
 		}
 
 		return 'yes' === $option_value;
+	}
+
+	/**
+	 * Check whether the merchant has confirmed that they sell products supported by Google.
+	 *
+	 * @return bool True when the merchant has confirmed supported products.
+	 */
+	public function has_confirmed_supported_products(): bool {
+		return 'yes' === $this->options->get( OptionsInterface::SUPPORTED_PRODUCTS_CONFIRMED );
+	}
+
+	/**
+	 * Record that the merchant has confirmed that they sell products supported by Google.
+	 *
+	 * @return void
+	 */
+	public function confirm_supported_products(): void {
+		$this->options->update( OptionsInterface::SUPPORTED_PRODUCTS_CONFIRMED, 'yes' );
+	}
+
+	/**
+	 * Clear the merchant's supported-products confirmation.
+	 *
+	 * This is intentionally separate from the catalog-derived status cache so
+	 * product changes cannot revoke an explicit merchant confirmation.
+	 *
+	 * @return void
+	 */
+	public function reset_supported_products_confirmation(): void {
+		$this->options->delete( OptionsInterface::SUPPORTED_PRODUCTS_CONFIRMED );
 	}
 
 	/**

--- a/tests/Unit/API/Site/Controllers/DisconnectControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/DisconnectControllerTest.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\DisconnectController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\OnboardingController;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\ServiceBasedMerchantState;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -22,6 +23,9 @@ class DisconnectControllerTest extends RESTControllerUnitTest {
 	/** @var MockObject|OptionsInterface $options */
 	protected $options;
 
+	/** @var MockObject|ServiceBasedMerchantState $service_based_merchant_state */
+	protected $service_based_merchant_state;
+
 	protected const ROUTE_CONNECTIONS         = '/wc/gla/connections';
 	protected const ROUTE_ONBOARDING_COMPLETE = '/wc/gla/google/onboarding/complete';
 
@@ -37,7 +41,8 @@ class DisconnectControllerTest extends RESTControllerUnitTest {
 		$onboarding_controller->set_options_object( $this->options );
 		$onboarding_controller->register();
 
-		$this->controller = new DisconnectController( $this->server );
+		$this->service_based_merchant_state = $this->createMock( ServiceBasedMerchantState::class );
+		$this->controller                   = new DisconnectController( $this->server, $this->service_based_merchant_state );
 		$this->controller->register();
 	}
 
@@ -50,12 +55,22 @@ class DisconnectControllerTest extends RESTControllerUnitTest {
 	}
 
 	/**
+	 * Test that existing consumers can still construct the controller with only the server.
+	 */
+	public function test_constructor_preserves_existing_signature(): void {
+		$this->assertInstanceOf( DisconnectController::class, new DisconnectController( $this->server ) );
+	}
+
+	/**
 	 * Test that disconnect calls the onboarding complete DELETE endpoint.
 	 *
 	 * Note: The actual DELETE endpoint behavior is tested in OnboardingControllerTest.
 	 * This test only verifies that DisconnectController includes it in the disconnect flow.
 	 */
 	public function test_disconnect_calls_onboarding_complete_endpoint(): void {
+		$this->service_based_merchant_state->expects( $this->once() )
+			->method( 'reset_supported_products_confirmation' );
+
 		// Expect the delete method to be called exactly once
 		$this->options->expects( $this->once() )
 			->method( 'delete' )

--- a/tests/Unit/API/Site/Controllers/DisconnectControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/DisconnectControllerTest.php
@@ -55,13 +55,6 @@ class DisconnectControllerTest extends RESTControllerUnitTest {
 	}
 
 	/**
-	 * Test that existing consumers can still construct the controller with only the server.
-	 */
-	public function test_constructor_preserves_existing_signature(): void {
-		$this->assertInstanceOf( DisconnectController::class, new DisconnectController( $this->server ) );
-	}
-
-	/**
 	 * Test that disconnect calls the onboarding complete DELETE endpoint.
 	 *
 	 * Note: The actual DELETE endpoint behavior is tested in OnboardingControllerTest.

--- a/tests/Unit/API/Site/Controllers/SupportedProductsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/SupportedProductsControllerTest.php
@@ -56,13 +56,4 @@ class SupportedProductsControllerTest extends RESTControllerUnitTest {
 
 		$this->assertEquals( 400, $response->get_status() );
 	}
-
-	public function test_confirmation_is_required(): void {
-		$this->service_based_merchant_state->expects( $this->never() )
-			->method( 'confirm_supported_products' );
-
-		$response = $this->do_request( self::ROUTE, 'POST' );
-
-		$this->assertEquals( 400, $response->get_status() );
-	}
 }

--- a/tests/Unit/API/Site/Controllers/SupportedProductsControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/SupportedProductsControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\SupportedProductsController;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\ServiceBasedMerchantState;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Class SupportedProductsControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers
+ */
+class SupportedProductsControllerTest extends RESTControllerUnitTest {
+
+	protected const ROUTE = '/wc/gla/merchant/supported-products';
+
+	/** @var MockObject|ServiceBasedMerchantState $service_based_merchant_state */
+	protected $service_based_merchant_state;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->service_based_merchant_state = $this->createMock( ServiceBasedMerchantState::class );
+		$this->controller                   = new SupportedProductsController( $this->server, $this->service_based_merchant_state );
+		$this->controller->register();
+	}
+
+	public function test_route_registered(): void {
+		$this->assertArrayHasKey( self::ROUTE, $this->server->get_routes() );
+	}
+
+	public function test_confirm_supported_products(): void {
+		$this->service_based_merchant_state->expects( $this->once() )
+			->method( 'confirm_supported_products' );
+
+		$response = $this->do_request( self::ROUTE, 'POST', [ 'confirmed' => true ] );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals(
+			[
+				'confirmed'              => true,
+				'service_based_merchant' => false,
+			],
+			$response->get_data()
+		);
+	}
+
+	public function test_confirmation_must_be_explicitly_true(): void {
+		$this->service_based_merchant_state->expects( $this->never() )
+			->method( 'confirm_supported_products' );
+
+		$response = $this->do_request( self::ROUTE, 'POST', [ 'confirmed' => false ] );
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_confirmation_is_required(): void {
+		$this->service_based_merchant_state->expects( $this->never() )
+			->method( 'confirm_supported_products' );
+
+		$response = $this->do_request( self::ROUTE, 'POST' );
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+}

--- a/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
@@ -33,7 +33,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options    = $this->createMock( OptionsInterface::class );
 		$this->connection = $this->createMock( Connection::class );
 		$this->controller = new AccountController( $this->server, $this->connection );
 		$this->controller->set_options_object( $this->options );

--- a/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
@@ -34,7 +34,6 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		parent::setUp();
 
 		$this->options = $this->createMock( OptionsInterface::class );
-		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
 		$this->connection = $this->createMock( Connection::class );
 		$this->controller = new AccountController( $this->server, $this->connection );
 		$this->controller->set_options_object( $this->options );
@@ -46,6 +45,10 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$return_url = admin_url(
 			'admin.php?page=wc-admin&path=/google/settings&section=accounts'
 		);
+
+		$this->options->expects( $this->once() )
+			->method( 'get_merchant_id' )
+			->willReturn( 1234 );
 
 		$this->connection->expects( $this->once() )
 			->method( 'connect' )
@@ -63,7 +66,30 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
+	public function test_connect_without_merchant_center_connection() {
+		$this->options->expects( $this->once() )
+			->method( 'get_merchant_id' )
+			->willReturn( 0 );
+
+		$this->connection->expects( $this->never() )
+			->method( 'connect' );
+
+		$response = $this->do_request( self::ROUTE_CONNECT, 'GET' );
+
+		$this->assertEquals(
+			[
+				'message' => 'A Merchant Center account must be connected before connecting YouTube.',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 409, $response->get_status() );
+	}
+
 	public function test_connect_with_error() {
+		$this->options->expects( $this->once() )
+			->method( 'get_merchant_id' )
+			->willReturn( 1234 );
+
 		$this->connection->expects( $this->once() )
 			->method( 'connect' )
 			->willThrowException( new Exception( 'error', 400 ) );

--- a/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
@@ -33,7 +33,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->options    = $this->createMock( OptionsInterface::class );
+		$this->options = $this->createMock( OptionsInterface::class );
 		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
 		$this->connection = $this->createMock( Connection::class );
 		$this->controller = new AccountController( $this->server, $this->connection );

--- a/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
@@ -34,6 +34,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		parent::setUp();
 
 		$this->options    = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_merchant_id' )->willReturn( 1234 );
 		$this->connection = $this->createMock( Connection::class );
 		$this->controller = new AccountController( $this->server, $this->connection );
 		$this->controller->set_options_object( $this->options );

--- a/tests/Unit/Options/ServiceBasedMerchantStateTest.php
+++ b/tests/Unit/Options/ServiceBasedMerchantStateTest.php
@@ -31,10 +31,13 @@ class ServiceBasedMerchantStateTest extends ContainerAwareUnitTest {
 	}
 
 	public function test_is_service_based_merchant_returns_cached_value_when_option_exists() {
-		$this->options->expects( $this->once() )
+		$this->options->expects( $this->exactly( 2 ) )
 			->method( 'get' )
-			->with( OptionsInterface::IS_SERVICE_BASED_MERCHANT )
-			->willReturn( 'yes' );
+			->withConsecutive(
+				[ OptionsInterface::SUPPORTED_PRODUCTS_CONFIRMED ],
+				[ OptionsInterface::IS_SERVICE_BASED_MERCHANT ]
+			)
+			->willReturnOnConsecutiveCalls( null, 'yes' );
 
 		$result = $this->service_based_merchant_state->is_service_based_merchant();
 
@@ -42,10 +45,13 @@ class ServiceBasedMerchantStateTest extends ContainerAwareUnitTest {
 	}
 
 	public function test_is_service_based_merchant_returns_false() {
-		$this->options->expects( $this->once() )
+		$this->options->expects( $this->exactly( 2 ) )
 			->method( 'get' )
-			->with( OptionsInterface::IS_SERVICE_BASED_MERCHANT )
-			->willReturn( 'no' );
+			->withConsecutive(
+				[ OptionsInterface::SUPPORTED_PRODUCTS_CONFIRMED ],
+				[ OptionsInterface::IS_SERVICE_BASED_MERCHANT ]
+			)
+			->willReturnOnConsecutiveCalls( null, 'no' );
 
 		$result = $this->service_based_merchant_state->is_service_based_merchant();
 
@@ -58,10 +64,13 @@ class ServiceBasedMerchantStateTest extends ContainerAwareUnitTest {
 		$physical_product->set_virtual( false );
 		$physical_product->save();
 
-		$this->options->expects( $this->once() )
+		$this->options->expects( $this->exactly( 2 ) )
 			->method( 'get' )
-			->with( OptionsInterface::IS_SERVICE_BASED_MERCHANT )
-			->willReturn( null );
+			->withConsecutive(
+				[ OptionsInterface::SUPPORTED_PRODUCTS_CONFIRMED ],
+				[ OptionsInterface::IS_SERVICE_BASED_MERCHANT ]
+			)
+			->willReturnOnConsecutiveCalls( null, null );
 
 		// Should calculate and save when option is null
 		$this->options->expects( $this->once() )
@@ -75,6 +84,39 @@ class ServiceBasedMerchantStateTest extends ContainerAwareUnitTest {
 
 		// Cleanup
 		$physical_product->delete( true );
+	}
+
+	public function test_supported_products_confirmation_overrides_service_based_status() {
+		$this->options->expects( $this->once() )
+			->method( 'get' )
+			->with( OptionsInterface::SUPPORTED_PRODUCTS_CONFIRMED )
+			->willReturn( 'yes' );
+
+		$this->assertFalse( $this->service_based_merchant_state->is_service_based_merchant() );
+	}
+
+	public function test_confirm_supported_products_updates_confirmation_option() {
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::SUPPORTED_PRODUCTS_CONFIRMED, 'yes' );
+
+		$this->service_based_merchant_state->confirm_supported_products();
+	}
+
+	public function test_reset_supported_products_confirmation_deletes_confirmation_option() {
+		$this->options->expects( $this->once() )
+			->method( 'delete' )
+			->with( OptionsInterface::SUPPORTED_PRODUCTS_CONFIRMED );
+
+		$this->service_based_merchant_state->reset_supported_products_confirmation();
+	}
+
+	public function test_reset_service_based_merchant_status_preserves_supported_products_confirmation() {
+		$this->options->expects( $this->once() )
+			->method( 'delete' )
+			->with( OptionsInterface::IS_SERVICE_BASED_MERCHANT );
+
+		$this->service_based_merchant_state->reset_service_based_merchant_status();
 	}
 
 	public function test_has_physical_products_returns_true_when_physical_products_exist() {

--- a/tests/e2e/specs/settings/settings.test.js
+++ b/tests/e2e/specs/settings/settings.test.js
@@ -477,27 +477,6 @@ test.describe( 'Settings', () => {
 			await clearServiceBasedMerchant();
 		} );
 
-		test( 'should explain why the Google Merchant Center connection is unavailable', async () => {
-			await settingsPage.gotoAccounts();
-
-			const gmcCard = page.locator(
-				'.gla-account-card:has-text("Google Merchant Center")'
-			);
-			await expect( gmcCard ).toBeVisible();
-			await expect(
-				gmcCard.getByText(
-					/The Google Merchant Center connection is not available/
-				)
-			).toBeVisible();
-			await expect(
-				gmcCard.getByRole( 'button', {
-					name: 'Confirm that I sell supported products',
-				} )
-			).toBeVisible();
-
-			await settingsPage.goto();
-		} );
-
 		test( 'should not show the tax rate setup section', async () => {
 			await expect(
 				page.getByText( 'Tax rate (required for U.S. only)' )
@@ -571,7 +550,7 @@ test.describe( 'Settings', () => {
 			expect( requestPayload ).toHaveProperty( 'location', 'all' );
 		} );
 
-		test( 'should confirm supported products and enable the Merchant Center connection', async () => {
+		test( 'should explain the unavailable Merchant Center connection and let the merchant confirm supported products', async () => {
 			await settingsPage.gotoAccounts();
 
 			const gmcCard = page.locator(
@@ -580,6 +559,13 @@ test.describe( 'Settings', () => {
 			const confirmationButton = gmcCard.getByRole( 'button', {
 				name: 'Confirm that I sell supported products',
 			} );
+
+			await expect(
+				gmcCard.getByText(
+					/The Google Merchant Center connection is not available/
+				)
+			).toBeVisible();
+			await expect( confirmationButton ).toBeVisible();
 
 			await confirmationButton.click();
 			await expect(

--- a/tests/e2e/specs/settings/settings.test.js
+++ b/tests/e2e/specs/settings/settings.test.js
@@ -477,12 +477,25 @@ test.describe( 'Settings', () => {
 			await clearServiceBasedMerchant();
 		} );
 
-		test( 'should not show Google Merchant Center account card', async () => {
-			// There should not be a `gla-account-card` with text 'Google Merchant Center'.
+		test( 'should explain why the Google Merchant Center connection is unavailable', async () => {
+			await settingsPage.gotoAccounts();
+
 			const gmcCard = page.locator(
 				'.gla-account-card:has-text("Google Merchant Center")'
 			);
-			await expect( gmcCard ).not.toBeVisible();
+			await expect( gmcCard ).toBeVisible();
+			await expect(
+				gmcCard.getByText(
+					/The Google Merchant Center connection is not available/
+				)
+			).toBeVisible();
+			await expect(
+				gmcCard.getByRole( 'button', {
+					name: 'Confirm that I sell supported products',
+				} )
+			).toBeVisible();
+
+			await settingsPage.goto();
 		} );
 
 		test( 'should not show the tax rate setup section', async () => {
@@ -491,17 +504,26 @@ test.describe( 'Settings', () => {
 			).not.toBeVisible();
 		} );
 
-		test( 'should hide YouTube on the Accounts tab until Merchant Center is connected', async () => {
+		test( 'should disable YouTube on the Accounts tab until Merchant Center is connected', async () => {
 			await settingsPage.gotoAccounts();
 
 			await page
 				.getByRole( 'button', { name: 'Disconnect from all accounts' } )
 				.waitFor();
 
-			await expect( settingsPage.youTubeAccountCard ).not.toBeVisible();
+			await expect( settingsPage.youTubeAccountCard ).toBeVisible();
 			await expect(
 				page.getByRole( 'heading', { name: 'Grow your reach' } )
-			).not.toBeVisible();
+			).toBeVisible();
+
+			const connectButton = settingsPage.getYouTubeConnectButton();
+			await expect( connectButton ).toBeDisabled();
+			await connectButton.hover();
+			await expect(
+				page.getByText(
+					'Connect a Google Merchant Center account before connecting YouTube.'
+				)
+			).toBeVisible();
 
 			await settingsPage.goto();
 		} );
@@ -547,6 +569,34 @@ test.describe( 'Settings', () => {
 			const requestPayload = await request.postDataJSON();
 
 			expect( requestPayload ).toHaveProperty( 'location', 'all' );
+		} );
+
+		test( 'should confirm supported products and enable the Merchant Center connection', async () => {
+			await settingsPage.gotoAccounts();
+
+			const gmcCard = page.locator(
+				'.gla-account-card:has-text("Google Merchant Center")'
+			);
+			const confirmationButton = gmcCard.getByRole( 'button', {
+				name: 'Confirm that I sell supported products',
+			} );
+
+			await confirmationButton.click();
+			await expect(
+				page.getByRole( 'heading', {
+					name: 'Confirm supported product types',
+				} )
+			).toBeVisible();
+
+			await page.getByRole( 'button', { name: 'Cancel' } ).click();
+			await expect( confirmationButton ).toBeVisible();
+
+			await confirmationButton.click();
+			await page.getByRole( 'button', { name: 'Confirm' } ).click();
+
+			await expect(
+				gmcCard.getByRole( 'link', { name: 'Connect' } )
+			).toBeVisible();
 		} );
 	} );
 } );

--- a/tests/e2e/test-data/test-data.php
+++ b/tests/e2e/test-data/test-data.php
@@ -188,6 +188,7 @@ function clear_onboarded_merchant() {
 function set_service_based_merchant() {
 	/** @var OptionsInterface $options */
 	$options = woogle_get_container()->get( OptionsInterface::class );
+	$options->delete( OptionsInterface::SUPPORTED_PRODUCTS_CONFIRMED );
 	$options->update(
 		OptionsInterface::IS_SERVICE_BASED_MERCHANT,
 		'yes'
@@ -200,6 +201,7 @@ function set_service_based_merchant() {
 function clear_service_based_merchant() {
 	/** @var OptionsInterface $options */
 	$options = woogle_get_container()->get( OptionsInterface::class );
+	$options->delete( OptionsInterface::SUPPORTED_PRODUCTS_CONFIRMED );
 	$options->update(
 		OptionsInterface::IS_SERVICE_BASED_MERCHANT,
 		'no'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-947

This PR: 
- makes the Merchant Center and YouTube account cards visible for service based merchants post onboarding, 
- ensures that YouTube cannot be connected until Merchant Center is connected, 
- explains why a Merchant Center account cannot be connected for service-based merchants, 
- adds a path for service-based merchants to confirm that they sell supported digital products and access the Merchant Center connection, 
- removes the YouTube promotional banner post-onboarding for service-based merchants. 


### Screenshots:

<img width="2056" height="2136" alt="Markup on 2026-08-28 at 15:21:33" src="https://github.com/user-attachments/assets/cc6180f6-ebd8-415f-8e51-6eff5dea3351" />

<img width="2176" height="1586" alt="Markup on 2026-08-28 at 16:28:03" src="https://github.com/user-attachments/assets/9598ccd9-1d93-4b4f-86e4-698443e25846" />


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. On a new store, create only digital, non-shippable products.
2. Install this version of Google for WooCommerce.
3. Start the Google for WooCommerce onboarding and ensure that only the Google Ads account is created. 
4. Post-onboarding confirm that you don't see the promotional banner for YouTube. 
5. Go to Settings > Accounts and confirm that both Merchant Center and YouTube accounts show up. 
6. Confirm that the YouTube account Connect button is disabled, the explanation remains readable, and hovering the button shows a message that connecting MC first is required. 
7. In the MC account, confirm that you see a notice that explains why MC connection is disabled and a way to enable the connection if you indeed sell supported products. 
8. Click on the confirmation button and proceed in the modal. Confirm that its actions remain disabled after submitting so the request cannot be sent twice. 
9. After confirmation, ensure that you can now connect MC. 
10. After MC is connected, ensure that you can connect YouTube. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Improved account connection experience for service-based merchants.

### Backward compatibility

- Adds `POST /wc/gla/mc/supported-products`, restricted to authenticated users with the `manage_woocommerce` capability. It requires a boolean `confirmed` parameter whose only accepted value is `true`. It returns HTTP 200 with `{ "confirmed": true, "service_based_merchant": false }`, or HTTP 400 with a `message` if the confirmation cannot be persisted. This route is additive and does not replace or alter an existing endpoint.
- Adds `has_confirmed_supported_products(): bool`, `confirm_supported_products(): bool`, and `reset_supported_products_confirmation(): void` to the concrete `ServiceBasedMerchantState` class. When clearing the confirmation, `reset_supported_products_confirmation()` also invalidates the cached catalog-derived classification so the next status read reflects the current catalog. These methods and this reset behavior are introduced together in this PR; no previously released contract or externally implementable interface changes.
- After confirmation, `ServiceBasedMerchantState::is_service_based_merchant()` and the exposed `glaData.serviceBasedMerchant` property intentionally report `false` even when the catalog-derived state remains service-based. Existing consumers should treat the value as current feature eligibility rather than an immutable catalog classification. No existing symbol or front-end property is renamed or removed.
- The confirmation uses the existing site-scoped Options service, so each site in a multisite network stores its confirmation independently. Multisite behavior was not manually tested.
- `GET /wc/gla/youtube/connect` now returns HTTP 409 with a `message` when no Merchant Center account is connected. This intentionally tightens an existing REST contract; callers that bypass the UI must handle the new response.
