### PR TITLE
fix(gsc): flatten store state, rename match type, polish select UI

### DIFF
--- a/js/src/data/reducer.js
+++ b/js/src/data/reducer.js
@@ -16,6 +16,12 @@ const DEFAULT_STATE = {
 		mcId: null,
 		adsId: null,
 	},
+	accounts: {
+		google_search_console: null,
+	},
+	google_search_console: {
+		properties: null,
+	},
 	mc: {
 		target_audience: null,
 		countries: null,
@@ -35,8 +41,6 @@ const DEFAULT_STATE = {
 			ads_billing_status: null,
 			google_access: null,
 			youtube: null,
-			google_search_console: null,
-			google_search_console_properties: null,
 		},
 		contact: null,
 		mapping: {
@@ -746,13 +750,13 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		case TYPES.RECEIVE_ACCOUNTS_GOOGLE_SEARCH_CONSOLE: {
 			return setIn(
 				state,
-				'mc.accounts.google_search_console',
+				'accounts.google_search_console',
 				action.account
 			);
 		}
 
 		case TYPES.DISCONNECT_ACCOUNTS_GOOGLE_SEARCH_CONSOLE: {
-			return setIn( state, 'mc.accounts.google_search_console', {
+			return setIn( state, 'accounts.google_search_console', {
 				status: GOOGLE_SEARCH_CONSOLE_ACCOUNT_STATUS.DISCONNECTED,
 			} );
 		}
@@ -760,7 +764,7 @@ const reducer = ( state = DEFAULT_STATE, action ) => {
 		case TYPES.RECEIVE_GOOGLE_SEARCH_CONSOLE_PROPERTIES: {
 			return setIn(
 				state,
-				'mc.accounts.google_search_console_properties',
+				'google_search_console.properties',
 				action.properties
 			);
 		}

--- a/js/src/data/selectors.js
+++ b/js/src/data/selectors.js
@@ -23,7 +23,7 @@ import {
  * @typedef {import('~/data/types.js').GeneralState} GeneralState
  * @typedef {import('~/data/types.js').AssetEntityGroup} AssetEntityGroup
  * @typedef {import('~/data/types.js').GoogleSearchConsoleAccount} GoogleSearchConsoleAccount
- * @typedef {import('~/data/types.js').GoogleSearchConsoleMatch} GoogleSearchConsoleMatch
+ * @typedef {import('~/data/types.js').GoogleSearchConsolePropertyCandidate} GoogleSearchConsolePropertyCandidate
  */
 
 /**
@@ -131,7 +131,7 @@ export const getYouTubeAccount = ( state ) => {
  * @return {GoogleSearchConsoleAccount|null} The Google Search Console connection state. It would return `null` before the data is fetched.
  */
 export const getGoogleSearchConsoleAccount = ( state ) => {
-	return state.mc.accounts.google_search_console;
+	return state.accounts.google_search_console;
 };
 
 /**
@@ -139,10 +139,10 @@ export const getGoogleSearchConsoleAccount = ( state ) => {
  * complete the connection.
  *
  * @param {Object} state The current store state will be injected by `wp.data`.
- * @return {GoogleSearchConsoleMatch[]|null} The candidate properties. It would return `null` before the data is fetched.
+ * @return {GoogleSearchConsolePropertyCandidate[]|null} The candidate properties. It would return `null` before the data is fetched.
  */
 export const getGoogleSearchConsoleProperties = ( state ) => {
-	return state.mc.accounts.google_search_console_properties;
+	return state.google_search_console.properties;
 };
 
 /**

--- a/js/src/data/test/reducer.test.js
+++ b/js/src/data/test/reducer.test.js
@@ -21,6 +21,12 @@ describe( 'reducer', () => {
 				mcId: null,
 				adsId: null,
 			},
+			accounts: {
+				google_search_console: null,
+			},
+			google_search_console: {
+				properties: null,
+			},
 			mc: {
 				target_audience: null,
 				countries: null,
@@ -40,8 +46,6 @@ describe( 'reducer', () => {
 					ads_billing_status: null,
 					google_access: null,
 					youtube: null,
-					google_search_console: null,
-					google_search_console_properties: null,
 				},
 				mapping: {
 					attributes: [],
@@ -1062,7 +1066,7 @@ describe( 'reducer', () => {
 			[ TYPES.RECEIVE_ACCOUNTS_GOOGLE_MC_EXISTING, 'accounts', 'mc.accounts.existing_mc' ],
 			[ TYPES.RECEIVE_ACCOUNTS_GOOGLE_ADS_BILLING_STATUS, 'billingStatus', 'mc.accounts.ads_billing_status' ],
 			[ TYPES.RECEIVE_ACCOUNTS_GOOGLE_ADS_EXISTING, 'accounts', 'mc.accounts.existing_ads' ],
-			[ TYPES.RECEIVE_GOOGLE_SEARCH_CONSOLE_PROPERTIES, 'properties', 'mc.accounts.google_search_console_properties' ],
+			[ TYPES.RECEIVE_GOOGLE_SEARCH_CONSOLE_PROPERTIES, 'properties', 'google_search_console.properties' ],
 			[ TYPES.RECEIVE_MC_CONTACT_INFORMATION, 'data', 'mc.contact' ],
 			[ TYPES.RECEIVE_TARGET_AUDIENCE, 'target_audience', 'mc.target_audience' ],
 			[ TYPES.SAVE_TARGET_AUDIENCE, 'target_audience', 'mc.target_audience' ],

--- a/js/src/data/types.js
+++ b/js/src/data/types.js
@@ -118,12 +118,9 @@
  */
 
 /**
- * A candidate Search Console property, as returned by `GET search-console/properties` — a raw
- * Sites API `siteEntry` plus two backend-computed booleans. That endpoint is a standalone listing,
- * not part of the connection status: the merchant may have candidates to choose between regardless
- * of whether a property has already been auto-resolved.
+ * A candidate Search Console property, as returned by `GET search-console/properties`.
  *
- * @typedef {Object} GoogleSearchConsoleMatch
+ * @typedef {Object} GoogleSearchConsoleProperty
  * @property {string} siteUrl Raw Sites API property identifier (a full URL-prefix, or an `sc-domain:` domain property).
  * @property {string} permissionLevel Raw Sites API permission enum (e.g. `siteOwner`, `siteFullUser`,
  *   `siteUnverifiedUser`). Never `siteRestrictedUser` — those properties are excluded entirely upstream.

--- a/js/src/hooks/useGoogleSearchConsoleProperties.js
+++ b/js/src/hooks/useGoogleSearchConsoleProperties.js
@@ -9,17 +9,16 @@ import { useSelect } from '@wordpress/data';
 import { STORE_KEY } from '~/data/constants';
 
 /**
- * @typedef {import('~/data/types.js').GoogleSearchConsoleMatch} GoogleSearchConsoleMatch
+ * @typedef {import('~/data/types.js').GoogleSearchConsoleProperty} GoogleSearchConsoleProperty
  */
 
 const selectorName = 'getGoogleSearchConsoleProperties';
 
 /**
  * A hook to load the candidate Google Search Console properties the merchant can choose
- * between to complete the connection. A standalone listing, separate from the connection's
- * own status — see `~/hooks/useGoogleSearchConsoleAccount`.
+ * between to complete the connection.
  *
- * @return {{ properties: GoogleSearchConsoleMatch[]|null, hasFinishedResolution: boolean }} The data and its resolution state.
+ * @return {{ properties: GoogleSearchConsoleProperty[]|null, hasFinishedResolution: boolean }} The data and its resolution state.
  */
 const useGoogleSearchConsoleProperties = () => {
 	return useSelect( ( select ) => {

--- a/js/src/pages/settings/accounts/google-search-console-account-card/connected-indicator.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/connected-indicator.js
@@ -26,7 +26,9 @@ const REPORTS_URL = geReportsUrl();
  * @return {JSX.Element} The connected indicator for the Google Search Console account card.
  */
 const ConnectedIndicator = ( { onDisconnect } ) => {
-	const handleViewReportClick = () => getHistory().push( REPORTS_URL );
+	const handleViewReportClick = () => {
+		getHistory().push( REPORTS_URL );
+	};
 
 	return (
 		<Flex>

--- a/js/src/pages/settings/accounts/google-search-console-account-card/connected-success-notice.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/connected-success-notice.js
@@ -30,8 +30,13 @@ export default function ConnectedSuccessNotice() {
 		return null;
 	}
 
-	const handleDismiss = () => setIsDismissed( true );
-	const handleViewReportsClick = () => getHistory().push( REPORTS_URL );
+	const handleDismiss = () => {
+		setIsDismissed( true );
+	};
+
+	const handleViewReportsClick = () => {
+		getHistory().push( REPORTS_URL );
+	};
 
 	return (
 		<Notice status="success" onDismiss={ handleDismiss }>

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.js
@@ -65,7 +65,6 @@ export default function PropertySelection() {
 	const [ createProperty, { loading: isCreating } ] = useApiFetchCallback( {
 		path: PROPERTIES_PATH,
 		method: 'POST',
-		data: {},
 	} );
 
 	const loading = isSelecting || isCreating;
@@ -92,8 +91,13 @@ export default function PropertySelection() {
 		}
 	};
 
-	const handleSelectClick = () => submitProperty( selectProperty );
-	const handleCreateNewClick = () => submitProperty( createProperty );
+	const handleSelectClick = () => {
+		submitProperty( selectProperty );
+	};
+
+	const handleCreateNewClick = () => {
+		submitProperty( createProperty );
+	};
 
 	if ( ! hasFinishedResolution ) {
 		return (
@@ -118,34 +122,32 @@ export default function PropertySelection() {
 				'google-listings-and-ads'
 			) }
 			body={
-				<Flex direction="column" gap={ 3 }>
-					{ __(
-						'Pick one to connect, or create a new one.',
-						'google-listings-and-ads'
-					) }
-					<Flex direction="column" gap={ 3 } expanded={ false }>
-						<FlexBlock>
-							<GoogleSearchConsoleSelectControl
-								properties={ properties }
-								value={ value }
-								onChange={ setValue }
-							/>
-						</FlexBlock>
-						<FlexItem>
-							<AppButton
-								eventName="gla_google_search_console_property_select_button_click"
-								eventProps={ {
-									context: 'settings-search-console',
-								} }
-								onClick={ handleSelectClick }
-								disabled={ ! value || loading }
-								loading={ isSelecting }
-								isSecondary
-							>
-								{ __( 'Save', 'google-listings-and-ads' ) }
-							</AppButton>
-						</FlexItem>
-					</Flex>
+				<Flex direction="column" gap={ 4 }>
+					<FlexBlock>
+						<GoogleSearchConsoleSelectControl
+							label={ __(
+								'Pick one to connect, or create a new one.',
+								'google-listings-and-ads'
+							) }
+							properties={ properties }
+							value={ value }
+							onChange={ setValue }
+						/>
+					</FlexBlock>
+					<FlexItem>
+						<AppButton
+							eventName="gla_google_search_console_property_select_button_click"
+							eventProps={ {
+								context: 'settings-search-console',
+							} }
+							onClick={ handleSelectClick }
+							disabled={ ! value }
+							loading={ isSelecting }
+							isSecondary
+						>
+							{ __( 'Save', 'google-listings-and-ads' ) }
+						</AppButton>
+					</FlexItem>
 				</Flex>
 			}
 			actions={ [
@@ -154,7 +156,6 @@ export default function PropertySelection() {
 					eventName="gla_google_search_console_property_create_button_click"
 					eventProps={ { context: 'settings-search-console' } }
 					onClick={ handleCreateNewClick }
-					disabled={ loading }
 					loading={ isCreating }
 					isTertiary
 				>

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.js
@@ -67,8 +67,6 @@ export default function PropertySelection() {
 		method: 'POST',
 	} );
 
-	const loading = isSelecting || isCreating;
-
 	// Shared by both actions below: `fetchProperty` is whichever already-configured request
 	// (`selectProperty` or `createProperty`) the caller wants to submit — both need identical
 	// success/failure handling, differing only in which endpoint call they wrap.

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/google-search-console-select-control.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/google-search-console-select-control.js
@@ -7,52 +7,62 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import AppSelectControl from '~/components/app-select-control';
+import './google-search-console-select-control.scss';
 
 /**
- * Derives explanatory copy for a non-usable match, since the backend supplies no `reason`
+ * @typedef {import('~/data/types.js').GoogleSearchConsoleProperty} GoogleSearchConsoleProperty
+ */
+
+/**
+ * Derives explanatory copy for a non-usable property, since the backend supplies no `reason`
  * field — only the `covers`/`permissionLevel` booleans a usability decision was made from.
  *
- * @param {import('~/data/types.js').GoogleSearchConsoleMatch} match A non-usable match.
- * @return {string} The explanation to show next to the match.
+ * @param {GoogleSearchConsoleProperty} property A non-usable property.
+ * @return {string} The explanation to show next to the property.
  */
-function getUnusableReason( match ) {
-	return match.covers
+function getUnusableReason( property ) {
+	return property.covers
 		? __( 'Not yet verified', 'google-listings-and-ads' )
 		: __( "Doesn't cover this store's URL", 'google-listings-and-ads' );
 }
 
 /**
- * Renders an `AppSelectControl` sourced from the candidate Google Search Console matches.
+ * Renders an `AppSelectControl` sourced from the candidate Google Search Console properties.
  *
  * No per-option "disabled but visible" primitive exists anywhere in this codebase (confirmed),
- * so non-usable matches are rendered as native disabled `<option>`s with an explanatory
+ * so non-usable properties are rendered as native disabled `<option>`s with an explanatory
  * suffix appended to their label — a deliberately provisional stand-in pending design for
  * this state.
  *
  * @param {Object} props Component props.
- * @param {import('~/data/types.js').GoogleSearchConsoleMatch[]} props.properties The candidate
+ * @param {GoogleSearchConsoleProperty[]} props.properties The candidate
  *   properties to render as options. The remaining props are forwarded to `AppSelectControl`.
  * @return {JSX.Element} An enhanced AppSelectControl component.
  */
-const GoogleSearchConsoleSelectControl = ( { properties, ...props } ) => {
-	const matches = properties ?? [];
-
-	const options = matches.map( ( match ) => {
+const GoogleSearchConsoleSelectControl = ( { properties = [], ...props } ) => {
+	const options = properties.map( ( property ) => {
 		return {
-			value: match.siteUrl,
-			label: match.usable
-				? match.siteUrl
+			value: property.siteUrl,
+			label: property.usable
+				? property.siteUrl
 				: sprintf(
 						// translators: 1: property URL, 2: reason why the property can't be selected.
 						__( '%1$s (%2$s)', 'google-listings-and-ads' ),
-						match.siteUrl,
-						getUnusableReason( match )
+						property.siteUrl,
+						getUnusableReason( property )
 				  ),
-			disabled: ! match.usable,
+			disabled: ! property.usable,
 		};
 	} );
 
-	return <AppSelectControl options={ options } { ...props } />;
+	return (
+		<AppSelectControl
+			className="gla-google-search-console-select-control"
+			options={ options }
+			autoSelectFirstOption
+			{ ...props }
+		/>
+	);
 };
 
 export default GoogleSearchConsoleSelectControl;

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/google-search-console-select-control.scss
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/google-search-console-select-control.scss
@@ -1,0 +1,9 @@
+.gla-google-search-console-select-control {
+	// hack with !important to override the specificity in @wordpress/components.
+	label.components-input-control__label {
+		color: var(--wp-components-notice-text-color) !important;
+		font-size: $gla-font-base !important;
+		font-weight: normal !important;
+		text-transform: none !important;
+	}
+}

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/index.test.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/index.test.js
@@ -195,11 +195,14 @@ describe( 'IncompleteGoogleSearchConsoleAccountCard', () => {
 		const saveButton = screen.getByRole( 'button', {
 			name: 'Save',
 		} );
-		expect( saveButton ).toBeDisabled();
+
+		// `autoSelectFirstOption` pre-selects the first candidate on mount, so Save is
+		// already enabled without any merchant interaction.
+		expect( saveButton ).toBeEnabled();
 
 		await user.selectOptions(
 			screen.getByRole( 'combobox' ),
-			'https://a.example.com/'
+			'https://b.example.com/'
 		);
 		expect( saveButton ).toBeEnabled();
 
@@ -211,7 +214,7 @@ describe( 'IncompleteGoogleSearchConsoleAccountCard', () => {
 			expect.objectContaining( {
 				path: PROPERTIES_PATH,
 				method: 'POST',
-				data: { site_url: 'https://a.example.com/' },
+				data: { site_url: 'https://b.example.com/' },
 			} )
 		);
 		expect( setProperty ).toHaveBeenCalledWith();

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
 			},
 			{
 				"path": "./js/build/index.js",
-				"maxSize": "22.6 kB"
+				"maxSize": "22.7 kB"
 			},
 			{
 				"path": "./js/build/commons.js",
@@ -163,7 +163,7 @@
 			},
 			{
 				"path": "./js/build/woo-marketing-notifications-slot.js",
-				"maxSize": "18.55 kB"
+				"maxSize": "18.7 kB"
 			},
 			{
 				"path": "./js/build/vendors.js",


### PR DESCRIPTION
Move google_search_console out of mc.accounts into top-level accounts/google_search_console keys — it's an OAuth connection, not merchant-center data, and nesting misrepresented that.

Rename GoogleSearchConsoleMatch -> GoogleSearchConsoleProperty; "match" implied a search result, not a raw Sites API property.

Fold the property-picker label into GoogleSearchConsoleSelectControl so it renders next to the field it describes, add scss to override default label styling, and auto-select the first option. Drop dead disabled/data props no longer needed after the loading-state cleanup.

### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes # .

_Replace this with a good description of your changes & reasoning._


### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. 
2. 
3. 


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
