### PR TITLE
Feature / GOOWOO-930 GTM Snippet Injection

### DIFF
--- a/src/API/Site/Controllers/TagManager/AccountController.php
+++ b/src/API/Site/Controllers/TagManager/AccountController.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\TagMa
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\BaseController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\TagManagerSiteTag;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use Exception;
 use WP_REST_Request as Request;
@@ -22,16 +23,21 @@ class AccountController extends BaseController {
 	/** @var Connection */
 	protected $connection;
 
+	/** @var TagManagerSiteTag */
+	protected $site_tag;
+
 	/**
 	 * AccountController constructor.
 	 *
-	 * @param RESTServer $server
-	 * @param Connection $connection
+	 * @param RESTServer        $server
+	 * @param Connection        $connection
+	 * @param TagManagerSiteTag $site_tag
 	 */
-	public function __construct( RESTServer $server, Connection $connection ) {
+	public function __construct( RESTServer $server, Connection $connection, TagManagerSiteTag $site_tag ) {
 		parent::__construct( $server );
 
 		$this->connection = $connection;
+		$this->site_tag   = $site_tag;
 	}
 
 	/**
@@ -124,7 +130,10 @@ class AccountController extends BaseController {
 	protected function get_connected_callback(): callable {
 		return function () {
 			try {
-				return $this->connection->get_status();
+				return array_merge(
+					$this->connection->get_status(),
+					[ 'injectionFailed' => $this->site_tag->has_injection_failed() ]
+				);
 			} catch ( Exception $e ) {
 				return $this->response_from_exception( $e );
 			}

--- a/src/Google/TagManagerSiteTag.php
+++ b/src/Google/TagManagerSiteTag.php
@@ -1,0 +1,116 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Conditional;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Registerable;
+use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Injects the Google Tag Manager container snippet on the storefront once a container is connected.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Google
+ */
+class TagManagerSiteTag implements Service, Registerable, Conditional {
+
+	/** @var Connection */
+	protected $connection;
+
+	/**
+	 * TagManagerSiteTag constructor.
+	 *
+	 * @param Connection $connection
+	 */
+	public function __construct( Connection $connection ) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * Register the service.
+	 */
+	public function register(): void {
+		$container_public_id = $this->connection->get_connection_data()['container_public_id'] ?? '';
+
+		if ( ! $container_public_id ) {
+			return;
+		}
+
+		add_action(
+			'wp_head',
+			function () use ( $container_public_id ) {
+				$this->display_snippet( $container_public_id );
+			},
+			999999
+		);
+
+		add_action(
+			'wp_body_open',
+			function () use ( $container_public_id ) {
+				$this->display_noscript_fallback( $container_public_id );
+			}
+		);
+	}
+
+	/**
+	 * Whether the connected container is missing a usable public ID at render time.
+	 *
+	 * Does not detect a failed connect attempt itself — this plugin has no stored
+	 * connection-recovery state to check yet, only what's derivable from the stored
+	 * connection data.
+	 *
+	 * @return bool
+	 */
+	public function has_injection_failed(): bool {
+		$data = $this->connection->get_connection_data();
+
+		return ! empty( $data['container_id'] ) && empty( $data['container_public_id'] );
+	}
+
+	/**
+	 * Display the JavaScript code to load the Google Tag Manager container.
+	 *
+	 * @param string $container_public_id The connected container's public ID (e.g. `GTM-XXXXXXX`).
+	 */
+	protected function display_snippet( string $container_public_id ) {
+		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		?>
+
+		<!-- Google Tag Manager - Google for WooCommerce -->
+		<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+		new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+		})(window,document,'script','dataLayer','<?php echo esc_js( $container_public_id ); ?>');</script>
+		<!-- End Google Tag Manager -->
+
+		<?php
+		// phpcs:enable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+	}
+
+	/**
+	 * Display the `<noscript>` iframe fallback required for non-JS clients.
+	 *
+	 * @param string $container_public_id The connected container's public ID (e.g. `GTM-XXXXXXX`).
+	 */
+	protected function display_noscript_fallback( string $container_public_id ) {
+		?>
+
+		<!-- Google Tag Manager (noscript) -->
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<?php echo esc_attr( $container_public_id ); ?>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+		<!-- End Google Tag Manager (noscript) -->
+
+		<?php
+	}
+
+	/**
+	 * @return bool True — real gating happens inside register(), not at the Conditional level,
+	 *              since a merchant's connection data isn't cheaply checkable statically.
+	 */
+	public static function is_needed(): bool {
+		return true;
+	}
+}

--- a/src/Internal/DependencyManagement/CoreServiceProvider.php
+++ b/src/Internal/DependencyManagement/CoreServiceProvider.php
@@ -43,6 +43,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiPro
 use Automattic\WooCommerce\GoogleListingsAndAds\API\YouTube\Connection as YouTubeConnection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection as TagManagerConnection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\TagManagerApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\TagManagerSiteTag;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\RequestReviewStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\SiteVerificationMeta;
 use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
@@ -151,6 +152,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		DateTimeUtility::class           => true,
 		EventTracking::class             => true,
 		GlobalSiteTag::class             => true,
+		TagManagerSiteTag::class         => true,
 		ISOUtility::class                => true,
 		SiteVerificationEvents::class    => true,
 		OptionsInterface::class          => true,
@@ -285,6 +287,7 @@ class CoreServiceProvider extends AbstractServiceProvider {
 		$this->share_with_tags( RESTControllers::class );
 		$this->share_with_tags( CompleteSetupTask::class );
 		$this->conditionally_share_with_tags( GlobalSiteTag::class, AssetsHandlerInterface::class, GoogleGtagJs::class, ProductHelper::class, WC::class, WP::class );
+		$this->conditionally_share_with_tags( TagManagerSiteTag::class, TagManagerConnection::class );
 		$this->share_with_tags( SiteVerificationMeta::class );
 		$this->conditionally_share_with_tags( MerchantSetupCompleted::class );
 		$this->conditionally_share_with_tags( AdsSetupCompleted::class );

--- a/src/Internal/DependencyManagement/RESTServiceProvider.php
+++ b/src/Internal/DependencyManagement/RESTServiceProvider.php
@@ -72,6 +72,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\WP\OAuthService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\YouTube\Connection as YouTubeConnection;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\TagManager\AccountController as TagManagerAccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection as TagManagerConnection;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\TagManagerSiteTag;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductFeedQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
@@ -177,7 +178,7 @@ class RESTServiceProvider extends AbstractServiceProvider {
 		$this->share( AdsSettingsController::class );
 		$this->share( ConnectController::class, Middleware::class, OptionsInterface::class );
 		$this->share( YouTubeAccountController::class, YouTubeConnection::class );
-		$this->share( TagManagerAccountController::class, TagManagerConnection::class );
+		$this->share( TagManagerAccountController::class, TagManagerConnection::class, TagManagerSiteTag::class );
 		$this->share( OnboardingController::class );
 		$this->share( MarketsController::class, MarketService::class );
 	}

--- a/tests/Unit/API/Site/Controllers/TagManager/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/TagManager/AccountControllerTest.php
@@ -98,6 +98,7 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
 
 		$this->assertTrue( $response->get_data()['injectionFailed'] );
+		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	public function test_get_connection_status_with_error() {

--- a/tests/Unit/API/Site/Controllers/TagManager/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/TagManager/AccountControllerTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Site\Contro
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\TagManager\AccountController;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\TagManagerSiteTag;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\RESTControllerUnitTest;
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -21,6 +22,9 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	/** @var MockObject|Connection $connection */
 	protected $connection;
 
+	/** @var MockObject|TagManagerSiteTag $site_tag */
+	protected $site_tag;
+
 	/** @var AccountController $controller */
 	protected $controller;
 
@@ -33,7 +37,8 @@ class AccountControllerTest extends RESTControllerUnitTest {
 		parent::setUp();
 
 		$this->connection = $this->createMock( Connection::class );
-		$this->controller = new AccountController( $this->server, $this->connection );
+		$this->site_tag   = $this->createMock( TagManagerSiteTag::class );
+		$this->controller = new AccountController( $this->server, $this->connection, $this->site_tag );
 		$this->controller->register();
 	}
 
@@ -70,10 +75,29 @@ class AccountControllerTest extends RESTControllerUnitTest {
 			->method( 'get_status' )
 			->willReturn( $status );
 
+		$this->site_tag->expects( $this->once() )
+			->method( 'has_injection_failed' )
+			->willReturn( false );
+
 		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
 
-		$this->assertEquals( $status, $response->get_data() );
+		$this->assertEquals(
+			array_merge( $status, [ 'injectionFailed' => false ] ),
+			$response->get_data()
+		);
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_get_connection_status_reports_injection_failure() {
+		$this->connection->method( 'get_status' )->willReturn( [ 'status' => 'connected' ] );
+
+		$this->site_tag->expects( $this->once() )
+			->method( 'has_injection_failed' )
+			->willReturn( true );
+
+		$response = $this->do_request( self::ROUTE_CONNECTION, 'GET' );
+
+		$this->assertTrue( $response->get_data()['injectionFailed'] );
 	}
 
 	public function test_get_connection_status_with_error() {

--- a/tests/Unit/Google/TagManagerSiteTagTest.php
+++ b/tests/Unit/Google/TagManagerSiteTagTest.php
@@ -1,0 +1,115 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\Google\TagManagerSiteTag;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class TagManagerSiteTagTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Google
+ */
+class TagManagerSiteTagTest extends UnitTest {
+
+	/** @var MockObject|Connection $connection */
+	protected $connection;
+
+	/** @var TagManagerSiteTag $tag */
+	protected $tag;
+
+	protected const TEST_CONTAINER_PUBLIC_ID = 'GTM-ABCDEF';
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->connection = $this->createMock( Connection::class );
+		$this->tag        = new TagManagerSiteTag( $this->connection );
+	}
+
+	public function test_register_injects_script_when_container_connected() {
+		$this->connection->method( 'get_connection_data' )->willReturn(
+			[
+				'container_id'        => '98765432',
+				'container_public_id' => self::TEST_CONTAINER_PUBLIC_ID,
+			]
+		);
+
+		$this->tag->register();
+
+		$this->assertStringContainsString( self::TEST_CONTAINER_PUBLIC_ID, $this->get_wp_head() );
+	}
+
+	public function test_register_injects_noscript_fallback_when_container_connected() {
+		$this->connection->method( 'get_connection_data' )->willReturn(
+			[
+				'container_id'        => '98765432',
+				'container_public_id' => self::TEST_CONTAINER_PUBLIC_ID,
+			]
+		);
+
+		$this->tag->register();
+
+		$this->assertStringContainsString(
+			'https://www.googletagmanager.com/ns.html?id=' . self::TEST_CONTAINER_PUBLIC_ID,
+			$this->get_wp_body_open()
+		);
+	}
+
+	public function test_register_does_not_inject_when_no_container_connected() {
+		$this->connection->method( 'get_connection_data' )->willReturn( [] );
+
+		$this->tag->register();
+
+		$this->assertStringNotContainsString( 'googletagmanager.com', $this->get_wp_head() );
+		$this->assertStringNotContainsString( 'googletagmanager.com', $this->get_wp_body_open() );
+	}
+
+	public function test_has_injection_failed_false_when_no_account_connected_at_all() {
+		$this->connection->method( 'get_connection_data' )->willReturn( [] );
+
+		$this->assertFalse( $this->tag->has_injection_failed() );
+	}
+
+	public function test_has_injection_failed_false_when_container_public_id_present() {
+		$this->connection->method( 'get_connection_data' )->willReturn(
+			[
+				'container_id'        => '98765432',
+				'container_public_id' => self::TEST_CONTAINER_PUBLIC_ID,
+			]
+		);
+
+		$this->assertFalse( $this->tag->has_injection_failed() );
+	}
+
+	public function test_has_injection_failed_true_when_container_id_present_but_public_id_missing() {
+		$this->connection->method( 'get_connection_data' )->willReturn(
+			[
+				'container_id'        => '98765432',
+				'container_public_id' => '',
+			]
+		);
+
+		$this->assertTrue( $this->tag->has_injection_failed() );
+	}
+
+	protected function get_wp_head(): string {
+		ob_start();
+		do_action( 'wp_head' );
+		return ob_get_clean();
+	}
+
+	protected function get_wp_body_open(): string {
+		ob_start();
+		do_action( 'wp_body_open' );
+		return ob_get_clean();
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes: [GOOWOO-930](https://linear.app/a8c/issue/GOOWOO-930/automatic-gtm-snippet-injection-storefront-script-and-noscript)

Automatic storefront injection of the connected GTM container snippet, plus disconnect-removal and a failure-state signal for the FE's future "Try again" indicator.

- New `Google\TagManagerSiteTag`: a sibling to `GlobalSiteTag`, same option-gated `register()` pattern. Reads the connected container's public ID from `API\TagManager\Connection` (GOOWOO-929) and, if present, injects the standard GTM script into `wp_head` (priority `999999`) and the `<noscript>` iframe fallback into `wp_body_open`.
- Disconnect removes the snippet from the storefront "for free": injection is re-derived from stored connection state on every page load, so there's no separate removal code path. Confirmed live (see test instructions).
- Exposes `has_injection_failed()`: `true` when a container is selected (`container_id` set) but its public ID couldn't be resolved (`container_public_id` empty). This is a real, checkable condition, not a guess at "did the hook silently not fire." Surfaced as a new `injectionFailed` field on the existing `GET tag-manager/connection` status response, alongside the account/container status fields GOOWOO-929 already returns.
- "Try again" needs no new endpoint: re-selecting the already-known container via the existing `POST tag-manager/containers` endpoint re-fetches from the Tag Manager API and can resolve a previously-missing public ID. Confirmed this reuse is sufficient; nothing new was built for it.
- Also includes the fix from GOOWOO-929's own review (@jjgrainger ): the account/container `id` param on the two POST routes now has a declared REST schema (`required: true`), so a missing `id` fails fast with a standard `rest_missing_callback_param` error instead of reaching the API client with an empty string.

**Known, accepted gap, not fixed here:** themes that don't call `wp_body_open()` never get the `<noscript>` fallback: confirmed there's no fallback mechanism anywhere in this codebase (`GlobalSiteTag`'s own Ads snippet has the identical gap). Ships with parity to that existing precedent rather than inventing a new one, per this ticket's own scope.

### Screenshots:

N/A - storefront `<head>`/`<body>` script injection, no admin UI change in this ticket.

### Detailed test instructions:

1. `composer install`, `vendor/bin/phpunit --testsuite unit`.
2. `vendor/bin/phpcs` (default ruleset) and `vendor/bin/phpcs --standard=tests/phpcs.xml.dist` (test files changed).

This logic only reads *stored* connection data. No live Google account, OAuth, or tunnel needed to verify it end-to-end.

#### Test 1: Seed a connected container and confirm injection

```
wp eval '
$c = woogle_get_container();
$conn = $c->get(\Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection::class);
$conn->update_connection_data( [
	"account_id"          => "123456",
	"account_name"        => "Test Account",
	"container_id"        => "98765432",
	"container_name"      => "Test Container",
	"container_public_id" => "GTM-TEST123",
] );
'
```

Visit any storefront page and view source: confirm the GTM script renders at the end of `<head>` and the `<noscript><iframe...ns.html?id=GTM-TEST123">` fallback renders right after `<body>`. Check more than one page type (home, a product, the shop archive). It's unconditional, not gated to one template.

#### Test 2: Disconnect removes it, no separate cleanup

```
wp eval '$c = woogle_get_container(); $c->get(\Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection::class)->disconnect();'
```

Reload: the GTM script and `noscript` fallback are both gone. (Note: this plugin's own Ads `gtag.js` snippet also lives on `googletagmanager.com`, don't confuse it with the GTM container snippet when checking.)

#### Test 3: Failure-state exposure

```
wp eval '
$c = woogle_get_container();
$conn = $c->get(\Automattic\WooCommerce\GoogleListingsAndAds\API\TagManager\Connection::class);
$conn->update_connection_data( [ "container_id" => "98765432", "container_public_id" => "" ] );
$tag = $c->get(\Automattic\WooCommerce\GoogleListingsAndAds\Google\TagManagerSiteTag::class);
var_dump( $tag->has_injection_failed() );
'
```

Expect `bool(true)`. Reload the storefront and confirm nothing injects (a missing public ID means nothing to inject, not a broken injection). Then confirm the REST field:

```
wp eval '
$request = new WP_REST_Request( "GET", "/wc/gla/tag-manager/connection" );
$response = rest_do_request( $request );
echo wp_json_encode( $response->get_data() ) . "\n";
' --user=1
```

Expect `injectionFailed: true` alongside the existing status fields.

#### Test 4: Required `id` param (GOOWOO-929 review fix, carried into this branch)

```
wp eval '
$request = new WP_REST_Request( "POST", "/wc/gla/tag-manager/accounts" );
$response = rest_do_request( $request );
echo $response->get_status() . " " . wp_json_encode( $response->get_data() ) . "\n";
'
```

Expect `400 {"code":"rest_missing_callback_param",...}` — no request reaches `select_account()` with an empty ID.

#### Cleanup

```
wp option delete gla_tag_manager
```

(Not `tag_manager`: this plugin prefixes all its stored options with `gla_`.)

### Additional details:
N/A

### Changelog entry

> Add - Automatically inject the Google Tag Manager container snippet on the storefront once a container is connected, and remove it on disconnect.
