### PR TITLE
GOOWOO-1008: Exclude failed orders from review opt-in prompt

### DIFF
--- a/src/Google/ReviewsOptIn.php
+++ b/src/Google/ReviewsOptIn.php
@@ -101,6 +101,10 @@ class ReviewsOptIn implements Service, Registerable, OptionsAwareInterface {
 			return;
 		}
 
+		if ( in_array( $order->get_status(), self::get_excluded_order_statuses(), true ) ) {
+			return;
+		}
+
 		if ( 1 === (int) $order->get_meta( self::ORDER_PROMPTED_META_KEY, true ) ) {
 			return;
 		}
@@ -139,6 +143,17 @@ class ReviewsOptIn implements Service, Registerable, OptionsAwareInterface {
 		$settings = $this->options->get( OptionsInterface::GOOGLE_CUSTOMER_REVIEWS, [] );
 
 		return ! empty( $settings[ self::SETTING_KEY ] );
+	}
+
+	/**
+	 * Order statuses excluded from the opt-in prompt by default. Filterable so a merchant or
+	 * developer can exclude additional statuses (e.g. cancelled, refunded, or unpaid offline-payment
+	 * orders) if they want stricter behavior than the default.
+	 *
+	 * @return string[]
+	 */
+	protected static function get_excluded_order_statuses(): array {
+		return (array) apply_filters( 'woocommerce_gla_reviews_opt_in_excluded_order_statuses', [ 'failed' ] );
 	}
 
 	/**

--- a/tests/Unit/Google/ReviewsOptInTest.php
+++ b/tests/Unit/Google/ReviewsOptInTest.php
@@ -199,4 +199,75 @@ class ReviewsOptInTest extends UnitTest {
 
 		$this->opt_in->maybe_display_opt_in_snippet();
 	}
+
+	public function test_no_injection_when_order_status_is_failed() {
+		$order = $this->create_eligible_order();
+		$order->set_status( 'failed' );
+		$order->save();
+
+		$this->expectOutputString( '' );
+
+		$this->opt_in->maybe_display_opt_in_snippet();
+	}
+
+	public function test_failed_order_does_not_burn_prompted_flag_so_a_later_retry_still_prompts() {
+		$order = $this->create_eligible_order();
+		$order->set_status( 'failed' );
+		$order->save();
+
+		ob_start();
+		$this->opt_in->maybe_display_opt_in_snippet();
+		ob_end_clean();
+
+		$order = wc_get_order( $order->get_id() );
+		$this->assertSame( 0, (int) $order->get_meta( '_gla_gcr_opt_in_prompted', true ) );
+
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$this->expectOutputRegex( '/surveyoptin\.render/' );
+
+		$this->opt_in->maybe_display_opt_in_snippet();
+	}
+
+	/**
+	 * @dataProvider return_non_excluded_order_statuses
+	 *
+	 * @param string $status Order status that must not be excluded by default.
+	 */
+	public function test_injection_not_excluded_by_default_for_other_order_statuses( string $status ) {
+		$order = $this->create_eligible_order();
+		$order->set_status( $status );
+		$order->save();
+
+		$this->expectOutputRegex( '/surveyoptin\.render/' );
+
+		$this->opt_in->maybe_display_opt_in_snippet();
+	}
+
+	public function return_non_excluded_order_statuses(): array {
+		return [
+			'pending'   => [ 'pending' ],
+			'on-hold'   => [ 'on-hold' ],
+			'cancelled' => [ 'cancelled' ],
+			'refunded'  => [ 'refunded' ],
+		];
+	}
+
+	public function test_excluded_order_statuses_filter_can_add_additional_statuses() {
+		$order = $this->create_eligible_order();
+		$order->set_status( 'cancelled' );
+		$order->save();
+
+		add_filter(
+			'woocommerce_gla_reviews_opt_in_excluded_order_statuses',
+			function () {
+				return [ 'failed', 'cancelled' ];
+			}
+		);
+
+		$this->expectOutputString( '' );
+
+		$this->opt_in->maybe_display_opt_in_snippet();
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes GOOWOO-1008.

WooCommerce renders the order-received (thank-you) page for `failed` orders the same as successful ones, so the Google Customer Reviews post-purchase opt-in script previously fired regardless — sharing the shopper's email and order details with Google for a purchase that never completed.

This excludes `failed` orders from the opt-in prompt via a new filterable status list (`ReviewsOptIn::get_excluded_order_statuses()`), checked immediately after the order is resolved and *before* the "already prompted" dedup meta is checked/written. That ordering is what makes a failed-then-retry-successful order still get prompted: a `failed`-status page view returns before the dedup flag is ever touched, so it can't suppress a later successful attempt on the same order.

Other order statuses (`pending`, `on-hold`, `cancelled`, `refunded`) are intentionally left un-excluded by default, to keep this fix scoped to the confirmed bug. A new `woocommerce_gla_reviews_opt_in_excluded_order_statuses` filter lets a merchant or developer add further statuses to the exclusion list if they want stricter behavior.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. On a store with Merchant Center connected, "Collect reviews after purchase" enabled, a resolvable estimated delivery time for the destination country, and marketing consent granted (or no consent-management plugin installed): place an order and force the payment to fail (e.g. a test gateway that declines). Confirm the Google Customer Reviews opt-in popup does **not** appear on the resulting order-received page.
2. From that same failed order, use WooCommerce's "Pay"/"Try again" link to complete payment successfully. Confirm the opt-in popup **does** appear on the resulting confirmation page.
3. Place a new order that completes successfully on the first attempt (no failed status in its history). Confirm the opt-in popup still appears as before — no regression.
4. Repeat steps 1–3 using WooCommerce's block-based checkout (Order Confirmation block), not just the classic checkout, to confirm the fix holds on both.
5. Optionally, add a `woocommerce_gla_reviews_opt_in_excluded_order_statuses` filter (e.g. returning `[ 'failed', 'cancelled' ]`) and confirm a `cancelled` order is now also excluded, demonstrating the extension point works.
6. Run `vendor/bin/phpunit --filter ReviewsOptInTest` — all tests should pass.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>