### PR TITLE
GOOWOO-994: Move GCR enrollment notice above collect-reviews toggle

### DIFF
--- a/js/src/pages/settings/google-customer-reviews/index.js
+++ b/js/src/pages/settings/google-customer-reviews/index.js
@@ -174,19 +174,6 @@ const GoogleCustomerReviewsSettings = () => {
 			<Section.Card>
 				<Section.Card.Body>
 					<VerticalGapLayout size="large">
-						<AppStandaloneToggleControl
-							label={ __(
-								'Collect reviews after purchase',
-								'google-listings-and-ads'
-							) }
-							onChange={ handleReviewCollectionChange }
-							help={ __(
-								'Google asks customers on the order confirmation page if they would like to review your store. Customers who opt in receive an email from Google once their order arrives.',
-								'google-listings-and-ads'
-							) }
-							checked={ isEnabled }
-							disabled={ isSaving }
-						/>
 						{ ! isGCRNoticeDismissed && (
 							<Notice
 								status="info"
@@ -217,6 +204,19 @@ const GoogleCustomerReviewsSettings = () => {
 								</AppButton>
 							</Notice>
 						) }
+						<AppStandaloneToggleControl
+							label={ __(
+								'Collect reviews after purchase',
+								'google-listings-and-ads'
+							) }
+							onChange={ handleReviewCollectionChange }
+							help={ __(
+								'Google asks customers on the order confirmation page if they would like to review your store. Customers who opt in receive an email from Google once their order arrives.',
+								'google-listings-and-ads'
+							) }
+							checked={ isEnabled }
+							disabled={ isSaving }
+						/>
 						<AppStandaloneToggleControl
 							label={ __(
 								'Google store widget',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes GOOWOO-994.

Moves the "This setting will only take effect if you're enrolled in the Merchant Center." Google Customer Reviews (GCR) enrollment notice so it renders above the "Collect reviews after purchase" toggle instead of below it, improving the settings layout flow (merchants see the enrollment context before the control it applies to).

### Screenshots:

<img width="894" height="546" alt="Screenshot 2026-09-03 at 9 00 41 PM" src="https://github.com/user-attachments/assets/96c88173-9bf9-4d49-bb03-c2e52222463a" />

### Detailed test instructions:

1. Go to Marketing > Google for WooCommerce > Settings > Google Customer Reviews.
2. Confirm the "This setting will only take effect if you're enrolled in the Merchant Center." notice now appears above the "Collect reviews after purchase" toggle.
3. Dismiss the notice and confirm it stays dismissed (via the `gla_gcr_enrollment_notice_dismissed` preference) and the toggle still functions normally (toggle on/off, save succeeds).
4. Run `npx jest js/src/pages/settings/google-customer-reviews/index.test.js` and confirm all 23 tests still pass (no test assertions rely on DOM order, so none needed updating).


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>