### PR TITLE
Pause syncing when the WordPress.com connection has no owner or its token is rejected

### DIFF
--- a/src/API/Google/JetpackAuthCircuitBreaker.php
+++ b/src/API/Google/JetpackAuthCircuitBreaker.php
@@ -1,0 +1,95 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class JetpackAuthCircuitBreaker
+ *
+ * Pauses syncing after the Connect Server rejects the site's Jetpack token.
+ *
+ * The Connect Server authenticates every proxied request with the Jetpack token, so a
+ * rejection applies to every request the site makes, and running sync jobs against it
+ * only produces more rejections. A failure pauses syncing for one hour, without backoff
+ * and without extension by further rejections: the next attempt after the window is a
+ * single probe, and any accepted response ends the pause early, so a repaired connection
+ * or a transient failure is picked up within the hour. The failure is also remembered
+ * for the rest of the current PHP request, so a loop making one request per product
+ * stops after the first rejection.
+ *
+ * The pause is stored in an option rather than a transient so that an object cache
+ * eviction cannot silently drop it.
+ *
+ * @since x.x.x
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
+ */
+class JetpackAuthCircuitBreaker implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/**
+	 * Whether a failure was recorded during the current request.
+	 *
+	 * @var bool
+	 */
+	private $tripped_in_request = false;
+
+	/**
+	 * Record an authentication failure.
+	 */
+	public function trip(): void {
+		$this->tripped_in_request = true;
+
+		// A rejection while already open (e.g. from an admin page load) keeps the current window.
+		if ( ! $this->is_open() ) {
+			$this->options->update( OptionsInterface::JETPACK_AUTH_FAILED_AT, time() );
+		}
+	}
+
+	/**
+	 * End the pause after an accepted response.
+	 */
+	public function reset(): void {
+		$this->tripped_in_request = false;
+
+		if ( $this->options->get( OptionsInterface::JETPACK_AUTH_FAILED_AT ) ) {
+			$this->options->delete( OptionsInterface::JETPACK_AUTH_FAILED_AT );
+		}
+	}
+
+	/**
+	 * Whether the breaker is open, i.e. syncing is paused.
+	 *
+	 * @return bool
+	 */
+	public function is_open(): bool {
+		return $this->get_retry_time() > time();
+	}
+
+	/**
+	 * Whether trip() ran earlier in this PHP request; used to fail fast for the rest of it.
+	 *
+	 * @return bool
+	 */
+	public function was_tripped_in_request(): bool {
+		return $this->tripped_in_request;
+	}
+
+	/**
+	 * The timestamp at which the pause ends, or 0 when no failure is recorded.
+	 *
+	 * @return int
+	 */
+	public function get_retry_time(): int {
+		$failed_at = (int) $this->options->get( OptionsInterface::JETPACK_AUTH_FAILED_AT, 0 );
+
+		return $failed_at > 0 ? $failed_at + HOUR_IN_SECONDS : 0;
+	}
+}

--- a/src/API/Google/JetpackAuthCircuitBreaker.php
+++ b/src/API/Google/JetpackAuthCircuitBreaker.php
@@ -18,8 +18,8 @@ defined( 'ABSPATH' ) || exit;
  * rejection applies to every request the site makes, and running sync jobs against it
  * only produces more rejections. A failure pauses syncing for one hour, without backoff
  * and without extension by further rejections: the next attempt after the window is a
- * single probe, and any accepted response ends the pause early, so a repaired connection
- * or a transient failure is picked up within the hour. The failure is also remembered
+ * single probe, and a reset ends the pause early (see reset()), so a repaired connection or a
+ * transient failure is picked up within the hour. The failure is also remembered
  * for the rest of the current PHP request, so a loop making one request per product
  * stops after the first rejection.
  *
@@ -54,7 +54,7 @@ class JetpackAuthCircuitBreaker implements OptionsAwareInterface {
 	}
 
 	/**
-	 * End the pause after an accepted response.
+	 * End the pause. Called by the response handler once a request is accepted.
 	 */
 	public function reset(): void {
 		$this->tripped_in_request = false;

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -21,6 +21,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\JetpackAuthCircuitBreaker;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountBusinessInfoService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
@@ -64,6 +65,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\Conn
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\RequestException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Middleware as GuzzleMiddleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Promise\Create as PromiseCreate;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Utils;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\Definition;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\RequestInterface;
@@ -95,6 +97,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		ShoppingContent::class                    => true,
 		GoogleAdsClient::class                    => true,
 		GuzzleClient::class                       => true,
+		JetpackAuthCircuitBreaker::class          => true,
 		Middleware::class                         => true,
 		Merchant::class                           => true,
 		MerchantMetrics::class                    => true,
@@ -145,6 +148,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->register_ads_client();
 		$this->register_google_classes();
 		$this->share( Middleware::class );
+		$this->share( JetpackAuthCircuitBreaker::class );
 		$this->add( Connection::class );
 		$this->add( Settings::class );
 
@@ -183,6 +187,9 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$callback = function () {
 			$handler_stack = HandlerStack::create();
 			$handler_stack->remove( 'http_errors' );
+			// Outermost of the plugin's own middlewares: after the Connect Server has rejected the
+			// Jetpack token once during this PHP request, no further HTTP request is sent through this client.
+			$handler_stack->push( $this->short_circuit_after_auth_failure(), 'auth_failure_short_circuit' );
 			$handler_stack->push( $this->error_handler(), 'http_errors' );
 			$handler_stack->push( $this->add_auth_header(), 'auth_header' );
 			$handler_stack->push( $this->add_plugin_version_header(), 'plugin_version_header' );
@@ -201,6 +208,28 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 
 		$this->share_concrete( GuzzleClient::class, new Definition( GuzzleClient::class, $callback ) );
 		$this->share_concrete( ClientInterface::class, new Definition( GuzzleClient::class, $callback ) );
+	}
+
+	/**
+	 * Middleware that rejects every request after the Connect Server rejected the
+	 * Jetpack token earlier in the same PHP request. The rejection is permanent for
+	 * the site until it reconnects, so repeating the request for every product in a
+	 * batch only multiplies the failures.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return callable
+	 */
+	protected function short_circuit_after_auth_failure(): callable {
+		return function ( callable $handler ) {
+			return function ( RequestInterface $request, array $options ) use ( $handler ) {
+				if ( $this->get_circuit_breaker()->was_tripped_in_request() ) {
+					return PromiseCreate::rejectionFor( AccountReconnect::jetpack_disconnected() );
+				}
+
+				return $handler( $request, $options );
+			};
+		};
 	}
 
 	/**
@@ -345,6 +374,9 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	/**
 	 * Custom error handler to detect and handle a disconnected status.
 	 *
+	 * The response status is the only evidence the plugin has about the Jetpack token, so
+	 * this is also where an accepted response marks Jetpack as connected and ends a pause.
+	 *
 	 * @return callable
 	 */
 	protected function error_handler(): callable {
@@ -362,6 +394,12 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 						}
 
 						if ( $code < 400 ) {
+							if ( $code < 300 ) {
+								// Only an accepted response proves the Jetpack token is valid.
+								$this->set_jetpack_connected( true );
+								$this->get_circuit_breaker()->reset();
+							}
+
 							return $response;
 						}
 
@@ -378,7 +416,9 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 
 	/**
 	 * Handle a 401 unauthorized error.
-	 * Marks either the Jetpack or the Google account as disconnected.
+	 * Marks either the Jetpack or the Google account as disconnected. A Jetpack
+	 * authentication failure also pauses syncing (see JetpackAuthCircuitBreaker);
+	 * a Google one already stops it through the GOOGLE_CONNECTED option.
 	 *
 	 * @since 1.12.5
 	 *
@@ -394,6 +434,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 			do_action( 'woocommerce_gla_exception', RequestException::create( $request, $response ), __METHOD__ );
 
 			$this->set_jetpack_connected( false );
+			$this->get_circuit_breaker()->trip();
 			throw AccountReconnect::jetpack_disconnected();
 		}
 
@@ -416,9 +457,6 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 			return function ( RequestInterface $request, array $options ) use ( $handler ) {
 				try {
 					$request = $request->withHeader( 'Authorization', $this->generate_auth_header() );
-
-					// Getting a valid authorization token, indicates Jetpack is connected.
-					$this->set_jetpack_connected( true );
 				} catch ( WPError $error ) {
 					do_action( 'woocommerce_gla_guzzle_client_exception', $error, __METHOD__ . ' in add_auth_header()' );
 
@@ -557,6 +595,13 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$parts = wp_parse_url( $this->get_connect_server_url_root( 'google/google-ads' ) );
 		$port  = empty( $parts['port'] ) ? 443 : $parts['port'];
 		return sprintf( '%s:%d%s', $parts['host'], $port, $parts['path'] );
+	}
+
+	/**
+	 * @return JetpackAuthCircuitBreaker
+	 */
+	protected function get_circuit_breaker(): JetpackAuthCircuitBreaker {
+		return $this->getContainer()->get( JetpackAuthCircuitBreaker::class );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -627,14 +627,17 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		/** @var Options $options */
 		$options = $this->getContainer()->get( OptionsInterface::class );
 
-		// Save previous connected status before updating.
 		$previous_connected = boolval( $options->get( OptionsInterface::JETPACK_CONNECTED ) );
 
-		$options->update( OptionsInterface::JETPACK_CONNECTED, $connected );
-
-		if ( $previous_connected !== $connected ) {
-			$this->jetpack_connected_change( $connected );
+		// Comparing here avoids a wp_options write on every accepted response: WordPress stores
+		// the value as '1' and compares it strictly against the boolean, so update_option()
+		// would issue an UPDATE each time even though nothing changes.
+		if ( $previous_connected === $connected ) {
+			return;
 		}
+
+		$options->update( OptionsInterface::JETPACK_CONNECTED, $connected );
+		$this->jetpack_connected_change( $connected );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -373,7 +373,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 
 	/**
 	 * Middleware that turns the response status into connection state and exceptions:
-	 * an accepted response marks Jetpack as connected and ends a sync pause, a 401 marks
+	 * a successful (2xx) response marks Jetpack as connected and ends a sync pause, a 401 marks
 	 * the Jetpack or Google account as disconnected, and any other error status is thrown
 	 * as a RequestException. The response status is the only evidence the plugin has about
 	 * the Jetpack token, which is why both connection state transitions live here.
@@ -397,8 +397,10 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 						}
 
 						if ( $code < 400 ) {
+							// Only a 2xx proves the token is valid. A 3xx is not treated as proof, but
+							// the proxy does not redirect and the client follows any redirect before
+							// this runs, so the final status seen here is 2xx or an error.
 							if ( $code < 300 ) {
-								// Only an accepted response proves the Jetpack token is valid.
 								$this->set_jetpack_connected( true );
 								$this->get_circuit_breaker()->reset();
 							}

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -190,7 +190,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 			// Outermost of the plugin's own middlewares: after the Connect Server has rejected the
 			// Jetpack token once during this PHP request, no further HTTP request is sent through this client.
 			$handler_stack->push( $this->short_circuit_after_auth_failure(), 'auth_failure_short_circuit' );
-			$handler_stack->push( $this->error_handler(), 'http_errors' );
+			$handler_stack->push( $this->handle_response_status(), 'http_errors' );
 			$handler_stack->push( $this->add_auth_header(), 'auth_header' );
 			$handler_stack->push( $this->add_plugin_version_header(), 'plugin_version_header' );
 			$handler_stack->push( $this->strip_apply_incentive_duplicates(), 'strip_incentive_duplicates' );
@@ -200,7 +200,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 				$handler_stack->push( $this->override_http_url(), 'override_http_url' );
 			}
 
-			// Innermost: retry transient failures before the error handler turns them into exceptions.
+			// Innermost: retry transient failures before handle_response_status() turns them into exceptions.
 			$handler_stack->push( $this->retry_on_transient_error(), 'retry_on_transient_error' );
 
 			return new GuzzleClient( [ 'handler' => $handler_stack ] );
@@ -372,14 +372,17 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	}
 
 	/**
-	 * Custom error handler to detect and handle a disconnected status.
+	 * Middleware that turns the response status into connection state and exceptions:
+	 * an accepted response marks Jetpack as connected and ends a sync pause, a 401 marks
+	 * the Jetpack or Google account as disconnected, and any other error status is thrown
+	 * as a RequestException. The response status is the only evidence the plugin has about
+	 * the Jetpack token, which is why both connection state transitions live here.
 	 *
-	 * The response status is the only evidence the plugin has about the Jetpack token, so
-	 * this is also where an accepted response marks Jetpack as connected and ends a pause.
+	 * Registered under Guzzle's `http_errors` name, replacing the built-in middleware.
 	 *
 	 * @return callable
 	 */
-	protected function error_handler(): callable {
+	protected function handle_response_status(): callable {
 		return function ( callable $handler ) {
 			return function ( RequestInterface $request, array $options ) use ( $handler ) {
 				return $handler( $request, $options )->then(

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\JetpackAuthCircuitBreaker;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
@@ -48,6 +49,7 @@ defined( 'ABSPATH' ) || exit;
  * - WP
  * - TargetAudience
  * - GoogleHelper
+ * - JetpackAuthCircuitBreaker
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter
  */
@@ -100,8 +102,9 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 
 	/**
 	 * Whether we are able to sync data to the Merchant Center account.
-	 * Account must be connected, the WordPress.com connection must have an owner,
-	 * and the URL we claimed with must match the site URL.
+	 * Account must be connected, the WordPress.com connection must have an owner
+	 * and not be paused after an authentication failure, and the URL we claimed
+	 * with must match the site URL.
 	 * URL matches is stored in a transient to prevent it from being refetched in cases
 	 * where the site is unable to access account data.
 	 *
@@ -114,6 +117,11 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		}
 
 		if ( ! $this->is_jetpack_owner_connected() ) {
+			return false;
+		}
+
+		// Paused after the Connect Server rejected the Jetpack token.
+		if ( $this->container->get( JetpackAuthCircuitBreaker::class )->is_open() ) {
 			return false;
 		}
 

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
@@ -35,6 +36,7 @@ defined( 'ABSPATH' ) || exit;
  * - AddressUtility
  * - AdsService
  * - ContactInformation
+ * - Manager
  * - Merchant
  * - MerchantAccountState
  * - MerchantStatuses
@@ -98,7 +100,8 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 
 	/**
 	 * Whether we are able to sync data to the Merchant Center account.
-	 * Account must be connected and the URL we claimed with must match the site URL.
+	 * Account must be connected, the WordPress.com connection must have an owner,
+	 * and the URL we claimed with must match the site URL.
 	 * URL matches is stored in a transient to prevent it from being refetched in cases
 	 * where the site is unable to access account data.
 	 *
@@ -107,6 +110,10 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 */
 	public function is_ready_for_syncing(): bool {
 		if ( ! $this->is_connected() ) {
+			return false;
+		}
+
+		if ( ! $this->is_jetpack_owner_connected() ) {
 			return false;
 		}
 
@@ -133,6 +140,27 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 */
 	public function should_push(): bool {
 		return $this->is_ready_for_syncing();
+	}
+
+	/**
+	 * Whether the WordPress.com (Jetpack) connection has a connected owner user.
+	 *
+	 * Every request to Google goes through the Connect Server proxy signed with the
+	 * site's blog token, and the proxy resolves the acting user from the connection
+	 * owner. A connection without an owner is therefore rejected with 401 on every
+	 * request, so syncing is gated on the owner here, before any job is scheduled or
+	 * request is sent. This is a local check: it cannot detect a token that
+	 * WordPress.com has revoked remotely.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	public function is_jetpack_owner_connected(): bool {
+		/** @var Manager $manager */
+		$manager = $this->container->get( Manager::class );
+
+		return $manager->is_connected() && $manager->has_connected_owner();
 	}
 
 	/**

--- a/src/Notes/ReconnectWordPress.php
+++ b/src/Notes/ReconnectWordPress.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 
 defined( 'ABSPATH' ) || exit;
@@ -77,6 +78,7 @@ class ReconnectWordPress extends AbstractNote implements MerchantCenterAwareInte
 	/**
 	 * Checks if a note can and should be added.
 	 *
+	 * - Checks if the WordPress.com connection has no owner (syncing is paused).
 	 * - Triggers a status check if not already disconnected.
 	 * - Checks if Jetpack is disconnected.
 	 *
@@ -85,6 +87,16 @@ class ReconnectWordPress extends AbstractNote implements MerchantCenterAwareInte
 	public function should_be_added(): bool {
 		if ( $this->has_been_added() || ! $this->merchant_center->is_setup_complete() ) {
 			return false;
+		}
+
+		// A missing owner is known locally, so the note is added without a request to the server.
+		// The connected option is cleared as well, so the note follows the same lifecycle as after
+		// a rejected token: no second copy on the next 401, and removal when an accepted response
+		// flips the state back to connected.
+		if ( ! $this->merchant_center->is_jetpack_owner_connected() ) {
+			$this->options->update( OptionsInterface::JETPACK_CONNECTED, false );
+
+			return true;
 		}
 
 		$this->maybe_check_status();

--- a/src/Notes/ReconnectWordPress.php
+++ b/src/Notes/ReconnectWordPress.php
@@ -95,7 +95,10 @@ class ReconnectWordPress extends AbstractNote implements MerchantCenterAwareInte
 		// a rejected token: no second copy on the next 401, and removal when an accepted response
 		// flips the state back to connected.
 		if ( ! $this->merchant_center->is_jetpack_owner_connected() ) {
-			$this->options->update( OptionsInterface::JETPACK_CONNECTED, false );
+			// Guard the write like set_jetpack_connected() does, so a daily no-owner run is a no-op.
+			if ( false !== boolval( $this->options->get( OptionsInterface::JETPACK_CONNECTED ) ) ) {
+				$this->options->update( OptionsInterface::JETPACK_CONNECTED, false );
+			}
 
 			return true;
 		}

--- a/src/Notes/ReconnectWordPress.php
+++ b/src/Notes/ReconnectWordPress.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwa
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Exception;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -101,7 +102,8 @@ class ReconnectWordPress extends AbstractNote implements MerchantCenterAwareInte
 
 		$this->maybe_check_status();
 
-		return ! $this->is_jetpack_connected();
+		// The status check itself may have added the note through the 401 handling.
+		return ! $this->is_jetpack_connected() && ! $this->has_been_added();
 	}
 
 	/**
@@ -116,7 +118,7 @@ class ReconnectWordPress extends AbstractNote implements MerchantCenterAwareInte
 		try {
 			$this->connection->get_status();
 		} catch ( Exception $e ) {
-			return;
+			do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
 		}
 	}
 }

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -35,6 +35,7 @@ interface OptionsInterface {
 	public const INSTALL_TIMESTAMP                         = 'install_timestamp';
 	public const INSTALL_VERSION                           = 'install_version';
 	public const JETPACK_CONNECTED                         = 'jetpack_connected';
+	public const JETPACK_AUTH_FAILED_AT                    = 'jetpack_auth_failed_at';
 	public const MAPI_DATA_SOURCES                         = 'mapi_data_sources';
 	public const MC_SETUP_COMPLETED_AT                     = 'mc_setup_completed_at';
 	public const MERCHANT_ACCOUNT_STATE                    = 'merchant_account_state';
@@ -85,6 +86,7 @@ interface OptionsInterface {
 		self::INSTALL_TIMESTAMP                         => true,
 		self::INSTALL_VERSION                           => true,
 		self::JETPACK_CONNECTED                         => true,
+		self::JETPACK_AUTH_FAILED_AT                    => true,
 		self::MAPI_DATA_SOURCES                         => true,
 		self::MC_SETUP_COMPLETED_AT                     => true,
 		self::MERCHANT_ACCOUNT_STATE                    => true,

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -134,6 +134,18 @@ class ClientTest extends UnitTest {
 	}
 
 	/**
+	 * Confirm that an accepted response does not rewrite an unchanged connected state.
+	 */
+	public function test_handle_response_status_regular_response_skips_unchanged_state() {
+		$this->options->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( true );
+		$this->options->expects( $this->never() )->method( 'update' );
+		$this->note->expects( $this->never() )->method( 'delete' );
+
+		$client = $this->mock_client_with_handler( 'handle_response_status', [ new Response( 200, [], 'response' ) ] );
+		$client->request( 'GET', 'https://testing.local' );
+	}
+
+	/**
 	 * Confirm that once the Jetpack token was rejected in this request, later requests are not sent.
 	 */
 	public function test_short_circuit_after_auth_failure_rejects_without_sending() {

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -105,14 +105,14 @@ class ClientTest extends UnitTest {
 	}
 
 	/**
-	 * Confirm that the error handler does not intervene for regular responses.
+	 * Confirm that the response status handler does not intervene for regular responses.
 	 */
-	public function test_error_handler_regular_response() {
+	public function test_handle_response_status_regular_response() {
 		$mocked_responses = [
 			new Response( 200, [], 'response' ),
 		];
 
-		$client   = $this->mock_client_with_handler( 'error_handler', $mocked_responses );
+		$client   = $this->mock_client_with_handler( 'handle_response_status', $mocked_responses );
 		$response = $client->request( 'GET', 'https://testing.local' );
 
 		$this->assertEquals( 200, $response->getStatusCode() );
@@ -122,14 +122,14 @@ class ClientTest extends UnitTest {
 	/**
 	 * Confirm that an accepted response is what marks Jetpack as connected and ends a sync pause.
 	 */
-	public function test_error_handler_regular_response_marks_jetpack_connected() {
+	public function test_handle_response_status_regular_response_marks_jetpack_connected() {
 		// Set Jetpack as previously disconnected to trigger removal of note.
 		$this->options->expects( $this->once() )->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( false );
 		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::JETPACK_CONNECTED, true );
 		$this->note->expects( $this->once() )->method( 'delete' );
 		$this->circuit_breaker->expects( $this->once() )->method( 'reset' );
 
-		$client = $this->mock_client_with_handler( 'error_handler', [ new Response( 200, [], 'response' ) ] );
+		$client = $this->mock_client_with_handler( 'handle_response_status', [ new Response( 200, [], 'response' ) ] );
 		$client->request( 'GET', 'https://testing.local' );
 	}
 
@@ -195,10 +195,10 @@ class ClientTest extends UnitTest {
 		$client->request( 'GET', 'https://testing.local' );
 	}
 
-	public function test_retry_runs_before_the_error_handler_on_the_full_stack() {
-		// Real stack order: error_handler pushed first (outermost), retry last (innermost). This
+	public function test_retry_runs_before_the_response_status_handler_on_the_full_stack() {
+		// Real stack order: handle_response_status pushed first (outermost), retry last (innermost). This
 		// POST is one is_retryable_request() rejects, so a 429 can only retry via the response
-		// branch, proving retry sees the response before error_handler throws.
+		// branch, proving retry sees the response before handle_response_status throws.
 		$handler_stack = HandlerStack::create(
 			new MockHandler(
 				[
@@ -208,7 +208,7 @@ class ClientTest extends UnitTest {
 			)
 		);
 		$handler_stack->remove( 'http_errors' );
-		$handler_stack->push( $this->invoke_handler( 'error_handler' ), 'http_errors' );
+		$handler_stack->push( $this->invoke_handler( 'handle_response_status' ), 'http_errors' );
 		$handler_stack->push( $this->invoke_handler( 'retry_on_transient_error' ), 'retry_on_transient_error' );
 
 		$response = ( new Client( [ 'handler' => $handler_stack ] ) )
@@ -324,9 +324,9 @@ class ClientTest extends UnitTest {
 	}
 
 	/**
-	 * Confirm that the error handler throws an error to reconnect Jetpack when the header is not included.
+	 * Confirm that the response status handler throws an error to reconnect Jetpack when the header is not included.
 	 */
-	public function test_error_handler_reconnect_jetpack() {
+	public function test_handle_response_status_reconnect_jetpack() {
 		$mocked_responses = [
 			new Response( 401, [ 'www-authenticate' => 'X_JP_Auth' ], 'error' ),
 		];
@@ -346,14 +346,14 @@ class ClientTest extends UnitTest {
 		$this->expectException( AccountReconnect::class );
 		$this->expectExceptionMessage( AccountReconnect::jetpack_disconnected()->getMessage() );
 
-		$client   = $this->mock_client_with_handler( 'error_handler', $mocked_responses );
+		$client   = $this->mock_client_with_handler( 'handle_response_status', $mocked_responses );
 		$response = $client->request( 'GET', 'https://testing.local' );
 	}
 
 	/**
-	 * Confirm that the error handler throws an error to reconnect Google with a permission denied status.
+	 * Confirm that the response status handler throws an error to reconnect Google with a permission denied status.
 	 */
-	public function test_error_handler_reconnect_google() {
+	public function test_handle_response_status_reconnect_google() {
 		$mocked_responses = [
 			new Response( 401, [], 'error' ),
 		];
@@ -364,14 +364,14 @@ class ClientTest extends UnitTest {
 		$this->expectException( AccountReconnect::class );
 		$this->expectExceptionMessage( AccountReconnect::google_disconnected()->getMessage() );
 
-		$client   = $this->mock_client_with_handler( 'error_handler', $mocked_responses );
+		$client   = $this->mock_client_with_handler( 'handle_response_status', $mocked_responses );
 		$response = $client->request( 'GET', 'https://testing.local' );
 	}
 
 	/**
 	 * Confirm that a request to listAccessibleCustomers does not return a redirect error.
 	 */
-	public function test_error_handler_list_accessible_customers() {
+	public function test_handle_response_status_list_accessible_customers() {
 		$mocked_responses = [
 			new Response( 401, [], 'error' ),
 		];
@@ -379,14 +379,14 @@ class ClientTest extends UnitTest {
 		$this->expectException( RequestException::class );
 		$this->expectExceptionMessage( 'error' );
 
-		$client   = $this->mock_client_with_handler( 'error_handler', $mocked_responses );
+		$client   = $this->mock_client_with_handler( 'handle_response_status', $mocked_responses );
 		$response = $client->request( 'GET', 'https://testing.local/google/google-ads/customers:listAccessibleCustomers' );
 	}
 
 	/**
-	 * Confirm that the error handler throws a generic error when the status code is higher than 400 except a 401.
+	 * Confirm that the response status handler throws a generic error when the status code is higher than 400 except a 401.
 	 */
-	public function test_error_handler_generic_error_response() {
+	public function test_handle_response_status_generic_error_response() {
 		$mocked_responses = [
 			new Response( 404, [], 'not found' ),
 		];
@@ -394,7 +394,7 @@ class ClientTest extends UnitTest {
 		$this->expectException( RequestException::class );
 		$this->expectExceptionMessage( 'not found' );
 
-		$client   = $this->mock_client_with_handler( 'error_handler', $mocked_responses );
+		$client   = $this->mock_client_with_handler( 'handle_response_status', $mocked_responses );
 		$response = $client->request( 'GET', 'https://testing.local' );
 	}
 

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API;
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Connection\Tokens;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\JetpackAuthCircuitBreaker;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\GoogleServiceProvider;
@@ -32,6 +33,9 @@ defined( 'ABSPATH' ) || exit;
 class ClientTest extends UnitTest {
 	use PluginHelper;
 
+	/** @var MockObject|JetpackAuthCircuitBreaker $circuit_breaker */
+	protected $circuit_breaker;
+
 	/** @var MockObject|Manager $manager */
 	protected $manager;
 
@@ -57,11 +61,13 @@ class ClientTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->manager = $this->createMock( Manager::class );
-		$this->note    = $this->createMock( ReconnectWordPress::class );
-		$this->options = $this->createMock( OptionsInterface::class );
+		$this->circuit_breaker = $this->createMock( JetpackAuthCircuitBreaker::class );
+		$this->manager         = $this->createMock( Manager::class );
+		$this->note            = $this->createMock( ReconnectWordPress::class );
+		$this->options         = $this->createMock( OptionsInterface::class );
 
 		$this->container = new Container();
+		$this->container->addShared( JetpackAuthCircuitBreaker::class, $this->circuit_breaker );
 		$this->container->addShared( Manager::class, $this->manager );
 		$this->container->addShared( ReconnectWordPress::class, $this->note );
 		$this->container->addShared( OptionsInterface::class, $this->options );
@@ -80,6 +86,7 @@ class ClientTest extends UnitTest {
 		// Get string representation of the handler stack (fetches handlers from main container).
 		$handlers = (string) woogle_get_container()->get( Client::class )->getConfig( 'handler' );
 
+		$this->assertStringContainsString( 'auth_failure_short_circuit', $handlers );
 		$this->assertStringContainsString( 'http_errors', $handlers );
 		$this->assertStringContainsString( 'auth_header', $handlers );
 		$this->assertStringContainsString( 'plugin_version_header', $handlers );
@@ -110,6 +117,54 @@ class ClientTest extends UnitTest {
 
 		$this->assertEquals( 200, $response->getStatusCode() );
 		$this->assertEquals( 'response', $response->getBody() );
+	}
+
+	/**
+	 * Confirm that an accepted response is what marks Jetpack as connected and ends a sync pause.
+	 */
+	public function test_error_handler_regular_response_marks_jetpack_connected() {
+		// Set Jetpack as previously disconnected to trigger removal of note.
+		$this->options->expects( $this->once() )->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( false );
+		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::JETPACK_CONNECTED, true );
+		$this->note->expects( $this->once() )->method( 'delete' );
+		$this->circuit_breaker->expects( $this->once() )->method( 'reset' );
+
+		$client = $this->mock_client_with_handler( 'error_handler', [ new Response( 200, [], 'response' ) ] );
+		$client->request( 'GET', 'https://testing.local' );
+	}
+
+	/**
+	 * Confirm that once the Jetpack token was rejected in this request, later requests are not sent.
+	 */
+	public function test_short_circuit_after_auth_failure_rejects_without_sending() {
+		$this->circuit_breaker->method( 'was_tripped_in_request' )->willReturn( true );
+
+		$mock     = new MockHandler( [ new Response( 200, [], 'never sent' ) ] );
+		$handlers = HandlerStack::create( $mock );
+		$handlers->push( $this->invoke_handler( 'short_circuit_after_auth_failure' ) );
+		$client = new Client( [ 'handler' => $handlers ] );
+
+		try {
+			$client->request( 'GET', 'https://testing.local' );
+			$this->fail( 'Expected AccountReconnect to be thrown.' );
+		} catch ( AccountReconnect $exception ) {
+			$this->assertEquals( AccountReconnect::jetpack_disconnected()->getMessage(), $exception->getMessage() );
+		}
+
+		// The mocked response is still queued: nothing reached the transport.
+		$this->assertSame( 1, $mock->count() );
+	}
+
+	/**
+	 * Confirm that the short circuit is transparent while no failure was recorded.
+	 */
+	public function test_short_circuit_after_auth_failure_passes_requests_through() {
+		$this->circuit_breaker->method( 'was_tripped_in_request' )->willReturn( false );
+
+		$client   = $this->mock_client_with_handler( 'short_circuit_after_auth_failure', [ new Response( 200, [], 'sent' ) ] );
+		$response = $client->request( 'GET', 'https://testing.local' );
+
+		$this->assertEquals( 'sent', $response->getBody() );
 	}
 
 	public function test_retry_on_transient_error_retries_transient_status() {
@@ -285,6 +340,9 @@ class ClientTest extends UnitTest {
 		// Expect ReconnectWordPress note to be triggered.
 		$this->note->expects( $this->once() )->method( 'get_entry' );
 
+		// Expect syncing to be paused.
+		$this->circuit_breaker->expects( $this->once() )->method( 'trip' );
+
 		$this->expectException( AccountReconnect::class );
 		$this->expectExceptionMessage( AccountReconnect::jetpack_disconnected()->getMessage() );
 
@@ -356,11 +414,9 @@ class ClientTest extends UnitTest {
 		);
 		$this->manager->expects( $this->once() )->method( 'get_tokens' )->willReturn( $tokens );
 
-		// Set Jetpack as previously disconnected to trigger removal of note.
-		$this->options->expects( $this->once() )->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( false );
-
-		// Expect ReconnectWordPress note to be removed.
-		$this->note->expects( $this->once() )->method( 'delete' );
+		// Having a token locally proves nothing about its validity: the connected state is left alone.
+		$this->options->expects( $this->never() )->method( 'update' );
+		$this->note->expects( $this->never() )->method( 'delete' );
 
 		$this->invoke_handler( 'add_auth_header' )(
 			function ( $request, $options ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed

--- a/tests/Unit/API/Google/JetpackAuthCircuitBreakerTest.php
+++ b/tests/Unit/API/Google/JetpackAuthCircuitBreakerTest.php
@@ -1,0 +1,111 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\JetpackAuthCircuitBreaker;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class JetpackAuthCircuitBreakerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ */
+class JetpackAuthCircuitBreakerTest extends UnitTest {
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var JetpackAuthCircuitBreaker $breaker */
+	protected $breaker;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->breaker = new JetpackAuthCircuitBreaker();
+		$this->breaker->set_options_object( $this->options );
+	}
+
+	public function test_trip_records_the_failure_and_short_circuits_the_request() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT, 0 )
+			->willReturn( 0 );
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT, $this->greaterThan( 0 ) );
+
+		$this->assertFalse( $this->breaker->was_tripped_in_request() );
+
+		$this->breaker->trip();
+
+		$this->assertTrue( $this->breaker->was_tripped_in_request() );
+	}
+
+	public function test_trip_does_not_extend_an_open_window() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT, 0 )
+			->willReturn( time() - 60 );
+		$this->options->expects( $this->never() )->method( 'update' );
+
+		$this->breaker->trip();
+
+		$this->assertTrue( $this->breaker->was_tripped_in_request() );
+	}
+
+	public function test_is_open_within_the_pause_window() {
+		$failed_at = time() - 60;
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT, 0 )
+			->willReturn( $failed_at );
+
+		$this->assertTrue( $this->breaker->is_open() );
+		$this->assertSame( $failed_at + HOUR_IN_SECONDS, $this->breaker->get_retry_time() );
+	}
+
+	public function test_is_not_open_after_the_pause_window() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT, 0 )
+			->willReturn( time() - HOUR_IN_SECONDS - 1 );
+
+		$this->assertFalse( $this->breaker->is_open() );
+	}
+
+	public function test_is_not_open_without_a_recorded_failure() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT, 0 )
+			->willReturn( 0 );
+
+		$this->assertFalse( $this->breaker->is_open() );
+		$this->assertSame( 0, $this->breaker->get_retry_time() );
+	}
+
+	public function test_reset_clears_the_failure() {
+		$this->options->method( 'get' )
+			->willReturn( time() );
+		$this->options->expects( $this->once() )
+			->method( 'delete' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT );
+
+		$this->breaker->trip();
+		$this->breaker->reset();
+
+		$this->assertFalse( $this->breaker->was_tripped_in_request() );
+	}
+
+	public function test_reset_without_a_failure_does_not_write() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT )
+			->willReturn( null );
+		$this->options->expects( $this->never() )->method( 'delete' );
+
+		$this->breaker->reset();
+	}
+}

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
 
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
@@ -47,6 +48,9 @@ class MerchantCenterServiceTest extends UnitTest {
 
 	/** @var MockObject|GoogleHelper $google_helper */
 	protected $google_helper;
+
+	/** @var MockObject|Manager $manager */
+	protected $manager;
 
 	/** @var MockObject|Merchant $merchant */
 	protected $merchant;
@@ -98,6 +102,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->ads_service            = $this->createMock( AdsService::class );
 		$this->contact_information    = $this->createMock( ContactInformation::class );
 		$this->google_helper          = $this->createMock( GoogleHelper::class );
+		$this->manager                = $this->createMock( Manager::class );
 		$this->merchant               = $this->createMock( Merchant::class );
 		$this->merchant_account_state = $this->createMock( MerchantAccountState::class );
 		$this->merchant_statuses      = $this->createMock( MerchantStatuses::class );
@@ -115,6 +120,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->container->addShared( AdsService::class, $this->ads_service );
 		$this->container->addShared( ContactInformation::class, $this->contact_information );
 		$this->container->addShared( GoogleHelper::class, $this->google_helper );
+		$this->container->addShared( Manager::class, $this->manager );
 		$this->container->addShared( Merchant::class, $this->merchant );
 		$this->container->addShared( MerchantAccountState::class, $this->merchant_account_state );
 		$this->container->addShared( MerchantStatuses::class, $this->merchant_statuses );
@@ -129,6 +135,17 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->mc_service = new MerchantCenterService();
 		$this->mc_service->set_container( $this->container );
 		$this->mc_service->set_options_object( $this->options );
+	}
+
+	/**
+	 * Stub the Jetpack connection state.
+	 *
+	 * @param bool $connected Whether the site has a blog token.
+	 * @param bool $has_owner Whether the connection has an owner user.
+	 */
+	protected function mock_jetpack_connection( bool $connected, bool $has_owner ): void {
+		$this->manager->method( 'is_connected' )->willReturn( $connected );
+		$this->manager->method( 'has_connected_owner' )->willReturn( $has_owner );
 	}
 
 	public function test_is_setup_complete() {
@@ -192,6 +209,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_is_ready_for_syncing() {
+		$this->mock_jetpack_connection( true, true );
 		$hash = md5( site_url() );
 		$this->merchant->method( 'get_claimed_url_hash' )->willReturn( $hash );
 		$this->options->method( 'get' )
@@ -208,6 +226,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_is_ready_for_syncing_not_setup() {
+		$this->mock_jetpack_connection( true, true );
 		$hash = md5( site_url() );
 		$this->merchant->method( 'get_claimed_url_hash' )->willReturn( $hash );
 		$this->options->method( 'get' )
@@ -228,6 +247,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_is_ready_for_syncing_filter_override() {
+		$this->mock_jetpack_connection( true, true );
 		$hash = md5( 'https://staging-site.test' );
 		$this->merchant->method( 'get_claimed_url_hash' )->willReturn( $hash );
 		$this->options->method( 'get' )
@@ -246,6 +266,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_is_ready_for_syncing_fetch_from_transient() {
+		$this->mock_jetpack_connection( true, true );
 		$hash = md5( site_url() );
 		$this->merchant->expects( $this->once() )
 			->method( 'get_claimed_url_hash' )
@@ -281,6 +302,50 @@ class MerchantCenterServiceTest extends UnitTest {
 		// Call twice to ensure we are getting the value from the transient the second time.
 		$this->assertTrue( $this->mc_service->is_ready_for_syncing() );
 		$this->assertTrue( $this->mc_service->is_ready_for_syncing() );
+	}
+
+	public function test_is_ready_for_syncing_without_jetpack_owner() {
+		$this->mock_jetpack_connection( true, false );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::GOOGLE_CONNECTED, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				self::TEST_SETUP_COMPLETED
+			);
+
+		// The claimed URL must not be checked once the owner check fails.
+		$this->merchant->expects( $this->never() )->method( 'get_claimed_url_hash' );
+		$this->transients->expects( $this->never() )->method( 'get' );
+
+		$this->assertFalse( $this->mc_service->is_ready_for_syncing() );
+	}
+
+	public function test_is_ready_for_syncing_without_jetpack_connection() {
+		$this->mock_jetpack_connection( false, false );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::GOOGLE_CONNECTED, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				self::TEST_SETUP_COMPLETED
+			);
+
+		$this->assertFalse( $this->mc_service->is_ready_for_syncing() );
+	}
+
+	public function test_is_jetpack_owner_connected() {
+		$this->mock_jetpack_connection( true, true );
+		$this->assertTrue( $this->mc_service->is_jetpack_owner_connected() );
+	}
+
+	public function test_is_jetpack_owner_connected_without_owner() {
+		$this->mock_jetpack_connection( true, false );
+		$this->assertFalse( $this->mc_service->is_jetpack_owner_connected() );
 	}
 
 	public function test_is_store_country_supported() {

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\JetpackAuthCircuitBreaker;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
@@ -48,6 +49,9 @@ class MerchantCenterServiceTest extends UnitTest {
 
 	/** @var MockObject|GoogleHelper $google_helper */
 	protected $google_helper;
+
+	/** @var MockObject|JetpackAuthCircuitBreaker $circuit_breaker */
+	protected $circuit_breaker;
 
 	/** @var MockObject|Manager $manager */
 	protected $manager;
@@ -102,6 +106,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->ads_service            = $this->createMock( AdsService::class );
 		$this->contact_information    = $this->createMock( ContactInformation::class );
 		$this->google_helper          = $this->createMock( GoogleHelper::class );
+		$this->circuit_breaker        = $this->createMock( JetpackAuthCircuitBreaker::class );
 		$this->manager                = $this->createMock( Manager::class );
 		$this->merchant               = $this->createMock( Merchant::class );
 		$this->merchant_account_state = $this->createMock( MerchantAccountState::class );
@@ -120,6 +125,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->container->addShared( AdsService::class, $this->ads_service );
 		$this->container->addShared( ContactInformation::class, $this->contact_information );
 		$this->container->addShared( GoogleHelper::class, $this->google_helper );
+		$this->container->addShared( JetpackAuthCircuitBreaker::class, $this->circuit_breaker );
 		$this->container->addShared( Manager::class, $this->manager );
 		$this->container->addShared( Merchant::class, $this->merchant );
 		$this->container->addShared( MerchantAccountState::class, $this->merchant_account_state );
@@ -140,12 +146,14 @@ class MerchantCenterServiceTest extends UnitTest {
 	/**
 	 * Stub the Jetpack connection state.
 	 *
-	 * @param bool $connected Whether the site has a blog token.
-	 * @param bool $has_owner Whether the connection has an owner user.
+	 * @param bool $connected   Whether the site has a blog token.
+	 * @param bool $has_owner   Whether the connection has an owner user.
+	 * @param bool $auth_paused Whether syncing is paused after an authentication failure.
 	 */
-	protected function mock_jetpack_connection( bool $connected, bool $has_owner ): void {
+	protected function mock_jetpack_connection( bool $connected, bool $has_owner, bool $auth_paused = false ): void {
 		$this->manager->method( 'is_connected' )->willReturn( $connected );
 		$this->manager->method( 'has_connected_owner' )->willReturn( $has_owner );
+		$this->circuit_breaker->method( 'is_open' )->willReturn( $auth_paused );
 	}
 
 	public function test_is_setup_complete() {
@@ -334,6 +342,24 @@ class MerchantCenterServiceTest extends UnitTest {
 				true,
 				self::TEST_SETUP_COMPLETED
 			);
+
+		$this->assertFalse( $this->mc_service->is_ready_for_syncing() );
+	}
+
+	public function test_is_ready_for_syncing_while_jetpack_auth_paused() {
+		$this->mock_jetpack_connection( true, true, true );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::GOOGLE_CONNECTED, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				self::TEST_SETUP_COMPLETED
+			);
+
+		$this->merchant->expects( $this->never() )->method( 'get_claimed_url_hash' );
+		$this->transients->expects( $this->never() )->method( 'get' );
 
 		$this->assertFalse( $this->mc_service->is_ready_for_syncing() );
 	}

--- a/tests/Unit/Notes/ReconnectWordPressTest.php
+++ b/tests/Unit/Notes/ReconnectWordPressTest.php
@@ -70,12 +70,14 @@ class ReconnectWordPressTest extends UnitTest {
 	}
 
 	public function test_should_add_not_added_and_mc_setup_complete() {
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( true );
 		$this->merchant_center->method( 'is_setup_complete' )->willReturn( true );
 
 		$this->assertTrue( $this->note->should_be_added() );
 	}
 
 	public function test_should_add_connected() {
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( true );
 		$this->options->expects( $this->exactly( 2 ) )
 			->method( 'get' )
 			->with( OptionsInterface::JETPACK_CONNECTED )
@@ -87,6 +89,7 @@ class ReconnectWordPressTest extends UnitTest {
 	}
 
 	public function test_should_add_already_disconnected() {
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( true );
 		$this->options->expects( $this->exactly( 2 ) )
 			->method( 'get' )
 			->with( OptionsInterface::JETPACK_CONNECTED )
@@ -100,7 +103,19 @@ class ReconnectWordPressTest extends UnitTest {
 		$this->assertTrue( $this->note->should_be_added() );
 	}
 
+	public function test_should_add_without_jetpack_owner() {
+		$this->merchant_center->method( 'is_setup_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( false );
+
+		$this->options->expects( $this->never() )->method( 'get' );
+		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::JETPACK_CONNECTED, false );
+		$this->connection->expects( $this->never() )->method( 'get_status' );
+
+		$this->assertTrue( $this->note->should_be_added() );
+	}
+
 	public function test_should_add_disconnected_after_status_check() {
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( true );
 		$this->options->expects( $this->exactly( 2 ) )
 			->method( 'get' )
 			->with( OptionsInterface::JETPACK_CONNECTED )

--- a/tests/Unit/Notes/ReconnectWordPressTest.php
+++ b/tests/Unit/Notes/ReconnectWordPressTest.php
@@ -108,8 +108,21 @@ class ReconnectWordPressTest extends UnitTest {
 		$this->merchant_center->method( 'is_setup_complete' )->willReturn( true );
 		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( false );
 
-		$this->options->expects( $this->never() )->method( 'get' );
+		// Connected state still truthy, so it is cleared once.
+		$this->options->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( true );
 		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::JETPACK_CONNECTED, false );
+		$this->connection->expects( $this->never() )->method( 'get_status' );
+
+		$this->assertTrue( $this->note->should_be_added() );
+	}
+
+	public function test_should_add_without_jetpack_owner_skips_redundant_write() {
+		$this->merchant_center->method( 'is_setup_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( false );
+
+		// Already disconnected, so no wp_options write is issued.
+		$this->options->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( false );
+		$this->options->expects( $this->never() )->method( 'update' );
 		$this->connection->expects( $this->never() )->method( 'get_status' );
 
 		$this->assertTrue( $this->note->should_be_added() );

--- a/tests/Unit/Notes/ReconnectWordPressTest.php
+++ b/tests/Unit/Notes/ReconnectWordPressTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notes;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ReconnectWordPress;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -112,6 +113,26 @@ class ReconnectWordPressTest extends UnitTest {
 		$this->connection->expects( $this->never() )->method( 'get_status' );
 
 		$this->assertTrue( $this->note->should_be_added() );
+	}
+
+	public function test_should_not_add_when_the_status_check_already_added_it() {
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( true );
+		$this->merchant_center->method( 'is_setup_complete' )->willReturn( true );
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_CONNECTED )
+			->will( $this->onConsecutiveCalls( true, false ) );
+
+		// A rejected token adds the note from the 401 handling before the exception surfaces.
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturnCallback(
+				function () {
+					$this->note->get_entry()->save();
+					throw AccountReconnect::jetpack_disconnected();
+				}
+			);
+
+		$this->assertFalse( $this->note->should_be_added() );
 	}
 
 	public function test_should_add_disconnected_after_status_check() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Every request to Google goes through the Connect Server proxy, signed with the site's Jetpack blog token, and the proxy resolves the acting user from the connection owner. A site whose connection has no owner user, or whose token WordPress.com no longer accepts, is rejected with a 401 on every request. Nothing in the sync pipeline reacted to either state: jobs kept being scheduled and kept sending requests that could never succeed, one per product, on every trigger, with no signal to the merchant.

This PR short-circuits the pipeline in both cases through the gate every sync path already consults, `MerchantCenterService::is_ready_for_syncing()`:

- **Local state:** the new `is_jetpack_owner_connected()` (`Manager::is_connected() && has_connected_owner()`) is now required. No requests involved, and the `ReconnectWordPress` inbox note is added from this state without a server round trip.
- **Server-reported state:** a 401 with the `X_JP_Auth` scheme trips the new `JetpackAuthCircuitBreaker`, which pauses syncing for a fixed one-hour window (stored in the `jetpack_auth_failed_at` option). Any accepted response ends the pause and is now the only thing that marks Jetpack as connected. A Guzzle middleware also rejects every further request in the same PHP request after such a 401, so a per-product loop stops after the first failure.
- **Two small fixes found on the way** (separate commits): the note's status-check `catch` never matched because `Exception` was not imported, and `set_jetpack_connected()` issued a `wp_options` UPDATE on every call even when the state was unchanged.

The other 401 flavour (without the scheme) already stops syncing through the `google_connected` option and is unchanged. Syncing resumes on the first accepted response or on the first trigger after the window; a batched sync interrupted by the pause is picked up by the next trigger, as was already the case for a failed batch.

### Detailed test instructions:

Prerequisites: a site connected to WordPress.com with an owner and onboarded to Merchant Center, with at least one product set to sync and show.

**Part 1: missing owner**

1. Confirm the baseline. Expect `true` twice.
   ```
   wp eval '$c = woogle_get_container(); $mc = $c->get( \Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService::class ); var_dump( $mc->is_jetpack_owner_connected(), $mc->is_ready_for_syncing() );'
   ```
1. Save a product and confirm a `gla/jobs/update_products/process_item` action appears under WooCommerce > Status > Scheduled Actions.
1. Remove the connection owner locally, keeping a backup. This is the site-only state the gate targets; on a site running the full Jetpack plugin, disconnecting the owner from their user profile reaches the same state.
   ```
   wp eval '$jo = get_option( "jetpack_options" ); update_option( "gla_test_master_user_backup", $jo["master_user"] ); unset( $jo["master_user"] ); update_option( "jetpack_options", $jo );'
   ```
1. Repeat step 1 (expect `false` twice), then save a product and confirm no new action is created.
1. Run the notes check and confirm the "Re-connect your store to Google for WooCommerce" inbox note appears.
   ```
   wp eval 'woogle_get_container()->get( \Automattic\WooCommerce\GoogleListingsAndAds\Notes\NoteInitializer::class )->add_notes();'
   ```
1. Restore the owner and confirm steps 1 and 2 pass again.
   ```
   wp eval '$jo = get_option( "jetpack_options" ); $jo["master_user"] = (int) get_option( "gla_test_master_user_backup" ); update_option( "jetpack_options", $jo ); delete_option( "gla_test_master_user_backup" );'
   ```

**Part 2: rejected token**

1. Break the site's blog token so the Connect Server rejects every request with the real 401, keeping a backup. While the token is broken, other Jetpack features on the site fail too, so use a test site.
   ```
   wp eval '$p = get_option( "jetpack_private_options" ); update_option( "gla_test_blog_token_backup", $p["blog_token"] ); $p["blog_token"] = "broken.broken"; update_option( "jetpack_private_options", $p );'
   ```
1. Trigger two requests in one process and inspect the state. Only the first call reaches the server; the second fails in about a millisecond without sending anything.
   ```
   wp eval '$c = woogle_get_container(); $conn = $c->get( \Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection::class ); foreach ( [ 1, 2 ] as $i ) { try { $conn->get_status(); } catch ( \Throwable $e ) { echo "call $i: ", $e->getMessage(), "\n"; } } $o = $c->get( \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::class ); var_dump( $o->get( "jetpack_connected" ), $o->get( "jetpack_auth_failed_at" ), $c->get( \Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService::class )->is_ready_for_syncing() );'
   ```
   Expected output:
   ```
   call 1: Please reconnect your Jetpack account.
   call 2: Please reconnect your Jetpack account.
   bool(false)
   int(<timestamp>)
   bool(false)
   ```
1. Save a product (no new action) and run the notes check from step 5 of Part 1 (note present).
1. Restore the token and repeat step 2: both calls succeed, `jetpack_connected` is `true`, `jetpack_auth_failed_at` is cleared, and `is_ready_for_syncing()` is `true`.
   ```
   wp eval '$p = get_option( "jetpack_private_options" ); $p["blog_token"] = get_option( "gla_test_blog_token_backup" ); update_option( "jetpack_private_options", $p ); delete_option( "gla_test_blog_token_backup" );'
   ```

### Changelog entry

> Update - Pause product and coupon sync, and show a reconnect notice when the WordPress.com connection has no owner user or the Connect Server rejects the site's token, instead of sending requests that are always rejected.
