### PR TITLE
GOOWOO-940: Don't block YouTube onboarding when channel lookup fails

### DIFF
--- a/js/src/pages/settings/accounts/youtube-account-card/connected-youtube-account-card.js
+++ b/js/src/pages/settings/accounts/youtube-account-card/connected-youtube-account-card.js
@@ -67,17 +67,27 @@ const ConnectedYouTubeAccountCard = ( { youTubeAccount, onDisconnect } ) => {
 		isReducedMotion,
 	] );
 
-	let accountCardProps = {
-		detail: (
-			<AccountCardTextDetail>
-				<ExternalLink
-					href={ getYouTubeChannelUrl( youTubeAccount.channel ) }
-				>
-					{ youTubeAccount.channel.label }
-				</ExternalLink>
-			</AccountCardTextDetail>
-		),
-	};
+	let accountCardProps = youTubeAccount.error
+		? {
+				detail: (
+					<Notice status="error" isDismissible={ false }>
+						{ youTubeAccount.error }
+					</Notice>
+				),
+		  }
+		: {
+				detail: (
+					<AccountCardTextDetail>
+						<ExternalLink
+							href={ getYouTubeChannelUrl(
+								youTubeAccount.channel
+							) }
+						>
+							{ youTubeAccount.channel.label }
+						</ExternalLink>
+					</AccountCardTextDetail>
+				),
+		  };
 
 	if ( shouldLinkYouTubeAccount ) {
 		accountCardProps = {

--- a/js/src/pages/settings/accounts/youtube-account-card/connected-youtube-account-card.test.js
+++ b/js/src/pages/settings/accounts/youtube-account-card/connected-youtube-account-card.test.js
@@ -79,4 +79,24 @@ describe( 'ConnectedYouTubeAccountCard', () => {
 		).not.toBeInTheDocument();
 		expect( recordGlaEvent ).not.toHaveBeenCalled();
 	} );
+
+	it( 'shows the channel error instead of the channel link when the channel lookup failed', () => {
+		render(
+			<ConnectedYouTubeAccountCard
+				youTubeAccount={ {
+					status: YOUTUBE_ACCOUNT_STATUS.CONNECTED,
+					channel: {},
+					error: 'Error retrieving channels',
+				} }
+				onDisconnect={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.getByText( 'Error retrieving channels', {
+				selector: '.components-notice__content',
+			} )
+		).toBeInTheDocument();
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/js/src/pages/settings/accounts/youtube-account-card/index.js
+++ b/js/src/pages/settings/accounts/youtube-account-card/index.js
@@ -17,6 +17,7 @@ import useGoogleMCAccount from '~/hooks/useGoogleMCAccount';
  * @typedef {Object} YouTubeAccount
  * @property {'connected'|'disconnected'|'incomplete'} status Connection status.
  * @property {YouTubeChannel} [channel] Selected channel when connected.
+ * @property {string} [error] Error message when channel details could not be retrieved, even though status is 'connected' or 'incomplete'.
  */
 
 /**

--- a/src/API/Site/Controllers/YouTube/AccountController.php
+++ b/src/API/Site/Controllers/YouTube/AccountController.php
@@ -133,6 +133,7 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 				$status     = $this->connection->get_status();
 				$connection = isset( $status['status'] ) ? $status['status'] : 'disconnected';
 				$channel    = [];
+				$error      = '';
 
 				// Get channel information if connected.
 				if ( 'connected' === $connection ) {
@@ -148,16 +149,19 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 							];
 						}
 					} catch ( Exception $e ) {
-						// Channel metadata is optional display info; don't let its failure
-						// override an already-confirmed connection status.
+						// Channel metadata couldn't be retrieved; treat setup as incomplete
+						// and surface the error message separately.
 						do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
+
+						$error = $e->getMessage();
 					}
 
 					/**
 					 * Check third party link.
 					 *
 					 * Check that the channel is eligible for YouTube Shopping and the store has been linked.
-					 * This step is required for the plugin functionality to work.
+					 * This step is required for the plugin functionality to work. Takes priority over a
+					 * channel-fetch error below, since linking is the action the merchant needs to take.
 					 *
 					 * Connection status:
 					 * - Disconnected - Google account not connected with the Google Cloud app.
@@ -166,12 +170,14 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 					 */
 					if ( ! $this->options->get( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK, false ) ) {
 						$connection = 'incomplete';
+						$error      = '';
 					}
 				}
 
 				return [
 					'status'  => $connection,
 					'channel' => $channel,
+					'error'   => $error,
 				];
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );

--- a/src/API/Site/Controllers/YouTube/AccountController.php
+++ b/src/API/Site/Controllers/YouTube/AccountController.php
@@ -141,9 +141,7 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 					 * Check third party link.
 					 *
 					 * Check that the channel is eligible for YouTube Shopping and the store has been linked.
-					 * This step is required for the plugin functionality to work. Checked before fetching
-					 * channel metadata below, since linking is the action the merchant needs to take and
-					 * a channel-fetch error is irrelevant while setup is still incomplete.
+					 * This step is required for the plugin functionality to work.
 					 *
 					 * Connection status:
 					 * - Disconnected - Google account not connected with the Google Cloud app.

--- a/src/API/Site/Controllers/YouTube/AccountController.php
+++ b/src/API/Site/Controllers/YouTube/AccountController.php
@@ -136,15 +136,21 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 
 				// Get channel information if connected.
 				if ( 'connected' === $connection ) {
-					$channels = $this->connection->get_channels();
+					try {
+						$channels = $this->connection->get_channels();
 
-					if ( isset( $channels['items'] ) && ! empty( $channels['items'] ) ) {
-						$details = array_shift( $channels['items'] );
+						if ( isset( $channels['items'] ) && ! empty( $channels['items'] ) ) {
+							$details = array_shift( $channels['items'] );
 
-						$channel = [
-							'id'    => $details['id'],
-							'label' => $details['snippet']['title'],
-						];
+							$channel = [
+								'id'    => $details['id'],
+								'label' => $details['snippet']['title'],
+							];
+						}
+					} catch ( Exception $e ) {
+						// Channel metadata is optional display info; don't let its failure
+						// override an already-confirmed connection status.
+						do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
 					}
 
 					/**

--- a/src/API/Site/Controllers/YouTube/AccountController.php
+++ b/src/API/Site/Controllers/YouTube/AccountController.php
@@ -137,31 +137,13 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 
 				// Get channel information if connected.
 				if ( 'connected' === $connection ) {
-					try {
-						$channels = $this->connection->get_channels();
-
-						if ( isset( $channels['items'] ) && ! empty( $channels['items'] ) ) {
-							$details = array_shift( $channels['items'] );
-
-							$channel = [
-								'id'    => $details['id'],
-								'label' => $details['snippet']['title'],
-							];
-						}
-					} catch ( Exception $e ) {
-						// Channel metadata couldn't be retrieved; treat setup as incomplete
-						// and surface the error message separately.
-						do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
-
-						$error = $e->getMessage();
-					}
-
 					/**
 					 * Check third party link.
 					 *
 					 * Check that the channel is eligible for YouTube Shopping and the store has been linked.
-					 * This step is required for the plugin functionality to work. Takes priority over a
-					 * channel-fetch error below, since linking is the action the merchant needs to take.
+					 * This step is required for the plugin functionality to work. Checked before fetching
+					 * channel metadata below, since linking is the action the merchant needs to take and
+					 * a channel-fetch error is irrelevant while setup is still incomplete.
 					 *
 					 * Connection status:
 					 * - Disconnected - Google account not connected with the Google Cloud app.
@@ -170,7 +152,24 @@ class AccountController extends BaseController implements ContainerAwareInterfac
 					 */
 					if ( ! $this->options->get( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK, false ) ) {
 						$connection = 'incomplete';
-						$error      = '';
+					} else {
+						try {
+							$channels = $this->connection->get_channels();
+
+							if ( isset( $channels['items'] ) && ! empty( $channels['items'] ) ) {
+								$details = array_shift( $channels['items'] );
+
+								$channel = [
+									'id'    => $details['id'],
+									'label' => $details['snippet']['title'],
+								];
+							}
+						} catch ( Exception $e ) {
+							// Channel metadata couldn't be retrieved; surface the error message separately.
+							do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
+
+							$error = $e->getMessage();
+						}
 					}
 				}
 

--- a/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
@@ -141,6 +141,75 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
+	public function test_connection_channel_lookup_fails() {
+		// Status is confirmed connected, but the channel metadata lookup throws
+		// (e.g. a 403 quota error from the Connect Server proxy).
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturn(
+				[
+					'status' => 'connected',
+				]
+			);
+
+		$this->connection->expects( $this->once() )
+			->method( 'get_channels' )
+			->willThrowException( new Exception( 'Error retrieving channels', 403 ) );
+
+		$this->options->expects( $this->once() )
+			->method( 'get' )
+			->with( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK, false )
+			->willReturn(
+				[
+					'status' => [
+						'linkStatus' => 'linked',
+					],
+				]
+			);
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
+
+		$this->assertEquals(
+			[
+				'status'  => 'connected',
+				'channel' => [],
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_connection_channel_lookup_fails_and_store_not_linked() {
+		// Even when the channel lookup fails, the store-link check still applies.
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturn(
+				[
+					'status' => 'connected',
+				]
+			);
+
+		$this->connection->expects( $this->once() )
+			->method( 'get_channels' )
+			->willThrowException( new Exception( 'Error retrieving channels', 403 ) );
+
+		$this->options->expects( $this->once() )
+			->method( 'get' )
+			->with( OptionsInterface::YOUTUBE_THIRD_PARTY_LINK, false )
+			->willReturn( false );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
+
+		$this->assertEquals(
+			[
+				'status'  => 'incomplete',
+				'channel' => [],
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
 	public function test_incomplete() {
 		$this->connection->expects( $this->once() )
 			->method( 'get_status' )

--- a/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
@@ -182,8 +182,9 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_connection_channel_lookup_fails_and_store_not_linked() {
-		// The store-link check takes priority over a channel-lookup error: status
-		// falls back to 'incomplete' and the channel error is not surfaced.
+		// The store-link check is done before the channel lookup, so when the
+		// store isn't linked, status falls back to 'incomplete' and channels
+		// are never fetched.
 		$this->connection->expects( $this->once() )
 			->method( 'get_status' )
 			->willReturn(
@@ -192,9 +193,8 @@ class AccountControllerTest extends RESTControllerUnitTest {
 				]
 			);
 
-		$this->connection->expects( $this->once() )
-			->method( 'get_channels' )
-			->willThrowException( new Exception( 'Error retrieving channels', 403 ) );
+		$this->connection->expects( $this->never() )
+			->method( 'get_channels' );
 
 		$this->options->expects( $this->once() )
 			->method( 'get' )
@@ -223,20 +223,9 @@ class AccountControllerTest extends RESTControllerUnitTest {
 				]
 			);
 
-		$this->connection->expects( $this->once() )
-			->method( 'get_channels' )
-			->willReturn(
-				[
-					'items' => [
-						[
-							'id'      => 1234,
-							'snippet' => [
-								'title' => 'Channel 1',
-							],
-						],
-					],
-				]
-			);
+		// Store not linked, so channel metadata is never fetched.
+		$this->connection->expects( $this->never() )
+			->method( 'get_channels' );
 
 		$this->options->expects( $this->once() )
 			->method( 'get' )
@@ -248,10 +237,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals(
 			[
 				'status'  => 'incomplete',
-				'channel' => [
-					'id'    => 1234,
-					'label' => 'Channel 1',
-				],
+				'channel' => [],
 				'error'   => '',
 			],
 			$response->get_data()

--- a/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/YouTube/AccountControllerTest.php
@@ -135,6 +135,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 					'id'    => 1234,
 					'label' => 'Channel 1',
 				],
+				'error'   => '',
 			],
 			$response->get_data()
 		);
@@ -173,6 +174,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			[
 				'status'  => 'connected',
 				'channel' => [],
+				'error'   => 'Error retrieving channels',
 			],
 			$response->get_data()
 		);
@@ -180,7 +182,8 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_connection_channel_lookup_fails_and_store_not_linked() {
-		// Even when the channel lookup fails, the store-link check still applies.
+		// The store-link check takes priority over a channel-lookup error: status
+		// falls back to 'incomplete' and the channel error is not surfaced.
 		$this->connection->expects( $this->once() )
 			->method( 'get_status' )
 			->willReturn(
@@ -204,6 +207,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			[
 				'status'  => 'incomplete',
 				'channel' => [],
+				'error'   => '',
 			],
 			$response->get_data()
 		);
@@ -248,6 +252,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 					'id'    => 1234,
 					'label' => 'Channel 1',
 				],
+				'error'   => '',
 			],
 			$response->get_data()
 		);
@@ -261,6 +266,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			[
 				'status'  => 'disconnected',
 				'channel' => [],
+				'error'   => '',
 			],
 			$response->get_data()
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-940/youtubeconnection-returns-an-error-instead-of-status-connected-when

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<img width="790" height="288" alt="image" src="https://github.com/user-attachments/assets/6ae39462-12f7-4ffe-884a-54ab7f735de9" />

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. In `src/API/YouTube/Connection.php`, make `get_channels()` throw as its first line:
```throw new Exception( 'Error retrieving channels', 403 ); ```
2. In `src/API/Site/Controllers/YouTube/AccountController.php`, force the third-party-link check to pass so the channel-fetch branch runs. Change the condition to always `false` (leave the `try { $channels = ... }` block below untouched):
```php
if ( false ) {
	$connection = 'incomplete';
} else {
```
3. Go to "Accounts Settings", connect a YouTube account.
4. Expect: error message "Error retrieving channels" connection status "connected" (not "incomplete") — confirms the link check no longer overwrites a genuine channel-fetch error.
5. Revert both edits after.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Don't block YouTube onboarding when channel details can't be retrieved
