### PR TITLE
GOOWOO-1001: Add E2E test coverage for Google Customer Reviews

### DIFF
--- a/tests/e2e/specs/dashboard/notification-badge.test.js
+++ b/tests/e2e/specs/dashboard/notification-badge.test.js
@@ -14,6 +14,7 @@ const { test, expect } = require( '@playwright/test' );
 import {
 	clearGCRNotificationsDismissed,
 	clearOnboardedMerchant,
+	getNotifications,
 	setGCRNotificationsDismissed,
 	setOnboardedMerchant,
 } from '../../utils/api';
@@ -33,6 +34,18 @@ let dashboardPage = null;
  */
 let page = null;
 
+/**
+ * Expected badge count: the real notification system's current count, plus
+ * the test-only `++` this environment's `google_for_woocommerce_admin_menu_notification_count`
+ * filter always adds (see tests/e2e/test-snippets/test-snippets.php). Read
+ * live rather than hardcoded — other E2E specs' own real orders, coupons,
+ * etc. legitimately push the real count above this test's own minimal setup,
+ * and nothing in the suite guarantees those get cleaned up first.
+ *
+ * @type {string}
+ */
+let expectedBadgeCount = null;
+
 test.use( { storageState: process.env.ADMINSTATE } );
 
 test.describe( 'Notification Badge', () => {
@@ -43,6 +56,9 @@ test.describe( 'Notification Badge', () => {
 		await setGCRNotificationsDismissed();
 		await dashboardPage.mockRequests();
 		await dashboardPage.goto();
+
+		const notifications = await getNotifications();
+		expectedBadgeCount = String( notifications.length + 1 );
 	} );
 
 	test.afterAll( async () => {
@@ -62,7 +78,7 @@ test.describe( 'Notification Badge', () => {
 			const badge = page
 				.getByRole( 'link', { name: 'Marketing' } )
 				.locator( 'span.update-plugins' )
-				.filter( { hasText: '2' } );
+				.filter( { hasText: expectedBadgeCount } );
 
 			await expect( badge ).toBeVisible();
 		} );
@@ -71,7 +87,7 @@ test.describe( 'Notification Badge', () => {
 			const badge = dashboardPage.page
 				.getByRole( 'link', { name: 'Overview' } )
 				.locator( 'span.update-plugins' )
-				.filter( { hasText: '2' } );
+				.filter( { hasText: expectedBadgeCount } );
 
 			await expect( badge ).toBeVisible();
 		} );
@@ -80,7 +96,7 @@ test.describe( 'Notification Badge', () => {
 			const badge = dashboardPage.page
 				.getByRole( 'link', { name: 'Overview' } )
 				.locator( 'span.update-plugins' )
-				.filter( { hasText: '2' } );
+				.filter( { hasText: expectedBadgeCount } );
 
 			await expect( badge ).toBeVisible();
 
@@ -91,7 +107,7 @@ test.describe( 'Notification Badge', () => {
 			const badgeMoved = dashboardPage.page
 				.getByRole( 'link', { name: 'Marketing' } )
 				.locator( 'span.update-plugins' )
-				.filter( { hasText: '2' } );
+				.filter( { hasText: expectedBadgeCount } );
 
 			await expect( badgeMoved ).toBeVisible();
 		} );
@@ -107,10 +123,13 @@ test.describe( 'Notification Badge', () => {
 				waitUntil: LOAD_STATE.DOM_CONTENT_LOADED,
 			} );
 
+			// The `no_notifications=true` test-only filter forces the count to
+			// a hard 0 regardless of the real notification system's state, so
+			// no badge of any kind should render — not just one that happens
+			// to avoid matching this file's own dynamic expected count.
 			const badge = page
 				.getByRole( 'link', { name: 'Marketing' } )
-				.locator( 'span.update-plugins' )
-				.filter( { hasText: '2' } );
+				.locator( 'span.update-plugins' );
 
 			await expect( badge ).not.toBeVisible();
 		} );

--- a/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
+++ b/tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js
@@ -42,6 +42,19 @@ test.describe( 'Price Benchmark Page', () => {
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage();
 		priceBenchmarkPage = new PriceBenchmarkPage( page );
+
+		// This file navigates to the same admin URL many times to exercise
+		// different mocked API responses. page.route() only intercepts
+		// requests that actually reach the network — a static asset (e.g.
+		// wp-dataviews-shim.js) served straight from the browser's HTTP cache
+		// on a later navigation never reaches that layer at all, silently
+		// defeating a route registered for it. Disabling the cache for the
+		// life of this page guarantees every navigation is interceptable.
+		const cdpSession = await page.context().newCDPSession( page );
+		await cdpSession.send( 'Network.setCacheDisabled', {
+			cacheDisabled: true,
+		} );
+
 		await setOnboardedMerchant();
 		await clearServiceBasedMerchant();
 		await priceBenchmarkPage.mockRequests();
@@ -98,13 +111,20 @@ test.describe( 'Price Benchmark Page', () => {
 		test( 'Displays error message when data view fails to load', async () => {
 			// wp-dataviews-shim.js is loaded as a blocking script during HTML parsing,
 			// not lazily — the route must be registered before goto() or the request is already gone.
-			const once = priceBenchmarkPage.withFulfillTimes( 1 );
-			await once.fulfillRequest(
-				/\/js\/build\/wp-dataviews-shim.js(\/.*)?\b/,
-				{},
-				500,
-				[ 'GET' ]
-			);
+			//
+			// useDataViewsScript (js/src/hooks/useDataViewsScript.js) resets its
+			// load-dedup promise specifically on failure so a later mount can
+			// retry — a real, intentional feature, not a bug. That means a
+			// single failing response isn't reliable: the hook can remount and
+			// successfully retry (a real, unmocked request) before this test's
+			// own assertion runs. Fail every request for this URL, not just the
+			// first, so a retry also fails — then unroute it once the error
+			// state is confirmed, so later tests in this file get the real,
+			// working shim script again.
+			const shimUrlPattern = /\/js\/build\/wp-dataviews-shim.js(\/.*)?\b/;
+			await priceBenchmarkPage.fulfillRequest( shimUrlPattern, {}, 500, [
+				'GET',
+			] );
 
 			await priceBenchmarkPage.fulfillPriceBenchmarkSuggestions( [] );
 			await priceBenchmarkPage.goto();
@@ -116,6 +136,8 @@ test.describe( 'Price Benchmark Page', () => {
 			await expect( errorMessage ).toContainText(
 				'There was an error loading the price benchmark suggestions.'
 			);
+
+			await page.unroute( shimUrlPattern );
 		} );
 	} );
 

--- a/tests/e2e/specs/reviews/badge-widget.test.js
+++ b/tests/e2e/specs/reviews/badge-widget.test.js
@@ -40,7 +40,7 @@ test.describe( 'Google Customer Reviews Badge Widget', () => {
 		await page.close();
 	} );
 
-	test( 'does not inject the badge widget script when the setting is disabled', async () => {
+	test( 'should not inject the badge widget script when the setting is disabled', async () => {
 		await page.goto( 'shop' );
 		await grantMarketingConsent( page );
 		await saveMCSettings( { gcr_badge_widget_enabled: false } );
@@ -52,7 +52,7 @@ test.describe( 'Google Customer Reviews Badge Widget', () => {
 		);
 	} );
 
-	test( 'injects the badge widget script when the setting is enabled and marketing consent is granted', async () => {
+	test( 'should inject the badge widget script when the setting is enabled and marketing consent is granted', async () => {
 		await saveMCSettings( { gcr_badge_widget_enabled: true } );
 
 		await page.reload();
@@ -63,7 +63,7 @@ test.describe( 'Google Customer Reviews Badge Widget', () => {
 		);
 	} );
 
-	test( 'does not fetch the badge widget script when marketing consent is denied', async () => {
+	test( 'should not fetch the badge widget script when marketing consent is denied', async () => {
 		await denyMarketingConsent( page );
 
 		await page.reload();
@@ -73,7 +73,7 @@ test.describe( 'Google Customer Reviews Badge Widget', () => {
 		);
 	} );
 
-	test( 'fetches the badge widget script once marketing consent is granted mid-visit, without an additional reload', async () => {
+	test( 'should fetch the badge widget script once marketing consent is granted mid-visit, without an additional reload', async () => {
 		await grantMarketingConsent( page );
 
 		// Freeze timers so the consent gate's own grace-period timer can't be
@@ -95,9 +95,15 @@ test.describe( 'Google Customer Reviews Badge Widget', () => {
 			'src',
 			BADGE_WIDGET_SCRIPT_SRC
 		);
+
+		// Let time flow normally again for any test that runs after this one
+		// in the file — otherwise a later test relying on a real timer (e.g.
+		// the consent gate's own grace-period setTimeout) would silently
+		// never fire, with nothing pointing back to this install() call.
+		await page.clock.resume();
 	} );
 
-	test( 'stops injecting the badge widget script once the setting is disabled again', async () => {
+	test( 'should stop injecting the badge widget script once the setting is disabled again', async () => {
 		// The setting has been enabled since earlier in this file — this
 		// proves turning it back off is respected, distinct from the very
 		// first test above, which only covers the never-enabled default.

--- a/tests/e2e/specs/reviews/badge-widget.test.js
+++ b/tests/e2e/specs/reviews/badge-widget.test.js
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import { expect, test } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import {
+	clearGCRNotificationsDismissed,
+	clearMerchantId,
+	saveMCSettings,
+	setMerchantId,
+} from '../../utils/api';
+import {
+	denyMarketingConsent,
+	dispatchMarketingConsentGranted,
+	grantMarketingConsent,
+} from '../../utils/consent';
+
+test.describe.configure( { mode: 'serial' } );
+
+const BADGE_WIDGET_SCRIPT_SRC =
+	'https://www.gstatic.com/shopping/merchant/merchantwidget.js';
+
+/**
+ * @type {import('@playwright/test').Page} page
+ */
+let page = null;
+
+test.describe( 'Google Customer Reviews Badge Widget', () => {
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		await setMerchantId();
+	} );
+
+	test.afterAll( async () => {
+		await clearMerchantId();
+		await clearGCRNotificationsDismissed();
+		await page.close();
+	} );
+
+	test( 'does not inject the badge widget script when the setting is disabled', async () => {
+		await page.goto( 'shop' );
+		await grantMarketingConsent( page );
+		await saveMCSettings( { gcr_badge_widget_enabled: false } );
+
+		await page.reload();
+
+		await expect( page.locator( '#merchantWidgetScript' ) ).toHaveCount(
+			0
+		);
+	} );
+
+	test( 'injects the badge widget script when the setting is enabled and marketing consent is granted', async () => {
+		await saveMCSettings( { gcr_badge_widget_enabled: true } );
+
+		await page.reload();
+
+		await expect( page.locator( '#merchantWidgetScript' ) ).toHaveAttribute(
+			'src',
+			BADGE_WIDGET_SCRIPT_SRC
+		);
+	} );
+
+	test( 'does not fetch the badge widget script when marketing consent is denied', async () => {
+		await denyMarketingConsent( page );
+
+		await page.reload();
+
+		await expect( page.locator( '#merchantWidgetScript' ) ).toHaveCount(
+			0
+		);
+	} );
+
+	test( 'fetches the badge widget script once marketing consent is granted mid-visit, without an additional reload', async () => {
+		await grantMarketingConsent( page );
+
+		// Freeze timers so the consent gate's own grace-period timer can't be
+		// what loads the script — isolates the wp_listen_for_consent_change
+		// event-driven path from the timer-driven one.
+		await page.clock.install();
+
+		// New navigation: the consent cookie set above is now attached, so the
+		// server-side gate passes and the consent-gated wrapper script loads,
+		// but its internal timer is frozen and never fires on its own.
+		await page.reload();
+		await expect( page.locator( '#merchantWidgetScript' ) ).toHaveCount(
+			0
+		);
+
+		await dispatchMarketingConsentGranted( page );
+
+		await expect( page.locator( '#merchantWidgetScript' ) ).toHaveAttribute(
+			'src',
+			BADGE_WIDGET_SCRIPT_SRC
+		);
+	} );
+
+	test( 'stops injecting the badge widget script once the setting is disabled again', async () => {
+		// The setting has been enabled since earlier in this file — this
+		// proves turning it back off is respected, distinct from the very
+		// first test above, which only covers the never-enabled default.
+		await saveMCSettings( { gcr_badge_widget_enabled: false } );
+
+		await page.reload();
+
+		await expect( page.locator( '#merchantWidgetScript' ) ).toHaveCount(
+			0
+		);
+	} );
+} );

--- a/tests/e2e/specs/reviews/reviews-opt-in-prompt.test.js
+++ b/tests/e2e/specs/reviews/reviews-opt-in-prompt.test.js
@@ -78,6 +78,13 @@ async function checkoutToQualifyingOrder() {
 	return orderReceivedUrl;
 }
 
+// These tests run in a fixed order and each one leans on state the previous
+// test left behind (the shipping time seeded once a country is known, and
+// whatever setting/consent value the previous test set) — see
+// checkoutToQualifyingOrder()'s own docblock for why. Adding a test here, or
+// reordering the existing ones, must keep that rule: set the setting/consent
+// state a new test wants to verify *before* calling checkoutToQualifyingOrder(),
+// never after.
 test.describe( 'Google Customer Reviews Post-Purchase Opt-In Prompt', () => {
 	test.beforeAll( async ( { browser } ) => {
 		page = await browser.newPage();
@@ -97,7 +104,7 @@ test.describe( 'Google Customer Reviews Post-Purchase Opt-In Prompt', () => {
 		await page.close();
 	} );
 
-	test( 'does not inject the opt-in prompt on a qualifying order when the setting is disabled', async () => {
+	test( 'should not inject the opt-in prompt on a qualifying order when the setting is disabled', async () => {
 		await saveMCSettings( { gcr_collect_reviews_after_purchase: false } );
 
 		await checkoutToQualifyingOrder();
@@ -105,7 +112,7 @@ test.describe( 'Google Customer Reviews Post-Purchase Opt-In Prompt', () => {
 		await expect( page.locator( OPT_IN_SCRIPT_LOCATOR ) ).toHaveCount( 0 );
 	} );
 
-	test( 'injects the opt-in prompt on a qualifying order-received page when the setting is enabled', async () => {
+	test( 'should inject the opt-in prompt on a qualifying order-received page when the setting is enabled', async () => {
 		await saveMCSettings( { gcr_collect_reviews_after_purchase: true } );
 
 		// No extra navigation after this: a shipping time already exists for
@@ -120,7 +127,7 @@ test.describe( 'Google Customer Reviews Post-Purchase Opt-In Prompt', () => {
 		);
 	} );
 
-	test( 'does not fetch the opt-in prompt script when marketing consent is denied', async () => {
+	test( 'should not fetch the opt-in prompt script when marketing consent is denied', async () => {
 		// Deny *before* checking out — the setting is still enabled from the
 		// previous test, so if consent weren't already denied by the time of
 		// the real post-checkout page view, the prompt would inject and mark
@@ -133,7 +140,7 @@ test.describe( 'Google Customer Reviews Post-Purchase Opt-In Prompt', () => {
 		await expect( page.locator( OPT_IN_SCRIPT_LOCATOR ) ).toHaveCount( 0 );
 	} );
 
-	test( 'fetches the opt-in prompt script once marketing consent is granted mid-visit, without an additional reload', async () => {
+	test( 'should fetch the opt-in prompt script once marketing consent is granted mid-visit, without an additional reload', async () => {
 		// Consent is still denied from the previous test, so this order's
 		// real post-checkout page view does not inject or mark it as
 		// prompted — leaving room for the deliberate reload below.
@@ -157,9 +164,15 @@ test.describe( 'Google Customer Reviews Post-Purchase Opt-In Prompt', () => {
 			'src',
 			/apis\.google\.com\/js\/platform\.js\?onload=renderOptIn/
 		);
+
+		// Let time flow normally again for any test that runs after this one
+		// in the file — otherwise a later test relying on a real timer (e.g.
+		// the consent gate's own grace-period setTimeout) would silently
+		// never fire, with nothing pointing back to this install() call.
+		await page.clock.resume();
 	} );
 
-	test( 'does not inject the opt-in prompt once the setting is disabled again, on a separate qualifying order', async () => {
+	test( 'should not inject the opt-in prompt once the setting is disabled again, on a separate qualifying order', async () => {
 		// The setting has been enabled since earlier in this file — this
 		// proves turning it back off is respected, distinct from the very
 		// first test above, which only covers the never-enabled default.

--- a/tests/e2e/specs/reviews/reviews-opt-in-prompt.test.js
+++ b/tests/e2e/specs/reviews/reviews-opt-in-prompt.test.js
@@ -1,0 +1,172 @@
+/**
+ * External dependencies
+ */
+import { expect, test } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import {
+	clearGCRNotificationsDismissed,
+	clearMerchantId,
+	clearShippingTime,
+	createSimpleProduct,
+	getOrder,
+	saveMCSettings,
+	setMerchantId,
+	setShippingTime,
+} from '../../utils/api';
+import { checkout, singleProductAddToCart } from '../../utils/customer';
+import {
+	denyMarketingConsent,
+	dispatchMarketingConsentGranted,
+	grantMarketingConsent,
+} from '../../utils/consent';
+
+test.describe.configure( { mode: 'serial' } );
+
+const OPT_IN_SCRIPT_LOCATOR = 'script[src*="apis.google.com/js/platform.js"]';
+
+/**
+ * @type {import('@playwright/test').Page} page
+ */
+let page = null;
+
+/**
+ * Countries a shipping time has already been seeded for, in this test run.
+ *
+ * @type {Set<string>}
+ */
+const seededCountries = new Set();
+
+/**
+ * Complete a checkout for a fresh product, then seed a shipping time for the
+ * resulting order's destination country so EstimatedDeliveryTimeResolver can
+ * resolve a delivery date for it.
+ *
+ * Whatever gate this call is meant to test (the setting, or consent) must
+ * already be in its intended state *before* calling this — the real
+ * post-checkout redirect to the order-received page is itself a qualifying
+ * page view once a shipping time exists for the order's country, so if every
+ * gate already passes at that point, the prompt injects and marks the order
+ * as prompted right then. A caller that changes a gate afterwards and then
+ * revisits the URL to assert on it would be checking a second view that the
+ * "already prompted" dedup guard blocks regardless of that gate's state.
+ *
+ * @return {Promise<string>} The order-received URL.
+ */
+async function checkoutToQualifyingOrder() {
+	const productId = await createSimpleProduct();
+	await singleProductAddToCart( page, productId );
+	await checkout( page );
+
+	const orderReceivedUrl = page.url();
+	const parsedUrl = new URL( orderReceivedUrl );
+	// Pretty permalinks put the order ID in the path (.../order-received/40/);
+	// plain permalinks put it in the query string (?order-received=40).
+	const orderId =
+		parsedUrl.searchParams.get( 'order-received' ) ||
+		parsedUrl.pathname.match( /order-received\/(\d+)/ )?.[ 1 ];
+	const order = await getOrder( orderId );
+	const country = order.shipping.country || order.billing.country;
+
+	if ( ! seededCountries.has( country ) ) {
+		await setShippingTime( country, 5, 5 );
+		seededCountries.add( country );
+	}
+
+	return orderReceivedUrl;
+}
+
+test.describe( 'Google Customer Reviews Post-Purchase Opt-In Prompt', () => {
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		await setMerchantId();
+		await page.goto( 'shop' );
+		await grantMarketingConsent( page );
+	} );
+
+	test.afterAll( async () => {
+		await clearMerchantId();
+		await clearGCRNotificationsDismissed();
+		await Promise.all(
+			[ ...seededCountries ].map( ( country ) =>
+				clearShippingTime( country )
+			)
+		);
+		await page.close();
+	} );
+
+	test( 'does not inject the opt-in prompt on a qualifying order when the setting is disabled', async () => {
+		await saveMCSettings( { gcr_collect_reviews_after_purchase: false } );
+
+		await checkoutToQualifyingOrder();
+
+		await expect( page.locator( OPT_IN_SCRIPT_LOCATOR ) ).toHaveCount( 0 );
+	} );
+
+	test( 'injects the opt-in prompt on a qualifying order-received page when the setting is enabled', async () => {
+		await saveMCSettings( { gcr_collect_reviews_after_purchase: true } );
+
+		// No extra navigation after this: a shipping time already exists for
+		// this address's country (seeded by the previous test), so the real
+		// post-checkout redirect to the order-received page is itself the
+		// qualifying view — asserting on the current page, not a revisit.
+		await checkoutToQualifyingOrder();
+
+		await expect( page.locator( OPT_IN_SCRIPT_LOCATOR ) ).toHaveAttribute(
+			'src',
+			/apis\.google\.com\/js\/platform\.js\?onload=renderOptIn/
+		);
+	} );
+
+	test( 'does not fetch the opt-in prompt script when marketing consent is denied', async () => {
+		// Deny *before* checking out — the setting is still enabled from the
+		// previous test, so if consent weren't already denied by the time of
+		// the real post-checkout page view, the prompt would inject and mark
+		// the order as prompted right there, and a later revisit would fail
+		// for the wrong reason (dedup), not because of the consent gate.
+		await denyMarketingConsent( page );
+
+		await checkoutToQualifyingOrder();
+
+		await expect( page.locator( OPT_IN_SCRIPT_LOCATOR ) ).toHaveCount( 0 );
+	} );
+
+	test( 'fetches the opt-in prompt script once marketing consent is granted mid-visit, without an additional reload', async () => {
+		// Consent is still denied from the previous test, so this order's
+		// real post-checkout page view does not inject or mark it as
+		// prompted — leaving room for the deliberate reload below.
+		const orderReceivedUrl = await checkoutToQualifyingOrder();
+		await grantMarketingConsent( page );
+
+		// Freeze timers so the consent gate's own grace-period timer can't be
+		// what loads the script — isolates the wp_listen_for_consent_change
+		// event-driven path from the timer-driven one.
+		await page.clock.install();
+
+		// New navigation: the consent cookie set above is now attached, so
+		// the server-side gate passes and the consent-gated wrapper script
+		// loads, but its internal timer is frozen and never fires on its own.
+		await page.goto( orderReceivedUrl );
+		await expect( page.locator( OPT_IN_SCRIPT_LOCATOR ) ).toHaveCount( 0 );
+
+		await dispatchMarketingConsentGranted( page );
+
+		await expect( page.locator( OPT_IN_SCRIPT_LOCATOR ) ).toHaveAttribute(
+			'src',
+			/apis\.google\.com\/js\/platform\.js\?onload=renderOptIn/
+		);
+	} );
+
+	test( 'does not inject the opt-in prompt once the setting is disabled again, on a separate qualifying order', async () => {
+		// The setting has been enabled since earlier in this file — this
+		// proves turning it back off is respected, distinct from the very
+		// first test above, which only covers the never-enabled default.
+		await saveMCSettings( { gcr_collect_reviews_after_purchase: false } );
+
+		await checkoutToQualifyingOrder();
+
+		await expect( page.locator( OPT_IN_SCRIPT_LOCATOR ) ).toHaveCount( 0 );
+	} );
+} );

--- a/tests/e2e/specs/reviews/settings.test.js
+++ b/tests/e2e/specs/reviews/settings.test.js
@@ -9,6 +9,7 @@ import { expect, test } from '@playwright/test';
 import {
 	clearGCRNotificationsDismissed,
 	clearOnboardedMerchant,
+	saveMCSettings,
 	setOnboardedMerchant,
 } from '../../utils/api';
 import SettingsPage from '../../utils/pages/settings';
@@ -38,6 +39,12 @@ test.describe( 'Google Customer Reviews Setting', () => {
 	} );
 
 	test.afterAll( async () => {
+		// Unlike `gcr_collect_reviews_after_purchase` and `gcr_badge_widget_enabled`,
+		// which the last two tests above already leave unchecked, nothing else in
+		// this file puts `gcr_badge_widget_position` back to its default. Reset it
+		// explicitly so a later run doesn't start from the position a previous run
+		// left it in.
+		await saveMCSettings( { gcr_badge_widget_position: 'bottom-right' } );
 		await clearOnboardedMerchant();
 		await clearGCRNotificationsDismissed();
 		await page.close();

--- a/tests/e2e/specs/reviews/settings.test.js
+++ b/tests/e2e/specs/reviews/settings.test.js
@@ -1,0 +1,154 @@
+/**
+ * External dependencies
+ */
+import { expect, test } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import {
+	clearGCRNotificationsDismissed,
+	clearOnboardedMerchant,
+	setOnboardedMerchant,
+} from '../../utils/api';
+import SettingsPage from '../../utils/pages/settings';
+
+test.use( { storageState: process.env.ADMINSTATE } );
+
+test.describe.configure( { mode: 'serial' } );
+
+/**
+ * @type {import('../../utils/pages/settings.js').default} settingsPage
+ */
+let settingsPage = null;
+
+/**
+ * @type {import('@playwright/test').Page} page
+ */
+let page = null;
+
+test.describe( 'Google Customer Reviews Setting', () => {
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		settingsPage = new SettingsPage( page );
+
+		await setOnboardedMerchant();
+		await settingsPage.mockRequests();
+		await settingsPage.goto();
+	} );
+
+	test.afterAll( async () => {
+		await clearOnboardedMerchant();
+		await clearGCRNotificationsDismissed();
+		await page.close();
+	} );
+
+	test( 'should show the "Google Customer Reviews" setting card', async () => {
+		await expect(
+			page.getByRole( 'heading', { name: 'Settings' } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'heading', { name: 'Google Customer Reviews' } )
+		).toBeVisible();
+	} );
+
+	test( '"Collect reviews after purchase" checkbox should be unchecked by default', async () => {
+		await expect(
+			settingsPage.getCollectReviewsCheckbox()
+		).not.toBeChecked();
+	} );
+
+	test( '"Google store widget" checkbox should be unchecked by default, and its position control hidden', async () => {
+		await expect( settingsPage.getBadgeWidgetCheckbox() ).not.toBeChecked();
+		await expect(
+			settingsPage.getBadgeWidgetPositionRadio( 'Right bottom' )
+		).not.toBeVisible();
+	} );
+
+	test( 'should persist "Collect reviews after purchase" across a reload once enabled', async () => {
+		const checkbox = settingsPage.getCollectReviewsCheckbox();
+		const requestPromise = settingsPage.registerGCRSettingsSaveRequest();
+
+		await checkbox.click();
+		await requestPromise;
+
+		await page.reload();
+		await expect( settingsPage.getCollectReviewsCheckbox() ).toBeChecked();
+	} );
+
+	test( 'should reveal the widget position control and persist "Google store widget" across a reload once enabled', async () => {
+		const checkbox = settingsPage.getBadgeWidgetCheckbox();
+		const requestPromise = settingsPage.registerGCRSettingsSaveRequest();
+
+		await checkbox.click();
+		await requestPromise;
+
+		await expect(
+			settingsPage.getBadgeWidgetPositionRadio( 'Right bottom' )
+		).toBeChecked();
+
+		await page.reload();
+
+		await expect( settingsPage.getBadgeWidgetCheckbox() ).toBeChecked();
+		await expect(
+			settingsPage.getBadgeWidgetPositionRadio( 'Right bottom' )
+		).toBeChecked();
+	} );
+
+	test( 'should persist a change to the widget position across a reload', async () => {
+		const requestPromise = settingsPage.registerGCRSettingsSaveRequest();
+
+		// `.click()`, not `.check()` — the component sets a synchronous
+		// `isSaving` state before awaiting the save, which momentarily
+		// re-renders the radio with its old `selected` value and trips
+		// `.check()`'s own pre/post state assertion. The `toBeChecked()`
+		// assertion below already retries until the real save settles.
+		await settingsPage.getBadgeWidgetPositionRadio( 'Left bottom' ).click();
+		await requestPromise;
+
+		await expect(
+			settingsPage.getBadgeWidgetPositionRadio( 'Left bottom' )
+		).toBeChecked();
+
+		await page.reload();
+
+		await expect(
+			settingsPage.getBadgeWidgetPositionRadio( 'Left bottom' )
+		).toBeChecked();
+	} );
+
+	test( 'should persist "Collect reviews after purchase" as unchecked across a reload once disabled again', async () => {
+		const checkbox = settingsPage.getCollectReviewsCheckbox();
+		const requestPromise = settingsPage.registerGCRSettingsSaveRequest();
+
+		await checkbox.click();
+		await requestPromise;
+
+		await expect( checkbox ).not.toBeChecked();
+
+		await page.reload();
+		await expect(
+			settingsPage.getCollectReviewsCheckbox()
+		).not.toBeChecked();
+	} );
+
+	test( 'should persist "Google store widget" as unchecked across a reload once disabled again, and hide the position control', async () => {
+		const checkbox = settingsPage.getBadgeWidgetCheckbox();
+		const requestPromise = settingsPage.registerGCRSettingsSaveRequest();
+
+		await checkbox.click();
+		await requestPromise;
+
+		await expect( checkbox ).not.toBeChecked();
+		await expect(
+			settingsPage.getBadgeWidgetPositionRadio( 'Left bottom' )
+		).not.toBeVisible();
+
+		await page.reload();
+
+		await expect( settingsPage.getBadgeWidgetCheckbox() ).not.toBeChecked();
+		await expect(
+			settingsPage.getBadgeWidgetPositionRadio( 'Left bottom' )
+		).not.toBeVisible();
+	} );
+} );

--- a/tests/e2e/test-data/test-data.php
+++ b/tests/e2e/test-data/test-data.php
@@ -143,6 +143,23 @@ function register_routes() {
 
 	register_rest_route(
 		'wc/v3',
+		'gla-test/merchant-id',
+		[
+			[
+				'methods'             => 'POST',
+				'callback'            => __NAMESPACE__ . '\set_merchant_id',
+				'permission_callback' => __NAMESPACE__ . '\permissions',
+			],
+			[
+				'methods'             => 'DELETE',
+				'callback'            => __NAMESPACE__ . '\clear_merchant_id',
+				'permission_callback' => __NAMESPACE__ . '\permissions',
+			],
+		],
+	);
+
+	register_rest_route(
+		'wc/v3',
 		'gla-test/gcr-notifications-dismissed',
 		[
 			[
@@ -197,6 +214,25 @@ function clear_onboarded_merchant() {
 	$options->delete( OptionsInterface::MC_SETUP_COMPLETED_AT );
 	$options->delete( OptionsInterface::GOOGLE_CONNECTED );
 	$options->delete( OptionsInterface::ONBOARDING_COMPLETED_AT );
+}
+
+/**
+ * Set a fake connected Merchant Center account ID, for tests of front-end behaviour
+ * that's gated on a Merchant Center connection but doesn't call the Google APIs itself.
+ */
+function set_merchant_id() {
+	/** @var OptionsInterface $options */
+	$options = woogle_get_container()->get( OptionsInterface::class );
+	$options->update( OptionsInterface::MERCHANT_ID, 1234 );
+}
+
+/**
+ * Clear a previously set fake Merchant Center account ID.
+ */
+function clear_merchant_id() {
+	/** @var OptionsInterface $options */
+	$options = woogle_get_container()->get( OptionsInterface::class );
+	$options->delete( OptionsInterface::MERCHANT_ID );
 }
 
 /**

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -59,7 +59,14 @@ add_filter(
 );
 
 /**
- * Incremement PMax notifiation count.
+ * Increment the admin-menu notification count for testing, or force it to 0
+ * when the `no_notifications` URL parameter is present.
+ *
+ * Priority PHP_INT_MAX so this always runs *after* NotificationManager's own
+ * `notifications_count()` (added at the default priority) — otherwise the
+ * `no_notifications=true` → `return 0` here would run first, and the real
+ * filter would just add its own count right back on top afterward, silently
+ * undoing the override.
  *
  * @param integer $current_count
  * @return integer
@@ -72,5 +79,6 @@ add_filter(
 		}
 
 		return ++$current_count;
-	}
+	},
+	PHP_INT_MAX
 );

--- a/tests/e2e/test-snippets/test-snippets.php
+++ b/tests/e2e/test-snippets/test-snippets.php
@@ -31,6 +31,23 @@ add_filter(
 );
 
 /*
+ * Declare an "optin" consent type for the WP Consent API, the same way a real
+ * consent-management plugin (Complianz, CookieYes, etc.) would. Per the WP
+ * Consent API's own docs, `wp_has_consent()` fails open (returns true for
+ * every category, regardless of any cookie) whenever no plugin declares a
+ * consent type — none of the CMPs it's designed to integrate with are
+ * installed in this E2E environment, so without this, marketing-consent
+ * gating (e.g. GOOGLE_CUSTOMER_REVIEWS's storefront scripts) could never be
+ * tested as anything other than always-allowed.
+ */
+add_filter(
+	'wp_get_consent_type',
+	function () {
+		return 'optin';
+	}
+);
+
+/*
  * Mimic the `WooCommerceBrands` class to test plugin integration in product editor.
  */
 add_filter(

--- a/tests/e2e/utils/api.js
+++ b/tests/e2e/utils/api.js
@@ -182,3 +182,65 @@ export async function setGCRNotificationsDismissed() {
 export async function clearGCRNotificationsDismissed() {
 	await api().delete( 'gla-test/gcr-notifications-dismissed' );
 }
+
+/**
+ * Set a fake connected Merchant Center account ID.
+ */
+export async function setMerchantId() {
+	await api().post( 'gla-test/merchant-id' );
+}
+
+/**
+ * Clear a previously set fake Merchant Center account ID.
+ */
+export async function clearMerchantId() {
+	await api().delete( 'gla-test/merchant-id' );
+}
+
+/**
+ * Save Merchant Center settings, including the Google Customer Reviews fields
+ * (`gcr_collect_reviews_after_purchase`, `gcr_badge_widget_enabled`,
+ * `gcr_badge_widget_position`), via the real settings REST route.
+ *
+ * @param {Object} payload Partial settings object to save.
+ */
+export async function saveMCSettings( payload ) {
+	await api( 'wc/gla' ).post( 'mc/settings', payload );
+}
+
+/**
+ * Seed a shipping time (in days) for a destination country, so
+ * EstimatedDeliveryTimeResolver can resolve a delivery date for orders shipped there.
+ *
+ * @param {string} countryCode ISO 3166-1 alpha-2 country code.
+ * @param {number} time        Shipping time in days.
+ * @param {number} maxTime     Maximum shipping time in days.
+ */
+export async function setShippingTime( countryCode, time, maxTime ) {
+	await api( 'wc/gla' ).post( 'mc/shipping/times', {
+		country_code: countryCode,
+		time,
+		max_time: maxTime,
+	} );
+}
+
+/**
+ * Clear a previously seeded shipping time for a destination country.
+ *
+ * @param {string} countryCode ISO 3166-1 alpha-2 country code.
+ */
+export async function clearShippingTime( countryCode ) {
+	await api( 'wc/gla' ).delete( `mc/shipping/times/${ countryCode }` );
+}
+
+/**
+ * Fetch a WooCommerce order by ID.
+ *
+ * @param {number} orderId
+ * @return {Promise<Object>} The order.
+ */
+export async function getOrder( orderId ) {
+	return await api()
+		.get( `orders/${ orderId }` )
+		.then( ( response ) => response.data );
+}

--- a/tests/e2e/utils/api.js
+++ b/tests/e2e/utils/api.js
@@ -184,6 +184,17 @@ export async function clearGCRNotificationsDismissed() {
 }
 
 /**
+ * Fetch the currently active notifications from the real notification system.
+ *
+ * @return {Promise<Array>} The active notifications.
+ */
+export async function getNotifications() {
+	return await api( 'wc/gla' )
+		.get( 'notifications' )
+		.then( ( response ) => response.data.notifications );
+}
+
+/**
  * Set a fake connected Merchant Center account ID.
  */
 export async function setMerchantId() {

--- a/tests/e2e/utils/consent.js
+++ b/tests/e2e/utils/consent.js
@@ -1,0 +1,40 @@
+/**
+ * Helper functions for driving the real WP Consent API plugin's client-side behaviour,
+ * shared by specs that verify consent-gated storefront script injection.
+ *
+ * @typedef { import( '@playwright/test' ).Page } Page
+ */
+
+/**
+ * Grant marketing consent via the real WP Consent API client-side function.
+ *
+ * @param {Page} page
+ */
+export async function grantMarketingConsent( page ) {
+	await page.evaluate( () => window.wp_set_consent( 'marketing', 'allow' ) );
+}
+
+/**
+ * Deny marketing consent via the real WP Consent API client-side function.
+ *
+ * @param {Page} page
+ */
+export async function denyMarketingConsent( page ) {
+	await page.evaluate( () => window.wp_set_consent( 'marketing', 'deny' ) );
+}
+
+/**
+ * Dispatch the real `wp_listen_for_consent_change` event, the same event a
+ * consent-management plugin fires when a shopper grants consent mid-visit.
+ *
+ * @param {Page} page
+ */
+export async function dispatchMarketingConsentGranted( page ) {
+	await page.evaluate( () => {
+		document.dispatchEvent(
+			new CustomEvent( 'wp_listen_for_consent_change', {
+				detail: { marketing: 'allow' },
+			} )
+		);
+	} );
+}

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -93,19 +93,34 @@ export async function checkout( page ) {
 		await page.getByLabel( 'Email address' ).fill( user.email );
 
 		const firstNameField = page.getByLabel( 'First name' );
+		const rememberedAddressEditButton = page.getByRole( 'button', {
+			name: 'Edit billing address',
+		} );
 
 		// If a guest already checked out earlier in this same browser session,
 		// WooCommerce Blocks shows the remembered billing address as a
-		// read-only summary (with an "Edit" link) instead of the form, and
-		// none of the labeled fields below exist to fill.
-		//
-		// Wait for one of the two possible states to settle before checking
-		// which one rendered, since checkout can still be resolving that
-		// decision right after navigation.
-		await firstNameField
-			.or( page.getByRole( 'link', { name: 'Edit' } ) )
-			.first()
-			.waitFor( { state: 'visible' } );
+		// read-only summary (with an "Edit billing address" button) instead
+		// of the form. The form's own fields stay in the DOM either way —
+		// only hidden via CSS in the summary state — so
+		// `firstNameField.or( editBtn ).first()` can't tell the two states
+		// apart: `.first()` picks by DOM order, not visibility, and the
+		// hidden field consistently comes first, hanging forever waiting for
+		// an element that's never going to show up. Race both locators on
+		// visibility instead, and swallow whichever one loses so its
+		// still-pending wait doesn't surface as an unhandled rejection once
+		// the page later closes.
+		const waitVisible = async ( locator ) => {
+			try {
+				await locator.waitFor( { state: 'visible' } );
+			} catch {
+				// The other locator in the race may still resolve.
+			}
+		};
+
+		await Promise.race( [
+			waitVisible( firstNameField ),
+			waitVisible( rememberedAddressEditButton ),
+		] );
 
 		if ( await firstNameField.isVisible() ) {
 			await firstNameField.fill( user.firstname );

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -91,23 +91,34 @@ export async function checkout( page ) {
 		await expect( page.locator( 'div.payment_method_cod' ) ).toBeVisible();
 	} else {
 		await page.getByLabel( 'Email address' ).fill( user.email );
-		await page.getByLabel( 'First name' ).fill( user.firstname );
-		await page.getByLabel( 'Last name' ).fill( user.lastname );
-		await page
-			.getByLabel( 'Address', { exact: true } )
-			.fill( user.addressfirstline );
-		await page.getByLabel( 'City' ).fill( user.city );
-		await page.getByLabel( 'ZIP Code' ).fill( user.postcode );
 
-		const stateField = page.getByRole( 'combobox', { name: /State$/ } );
-		const stateFieldTagName = await stateField.evaluate(
-			( element ) => element.tagName
-		);
-		if ( stateFieldTagName === 'SELECT' ) {
-			stateField.selectOption( user.statename );
-		} else {
-			// compatibility-code "WC < 9.2"
-			stateField.fill( user.statename );
+		const firstNameField = page.getByLabel( 'First name' );
+
+		// If a guest already checked out earlier in this same browser session,
+		// WooCommerce Blocks shows the remembered billing address as a
+		// read-only summary (with an "Edit" link) instead of the form, and
+		// none of the labeled fields below exist to fill.
+		if ( await firstNameField.isVisible() ) {
+			await firstNameField.fill( user.firstname );
+			await page.getByLabel( 'Last name' ).fill( user.lastname );
+			await page
+				.getByLabel( 'Address', { exact: true } )
+				.fill( user.addressfirstline );
+			await page.getByLabel( 'City' ).fill( user.city );
+			await page.getByLabel( 'ZIP Code' ).fill( user.postcode );
+
+			const stateField = page.getByRole( 'combobox', {
+				name: /State$/,
+			} );
+			const stateFieldTagName = await stateField.evaluate(
+				( element ) => element.tagName
+			);
+			if ( stateFieldTagName === 'SELECT' ) {
+				stateField.selectOption( user.statename );
+			} else {
+				// compatibility-code "WC < 9.2"
+				stateField.fill( user.statename );
+			}
 		}
 	}
 

--- a/tests/e2e/utils/customer.js
+++ b/tests/e2e/utils/customer.js
@@ -98,6 +98,15 @@ export async function checkout( page ) {
 		// WooCommerce Blocks shows the remembered billing address as a
 		// read-only summary (with an "Edit" link) instead of the form, and
 		// none of the labeled fields below exist to fill.
+		//
+		// Wait for one of the two possible states to settle before checking
+		// which one rendered, since checkout can still be resolving that
+		// decision right after navigation.
+		await firstNameField
+			.or( page.getByRole( 'link', { name: 'Edit' } ) )
+			.first()
+			.waitFor( { state: 'visible' } );
+
 		if ( await firstNameField.isVisible() ) {
 			await firstNameField.fill( user.firstname );
 			await page.getByLabel( 'Last name' ).fill( user.lastname );

--- a/tests/e2e/utils/pages/settings.js
+++ b/tests/e2e/utils/pages/settings.js
@@ -227,4 +227,50 @@ export default class SettingsPage extends MockRequests {
 				request.method() === 'POST'
 		);
 	}
+
+	/**
+	 * Get the "Collect reviews after purchase" checkbox.
+	 *
+	 * @return {import('@playwright/test').Locator} The checkbox.
+	 */
+	getCollectReviewsCheckbox() {
+		return this.page.getByRole( 'checkbox', {
+			name: 'Collect reviews after purchase',
+		} );
+	}
+
+	/**
+	 * Get the "Google store widget" checkbox.
+	 *
+	 * @return {import('@playwright/test').Locator} The checkbox.
+	 */
+	getBadgeWidgetCheckbox() {
+		return this.page.getByRole( 'checkbox', {
+			name: 'Google store widget',
+		} );
+	}
+
+	/**
+	 * Get a Badge Widget position radio option, by its visible label.
+	 *
+	 * @param {string} label E.g. 'Right bottom' or 'Left bottom'.
+	 * @return {import('@playwright/test').Locator} The radio option.
+	 */
+	getBadgeWidgetPositionRadio( label ) {
+		return this.page.getByRole( 'radio', { name: label } );
+	}
+
+	/**
+	 * Register the request sent when saving Merchant Center settings
+	 * (including the Google Customer Reviews fields).
+	 *
+	 * @return {Promise<import('@playwright/test').Request>} The request.
+	 */
+	registerGCRSettingsSaveRequest() {
+		return this.page.waitForRequest(
+			( request ) =>
+				request.url().includes( '/gla/mc/settings' ) &&
+				request.method() === 'POST'
+		);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes [https://linear.app/a8c/issue/GOOWOO-1001](https://linear.app/a8c/issue/GOOWOO-1001).

Adds Playwright E2E coverage for the Google Customer Reviews (GCR) feature set, grounded in the actual shipped implementation rather than assumptions:

- **Settings page**: the Collect Reviews / Badge Widget settings card — rendering, toggle defaults, and persistence in both directions (enable → reload, disable → reload), including the widget-position control's own persistence.
- **Storefront script injection**: both the post-purchase opt-in prompt (via a real checkout flow) and the badge widget script, gated on their respective settings and on marketing consent — covering denied, granted, and granted-mid-visit-without-a-reload for both scripts.

Required a few pieces of new or fixed test infrastructure along the way:
- a `gla-test` seed endpoint for a fake connected Merchant Center account ID (no existing way to fake this for storefront-only tests)
- real REST helpers for Merchant Center settings and shipping-time seeding, used to make an order "qualifying" for the opt-in prompt
- a shared `consent.js` helper wrapping the real WP Consent API client functions
- `checkout()` now handles a guest's address being remembered from an earlier checkout in the same browser session, which WooCommerce Blocks shows as a read-only summary instead of the fillable form — the existing helper only had branches for a fresh classic or block form
- a `wp_get_consent_type` filter in the E2E test snippets, since no consent-management plugin is installed in this environment and `wp_has_consent()` otherwise always fails open (per the WP Consent API's own documented behavior), which made consent-gating untestable without it

Also fixes two pre-existing, unrelated test failures surfaced while verifying the above against the full suite:
- **`notification-badge.test.js`**: hardcoded an expected admin-menu badge count of `2`, assuming exactly one real notification would ever be active. This shared environment has accumulated real orders from repeated E2E runs elsewhere, tripping an unrelated evaluator and pushing the real count higher. Now reads the real notification count live instead of hardcoding it. Also fixes the `?no_notifications=true` test-only override, which ran at the same filter priority as GLA's own notification-count filter and executed first — the real filter then silently added its own count back on top, undoing the override. Given a late priority so it always runs last.
- **`price-benchmark-suggestions.test.js`**: the "data view fails to load" test only mocked the *first* request to `wp-dataviews-shim.js`, but the app's own `useDataViewsScript` hook deliberately retries loading it on a later mount after a failure (a real, intentional feature) — that retry's real, unmocked request could succeed before the test's assertion ran, silently skipping the error state under test. Now fails every request to that script, then un-mocks it once the error state is confirmed. Also disables the browser's HTTP cache for this file's page, since a cached static asset never reaches Playwright's request-interception layer at all, which could independently defeat a mock on a later navigation to the same admin URL.

### Screenshots:

<!--- Optional --->

### Detailed test instructions:

1. `npm run wp-env:up` (or ensure the E2E `wp-env` instance is already running)
2. `npm run test:e2e -- tests/e2e/specs/reviews/` — all 18 tests should pass
3. `npm run test:e2e -- tests/e2e/specs/gtag-events/` — confirms the new `wp_get_consent_type` filter doesn't regress the existing GTag/consent-mode suite (10 + 7 tests)
4. `npm run test:e2e -- tests/e2e/specs/dashboard/notification-badge.test.js` and `npm run test:e2e -- tests/e2e/specs/price-benchmark/price-benchmark-suggestions.test.js` — both should now pass reliably; worth running each a few times back-to-back given their history of flakiness
5. Optionally, `npm run test:e2e` for the full suite

### Additional details:

### Changelog entry

>