### PR TITLE
GOOWOO-995: Referral tracking for In Product Placements

### DIFF
--- a/js/src/meta-boxes/channel-visibility/get-started-cta.js
+++ b/js/src/meta-boxes/channel-visibility/get-started-cta.js
@@ -7,7 +7,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import AppButton from '~/components/app-button';
-import { getOnboardingUrl } from '~/utils/urls';
+import { getOnboardingUrl, getReferrerUrl } from '~/utils/urls';
+import { REFERRER_TYPE_IN_PRODUCT_PLACEMENTS } from '~/utils/tracks';
 import { CHANNEL_VISIBILITY_CONTEXT } from './constants';
 
 /**
@@ -26,7 +27,11 @@ import { CHANNEL_VISIBILITY_CONTEXT } from './constants';
  * @return {JSX.Element} The Get Started CTA component.
  */
 const GetStartedCTA = () => {
-	const onboardingUrl = getOnboardingUrl();
+	const onboardingUrl = getReferrerUrl(
+		getOnboardingUrl(),
+		REFERRER_TYPE_IN_PRODUCT_PLACEMENTS,
+		CHANNEL_VISIBILITY_CONTEXT
+	);
 
 	return (
 		<AppButton

--- a/js/src/meta-boxes/channel-visibility/get-started-cta.js
+++ b/js/src/meta-boxes/channel-visibility/get-started-cta.js
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import AppButton from '~/components/app-button';
-import { getOnboardingUrl, getReferrerUrl } from '~/utils/urls';
+import { getOnboardingUrl, addReferrerParams } from '~/utils/urls';
 import { REFERRER_TYPE_IN_PRODUCT_PLACEMENTS } from '~/utils/tracks';
 import { CHANNEL_VISIBILITY_CONTEXT } from './constants';
 
@@ -27,7 +27,7 @@ import { CHANNEL_VISIBILITY_CONTEXT } from './constants';
  * @return {JSX.Element} The Get Started CTA component.
  */
 const GetStartedCTA = () => {
-	const onboardingUrl = getReferrerUrl(
+	const onboardingUrl = addReferrerParams(
 		getOnboardingUrl(),
 		REFERRER_TYPE_IN_PRODUCT_PLACEMENTS,
 		CHANNEL_VISIBILITY_CONTEXT

--- a/js/src/meta-boxes/channel-visibility/get-started-cta.test.js
+++ b/js/src/meta-boxes/channel-visibility/get-started-cta.test.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { recordGlaEvent } from '~/utils/tracks';
+import GetStartedCTA from './get-started-cta';
+
+jest.mock( '~/utils/tracks', () => ( {
+	...jest.requireActual( '~/utils/tracks' ),
+	recordGlaEvent: jest.fn(),
+} ) );
+
+jest.mock( '~/utils/urls', () => ( {
+	...jest.requireActual( '~/utils/urls' ),
+	getOnboardingUrl: jest.fn( () => '/onboarding' ),
+} ) );
+
+describe( 'GetStartedCTA Component', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'Renders a "Get started" link', () => {
+		render( <GetStartedCTA /> );
+
+		expect(
+			screen.getByRole( 'link', { name: 'Get started' } )
+		).toBeInTheDocument();
+	} );
+
+	test( 'href includes referrer_type and referrer_id for the channel visibility placement', () => {
+		render( <GetStartedCTA /> );
+
+		expect(
+			screen.getByRole( 'link', { name: 'Get started' } )
+		).toHaveAttribute(
+			'href',
+			'/onboarding?referrer_type=in_product_placements&referrer_id=channel-visibility-meta-box'
+		);
+	} );
+
+	test( 'Fires gla_google_ads_promo_get_started_click event with the referrer-tagged href when clicked', () => {
+		render( <GetStartedCTA /> );
+
+		fireEvent.click( screen.getByRole( 'link', { name: 'Get started' } ) );
+
+		expect( recordGlaEvent ).toHaveBeenCalledWith(
+			'gla_google_ads_promo_get_started_click',
+			{
+				context: 'channel-visibility-meta-box',
+				href: '/onboarding?referrer_type=in_product_placements&referrer_id=channel-visibility-meta-box',
+			}
+		);
+	} );
+} );

--- a/js/src/meta-boxes/order-attribution/google-ads-promo.js
+++ b/js/src/meta-boxes/order-attribution/google-ads-promo.js
@@ -15,7 +15,7 @@ import {
 import {
 	getCreateCampaignUrl,
 	getOnboardingUrl,
-	getReferrerUrl,
+	addReferrerParams,
 } from '~/utils/urls';
 import { ORDER_ATTRIBUTION_CONTEXT } from './constants';
 import AppButton from '~/components/app-button';
@@ -91,7 +91,7 @@ const GoogleAdsPromo = () => {
 
 	let content;
 	if ( hasGoogleAdsConnection ) {
-		const campaignUrl = getReferrerUrl(
+		const campaignUrl = addReferrerParams(
 			getCreateCampaignUrl(),
 			REFERRER_TYPE_IN_PRODUCT_PLACEMENTS,
 			`${ ORDER_ATTRIBUTION_CONTEXT }-create-campaign`
@@ -120,7 +120,7 @@ const GoogleAdsPromo = () => {
 			),
 		};
 	} else {
-		const onboardingUrl = getReferrerUrl(
+		const onboardingUrl = addReferrerParams(
 			getOnboardingUrl(),
 			REFERRER_TYPE_IN_PRODUCT_PLACEMENTS,
 			`${ ORDER_ATTRIBUTION_CONTEXT }-get-started`

--- a/js/src/meta-boxes/order-attribution/google-ads-promo.js
+++ b/js/src/meta-boxes/order-attribution/google-ads-promo.js
@@ -8,8 +8,15 @@ import { Flex, FlexBlock, FlexItem } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { recordGlaEvent } from '~/utils/tracks';
-import { getCreateCampaignUrl, getOnboardingUrl } from '~/utils/urls';
+import {
+	recordGlaEvent,
+	REFERRER_TYPE_IN_PRODUCT_PLACEMENTS,
+} from '~/utils/tracks';
+import {
+	getCreateCampaignUrl,
+	getOnboardingUrl,
+	getReferrerUrl,
+} from '~/utils/urls';
 import { ORDER_ATTRIBUTION_CONTEXT } from './constants';
 import AppButton from '~/components/app-button';
 import AppSpinner from '~/components/app-spinner';
@@ -84,7 +91,11 @@ const GoogleAdsPromo = () => {
 
 	let content;
 	if ( hasGoogleAdsConnection ) {
-		const campaignUrl = getCreateCampaignUrl();
+		const campaignUrl = getReferrerUrl(
+			getCreateCampaignUrl(),
+			REFERRER_TYPE_IN_PRODUCT_PLACEMENTS,
+			`${ ORDER_ATTRIBUTION_CONTEXT }-create-campaign`
+		);
 		content = {
 			title: __(
 				'Get more sales with Google Ads',
@@ -109,7 +120,11 @@ const GoogleAdsPromo = () => {
 			),
 		};
 	} else {
-		const onboardingUrl = getOnboardingUrl();
+		const onboardingUrl = getReferrerUrl(
+			getOnboardingUrl(),
+			REFERRER_TYPE_IN_PRODUCT_PLACEMENTS,
+			`${ ORDER_ATTRIBUTION_CONTEXT }-get-started`
+		);
 		content = {
 			...( isServiceBasedMerchant
 				? {

--- a/js/src/meta-boxes/order-attribution/google-ads-promo.test.js
+++ b/js/src/meta-boxes/order-attribution/google-ads-promo.test.js
@@ -26,10 +26,12 @@ jest.mock( '~/hooks/useServiceBasedMerchant', () =>
 );
 
 jest.mock( '~/utils/tracks', () => ( {
+	...jest.requireActual( '~/utils/tracks' ),
 	recordGlaEvent: jest.fn(),
 } ) );
 
 jest.mock( '~/utils/urls', () => ( {
+	...jest.requireActual( '~/utils/urls' ),
 	getOnboardingUrl: jest.fn( () => '/onboarding' ),
 	getCreateCampaignUrl: jest.fn( () => '/create-campaign' ),
 } ) );
@@ -234,7 +236,7 @@ describe( 'GoogleAdsPromo Component', () => {
 				'gla_google_ads_promo_create_campaign_click',
 				{
 					context: 'order-attribution-meta-box',
-					href: '/create-campaign',
+					href: '/create-campaign?referrer_type=in_product_placements&referrer_id=order-attribution-meta-box-create-campaign',
 				}
 			);
 		} );
@@ -256,7 +258,52 @@ describe( 'GoogleAdsPromo Component', () => {
 
 			expect( recordGlaEvent ).toHaveBeenCalledWith(
 				'gla_google_ads_promo_get_started_click',
-				{ context: 'order-attribution-meta-box', href: '/onboarding' }
+				{
+					context: 'order-attribution-meta-box',
+					href: '/onboarding?referrer_type=in_product_placements&referrer_id=order-attribution-meta-box-get-started',
+				}
+			);
+		} );
+	} );
+
+	describe( 'Referrer attribution', () => {
+		test( 'Get started CTA href includes referrer_type and referrer_id for the order attribution placement', () => {
+			useGoogleAdsAccount.mockReturnValue( {
+				hasGoogleAdsConnection: false,
+				hasFinishedResolution: true,
+			} );
+			useHasRecentAdSpend.mockReturnValue( {
+				hasFinishedResolution: true,
+				hasAdSpend: false,
+			} );
+
+			render( <GoogleAdsPromo /> );
+
+			expect(
+				screen.getByRole( 'link', { name: 'Get started' } )
+			).toHaveAttribute(
+				'href',
+				'/onboarding?referrer_type=in_product_placements&referrer_id=order-attribution-meta-box-get-started'
+			);
+		} );
+
+		test( 'Create campaign CTA href includes referrer_type and referrer_id for the order attribution placement', () => {
+			useGoogleAdsAccount.mockReturnValue( {
+				hasGoogleAdsConnection: true,
+				hasFinishedResolution: true,
+			} );
+			useHasRecentAdSpend.mockReturnValue( {
+				hasFinishedResolution: true,
+				hasAdSpend: false,
+			} );
+
+			render( <GoogleAdsPromo /> );
+
+			expect(
+				screen.getByRole( 'link', { name: 'Create campaign' } )
+			).toHaveAttribute(
+				'href',
+				'/create-campaign?referrer_type=in_product_placements&referrer_id=order-attribution-meta-box-create-campaign'
 			);
 		} );
 	} );

--- a/js/src/notifications-system/notification.js
+++ b/js/src/notifications-system/notification.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
 import { dateI18n } from '@wordpress/date';
-import { addQueryArgs } from '@wordpress/url';
 import { CardBody, Flex, FlexBlock, FlexItem } from '@wordpress/components';
 import { closeSmall } from '@wordpress/icons';
 
@@ -13,6 +12,7 @@ import { closeSmall } from '@wordpress/icons';
  */
 import { glaData } from '~/constants';
 import { useAppDispatch } from '~/data';
+import { addReferrerParams } from '~/utils/urls';
 import AppButton from '~/components/app-button';
 import NotificationSkeleton from './notification-skeleton';
 import googleLogoURL from '~/images/logo/google-g-logo.svg';
@@ -22,21 +22,6 @@ import {
 	REFERRER_TYPE_NOTIFICATION,
 } from '~/utils/tracks';
 import './notification.scss';
-
-/**
- * Appends the notification's referrer info to a CTA href, so the destination
- * flow can attribute its own tracking events back to this notification.
- *
- * @param {string} href Original CTA destination.
- * @param {string} notificationId Notification ID to attribute the referral to.
- * @return {string} `href` with `referrer_type`/`referrer_id` query params appended.
- */
-function withReferrer( href, notificationId ) {
-	return addQueryArgs( href, {
-		referrer_type: REFERRER_TYPE_NOTIFICATION,
-		referrer_id: notificationId,
-	} );
-}
 
 /**
  * @typedef {Object} NotificationAction
@@ -165,7 +150,11 @@ const Notification = ( {
 										key={ actionId }
 										className="gla-notification__action"
 										variant="link"
-										href={ withReferrer( href, id ) }
+										href={ addReferrerParams(
+											href,
+											REFERRER_TYPE_NOTIFICATION,
+											id
+										) }
 										target={ target }
 										rel={ rel }
 										onClick={ () => handleCtaClick( href ) }

--- a/js/src/utils/tracks.js
+++ b/js/src/utils/tracks.js
@@ -56,6 +56,11 @@ export const CONTEXT_MARKETING_OVERVIEW = 'marketing-overview';
 export const REFERRER_TYPE_NOTIFICATION = 'notification';
 
 /**
+ * Referrer type indicating a flow was entered from an in-product placement's CTA.
+ */
+export const REFERRER_TYPE_IN_PRODUCT_PLACEMENTS = 'in_product_placements';
+
+/**
  * When table pagination is changed by entering page via "Go to page" input.
  *
  * @event gla_table_go_to_page

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -190,3 +190,19 @@ export const getWCCouponsUrl = () => {
 		post_type: 'shop_coupon',
 	} );
 };
+
+/**
+ * Appends referrer attribution query params (`referrer_type` and `referrer_id`) to a URL.
+ *
+ * @param {string} href Original destination URL.
+ * @param {string} referrerType Type of referring item.
+ * @param {string} referrerId Identifier of the specific referring item.
+ *
+ * @return {string} `href` with `referrer_type` and `referrer_id` query params appended.
+ */
+export const getReferrerUrl = ( href, referrerType, referrerId ) => {
+	return addQueryArgs( href, {
+		referrer_type: referrerType,
+		referrer_id: referrerId,
+	} );
+};

--- a/js/src/utils/urls.js
+++ b/js/src/utils/urls.js
@@ -200,7 +200,7 @@ export const getWCCouponsUrl = () => {
  *
  * @return {string} `href` with `referrer_type` and `referrer_id` query params appended.
  */
-export const getReferrerUrl = ( href, referrerType, referrerId ) => {
+export const addReferrerParams = ( href, referrerType, referrerId ) => {
 	return addQueryArgs( href, {
 		referrer_type: referrerType,
 		referrer_id: referrerId,

--- a/js/src/utils/urls.test.js
+++ b/js/src/utils/urls.test.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { getReferrerUrl } from '~/utils/urls';
+
+describe( 'getReferrerUrl', () => {
+	it( 'appends referrer_type and referrer_id query params to the given href', () => {
+		expect(
+			getReferrerUrl( '/onboarding', 'in_product_placements', 'foo' )
+		).toBe(
+			'/onboarding?referrer_type=in_product_placements&referrer_id=foo'
+		);
+	} );
+
+	it( 'preserves existing query params on the href', () => {
+		expect(
+			getReferrerUrl(
+				'/onboarding?foo=bar',
+				'in_product_placements',
+				'baz'
+			)
+		).toBe(
+			'/onboarding?foo=bar&referrer_type=in_product_placements&referrer_id=baz'
+		);
+	} );
+} );

--- a/js/src/utils/urls.test.js
+++ b/js/src/utils/urls.test.js
@@ -1,12 +1,12 @@
 /**
  * Internal dependencies
  */
-import { getReferrerUrl } from '~/utils/urls';
+import { addReferrerParams } from '~/utils/urls';
 
-describe( 'getReferrerUrl', () => {
+describe( 'addReferrerParams', () => {
 	it( 'appends referrer_type and referrer_id query params to the given href', () => {
 		expect(
-			getReferrerUrl( '/onboarding', 'in_product_placements', 'foo' )
+			addReferrerParams( '/onboarding', 'in_product_placements', 'foo' )
 		).toBe(
 			'/onboarding?referrer_type=in_product_placements&referrer_id=foo'
 		);
@@ -14,7 +14,7 @@ describe( 'getReferrerUrl', () => {
 
 	it( 'preserves existing query params on the href', () => {
 		expect(
-			getReferrerUrl(
+			addReferrerParams(
 				'/onboarding?foo=bar',
 				'in_product_placements',
 				'baz'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-995/referral-tracking-for-in-product-placements-product-editor-orders

Add referral attribution (referrer_type/referrer_id) to the Channel Visibility and Order Attribution meta box CTAs, so onboarding-completion and campaign-creation tracking events can be attributed back to the originating placement.

### Screenshots:

<img width="3008" height="1403" alt="image" src="https://github.com/user-attachments/assets/1d8d989a-f3a1-4553-9d50-d3ecb119cd5a" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

#### Channel Visibility meta box (product editor)
**Scenario:** an existing product (not a new/unsaved one, the meta box only renders once the product has an ID), on a store where Merchant Center is **not connected**.
1. Edit the product. Check the "Get started" CTA's `href` includes `referrer_type=in_product_placements&referrer_id=channel-visibility-meta-box`.
2. Dismiss the promo (so the `gla_google_ads_promo_dismissed` preference is set) and reload, check the same on the compact "Get started" link that now appears next to the Google label.

#### Order Attribution meta box (order edit screen)
**Scenario:** an order whose attribution source is Google (`orderAttributionSource === 'google'`), viewed on its single edit screen.
1. With the store's Google Ads account **not connected**, check the "Get started" CTA's `href` includes `referrer_id=order-attribution-meta-box-get-started`.
2. With Google Ads **connected** and no recent ad spend on the account, check the "Create campaign" CTA's `href` includes `referrer_id=order-attribution-meta-box-create-campaign`.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Add referral attribution to the Channel Visibility and Order Attribution meta box CTAs