### PR TITLE
GOOWOO-929: Connect Google Tag Manager - Backend Connection, Account & Container

### DIFF
--- a/src/API/Site/Controllers/TagManager/AccountController.php
+++ b/src/API/Site/Controllers/TagManager/AccountController.php
@@ -1,0 +1,241 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\TagManager;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
+use Exception;
+use WP_REST_Request as Request;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AccountController
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\TagManager
+ */
+class AccountController extends BaseController {
+
+	/** @var Connection */
+	protected $connection;
+
+	/**
+	 * AccountController constructor.
+	 *
+	 * @param RESTServer $server
+	 * @param Connection $connection
+	 */
+	public function __construct( RESTServer $server, Connection $connection ) {
+		parent::__construct( $server );
+
+		$this->connection = $connection;
+	}
+
+	/**
+	 * Register rest routes with WordPress.
+	 */
+	public function register_routes(): void {
+		$this->register_route(
+			'tag-manager/connect',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_connect_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+			]
+		);
+		$this->register_route(
+			'tag-manager/connection',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_connected_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+				[
+					'methods'             => TransportMethods::DELETABLE,
+					'callback'            => $this->get_disconnect_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+			]
+		);
+		$this->register_route(
+			'tag-manager/accounts',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_accounts_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+				[
+					'methods'             => TransportMethods::CREATABLE,
+					'callback'            => $this->get_select_account_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+			]
+		);
+		$this->register_route(
+			'tag-manager/containers',
+			[
+				[
+					'methods'             => TransportMethods::READABLE,
+					'callback'            => $this->get_containers_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+				[
+					'methods'             => TransportMethods::CREATABLE,
+					'callback'            => $this->get_select_container_callback(),
+					'permission_callback' => $this->get_permission_callback(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get the callback function for the connection request.
+	 *
+	 * @return callable
+	 */
+	protected function get_connect_callback(): callable {
+		return function () {
+			try {
+				return [
+					'url' => $this->connection->connect(
+						admin_url( 'admin.php?page=wc-admin&path=/google/settings' )
+					),
+				];
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
+		};
+	}
+
+	/**
+	 * Get the callback function for the connection status request.
+	 *
+	 * @return callable
+	 */
+	protected function get_connected_callback(): callable {
+		return function () {
+			try {
+				return $this->connection->get_status();
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
+		};
+	}
+
+	/**
+	 * Get the callback function for the disconnection request.
+	 *
+	 * @return callable
+	 */
+	protected function get_disconnect_callback(): callable {
+		return function () {
+			return [
+				'status'  => 'success',
+				'message' => $this->connection->disconnect(),
+			];
+		};
+	}
+
+	/**
+	 * Get the callback function for listing the connected Google user's accounts.
+	 *
+	 * @return callable
+	 */
+	protected function get_accounts_callback(): callable {
+		return function () {
+			try {
+				return $this->connection->list_accounts();
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
+		};
+	}
+
+	/**
+	 * Get the callback function for selecting an account.
+	 *
+	 * @return callable
+	 */
+	protected function get_select_account_callback(): callable {
+		return function ( Request $request ) {
+			try {
+				$this->connection->select_account( sanitize_text_field( (string) $request['id'] ) );
+
+				return [
+					'status'  => 'success',
+					'message' => __( 'Successfully selected Tag Manager account.', 'google-listings-and-ads' ),
+				];
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
+		};
+	}
+
+	/**
+	 * Get the callback function for listing the selected account's containers.
+	 *
+	 * @return callable
+	 */
+	protected function get_containers_callback(): callable {
+		return function () {
+			try {
+				return $this->connection->list_containers();
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
+		};
+	}
+
+	/**
+	 * Get the callback function for selecting a container.
+	 *
+	 * @return callable
+	 */
+	protected function get_select_container_callback(): callable {
+		return function ( Request $request ) {
+			try {
+				$this->connection->select_container( sanitize_text_field( (string) $request['id'] ) );
+
+				return [
+					'status'  => 'success',
+					'message' => __( 'Successfully selected Tag Manager container.', 'google-listings-and-ads' ),
+				];
+			} catch ( Exception $e ) {
+				return $this->response_from_exception( $e );
+			}
+		};
+	}
+
+	/**
+	 * Get the item schema for the controller.
+	 *
+	 * @return array
+	 */
+	protected function get_schema_properties(): array {
+		return [
+			'id' => [
+				'type'        => 'string',
+				'description' => __( 'The Tag Manager account or container ID to select.', 'google-listings-and-ads' ),
+				'context'     => [ 'edit' ],
+			],
+		];
+	}
+
+	/**
+	 * Get the item schema name for the controller.
+	 *
+	 * Used for building the API response schema.
+	 *
+	 * @return string
+	 */
+	protected function get_schema_title(): string {
+		return 'tag_manager_account';
+	}
+}

--- a/src/API/Site/Controllers/TagManager/AccountController.php
+++ b/src/API/Site/Controllers/TagManager/AccountController.php
@@ -75,6 +75,7 @@ class AccountController extends BaseController {
 					'methods'             => TransportMethods::CREATABLE,
 					'callback'            => $this->get_select_account_callback(),
 					'permission_callback' => $this->get_permission_callback(),
+					'args'                => $this->get_schema_properties(),
 				],
 			]
 		);
@@ -90,6 +91,7 @@ class AccountController extends BaseController {
 					'methods'             => TransportMethods::CREATABLE,
 					'callback'            => $this->get_select_container_callback(),
 					'permission_callback' => $this->get_permission_callback(),
+					'args'                => $this->get_schema_properties(),
 				],
 			]
 		);
@@ -224,6 +226,7 @@ class AccountController extends BaseController {
 				'type'        => 'string',
 				'description' => __( 'The Tag Manager account or container ID to select.', 'google-listings-and-ads' ),
 				'context'     => [ 'edit' ],
+				'required'    => true,
 			],
 		];
 	}

--- a/src/API/TagManager/Connection.php
+++ b/src/API/TagManager/Connection.php
@@ -1,0 +1,362 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\ExceptionTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\ContainerAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Internal\Interfaces\ContainerAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Client\ClientExceptionInterface;
+use Exception;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Connection
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager
+ */
+class Connection implements ContainerAwareInterface, OptionsAwareInterface {
+
+	use ContainerAwareTrait;
+	use ExceptionTrait;
+	use OptionsAwareTrait;
+
+	/** @var string The connection is active, but no account/container has been selected yet. */
+	public const STATUS_INCOMPLETE = 'incomplete';
+
+	/** @var string An account and container are both selected. */
+	public const STATUS_CONNECTED = 'connected';
+
+	/** @var string No connection has been established, or it was explicitly disconnected. */
+	public const STATUS_DISCONNECTED = 'disconnected';
+
+	/**
+	 * The OAuth scope Woo Connect Server grants for Tag Manager API access,
+	 * requested as an additional scope on the shared Google connection.
+	 *
+	 * Confirmed via a live request against Woo's actual Connect Server:
+	 * `additionalScopes` accepts this scope and rejects
+	 * `tagmanager.edit.containers` outright ("Unsupported additional scopes") —
+	 * not needed now that in-plugin container creation is off-site only.
+	 *
+	 * @var string
+	 */
+	public const SCOPE_TAG_MANAGER = 'https://www.googleapis.com/auth/tagmanager.readonly';
+
+	/**
+	 * Default shape of the `tag_manager` option.
+	 *
+	 * @var array
+	 */
+	protected const DEFAULT_CONNECTION_DATA = [
+		'account_id'          => null,
+		'account_name'        => null,
+		'container_id'        => null,
+		'container_name'      => null,
+		'container_public_id' => null,
+	];
+
+	/** @var TagManagerApiClient */
+	protected $client;
+
+	/**
+	 * Connection constructor.
+	 *
+	 * @param TagManagerApiClient $client
+	 */
+	public function __construct( TagManagerApiClient $client ) {
+		$this->client = $client;
+	}
+
+	/**
+	 * Get the stored Tag Manager connection data.
+	 *
+	 * @return array
+	 */
+	public function get_connection_data(): array {
+		return $this->options->get( OptionsInterface::TAG_MANAGER, self::DEFAULT_CONNECTION_DATA );
+	}
+
+	/**
+	 * Update the stored Tag Manager connection data.
+	 *
+	 * Merges the given fields onto the existing stored data (or the defaults, if
+	 * nothing has been stored yet) so callers can update a subset of fields.
+	 *
+	 * @param array $data The connection data fields to update.
+	 *
+	 * @return bool
+	 */
+	public function update_connection_data( array $data ): bool {
+		return $this->options->update(
+			OptionsInterface::TAG_MANAGER,
+			array_merge( $this->get_connection_data(), $data )
+		);
+	}
+
+	/**
+	 * Get the connection URL for performing a connection redirect.
+	 *
+	 * Tag Manager has no dedicated OAuth connection of its own — it requests the
+	 * `tagmanager.readonly` scope as an additional scope on the shared Google
+	 * connection, the same connection Merchant Center/Ads already establish.
+	 * Confirmed directly against Woo's live Connect Server, not assumed from
+	 * Search Console's equivalent mechanism.
+	 *
+	 * @param string $return_url The return URL.
+	 *
+	 * @return string
+	 * @throws Exception When a ClientException is caught or the response doesn't contain the oauthUrl.
+	 */
+	public function connect( string $return_url ): string {
+		try {
+			/** @var Client $client */
+			$client = $this->container->get( Client::class );
+			$result = $client->post(
+				$this->get_connection_url(),
+				[
+					'body' => wp_json_encode(
+						[
+							'returnUrl'        => $return_url,
+							'additionalScopes' => [ self::SCOPE_TAG_MANAGER ],
+						]
+					),
+				]
+			);
+
+			$response = json_decode( $result->getBody()->getContents(), true );
+			if ( 200 === $result->getStatusCode() && ! empty( $response['oauthUrl'] ) ) {
+				return $response['oauthUrl'];
+			}
+
+			do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
+
+			throw new Exception( __( 'Unable to connect Tag Manager account', 'google-listings-and-ads' ) );
+		} catch ( ClientExceptionInterface $e ) {
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
+
+			throw new Exception( __( 'Unable to connect Tag Manager account', 'google-listings-and-ads' ) );
+		}
+	}
+
+	/**
+	 * Disconnect from the Tag Manager account.
+	 *
+	 * Purely local. The connection URL is shared with Merchant Center/Ads (see
+	 * {@see self::get_connection_url()}), so a remote DELETE here would tear
+	 * down that shared connection instead of just Tag Manager's own state —
+	 * only the locally stored account/container selection is cleared.
+	 *
+	 * @return string
+	 */
+	public function disconnect(): string {
+		$this->options->delete( OptionsInterface::TAG_MANAGER );
+
+		return __( 'Successfully disconnected.', 'google-listings-and-ads' );
+	}
+
+	/**
+	 * Get the status of the connection.
+	 *
+	 * @return array {
+	 *     @type string $status            One of the self::STATUS_* constants.
+	 *     @type string $id                The selected account's ID, once one has been chosen.
+	 *     @type string $name              The selected account's name, once one has been chosen.
+	 *     @type string $containerId       The selected container's ID, once one has been chosen.
+	 *     @type string $containerName     The selected container's name, once one has been chosen.
+	 *     @type string $containerPublicId The selected container's merchant-facing ID, once one has been chosen.
+	 * }
+	 * @throws Exception When a ClientException is caught or the response contains an error.
+	 */
+	public function get_status(): array {
+		if ( ! $this->is_scope_granted() ) {
+			return [ 'status' => self::STATUS_DISCONNECTED ];
+		}
+
+		$data = $this->get_connection_data();
+
+		if ( empty( $data['account_id'] ) || empty( $data['container_id'] ) ) {
+			return array_merge( [ 'status' => self::STATUS_INCOMPLETE ], $this->format_connection_data( $data ) );
+		}
+
+		return array_merge( [ 'status' => self::STATUS_CONNECTED ], $this->format_connection_data( $data ) );
+	}
+
+	/**
+	 * List the connected Google user's Tag Manager accounts.
+	 *
+	 * @return array Each entry shaped `{ id, name }`.
+	 * @throws TagManagerApiException On a non-2xx Tag Manager API response.
+	 */
+	public function list_accounts(): array {
+		$response = $this->client->get( 'accounts' );
+
+		return array_map( [ $this, 'format_account' ], $response['account'] ?? [] );
+	}
+
+	/**
+	 * Select an account, storing it as this connection's account_id.
+	 *
+	 * Clears any previously selected container — it belonged to a different
+	 * account and is no longer valid once the account selection changes.
+	 *
+	 * @param string $account_id The Tag Manager account ID.
+	 *
+	 * @return bool
+	 * @throws TagManagerApiException On a non-2xx Tag Manager API response.
+	 */
+	public function select_account( string $account_id ): bool {
+		$account = $this->format_account( $this->client->get( "accounts/{$account_id}" ) );
+
+		return $this->update_connection_data(
+			[
+				'account_id'          => $account['id'],
+				'account_name'        => $account['name'],
+				'container_id'        => null,
+				'container_name'      => null,
+				'container_public_id' => null,
+			]
+		);
+	}
+
+	/**
+	 * List the selected account's existing containers.
+	 *
+	 * @return array Each entry shaped `{ id, publicId, name }`.
+	 * @throws Exception When no account has been selected yet.
+	 * @throws TagManagerApiException On a non-2xx Tag Manager API response.
+	 */
+	public function list_containers(): array {
+		$account_id = $this->get_connection_data()['account_id'];
+
+		if ( empty( $account_id ) ) {
+			throw new Exception( __( 'No Tag Manager account has been selected yet.', 'google-listings-and-ads' ) );
+		}
+
+		$response = $this->client->get( "accounts/{$account_id}/containers" );
+
+		return array_map( [ $this, 'format_container' ], $response['container'] ?? [] );
+	}
+
+	/**
+	 * Select a container, completing the connection.
+	 *
+	 * @param string $container_id The Tag Manager container ID.
+	 *
+	 * @return bool
+	 * @throws Exception When no account has been selected yet.
+	 * @throws TagManagerApiException On a non-2xx Tag Manager API response.
+	 */
+	public function select_container( string $container_id ): bool {
+		$account_id = $this->get_connection_data()['account_id'];
+
+		if ( empty( $account_id ) ) {
+			throw new Exception( __( 'No Tag Manager account has been selected yet.', 'google-listings-and-ads' ) );
+		}
+
+		$container = $this->format_container( $this->client->get( "accounts/{$account_id}/containers/{$container_id}" ) );
+
+		return $this->update_connection_data(
+			[
+				'container_id'        => $container['id'],
+				'container_name'      => $container['name'],
+				'container_public_id' => $container['publicId'],
+			]
+		);
+	}
+
+	/**
+	 * Whether the shared Google connection currently carries the Tag Manager scope.
+	 *
+	 * @return bool
+	 * @throws Exception When a ClientException is caught or the response contains an error.
+	 */
+	protected function is_scope_granted(): bool {
+		try {
+			/** @var Client $client */
+			$client   = $this->container->get( Client::class );
+			$result   = $client->get( $this->get_connection_url() );
+			$response = json_decode( $result->getBody()->getContents(), true );
+
+			if ( 200 === $result->getStatusCode() ) {
+				return in_array( self::SCOPE_TAG_MANAGER, $response['scope'] ?? [], true );
+			}
+
+			do_action( 'woocommerce_gla_guzzle_invalid_response', $response, __METHOD__ );
+
+			$message = $response['message'] ?? __( 'Invalid response when retrieving status', 'google-listings-and-ads' );
+			throw new Exception( $message, $result->getStatusCode() );
+		} catch ( ClientExceptionInterface $e ) {
+			do_action( 'woocommerce_gla_guzzle_client_exception', $e, __METHOD__ );
+
+			throw new Exception( $this->client_exception_message( $e, __( 'Error retrieving status', 'google-listings-and-ads' ) ) );
+		}
+	}
+
+	/**
+	 * Map the stored connection data onto the response shape the account card expects.
+	 *
+	 * @param array $data Stored connection data (`self::DEFAULT_CONNECTION_DATA` shape).
+	 *
+	 * @return array
+	 */
+	protected function format_connection_data( array $data ): array {
+		$formatted = [];
+
+		if ( ! empty( $data['account_id'] ) ) {
+			$formatted['id']   = $data['account_id'];
+			$formatted['name'] = $data['account_name'];
+		}
+
+		if ( ! empty( $data['container_id'] ) ) {
+			$formatted['containerId']       = $data['container_id'];
+			$formatted['containerName']     = $data['container_name'];
+			$formatted['containerPublicId'] = $data['container_public_id'];
+		}
+
+		return $formatted;
+	}
+
+	/**
+	 * Map a Tag Manager API account resource onto the shape the account card expects.
+	 *
+	 * @param array $account Raw `account` resource (`accountId`, `name`, ...).
+	 *
+	 * @return array Shaped `{ id, name }`.
+	 */
+	protected function format_account( array $account ): array {
+		return [
+			'id'   => $account['accountId'] ?? '',
+			'name' => $account['name'] ?? '',
+		];
+	}
+
+	/**
+	 * Map a Tag Manager API container resource onto the shape the account card expects.
+	 *
+	 * @param array $container Raw `container` resource (`containerId`, `publicId`, `name`, ...).
+	 *
+	 * @return array Shaped `{ id, publicId, name }`.
+	 */
+	protected function format_container( array $container ): array {
+		return [
+			'id'       => $container['containerId'] ?? '',
+			'publicId' => $container['publicId'] ?? '',
+			'name'     => $container['name'] ?? '',
+		];
+	}
+
+	/**
+	 * Get the shared Google connection URL.
+	 *
+	 * @return string
+	 */
+	protected function get_connection_url(): string {
+		return "{$this->container->get( 'connect_server_root' )}google/connection/google-mc";
+	}
+}

--- a/src/API/TagManager/TagManagerApiClient.php
+++ b/src/API/TagManager/TagManagerApiClient.php
@@ -1,0 +1,81 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\ClientInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\RequestException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Request;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\ResponseInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class TagManagerApiClient
+ *
+ * Small wrapper over Guzzle for talking to the Tag Manager API. Routes through
+ * the Connect Server proxy, throws {@see TagManagerApiException} on non-2xx.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager
+ */
+class TagManagerApiClient {
+
+	/** @var ClientInterface */
+	protected $http;
+
+	/** @var string */
+	protected $base_url;
+
+	/**
+	 * TagManagerApiClient constructor.
+	 *
+	 * @param ClientInterface $http     Guzzle HTTP client.
+	 * @param string          $base_url Connect Server Tag Manager proxy root.
+	 */
+	public function __construct( ClientInterface $http, string $base_url ) {
+		$this->http     = $http;
+		$this->base_url = rtrim( $base_url, '/' ) . '/';
+	}
+
+	/**
+	 * Send a GET request and decode the JSON response.
+	 *
+	 * @param string $path Resource path appended to the base URL.
+	 *
+	 * @return array Decoded response body.
+	 * @throws TagManagerApiException On non-2xx response.
+	 */
+	public function get( string $path ): array {
+		$url     = $this->base_url . ltrim( $path, '/' );
+		$request = new Request( 'GET', $url );
+
+		try {
+			$response = $this->http->send( $request );
+
+			return $this->decode_response( $response );
+		} catch ( RequestException $e ) {
+			if ( $e->hasResponse() ) {
+				throw new TagManagerApiException(
+					$e->getResponse()->getStatusCode(),
+					$this->decode_response( $e->getResponse() ),
+					__METHOD__,
+					$e
+				);
+			}
+
+			throw $e;
+		}
+	}
+
+	/**
+	 * @param ResponseInterface $response
+	 *
+	 * @return array
+	 */
+	protected function decode_response( ResponseInterface $response ): array {
+		$body    = (string) $response->getBody();
+		$decoded = '' === $body ? [] : json_decode( $body, true );
+
+		return is_array( $decoded ) ? $decoded : [];
+	}
+}

--- a/src/API/TagManager/TagManagerApiException.php
+++ b/src/API/TagManager/TagManagerApiException.php
@@ -1,0 +1,72 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\GoogleListingsAndAdsException;
+use Exception;
+use Throwable;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class TagManagerApiException
+ *
+ * Wraps a non-2xx response from the Tag Manager API proxy.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager
+ */
+class TagManagerApiException extends Exception implements GoogleListingsAndAdsException {
+
+	/** @var int $http_status */
+	protected $http_status;
+
+	/** @var array $response_body */
+	protected $response_body = [];
+
+	/** @var array $errors */
+	protected $errors = [];
+
+	/**
+	 * TagManagerApiException constructor.
+	 *
+	 * @param int            $http_status   HTTP status code from the Tag Manager API response.
+	 * @param array          $response_body Decoded response body.
+	 * @param string         $method        Calling method (passed to the logging action).
+	 * @param Throwable|null $previous      Optional previous throwable.
+	 */
+	public function __construct( int $http_status, array $response_body, string $method, ?Throwable $previous = null ) {
+		$this->http_status   = $http_status;
+		$this->response_body = $response_body;
+		$this->errors        = $response_body['error']['errors'] ?? [];
+
+		// The proxy itself (a bad path, an unsupported scope) returns a flat
+		// `message` string; a proxied Google API error nests it under `error`.
+		$message = $response_body['error']['message'] ?? $response_body['message'] ?? 'Tag Manager API request failed';
+
+		parent::__construct( $message, $http_status, $previous );
+
+		do_action( 'woocommerce_gla_tag_manager_client_exception', $this, $method );
+	}
+
+	/**
+	 * @return int
+	 */
+	public function get_http_status(): int {
+		return $this->http_status;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_response_body(): array {
+		return $this->response_body;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function get_errors(): array {
+		return $this->errors;
+	}
+}

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -41,6 +41,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Google\GoogleHelperAwareInterfac
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiPromotionsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\YouTube\Connection as YouTubeConnection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection as TagManagerConnection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\TagManagerApiClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\RequestReviewStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\SiteVerificationMeta;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
@@ -289,6 +291,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( AdsAccountService::class, AdsAccountState::class );
 		$this->share_with_tags( MerchantAccountService::class, MerchantAccountState::class );
 		$this->share_with_tags( YouTubeConnection::class );
+		$this->share_with_tags( TagManagerConnection::class, TagManagerApiClient::class );
 
 		// Inbox Notes
 		$this->share_with_tags( ContactInformationNote::class );

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -22,6 +22,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\TagManagerApiClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountBusinessInfoService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
@@ -117,6 +118,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		Connection::class                         => true,
 		GoogleProductService::class               => true,
 		MerchantApiClient::class                  => true,
+		TagManagerApiClient::class                => true,
 		MapiProductsService::class                => true,
 		MapiDataSourcesService::class             => true,
 		MapiProductInputsService::class           => true,
@@ -340,6 +342,12 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( MapiAccountShippingSettingsService::class, MerchantApiClient::class );
 		$this->share( MapiAccountRegionsService::class, MerchantApiClient::class );
 		$this->share( MapiAccountServicesService::class, MerchantApiClient::class );
+
+		$this->share(
+			TagManagerApiClient::class,
+			ClientInterface::class,
+			$this->get_connect_server_url_root( 'google/google-gtm/v2' )
+		);
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -70,6 +70,8 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\RestAPI\Aut
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\YouTube\AccountController as YouTubeAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\OAuthService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\YouTube\Connection as YouTubeConnection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\TagManager\AccountController as TagManagerAccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection as TagManagerConnection;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
@@ -175,6 +177,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( AdsSettingsController::class );
 		$this->share( ConnectController::class, Middleware::class, OptionsInterface::class );
 		$this->share( YouTubeAccountController::class, YouTubeConnection::class );
+		$this->share( TagManagerAccountController::class, TagManagerConnection::class );
 		$this->share( OnboardingController::class );
 		$this->share( MarketsController::class, MarketService::class );
 	}

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -46,6 +46,7 @@ interface OptionsInterface {
 	public const SHIPPING_SYNC_FAILURE                     = 'shipping_sync_failure';
 	public const SHIPPING_TIMES                            = 'shipping_times';
 	public const SITE_VERIFICATION                         = 'site_verification';
+	public const TAG_MANAGER                               = 'tag_manager';
 	public const SYNCABLE_PRODUCTS_COUNT                   = 'syncable_products_count';
 	public const SYNCABLE_PRODUCTS_COUNT_INTERMEDIATE_DATA = 'syncable_products_count_intermediate_data';
 	public const PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA  = 'product_statuses_count_intermediate_data';
@@ -97,6 +98,7 @@ interface OptionsInterface {
 		self::SHIPPING_TIMES                            => true,
 		self::REDIRECT_TO_ONBOARDING                    => true,
 		self::SITE_VERIFICATION                         => true,
+		self::TAG_MANAGER                               => true,
 		self::SYNCABLE_PRODUCTS_COUNT                   => true,
 		self::SYNCABLE_PRODUCTS_COUNT_INTERMEDIATE_DATA => true,
 		self::PRODUCT_STATUSES_COUNT_INTERMEDIATE_DATA  => true,

--- a/tests/Unit/API/Site/Controllers/TagManager/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/TagManager/AccountControllerTest.php
@@ -150,6 +150,14 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
+	public function test_select_account_requires_id() {
+		$this->connection->expects( $this->never() )->method( 'select_account' );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'POST', [] );
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
 	public function test_select_account_with_error() {
 		$this->connection->expects( $this->once() )
 			->method( 'select_account' )
@@ -206,6 +214,14 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			$response->get_data()
 		);
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_select_container_requires_id() {
+		$this->connection->expects( $this->never() )->method( 'select_container' );
+
+		$response = $this->do_request( self::ROUTE_CONTAINERS, 'POST', [] );
+
+		$this->assertEquals( 400, $response->get_status() );
 	}
 
 	public function test_select_container_with_error() {

--- a/tests/Unit/API/Site/Controllers/TagManager/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/TagManager/AccountControllerTest.php
@@ -1,0 +1,221 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\TagManager;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\TagManager\AccountController;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class AccountControllerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Controllers\TagManager
+ */
+class AccountControllerTest extends RESTControllerUnitTest {
+
+	/** @var MockObject|Connection $connection */
+	protected $connection;
+
+	/** @var AccountController $controller */
+	protected $controller;
+
+	protected const ROUTE_CONNECT    = '/wc/gla/tag-manager/connect';
+	protected const ROUTE_CONNECTION = '/wc/gla/tag-manager/connection';
+	protected const ROUTE_ACCOUNTS   = '/wc/gla/tag-manager/accounts';
+	protected const ROUTE_CONTAINERS = '/wc/gla/tag-manager/containers';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->connection = $this->createMock( Connection::class );
+		$this->controller = new AccountController( $this->server, $this->connection );
+		$this->controller->register();
+	}
+
+	public function test_connect() {
+		$auth_url   = 'https://domain.test?auth=1';
+		$return_url = admin_url( 'admin.php?page=wc-admin&path=/google/settings' );
+
+		$this->connection->expects( $this->once() )
+			->method( 'connect' )
+			->with( $return_url )
+			->willReturn( $auth_url );
+
+		$response = $this->do_request( self::ROUTE_CONNECT, 'GET' );
+
+		$this->assertEquals( [ 'url' => $auth_url ], $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_connect_with_error() {
+		$this->connection->expects( $this->once() )
+			->method( 'connect' )
+			->willThrowException( new Exception( 'error', 400 ) );
+
+		$response = $this->do_request( self::ROUTE_CONNECT, 'GET' );
+
+		$this->assertEquals( [ 'message' => 'error' ], $response->get_data() );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_get_connection_status() {
+		$status = [ 'status' => 'connected' ];
+
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturn( $status );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
+
+		$this->assertEquals( $status, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_connection_status_with_error() {
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willThrowException( new Exception( 'error', 400 ) );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
+
+		$this->assertEquals( [ 'message' => 'error' ], $response->get_data() );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_disconnect() {
+		$this->connection->expects( $this->once() )
+			->method( 'disconnect' )
+			->willReturn( 'Successfully disconnected.' );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'DELETE' );
+
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully disconnected.',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_accounts() {
+		$accounts = [
+			[
+				'id'   => '123',
+				'name' => 'Example Store',
+			],
+		];
+
+		$this->connection->expects( $this->once() )
+			->method( 'list_accounts' )
+			->willReturn( $accounts );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'GET' );
+
+		$this->assertEquals( $accounts, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_accounts_with_error() {
+		$this->connection->expects( $this->once() )
+			->method( 'list_accounts' )
+			->willThrowException( new Exception( 'error', 401 ) );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'GET' );
+
+		$this->assertEquals( [ 'message' => 'error' ], $response->get_data() );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	public function test_select_account() {
+		$this->connection->expects( $this->once() )
+			->method( 'select_account' )
+			->with( '123' );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'POST', [ 'id' => '123' ] );
+
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully selected Tag Manager account.',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_select_account_with_error() {
+		$this->connection->expects( $this->once() )
+			->method( 'select_account' )
+			->willThrowException( new Exception( 'error', 400 ) );
+
+		$response = $this->do_request( self::ROUTE_ACCOUNTS, 'POST', [ 'id' => '123' ] );
+
+		$this->assertEquals( [ 'message' => 'error' ], $response->get_data() );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_get_containers() {
+		$containers = [
+			[
+				'id'       => '456',
+				'publicId' => 'GTM-ABCDEFG',
+				'name'     => 'Example Store - Web',
+			],
+		];
+
+		$this->connection->expects( $this->once() )
+			->method( 'list_containers' )
+			->willReturn( $containers );
+
+		$response = $this->do_request( self::ROUTE_CONTAINERS, 'GET' );
+
+		$this->assertEquals( $containers, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_containers_with_error() {
+		$this->connection->expects( $this->once() )
+			->method( 'list_containers' )
+			->willThrowException( new Exception( 'No Tag Manager account has been selected yet.', 400 ) );
+
+		$response = $this->do_request( self::ROUTE_CONTAINERS, 'GET' );
+
+		$this->assertEquals( [ 'message' => 'No Tag Manager account has been selected yet.' ], $response->get_data() );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	public function test_select_container() {
+		$this->connection->expects( $this->once() )
+			->method( 'select_container' )
+			->with( '456' );
+
+		$response = $this->do_request( self::ROUTE_CONTAINERS, 'POST', [ 'id' => '456' ] );
+
+		$this->assertEquals(
+			[
+				'status'  => 'success',
+				'message' => 'Successfully selected Tag Manager container.',
+			],
+			$response->get_data()
+		);
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_select_container_with_error() {
+		$this->connection->expects( $this->once() )
+			->method( 'select_container' )
+			->willThrowException( new Exception( 'error', 400 ) );
+
+		$response = $this->do_request( self::ROUTE_CONTAINERS, 'POST', [ 'id' => '456' ] );
+
+		$this->assertEquals( [ 'message' => 'error' ], $response->get_data() );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+}

--- a/tests/Unit/API/TagManager/ConnectionTest.php
+++ b/tests/Unit/API/TagManager/ConnectionTest.php
@@ -8,8 +8,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\TagManagerApiClie
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\ConnectException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Handler\MockHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Request;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Response;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
 use Exception;
@@ -62,6 +64,16 @@ class ConnectionTest extends UnitTest {
 		$this->container->add( Client::class, new Client( [ 'handler' => $stack ] ) );
 	}
 
+	/**
+	 * Queue a connection-level failure (no response at all) for the raw `Client::class` calls.
+	 */
+	protected function queue_guzzle_connection_failure(): void {
+		$stack = HandlerStack::create(
+			new MockHandler( [ new ConnectException( 'Connection timed out', new Request( 'GET', 'https://wcs.example.com/' ) ) ] )
+		);
+		$this->container->add( Client::class, new Client( [ 'handler' => $stack ] ) );
+	}
+
 	public function test_connect_returns_oauth_url_on_success() {
 		$this->queue_guzzle_response(
 			new Response( 200, [], wp_json_encode( [ 'oauthUrl' => 'https://accounts.google.com/o/oauth2/auth' ] ) )
@@ -79,6 +91,13 @@ class ConnectionTest extends UnitTest {
 		$this->connection->connect( 'https://example.com/return' );
 	}
 
+	public function test_connect_throws_when_the_request_itself_fails() {
+		$this->queue_guzzle_connection_failure();
+
+		$this->expectException( Exception::class );
+		$this->connection->connect( 'https://example.com/return' );
+	}
+
 	public function test_disconnect_is_purely_local() {
 		// No Client::class registered in the container at all — if disconnect()
 		// ever tried a remote call, resolving it would throw and fail this test.
@@ -89,6 +108,13 @@ class ConnectionTest extends UnitTest {
 		$message = $this->connection->disconnect();
 
 		$this->assertSame( 'Successfully disconnected.', $message );
+	}
+
+	public function test_get_status_throws_when_the_request_itself_fails() {
+		$this->queue_guzzle_connection_failure();
+
+		$this->expectException( Exception::class );
+		$this->connection->get_status();
 	}
 
 	public function test_get_status_returns_disconnected_when_scope_not_granted() {

--- a/tests/Unit/API/TagManager/ConnectionTest.php
+++ b/tests/Unit/API/TagManager/ConnectionTest.php
@@ -1,0 +1,322 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\TagManager;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\TagManagerApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Handler\MockHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Response;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Container;
+use Exception;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ConnectionTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\TagManager
+ */
+class ConnectionTest extends UnitTest {
+
+	protected const CONNECT_SERVER_ROOT = 'https://wcs.example.com/';
+
+	/** @var Container */
+	protected $container;
+
+	/** @var MockObject|TagManagerApiClient */
+	protected $client;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var Connection */
+	protected $connection;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->container = new Container();
+		$this->container->add( 'connect_server_root', self::CONNECT_SERVER_ROOT );
+
+		$this->client  = $this->createMock( TagManagerApiClient::class );
+		$this->options = $this->createMock( OptionsInterface::class );
+
+		$this->connection = new Connection( $this->client );
+		$this->connection->set_container( $this->container );
+		$this->connection->set_options_object( $this->options );
+	}
+
+	/**
+	 * Queue a Guzzle response for the raw `Client::class` (connect/disconnect/status) calls.
+	 *
+	 * @param Response $response
+	 */
+	protected function queue_guzzle_response( Response $response ): void {
+		$stack = HandlerStack::create( new MockHandler( [ $response ] ) );
+		$this->container->add( Client::class, new Client( [ 'handler' => $stack ] ) );
+	}
+
+	public function test_connect_returns_oauth_url_on_success() {
+		$this->queue_guzzle_response(
+			new Response( 200, [], wp_json_encode( [ 'oauthUrl' => 'https://accounts.google.com/o/oauth2/auth' ] ) )
+		);
+
+		$url = $this->connection->connect( 'https://example.com/return' );
+
+		$this->assertSame( 'https://accounts.google.com/o/oauth2/auth', $url );
+	}
+
+	public function test_connect_throws_when_response_has_no_oauth_url() {
+		$this->queue_guzzle_response( new Response( 200, [], wp_json_encode( [ 'status' => 'ok' ] ) ) );
+
+		$this->expectException( Exception::class );
+		$this->connection->connect( 'https://example.com/return' );
+	}
+
+	public function test_disconnect_is_purely_local() {
+		// No Client::class registered in the container at all — if disconnect()
+		// ever tried a remote call, resolving it would throw and fail this test.
+		$this->options->expects( $this->once() )
+			->method( 'delete' )
+			->with( OptionsInterface::TAG_MANAGER );
+
+		$message = $this->connection->disconnect();
+
+		$this->assertSame( 'Successfully disconnected.', $message );
+	}
+
+	public function test_get_status_returns_disconnected_when_scope_not_granted() {
+		$this->queue_guzzle_response(
+			new Response( 200, [], wp_json_encode( [ 'scope' => [ 'https://www.googleapis.com/auth/content' ] ] ) )
+		);
+
+		$status = $this->connection->get_status();
+
+		$this->assertSame( [ 'status' => Connection::STATUS_DISCONNECTED ], $status );
+	}
+
+	public function test_get_status_returns_incomplete_when_scope_granted_but_nothing_selected() {
+		$this->queue_guzzle_response(
+			new Response( 200, [], wp_json_encode( [ 'scope' => [ Connection::SCOPE_TAG_MANAGER ] ] ) )
+		);
+		$this->options->method( 'get' )->willReturn(
+			[
+				'account_id'          => null,
+				'account_name'        => null,
+				'container_id'        => null,
+				'container_name'      => null,
+				'container_public_id' => null,
+			]
+		);
+
+		$status = $this->connection->get_status();
+
+		$this->assertSame( [ 'status' => Connection::STATUS_INCOMPLETE ], $status );
+	}
+
+	public function test_get_status_returns_connected_with_full_shape_when_account_and_container_selected() {
+		$this->queue_guzzle_response(
+			new Response( 200, [], wp_json_encode( [ 'scope' => [ Connection::SCOPE_TAG_MANAGER ] ] ) )
+		);
+		$this->options->method( 'get' )->willReturn(
+			[
+				'account_id'          => '123',
+				'account_name'        => 'Example Store',
+				'container_id'        => '456',
+				'container_name'      => 'Example Store - Web',
+				'container_public_id' => 'GTM-ABCDEFG',
+			]
+		);
+
+		$status = $this->connection->get_status();
+
+		$this->assertSame(
+			[
+				'status'            => Connection::STATUS_CONNECTED,
+				'id'                => '123',
+				'name'              => 'Example Store',
+				'containerId'       => '456',
+				'containerName'     => 'Example Store - Web',
+				'containerPublicId' => 'GTM-ABCDEFG',
+			],
+			$status
+		);
+	}
+
+	public function test_list_accounts_maps_response_to_id_name_shape() {
+		$this->client->method( 'get' )->with( 'accounts' )->willReturn(
+			[
+				'account' => [
+					[
+						'accountId' => '123',
+						'name'      => 'Example Store',
+						'features'  => [ 'supportUserPermissions' => true ],
+					],
+				],
+			]
+		);
+
+		$accounts = $this->connection->list_accounts();
+
+		$this->assertSame(
+			[
+				[
+					'id'   => '123',
+					'name' => 'Example Store',
+				],
+			],
+			$accounts
+		);
+	}
+
+	public function test_list_accounts_returns_empty_array_when_no_accounts() {
+		$this->client->method( 'get' )->willReturn( [] );
+
+		$this->assertSame( [], $this->connection->list_accounts() );
+	}
+
+	public function test_select_account_stores_account_and_clears_container() {
+		$this->options->method( 'get' )->willReturn(
+			[
+				'account_id'          => null,
+				'account_name'        => null,
+				'container_id'        => null,
+				'container_name'      => null,
+				'container_public_id' => null,
+			]
+		);
+		$this->client->method( 'get' )
+			->with( 'accounts/123' )
+			->willReturn(
+				[
+					'accountId' => '123',
+					'name'      => 'Example Store',
+				]
+			);
+
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				OptionsInterface::TAG_MANAGER,
+				[
+					'account_id'          => '123',
+					'account_name'        => 'Example Store',
+					'container_id'        => null,
+					'container_name'      => null,
+					'container_public_id' => null,
+				]
+			)
+			->willReturn( true );
+
+		$this->connection->select_account( '123' );
+	}
+
+	public function test_list_containers_throws_when_no_account_selected() {
+		$this->options->method( 'get' )->willReturn(
+			[
+				'account_id'          => null,
+				'account_name'        => null,
+				'container_id'        => null,
+				'container_name'      => null,
+				'container_public_id' => null,
+			]
+		);
+
+		$this->expectException( Exception::class );
+		$this->connection->list_containers();
+	}
+
+	public function test_list_containers_maps_response_to_id_publicid_name_shape() {
+		$this->options->method( 'get' )->willReturn(
+			[
+				'account_id'          => '123',
+				'account_name'        => 'Example Store',
+				'container_id'        => null,
+				'container_name'      => null,
+				'container_public_id' => null,
+			]
+		);
+		$this->client->method( 'get' )->with( 'accounts/123/containers' )->willReturn(
+			[
+				'container' => [
+					[
+						'containerId' => '456',
+						'publicId'    => 'GTM-ABCDEFG',
+						'name'        => 'Example Store - Web',
+					],
+				],
+			]
+		);
+
+		$containers = $this->connection->list_containers();
+
+		$this->assertSame(
+			[
+				[
+					'id'       => '456',
+					'publicId' => 'GTM-ABCDEFG',
+					'name'     => 'Example Store - Web',
+				],
+			],
+			$containers
+		);
+	}
+
+	public function test_select_container_throws_when_no_account_selected() {
+		$this->options->method( 'get' )->willReturn(
+			[
+				'account_id'          => null,
+				'account_name'        => null,
+				'container_id'        => null,
+				'container_name'      => null,
+				'container_public_id' => null,
+			]
+		);
+
+		$this->expectException( Exception::class );
+		$this->connection->select_container( '456' );
+	}
+
+	public function test_select_container_stores_container() {
+		$this->options->method( 'get' )->willReturn(
+			[
+				'account_id'          => '123',
+				'account_name'        => 'Example Store',
+				'container_id'        => null,
+				'container_name'      => null,
+				'container_public_id' => null,
+			]
+		);
+		$this->client->method( 'get' )
+			->with( 'accounts/123/containers/456' )
+			->willReturn(
+				[
+					'containerId' => '456',
+					'publicId'    => 'GTM-ABCDEFG',
+					'name'        => 'Example Store - Web',
+				]
+			);
+
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with(
+				OptionsInterface::TAG_MANAGER,
+				[
+					'account_id'          => '123',
+					'account_name'        => 'Example Store',
+					'container_id'        => '456',
+					'container_name'      => 'Example Store - Web',
+					'container_public_id' => 'GTM-ABCDEFG',
+				]
+			)
+			->willReturn( true );
+
+		$this->connection->select_container( '456' );
+	}
+}

--- a/tests/Unit/API/TagManager/TagManagerApiClientTest.php
+++ b/tests/Unit/API/TagManager/TagManagerApiClientTest.php
@@ -1,0 +1,114 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\TagManager;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\TagManagerApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\TagManagerApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Handler\MockHandler;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Middleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Response;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class TagManagerApiClientTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\TagManager
+ */
+class TagManagerApiClientTest extends UnitTest {
+
+	protected const BASE_URL = 'https://example.test/base/';
+
+	/** @var MockHandler */
+	protected $mock;
+
+	/** @var array<int, array> */
+	protected $history = [];
+
+	/** @var TagManagerApiClient */
+	protected $client;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->history = [];
+		$this->mock    = new MockHandler();
+
+		$stack = HandlerStack::create( $this->mock );
+		$stack->push( Middleware::history( $this->history ) );
+
+		$this->client = new TagManagerApiClient(
+			new Client( [ 'handler' => $stack ] ),
+			self::BASE_URL
+		);
+	}
+
+	public function test_get_returns_decoded_array_on_success() {
+		$this->mock->append( new Response( 200, [], wp_json_encode( [ 'account' => [] ] ) ) );
+
+		$result = $this->client->get( 'accounts' );
+
+		$this->assertSame( [ 'account' => [] ], $result );
+
+		$request = $this->history[0]['request'];
+		$this->assertSame( 'GET', $request->getMethod() );
+		$this->assertSame( self::BASE_URL . 'accounts', (string) $request->getUri() );
+	}
+
+	public function test_get_strips_leading_slash_from_path() {
+		$this->mock->append( new Response( 200, [], '{}' ) );
+
+		$this->client->get( '/accounts/123/containers' );
+
+		$request = $this->history[0]['request'];
+		$this->assertSame( self::BASE_URL . 'accounts/123/containers', (string) $request->getUri() );
+	}
+
+	public function test_4xx_response_throws_tag_manager_api_exception() {
+		$body = [
+			'error' => [
+				'code'    => 403,
+				'message' => 'Request had insufficient authentication scopes.',
+			],
+		];
+		$this->mock->append( new Response( 403, [], wp_json_encode( $body ) ) );
+
+		try {
+			$this->client->get( 'accounts' );
+			$this->fail( 'Expected TagManagerApiException' );
+		} catch ( TagManagerApiException $e ) {
+			$this->assertSame( 403, $e->get_http_status() );
+			$this->assertSame( $body, $e->get_response_body() );
+		}
+	}
+
+	public function test_4xx_response_with_flat_message_shape_throws_exception_with_that_message() {
+		// The Connect Server's own routing errors (e.g. an unsupported service or
+		// path) return a flat `message` string, not a nested `error.message` —
+		// a different shape than a proxied Google API error.
+		$body = [
+			'statusCode' => 400,
+			'error'      => 'Bad Request',
+			'message'    => 'Unsupported Google service',
+		];
+		$this->mock->append( new Response( 400, [], wp_json_encode( $body ) ) );
+
+		try {
+			$this->client->get( 'accounts' );
+			$this->fail( 'Expected TagManagerApiException' );
+		} catch ( TagManagerApiException $e ) {
+			$this->assertSame( 'Unsupported Google service', $e->getMessage() );
+		}
+	}
+
+	public function test_5xx_response_throws_tag_manager_api_exception() {
+		$this->mock->append( new Response( 503, [], 'Service Unavailable' ) );
+
+		$this->expectException( TagManagerApiException::class );
+		$this->client->get( 'accounts' );
+	}
+}

--- a/tests/Unit/API/TagManager/TagManagerApiClientTest.php
+++ b/tests/Unit/API/TagManager/TagManagerApiClientTest.php
@@ -7,9 +7,11 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\TagManagerApiClie
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\TagManagerApiException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Client;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\RequestException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Handler\MockHandler;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Middleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Request;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Response;
 
 defined( 'ABSPATH' ) || exit;
@@ -103,6 +105,16 @@ class TagManagerApiClientTest extends UnitTest {
 		} catch ( TagManagerApiException $e ) {
 			$this->assertSame( 'Unsupported Google service', $e->getMessage() );
 		}
+	}
+
+	public function test_request_exception_with_no_response_rethrows_original_exception() {
+		// A RequestException without a response (e.g. the connection dropped
+		// mid-request) has no body to wrap into a TagManagerApiException — the
+		// original exception should propagate as-is instead.
+		$this->mock->append( new RequestException( 'Connection timed out', new Request( 'GET', self::BASE_URL . 'accounts' ) ) );
+
+		$this->expectException( RequestException::class );
+		$this->client->get( 'accounts' );
 	}
 
 	public function test_5xx_response_throws_tag_manager_api_exception() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes: https://linear.app/a8c/issue/GOOWOO-929/connect-google-tag-manager-backend-connection-account-and-container

Backend half of the GTM connect flow: account/container listing, selection, and a purely-local disconnect, confirmed end-to-end against Woo's live Connect Server (not a mock).

- New `API\TagManager\Connection` - `connect()`/`disconnect()`/`get_status()`, modeled on Search Console's connection class (shared-endpoint connect, purely local disconnect), not YouTube's dedicated-endpoint pattern. `list_accounts()`/`select_account()`/`list_containers()`/`select_container()` delegate to a new `TagManagerApiClient`.
- `tagmanager.readonly` is requested as an `additionalScopes` addition to the existing shared `google/connection/google-mc` endpoint - the same mechanism already used for Search Console's scope, not a dedicated GTM connection endpoint.
- New `Site\Controllers\TagManager\AccountController` exposing the REST routes the FE (GOOWOO-924) already consumes: `tag-manager/connect`, `tag-manager/connection`, `tag-manager/accounts`, `tag-manager/containers`.
- Disconnect is local-only - it never calls a remote Connect Server endpoint, so it can't tear down the shared Merchant Center/Ads connection.

> **Requires ENG QA, not regular QA.** Verifying this needs direct code-level testing against a real, live-connected Google/GTM environment (`wp eval`/`wp-cli` access to `TagManager\Connection`), since the whole point is confirming real OAuth scope-granting and a real external API's response shape, not just that a screen renders correctly.

### Detailed test instructions:

1. `composer install`, `vendor/bin/phpunit --testsuite unit`.
2. `vendor/bin/phpcs` (default ruleset) and `vendor/bin/phpcs --standard=tests/phpcs.xml.dist` (tests ruleset).
3. Manually verified against a live, connected Google account with a real GTM account/container — confirmed the scope grant, account listing, container listing, and disconnect all behave as expected against Woo's real Connect Server.

#### Setup

Requires a real, live Google account with at least one GTM account/container, connected through a publicly reachable tunnel (e.g. Cloudflare quick tunnel or ngrok) — Google's OAuth flow needs a real HTTPS callback.

#### Test 4 — Get a real oauthUrl and grant the `tagmanager.readonly` scope (one-time, can't be scripted)

```
wp eval '
$c = woogle_get_container();
$conn = $c->get(\Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection::class);
echo $conn->connect( admin_url( "admin.php?page=wc-admin&path=/google/settings" ) ) . "\n";
'
```

Visit the printed URL in a real browser and complete Google's consent screen. Confirm the consent screen actually lists Tag Manager access as one of the requested permissions.

#### Test 5 — Confirm the scope landed and check status

```
wp eval '
$c = woogle_get_container();
$conn = $c->get(\Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection::class);
echo wp_json_encode( $conn->get_status(), JSON_PRETTY_PRINT ) . "\n";
'
```

Expect `status: "incomplete"` (scope granted, no account/container selected yet).

#### Test 6 — List accounts, select one, list containers, select one

```
wp eval '
$c = woogle_get_container();
$conn = $c->get(\Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection::class);
echo wp_json_encode( $conn->list_accounts(), JSON_PRETTY_PRINT ) . "\n";
// pick a real account id from the output above
$conn->select_account( "<account id>" );
echo wp_json_encode( $conn->list_containers(), JSON_PRETTY_PRINT ) . "\n";
// pick a real container id from the output above
$conn->select_container( "<container id>" );
echo wp_json_encode( $conn->get_status(), JSON_PRETTY_PRINT ) . "\n";
'
```

Expect `get_status()` to now return `status: "connected"` with `id`/`name`/`containerId`/`containerName`/`containerPublicId` populated.

#### Test 7 — Disconnect is local-only

```
wp eval '
$c = woogle_get_container();
$conn = $c->get(\Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection::class);
echo $conn->disconnect() . "\n";
echo wp_json_encode( $conn->get_status(), JSON_PRETTY_PRINT ) . "\n";
'
```

**Expect `get_status()` to report `status: "incomplete"`, not `"disconnected"`** — this is the correct, expected behavior, not a bug. Disconnect is deliberately local-only and never revokes the shared `tagmanager.readonly` scope grant (revoking it would risk tearing down the shared Merchant Center/Ads connection). Since the scope is still granted, `get_status()` falls through past its scope check to "no account/container selected" (`incomplete`), the same state a merchant sees before ever selecting an account. This is a known, shared behavior with Search Console's identical local-disconnect design, not something specific to this ticket — a dedicated follow-up covering both integrations is planned separately, not part of this PR's scope.

Separately confirm the shared Merchant Center/Ads connection is untouched — check via `API\Google\Connection::get_status()` (or reload Settings > Accounts) and confirm it still shows connected with the same account.

### Additional details:
N/A

### Changelog entry
> Add backend connection support for Google Tag Manager account and container selection.