### PR TITLE
Compatibility testing with Woo 11.1

### DIFF
--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -12,8 +12,8 @@
  * Requires PHP: 7.4
  * Requires PHP Architecture: 64 bits
  * Requires Plugins: woocommerce
- * WC requires at least: 10.8
- * WC tested up to: 11.0
+ * WC requires at least: 10.9
+ * WC tested up to: 11.1
  * Woo:
  *
  * License: GPLv3
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'WC_GLA_VERSION', '3.9.1' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.4' );
-define( 'WC_GLA_MIN_WC_VER', '10.8' );
+define( 'WC_GLA_MIN_WC_VER', '10.9' );
 
 // Load and initialize the autoloader.
 require_once __DIR__ . '/src/Autoloader.php';

--- a/readme.txt
+++ b/readme.txt
@@ -52,7 +52,7 @@ Once you’re running Google Ads campaigns, the Google tag feature in the extens
 = Minimum Requirements =
 
 * WordPress 6.8 or greater
-* WooCommerce 10.8 or greater
+* WooCommerce 10.9 or greater
 * PHP version 7.4 or greater
 * PHP Architecture 64 bits
 * MySQL version 5.6 or greater


### PR DESCRIPTION
### All Submissions:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Dev - Bump WooCommerce "tested up to" version 11.1.
- Dev - Bump WooCommerce minimum supported version to 10.9.

Closes  https://linear.app/a8c/issue/GOOWOO-945/compatibility-testing-with-woo-111-beta-1

### Steps to test the changes in this Pull Request:

1. Run the e2e test using GitHub action to test this PR.
2. All tests should be passed.
3. Manually check plugin setup and plugin core functionality.

### Changelog entry
<!--
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Tweak - Bump WooCommerce "tested up to" version 11.1
> Tweak - Bump WooCommerce minimum supported version to 10.9.


