### PR TITLE
GOOWOO-910: Gen AI prompt driven generation

### DIFF
--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -130,7 +130,7 @@ class AdsAsset implements OptionsAwareInterface {
 	 * @return array The image data.
 	 * @throws Exception If the image url is not a valid url or the image size is too large.
 	 */
-	protected function get_image_data( string $url ): array {
+	public function get_image_data( string $url ): array {
 		$image_data = $this->wp->wp_remote_get( $url );
 
 		if ( is_wp_error( $image_data ) || empty( $image_data['body'] ) ) {

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -17,6 +17,7 @@ use Google\Ads\GoogleAds\V23\Common\TextAsset;
 use Google\Ads\GoogleAds\V23\Common\ImageAsset;
 use Google\Ads\GoogleAds\V23\Common\CallToActionAsset;
 use Google\Ads\GoogleAds\V23\Common\YoutubeVideoAsset;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidSourceImage;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Google\ApiCore\ApiException;
 use Exception;
@@ -128,19 +129,19 @@ class AdsAsset implements OptionsAwareInterface {
 	 * @param string $url The image url.
 	 *
 	 * @return array The image data.
-	 * @throws Exception If the image url is not a valid url or the image size is too large.
+	 * @throws InvalidSourceImage If the image url is not a valid url or the image size is too large.
 	 */
 	public function get_image_data( string $url ): array {
 		$image_data = $this->wp->wp_remote_get( $url );
 
 		if ( is_wp_error( $image_data ) || empty( $image_data['body'] ) ) {
-			throw new Exception( sprintf( 'There was a problem loading the url: %s', $url ) );
+			throw InvalidSourceImage::fetch_failed( $url );
 		}
 
 		$size = $image_data['headers']->offsetGet( 'content-length' );
 
 		if ( $size > self::MAX_IMAGE_SIZE_BYTES ) {
-			throw new Exception( 'Image size is too large.' );
+			throw InvalidSourceImage::too_large();
 		}
 
 		return [

--- a/src/API/Google/AdsAsset.php
+++ b/src/API/Google/AdsAsset.php
@@ -132,7 +132,7 @@ class AdsAsset implements OptionsAwareInterface {
 	 * @throws InvalidSourceImage If the image url is not a valid url or the image size is too large.
 	 */
 	public function get_image_data( string $url ): array {
-		$image_data = $this->wp->wp_remote_get( $url );
+		$image_data = $this->wp->wp_remote_get( $url, [ 'reject_unsafe_urls' => true ] );
 
 		if ( is_wp_error( $image_data ) || empty( $image_data['body'] ) ) {
 			throw InvalidSourceImage::fetch_failed( $url );

--- a/src/API/Site/Controllers/Ads/AssetGenerationController.php
+++ b/src/API/Site/Controllers/Ads/AssetGenerationController.php
@@ -9,7 +9,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\ResponseFro
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use WP_REST_Request as Request;
-use WP_Error;
 use Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -128,17 +127,7 @@ class AssetGenerationController extends BaseController {
 				'type'              => 'string',
 				'default'           => '',
 				'sanitize_callback' => 'sanitize_text_field',
-				'validate_callback' => function ( $value ) {
-					if ( is_string( $value ) && mb_strlen( $value ) > self::MAX_PROMPT_LENGTH ) {
-						return new WP_Error(
-							'woocommerce_gla_prompt_too_long',
-							__( 'Prompt must be 1500 characters or fewer.', 'google-listings-and-ads' ),
-							[ 'status' => 400 ]
-						);
-					}
-
-					return true;
-				},
+				'validate_callback' => 'rest_validate_request_arg',
 			],
 			'source_image_url' => [
 				'description'       => __( 'The source image URL to use for recontext image generation', 'google-listings-and-ads' ),
@@ -208,6 +197,10 @@ class AssetGenerationController extends BaseController {
 				$prompt           = $request->get_param( 'prompt' ) ?: '';
 				$source_image_url = $request->get_param( 'source_image_url' ) ?: '';
 				$types            = $request->get_param( 'types' ) ?: [];
+
+				if ( mb_strlen( $prompt ) > self::MAX_PROMPT_LENGTH ) {
+					throw new Exception( __( 'Prompt must be 1500 characters or fewer.', 'google-listings-and-ads' ) );
+				}
 
 				// Call service with lowercase types.
 				$args = [

--- a/src/API/Site/Controllers/Ads/AssetGenerationController.php
+++ b/src/API/Site/Controllers/Ads/AssetGenerationController.php
@@ -126,7 +126,7 @@ class AssetGenerationController extends BaseController {
 				'description'       => __( 'The prompt to use for freeform or recontext image generation', 'google-listings-and-ads' ),
 				'type'              => 'string',
 				'default'           => '',
-				'sanitize_callback' => 'sanitize_text_field',
+				'sanitize_callback' => 'sanitize_textarea_field',
 				'validate_callback' => 'rest_validate_request_arg',
 			],
 			'source_image_url' => [

--- a/src/API/Site/Controllers/Ads/AssetGenerationController.php
+++ b/src/API/Site/Controllers/Ads/AssetGenerationController.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Site\Controllers\ResponseFro
 use Automattic\WooCommerce\GoogleListingsAndAds\API\TransportMethods;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\RESTServer;
 use WP_REST_Request as Request;
+use WP_Error;
 use Exception;
 
 defined( 'ABSPATH' ) || exit;
@@ -28,6 +29,13 @@ class AssetGenerationController extends BaseController {
 	 * @var AdsAssetGenerationService
 	 */
 	protected $service;
+
+	/**
+	 * Maximum allowed length for the image generation prompt.
+	 *
+	 * @var int
+	 */
+	protected const MAX_PROMPT_LENGTH = 1500;
 
 	/**
 	 * AssetGenerationController constructor.
@@ -108,14 +116,38 @@ class AssetGenerationController extends BaseController {
 	 */
 	protected function get_generate_images_params(): array {
 		return [
-			'final_url' => [
+			'final_url'        => [
 				'description'       => __( 'The final URL for asset generation', 'google-listings-and-ads' ),
 				'type'              => 'string',
 				'default'           => '',
 				'sanitize_callback' => 'esc_url_raw',
 				'validate_callback' => 'rest_validate_request_arg',
 			],
-			'types'     => [
+			'prompt'           => [
+				'description'       => __( 'The prompt to use for freeform or recontext image generation', 'google-listings-and-ads' ),
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => function ( $value ) {
+					if ( is_string( $value ) && mb_strlen( $value ) > self::MAX_PROMPT_LENGTH ) {
+						return new WP_Error(
+							'woocommerce_gla_prompt_too_long',
+							__( 'Prompt must be 1500 characters or fewer.', 'google-listings-and-ads' ),
+							[ 'status' => 400 ]
+						);
+					}
+
+					return true;
+				},
+			],
+			'source_image_url' => [
+				'description'       => __( 'The source image URL to use for recontext image generation', 'google-listings-and-ads' ),
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => 'esc_url_raw',
+				'validate_callback' => 'rest_validate_request_arg',
+			],
+			'types'            => [
 				'description'       => __( 'Asset types to generate', 'google-listings-and-ads' ),
 				'type'              => 'array',
 				'default'           => [],
@@ -172,11 +204,17 @@ class AssetGenerationController extends BaseController {
 			set_time_limit( 90 ); // AI image generation can take time.
 
 			try {
-				$final_url = $request->get_param( 'final_url' ) ?: $this->get_site_url();
-				$types     = $request->get_param( 'types' ) ?: [];
+				$final_url        = $request->get_param( 'final_url' ) ?: $this->get_site_url();
+				$prompt           = $request->get_param( 'prompt' ) ?: '';
+				$source_image_url = $request->get_param( 'source_image_url' ) ?: '';
+				$types            = $request->get_param( 'types' ) ?: [];
 
 				// Call service with lowercase types.
-				$args = [ 'final_url' => $final_url ];
+				$args = [
+					'final_url'        => $final_url,
+					'prompt'           => $prompt,
+					'source_image_url' => $source_image_url,
+				];
 				if ( ! empty( $types ) ) {
 					$args['asset_field_types'] = $types;
 				}

--- a/src/Ads/AdsAssetGenerationService.php
+++ b/src/Ads/AdsAssetGenerationService.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseD
 use Google\Ads\GoogleAds\V23\Services\GenerateTextRequest;
 use Google\Ads\GoogleAds\V23\Services\GenerateImagesRequest;
 use Google\Ads\GoogleAds\V23\Services\FinalUrlImageGenerationInput;
+use Google\Ads\GoogleAds\V23\Services\FreeformImageGenerationInput;
 use Google\Ads\GoogleAds\V23\Enums\AdvertisingChannelTypeEnum\AdvertisingChannelType;
 use Google\ApiCore\ApiException;
 use Exception;
@@ -179,6 +180,7 @@ class AdsAssetGenerationService implements OptionsAwareInterface, Service {
 	 *     Optional. Arguments for generating image assets.
 	 *
 	 *     @type string $final_url        The final URL - defaults to the Site URL.
+	 *     @type string $prompt           Optional prompt for freeform generation.
 	 *     @type array  $asset_field_types Can be one or more of: marketing_image, square_marketing_image, portrait_marketing_image.
 	 * }
 	 * @return array Array of generated image objects with 'temporary_image_url' and 'type' keys.
@@ -190,8 +192,6 @@ class AdsAssetGenerationService implements OptionsAwareInterface, Service {
 			throw new Exception( __( 'Ads account ID is required.', 'google-listings-and-ads' ) );
 		}
 
-		$final_url = $args['final_url'] ?? $this->get_site_url();
-
 		// Default to all valid image types if not specified.
 		if ( empty( $args['asset_field_types'] ) ) {
 			$args['asset_field_types'] = self::VALID_IMAGE_TYPES;
@@ -199,14 +199,12 @@ class AdsAssetGenerationService implements OptionsAwareInterface, Service {
 
 		$asset_field_types = $this->convert_types_to_enums( $args['asset_field_types'], self::VALID_IMAGE_TYPES );
 
+		[ $generation_type, $generation_input ] = $this->get_generation_input( $args );
+
 		$request_data = [
 			'customer_id'              => $customer_id,
 			'advertising_channel_type' => AdvertisingChannelType::PERFORMANCE_MAX,
-			'final_url_generation'     => new FinalUrlImageGenerationInput(
-				[
-					'final_url' => $final_url,
-				]
-			),
+			$generation_type           => $generation_input,
 			'asset_field_types'        => $asset_field_types,
 		];
 
@@ -239,6 +237,39 @@ class AdsAssetGenerationService implements OptionsAwareInterface, Service {
 				[ 'errors' => $errors ]
 			);
 		}
+	}
+
+	/**
+	 * Determine the `GenerateImagesRequest` oneof generation input from the supplied args.
+	 *
+	 * There is no explicit mode param: a prompt selects freeform generation,
+	 * otherwise generation falls back to the final URL.
+	 *
+	 * @param array $args {
+	 *     @type string $final_url The final URL - defaults to the Site URL.
+	 *     @type string $prompt    Optional prompt for freeform generation.
+	 * }
+	 * @return array {
+	 *     @type string $0 The `GenerateImagesRequest` oneof field name.
+	 *     @type object $1 The generation input instance for that field.
+	 * }
+	 */
+	protected function get_generation_input( array $args ): array {
+		$prompt = $args['prompt'] ?? '';
+
+		if ( ! empty( $prompt ) ) {
+			return [
+				'freeform_generation',
+				new FreeformImageGenerationInput( [ 'freeform_prompt' => $prompt ] ),
+			];
+		}
+
+		$final_url = $args['final_url'] ?? $this->get_site_url();
+
+		return [
+			'final_url_generation',
+			new FinalUrlImageGenerationInput( [ 'final_url' => $final_url ] ),
+		];
 	}
 
 	/**

--- a/src/Ads/AdsAssetGenerationService.php
+++ b/src/Ads/AdsAssetGenerationService.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Infrastructure\Service;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\ExceptionTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
@@ -48,6 +49,13 @@ class AdsAssetGenerationService implements OptionsAwareInterface, Service {
 	protected $google_ads_client;
 
 	/**
+	 * The Ads Asset helper.
+	 *
+	 * @var AdsAsset
+	 */
+	protected $ads_asset;
+
+	/**
 	 * Valid text asset field types.
 	 *
 	 * @var array
@@ -73,9 +81,11 @@ class AdsAssetGenerationService implements OptionsAwareInterface, Service {
 	 * AdsAssetGenerationService constructor.
 	 *
 	 * @param GoogleAdsClient $client The Google Ads client.
+	 * @param AdsAsset        $ads_asset The Ads Asset helper.
 	 */
-	public function __construct( GoogleAdsClient $client ) {
+	public function __construct( GoogleAdsClient $client, AdsAsset $ads_asset ) {
 		$this->google_ads_client = $client;
+		$this->ads_asset         = $ads_asset;
 	}
 
 	/**

--- a/src/Ads/AdsAssetGenerationService.php
+++ b/src/Ads/AdsAssetGenerationService.php
@@ -12,10 +12,13 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\ExceptionTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ExceptionWithResponseData;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidSourceImage;
 use Google\Ads\GoogleAds\V23\Services\GenerateTextRequest;
 use Google\Ads\GoogleAds\V23\Services\GenerateImagesRequest;
 use Google\Ads\GoogleAds\V23\Services\FinalUrlImageGenerationInput;
 use Google\Ads\GoogleAds\V23\Services\FreeformImageGenerationInput;
+use Google\Ads\GoogleAds\V23\Services\ProductRecontextGenerationImageInput;
+use Google\Ads\GoogleAds\V23\Services\SourceImage;
 use Google\Ads\GoogleAds\V23\Enums\AdvertisingChannelTypeEnum\AdvertisingChannelType;
 use Google\ApiCore\ApiException;
 use Exception;
@@ -180,7 +183,8 @@ class AdsAssetGenerationService implements OptionsAwareInterface, Service {
 	 *     Optional. Arguments for generating image assets.
 	 *
 	 *     @type string $final_url        The final URL - defaults to the Site URL.
-	 *     @type string $prompt           Optional prompt for freeform generation.
+	 *     @type string $prompt           Optional prompt for freeform or recontext generation.
+	 *     @type string $source_image_url Optional source image URL - triggers recontext generation.
 	 *     @type array  $asset_field_types Can be one or more of: marketing_image, square_marketing_image, portrait_marketing_image.
 	 * }
 	 * @return array Array of generated image objects with 'temporary_image_url' and 'type' keys.
@@ -242,19 +246,31 @@ class AdsAssetGenerationService implements OptionsAwareInterface, Service {
 	/**
 	 * Determine the `GenerateImagesRequest` oneof generation input from the supplied args.
 	 *
-	 * There is no explicit mode param: a prompt selects freeform generation,
-	 * otherwise generation falls back to the final URL.
+	 * There is no explicit mode param: a source image selects recontext generation,
+	 * otherwise a prompt selects freeform generation, otherwise generation falls
+	 * back to the final URL.
 	 *
 	 * @param array $args {
-	 *     @type string $final_url The final URL - defaults to the Site URL.
-	 *     @type string $prompt    Optional prompt for freeform generation.
+	 *     @type string $final_url        The final URL - defaults to the Site URL.
+	 *     @type string $prompt           Optional prompt for freeform or recontext generation.
+	 *     @type string $source_image_url Optional source image URL - triggers recontext generation.
 	 * }
 	 * @return array {
 	 *     @type string $0 The `GenerateImagesRequest` oneof field name.
 	 *     @type object $1 The generation input instance for that field.
 	 * }
+	 * @throws Exception If a source image is supplied but can't be fetched or exceeds the maximum allowed size.
 	 */
 	protected function get_generation_input( array $args ): array {
+		$source_image_url = $args['source_image_url'] ?? '';
+
+		if ( ! empty( $source_image_url ) ) {
+			return [
+				'product_recontext_generation',
+				$this->get_recontext_generation_input( $args, $source_image_url ),
+			];
+		}
+
 		$prompt = $args['prompt'] ?? '';
 
 		if ( ! empty( $prompt ) ) {
@@ -270,6 +286,38 @@ class AdsAssetGenerationService implements OptionsAwareInterface, Service {
 			'final_url_generation',
 			new FinalUrlImageGenerationInput( [ 'final_url' => $final_url ] ),
 		];
+	}
+
+	/**
+	 * Build the recontext generation input, downloading the source image bytes server-side.
+	 *
+	 * @param array  $args              The generate_images() args (may include an optional prompt).
+	 * @param string $source_image_url The source image URL.
+	 * @return ProductRecontextGenerationImageInput
+	 * @throws Exception If the source image can't be fetched or exceeds the maximum allowed size.
+	 */
+	protected function get_recontext_generation_input( array $args, string $source_image_url ): ProductRecontextGenerationImageInput {
+		try {
+			$image_data = $this->ads_asset->get_image_data( $source_image_url );
+		} catch ( InvalidSourceImage $e ) {
+			if ( InvalidSourceImage::REASON_TOO_LARGE === $e->get_reason() ) {
+				throw new Exception( __( 'Source image exceeds the maximum allowed size.', 'google-listings-and-ads' ) );
+			}
+
+			throw new Exception( __( 'Could not fetch the source image.', 'google-listings-and-ads' ) );
+		}
+
+		$input_data = [
+			'source_images' => [
+				new SourceImage( [ 'image_data' => $image_data['body'] ] ),
+			],
+		];
+
+		if ( ! empty( $args['prompt'] ) ) {
+			$input_data['prompt'] = $args['prompt'];
+		}
+
+		return new ProductRecontextGenerationImageInput( $input_data );
 	}
 
 	/**

--- a/src/Exception/InvalidSourceImage.php
+++ b/src/Exception/InvalidSourceImage.php
@@ -1,0 +1,59 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Exception;
+
+use RuntimeException;
+
+/**
+ * Class InvalidSourceImage
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Exception
+ */
+class InvalidSourceImage extends RuntimeException implements GoogleListingsAndAdsException {
+
+	public const REASON_FETCH_FAILED = 'fetch_failed';
+	public const REASON_TOO_LARGE    = 'too_large';
+
+	/**
+	 * The reason the source image was invalid.
+	 *
+	 * @var string
+	 */
+	protected $reason;
+
+	/**
+	 * Return an instance of the exception for a source image URL that could not be fetched.
+	 *
+	 * @param string $url The source image URL.
+	 *
+	 * @return static
+	 */
+	public static function fetch_failed( string $url ) {
+		$exception         = new static( sprintf( 'There was a problem loading the url: %s', $url ) );
+		$exception->reason = self::REASON_FETCH_FAILED;
+
+		return $exception;
+	}
+
+	/**
+	 * Return an instance of the exception for a source image exceeding the maximum allowed size.
+	 *
+	 * @return static
+	 */
+	public static function too_large() {
+		$exception         = new static( 'Image size is too large.' );
+		$exception->reason = self::REASON_TOO_LARGE;
+
+		return $exception;
+	}
+
+	/**
+	 * Get the reason the source image was invalid.
+	 *
+	 * @return string
+	 */
+	public function get_reason(): string {
+		return $this->reason;
+	}
+}

--- a/src/Exception/InvalidSourceImage.php
+++ b/src/Exception/InvalidSourceImage.php
@@ -5,6 +5,8 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Exception;
 
 use RuntimeException;
 
+defined( 'ABSPATH' ) || exit;
+
 /**
  * Class InvalidSourceImage
  *

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -161,7 +161,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->share( AdsConversionAction::class, GoogleAdsClient::class );
 		$this->share( AdsReport::class, GoogleAdsClient::class );
 		$this->share( AdsRecommendationsService::class, GoogleAdsClient::class );
-		$this->share( AdsAssetGenerationService::class, GoogleAdsClient::class );
+		$this->share( AdsAssetGenerationService::class, GoogleAdsClient::class, AdsAsset::class );
 		$this->share( BudgetMetrics::class, GoogleAdsClient::class, MerchantMetrics::class );
 		$this->share( BudgetRecommendations::class, GoogleAdsClient::class, MerchantMetrics::class );
 

--- a/tests/Unit/API/Google/AdsAssetTest.php
+++ b/tests/Unit/API/Google/AdsAssetTest.php
@@ -155,7 +155,7 @@ class AdsAssetTest extends UnitTest {
 
 		$this->wp->expects( $this->exactly( 1 ) )
 			->method( 'wp_remote_get' )
-			->with( $data['content'] )
+			->with( $data['content'], [ 'reject_unsafe_urls' => true ] )
 			->willReturn(
 				[
 					'body'    => $data['content'],
@@ -175,7 +175,7 @@ class AdsAssetTest extends UnitTest {
 
 		$this->wp->expects( $this->exactly( 1 ) )
 			->method( 'wp_remote_get' )
-			->with( $data['content'] )
+			->with( $data['content'], [ 'reject_unsafe_urls' => true ] )
 			->willReturn(
 				new WP_Error( 'Incorrect image asset url.' )
 			);
@@ -276,7 +276,7 @@ class AdsAssetTest extends UnitTest {
 
 		$this->wp->expects( $this->once() )
 			->method( 'wp_remote_get' )
-			->with( 'https://example.com/image.jpg' )
+			->with( 'https://example.com/image.jpg', [ 'reject_unsafe_urls' => true ] )
 			->willReturn(
 				[
 					'body'    => 'image-binary-data',
@@ -316,7 +316,7 @@ class AdsAssetTest extends UnitTest {
 		return array_reduce(
 			$assets,
 			function ( $carry, $item ) {
-				$carry[] = [ 'content' => $item['content'] ];
+				$carry[] = [ $item['content'], [ 'reject_unsafe_urls' => true ] ];
 				return $carry;
 			},
 			[]

--- a/tests/Unit/API/Site/Controllers/Ads/AssetGenerationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetGenerationControllerTest.php
@@ -333,7 +333,6 @@ class AssetGenerationControllerTest extends RESTControllerUnitTest {
 		$response = $this->do_request( self::ROUTE_GENERATE_IMAGES, 'POST', $params );
 
 		$this->assertEquals( 400, $response->get_status() );
-		$this->assertEquals( 'woocommerce_gla_prompt_too_long', $response->get_data()['code'] );
 		$this->assertEquals( 'Prompt must be 1500 characters or fewer.', $response->get_data()['message'] );
 	}
 

--- a/tests/Unit/API/Site/Controllers/Ads/AssetGenerationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetGenerationControllerTest.php
@@ -198,7 +198,9 @@ class AssetGenerationControllerTest extends RESTControllerUnitTest {
 			->method( 'generate_images' )
 			->with(
 				[
-					'final_url' => self::TEST_SITE_URL,
+					'final_url'        => self::TEST_SITE_URL,
+					'prompt'           => '',
+					'source_image_url' => '',
 				]
 			)
 			->willReturn(
@@ -239,7 +241,9 @@ class AssetGenerationControllerTest extends RESTControllerUnitTest {
 			->method( 'generate_images' )
 			->with(
 				[
-					'final_url' => 'https://custom-url.com',
+					'final_url'        => 'https://custom-url.com',
+					'prompt'           => '',
+					'source_image_url' => '',
 				]
 			)
 			->willReturn(
@@ -259,6 +263,80 @@ class AssetGenerationControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'marketing_image', $data['items'][0]['type'] );
 	}
 
+	public function test_generate_images_with_prompt() {
+		$params = [
+			'prompt' => 'A red bicycle on a white background',
+		];
+
+		$this->service->expects( $this->once() )
+			->method( 'generate_images' )
+			->with(
+				[
+					'final_url'        => self::TEST_SITE_URL,
+					'prompt'           => 'A red bicycle on a white background',
+					'source_image_url' => '',
+				]
+			)
+			->willReturn(
+				[
+					[
+						'temporary_image_url' => 'https://example.com/freeform-image.jpg',
+						'type'                => 'marketing_image',
+					],
+				]
+			);
+
+		$response = $this->do_request( self::ROUTE_GENERATE_IMAGES, 'POST', $params );
+
+		$data = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'marketing_image', $data['items'][0]['type'] );
+	}
+
+	public function test_generate_images_with_source_image_url() {
+		$params = [
+			'source_image_url' => 'https://example.com/source.jpg',
+		];
+
+		$this->service->expects( $this->once() )
+			->method( 'generate_images' )
+			->with(
+				[
+					'final_url'        => self::TEST_SITE_URL,
+					'prompt'           => '',
+					'source_image_url' => 'https://example.com/source.jpg',
+				]
+			)
+			->willReturn(
+				[
+					[
+						'temporary_image_url' => 'https://example.com/recontext-image.jpg',
+						'type'                => 'marketing_image',
+					],
+				]
+			);
+
+		$response = $this->do_request( self::ROUTE_GENERATE_IMAGES, 'POST', $params );
+
+		$data = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'marketing_image', $data['items'][0]['type'] );
+	}
+
+	public function test_generate_images_prompt_too_long() {
+		$this->service->expects( $this->never() )->method( 'generate_images' );
+
+		$params = [
+			'prompt' => str_repeat( 'a', 1501 ),
+		];
+
+		$response = $this->do_request( self::ROUTE_GENERATE_IMAGES, 'POST', $params );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'woocommerce_gla_prompt_too_long', $response->get_data()['code'] );
+		$this->assertEquals( 'Prompt must be 1500 characters or fewer.', $response->get_data()['message'] );
+	}
+
 	public function test_generate_images_with_specific_types() {
 		$params = [
 			'types' => [ 'marketing_image' ],
@@ -270,6 +348,8 @@ class AssetGenerationControllerTest extends RESTControllerUnitTest {
 			->with(
 				[
 					'final_url'         => self::TEST_SITE_URL,
+					'prompt'            => '',
+					'source_image_url'  => '',
 					'asset_field_types' => [ 'marketing_image' ],
 				]
 			)

--- a/tests/Unit/API/Site/Controllers/Ads/AssetGenerationControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/Ads/AssetGenerationControllerTest.php
@@ -337,6 +337,36 @@ class AssetGenerationControllerTest extends RESTControllerUnitTest {
 		$this->assertEquals( 'Prompt must be 1500 characters or fewer.', $response->get_data()['message'] );
 	}
 
+	public function test_generate_images_source_image_fetch_failure() {
+		$this->service
+			->method( 'generate_images' )
+			->willThrowException( new Exception( 'Could not fetch the source image.' ) );
+
+		$params = [
+			'source_image_url' => 'https://example.com/source.jpg',
+		];
+
+		$response = $this->do_request( self::ROUTE_GENERATE_IMAGES, 'POST', $params );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Could not fetch the source image.', $response->get_data()['message'] );
+	}
+
+	public function test_generate_images_source_image_too_large() {
+		$this->service
+			->method( 'generate_images' )
+			->willThrowException( new Exception( 'Source image exceeds the maximum allowed size.' ) );
+
+		$params = [
+			'source_image_url' => 'https://example.com/source.jpg',
+		];
+
+		$response = $this->do_request( self::ROUTE_GENERATE_IMAGES, 'POST', $params );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'Source image exceeds the maximum allowed size.', $response->get_data()['message'] );
+	}
+
 	public function test_generate_images_with_specific_types() {
 		$params = [
 			'types' => [ 'marketing_image' ],

--- a/tests/Unit/Ads/AdsAssetGenerationServiceTest.php
+++ b/tests/Unit/Ads/AdsAssetGenerationServiceTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Ads;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAssetGenerationService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -33,6 +34,9 @@ class AdsAssetGenerationServiceTest extends UnitTest {
 	/** @var AdsAssetGenerationService $service */
 	protected $service;
 
+	/** @var MockObject|AdsAsset $ads_asset */
+	protected $ads_asset;
+
 	protected const TEST_ADS_ID   = 1234567890;
 	protected const TEST_SITE_URL = 'https://example.com';
 
@@ -44,8 +48,9 @@ class AdsAssetGenerationServiceTest extends UnitTest {
 
 		$this->ads_client_setup();
 
-		$this->options = $this->createMock( OptionsInterface::class );
-		$this->service = new AdsAssetGenerationService( $this->client );
+		$this->options   = $this->createMock( OptionsInterface::class );
+		$this->ads_asset = $this->createMock( AdsAsset::class );
+		$this->service   = new AdsAssetGenerationService( $this->client, $this->ads_asset );
 		$this->service->set_options_object( $this->options );
 
 		$this->options->method( 'get_ads_id' )->willReturn( self::TEST_ADS_ID );
@@ -291,7 +296,7 @@ class AdsAssetGenerationServiceTest extends UnitTest {
 		$ads_client = $this->createMock( GoogleAdsClient::class );
 		$ads_client->expects( $this->never() )->method( 'getAssetGenerationServiceClient' );
 
-		new AdsAssetGenerationService( $ads_client );
+		new AdsAssetGenerationService( $ads_client, $this->ads_asset );
 	}
 
 	/**
@@ -304,7 +309,7 @@ class AdsAssetGenerationServiceTest extends UnitTest {
 		$ads_client->method( 'getAssetGenerationServiceClient' )
 			->willThrowException( new RuntimeException( 'V23 Service Clients are not fully loaded.' ) );
 
-		new AdsAssetGenerationService( $ads_client );
+		new AdsAssetGenerationService( $ads_client, $this->ads_asset );
 
 		$this->assertTrue( true, 'Constructor must not invoke the V23 service client factory.' );
 	}

--- a/tests/Unit/Ads/AdsAssetGenerationServiceTest.php
+++ b/tests/Unit/Ads/AdsAssetGenerationServiceTest.php
@@ -229,6 +229,61 @@ class AdsAssetGenerationServiceTest extends UnitTest {
 		$this->assertEquals( $expected_image_assets, $result );
 	}
 
+	public function test_generate_images_with_prompt_uses_freeform_generation() {
+		$prompt = 'A red bicycle on a white background';
+
+		$image_asset = $this->createMock( GeneratedImage::class );
+		$image_asset->method( 'getImageTemporaryUrl' )->willReturn( 'https://example.com/freeform.jpg' );
+		$image_asset->method( 'getAssetFieldType' )->willReturn( AssetFieldType::number( 'marketing_image' ) );
+
+		$response = $this->createMock( GenerateImagesResponse::class );
+		$response->method( 'getGeneratedImages' )->willReturn( [ $image_asset ] );
+
+		$this->asset_generation_service
+			->expects( $this->once() )
+			->method( 'generateImages' )
+			->with(
+				$this->callback(
+					function ( $request ) use ( $prompt ) {
+						return 'freeform_generation' === $request->getGenerationType()
+							&& $prompt === $request->getFreeformGeneration()->getFreeformPrompt();
+					}
+				)
+			)
+			->willReturn( $response );
+
+		$result = $this->service->generate_images( [ 'prompt' => $prompt ] );
+
+		$this->assertEquals(
+			[
+				[
+					'temporary_image_url' => 'https://example.com/freeform.jpg',
+					'type'                => 'marketing_image',
+				],
+			],
+			$result
+		);
+	}
+
+	public function test_generate_images_without_prompt_uses_final_url_generation() {
+		$response = $this->createMock( GenerateImagesResponse::class );
+		$response->method( 'getGeneratedImages' )->willReturn( [] );
+
+		$this->asset_generation_service
+			->expects( $this->once() )
+			->method( 'generateImages' )
+			->with(
+				$this->callback(
+					function ( $request ) {
+						return 'final_url_generation' === $request->getGenerationType();
+					}
+				)
+			)
+			->willReturn( $response );
+
+		$this->service->generate_images( [] );
+	}
+
 	public function test_generate_images_exception() {
 		$this->generate_image_assets_mock_exception(
 			new ApiException( 'API error', 7 )

--- a/tests/Unit/Ads/AdsAssetGenerationServiceTest.php
+++ b/tests/Unit/Ads/AdsAssetGenerationServiceTest.php
@@ -6,6 +6,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Ads;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsAssetGenerationService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AssetFieldType;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidSourceImage;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
@@ -282,6 +283,107 @@ class AdsAssetGenerationServiceTest extends UnitTest {
 			->willReturn( $response );
 
 		$this->service->generate_images( [] );
+	}
+
+	public function test_generate_images_with_source_image_url_uses_recontext_generation() {
+		$source_image_url = 'https://example.com/source.jpg';
+		$prompt            = 'Place the product on a beach';
+
+		$this->ads_asset->expects( $this->once() )
+			->method( 'get_image_data' )
+			->with( $source_image_url )
+			->willReturn( [ 'body' => 'raw-image-bytes', 'size' => 12345 ] );
+
+		$image_asset = $this->createMock( GeneratedImage::class );
+		$image_asset->method( 'getImageTemporaryUrl' )->willReturn( 'https://example.com/recontext.jpg' );
+		$image_asset->method( 'getAssetFieldType' )->willReturn( AssetFieldType::number( 'marketing_image' ) );
+
+		$response = $this->createMock( GenerateImagesResponse::class );
+		$response->method( 'getGeneratedImages' )->willReturn( [ $image_asset ] );
+
+		$this->asset_generation_service
+			->expects( $this->once() )
+			->method( 'generateImages' )
+			->with(
+				$this->callback(
+					function ( $request ) use ( $prompt ) {
+						if ( 'product_recontext_generation' !== $request->getGenerationType() ) {
+							return false;
+						}
+
+						$recontext = $request->getProductRecontextGeneration();
+						$images    = iterator_to_array( $recontext->getSourceImages() );
+
+						return $prompt === $recontext->getPrompt()
+							&& 1 === count( $images )
+							&& 'raw-image-bytes' === $images[0]->getImageData();
+					}
+				)
+			)
+			->willReturn( $response );
+
+		$result = $this->service->generate_images(
+			[
+				'source_image_url' => $source_image_url,
+				'prompt'           => $prompt,
+			]
+		);
+
+		$this->assertEquals(
+			[
+				[
+					'temporary_image_url' => 'https://example.com/recontext.jpg',
+					'type'                => 'marketing_image',
+				],
+			],
+			$result
+		);
+	}
+
+	public function test_generate_images_source_image_url_takes_precedence_over_prompt() {
+		$this->ads_asset->method( 'get_image_data' )->willReturn( [ 'body' => 'raw-image-bytes', 'size' => 1 ] );
+
+		$response = $this->createMock( GenerateImagesResponse::class );
+		$response->method( 'getGeneratedImages' )->willReturn( [] );
+
+		$this->asset_generation_service
+			->expects( $this->once() )
+			->method( 'generateImages' )
+			->with(
+				$this->callback(
+					function ( $request ) {
+						return 'product_recontext_generation' === $request->getGenerationType();
+					}
+				)
+			)
+			->willReturn( $response );
+
+		$this->service->generate_images(
+			[
+				'source_image_url' => 'https://example.com/source.jpg',
+				'prompt'           => 'A freeform prompt that should be ignored as the top-level branch',
+			]
+		);
+	}
+
+	public function test_generate_images_source_image_fetch_failure() {
+		$this->ads_asset->method( 'get_image_data' )
+			->willThrowException( InvalidSourceImage::fetch_failed( 'https://example.com/source.jpg' ) );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Could not fetch the source image.' );
+
+		$this->service->generate_images( [ 'source_image_url' => 'https://example.com/source.jpg' ] );
+	}
+
+	public function test_generate_images_source_image_too_large() {
+		$this->ads_asset->method( 'get_image_data' )
+			->willThrowException( InvalidSourceImage::too_large() );
+
+		$this->expectException( Exception::class );
+		$this->expectExceptionMessage( 'Source image exceeds the maximum allowed size.' );
+
+		$this->service->generate_images( [ 'source_image_url' => 'https://example.com/source.jpg' ] );
 	}
 
 	public function test_generate_images_exception() {

--- a/tests/Unit/Ads/AdsAssetGenerationServiceTest.php
+++ b/tests/Unit/Ads/AdsAssetGenerationServiceTest.php
@@ -287,12 +287,17 @@ class AdsAssetGenerationServiceTest extends UnitTest {
 
 	public function test_generate_images_with_source_image_url_uses_recontext_generation() {
 		$source_image_url = 'https://example.com/source.jpg';
-		$prompt            = 'Place the product on a beach';
+		$prompt           = 'Place the product on a beach';
 
 		$this->ads_asset->expects( $this->once() )
 			->method( 'get_image_data' )
 			->with( $source_image_url )
-			->willReturn( [ 'body' => 'raw-image-bytes', 'size' => 12345 ] );
+			->willReturn(
+				[
+					'body' => 'raw-image-bytes',
+					'size' => 12345,
+				]
+			);
 
 		$image_asset = $this->createMock( GeneratedImage::class );
 		$image_asset->method( 'getImageTemporaryUrl' )->willReturn( 'https://example.com/recontext.jpg' );
@@ -341,7 +346,12 @@ class AdsAssetGenerationServiceTest extends UnitTest {
 	}
 
 	public function test_generate_images_source_image_url_takes_precedence_over_prompt() {
-		$this->ads_asset->method( 'get_image_data' )->willReturn( [ 'body' => 'raw-image-bytes', 'size' => 1 ] );
+		$this->ads_asset->method( 'get_image_data' )->willReturn(
+			[
+				'body' => 'raw-image-bytes',
+				'size' => 1,
+			]
+		);
 
 		$response = $this->createMock( GenerateImagesResponse::class );
 		$response->method( 'getGeneratedImages' )->willReturn( [] );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-910/backend-prompt-driven-generation-freeform-recontext

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Requires a site with GLA active and a connected Google Ads account (needed for anything that reaches generate_images(), i.e. everything except the prompt-length check). Send authenticated `POST` requests (logged-in admin / WC REST API credentials) to:
`/wp-json/wc/gla/ads/assets/generate-images`

1. Regression test: Without using the new params, make a `POST` with no body (or just `final_url`). Confirm it behaves exactly as before with images generated from the final URL, response shape `{ final_url, items: [...] }`.
2. Freeform generation: `POST` request with `{ "prompt": "A red bicycle on a white background" }`. Confirm images are generated from the prompt (not the site's final URL) and the response items include the expected `type/temporary_image_url` shape.
3. Recontext generation: `POST` request with `{ "source_image_url": "<a real, reachable product image URL>" }`. Confirm images are generated using that source image.
4. Recontext + prompt together: `POST` request with both `source_image_url` and prompt set. Confirm recontext generation is used (source image takes priority) and the prompt is also applied to steer the recontext result.
5. Types honored across all three branches: repeat steps 2–5 with `"types": ["marketing_image"]` and confirm only that asset type is returned in each case.
6. Prompt too long: `POST` request with "prompt" longer than 1500 characters. Expect a 400 response with message "Prompt must be 1500 characters or fewer."
7. Source image can't be fetched: `POST` request with "source_image_url" pointing to a URL that 404s or isn't reachable. Expect a 400 response with message "Could not fetch the source image."
8. Source image too large: `POST` request with "source_image_url" pointing to an image over 5MB. Expect a 400 response with message "Source image exceeds the maximum allowed size."

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
