### PR TITLE
Drive the product status refresh from products.list and right-size the write batches

### DIFF
--- a/src/API/Google/Mapi/Models/ProductStatus.php
+++ b/src/API/Google/Mapi/Models/ProductStatus.php
@@ -21,6 +21,9 @@ class ProductStatus {
 	/** @var string|null */
 	protected $last_update_date;
 
+	/** @var string|null */
+	protected $google_expiration_date;
+
 	/**
 	 * Hydrate from a MAPI response array.
 	 *
@@ -35,8 +38,9 @@ class ProductStatus {
 			$instance->item_level_issues[] = ItemLevelIssue::from_array( $issue );
 		}
 
-		$instance->destination_statuses = $data['destinationStatuses'] ?? [];
-		$instance->last_update_date     = $data['lastUpdateDate'] ?? null;
+		$instance->destination_statuses   = $data['destinationStatuses'] ?? [];
+		$instance->last_update_date       = $data['lastUpdateDate'] ?? null;
+		$instance->google_expiration_date = $data['googleExpirationDate'] ?? null;
 
 		return $instance;
 	}
@@ -60,5 +64,47 @@ class ProductStatus {
 	 */
 	public function get_last_update_date(): ?string {
 		return $this->last_update_date;
+	}
+
+	/**
+	 * @return string|null RFC 3339 timestamp, or null when Google reports no expiration.
+	 */
+	public function get_google_expiration_date(): ?string {
+		return $this->google_expiration_date;
+	}
+
+	/**
+	 * Derive the aggregated reporting context status from the per-context destination
+	 * statuses, following the official enum semantics (eligible for all contexts and
+	 * countries = ELIGIBLE, some = ELIGIBLE_LIMITED, pending in all = PENDING,
+	 * otherwise NOT_ELIGIBLE_OR_DISAPPROVED). The product_view report precomputes this
+	 * value; products.list does not carry it, so it is rebuilt here from the same inputs.
+	 *
+	 * A product with no destination statuses at all (still processing) returns an empty
+	 * string: callers treat it like a product absent from the report.
+	 *
+	 * @return string Aggregated status enum value, or '' when no destination statuses exist.
+	 */
+	public function get_aggregated_reporting_context_status(): string {
+		$has_approved    = false;
+		$has_pending     = false;
+		$has_disapproved = false;
+
+		foreach ( $this->destination_statuses as $destination_status ) {
+			$has_approved    = $has_approved || ! empty( $destination_status['approvedCountries'] );
+			$has_pending     = $has_pending || ! empty( $destination_status['pendingCountries'] );
+			$has_disapproved = $has_disapproved || ! empty( $destination_status['disapprovedCountries'] );
+		}
+
+		if ( ! $has_approved && ! $has_pending && ! $has_disapproved ) {
+			return '';
+		}
+
+		if ( $has_approved ) {
+			return ( $has_pending || $has_disapproved ) ? 'ELIGIBLE_LIMITED' : 'ELIGIBLE';
+		}
+
+		// No approvals: all-pending is PENDING; any disapproval makes it not eligible anywhere.
+		return $has_disapproved ? 'NOT_ELIGIBLE_OR_DISAPPROVED' : 'PENDING';
 	}
 }

--- a/src/API/Google/Mapi/Services/MapiProductInputsService.php
+++ b/src/API/Google/Mapi/Services/MapiProductInputsService.php
@@ -441,7 +441,8 @@ class MapiProductInputsService implements OptionsAwareInterface {
 	 * @return int
 	 */
 	protected function get_batch_size(): int {
-		return max( 1, (int) apply_filters( 'woocommerce_gla_mapi_batch_size', 50 ) );
+		// 100 is the Merchant API's recommended maximum sub-requests per batch.
+		return max( 1, (int) apply_filters( 'woocommerce_gla_mapi_batch_size', 100 ) );
 	}
 
 	/**

--- a/src/API/Google/Mapi/Services/MapiProductsService.php
+++ b/src/API/Google/Mapi/Services/MapiProductsService.php
@@ -102,17 +102,46 @@ class MapiProductsService implements OptionsAwareInterface {
 	 * @throws MerchantApiException On non-2xx response.
 	 */
 	public function list( int $page_size = 250 ): iterable {
-		$page_token = '';
+		$page_token = null;
 
 		do {
-			$body = $this->client->get( $this->build_list_path( $page_size, $page_token ) );
+			$page = $this->list_page( $page_token, $page_size );
 
-			foreach ( $body['products'] ?? [] as $product ) {
-				yield Product::from_array( $product );
+			foreach ( $page['products'] as $product ) {
+				yield $product;
 			}
 
-			$page_token = $body['nextPageToken'] ?? '';
-		} while ( '' !== $page_token );
+			$page_token = $page['next_page_token'];
+		} while ( null !== $page_token );
+	}
+
+	/**
+	 * Fetch a single page of the account's products.
+	 *
+	 * Page-wise counterpart of {@see list()} for callers that carry the pagination
+	 * state themselves across separate PHP requests (e.g. a batched job storing the
+	 * token between scheduled actions).
+	 *
+	 * @param string|null $page_token Token of the page to fetch; null for the first page.
+	 * @param int         $page_size  Maximum products per page (the API caps this at 1000).
+	 *
+	 * @return array{products: Product[], next_page_token: ?string}
+	 * @throws MerchantApiException On non-2xx response.
+	 */
+	public function list_page( ?string $page_token = null, int $page_size = 1000 ): array {
+		$body = $this->client->get( $this->build_list_path( $page_size, $page_token ?? '' ) );
+
+		$products = [];
+		foreach ( $body['products'] ?? [] as $product ) {
+			$products[] = Product::from_array( $product );
+		}
+
+		$next_token = $body['nextPageToken'] ?? null;
+
+		return [
+			'products'        => $products,
+			'next_page_token' => is_string( $next_token ) && '' !== $next_token ? $next_token : null,
+		];
 	}
 
 	/**

--- a/src/API/Google/Mapi/Services/MapiProductsService.php
+++ b/src/API/Google/Mapi/Services/MapiProductsService.php
@@ -123,12 +123,14 @@ class MapiProductsService implements OptionsAwareInterface {
 	 * token between scheduled actions).
 	 *
 	 * @param string|null $page_token Token of the page to fetch; null for the first page.
-	 * @param int         $page_size  Maximum products per page (the API caps this at 1000).
+	 * @param int         $page_size  Maximum products per page; clamped to the API range 1-1000.
 	 *
 	 * @return array{products: Product[], next_page_token: ?string}
 	 * @throws MerchantApiException On non-2xx response.
 	 */
 	public function list_page( ?string $page_token = null, int $page_size = 1000 ): array {
+		$page_size = min( 1000, max( 1, $page_size ) );
+
 		$body = $this->client->get( $this->build_list_path( $page_size, $page_token ?? '' ) );
 
 		$products = [];

--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -118,18 +118,7 @@ class MerchantReport implements OptionsAwareInterface {
 	 * @return string The MC status.
 	 */
 	protected function convert_aggregated_status_to_mc_status( string $status ): string {
-		switch ( $status ) {
-			case 'ELIGIBLE':
-				return MCStatus::APPROVED;
-			case 'ELIGIBLE_LIMITED':
-				return MCStatus::PARTIALLY_APPROVED;
-			case 'NOT_ELIGIBLE_OR_DISAPPROVED':
-				return MCStatus::DISAPPROVED;
-			case 'PENDING':
-				return MCStatus::PENDING;
-			default:
-				return MCStatus::NOT_SYNCED;
-		}
+		return MCStatus::from_aggregated_reporting_context_status( $status );
 	}
 
 	/**

--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -55,6 +55,10 @@ class MerchantReport implements OptionsAwareInterface {
 	/**
 	 * Get ProductView Query response.
 	 *
+	 * @deprecated No longer used by the status refresh, which walks
+	 *             MapiProductsService::list_page() and derives statuses via
+	 *             MerchantStatuses::process_mapi_products() instead.
+	 *
 	 * @param string|null $next_page_token The next page token.
 	 * @return array Associative array with product statuses and the next page token.
 	 *

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -77,6 +77,22 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
 	}
 
 	/**
+	 * Delete issue records by their row IDs.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int[] $ids Row IDs to delete.
+	 */
+	public function delete_by_ids( array $ids ): void {
+		if ( empty( $ids ) ) {
+			return;
+		}
+
+		$placeholder = '(' . implode( ',', array_fill( 0, count( $ids ), '%d' ) ) . ')';
+		$this->wpdb->query( $this->wpdb->prepare( "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `id` IN {$placeholder}", $ids ) ); // phpcs:ignore WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+	}
+
+	/**
 	 * Get the columns for the table.
 	 *
 	 * @return array

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -14,7 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\Writer\CsvExportWr
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantReport;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidClass;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
@@ -183,7 +183,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 		$this->share_action_scheduler_job( CreateYouTubeOrderIdsCache::class, YouTubeOrders::class, JobRepository::class );
 		$this->share_action_scheduler_job( CreateMerchantReportedConversionReport::class, OrderItemRowBuilder::class, CsvExportWriter::class, YouTubeConnection::class );
 
-		$this->share_action_scheduler_job( UpdateMerchantProductStatuses::class, MerchantCenterService::class, MerchantReport::class, MerchantStatuses::class );
+		$this->share_action_scheduler_job( UpdateMerchantProductStatuses::class, MerchantCenterService::class, MapiProductsService::class, MerchantStatuses::class );
 
 		$this->share_action_scheduler_job( UpdateMerchantPriceBenchmarks::class, MerchantCenterService::class, PriceBenchmarks::class );
 

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -78,16 +78,17 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 	/**
 	 * Process the job.
 	 *
-	 * @param int[] $items An array of job arguments.
+	 * @param array $items Job arguments, optionally carrying the next_page_token to continue from.
 	 *
-	 * @throws JobException If the merchant product statuses cannot be retrieved..
+	 * @throws JobException If the merchant product statuses cannot be retrieved.
 	 */
 	public function process_items( array $items ) {
 		try {
 			$next_page_token = $items['next_page_token'] ?? null;
 
-			// Clear the cache if we're starting from the beginning.
-			if ( ! $next_page_token ) {
+			// Clear the cache if we're starting from the beginning. Strict check: a
+			// pagination token is an opaque string, and PHP would treat "0" as falsy.
+			if ( null === $next_page_token ) {
 				$this->merchant_statuses->clear_product_statuses_cache_and_issues();
 				$this->merchant_statuses->refresh_account_and_presync_issues();
 			}
@@ -113,7 +114,7 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 
 			$this->merchant_statuses->process_mapi_products( $page['products'] );
 
-			if ( $next_page_token ) {
+			if ( null !== $next_page_token ) {
 				$this->schedule( [ [ 'next_page_token' => $next_page_token ] ] );
 			} else {
 				$this->merchant_statuses->handle_complete_mc_statuses_fetching();

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -5,7 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantReport;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Throwable;
 
@@ -29,9 +29,9 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 	protected $merchant_center;
 
 	/**
-	 * @var MerchantReport
+	 * @var MapiProductsService
 	 */
-	protected $merchant_report;
+	protected $mapi_products;
 
 	/**
 	 * @var MerchantStatuses
@@ -45,13 +45,13 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 	 * @param ActionSchedulerInterface  $action_scheduler
 	 * @param ActionSchedulerJobMonitor $monitor
 	 * @param MerchantCenterService     $merchant_center
-	 * @param MerchantReport            $merchant_report
+	 * @param MapiProductsService       $mapi_products
 	 * @param MerchantStatuses          $merchant_statuses
 	 */
-	public function __construct( ActionSchedulerInterface $action_scheduler, ActionSchedulerJobMonitor $monitor, MerchantCenterService $merchant_center, MerchantReport $merchant_report, MerchantStatuses $merchant_statuses ) {
+	public function __construct( ActionSchedulerInterface $action_scheduler, ActionSchedulerJobMonitor $monitor, MerchantCenterService $merchant_center, MapiProductsService $mapi_products, MerchantStatuses $merchant_statuses ) {
 		parent::__construct( $action_scheduler, $monitor );
 		$this->merchant_center   = $merchant_center;
-		$this->merchant_report   = $merchant_report;
+		$this->mapi_products     = $mapi_products;
 		$this->merchant_statuses = $merchant_statuses;
 	}
 
@@ -92,10 +92,26 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 				$this->merchant_statuses->refresh_account_and_presync_issues();
 			}
 
-			$results         = $this->merchant_report->get_product_view_report( $next_page_token );
-			$next_page_token = $results['next_page_token'];
+			// One list page per action: the token travels in the action args, exactly
+			// like the report page token did, but each page also carries the item-level
+			// issues, so the whole refresh costs ceil(N/1000) requests in total.
+			/**
+			 * Filters the products.list page size used by the status refresh.
+			 *
+			 * Successor of the tuning point the retired report-driven flow exposed as
+			 * woocommerce_gla_product_view_report_page_size; a constrained host can lower
+			 * it to trade request count for peak memory. Clamped to the API range 1-1000.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param int $page_size Products per list page. Default 1000, the API maximum.
+			 */
+			$page_size = min( 1000, max( 1, (int) apply_filters( 'woocommerce_gla_mapi_products_list_page_size', 1000 ) ) );
 
-			$this->merchant_statuses->process_product_statuses( $results['statuses'] );
+			$page            = $this->mapi_products->list_page( $next_page_token, $page_size );
+			$next_page_token = $page['next_page_token'];
+
+			$this->merchant_statuses->process_mapi_products( $page['products'] );
 
 			if ( $next_page_token ) {
 				$this->schedule( [ [ 'next_page_token' => $next_page_token ] ] );

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -96,17 +96,17 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 			// like the report page token did, but each page also carries the item-level
 			// issues, so the whole refresh costs ceil(N/1000) requests in total.
 			/**
-			 * Filters the products.list page size used by the status refresh.
+			 * Filters the page size of the status refresh source.
 			 *
-			 * Successor of the tuning point the retired report-driven flow exposed as
-			 * woocommerce_gla_product_view_report_page_size; a constrained host can lower
-			 * it to trade request count for peak memory. Clamped to the API range 1-1000.
+			 * The hook predates the list-driven refresh: it originally sized the
+			 * product_view report pages, and its name is kept on purpose so caps set
+			 * by constrained hosts keep working now that the pages come from
+			 * products.list instead. Default 1000 (500 in the report era), clamped
+			 * to the API range 1-1000.
 			 *
-			 * @since x.x.x
-			 *
-			 * @param int $page_size Products per list page. Default 1000, the API maximum.
+			 * @param int $page_size Products per list page.
 			 */
-			$page_size = min( 1000, max( 1, (int) apply_filters( 'woocommerce_gla_mapi_products_list_page_size', 1000 ) ) );
+			$page_size = min( 1000, max( 1, (int) apply_filters( 'woocommerce_gla_product_view_report_page_size', 1000 ) ) );
 
 			$page            = $this->mapi_products->list_page( $next_page_token, $page_size );
 			$next_page_token = $page['next_page_token'];

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -95,19 +95,22 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 
 			// One list page per action: the token travels in the action args, exactly
 			// like the report page token did, but each page also carries the item-level
-			// issues, so the whole refresh costs ceil(N/1000) requests in total.
+			// issues, so the whole refresh costs one request per list page.
 			/**
 			 * Filters the page size of the status refresh source.
 			 *
 			 * The hook predates the list-driven refresh: it originally sized the
 			 * product_view report pages, and its name is kept on purpose so caps set
 			 * by constrained hosts keep working now that the pages come from
-			 * products.list instead. Default 1000 (500 in the report era), clamped
-			 * to the API range 1-1000.
+			 * products.list instead. The default stays at the report era's 500: a
+			 * list entry is far heavier than a report row (productStatus carries the
+			 * item-level issues with per-reporting-context country lists), so a full
+			 * 1000-entry page can cost hundreds of MB of decode peak on issue-heavy
+			 * catalogues. Clamped to the API range 1-1000.
 			 *
 			 * @param int $page_size Products per list page.
 			 */
-			$page_size = min( 1000, max( 1, (int) apply_filters( 'woocommerce_gla_product_view_report_page_size', 1000 ) ) );
+			$page_size = min( 1000, max( 1, (int) apply_filters( 'woocommerce_gla_product_view_report_page_size', 500 ) ) );
 
 			$page            = $this->mapi_products->list_page( $next_page_token, $page_size );
 			$next_page_token = $page['next_page_token'];

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -385,7 +385,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * Get MC product issues from a list of Product View statuses.
 	 *
 	 * @param array $statuses The list of Product View statuses.
-	 * @param array $products_by_google_id Merchant API products keyed by product id; issues are read from these, so no request is made here.
+	 * @param array $products_by_google_id Merchant API products keyed by their Merchant API product id (the resource name's last segment, e.g. en~US~gla_123); issues are read from these, so no request is made here.
 	 * @throws NotFoundExceptionInterface  If the class is not found in the container.
 	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 *
@@ -772,7 +772,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * Process product status statistics.
 	 *
 	 * @param array $product_view_statuses Product View statuses.
-	 * @param array $products_by_google_id Merchant API products keyed by product id, the source of item-level issues.
+	 * @param array $products_by_google_id Merchant API products keyed by their Merchant API product id (the resource name's last segment, e.g. en~US~gla_123), the source of item-level issues.
 	 * @see UpdateMerchantProductStatuses::process_items
 	 *
 	 * @throws NotFoundExceptionInterface  If the class is not found in the container.

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -430,7 +430,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			return [];
 		}
 
-		$created_at     = $this->cache_created_time->format( 'Y-m-d H:i:s' );
+		$created_at = $this->cache_created_time->format( 'Y-m-d H:i:s' );
+		// Issues come only from the provided page, so a product whose synced variants
+		// (multiple google ids) span list pages gets its applicable countries from the
+		// last page written rather than a cross-variant merge. Today the plugin creates
+		// one input per product, so variants never split; revisit if multi-feed lands.
 		$products       = array_intersect_key( $products_by_google_id, $google_id_to_wc_id );
 		$product_issues = [];
 
@@ -752,7 +756,13 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 
 			$expiration_date = null;
 			if ( $product_status->get_google_expiration_date() ) {
-				$expiration_date = new DateTime( $product_status->get_google_expiration_date() );
+				try {
+					$expiration_date = new DateTime( $product_status->get_google_expiration_date() );
+				} catch ( Exception $e ) {
+					// An unparsable timestamp only loses the expiring hint; it must not
+					// fail the page and, through the retry chain, kill the refresh.
+					$expiration_date = null;
+				}
 			}
 
 			$statuses[ $wc_product_id ] = [
@@ -772,7 +782,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * Process product status statistics.
 	 *
 	 * @param array $product_view_statuses Product View statuses.
-	 * @param array $products_by_google_id Merchant API products keyed by their Merchant API product id (the resource name's last segment, e.g. en~US~gla_123), the source of item-level issues.
+	 * @param array $products_by_google_id Merchant API products keyed by their Merchant API product id (the resource name's last segment, e.g. en~US~gla_123), the source of item-level issues. When omitted, no product issues are written.
 	 * @see UpdateMerchantProductStatuses::process_items
 	 *
 	 * @throws NotFoundExceptionInterface  If the class is not found in the container.

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -431,10 +431,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		}
 
 		$created_at = $this->cache_created_time->format( 'Y-m-d H:i:s' );
-		// Issues come only from the provided page, so a product whose synced variants
-		// (multiple google ids) span list pages gets its applicable countries from the
-		// last page written rather than a cross-variant merge. Today the plugin creates
-		// one input per product, so variants never split; revisit if multi-feed lands.
+		// Issues come only from the provided page. A product synced to several feeds
+		// (markets, and languages with WPML) has one Merchant Center entry per feed,
+		// and those entries can land on different list pages; the countries seen by
+		// the pages processed before this one are folded back in by
+		// merge_issue_countries_from_earlier_pages().
 		$products       = array_intersect_key( $products_by_google_id, $google_id_to_wc_id );
 		$product_issues = [];
 
@@ -642,6 +643,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 */
 	protected function refresh_product_issues( array $product_issues ): void {
+		$stale_row_ids = $this->merge_issue_countries_from_earlier_pages( $product_issues );
+
 		// Alphabetize all product/issue country lists.
 		array_walk(
 			$this->product_issue_countries,
@@ -651,10 +654,14 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		);
 
 		// Product issue cleanup: sorting (by product ID) and encode applicable countries.
+		// The countries are de-duplicated: the source repeats them once per reporting
+		// context, and merging earlier pages in would compound that repetition.
 		ksort( $product_issues );
 		$product_issues = array_map(
 			function ( $unique_key, $issue ) {
-				$issue['applicable_countries'] = wp_json_encode( $this->product_issue_countries[ $unique_key ] );
+				$issue['applicable_countries'] = wp_json_encode(
+					array_values( array_unique( $this->product_issue_countries[ $unique_key ] ) )
+				);
 				return $issue;
 			},
 			array_keys( $product_issues ),
@@ -664,6 +671,65 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		/** @var MerchantIssueQuery $issue_query */
 		$issue_query = $this->container->get( MerchantIssueQuery::class );
 		$issue_query->update_or_insert( array_values( $product_issues ) );
+
+		// Deleted only after the merged rows are written: a page interrupted in
+		// between leaves duplicate rows, which the next page or cycle absorbs,
+		// instead of losing the countries collected by earlier pages.
+		if ( ! empty( $stale_row_ids ) ) {
+			$this->container->get( MerchantIssueTable::class )->delete_by_ids( $stale_row_ids );
+		}
+	}
+
+	/**
+	 * Fold in the product issue rows written by the pages processed before this one.
+	 *
+	 * One status refresh spans several list pages, each processed in its own
+	 * scheduled action, and a product synced to several feeds (markets, and
+	 * languages with WPML) can have its Merchant Center entries spread over
+	 * several of those pages. Each page only sees the item-level issues of its
+	 * own entries, so the rows written so far carry the applicable countries of
+	 * earlier pages. Merging them into this page's countries, and replacing them
+	 * because the table has no unique key an upsert could update through, leaves
+	 * one row per product and issue whose country list is the union across all
+	 * of the product's entries, the same result a single-page refresh produces.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $product_issues Product issue rows about to be written, keyed by product ID and hashed issue text.
+	 *
+	 * @return int[] IDs of the folded-in rows, for deletion once the merged rows are written.
+	 * @throws NotFoundExceptionInterface  If the class is not found in the container.
+	 * @throws ContainerExceptionInterface If the container throws an exception.
+	 */
+	protected function merge_issue_countries_from_earlier_pages( array $product_issues ): array {
+		if ( empty( $product_issues ) ) {
+			return [];
+		}
+
+		/** @var MerchantIssueQuery $issue_query */
+		$issue_query = $this->container->get( MerchantIssueQuery::class );
+		$issue_query->where( 'product_id', array_unique( array_column( $product_issues, 'product_id' ) ), 'IN' );
+		$issue_query->where( 'source', 'mc' );
+		$issue_query->where( 'type', self::TYPE_PRODUCT );
+
+		$stale_row_ids = [];
+		foreach ( $issue_query->get_results() as $row ) {
+			$unique_key = $row['product_id'] . '__' . md5( $row['issue'] );
+			if ( ! isset( $product_issues[ $unique_key ] ) ) {
+				continue;
+			}
+
+			$stale_row_ids[] = (int) $row['id'];
+
+			$stored_countries = json_decode( $row['applicable_countries'], true );
+
+			$this->product_issue_countries[ $unique_key ] = array_merge(
+				$this->product_issue_countries[ $unique_key ] ?? [],
+				is_array( $stored_countries ) ? $stored_countries : []
+			);
+		}
+
+		return $stale_row_ids;
 	}
 
 	/**
@@ -789,7 +855,14 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 */
 	public function process_product_statuses( array $product_view_statuses, array $products_by_google_id = [] ): void {
-		$this->mc_statuses         = [];
+		$this->mc_statuses = [];
+		// This service is a shared singleton, so in a long-lived process the map
+		// still holds the countries of previously processed pages, or of an earlier
+		// refresh cycle entirely. Earlier pages of the current cycle are re-supplied
+		// from their rows by merge_issue_countries_from_earlier_pages(); anything
+		// older would pollute the new rows, so each page starts from an empty map.
+		$this->product_issue_countries = [];
+
 		$product_repository        = $this->container->get( ProductRepository::class );
 		$this->product_data_lookup = $product_repository->find_by_ids_as_associative_array( array_column( $product_view_statuses, 'product_id' ) );
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -653,9 +653,10 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			}
 		);
 
-		// Product issue cleanup: sorting (by product ID) and encode applicable countries.
-		// The countries are de-duplicated: the source repeats them once per reporting
-		// context, and merging earlier pages in would compound that repetition.
+		// Product issue cleanup: sort by unique key for a deterministic write order
+		// and encode applicable countries. The countries are de-duplicated: the source
+		// repeats them once per reporting context, and merging earlier pages in would
+		// compound that repetition.
 		ksort( $product_issues );
 		$product_issues = array_map(
 			function ( $unique_key, $issue ) {

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -4,7 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductMetaQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
@@ -385,16 +385,15 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * Get MC product issues from a list of Product View statuses.
 	 *
 	 * @param array $statuses The list of Product View statuses.
+	 * @param array $products_by_google_id Merchant API products keyed by product id; issues are read from these, so no request is made here.
 	 * @throws NotFoundExceptionInterface  If the class is not found in the container.
 	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 *
 	 * @return array The list of product issues.
 	 */
-	protected function get_product_issues( array $statuses ): array {
+	protected function get_product_issues( array $statuses, array $products_by_google_id = [] ): array {
 		/** @var ProductHelper $product_helper */
 		$product_helper = $this->container->get( ProductHelper::class );
-		/** @var MapiProductsService $mapi_products */
-		$mapi_products = $this->container->get( MapiProductsService::class );
 		/** @var BatchProductHelper $batch_product_helper */
 		$batch_product_helper = $this->container->get( BatchProductHelper::class );
 		$visibility_meta_key  = $this->prefix_meta_key( ProductMetaHandler::KEY_VISIBILITY );
@@ -432,7 +431,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		}
 
 		$created_at     = $this->cache_created_time->format( 'Y-m-d H:i:s' );
-		$products       = $mapi_products->get_many( array_keys( $google_id_to_wc_id ) );
+		$products       = array_intersect_key( $products_by_google_id, $google_id_to_wc_id );
 		$product_issues = [];
 
 		foreach ( $products as $google_id => $product ) {
@@ -721,15 +720,65 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	}
 
 	/**
+	 * Convert one page of Merchant API products into product view statuses and process them.
+	 *
+	 * Replaces the product_view report as the driver of the status refresh: the aggregated
+	 * status is derived from each product's destination statuses, and the same page of
+	 * products doubles as the item-level issue source, so no further request is needed.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param Product[] $products One page of Merchant API products.
+	 */
+	public function process_mapi_products( array $products ): void {
+		$product_helper        = $this->container->get( ProductHelper::class );
+		$statuses              = [];
+		$products_by_google_id = [];
+
+		foreach ( $products as $product ) {
+			$product_status = $product->get_product_status();
+			$aggregated     = $product_status ? $product_status->get_aggregated_reporting_context_status() : '';
+
+			// No destination statuses yet: the product is still processing, and the
+			// product_view report would not return it either. Skip it for parity.
+			if ( '' === $aggregated ) {
+				continue;
+			}
+
+			$wc_product_id = $product_helper->get_wc_product_id( $product->get_id() );
+			if ( ! $wc_product_id ) {
+				continue;
+			}
+
+			$expiration_date = null;
+			if ( $product_status->get_google_expiration_date() ) {
+				$expiration_date = new DateTime( $product_status->get_google_expiration_date() );
+			}
+
+			$statuses[ $wc_product_id ] = [
+				'mc_id'           => $product->get_id(),
+				'product_id'      => $wc_product_id,
+				'status'          => MCStatus::from_aggregated_reporting_context_status( $aggregated ),
+				'expiration_date' => $expiration_date,
+			];
+
+			$products_by_google_id[ $product->get_id() ] = $product;
+		}
+
+		$this->process_product_statuses( $statuses, $products_by_google_id );
+	}
+
+	/**
 	 * Process product status statistics.
 	 *
 	 * @param array $product_view_statuses Product View statuses.
-	 * @see MerchantReport::get_product_view_report
+	 * @param array $products_by_google_id Merchant API products keyed by product id, the source of item-level issues.
+	 * @see UpdateMerchantProductStatuses::process_items
 	 *
 	 * @throws NotFoundExceptionInterface  If the class is not found in the container.
 	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 */
-	public function process_product_statuses( array $product_view_statuses ): void {
+	public function process_product_statuses( array $product_view_statuses, array $products_by_google_id = [] ): void {
 		$this->mc_statuses         = [];
 		$product_repository        = $this->container->get( ProductRepository::class );
 		$this->product_data_lookup = $product_repository->find_by_ids_as_associative_array( array_column( $product_view_statuses, 'product_id' ) );
@@ -779,7 +828,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		$this->update_products_meta_with_mc_status();
 		$this->update_intermediate_product_statistics();
 
-		$product_issues = $this->get_product_issues( $product_view_statuses );
+		$product_issues = $this->get_product_issues( $product_view_statuses, $products_by_google_id );
 		$this->refresh_product_issues( $product_issues );
 	}
 

--- a/src/Value/MCStatus.php
+++ b/src/Value/MCStatus.php
@@ -65,4 +65,30 @@ class MCStatus implements ValueInterface {
 	public function __toString(): string {
 		return $this->get();
 	}
+
+	/**
+	 * Map a Merchant API aggregated reporting context status (as returned by the
+	 * product_view report, or derived from a product's destination statuses) to
+	 * the plugin's MC status vocabulary.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $status Aggregated reporting context status, e.g. 'ELIGIBLE'.
+	 *
+	 * @return string One of the MCStatus constants.
+	 */
+	public static function from_aggregated_reporting_context_status( string $status ): string {
+		switch ( $status ) {
+			case 'ELIGIBLE':
+				return self::APPROVED;
+			case 'ELIGIBLE_LIMITED':
+				return self::PARTIALLY_APPROVED;
+			case 'NOT_ELIGIBLE_OR_DISAPPROVED':
+				return self::DISAPPROVED;
+			case 'PENDING':
+				return self::PENDING;
+			default:
+				return self::NOT_SYNCED;
+		}
+	}
 }

--- a/tests/Unit/API/Google/Mapi/Models/ProductStatusTest.php
+++ b/tests/Unit/API/Google/Mapi/Models/ProductStatusTest.php
@@ -50,5 +50,143 @@ class ProductStatusTest extends UnitTest {
 		$this->assertSame( [], $status->get_item_level_issues() );
 		$this->assertSame( [], $status->get_destination_statuses() );
 		$this->assertNull( $status->get_last_update_date() );
+		$this->assertNull( $status->get_google_expiration_date() );
+	}
+
+	public function test_from_array_populates_google_expiration_date() {
+		$status = ProductStatus::from_array( [ 'googleExpirationDate' => '2026-10-02T16:35:10.725858Z' ] );
+
+		$this->assertSame( '2026-10-02T16:35:10.725858Z', $status->get_google_expiration_date() );
+	}
+
+	/**
+	 * @dataProvider aggregated_status_provider
+	 *
+	 * @param array  $destination_statuses
+	 * @param string $expected
+	 */
+	public function test_get_aggregated_reporting_context_status( array $destination_statuses, string $expected ) {
+		$status = ProductStatus::from_array( [ 'destinationStatuses' => $destination_statuses ] );
+
+		$this->assertSame( $expected, $status->get_aggregated_reporting_context_status() );
+	}
+
+	/**
+	 * Matrix following the official enum semantics.
+	 *
+	 * @return array
+	 */
+	public function aggregated_status_provider(): array {
+		$ads  = 'SHOPPING_ADS';
+		$free = 'FREE_LISTINGS';
+
+		return [
+			'approved everywhere'                        => [
+				[
+					[
+						'reportingContext'  => $ads,
+						'approvedCountries' => [ 'US', 'CA' ],
+					],
+				],
+				'ELIGIBLE',
+			],
+			'approved in all contexts'                   => [
+				[
+					[
+						'reportingContext'  => $ads,
+						'approvedCountries' => [ 'US' ],
+					],
+					[
+						'reportingContext'  => $free,
+						'approvedCountries' => [ 'US' ],
+					],
+				],
+				'ELIGIBLE',
+			],
+			'approved and disapproved mix'               => [
+				[
+					[
+						'reportingContext'     => $ads,
+						'approvedCountries'    => [ 'US' ],
+						'disapprovedCountries' => [ 'CA' ],
+					],
+				],
+				'ELIGIBLE_LIMITED',
+			],
+			'approved in one context, disapproved other' => [
+				[
+					[
+						'reportingContext'  => $ads,
+						'approvedCountries' => [ 'US' ],
+					],
+					[
+						'reportingContext'     => $free,
+						'disapprovedCountries' => [ 'US' ],
+					],
+				],
+				'ELIGIBLE_LIMITED',
+			],
+			'approved and pending mix'                   => [
+				[
+					[
+						'reportingContext'  => $ads,
+						'approvedCountries' => [ 'US' ],
+					],
+					[
+						'reportingContext' => $free,
+						'pendingCountries' => [ 'US' ],
+					],
+				],
+				'ELIGIBLE_LIMITED',
+			],
+			'pending everywhere'                         => [
+				[
+					[
+						'reportingContext' => $ads,
+						'pendingCountries' => [ 'US' ],
+					],
+					[
+						'reportingContext' => $free,
+						'pendingCountries' => [ 'US' ],
+					],
+				],
+				'PENDING',
+			],
+			'disapproved everywhere'                     => [
+				[
+					[
+						'reportingContext'     => $ads,
+						'disapprovedCountries' => [ 'US' ],
+					],
+				],
+				'NOT_ELIGIBLE_OR_DISAPPROVED',
+			],
+			'pending and disapproved, no approval'       => [
+				[
+					[
+						'reportingContext'     => $ads,
+						'disapprovedCountries' => [ 'US' ],
+					],
+					[
+						'reportingContext' => $free,
+						'pendingCountries' => [ 'US' ],
+					],
+				],
+				'NOT_ELIGIBLE_OR_DISAPPROVED',
+			],
+			'no destination statuses (still processing)' => [
+				[],
+				'',
+			],
+			'contexts with empty country lists'          => [
+				[
+					[
+						'reportingContext'  => $ads,
+						'approvedCountries' => [],
+					],
+				],
+				'',
+			],
+		];
 	}
 }

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
@@ -295,6 +295,13 @@ class MapiProductInputsServiceTest extends UnitTest {
 		$this->assertSame( 503, $result['failures'][0]->get_http_status() );
 	}
 
+	public function test_default_batch_size_is_100() {
+		$method = new \ReflectionMethod( MapiProductInputsService::class, 'get_batch_size' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 100, $method->invoke( $this->service ) );
+	}
+
 	public function test_insert_many_chunks_into_multiple_batches_and_keys_by_original_index() {
 		add_filter(
 			'woocommerce_gla_mapi_batch_size',

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
@@ -180,6 +180,26 @@ class MapiProductsServiceTest extends UnitTest {
 		$this->assertSame( 'tok/2', $page['next_page_token'] );
 	}
 
+	public function test_list_page_clamps_page_size_to_api_bounds() {
+		$matcher = $this->exactly( 2 );
+		$this->client->expects( $matcher )
+			->method( 'get' )
+			->willReturnCallback(
+				function ( string $path ) use ( $matcher ) {
+					if ( 1 === $matcher->getInvocationCount() ) {
+						$this->assertStringContainsString( 'pageSize=1000', $path );
+					} else {
+						$this->assertStringContainsString( 'pageSize=1', $path );
+					}
+
+					return [ 'products' => [] ];
+				}
+			);
+
+		$this->service->list_page( null, 5000 );
+		$this->service->list_page( null, 0 );
+	}
+
 	public function test_list_page_encodes_token_and_ends_pagination() {
 		$this->client->expects( $this->once() )
 			->method( 'get' )

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
@@ -186,10 +186,12 @@ class MapiProductsServiceTest extends UnitTest {
 			->method( 'get' )
 			->willReturnCallback(
 				function ( string $path ) use ( $matcher ) {
+					// The token is null, so pageSize is the final query argument; an
+					// exact suffix match cannot be satisfied by a longer number.
 					if ( 1 === $matcher->getInvocationCount() ) {
-						$this->assertStringContainsString( 'pageSize=1000', $path );
+						$this->assertStringEndsWith( 'pageSize=1000', $path );
 					} else {
-						$this->assertStringContainsString( 'pageSize=1', $path );
+						$this->assertStringEndsWith( 'pageSize=1', $path );
 					}
 
 					return [ 'products' => [] ];

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
@@ -157,6 +157,41 @@ class MapiProductsServiceTest extends UnitTest {
 		$this->assertSame( $boom, $captured[0][0] );
 	}
 
+	public function test_list_page_requests_first_page_at_default_size_1000() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( 'products/v1/accounts/12345/products?pageSize=1000' )
+			->willReturn(
+				[
+					'products'      => [
+						[
+							'name'    => 'accounts/12345/products/en~US~gla_1',
+							'offerId' => 'gla_1',
+						],
+					],
+					'nextPageToken' => 'tok/2',
+				]
+			);
+
+		$page = $this->service->list_page();
+
+		$this->assertCount( 1, $page['products'] );
+		$this->assertInstanceOf( Product::class, $page['products'][0] );
+		$this->assertSame( 'tok/2', $page['next_page_token'] );
+	}
+
+	public function test_list_page_encodes_token_and_ends_pagination() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( 'products/v1/accounts/12345/products?pageSize=1000&pageToken=tok%2F2' )
+			->willReturn( [ 'products' => [] ] );
+
+		$page = $this->service->list_page( 'tok/2' );
+
+		$this->assertSame( [], $page['products'] );
+		$this->assertNull( $page['next_page_token'] );
+	}
+
 	public function test_list_follows_pagination_and_returns_products() {
 		$this->client->expects( $this->exactly( 2 ) )
 			->method( 'get' )

--- a/tests/Unit/DB/Table/MerchantIssueTableTest.php
+++ b/tests/Unit/DB/Table/MerchantIssueTableTest.php
@@ -66,6 +66,30 @@ class MerchantIssueTableTest extends UnitTest {
 		$this->mock_merchant_issue->delete_specific_product_issues( [ 1 ] );
 	}
 
+	public function test_delete_by_ids_with_empty_array() {
+		$this->wpdb->expects( $this->never() )
+		->method( 'query' );
+
+		$this->mock_merchant_issue->delete_by_ids( [] );
+	}
+
+	public function test_delete_by_ids_deletes_the_given_rows() {
+		$this->mock_merchant_issue->method( 'get_sql_safe_name' )->willReturn( 'wp_gla_merchant_issues' );
+
+		$this->wpdb->method( 'prepare' )
+		->willReturnCallback(
+			function ( $query, $args ) {
+				return vsprintf( str_replace( '%d', '%s', $query ), (array) $args );
+			}
+		);
+
+		$this->wpdb->expects( $this->once() )
+		->method( 'query' )
+		->with( 'DELETE FROM `wp_gla_merchant_issues` WHERE `id` IN (5,8)' );
+
+		$this->mock_merchant_issue->delete_by_ids( [ 5, 8 ] );
+	}
+
 	/**
 	 * Test installing the DB table to ensure there are no errors during install.
 	 */

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -234,7 +234,7 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 
 		$this->mapi_products->expects( $this->once() )
 			->method( 'list_page' )
-			->with( '0', 1000 )
+			->with( '0', 500 )
 			->willReturn(
 				[
 					'products'        => [],

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -184,10 +184,30 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		$this->job->schedule();
 	}
 
-	public function test_page_size_filter_is_applied_and_clamped() {
+	public function test_page_size_filter_is_applied() {
 		$this->merchant_center_service->method( 'is_connected' )->willReturn( true );
 
-		add_filter( 'woocommerce_gla_mapi_products_list_page_size', fn() => 5000 );
+		add_filter( 'woocommerce_gla_product_view_report_page_size', fn() => 250 );
+
+		$this->mapi_products->expects( $this->once() )
+			->method( 'list_page' )
+			->with( null, 250 )
+			->willReturn(
+				[
+					'products'        => [],
+					'next_page_token' => null,
+				]
+			);
+
+		do_action( self::PROCESS_ITEM_HOOK, [] );
+
+		remove_all_filters( 'woocommerce_gla_product_view_report_page_size' );
+	}
+
+	public function test_page_size_filter_is_clamped_to_the_api_maximum() {
+		$this->merchant_center_service->method( 'is_connected' )->willReturn( true );
+
+		add_filter( 'woocommerce_gla_product_view_report_page_size', fn() => 5000 );
 
 		$this->mapi_products->expects( $this->once() )
 			->method( 'list_page' )
@@ -201,7 +221,7 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 
 		do_action( self::PROCESS_ITEM_HOOK, [] );
 
-		remove_all_filters( 'woocommerce_gla_mapi_products_list_page_size' );
+		remove_all_filters( 'woocommerce_gla_product_view_report_page_size' );
 	}
 
 	public function test_update_merchant_product_statuses_when_view_report_throws_error() {

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -224,6 +224,49 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		remove_all_filters( 'woocommerce_gla_product_view_report_page_size' );
 	}
 
+	public function test_a_zero_string_page_token_does_not_restart_the_refresh() {
+		$this->merchant_center_service->method( 'is_connected' )->willReturn( true );
+
+		$this->merchant_statuses->expects( $this->never() )
+			->method( 'clear_product_statuses_cache_and_issues' );
+		$this->merchant_statuses->expects( $this->never() )
+			->method( 'refresh_account_and_presync_issues' );
+
+		$this->mapi_products->expects( $this->once() )
+			->method( 'list_page' )
+			->with( '0', 1000 )
+			->willReturn(
+				[
+					'products'        => [],
+					'next_page_token' => null,
+				]
+			);
+
+		do_action( self::PROCESS_ITEM_HOOK, [ 'next_page_token' => '0' ] );
+	}
+
+	public function test_a_zero_string_page_token_continues_pagination() {
+		$this->merchant_center_service->method( 'is_connected' )->willReturn( true );
+
+		$this->mapi_products->expects( $this->once() )
+			->method( 'list_page' )
+			->willReturn(
+				[
+					'products'        => [],
+					'next_page_token' => '0',
+				]
+			);
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with( self::PROCESS_ITEM_HOOK, [ [ 'next_page_token' => '0' ] ] );
+
+		$this->merchant_statuses->expects( $this->never() )
+			->method( 'handle_complete_mc_statuses_fetching' );
+
+		do_action( self::PROCESS_ITEM_HOOK, [] );
+	}
+
 	public function test_update_merchant_product_statuses_when_view_report_throws_error() {
 		$this->merchant_center_service->method( 'is_connected' )
 		->willReturn( true );

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -8,10 +8,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerI
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateMerchantProductStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantReport;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\Product;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Exception;
@@ -33,8 +33,8 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 	/** @var MockObject|MerchantCenterService $merchant_center_service */
 	protected $merchant_center_service;
 
-	/** @var MockObject|MerchantReport $merchant_report */
-	protected $merchant_report;
+	/** @var MockObject|MapiProductsService $mapi_products */
+	protected $mapi_products;
 
 	/** @var MockObject|MerchantStatuses $merchant_statuses */
 	protected $merchant_statuses;
@@ -54,17 +54,33 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		$this->action_scheduler        = $this->createMock( ActionSchedulerInterface::class );
 		$this->monitor                 = $this->createMock( ActionSchedulerJobMonitor::class );
 		$this->merchant_center_service = $this->createMock( MerchantCenterService::class );
-		$this->merchant_report         = $this->createMock( MerchantReport::class );
+		$this->mapi_products           = $this->createMock( MapiProductsService::class );
 		$this->merchant_statuses       = $this->createMock( MerchantStatuses::class );
 		$this->job                     = new UpdateMerchantProductStatuses(
 			$this->action_scheduler,
 			$this->monitor,
 			$this->merchant_center_service,
-			$this->merchant_report,
+			$this->mapi_products,
 			$this->merchant_statuses
 		);
 
 		$this->job->init();
+	}
+
+	/**
+	 * Build a minimal Merchant API product for the given id.
+	 *
+	 * @param string $google_id
+	 *
+	 * @return Product
+	 */
+	protected function make_product( string $google_id ): Product {
+		return Product::from_array(
+			[
+				'name'    => 'accounts/12345/products/' . $google_id,
+				'offerId' => explode( '~', $google_id )[2],
+			]
+		);
 	}
 
 	public function test_update_merchant_product_statuses_not_connected() {
@@ -78,55 +94,44 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		$this->merchant_center_service->method( 'is_connected' )
 			->willReturn( true );
 
+		$pages = [
+			[
+				'products'        => [ $this->make_product( 'en~US~gla_1' ) ],
+				'next_page_token' => 'ABC=',
+			],
+			[
+				'products'        => [ $this->make_product( 'en~US~gla_2' ) ],
+				'next_page_token' => 'DEF=',
+			],
+			[
+				'products'        => [ $this->make_product( 'en~US~gla_3' ) ],
+				'next_page_token' => null,
+			],
+		];
+
 		$matcher = $this->exactly( 3 );
-		$this->merchant_report->expects( $matcher )
-			->method( 'get_product_view_report' )
+		$this->mapi_products->expects( $matcher )
+			->method( 'list_page' )
 			->will(
 				$this->returnCallback(
-					function ( $next_page_token ) use ( $matcher ) {
+					function ( $next_page_token ) use ( $matcher, $pages ) {
 						$invocation_count = $matcher->getInvocationCount();
 
 						if ( $invocation_count === 1 ) {
-
 							$this->assertNull( $next_page_token );
-							return [
-								'statuses'        => [
-									[
-										'product_id' => 1,
-										'status'     => MCStatus::APPROVED,
-									],
-								],
-								'next_page_token' => 'ABC=',
-							];
 						}
-
 						if ( $invocation_count === 2 ) {
 							$this->assertEquals( 'ABC=', $next_page_token );
-							return [
-								'statuses'        => [
-									[
-										'product_id' => 2,
-										'status'     => MCStatus::APPROVED,
-									],
-								],
-								'next_page_token' => 'DEF=',
-							];
 						}
-
 						if ( $invocation_count === 3 ) {
 							$this->assertEquals( 'DEF=', $next_page_token );
-							return [
-								'statuses'        => [
-									[
-										'product_id' => 3,
-										'status'     => MCStatus::APPROVED,
-									],
-								],
-								'next_page_token' => null,
-							];
 						}
 
-						throw new Exception( 'Invalid next page token' );
+						if ( ! isset( $pages[ $invocation_count - 1 ] ) ) {
+							throw new Exception( 'Invalid next page token' );
+						}
+
+						return $pages[ $invocation_count - 1 ];
 					}
 				)
 			);
@@ -158,46 +163,12 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 
 			$matcher = $this->exactly( 3 );
 			$this->merchant_statuses->expects( $matcher )
-				->method( 'process_product_statuses' )
+				->method( 'process_mapi_products' )
 				->willReturnCallback(
-					function ( $statuses ) use ( $matcher ) {
+					function ( $products ) use ( $matcher, $pages ) {
 						$invocation_count = $matcher->getInvocationCount();
 
-						if ( $invocation_count === 1 ) {
-							$this->assertEquals(
-								[
-									[
-										'product_id' => 1,
-										'status'     => MCStatus::APPROVED,
-									],
-								],
-								$statuses
-							);
-						}
-
-						if ( $invocation_count === 2 ) {
-							$this->assertEquals(
-								[
-									[
-										'product_id' => 2,
-										'status'     => MCStatus::APPROVED,
-									],
-								],
-								$statuses
-							);
-						}
-
-						if ( $invocation_count === 3 ) {
-							$this->assertEquals(
-								[
-									[
-										'product_id' => 3,
-										'status'     => MCStatus::APPROVED,
-									],
-								],
-								$statuses
-							);
-						}
+						$this->assertEquals( $pages[ $invocation_count - 1 ]['products'], $products );
 					}
 				);
 
@@ -213,12 +184,32 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		$this->job->schedule();
 	}
 
+	public function test_page_size_filter_is_applied_and_clamped() {
+		$this->merchant_center_service->method( 'is_connected' )->willReturn( true );
+
+		add_filter( 'woocommerce_gla_mapi_products_list_page_size', fn() => 5000 );
+
+		$this->mapi_products->expects( $this->once() )
+			->method( 'list_page' )
+			->with( null, 1000 )
+			->willReturn(
+				[
+					'products'        => [],
+					'next_page_token' => null,
+				]
+			);
+
+		do_action( self::PROCESS_ITEM_HOOK, [] );
+
+		remove_all_filters( 'woocommerce_gla_mapi_products_list_page_size' );
+	}
+
 	public function test_update_merchant_product_statuses_when_view_report_throws_error() {
 		$this->merchant_center_service->method( 'is_connected' )
 		->willReturn( true );
 
-		$this->merchant_report->expects( $this->exactly( 1 ) )
-		->method( 'get_product_view_report' )
+		$this->mapi_products->expects( $this->exactly( 1 ) )
+		->method( 'list_page' )
 		->willThrowException( new Error( 'error' ) );
 
 		$this->merchant_statuses->expects( $this->exactly( 1 ) )
@@ -235,8 +226,8 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		$this->merchant_center_service->method( 'is_connected' )
 		->willReturn( true );
 
-		$this->merchant_report->expects( $this->exactly( 1 ) )
-		->method( 'get_product_view_report' )
+		$this->mapi_products->expects( $this->exactly( 1 ) )
+		->method( 'list_page' )
 		->willThrowException( new Exception( 'error' ) );
 
 		$this->merchant_statuses->expects( $this->exactly( 1 ) )

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -687,6 +687,10 @@ class MerchantStatusesTest extends UnitTest {
 			$this->get_mapi_id( $product_4->get_id() ) => $this->get_mapi_product( $product_4->get_id() ),
 		];
 
+		// No rows from earlier pages of the refresh, so none are deleted.
+		$this->merchant_issue_query->method( 'get_results' )->willReturn( [] );
+		$this->merchant_issue_table->expects( $this->never() )->method( 'delete_by_ids' );
+
 		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
 			[
 				[
@@ -854,6 +858,8 @@ class MerchantStatusesTest extends UnitTest {
 			}
 		);
 
+		$this->merchant_issue_query->method( 'get_results' )->willReturn( [] );
+
 		// Products are provided under both id forms; only the valid Merchant API id may
 		// produce issues, the legacy colon-format id is filtered out of the id map.
 		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
@@ -909,9 +915,11 @@ class MerchantStatusesTest extends UnitTest {
 			}
 		);
 
+		$this->merchant_issue_query->method( 'get_results' )->willReturn( [] );
+
 		// Products are provided under both id forms; issues may only come from the
-		// Merchant API id. The countries assertion is the discriminator: if the legacy
-		// id leaked through, both copies would merge into ["ES","ES"].
+		// Merchant API id. The countries assertion is the discriminator: the copy under
+		// the legacy id carries FR, so a leak would produce ["ES","FR"].
 		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
 			$this->callback(
 				function ( array $issues ) use ( $product ) {
@@ -932,9 +940,217 @@ class MerchantStatusesTest extends UnitTest {
 				],
 			],
 			[
-				$this->get_mc_id( $product->get_id() )   => $this->get_mapi_product( $product->get_id() ),
+				$this->get_mc_id( $product->get_id() )   => $this->get_mapi_product( $product->get_id(), 'merchant_action', [ 'FR' ] ),
 				$this->get_mapi_id( $product->get_id() ) => $this->get_mapi_product( $product->get_id() ),
 			]
+		);
+	}
+
+	public function test_refresh_product_issues_folds_in_rows_from_earlier_pages() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->product_repository->method( 'find_by_ids_as_associative_array' )
+		->willReturnCallback(
+			function ( $ids ) use ( $product ) {
+				return array_intersect_key( [ $product->get_id() => $product ], array_flip( $ids ) );
+			}
+		);
+
+		$this->options->method( 'get' )->willReturn( null );
+
+		$this->product_helper->method( 'get_synced_google_product_ids' )
+		->willReturnCallback(
+			function ( $wc_product ) {
+				return [ 'ES' => $this->get_mapi_id( $wc_product->get_id() ) ];
+			}
+		);
+
+		// Rows written by earlier pages of the same refresh: one for the same product
+		// and issue (folded in and deleted) and one for a different issue of the same
+		// product (left untouched).
+		$this->merchant_issue_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'                   => 5,
+					'product_id'           => $product->get_id(),
+					'issue'                => 'issue_description',
+					'applicable_countries' => wp_json_encode( [ 'US', 'GB', 'ES' ] ),
+				],
+				[
+					'id'                   => 6,
+					'product_id'           => $product->get_id(),
+					'issue'                => 'another_issue',
+					'applicable_countries' => wp_json_encode( [ 'US' ] ),
+				],
+			]
+		);
+
+		$where_calls = [];
+		$this->merchant_issue_query->method( 'where' )
+		->willReturnCallback(
+			function ( $column, $value, $compare = '=' ) use ( &$where_calls ) {
+				$where_calls[] = [ $column, $value, $compare ];
+				return $this->merchant_issue_query;
+			}
+		);
+
+		$call_order = [];
+
+		// Only the row for the same product and issue is replaced, and only after
+		// the merged row is written, so an interrupted page cannot lose countries.
+		$this->merchant_issue_table->expects( $this->once() )->method( 'delete_by_ids' )
+		->with( [ 5 ] )
+		->willReturnCallback(
+			function () use ( &$call_order ) {
+				$call_order[] = 'delete';
+			}
+		);
+
+		// The stored countries are the union of the earlier page's row and this page's
+		// entry, de-duplicated (ES appears in both) and sorted.
+		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
+			$this->callback(
+				function ( array $issues ) use ( $product ) {
+					return 1 === count( $issues )
+						&& $issues[0]['product_id'] === $product->get_id()
+						&& wp_json_encode( [ 'ES', 'GB', 'US' ] ) === $issues[0]['applicable_countries'];
+				}
+			)
+		)
+		->willReturnCallback(
+			function () use ( &$call_order ) {
+				$call_order[] = 'insert';
+			}
+		);
+
+		$this->merchant_statuses->process_product_statuses(
+			[
+				[
+					'mc_id'           => $this->get_mapi_id( $product->get_id() ),
+					'product_id'      => $product->get_id(),
+					'status'          => MCStatus::APPROVED,
+					'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
+				],
+			],
+			[ $this->get_mapi_id( $product->get_id() ) => $this->get_mapi_product( $product->get_id() ) ]
+		);
+
+		// The lookup covers exactly this page's products and no other issue source.
+		$this->assertContains( [ 'product_id', [ $product->get_id() ], 'IN' ], $where_calls );
+		$this->assertContains( [ 'source', 'mc', '=' ], $where_calls );
+		$this->assertContains( [ 'type', 'product', '=' ], $where_calls );
+
+		$this->assertSame( [ 'insert', 'delete' ], $call_order );
+	}
+
+	public function test_refresh_product_issues_resets_the_country_map_between_pages() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->product_repository->method( 'find_by_ids_as_associative_array' )
+		->willReturnCallback(
+			function ( $ids ) use ( $product ) {
+				return array_intersect_key( [ $product->get_id() => $product ], array_flip( $ids ) );
+			}
+		);
+
+		$this->options->method( 'get' )->willReturn( null );
+
+		$this->product_helper->method( 'get_synced_google_product_ids' )
+		->willReturnCallback(
+			function ( $wc_product ) {
+				return [ 'ES' => $this->get_mapi_id( $wc_product->get_id() ) ];
+			}
+		);
+
+		// No rows in the table either time: the second call stands for a page of a
+		// later refresh cycle running in the same long-lived process.
+		$this->merchant_issue_query->method( 'get_results' )->willReturn( [] );
+
+		$captured_rows = [];
+		$this->merchant_issue_query->expects( $this->exactly( 2 ) )->method( 'update_or_insert' )
+		->willReturnCallback(
+			function ( array $issues ) use ( &$captured_rows ) {
+				$captured_rows[] = $issues;
+			}
+		);
+
+		$page = [
+			[
+				'mc_id'           => $this->get_mapi_id( $product->get_id() ),
+				'product_id'      => $product->get_id(),
+				'status'          => MCStatus::APPROVED,
+				'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
+			],
+		];
+
+		$this->merchant_statuses->process_product_statuses(
+			$page,
+			[ $this->get_mapi_id( $product->get_id() ) => $this->get_mapi_product( $product->get_id(), 'merchant_action', [ 'FR' ] ) ]
+		);
+		$this->merchant_statuses->process_product_statuses(
+			$page,
+			[ $this->get_mapi_id( $product->get_id() ) => $this->get_mapi_product( $product->get_id() ) ]
+		);
+
+		// Without the per-page reset, the singleton's in-memory map would leak FR
+		// from the first call into the second call's row.
+		$this->assertSame( wp_json_encode( [ 'FR' ] ), $captured_rows[0][0]['applicable_countries'] );
+		$this->assertSame( wp_json_encode( [ 'ES' ] ), $captured_rows[1][0]['applicable_countries'] );
+	}
+
+	public function test_refresh_product_issues_tolerates_malformed_stored_countries() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->product_repository->method( 'find_by_ids_as_associative_array' )
+		->willReturnCallback(
+			function ( $ids ) use ( $product ) {
+				return array_intersect_key( [ $product->get_id() => $product ], array_flip( $ids ) );
+			}
+		);
+
+		$this->options->method( 'get' )->willReturn( null );
+
+		$this->product_helper->method( 'get_synced_google_product_ids' )
+		->willReturnCallback(
+			function ( $wc_product ) {
+				return [ 'ES' => $this->get_mapi_id( $wc_product->get_id() ) ];
+			}
+		);
+
+		// A matching row whose stored countries are valid JSON but not an array
+		// contributes nothing, and must not fail the page.
+		$this->merchant_issue_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'                   => 7,
+					'product_id'           => $product->get_id(),
+					'issue'                => 'issue_description',
+					'applicable_countries' => '"GB"',
+				],
+			]
+		);
+
+		$this->merchant_issue_table->expects( $this->once() )->method( 'delete_by_ids' )->with( [ 7 ] );
+
+		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
+			$this->callback(
+				function ( array $issues ) {
+					return 1 === count( $issues )
+						&& wp_json_encode( [ 'ES' ] ) === $issues[0]['applicable_countries'];
+				}
+			)
+		);
+
+		$this->merchant_statuses->process_product_statuses(
+			[
+				[
+					'mc_id'           => $this->get_mapi_id( $product->get_id() ),
+					'product_id'      => $product->get_id(),
+					'status'          => MCStatus::APPROVED,
+					'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
+				],
+			],
+			[ $this->get_mapi_id( $product->get_id() ) => $this->get_mapi_product( $product->get_id() ) ]
 		);
 	}
 
@@ -1306,7 +1522,7 @@ class MerchantStatusesTest extends UnitTest {
 		$this->merchant_statuses->clear_product_statuses_cache_and_issues();
 	}
 
-	protected function get_mapi_product( $wc_product_id, string $resolution = 'merchant_action' ): Product {
+	protected function get_mapi_product( $wc_product_id, string $resolution = 'merchant_action', array $countries = [ 'ES' ] ): Product {
 		return Product::from_array(
 			[
 				'name'          => 'accounts/123/products/' . $this->get_mapi_id( $wc_product_id ),
@@ -1319,7 +1535,7 @@ class MerchantStatusesTest extends UnitTest {
 							'documentation'       => 'https://example.com',
 							'resolution'          => $resolution,
 							'severity'            => 'DISAPPROVED',
-							'applicableCountries' => [ 'ES' ],
+							'applicableCountries' => $countries,
 						],
 					],
 				],

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -710,6 +710,41 @@ class MerchantStatusesTest extends UnitTest {
 		);
 	}
 
+	public function test_process_mapi_products_tolerates_a_malformed_expiration_date() {
+		$statuses_spy = $this->createPartialMock( MerchantStatuses::class, [ 'process_product_statuses' ] );
+		$statuses_spy->set_container( $this->container );
+
+		$this->product_helper->method( 'get_wc_product_id' )->willReturn( 11 );
+
+		$product = Product::from_array(
+			[
+				'name'          => 'accounts/123/products/en~ES~gla_11',
+				'productStatus' => [
+					'destinationStatuses'  => [
+						[
+							'reportingContext'  => 'SHOPPING_ADS',
+							'approvedCountries' => [ 'ES' ],
+						],
+					],
+					'googleExpirationDate' => 'not-a-timestamp',
+				],
+			]
+		);
+
+		$statuses_spy->expects( $this->once() )
+		->method( 'process_product_statuses' )
+		->with(
+			$this->callback(
+				function ( array $statuses ) {
+					return null === $statuses[11]['expiration_date'] && MCStatus::APPROVED === $statuses[11]['status'];
+				}
+			),
+			[ 'en~ES~gla_11' => $product ]
+		);
+
+		$statuses_spy->process_mapi_products( [ $product ] );
+	}
+
 	public function test_process_mapi_products_converts_and_skips() {
 		$statuses_spy = $this->createPartialMock( MerchantStatuses::class, [ 'process_product_statuses' ] );
 		$statuses_spy->set_container( $this->container );

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -26,7 +26,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingCo
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
@@ -67,7 +66,6 @@ class MerchantStatusesTest extends UnitTest {
 	protected const MC_STATUS_LIFETIME = 60;
 
 	private $merchant;
-	private $mapi_products_service;
 	private $mapi_account_issues_service;
 	private $merchant_issue_query;
 	private $merchant_center_service;
@@ -94,7 +92,6 @@ class MerchantStatusesTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 		$this->merchant                             = $this->createMock( Merchant::class );
-		$this->mapi_products_service                = $this->createMock( MapiProductsService::class );
 		$this->mapi_account_issues_service          = $this->createMock( MapiAccountIssuesService::class );
 		$this->merchant_issue_query                 = $this->createMock( MerchantIssueQuery::class );
 		$this->merchant_center_service              = $this->createMock( MerchantCenterService::class );
@@ -112,7 +109,6 @@ class MerchantStatusesTest extends UnitTest {
 
 		$this->container = new Container();
 		$this->container->addShared( Merchant::class, $this->merchant );
-		$this->container->addShared( MapiProductsService::class, $this->mapi_products_service );
 		$this->container->addShared( MapiAccountIssuesService::class, $this->mapi_account_issues_service );
 		$this->container->addShared( MerchantIssueQuery::class, $this->merchant_issue_query );
 		$this->container->addShared( MerchantCenterService::class, $this->merchant_center_service );
@@ -683,25 +679,13 @@ class MerchantStatusesTest extends UnitTest {
 			}
 		);
 
-		// product_4 (DONT_SYNC_AND_SHOW) must be excluded from the fetch; product_2's issue
-		// is pending_processing and must be filtered out of the resulting product issues.
-		$this->mapi_products_service->expects( $this->once() )
-		->method( 'get_many' )
-		->with(
-			[
-				$this->get_mapi_id( $product_1->get_id() ),
-				$this->get_mapi_id( $product_2->get_id() ),
-				$this->get_mapi_id( $product_3->get_id() ),
-				$this->get_mapi_id( $variation_id_1 ),
-				$this->get_mapi_id( $variation_id_2 ),
-			]
-		)
-		->willReturn(
-			[
-				$this->get_mapi_id( $product_1->get_id() ) => $this->get_mapi_product( $product_1->get_id() ),
-				$this->get_mapi_id( $product_2->get_id() ) => $this->get_mapi_product( $product_2->get_id(), 'pending_processing' ),
-			]
-		);
+		// product_4 (DONT_SYNC_AND_SHOW) is provided but must be excluded from the issues;
+		// product_2's issue is pending_processing and must be filtered out as well.
+		$products_by_google_id = [
+			$this->get_mapi_id( $product_1->get_id() ) => $this->get_mapi_product( $product_1->get_id() ),
+			$this->get_mapi_id( $product_2->get_id() ) => $this->get_mapi_product( $product_2->get_id(), 'pending_processing' ),
+			$this->get_mapi_id( $product_4->get_id() ) => $this->get_mapi_product( $product_4->get_id() ),
+		];
 
 		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
 			[
@@ -721,8 +705,89 @@ class MerchantStatusesTest extends UnitTest {
 		);
 
 		$this->merchant_statuses->process_product_statuses(
-			$product_statuses
+			$product_statuses,
+			$products_by_google_id
 		);
+	}
+
+	public function test_process_mapi_products_converts_and_skips() {
+		$statuses_spy = $this->createPartialMock( MerchantStatuses::class, [ 'process_product_statuses' ] );
+		$statuses_spy->set_container( $this->container );
+
+		$this->product_helper->method( 'get_wc_product_id' )
+		->willReturnCallback(
+			function ( string $google_id ) {
+				// The foreign product carries no gla_ offer id and resolves to no WC product.
+				return 'en~ES~foreign_offer' === $google_id ? 0 : (int) substr( $google_id, strrpos( $google_id, '_' ) + 1 );
+			}
+		);
+
+		$approved    = Product::from_array(
+			[
+				'name'          => 'accounts/123/products/en~ES~gla_11',
+				'productStatus' => [
+					'destinationStatuses'  => [
+						[
+							'reportingContext'  => 'SHOPPING_ADS',
+							'approvedCountries' => [ 'ES' ],
+						],
+					],
+					'googleExpirationDate' => '2030-01-01T00:00:00Z',
+				],
+			]
+		);
+		$disapproved = Product::from_array(
+			[
+				'name'          => 'accounts/123/products/en~ES~gla_12',
+				'productStatus' => [
+					'destinationStatuses' => [
+						[
+							'reportingContext'     => 'SHOPPING_ADS',
+							'disapprovedCountries' => [ 'ES' ],
+						],
+					],
+				],
+			]
+		);
+		$processing  = Product::from_array( [ 'name' => 'accounts/123/products/en~ES~gla_13' ] );
+		$foreign     = Product::from_array(
+			[
+				'name'          => 'accounts/123/products/en~ES~foreign_offer',
+				'productStatus' => [
+					'destinationStatuses' => [
+						[
+							'reportingContext'  => 'SHOPPING_ADS',
+							'approvedCountries' => [ 'ES' ],
+						],
+					],
+				],
+			]
+		);
+
+		$statuses_spy->expects( $this->once() )
+		->method( 'process_product_statuses' )
+		->with(
+			[
+				11 => [
+					'mc_id'           => 'en~ES~gla_11',
+					'product_id'      => 11,
+					'status'          => MCStatus::APPROVED,
+					'expiration_date' => new DateTime( '2030-01-01T00:00:00Z' ),
+				],
+				12 => [
+					'mc_id'           => 'en~ES~gla_12',
+					'product_id'      => 12,
+					'status'          => MCStatus::DISAPPROVED,
+					'expiration_date' => null,
+				],
+			],
+			[
+				'en~ES~gla_11' => $approved,
+				'en~ES~gla_12' => $disapproved,
+			]
+		);
+
+		$statuses_spy->process_mapi_products( [ $approved, $disapproved, $processing, $foreign ] );
 	}
 
 	public function test_process_product_statuses_skips_legacy_google_ids() {
@@ -754,11 +819,15 @@ class MerchantStatusesTest extends UnitTest {
 			}
 		);
 
-		// Only the valid Merchant API id reaches the products service; the legacy id is filtered out.
-		$this->mapi_products_service->expects( $this->once() )
-		->method( 'get_many' )
-		->with( [ $this->get_mapi_id( $product_valid->get_id() ) ] )
-		->willReturn( [] );
+		// Products are provided under both id forms; only the valid Merchant API id may
+		// produce issues, the legacy colon-format id is filtered out of the id map.
+		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
+			$this->callback(
+				function ( array $issues ) use ( $product_valid ) {
+					return 1 === count( $issues ) && $issues[0]['product_id'] === $product_valid->get_id();
+				}
+			)
+		);
 
 		$this->merchant_statuses->process_product_statuses(
 			[
@@ -774,6 +843,10 @@ class MerchantStatusesTest extends UnitTest {
 					'status'          => MCStatus::APPROVED,
 					'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
 				],
+			],
+			[
+				$this->get_mapi_id( $product_valid->get_id() )  => $this->get_mapi_product( $product_valid->get_id() ),
+				$this->get_mc_id( $product_legacy->get_id() )   => $this->get_mapi_product( $product_legacy->get_id() ),
 			]
 		);
 	}
@@ -801,11 +874,18 @@ class MerchantStatusesTest extends UnitTest {
 			}
 		);
 
-		// Only the Merchant API id reaches the products service; the legacy id is dropped.
-		$this->mapi_products_service->expects( $this->once() )
-		->method( 'get_many' )
-		->with( [ $this->get_mapi_id( $product->get_id() ) ] )
-		->willReturn( [] );
+		// Products are provided under both id forms; issues may only come from the
+		// Merchant API id. The countries assertion is the discriminator: if the legacy
+		// id leaked through, both copies would merge into ["ES","ES"].
+		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
+			$this->callback(
+				function ( array $issues ) use ( $product ) {
+					return 1 === count( $issues )
+						&& $issues[0]['product_id'] === $product->get_id()
+						&& wp_json_encode( [ 'ES' ] ) === $issues[0]['applicable_countries'];
+				}
+			)
+		);
 
 		$this->merchant_statuses->process_product_statuses(
 			[
@@ -815,6 +895,10 @@ class MerchantStatusesTest extends UnitTest {
 					'status'          => MCStatus::APPROVED,
 					'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
 				],
+			],
+			[
+				$this->get_mc_id( $product->get_id() )   => $this->get_mapi_product( $product->get_id() ),
+				$this->get_mapi_id( $product->get_id() ) => $this->get_mapi_product( $product->get_id() ),
 			]
 		);
 	}

--- a/tests/Unit/Value/MCStatusTest.php
+++ b/tests/Unit/Value/MCStatusTest.php
@@ -1,0 +1,41 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Value;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MCStatusTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Value
+ */
+class MCStatusTest extends UnitTest {
+
+	/**
+	 * @dataProvider aggregated_status_provider
+	 *
+	 * @param string $aggregated
+	 * @param string $expected
+	 */
+	public function test_from_aggregated_reporting_context_status( string $aggregated, string $expected ) {
+		$this->assertSame( $expected, MCStatus::from_aggregated_reporting_context_status( $aggregated ) );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function aggregated_status_provider(): array {
+		return [
+			[ 'ELIGIBLE', MCStatus::APPROVED ],
+			[ 'ELIGIBLE_LIMITED', MCStatus::PARTIALLY_APPROVED ],
+			[ 'NOT_ELIGIBLE_OR_DISAPPROVED', MCStatus::DISAPPROVED ],
+			[ 'PENDING', MCStatus::PENDING ],
+			[ 'AGGREGATED_REPORTING_CONTEXT_STATUS_UNSPECIFIED', MCStatus::NOT_SYNCED ],
+			[ '', MCStatus::NOT_SYNCED ],
+		];
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Merchant API migration turned the batched status reads into per-product calls and left the write batches at half their recommended size, which is the bulk of the request volume the migration added (fleet-wide, an unchanged workload measured ~4.8x more requests after the migration; the per-store multiplier varies with how status-read-heavy the store is).

- **Status refresh (the big one):** the refresh job paged the `product_view` report (500 per page) and then fetched every synced product individually with `products.get` for its item-level issues, so a full refresh of N products cost 1 account-issues request + ceil(N/500) report requests + N per-product GETs, repeated every 30 minutes while an admin keeps a status page open. The job is now driven entirely by [`products.list`](https://developers.google.com/merchant/api/reference/rest/products_v1/accounts.products/list) (up to 1000 per page; the default stays at the report era's 500 for memory parity, see Additional details; one page per scheduled action, the token carried in the action args exactly as the report token was): each page serves as both the status source (aggregated status derived from `destinationStatuses`, expiration from `googleExpirationDate`) and the issue source, so a full refresh costs 1 account-issues request + ceil(N/500) list requests. A 10,000-product store drops from ~10,021 requests per refresh to 21.
- **Write batch size:** `MapiProductInputsService` packs product upserts/deletes into multipart `/batch` requests, but the default was 50, half of the Merchant API's recommended maximum of 100 per the [batch request guide](https://developers.google.com/merchant/api/guides/send-multiple-requests). Raised to 100, which halves the batch POST count (a 1000-product chunk goes from 20 batches to 10, exactly one concurrency wave). Real product payloads are ~1-2KB, so a 100-item batch body is ~0.2MB, far under the proxy's request-size limit.
- **Multi-feed issue rows:** a product synced to several feeds (secondary markets, and languages with WPML) has one Merchant Center entry per feed, and its entries can land on different pages of either source. The report-driven flow wrote one issue row per page that carried any of the product's entries, so such products accumulated duplicate rows for the same issue, every applicable country repeated once per reporting context. Each page now folds the rows written by earlier pages of the same refresh back in and replaces them (the issues table has no unique key an upsert could update through), so every product and issue keeps a single row whose applicable-countries list is the de-duplicated union across all of the product's entries.

The aggregated status derivation follows the official enum semantics (eligible for all reporting contexts and countries = `ELIGIBLE`, some = `ELIGIBLE_LIMITED`, pending everywhere = `PENDING`, otherwise `NOT_ELIGIBLE_OR_DISAPPROVED`), is unit-tested as a matrix, and matched the report's `aggregatedReportingContextStatus` for every product in every live check (details under Additional details). A just-inserted product that Google is still processing (absent from the list, or returned without destination statuses yet) is skipped, so it reads as "not synced" until the next refresh instead of flashing a half-processed state; details in the backward-compatibility notes below.

**Backward compatibility notes:** `MerchantStatuses::process_product_statuses()` gains an optional second parameter (the page's products, used as the issue source); a caller passing only statuses now writes no product issues instead of fetching them per product, which is the point of the change (no known external callers). `UpdateMerchantProductStatuses`' constructor now takes `MapiProductsService` instead of `MerchantReport` (DI updated; fatal only for code constructing the job directly). `MerchantReport::get_product_view_report()` is deprecated but kept, and the documented `woocommerce_gla_product_view_report_page_size` filter keeps working: it now sizes the `products.list` pages (default 500 as in the report era, clamped to the API range 1-1000, so it can also raise the size where memory allows), so existing memory caps carry over unchanged. The issues table's shape also changes for readers of the raw table or the REST issues payload: a multi-feed product's issue appears as one merged row instead of duplicates, and `applicable_countries` no longer repeats a country once per reporting context.

One transient behavior difference, observed live with a probe product: the report pipeline runs about a minute ahead of `products.list`, so a refresh landing inside a just-inserted product's processing window shows it as "not synced" (absent meta falls back to `not_synced` in `ProductHelper::get_mc_status()`, statistics count it the same way) where the report-driven flow already showed a definitive status, and a refresh landing mid-transition shows the previous status. Both cases last at most one refresh cycle, self-correct on convergence, and only ever under-claim; a product is never shown healthier than it is. Account leftovers whose WooCommerce product no longer exists are dropped by the existing WooCommerce lookup in `process_product_statuses`, unchanged from the report-driven flow.

### Detailed test instructions:

Prerequisites: a store connected to Merchant Center with synced products, at least one of which has an item-level issue in Merchant Center.

1. Confirm the status UI is unchanged. Load Google for WooCommerce > Product Feed (and the dashboard) and verify the status statistics and the product issues list match what Merchant Center shows.
2. Force a full refresh and confirm it repopulates statistics and issues.
   ```
   wp eval 'woogle_get_container()->get( \Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses::class )->maybe_refresh_status_data( true );'
   ```
   ```
   wp action-scheduler run
   ```
   ```
   wp eval '$t = get_transient( "gla_mc_statuses" ); echo json_encode( $t["statistics"] );'
   ```
   Expected output shape:
   ```
   {"approved":0,"partially_approved":15,"expiring":0,"pending":0,"disapproved":0,"not_synced":5}
   ```
3. Verify the derived status matches the report for every product (the command compares the first page of each source, so it covers stores with up to 500 products; a transient mismatch can appear while a status transition is propagating, re-run to confirm).
   ```
   wp eval '$c = woogle_get_container(); $client = $c->get( \Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient::class ); $mid = $c->get( \Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface::class )->get_merchant_id(); $body = $client->post( sprintf( "reports/v1/accounts/%s/reports:search", $mid ), [ "query" => "SELECT id, aggregated_reporting_context_status FROM product_view", "pageSize" => 500 ] ); $report = []; foreach ( $body["results"] ?? [] as $row ) { $v = $row["productView"]; $report[ substr( $v["id"], strrpos( $v["id"], "~" ) + 1 ) ] = $v["aggregatedReportingContextStatus"] ?? ""; } $page = $c->get( \Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService::class )->list_page(); $m = 0; $d = 0; foreach ( $page["products"] as $p ) { $derived = $p->get_product_status() ? $p->get_product_status()->get_aggregated_reporting_context_status() : ""; if ( "" === $derived ) { continue; } ( $report[ $p->get_offer_id() ] ?? "" ) === $derived ? $m++ : $d++; } printf( "matches=%d, mismatches=%d\n", $m, $d );'
   ```
   Expected output (with N synced products):
   ```
   matches=N, mismatches=0
   ```
4. Confirm the write batch size default is 100.
   ```
   wp eval '$m = new ReflectionMethod( \Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService::class, "get_batch_size" ); $m->setAccessible( true ); var_dump( $m->invoke( woogle_get_container()->get( \Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService::class ) ) );'
   ```
   Expected output:
   ```
   int(100)
   ```
5. Edit and re-sync products to confirm the write path still works and products sync to Merchant Center as before.
6. Optional, multi-feed coverage: on a store with a secondary market in the store language (so each product syncs under two feed labels), pick a product with an item-level issue, force a refresh as in step 2, and confirm the issues table holds a single row per issue whose countries cover both markets.
   ```
   wp db query "SELECT issue, applicable_countries FROM wp_gla_merchant_issues WHERE product_id=<ID> AND source='mc'"
   ```
   Expected output: one row per issue, no duplicated rows, each country listed once, the secondary market's country included.

### Additional details:

The status job feeds the existing pipeline page by page, so intermediate statistics accumulation, parent aggregation, and the expiring override behave exactly as before; besides the fetch shape, the only behavior change is the merged multi-feed issue row described above. The merged rows are written before the stale ones are deleted, so a page interrupted in between leaves duplicates for the next page or cycle to absorb instead of losing countries, and the in-memory country map resets per page, so the result does not depend on how Action Scheduler groups the page actions into processes.

Verification performed: the derived aggregate matched the report value for every product on two Merchant Center accounts, including a live transition of the whole catalogue from `NOT_ELIGIBLE_OR_DISAPPROVED` to `ELIGIBLE_LIMITED` (two destination-status composition shapes, exercising the partially-approved statistics path end to end); a full refresh produced byte-identical statistics and a set-identical issues table versus the report-driven flow; the on-wire shape was confirmed as exactly one issues GET plus one list GET per page (verified at `pageSize=1000`; the shipped default is 500). The page-size default stays at 500 rather than the API maximum on purpose: a list entry is far heavier than a report row (on an issue-heavy catalogue an entry measured ~28KB of JSON, 91% of it `productStatus` with per-reporting-context country lists), so a 1000-entry page peaked near 200MB during decode in a live measurement, out of reach for stock 128M PHP memory limits; the filter can raise the size where memory allows. The multi-feed merge was verified live on a store with a same-language secondary market (every product synced under two feed labels, list pages forced down to 5 entries so each product's entries split across pages) in both execution shapes, all pages in one PHP process and one page per process: every product ended with exactly one row per issue whose countries are the de-duplicated union of both entries. Google API quota drops with the request count: per the [quota guide](https://developers.google.com/merchant/api/guides/quotas-limits/quotas), each `products.list` page counts as one call against the products quota, not one call per product.

Merchant API references: the retired per-product read was [`products.get`](https://developers.google.com/merchant/api/reference/rest/products_v1/accounts.products/get); the deprecated report path used `reports:search` on `product_view`, which cannot return the merchant-facing issue text (`description`/`detail`/`documentation`), which is why issues now come from the list page's `productStatus.itemLevelIssues`.

### Changelog entry

> Update - Drive the Merchant Center product status refresh from paginated product list requests instead of a report plus one request per product, and raise the write batch size to its recommended maximum, cutting the requests made to Google.

> Fix - Show a single merged issue row with the combined applicable countries for a product synced to multiple feeds, instead of duplicate rows with repeated country codes.
