### PR TITLE
Feature / GOOWOO-931/927 -Publish eCommerce Events to The GTM dataLayer

### DIFF
--- a/js/src/gtag-events/utils.js
+++ b/js/src/gtag-events/utils.js
@@ -55,6 +55,59 @@ export const getCartItemObject = ( product, quantity ) => {
 };
 
 /**
+ * Formats data into a GA4-schema data layer item object. Uses GA4's own field names
+ * (item_id/item_name/item_category), distinct from the Ads-gtag item shape in
+ * `getCartItemObject`, since the two formats don't share a schema.
+ *
+ * @param {Product} product
+ * @param {number} quantity
+ * @return {Ga4Item} GA4-schema item object.
+ */
+export const getGa4ItemObject = ( product, quantity ) => {
+	const item = {
+		item_id: 'gla_' + product.id,
+		quantity,
+	};
+
+	if ( product.name ) {
+		item.item_name = product.name;
+	}
+
+	if ( product?.categories?.length ) {
+		item.item_category = product.categories[ 0 ].name;
+	}
+
+	if ( product?.prices?.price ) {
+		item.price =
+			parseInt( product.prices.price, 10 ) /
+			10 ** product.prices.currency_minor_unit;
+	}
+
+	return item;
+};
+
+/**
+ * Pushes a GA4-schema add_to_cart event to the GTM data layer, parallel to the existing
+ * Ads-gtag `trackAddToCartEvent` below, so the merchant's own GTM tags can trigger on it.
+ *
+ * @param {Product} product
+ * @param {number} quantity
+ */
+export const pushAddToCartDataLayerEvent = ( product, quantity = 1 ) => {
+	const item = getGa4ItemObject( product, quantity );
+
+	window.dataLayer = window.dataLayer || [];
+	window.dataLayer.push( {
+		event: 'add_to_cart',
+		ecommerce: {
+			currency: glaGtagData.currency_code,
+			value: item.price ? item.price * quantity : undefined,
+			items: [ item ],
+		},
+	} );
+};
+
+/**
  * Track an add_to_cart event.
  *
  * @param {Product} product
@@ -66,6 +119,8 @@ export const trackAddToCartEvent = ( product, quantity = 1 ) => {
 		event_category: 'ecommerce',
 		items: [ getCartItemObject( product, quantity ) ],
 	} );
+
+	pushAddToCartDataLayerEvent( product, quantity );
 };
 
 /**
@@ -141,6 +196,17 @@ export const retrievedVariation = ( variation ) => {
  * @property {string} [category]               First product category name.
  * @property {number} [price]                  Price as a decimal number.
  * @property {string} google_business_vertical Set to `retail`.
+ */
+
+/**
+ * GA4-schema item data, pushed to the GTM data layer.
+ *
+ * @typedef {Object} Ga4Item
+ * @property {string} item_id           ID number including the `gla_` prefix.
+ * @property {number} [quantity]        Quantity of this item.
+ * @property {string} [item_name]       Product name.
+ * @property {string} [item_category]   First product category name.
+ * @property {number} [price]           Price as a decimal number.
  */
 
 /**

--- a/js/src/gtag-events/utils.test.js
+++ b/js/src/gtag-events/utils.test.js
@@ -3,8 +3,10 @@
  */
 import {
 	getCartItemObject,
+	getGa4ItemObject,
 	getPriceObject,
 	getProductObject,
+	pushAddToCartDataLayerEvent,
 	retrievedVariation,
 	trackAddToCartEvent,
 	trackEvent,
@@ -13,8 +15,10 @@ import {
 describe( 'gtag-events utils', () => {
 	beforeEach( () => {
 		window.gtag = jest.fn();
+		window.dataLayer = [];
 		window.glaGtagData = {
 			currency_minor_unit: 2,
+			currency_code: 'USD',
 			products: [],
 		};
 
@@ -76,6 +80,80 @@ describe( 'gtag-events utils', () => {
 				},
 			],
 			send_to: 'GLA',
+		} );
+	} );
+
+	it( 'track add to cart event also pushes a parallel GA4 event to the data layer', () => {
+		const product = {
+			id: 1234,
+			name: 'Test name',
+			categories: [ { name: 'One' } ],
+			prices: {
+				price: 1012,
+				currency_minor_unit: 2,
+			},
+		};
+		trackAddToCartEvent( product, 3 );
+		expect( window.dataLayer ).toContainEqual( {
+			event: 'add_to_cart',
+			ecommerce: {
+				currency: 'USD',
+				value: 30.36,
+				items: [
+					{
+						item_id: 'gla_1234',
+						item_name: 'Test name',
+						item_category: 'One',
+						price: 10.12,
+						quantity: 3,
+					},
+				],
+			},
+		} );
+	} );
+
+	it( 'push add to cart data layer event - no price available', () => {
+		const product = { id: 3456 };
+		pushAddToCartDataLayerEvent( product );
+		expect( window.dataLayer ).toContainEqual( {
+			event: 'add_to_cart',
+			ecommerce: {
+				currency: 'USD',
+				value: undefined,
+				items: [
+					{
+						item_id: 'gla_3456',
+						quantity: 1,
+					},
+				],
+			},
+		} );
+	} );
+
+	it( 'formatted GA4 item object', () => {
+		const product = {
+			id: 1234,
+			name: 'Test name',
+			categories: [ { name: 'One' }, { name: 'Two' } ],
+			prices: {
+				price: 9999,
+				currency_minor_unit: 2,
+			},
+		};
+		expect( getGa4ItemObject( product, 2 ) ).toEqual( {
+			item_id: 'gla_1234',
+			item_name: 'Test name',
+			item_category: 'One',
+			price: 99.99,
+			quantity: 2,
+		} );
+	} );
+
+	it( 'formatted GA4 item object - no additional details', () => {
+		const product = { id: 1234 };
+		expect( getGa4ItemObject( product, 2 ) ).toEqual( {
+			item_id: 'gla_1234',
+			quantity: 2,
 		} );
 	} );
 

--- a/src/Google/GlobalSiteTag.php
+++ b/src/Google/GlobalSiteTag.php
@@ -213,6 +213,7 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 					'glaGtagData',
 					[
 						'currency_minor_unit' => wc_get_price_decimals(),
+						'currency_code'       => get_woocommerce_currency(),
 						'products'            => $this->products,
 					]
 				);
@@ -372,7 +373,8 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 		$order->save_meta_data();
 
 		// Get the item info in the order
-		$item_info = [];
+		$item_info     = [];
+		$ga4_item_info = [];
 		foreach ( $order->get_items() as $item_id => $item ) {
 			$product_id   = $item->get_variation_id() ?: $item->get_product_id();
 			$product_name = $item->get_name();
@@ -389,6 +391,23 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 				esc_js( $product_id ),
 				$price,
 				esc_js( $product_name ),
+				$quantity,
+			);
+
+			$product         = wc_get_product( $product_id );
+			$category        = $product instanceof WC_Product ? join( ' & ', $this->product_helper->get_categories( $product ) ) : '';
+			$ga4_item_info[] = sprintf(
+				'{
+				item_id: "gla_%s",
+				item_name: "%s",
+				price: %f,
+				item_category: "%s",
+				quantity: %d,
+				}',
+				esc_js( $product_id ),
+				esc_js( $product_name ),
+				$price,
+				esc_js( $category ),
 				$quantity,
 			);
 		}
@@ -431,6 +450,28 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			join( ',', $item_info ),
 		);
 		$this->add_inline_event_script( $purchase_page_gtag );
+
+		// Parallel GA4-schema push to window.dataLayer for the merchant's own GTM tags.
+		$purchase_data_layer = sprintf(
+			'window.dataLayer = window.dataLayer || [];
+			dataLayer.push({
+			event: "purchase",
+			ecommerce: {
+				transaction_id: "%s",
+				currency: "%s",
+				value: %f,
+				tax: %f,
+				shipping: %f,
+				items: [%s]
+			}});',
+			esc_js( $order->get_id() ),
+			esc_js( $order->get_currency() ),
+			$order->get_total(),
+			esc_js( $order->get_cart_tax() ),
+			$order->get_total_shipping(),
+			join( ',', $ga4_item_info ),
+		);
+		$this->add_inline_event_script( $purchase_data_layer );
 	}
 
 	/**
@@ -463,6 +504,31 @@ class GlobalSiteTag implements Service, Registerable, Conditional, OptionsAwareI
 			esc_js( join( ' & ', $this->product_helper->get_categories( $product ) ) ),
 		);
 		$this->add_inline_event_script( $view_item_gtag );
+
+		// Parallel GA4-schema push to window.dataLayer for the merchant's own GTM tags.
+		$view_item_data_layer = sprintf(
+			'window.dataLayer = window.dataLayer || [];
+			dataLayer.push({
+			event: "view_item",
+			ecommerce: {
+				currency: "%s",
+				value: %f,
+				items: [{
+					item_id: "gla_%s",
+					item_name: "%s",
+					price: %f,
+					item_category: "%s",
+					quantity: 1,
+				}]
+			}});',
+			esc_js( get_woocommerce_currency() ),
+			wc_get_price_to_display( $product ),
+			esc_js( $product->get_id() ),
+			esc_js( $product->get_name() ),
+			wc_get_price_to_display( $product ),
+			esc_js( join( ' & ', $this->product_helper->get_categories( $product ) ) ),
+		);
+		$this->add_inline_event_script( $view_item_data_layer );
 	}
 
 	/**

--- a/tests/Unit/Google/GlobalSiteTagTest.php
+++ b/tests/Unit/Google/GlobalSiteTagTest.php
@@ -12,7 +12,9 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WC;
 use Automattic\WooCommerce\GoogleListingsAndAds\Proxies\WP;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
 use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionMethod;
 use WC_Helper_Order;
+use WC_Helper_Product;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -105,13 +107,18 @@ class GlobalSiteTagTest extends UnitTest {
 
 		$order = WC_Helper_Order::create_order();
 
-		$invoked_count = $this->exactly( 1 );
+		$invoked_count = $this->exactly( 2 );
 		$this->wp->expects( $invoked_count )
 			->method( 'wp_print_inline_script_tag' )
 			->willReturnCallback(
 				function ( string $script ) use ( $invoked_count ) {
 					if ( 1 === $invoked_count->getInvocationCount() ) {
 						$this->assertStringStartsWith( 'gtag("event", "purchase"', $script );
+					} elseif ( 2 === $invoked_count->getInvocationCount() ) {
+						// The parallel GA4-schema push for the merchant's own GTM tags.
+						$this->assertStringContainsString( 'dataLayer.push({', $script );
+						$this->assertStringContainsString( 'event: "purchase"', $script );
+						$this->assertStringContainsString( 'item_id: "gla_', $script );
 					}
 				}
 			);
@@ -121,6 +128,47 @@ class GlobalSiteTagTest extends UnitTest {
 		// Reload order and confirm tracked meta is set.
 		$order = wc_get_order( $order->get_id() );
 		$this->assertSame( 1, (int) $order->get_meta( '_gla_tracked', true ) );
+	}
+
+	public function test_view_item_event_snippet() {
+		$product = WC_Helper_Product::create_simple_product();
+		$this->go_to( get_permalink( $product->get_id() ) );
+
+		$this->product_helper->expects( $this->exactly( 2 ) )
+			->method( 'get_categories' )
+			->willReturn( [ 'Test Category' ] );
+
+		$invoked_count = $this->exactly( 2 );
+		$this->wp->expects( $invoked_count )
+			->method( 'wp_print_inline_script_tag' )
+			->willReturnCallback(
+				function ( string $script ) use ( $invoked_count, $product ) {
+					if ( 1 === $invoked_count->getInvocationCount() ) {
+						$this->assertStringStartsWith( 'gtag("event", "view_item"', $script );
+					} elseif ( 2 === $invoked_count->getInvocationCount() ) {
+						// The parallel GA4-schema push for the merchant's own GTM tags.
+						$this->assertStringContainsString( 'dataLayer.push({', $script );
+						$this->assertStringContainsString( 'event: "view_item"', $script );
+						$this->assertStringContainsString( 'item_id: "gla_' . $product->get_id() . '"', $script );
+						$this->assertStringContainsString( 'item_category: "Test Category"', $script );
+						$this->assertStringContainsString( 'currency: "' . get_woocommerce_currency() . '"', $script );
+					}
+				}
+			);
+
+		$method = new ReflectionMethod( $this->tag, 'display_view_item_event_snippet' );
+		$method->setAccessible( true );
+		$method->invoke( $this->tag );
+	}
+
+	public function test_view_item_event_snippet_not_a_product_page() {
+		$this->go_to( home_url( '/' ) );
+
+		$this->wp->expects( $this->never() )->method( 'wp_print_inline_script_tag' );
+
+		$method = new ReflectionMethod( $this->tag, 'display_view_item_event_snippet' );
+		$method->setAccessible( true );
+		$method->invoke( $this->tag );
 	}
 
 	public function test_enhanced_conversion_data_is_null_when_no_customer_data() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes: [GOOWOO-931](https://linear.app/a8c/issue/GOOWOO-931/ecommerce-data-layer-integration-backend-event-pushes)
Also closes: [GOOWOO-927](https://linear.app/a8c/issue/GOOWOO-927/ecommerce-data-layer-integration-add-to-cart-data-layer-push)

Pushes `view_item`, `add_to_cart`, and `purchase` events to `window.dataLayer` in the GA4 ecommerce schema, alongside the plugin's existing Ads-gtag tracking, so a merchant's own GTM tags and triggers can react to real shopper activity without any code editing. Both sibling tickets ([931](https://linear.app/a8c/issue/GOOWOO-931/ecommerce-data-layer-integration-backend-event-pushes) BE, [927](https://linear.app/a8c/issue/GOOWOO-927/ecommerce-data-layer-integration-add-to-cart-data-layer-push) FE) are covered here in one pass, since 927's push needs 931's `currency_code` addition to exist first. 

- `GlobalSiteTag.php`'s existing `display_view_item_event_snippet()` and `maybe_display_purchase_event_snippet()` methods each gained a parallel `dataLayer.push()`, sourced from the exact same already-computed values (item ID, price, name, category, quantity, transaction ID, tax, shipping, value) as the existing Ads-gtag snippets right next to them - no new data-gathering.
- `js/src/gtag-events/utils.js` gained a new `getGa4ItemObject()` / `pushAddToCartDataLayerEvent()` pair, called from the existing `trackAddToCartEvent()`. A new function rather than a tweak of the existing one, since that one mixes in Ads-only fields (`send_to`, `ecomm_pagetype`) that don't belong in a GA4-schema push.
- All three pushes use GA4's own canonical item field names (`item_id`/`item_name`/`item_category`), distinct from the Ads-gtag item shape's plain `id`/`name`/`category` - the two formats don't share a schema, confirmed directly in the source PRD's own field-shape example.
- **One deliberate BE/FE asymmetry**: the PHP pushes (`view_item`/`purchase`) always include `item_category` (empty string when the product has none), since PHP always has the full product/order object available. The JS push (`add_to_cart`) omits `item_category` entirely when unavailable, matching the *existing* Ads-gtag click-tracking's own conditional-field pattern (client-side data can genuinely be incomplete). Not a bug - see the test instructions' note on this.
- Added a `currency_code` key (`get_woocommerce_currency()`) to the existing `glaGtagData` localization, alongside `currency_minor_unit` - needed by all three pushes, none of which had a currency code available before this.
- **No consent-gating code added.** GTM's own Consent Mode signal already lands on `window.dataLayer` automatically via the existing `gtag()` shim, per the project overview's own Risks section - this was corrected out of both tickets' original scope on 2026-08-18, so there's nothing new to gate here.
- **No GTM-connection-state check added anywhere**, and this is deliberate, not an oversight: per the PRD's own Edge Cases, these pushes are meant to be unconditional, harmless no-ops - pushing to `window.dataLayer` has no effect unless a GTM container script is actually present to consume it. That's enforced structurally by `TagManagerSiteTag` ([GOOWOO-930](https://linear.app/a8c/issue/GOOWOO-930/automatic-gtm-snippet-injection-storefront-script-and-noscript)): it only injects the actual container script when a container is connected, and stops once the merchant disconnects. So "stops firing after disconnect" comes for free from that existing gate, not from a redundant check in this code.

### Screenshots:

N/A: No merchant- or shopper-facing UI change; this is data-layer instrumentation only.

### Detailed test instructions:

1. `composer install`, `vendor/bin/phpunit --testsuite unit` — full suite passes.
2. `vendor/bin/phpcs` (default ruleset) and `vendor/bin/phpcs --standard=tests/phpcs.xml.dist` (test files changed).
3. `npm install`, `npx wp-scripts lint-js js/src/gtag-events/utils.js js/src/gtag-events/utils.test.js` — clean.
4. `npx wp-scripts test-unit-js js/src/gtag-events/utils.test.js` — passes.

**Note on the examples below:** anywhere a value is store-specific (a real price, product ID, order ID, currency, category), the example shows one worked-through case using a real test product — substitute your own store's actual values, don't expect an exact text match against the example.

**Note on `item_category`:** the `view_item`/`purchase` pushes (PHP) always include `item_category` — as an empty string `""` when the product has none — while the `add_to_cart` push (JS) omits `item_category` entirely when unavailable. This is intentional, not a bug: PHP always has the full product/order object to read from, so it always populates every field; the JS side mirrors the *existing* Ads-gtag click-tracking's own behavior, which only includes a field when the client-side data for it actually exists. If you compare a `view_item` payload against an `add_to_cart` payload for the same product, don't flag the field-presence difference — it's expected.

#### Test 1: `view_item` on a product page

Visit a product page — for example, a product named "Test Product" priced at $19.99 with the category "Widgets" — and view source. Alongside the existing `gtag("event", "view_item", ...)` snippet, confirm a second script renders:

```js
window.dataLayer = window.dataLayer || [];
dataLayer.push({
event: "view_item",
ecommerce: {
	currency: "USD",
	value: 19.99,
	items: [{
		item_id: "gla_123",
		item_name: "Test Product",
		price: 19.99,
		item_category: "Widgets",
		quantity: 1,
	}]
}});
```

("123" is that product's own ID — your real product's ID will differ.) Then check a second product that has **no** category set, and confirm `item_category` still renders, as an empty string (`item_category: "",`) — see the `item_category` note above.

#### Test 2: `purchase` on the order-confirmation page

Place a real test order through checkout and land on the order-received page. View source and confirm, alongside the existing `gtag("event", "purchase", ...)` snippet, a second script with your real order's data in the same shape:

```js
window.dataLayer = window.dataLayer || [];
dataLayer.push({
event: "purchase",
ecommerce: {
	transaction_id: "1234",
	currency: "USD",
	value: 19.99,
	tax: 0,
	shipping: 5,
	items: [{ item_id: "gla_123", item_name: "Test Product", price: 19.99, item_category: "Widgets", quantity: 1 }]
}});
```

Reload the order-received page: the snippet should NOT re-render (existing `_gla_tracked` order-meta guard against double-reporting applies to both snippets, since they're both gated by the same early-return).

#### Test 3: `add_to_cart` on add-to-cart interactions

Open the browser console on a shop or product page. Run `window.dataLayer = []` to start clean, then add a product to cart (archive-loop button, single-product button, or a Gutenberg add-to-cart block all exercise this — Gutenberg-block-button tracking has the same pre-existing gap as the Ads-gtag tracking it parallels, not a regression here). Run `console.log(window.dataLayer)` and confirm an entry with your product's real data, e.g.:

```js
{
	event: "add_to_cart",
	ecommerce: {
		currency: "USD",
		value: 19.99,
		items: [{ item_id: "gla_123", item_name: "Test Product", price: 19.99, item_category: "Widgets", quantity: 1 }]
	}
}
```

(If the product has no category, `item_category` will be missing from this one entirely — see the note above, that's expected here, unlike Test 1.) Confirm the existing `gtag("event", "add_to_cart", ...)` call (visible via a `window.gtag` breakpoint, or the Network tab if GA/Ads is actually configured) still fires unchanged alongside it.

#### Test 4: `currency_code` localization

```
wp eval 'echo wp_json_encode( array( "currency_code" => get_woocommerce_currency() ) ) . "\n";'
```

Then confirm the same value appears in `glaGtagData` in the page source (search for `glaGtagData` in view-source on any storefront page) - `currency_code` should sit alongside the existing `currency_minor_unit` and `products` keys.

#### Note: consent gating is unaffected

This PR adds no consent-gating code of its own — GTM's Consent Mode signal already lands on `window.dataLayer` automatically via the existing `gtag()` shim once the script loads, and the existing `wp_has_consent()` gate on whether the script loads at all is untouched. Nothing new to test here specifically.

### Additional details:
Also covers [GOOWOO-927](https://linear.app/a8c/issue/GOOWOO-927/ecommerce-data-layer-integration-add-to-cart-data-layer-push) (FE, `add_to_cart`) - see PR description above for why both are combined here.

### Changelog entry

> Add - Publish `view_item`, `add_to_cart`, and `purchase` events to the GTM data layer in GA4 ecommerce schema, alongside the plugin's existing Ads conversion tracking.

