### PR TITLE
Stop swallowing an authentication failure per product during sync

### DIFF
--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiExcep
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\GoogleListingsAndAdsException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
@@ -255,6 +256,8 @@ class BatchProductHelper implements Service {
 	 * @param WC_Product[] $products
 	 *
 	 * @return array<int, array{product: WC_Product, country: string, input: ProductInput, hash: string}>
+	 *
+	 * @throws AccountReconnect When the Connect Server rejects the Jetpack token while resolving a data source.
 	 */
 	public function generate_mapi_update_entries( array $products ): array {
 		$entries       = [];
@@ -390,6 +393,11 @@ class BatchProductHelper implements Service {
 				if ( ! empty( $product_entries ) ) {
 					array_push( $entries, ...$product_entries );
 				}
+			} catch ( AccountReconnect $exception ) {
+				// An authentication failure is account-wide, not specific to this product. Rethrow to
+				// fail the run loudly instead of silently skipping every product and re-attempting it
+				// against the same rejected token.
+				throw $exception;
 			} catch ( GoogleListingsAndAdsException $exception ) {
 				do_action(
 					'woocommerce_gla_error',

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\ConnectException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\RequestException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
@@ -101,7 +102,13 @@ class ProductSyncer implements Service {
 	public function update( array $products ): BatchProductResponse {
 		$this->validate_merchant_center_setup();
 
-		$entries = $this->batch_helper->generate_mapi_update_entries( $products );
+		try {
+			$entries = $this->batch_helper->generate_mapi_update_entries( $products );
+		} catch ( AccountReconnect $exception ) {
+			// Surface an account-wide auth failure as a ProductSyncerException, like the other sync
+			// paths, so update()'s contract holds and callers catching that type still handle it.
+			throw new ProductSyncerException( $exception->getMessage(), 0, $exception );
+		}
 
 		return $this->update_mapi_entries( $entries );
 	}

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -354,7 +354,13 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 	public function test_generate_mapi_update_entries_rethrows_account_reconnect() {
 		$products = $this->create_and_return_supported_test_products();
 
-		$this->market_service->method( 'get_primary_market' )->willReturn( [ 'country' => null, 'feed_label' => null, 'language' => 'en' ] );
+		$this->market_service->method( 'get_primary_market' )->willReturn(
+			[
+				'country'    => null,
+				'feed_label' => null,
+				'language'   => 'en',
+			]
+		);
 		$this->market_service->method( 'get_main_feed_label' )->willReturn( 'US' );
 		$this->market_service->method( 'get_all_countries' )->willReturn( [ 'US' ] );
 		$this->validator->method( 'validate' )->willReturn( [] );
@@ -371,7 +377,13 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 	public function test_generate_mapi_update_entries_skips_product_on_other_exception() {
 		$products = $this->create_and_return_supported_test_products();
 
-		$this->market_service->method( 'get_primary_market' )->willReturn( [ 'country' => null, 'feed_label' => null, 'language' => 'en' ] );
+		$this->market_service->method( 'get_primary_market' )->willReturn(
+			[
+				'country'    => null,
+				'feed_label' => null,
+				'language'   => 'en',
+			]
+		);
 		$this->market_service->method( 'get_main_feed_label' )->willReturn( 'US' );
 		$this->market_service->method( 'get_all_countries' )->willReturn( [ 'US' ] );
 		$this->validator->method( 'validate' )->willReturn( [] );

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiExcep
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidClass;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
@@ -348,6 +349,38 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			$this->assertSame( 'US', $entry['input']->get_feed_label() );
 			$this->assertSame( 'US', $entry['country'] );
 		}
+	}
+
+	public function test_generate_mapi_update_entries_rethrows_account_reconnect() {
+		$products = $this->create_and_return_supported_test_products();
+
+		$this->market_service->method( 'get_primary_market' )->willReturn( [ 'country' => null, 'feed_label' => null, 'language' => 'en' ] );
+		$this->market_service->method( 'get_main_feed_label' )->willReturn( 'US' );
+		$this->market_service->method( 'get_all_countries' )->willReturn( [ 'US' ] );
+		$this->validator->method( 'validate' )->willReturn( [] );
+		$this->rules_query->method( 'get_results' )->willReturn( [] );
+
+		// An account-wide auth failure surfaces while resolving the data source.
+		$this->data_sources->method( 'ensure_data_source_for' )->willThrowException( AccountReconnect::jetpack_disconnected() );
+
+		$this->expectException( AccountReconnect::class );
+
+		$this->batch_product_helper->generate_mapi_update_entries( $products );
+	}
+
+	public function test_generate_mapi_update_entries_skips_product_on_other_exception() {
+		$products = $this->create_and_return_supported_test_products();
+
+		$this->market_service->method( 'get_primary_market' )->willReturn( [ 'country' => null, 'feed_label' => null, 'language' => 'en' ] );
+		$this->market_service->method( 'get_main_feed_label' )->willReturn( 'US' );
+		$this->market_service->method( 'get_all_countries' )->willReturn( [ 'US' ] );
+		$this->validator->method( 'validate' )->willReturn( [] );
+		$this->rules_query->method( 'get_results' )->willReturn( [] );
+
+		// A per-product failure (not account-wide) is still swallowed and the product skipped.
+		$this->data_sources->method( 'ensure_data_source_for' )->willThrowException( new MerchantApiException( 400, [], __METHOD__ ) );
+
+		$this->assertSame( [], $this->batch_product_helper->generate_mapi_update_entries( $products ) );
 	}
 
 	public function test_generate_mapi_update_entries_primary_plus_secondary_two_entries_per_product() {

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiPro
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
@@ -675,6 +676,40 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 			$this->assertNotEmpty( $error_entry->get_errors() );
 			// product is no longer synced if Google API returns Not Found error for it
 			$this->assertFalse( $this->product_helper->is_product_synced( $wc_product ) );
+		}
+	}
+
+	public function test_update_wraps_auth_failure_from_entry_generation() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$batch_helper = $this->getMockBuilder( BatchProductHelper::class )
+								->setMethods( [ 'generate_mapi_update_entries' ] )
+								->setConstructorArgs(
+									[
+										$this->product_meta,
+										$this->product_helper,
+										$this->createMock( ValidatorInterface::class ),
+										$this->container->get( ProductFactory::class ),
+										$this->rules_query,
+										$this->market_service,
+										$this->createMock( WPML::class ),
+										$this->container->get( AttributeManager::class ),
+										$this->createMock( MapiDataSourcesService::class ),
+									]
+								)
+								->getMock();
+		$batch_helper->method( 'generate_mapi_update_entries' )
+			->willThrowException( AccountReconnect::jetpack_disconnected() );
+
+		$product_syncer = $this->get_product_syncer( [ 'batch_helper' => $batch_helper ] );
+
+		// The account-wide auth failure surfaces as a ProductSyncerException, not a raw
+		// AccountReconnect, so update() keeps its documented contract.
+		try {
+			$product_syncer->update( [ $product ] );
+			$this->fail( 'Expected a ProductSyncerException.' );
+		} catch ( ProductSyncerException $exception ) {
+			$this->assertInstanceOf( AccountReconnect::class, $exception->getPrevious() );
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`BatchProductHelper::generate_mapi_update_entries()` catches `GoogleListingsAndAdsException` per product so that one product failing local validation is skipped without aborting the batch. `AccountReconnect` (raised when the Connect Server rejects the Jetpack token) implements that same interface, so an authentication failure was swallowed the same way: the loop logged "Skipping product" and moved on to the next product, re-attempting it against the same rejected token, one 401 per product.

That failure is account-wide, not specific to a product. This PR rethrows `AccountReconnect` from the catch so the run stops on the first one. The sync job then records the failure instead of completing silently, and (with #3771) the circuit breaker pauses further syncing.

The Merchant API migration introduced this: resolving a product's data source is a per-product network call made inside the entry-building loop, whereas the Content API path built entries locally and only hit the network in a single batched insert that already surfaced the failure. Genuine per-product exceptions are still skipped as before.

### Detailed test instructions:

Prerequisites: a site onboarded to Merchant Center with syncing enabled, and at least one product set to sync and show.

1. Break the site's blog token so the Connect Server rejects requests, and clear any active auth pause so the run reaches the entry builder. Keep a backup of the token.
   ```
   wp eval '$o = woogle_get_container()->get( \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::class ); $p = get_option( "jetpack_private_options" ); update_option( "gla_test_blog_token_backup", $p["blog_token"] ); $p["blog_token"] = "broken.broken"; update_option( "jetpack_private_options", $p ); $o->delete( "jetpack_auth_failed_at" );'
   ```
2. Run a product sync and confirm it fails on the auth error rather than returning silently. Expect a `ProductSyncerException` wrapping an `AccountReconnect`, not an empty result.
   ```
   wp eval '$c = woogle_get_container(); $ps = $c->get( \Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncer::class ); $repo = $c->get( \Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductRepository::class ); $products = $repo->find_sync_ready_products( [], 1 )->get(); try { $ps->update( $products ); echo "returned without throwing\n"; } catch ( \Throwable $e ) { echo get_class( $e ), " / previous: ", $e->getPrevious() ? get_class( $e->getPrevious() ) : "(none)", "\n"; }'
   ```
3. Confirm the WooCommerce log shows the run stopping on the auth failure, not a "Skipping product (ID: …)" line for every product.
4. Restore the token and clear the pause the test tripped.
   ```
   wp eval '$o = woogle_get_container()->get( \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::class ); $p = get_option( "jetpack_private_options" ); $p["blog_token"] = get_option( "gla_test_blog_token_backup" ); update_option( "jetpack_private_options", $p ); delete_option( "gla_test_blog_token_backup" ); $o->delete( "jetpack_auth_failed_at" );'
   ```

   Expected output for step 2:
   ```
   Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductSyncerException / previous: Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect
   ```

### Changelog entry

> Fix - Stop retrying every product against a rejected authentication token during sync; fail the sync run on the first authentication error instead.
