### PR TITLE
Add unit test coverage for GlobalSiteTag disable-tracking filter

### DIFF
--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -531,7 +531,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 	}
 
 	/**
-	 * TODO: Should the Global Site Tag framework be used if there are no paid Ads campaigns?
+	 * Controls whether the Google Ads tag and event snippets should be included on the page.
 	 *
 	 * @return bool True if the Global Site Tag framework should be included.
 	 */

--- a/tests/Unit/Google/GlobalSiteTagTest.php
+++ b/tests/Unit/Google/GlobalSiteTagTest.php
@@ -64,6 +64,16 @@ class GlobalSiteTagTest extends UnitTest {
 		$this->tag->set_options_object( $this->options );
 	}
 
+	public function test_is_needed_returns_true_by_default() {
+		$this->assertTrue( GlobalSiteTag::is_needed() );
+	}
+
+	public function test_is_needed_returns_false_when_disabled_by_filter() {
+		add_filter( 'woocommerce_gla_disable_gtag_tracking', '__return_true' );
+
+		$this->assertFalse( GlobalSiteTag::is_needed() );
+	}
+
 	public function test_purchase_event_not_order_received_page() {
 		add_filter( 'woocommerce_is_order_received_page', '__return_false' );
 		$this->wp->expects( $this->never() )->method( 'wp_print_inline_script_tag' );


### PR DESCRIPTION
## Summary
- Adds unit test coverage for `GlobalSiteTag::is_needed()`, which was previously untested.
- Confirms `is_needed()` returns `true` by default, and `false` when the `woocommerce_gla_disable_gtag_tracking` filter is set to `true`.
- This filter acts as the sole kill-switch for all client-side Google Ads tracking shipped by the plugin: `is_needed()` gates whether the `GlobalSiteTag` service is added to the container at all (`AbstractServiceProvider::conditionally_share_with_tags()`), so when it returns `false`, `register()` never runs and none of the base gtag snippet, purchase/view_item/page_view conversion events, add-to-cart product data hooks, or gtag-events/consent-api assets are registered.
- Replaces the stale `TODO` docblock on `is_needed()` with an accurate description of what it controls.

## Test plan
- [x] `composer test-unit` (or CI) passes, including the two new tests in `tests/Unit/Google/GlobalSiteTagTest.php`:
  - `test_is_needed_returns_true_by_default`
  - `test_is_needed_returns_false_when_disabled_by_filter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)