### PR TITLE
GOOWOO-1009: E2E test coverage for Google Search Console

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,11 @@
 *** Google for WooCommerce Changelog ***
 
+= 3.9.3 - 2026-09-03 =
+* Fix - Add unit test coverage for GlobalSiteTag disable-tracking filter.
+* Fix - Stop retrying every product against a rejected authentication token during sync; fail the sync run on the first authentication error instead.
+* Update - Drive the Merchant Center product status refresh from paginated product list requests instead of a report plus one request per product, and raise the write batch size to its recommended maximum, cutting the requests made to Google.
+* Update - Pause product and coupon sync, and show a reconnect notice when the WordPress.com connection has no owner user or the Connect Server rejects the site's token, instead of sending requests that are always rejected.
+
 = 3.9.2 - 2026-08-31 =
 * Add - Google Ads credits offer text to dashboard.
 * Fix - Prevent VAT from being removed or added twice when syncing tax-inclusive product prices.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,8 @@
 *** Google for WooCommerce Changelog ***
 
 = 3.9.3 - 2026-09-03 =
-* Fix - Add unit test coverage for GlobalSiteTag disable-tracking filter.
 * Fix - Stop retrying every product against a rejected authentication token during sync; fail the sync run on the first authentication error instead.
+* Fix - Show a single merged issue row with the combined applicable countries for a product synced to multiple feeds, instead of duplicate rows with repeated country codes.
 * Update - Drive the Merchant Center product status refresh from paginated product list requests instead of a report plus one request per product, and raise the write batch size to its recommended maximum, cutting the requests made to Google.
 * Update - Pause product and coupon sync, and show a reconnect notice when the WordPress.com connection has no owner user or the Connect Server rejects the site's token, instead of sending requests that are always rejected.
 

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -12,8 +12,8 @@
  * Requires PHP: 7.4
  * Requires PHP Architecture: 64 bits
  * Requires Plugins: woocommerce
- * WC requires at least: 10.8
- * WC tested up to: 11.0
+ * WC requires at least: 10.9
+ * WC tested up to: 11.1
  * Woo:
  *
  * License: GPLv3
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) || exit;
 
 define( 'WC_GLA_VERSION', '3.9.1' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.4' );
-define( 'WC_GLA_MIN_WC_VER', '10.8' );
+define( 'WC_GLA_MIN_WC_VER', '10.9' );
 
 // Load and initialize the autoloader.
 require_once __DIR__ . '/src/Autoloader.php';

--- a/google-listings-and-ads.php
+++ b/google-listings-and-ads.php
@@ -3,7 +3,7 @@
  * Plugin Name: Google for WooCommerce
  * Plugin URL: https://wordpress.org/plugins/google-listings-and-ads/
  * Description: Native integration with Google that allows merchants to easily display their products across Google’s network.
- * Version: 3.9.2
+ * Version: 3.9.3
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: google-listings-and-ads
@@ -33,7 +33,7 @@ use Automattic\WooCommerce\Utilities\FeaturesUtil;
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_GLA_VERSION', '3.9.2' ); // WRCS: DEFINED_VERSION.
+define( 'WC_GLA_VERSION', '3.9.3' ); // WRCS: DEFINED_VERSION.
 define( 'WC_GLA_MIN_PHP_VER', '7.4' );
 define( 'WC_GLA_MIN_WC_VER', '10.8' );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "google-listings-and-ads",
-	"version": "3.9.2",
+	"version": "3.9.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "google-listings-and-ads",
-			"version": "3.9.2",
+			"version": "3.9.3",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@woocommerce/components": "^12.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "google-listings-and-ads",
 	"title": "Google for WooCommerce",
-	"version": "3.9.2",
+	"version": "3.9.3",
 	"description": "Google for WooCommerce",
 	"author": "Automattic",
 	"license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -52,7 +52,7 @@ Once you’re running Google Ads campaigns, the Google tag feature in the extens
 = Minimum Requirements =
 
 * WordPress 6.8 or greater
-* WooCommerce 10.8 or greater
+* WooCommerce 10.9 or greater
 * PHP version 7.4 or greater
 * PHP Architecture 64 bits
 * MySQL version 5.6 or greater

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,12 @@ To allow your products to appear in all relevant locations, make sure you’ve c
 
 == Changelog ==
 
+= 3.9.3 - 2026-09-03 =
+* Fix - Add unit test coverage for GlobalSiteTag disable-tracking filter.
+* Fix - Stop retrying every product against a rejected authentication token during sync; fail the sync run on the first authentication error instead.
+* Update - Drive the Merchant Center product status refresh from paginated product list requests instead of a report plus one request per product, and raise the write batch size to its recommended maximum, cutting the requests made to Google.
+* Update - Pause product and coupon sync, and show a reconnect notice when the WordPress.com connection has no owner user or the Connect Server rejects the site's token, instead of sending requests that are always rejected.
+
 = 3.9.2 - 2026-08-31 =
 * Add - Google Ads credits offer text to dashboard.
 * Fix - Prevent VAT from being removed or added twice when syncing tax-inclusive product prices.
@@ -160,15 +166,5 @@ To allow your products to appear in all relevant locations, make sure you’ve c
 * Update - Always show the "Add market" button, and choose a market's country from a tree-select list grouped by continent.
 * Update - Re-designed Account connection settings.
 * Dev - Remove inactive google-manager flow from the connection test page.
-
-= 3.9.0 - 2026-08-05 =
-* Add - Adds Croatia (HR) to the list of countries supported by Google Merchant Center.
-* Add - Marketing notifications system.
-* Add - Multi-lingual support for markets, currencies, and shipping feeds.
-* Fix - Fixed an issue that affected product sync when current user has no personal WPCOM token.
-* Fix - Avoid memory exhaustion fatals when loading Google Ads performance reports.
-* Fix - Estimated shipping times no longer show validation errors when continuing onboarding without changing the prefilled defaults.
-* Fix - Resolve autoload collisions resulting in undefined `trigger_deprecation()` errors.
-* Fix - Verify data source during Merchant API product sync.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/google-listings-and-ads/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires at least: 6.9
 Tested up to: 7.1
 Requires PHP: 7.4
 Requires PHP Architecture: 64 Bits
-Stable tag: 3.9.2
+Stable tag: 3.9.3
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -141,8 +141,8 @@ To allow your products to appear in all relevant locations, make sure you’ve c
 == Changelog ==
 
 = 3.9.3 - 2026-09-03 =
-* Fix - Add unit test coverage for GlobalSiteTag disable-tracking filter.
 * Fix - Stop retrying every product against a rejected authentication token during sync; fail the sync run on the first authentication error instead.
+* Fix - Show a single merged issue row with the combined applicable countries for a product synced to multiple feeds, instead of duplicate rows with repeated country codes.
 * Update - Drive the Merchant Center product status refresh from paginated product list requests instead of a report plus one request per product, and raise the write batch size to its recommended maximum, cutting the requests made to Google.
 * Update - Pause product and coupon sync, and show a reconnect notice when the WordPress.com connection has no owner user or the Connect Server rejects the site's token, instead of sending requests that are always rejected.
 

--- a/src/API/Google/JetpackAuthCircuitBreaker.php
+++ b/src/API/Google/JetpackAuthCircuitBreaker.php
@@ -26,7 +26,7 @@ defined( 'ABSPATH' ) || exit;
  * The pause is stored in an option rather than a transient so that an object cache
  * eviction cannot silently drop it.
  *
- * @since x.x.x
+ * @since 3.9.3
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
  */

--- a/src/API/Google/JetpackAuthCircuitBreaker.php
+++ b/src/API/Google/JetpackAuthCircuitBreaker.php
@@ -1,0 +1,95 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class JetpackAuthCircuitBreaker
+ *
+ * Pauses syncing after the Connect Server rejects the site's Jetpack token.
+ *
+ * The Connect Server authenticates every proxied request with the Jetpack token, so a
+ * rejection applies to every request the site makes, and running sync jobs against it
+ * only produces more rejections. A failure pauses syncing for one hour, without backoff
+ * and without extension by further rejections: the next attempt after the window is a
+ * single probe, and any accepted response ends the pause early, so a repaired connection
+ * or a transient failure is picked up within the hour. The failure is also remembered
+ * for the rest of the current PHP request, so a loop making one request per product
+ * stops after the first rejection.
+ *
+ * The pause is stored in an option rather than a transient so that an object cache
+ * eviction cannot silently drop it.
+ *
+ * @since x.x.x
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\API\Google
+ */
+class JetpackAuthCircuitBreaker implements OptionsAwareInterface {
+
+	use OptionsAwareTrait;
+
+	/**
+	 * Whether a failure was recorded during the current request.
+	 *
+	 * @var bool
+	 */
+	private $tripped_in_request = false;
+
+	/**
+	 * Record an authentication failure.
+	 */
+	public function trip(): void {
+		$this->tripped_in_request = true;
+
+		// A rejection while already open (e.g. from an admin page load) keeps the current window.
+		if ( ! $this->is_open() ) {
+			$this->options->update( OptionsInterface::JETPACK_AUTH_FAILED_AT, time() );
+		}
+	}
+
+	/**
+	 * End the pause after an accepted response.
+	 */
+	public function reset(): void {
+		$this->tripped_in_request = false;
+
+		if ( $this->options->get( OptionsInterface::JETPACK_AUTH_FAILED_AT ) ) {
+			$this->options->delete( OptionsInterface::JETPACK_AUTH_FAILED_AT );
+		}
+	}
+
+	/**
+	 * Whether the breaker is open, i.e. syncing is paused.
+	 *
+	 * @return bool
+	 */
+	public function is_open(): bool {
+		return $this->get_retry_time() > time();
+	}
+
+	/**
+	 * Whether trip() ran earlier in this PHP request; used to fail fast for the rest of it.
+	 *
+	 * @return bool
+	 */
+	public function was_tripped_in_request(): bool {
+		return $this->tripped_in_request;
+	}
+
+	/**
+	 * The timestamp at which the pause ends, or 0 when no failure is recorded.
+	 *
+	 * @return int
+	 */
+	public function get_retry_time(): int {
+		$failed_at = (int) $this->options->get( OptionsInterface::JETPACK_AUTH_FAILED_AT, 0 );
+
+		return $failed_at > 0 ? $failed_at + HOUR_IN_SECONDS : 0;
+	}
+}

--- a/src/API/Google/JetpackAuthCircuitBreaker.php
+++ b/src/API/Google/JetpackAuthCircuitBreaker.php
@@ -18,8 +18,8 @@ defined( 'ABSPATH' ) || exit;
  * rejection applies to every request the site makes, and running sync jobs against it
  * only produces more rejections. A failure pauses syncing for one hour, without backoff
  * and without extension by further rejections: the next attempt after the window is a
- * single probe, and any accepted response ends the pause early, so a repaired connection
- * or a transient failure is picked up within the hour. The failure is also remembered
+ * single probe, and a reset ends the pause early (see reset()), so a repaired connection or a
+ * transient failure is picked up within the hour. The failure is also remembered
  * for the rest of the current PHP request, so a loop making one request per product
  * stops after the first rejection.
  *
@@ -54,7 +54,7 @@ class JetpackAuthCircuitBreaker implements OptionsAwareInterface {
 	}
 
 	/**
-	 * End the pause after an accepted response.
+	 * End the pause. Called by the response handler once a request is accepted.
 	 */
 	public function reset(): void {
 		$this->tripped_in_request = false;

--- a/src/API/Google/Mapi/Models/ProductStatus.php
+++ b/src/API/Google/Mapi/Models/ProductStatus.php
@@ -21,6 +21,9 @@ class ProductStatus {
 	/** @var string|null */
 	protected $last_update_date;
 
+	/** @var string|null */
+	protected $google_expiration_date;
+
 	/**
 	 * Hydrate from a MAPI response array.
 	 *
@@ -35,8 +38,9 @@ class ProductStatus {
 			$instance->item_level_issues[] = ItemLevelIssue::from_array( $issue );
 		}
 
-		$instance->destination_statuses = $data['destinationStatuses'] ?? [];
-		$instance->last_update_date     = $data['lastUpdateDate'] ?? null;
+		$instance->destination_statuses   = $data['destinationStatuses'] ?? [];
+		$instance->last_update_date       = $data['lastUpdateDate'] ?? null;
+		$instance->google_expiration_date = $data['googleExpirationDate'] ?? null;
 
 		return $instance;
 	}
@@ -60,5 +64,47 @@ class ProductStatus {
 	 */
 	public function get_last_update_date(): ?string {
 		return $this->last_update_date;
+	}
+
+	/**
+	 * @return string|null RFC 3339 timestamp, or null when Google reports no expiration.
+	 */
+	public function get_google_expiration_date(): ?string {
+		return $this->google_expiration_date;
+	}
+
+	/**
+	 * Derive the aggregated reporting context status from the per-context destination
+	 * statuses, following the official enum semantics (eligible for all contexts and
+	 * countries = ELIGIBLE, some = ELIGIBLE_LIMITED, pending in all = PENDING,
+	 * otherwise NOT_ELIGIBLE_OR_DISAPPROVED). The product_view report precomputes this
+	 * value; products.list does not carry it, so it is rebuilt here from the same inputs.
+	 *
+	 * A product with no destination statuses at all (still processing) returns an empty
+	 * string: callers treat it like a product absent from the report.
+	 *
+	 * @return string Aggregated status enum value, or '' when no destination statuses exist.
+	 */
+	public function get_aggregated_reporting_context_status(): string {
+		$has_approved    = false;
+		$has_pending     = false;
+		$has_disapproved = false;
+
+		foreach ( $this->destination_statuses as $destination_status ) {
+			$has_approved    = $has_approved || ! empty( $destination_status['approvedCountries'] );
+			$has_pending     = $has_pending || ! empty( $destination_status['pendingCountries'] );
+			$has_disapproved = $has_disapproved || ! empty( $destination_status['disapprovedCountries'] );
+		}
+
+		if ( ! $has_approved && ! $has_pending && ! $has_disapproved ) {
+			return '';
+		}
+
+		if ( $has_approved ) {
+			return ( $has_pending || $has_disapproved ) ? 'ELIGIBLE_LIMITED' : 'ELIGIBLE';
+		}
+
+		// No approvals: all-pending is PENDING; any disapproval makes it not eligible anywhere.
+		return $has_disapproved ? 'NOT_ELIGIBLE_OR_DISAPPROVED' : 'PENDING';
 	}
 }

--- a/src/API/Google/Mapi/Services/MapiProductInputsService.php
+++ b/src/API/Google/Mapi/Services/MapiProductInputsService.php
@@ -441,7 +441,8 @@ class MapiProductInputsService implements OptionsAwareInterface {
 	 * @return int
 	 */
 	protected function get_batch_size(): int {
-		return max( 1, (int) apply_filters( 'woocommerce_gla_mapi_batch_size', 50 ) );
+		// 100 is the Merchant API's recommended maximum sub-requests per batch.
+		return max( 1, (int) apply_filters( 'woocommerce_gla_mapi_batch_size', 100 ) );
 	}
 
 	/**

--- a/src/API/Google/Mapi/Services/MapiProductsService.php
+++ b/src/API/Google/Mapi/Services/MapiProductsService.php
@@ -102,17 +102,46 @@ class MapiProductsService implements OptionsAwareInterface {
 	 * @throws MerchantApiException On non-2xx response.
 	 */
 	public function list( int $page_size = 250 ): iterable {
-		$page_token = '';
+		$page_token = null;
 
 		do {
-			$body = $this->client->get( $this->build_list_path( $page_size, $page_token ) );
+			$page = $this->list_page( $page_token, $page_size );
 
-			foreach ( $body['products'] ?? [] as $product ) {
-				yield Product::from_array( $product );
+			foreach ( $page['products'] as $product ) {
+				yield $product;
 			}
 
-			$page_token = $body['nextPageToken'] ?? '';
-		} while ( '' !== $page_token );
+			$page_token = $page['next_page_token'];
+		} while ( null !== $page_token );
+	}
+
+	/**
+	 * Fetch a single page of the account's products.
+	 *
+	 * Page-wise counterpart of {@see list()} for callers that carry the pagination
+	 * state themselves across separate PHP requests (e.g. a batched job storing the
+	 * token between scheduled actions).
+	 *
+	 * @param string|null $page_token Token of the page to fetch; null for the first page.
+	 * @param int         $page_size  Maximum products per page (the API caps this at 1000).
+	 *
+	 * @return array{products: Product[], next_page_token: ?string}
+	 * @throws MerchantApiException On non-2xx response.
+	 */
+	public function list_page( ?string $page_token = null, int $page_size = 1000 ): array {
+		$body = $this->client->get( $this->build_list_path( $page_size, $page_token ?? '' ) );
+
+		$products = [];
+		foreach ( $body['products'] ?? [] as $product ) {
+			$products[] = Product::from_array( $product );
+		}
+
+		$next_token = $body['nextPageToken'] ?? null;
+
+		return [
+			'products'        => $products,
+			'next_page_token' => is_string( $next_token ) && '' !== $next_token ? $next_token : null,
+		];
 	}
 
 	/**

--- a/src/API/Google/Mapi/Services/MapiProductsService.php
+++ b/src/API/Google/Mapi/Services/MapiProductsService.php
@@ -123,12 +123,14 @@ class MapiProductsService implements OptionsAwareInterface {
 	 * token between scheduled actions).
 	 *
 	 * @param string|null $page_token Token of the page to fetch; null for the first page.
-	 * @param int         $page_size  Maximum products per page (the API caps this at 1000).
+	 * @param int         $page_size  Maximum products per page; clamped to the API range 1-1000.
 	 *
 	 * @return array{products: Product[], next_page_token: ?string}
 	 * @throws MerchantApiException On non-2xx response.
 	 */
 	public function list_page( ?string $page_token = null, int $page_size = 1000 ): array {
+		$page_size = min( 1000, max( 1, $page_size ) );
+
 		$body = $this->client->get( $this->build_list_path( $page_size, $page_token ?? '' ) );
 
 		$products = [];

--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -118,18 +118,7 @@ class MerchantReport implements OptionsAwareInterface {
 	 * @return string The MC status.
 	 */
 	protected function convert_aggregated_status_to_mc_status( string $status ): string {
-		switch ( $status ) {
-			case 'ELIGIBLE':
-				return MCStatus::APPROVED;
-			case 'ELIGIBLE_LIMITED':
-				return MCStatus::PARTIALLY_APPROVED;
-			case 'NOT_ELIGIBLE_OR_DISAPPROVED':
-				return MCStatus::DISAPPROVED;
-			case 'PENDING':
-				return MCStatus::PENDING;
-			default:
-				return MCStatus::NOT_SYNCED;
-		}
+		return MCStatus::from_aggregated_reporting_context_status( $status );
 	}
 
 	/**

--- a/src/API/Google/MerchantReport.php
+++ b/src/API/Google/MerchantReport.php
@@ -55,6 +55,10 @@ class MerchantReport implements OptionsAwareInterface {
 	/**
 	 * Get ProductView Query response.
 	 *
+	 * @deprecated No longer used by the status refresh, which walks
+	 *             MapiProductsService::list_page() and derives statuses via
+	 *             MerchantStatuses::process_mapi_products() instead.
+	 *
 	 * @param string|null $next_page_token The next page token.
 	 * @return array Associative array with product statuses and the next page token.
 	 *

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -77,6 +77,22 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
 	}
 
 	/**
+	 * Delete issue records by their row IDs.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int[] $ids Row IDs to delete.
+	 */
+	public function delete_by_ids( array $ids ): void {
+		if ( empty( $ids ) ) {
+			return;
+		}
+
+		$placeholder = '(' . implode( ',', array_fill( 0, count( $ids ), '%d' ) ) . ')';
+		$this->wpdb->query( $this->wpdb->prepare( "DELETE FROM `{$this->get_sql_safe_name()}` WHERE `id` IN {$placeholder}", $ids ) ); // phpcs:ignore WordPress.DB.PreparedSQL, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+	}
+
+	/**
 	 * Get the columns for the table.
 	 *
 	 * @return array

--- a/src/DB/Table/MerchantIssueTable.php
+++ b/src/DB/Table/MerchantIssueTable.php
@@ -79,7 +79,7 @@ CREATE TABLE `{$this->get_sql_safe_name()}` (
 	/**
 	 * Delete issue records by their row IDs.
 	 *
-	 * @since x.x.x
+	 * @since 3.9.3
 	 *
 	 * @param int[] $ids Row IDs to delete.
 	 */

--- a/src/Hooks/README.md
+++ b/src/Hooks/README.md
@@ -8,7 +8,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BulkEditInitializer.php#L36](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/BulkEdit/BulkEditInitializer.php#L36)
+- [BulkEditInitializer.php#L36](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Admin/BulkEdit/BulkEditInitializer.php#L36)
 
 ## google_for_woocommerce_admin_menu_notification_count
 
@@ -16,7 +16,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [NotificationManager.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Menu/NotificationManager.php#L166)
+- [NotificationManager.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Menu/NotificationManager.php#L166)
 
 ## jetpack_verify_api_authorization_request_error_double_encode
 
@@ -24,7 +24,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [JetpackWPCOM.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/JetpackWPCOM.php#L223)
+- [JetpackWPCOM.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Integration/JetpackWPCOM.php#L223)
 
 ## wcml_raw_price_amount
 
@@ -32,9 +32,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L233](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L233)
-- [WPML.php#L277](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L277)
-- [WPML.php#L333](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L333)
+- [WPML.php#L233](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Integration/WPML.php#L233)
+- [WPML.php#L277](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Integration/WPML.php#L277)
+- [WPML.php#L333](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Integration/WPML.php#L333)
 
 ## woocommerce_adjust_non_base_location_prices
 
@@ -42,7 +42,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L463](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L463)
+- [WCProductInputAdapter.php#L463](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L463)
 
 ## woocommerce_admin_disabled
 
@@ -50,7 +50,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCAdminValidator.php#L38](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Internal/Requirements/WCAdminValidator.php#L38)
+- [WCAdminValidator.php#L38](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Internal/Requirements/WCAdminValidator.php#L38)
 
 ## woocommerce_gla_ads_billing_setup_status
 
@@ -58,8 +58,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Ads.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L113)
-- [Ads.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L122)
+- [Ads.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Ads.php#L113)
+- [Ads.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Ads.php#L122)
 
 ## woocommerce_gla_ads_client_exception
 
@@ -67,36 +67,36 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AdsAssetGenerationService.php#L151](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Ads/AdsAssetGenerationService.php#L151)
-- [AdsAssetGenerationService.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Ads/AdsAssetGenerationService.php#L220)
-- [AdsAssetGroup.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsAssetGroup.php#L122)
-- [AdsAssetGroup.php#L329](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsAssetGroup.php#L329)
-- [AdsAssetGroup.php#L402](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsAssetGroup.php#L402)
-- [AdsAssetGroup.php#L458](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsAssetGroup.php#L458)
-- [AdsIncentives.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsIncentives.php#L109)
-- [AdsIncentives.php#L200](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsIncentives.php#L200)
-- [Ads.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L74)
-- [Ads.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L118)
-- [Ads.php#L163](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L163)
-- [Ads.php#L205](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L205)
-- [Ads.php#L315](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L315)
-- [LocationIDTrait.php#L132](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/LocationIDTrait.php#L132)
-- [AdsConversionAction.php#L100](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsConversionAction.php#L100)
-- [AdsConversionAction.php#L146](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsConversionAction.php#L146)
-- [BudgetRecommendations.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/BudgetRecommendations.php#L125)
-- [AdsReport.php#L170](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsReport.php#L170)
-- [AdsCampaign.php#L181](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L181)
-- [AdsCampaign.php#L227](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L227)
-- [AdsCampaign.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L273)
-- [AdsCampaign.php#L378](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L378)
-- [AdsCampaign.php#L441](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L441)
-- [AdsCampaign.php#L485](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L485)
-- [AdsCampaign.php#L548](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L548)
-- [AdsCampaign.php#L1091](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L1091)
-- [AdsCampaign.php#L1140](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L1140)
-- [BudgetMetrics.php#L137](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/BudgetMetrics.php#L137)
-- [AdsAssetGroupAsset.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsAssetGroupAsset.php#L136)
-- [AdsAssetGroupAsset.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsAssetGroupAsset.php#L208)
+- [AdsAssetGenerationService.php#L151](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Ads/AdsAssetGenerationService.php#L151)
+- [AdsAssetGenerationService.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Ads/AdsAssetGenerationService.php#L220)
+- [AdsAssetGroup.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsAssetGroup.php#L122)
+- [AdsAssetGroup.php#L329](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsAssetGroup.php#L329)
+- [AdsAssetGroup.php#L402](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsAssetGroup.php#L402)
+- [AdsAssetGroup.php#L458](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsAssetGroup.php#L458)
+- [AdsIncentives.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsIncentives.php#L109)
+- [AdsIncentives.php#L200](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsIncentives.php#L200)
+- [Ads.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Ads.php#L74)
+- [Ads.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Ads.php#L118)
+- [Ads.php#L163](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Ads.php#L163)
+- [Ads.php#L205](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Ads.php#L205)
+- [Ads.php#L315](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Ads.php#L315)
+- [LocationIDTrait.php#L132](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/LocationIDTrait.php#L132)
+- [AdsConversionAction.php#L100](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsConversionAction.php#L100)
+- [AdsConversionAction.php#L146](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsConversionAction.php#L146)
+- [BudgetRecommendations.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/BudgetRecommendations.php#L125)
+- [AdsReport.php#L170](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsReport.php#L170)
+- [AdsCampaign.php#L181](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsCampaign.php#L181)
+- [AdsCampaign.php#L227](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsCampaign.php#L227)
+- [AdsCampaign.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsCampaign.php#L273)
+- [AdsCampaign.php#L378](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsCampaign.php#L378)
+- [AdsCampaign.php#L441](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsCampaign.php#L441)
+- [AdsCampaign.php#L485](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsCampaign.php#L485)
+- [AdsCampaign.php#L548](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsCampaign.php#L548)
+- [AdsCampaign.php#L1091](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsCampaign.php#L1091)
+- [AdsCampaign.php#L1140](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsCampaign.php#L1140)
+- [BudgetMetrics.php#L137](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/BudgetMetrics.php#L137)
+- [AdsAssetGroupAsset.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsAssetGroupAsset.php#L136)
+- [AdsAssetGroupAsset.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsAssetGroupAsset.php#L208)
 
 ## woocommerce_gla_ads_id
 
@@ -104,7 +104,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L119](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Options/Options.php#L119)
+- [Options.php#L119](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Options/Options.php#L119)
 
 ## woocommerce_gla_ads_setup_completed
 
@@ -112,7 +112,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SetupCompleteController.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/SetupCompleteController.php#L66)
+- [SetupCompleteController.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/Ads/SetupCompleteController.php#L66)
 
 ## woocommerce_gla_attribute_applicable_product_types_
 
@@ -120,8 +120,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeManager.php#L368](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/Attributes/AttributeManager.php#L368)
-- [AttributesForm.php#L99](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Product/Attributes/AttributesForm.php#L99)
+- [AttributeManager.php#L368](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/Attributes/AttributeManager.php#L368)
+- [AttributesForm.php#L99](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Admin/Product/Attributes/AttributesForm.php#L99)
 
 ## woocommerce_gla_attribute_hidden_product_types_
 
@@ -129,7 +129,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesForm.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Product/Attributes/AttributesForm.php#L104)
+- [AttributesForm.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Admin/Product/Attributes/AttributesForm.php#L104)
 
 ## woocommerce_gla_attribute_mapping_sources
 
@@ -137,7 +137,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L31](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L31)
+- [IsFieldTrait.php#L31](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L31)
 
 ## woocommerce_gla_attribute_mapping_sources_custom_attributes
 
@@ -145,7 +145,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L125)
+- [IsFieldTrait.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L125)
 
 ## woocommerce_gla_attribute_mapping_sources_global_attributes
 
@@ -153,7 +153,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L64](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L64)
+- [IsFieldTrait.php#L64](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L64)
 
 ## woocommerce_gla_attribute_mapping_sources_product_fields
 
@@ -161,7 +161,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L115)
+- [IsFieldTrait.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L115)
 
 ## woocommerce_gla_attribute_mapping_sources_taxonomies
 
@@ -169,7 +169,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L65)
+- [IsFieldTrait.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L65)
 
 ## woocommerce_gla_attributes_tab_applicable_product_types
 
@@ -177,7 +177,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesTrait.php#L18](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Product/Attributes/AttributesTrait.php#L18)
+- [AttributesTrait.php#L18](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Admin/Product/Attributes/AttributesTrait.php#L18)
 
 ## woocommerce_gla_batch_deleted_products
 
@@ -185,8 +185,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L401](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L401)
-- [ProductSyncer.php#L462](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L462)
+- [ProductSyncer.php#L401](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L401)
+- [ProductSyncer.php#L462](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L462)
 
 ## woocommerce_gla_batch_retry_delete_products
 
@@ -194,7 +194,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L581](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L581)
+- [ProductSyncer.php#L581](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L581)
 
 ## woocommerce_gla_batch_retry_update_products
 
@@ -202,7 +202,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L525](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L525)
+- [ProductSyncer.php#L525](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L525)
 
 ## woocommerce_gla_batch_updated_products
 
@@ -210,7 +210,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L179](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L179)
+- [ProductSyncer.php#L179](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L179)
 
 ## woocommerce_gla_batched_cli_size
 
@@ -218,7 +218,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPCLIMigrationGTIN.php#L151](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Utility/WPCLIMigrationGTIN.php#L151)
+- [WPCLIMigrationGTIN.php#L151](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Utility/WPCLIMigrationGTIN.php#L151)
 
 ## woocommerce_gla_batched_job_size
 
@@ -226,11 +226,11 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [UpdateSyncableProductsCount.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/UpdateSyncableProductsCount.php#L74)
-- [UpdateEuPoliticalCampaigns.php#L89](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/UpdateEuPoliticalCampaigns.php#L89)
-- [CreateMerchantReportedConversionReport.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateMerchantReportedConversionReport.php#L90)
-- [AbstractBatchedActionSchedulerJob.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104)
-- [CreateYouTubeOrderIdsCache.php#L71](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateYouTubeOrderIdsCache.php#L71)
+- [UpdateSyncableProductsCount.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/UpdateSyncableProductsCount.php#L74)
+- [UpdateEuPoliticalCampaigns.php#L89](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/UpdateEuPoliticalCampaigns.php#L89)
+- [CreateMerchantReportedConversionReport.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/CreateMerchantReportedConversionReport.php#L90)
+- [AbstractBatchedActionSchedulerJob.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104)
+- [CreateYouTubeOrderIdsCache.php#L71](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/CreateYouTubeOrderIdsCache.php#L71)
 
 ## woocommerce_gla_bulk_update_coupon
 
@@ -238,7 +238,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponBulkEdit.php#L133](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/BulkEdit/CouponBulkEdit.php#L133)
+- [CouponBulkEdit.php#L133](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Admin/BulkEdit/CouponBulkEdit.php#L133)
 
 ## woocommerce_gla_conversion_action_name
 
@@ -246,7 +246,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AdsConversionAction.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsConversionAction.php#L67)
+- [AdsConversionAction.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/AdsConversionAction.php#L67)
 
 ## woocommerce_gla_coupon_destinations
 
@@ -254,7 +254,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCCouponAdapter.php#L439](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/WCCouponAdapter.php#L439)
+- [WCCouponAdapter.php#L439](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/WCCouponAdapter.php#L439)
 
 ## woocommerce_gla_coupons_delete_retry_on_failure
 
@@ -262,7 +262,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L450](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L450)
+- [CouponSyncer.php#L450](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L450)
 
 ## woocommerce_gla_coupons_update_retry_on_failure
 
@@ -270,7 +270,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L412](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L412)
+- [CouponSyncer.php#L412](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L412)
 
 ## woocommerce_gla_custom_merchant_issues
 
@@ -278,7 +278,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L626](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantStatuses.php#L626)
+- [MerchantStatuses.php#L626](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/MerchantStatuses.php#L626)
 
 ## woocommerce_gla_debug_message
 
@@ -286,43 +286,43 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AdsRecommendationsService.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Ads/AdsRecommendationsService.php#L90)
-- [ProductRepository.php#L402](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductRepository.php#L402)
-- [BatchProductHelper.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L302)
-- [BatchProductHelper.php#L333](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L333)
-- [BatchProductHelper.php#L350](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L350)
-- [BatchProductHelper.php#L438](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L438)
-- [BatchProductHelper.php#L451](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L451)
-- [BatchProductHelper.php#L472](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L472)
-- [ProductHelper.php#L540](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L540)
-- [ProductHelper.php#L573](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L573)
-- [SyncerHooks.php#L221](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/SyncerHooks.php#L221)
-- [WCProductAdapter.php#L222](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L222)
-- [CouponHelper.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponHelper.php#L247)
-- [CouponHelper.php#L284](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponHelper.php#L284)
-- [CouponSyncer.php#L114](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L114)
-- [CouponSyncer.php#L127](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L127)
-- [CouponSyncer.php#L152](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L152)
-- [CouponSyncer.php#L168](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L168)
-- [CouponSyncer.php#L185](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L185)
-- [CouponSyncer.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L208)
-- [CouponSyncer.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L273)
-- [CouponSyncer.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L321)
-- [CouponSyncer.php#L340](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L340)
-- [SyncerHooks.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/SyncerHooks.php#L208)
-- [MapiProductInputsService.php#L435](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Mapi/Services/MapiProductInputsService.php#L435)
-- [IssuesController.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L95)
-- [PriceBenchmarks.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/PriceBenchmarks.php#L193)
-- [MerchantStatuses.php#L409](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantStatuses.php#L409)
-- [MerchantStatuses.php#L884](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantStatuses.php#L884)
-- [MerchantStatuses.php#L1133](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantStatuses.php#L1133)
-- [MerchantCenterService.php#L353](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantCenterService.php#L353)
-- [AccountService.php#L712](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L712)
-- [AccountService.php#L720](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L720)
-- [ActionSchedulerJobMonitor.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/ActionSchedulerJobMonitor.php#L117)
-- [ActionSchedulerJobMonitor.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/ActionSchedulerJobMonitor.php#L126)
-- [CleanupSyncedProducts.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CleanupSyncedProducts.php#L74)
-- [MigrateGTIN.php#L169](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/MigrateGTIN.php#L169)
+- [AdsRecommendationsService.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Ads/AdsRecommendationsService.php#L90)
+- [ProductRepository.php#L402](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductRepository.php#L402)
+- [BatchProductHelper.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/BatchProductHelper.php#L302)
+- [BatchProductHelper.php#L333](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/BatchProductHelper.php#L333)
+- [BatchProductHelper.php#L350](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/BatchProductHelper.php#L350)
+- [BatchProductHelper.php#L438](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/BatchProductHelper.php#L438)
+- [BatchProductHelper.php#L451](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/BatchProductHelper.php#L451)
+- [BatchProductHelper.php#L472](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/BatchProductHelper.php#L472)
+- [ProductHelper.php#L540](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductHelper.php#L540)
+- [ProductHelper.php#L573](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductHelper.php#L573)
+- [SyncerHooks.php#L221](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/SyncerHooks.php#L221)
+- [WCProductAdapter.php#L222](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L222)
+- [CouponHelper.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponHelper.php#L247)
+- [CouponHelper.php#L284](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponHelper.php#L284)
+- [CouponSyncer.php#L114](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L114)
+- [CouponSyncer.php#L127](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L127)
+- [CouponSyncer.php#L152](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L152)
+- [CouponSyncer.php#L168](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L168)
+- [CouponSyncer.php#L185](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L185)
+- [CouponSyncer.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L208)
+- [CouponSyncer.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L273)
+- [CouponSyncer.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L321)
+- [CouponSyncer.php#L340](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L340)
+- [SyncerHooks.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/SyncerHooks.php#L208)
+- [MapiProductInputsService.php#L435](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Mapi/Services/MapiProductInputsService.php#L435)
+- [IssuesController.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L95)
+- [PriceBenchmarks.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/PriceBenchmarks.php#L193)
+- [MerchantStatuses.php#L409](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/MerchantStatuses.php#L409)
+- [MerchantStatuses.php#L884](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/MerchantStatuses.php#L884)
+- [MerchantStatuses.php#L1133](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/MerchantStatuses.php#L1133)
+- [MerchantCenterService.php#L353](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/MerchantCenterService.php#L353)
+- [AccountService.php#L712](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/AccountService.php#L712)
+- [AccountService.php#L720](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/AccountService.php#L720)
+- [ActionSchedulerJobMonitor.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/ActionSchedulerJobMonitor.php#L117)
+- [ActionSchedulerJobMonitor.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/ActionSchedulerJobMonitor.php#L126)
+- [CleanupSyncedProducts.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/CleanupSyncedProducts.php#L74)
+- [MigrateGTIN.php#L169](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/MigrateGTIN.php#L169)
 
 ## woocommerce_gla_deleted_promotions
 
@@ -330,7 +330,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L334](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L334)
+- [CouponSyncer.php#L334](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L334)
 
 ## woocommerce_gla_dimension_unit
 
@@ -338,8 +338,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L694](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L694)
-- [WCProductAdapter.php#L448](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L448)
+- [WCProductInputAdapter.php#L694](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L694)
+- [WCProductAdapter.php#L448](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L448)
 
 ## woocommerce_gla_disable_gtag_tracking
 
@@ -347,7 +347,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GlobalSiteTag.php#L539](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Google/GlobalSiteTag.php#L539)
+- [GlobalSiteTag.php#L539](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Google/GlobalSiteTag.php#L539)
 
 ## woocommerce_gla_enable_connection_test
 
@@ -355,7 +355,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ConnectionTest.php#L89](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/ConnectionTest.php#L89)
+- [ConnectionTest.php#L89](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/ConnectionTest.php#L89)
 
 ## woocommerce_gla_enable_debug_logging
 
@@ -363,7 +363,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [DebugLogger.php#L33](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Logging/DebugLogger.php#L33)
+- [DebugLogger.php#L33](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Logging/DebugLogger.php#L33)
 
 ## woocommerce_gla_enable_mcm
 
@@ -371,7 +371,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GLAChannel.php#L86](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MultichannelMarketing/GLAChannel.php#L86)
+- [GLAChannel.php#L86](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MultichannelMarketing/GLAChannel.php#L86)
 
 ## woocommerce_gla_enable_reports
 
@@ -379,7 +379,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Admin.php#L421](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Admin.php#L421)
+- [Admin.php#L421](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Admin/Admin.php#L421)
 
 ## woocommerce_gla_error
 
@@ -387,35 +387,35 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BatchProductHelper.php#L403](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L403)
-- [ProductHelper.php#L432](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L432)
-- [ProductHelper.php#L649](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L649)
-- [AttributeManager.php#L342](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/Attributes/AttributeManager.php#L342)
-- [ProductSyncer.php#L528](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L528)
-- [ProductSyncer.php#L551](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L551)
-- [ProductSyncer.php#L584](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L584)
-- [ProductSyncer.php#L599](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L599)
-- [ProductSyncer.php#L606](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L606)
-- [ProductMetaHandler.php#L183](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductMetaHandler.php#L183)
-- [PHPView.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/View/PHPView.php#L136)
-- [PHPView.php#L164](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/View/PHPView.php#L164)
-- [PHPView.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/View/PHPView.php#L208)
-- [CouponMetaHandler.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponMetaHandler.php#L220)
-- [CouponSyncer.php#L422](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L422)
-- [CouponSyncer.php#L460](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L460)
-- [CouponSyncer.php#L516](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L516)
-- [CouponSyncer.php#L531](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L531)
-- [MapiDataSourcesService.php#L301](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Mapi/Services/MapiDataSourcesService.php#L301)
-- [MerchantApiClient.php#L240](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Mapi/MerchantApiClient.php#L240)
-- [OAuthService.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/WP/OAuthService.php#L247)
-- [RESTControllers.php#L59](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/RESTControllers.php#L59)
-- [RESTControllers.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/RESTControllers.php#L67)
-- [CreateMerchantReportedConversionReport.php#L204](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateMerchantReportedConversionReport.php#L204)
-- [CreateMerchantReportedConversionReport.php#L260](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateMerchantReportedConversionReport.php#L260)
-- [CreateYouTubeOrderIdsCache.php#L128](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateYouTubeOrderIdsCache.php#L128)
-- [AbstractShippingSettingsAdapter.php#L169](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php#L169)
-- [AbstractShippingSettingsAdapter.php#L201](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php#L201)
-- [ProductMetaQueryHelper.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/DB/ProductMetaQueryHelper.php#L87)
+- [BatchProductHelper.php#L403](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/BatchProductHelper.php#L403)
+- [ProductHelper.php#L432](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductHelper.php#L432)
+- [ProductHelper.php#L649](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductHelper.php#L649)
+- [AttributeManager.php#L342](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/Attributes/AttributeManager.php#L342)
+- [ProductSyncer.php#L528](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L528)
+- [ProductSyncer.php#L551](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L551)
+- [ProductSyncer.php#L584](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L584)
+- [ProductSyncer.php#L599](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L599)
+- [ProductSyncer.php#L606](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L606)
+- [ProductMetaHandler.php#L183](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductMetaHandler.php#L183)
+- [PHPView.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/View/PHPView.php#L136)
+- [PHPView.php#L164](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/View/PHPView.php#L164)
+- [PHPView.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/View/PHPView.php#L208)
+- [CouponMetaHandler.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponMetaHandler.php#L220)
+- [CouponSyncer.php#L422](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L422)
+- [CouponSyncer.php#L460](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L460)
+- [CouponSyncer.php#L516](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L516)
+- [CouponSyncer.php#L531](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L531)
+- [MapiDataSourcesService.php#L301](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Mapi/Services/MapiDataSourcesService.php#L301)
+- [MerchantApiClient.php#L240](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Mapi/MerchantApiClient.php#L240)
+- [OAuthService.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/WP/OAuthService.php#L247)
+- [RESTControllers.php#L59](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/RESTControllers.php#L59)
+- [RESTControllers.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/RESTControllers.php#L67)
+- [CreateMerchantReportedConversionReport.php#L204](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/CreateMerchantReportedConversionReport.php#L204)
+- [CreateMerchantReportedConversionReport.php#L260](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/CreateMerchantReportedConversionReport.php#L260)
+- [CreateYouTubeOrderIdsCache.php#L128](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/CreateYouTubeOrderIdsCache.php#L128)
+- [AbstractShippingSettingsAdapter.php#L169](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php#L169)
+- [AbstractShippingSettingsAdapter.php#L201](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php#L201)
+- [ProductMetaQueryHelper.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/DB/ProductMetaQueryHelper.php#L87)
 
 ## woocommerce_gla_exception
 
@@ -423,41 +423,41 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BaseAsset.php#L218](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Assets/BaseAsset.php#L218)
-- [ScriptWithBuiltDependenciesAsset.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Assets/ScriptWithBuiltDependenciesAsset.php#L66)
-- [ProductHelper.php#L311](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L311)
-- [ProductSyncer.php#L144](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L144)
-- [ProductSyncer.php#L371](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L371)
-- [ProductSyncer.php#L439](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L439)
-- [CouponChannelVisibilityMetaBox.php#L205](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php#L205)
-- [ChannelVisibilityMetaBox.php#L201](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L201)
-- [DateTime.php#L44](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Input/DateTime.php#L44)
-- [DateTime.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Input/DateTime.php#L80)
-- [PHPView.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/View/PHPView.php#L87)
-- [CouponSyncer.php#L216](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L216)
-- [CouponSyncer.php#L305](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L305)
-- [WooCommercePreOrders.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WooCommercePreOrders.php#L111)
-- [WooCommercePreOrders.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WooCommercePreOrders.php#L131)
-- [Settings.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Settings.php#L110)
-- [Connection.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Connection.php#L95)
-- [MapiProductsService.php#L83](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Mapi/Services/MapiProductsService.php#L83)
-- [Middleware.php#L498](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L498)
-- [Connection.php#L86](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L86)
-- [Connection.php#L329](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L329)
-- [IncentivesController.php#L142](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/IncentivesController.php#L142)
-- [AccountController.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/YouTube/AccountController.php#L167)
-- [SettingsSyncController.php#L96](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L96)
-- [RequestReviewController.php#L340](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L340)
-- [ContactInformationController.php#L242](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php#L242)
-- [ProductVisibilityController.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L193)
-- [ReconnectWordPress.php#L124](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Notes/ReconnectWordPress.php#L124)
-- [NoteInitializer.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Notes/NoteInitializer.php#L74)
-- [NoteInitializer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Notes/NoteInitializer.php#L116)
-- [ClearProductStatsCache.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Event/ClearProductStatsCache.php#L61)
-- [PluginUpdate.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/Update/PluginUpdate.php#L80)
-- [GoogleServiceProvider.php#L439](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Internal/DependencyManagement/GoogleServiceProvider.php#L439)
-- [GoogleServiceProvider.php#L450](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Internal/DependencyManagement/GoogleServiceProvider.php#L450)
-- [Migration20260813T1653383133.php#L184](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/DB/Migration/Migration20260813T1653383133.php#L184)
+- [BaseAsset.php#L218](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Assets/BaseAsset.php#L218)
+- [ScriptWithBuiltDependenciesAsset.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Assets/ScriptWithBuiltDependenciesAsset.php#L66)
+- [ProductHelper.php#L311](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductHelper.php#L311)
+- [ProductSyncer.php#L144](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L144)
+- [ProductSyncer.php#L371](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L371)
+- [ProductSyncer.php#L439](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L439)
+- [CouponChannelVisibilityMetaBox.php#L205](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php#L205)
+- [ChannelVisibilityMetaBox.php#L201](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L201)
+- [DateTime.php#L44](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Admin/Input/DateTime.php#L44)
+- [DateTime.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Admin/Input/DateTime.php#L80)
+- [PHPView.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/View/PHPView.php#L87)
+- [CouponSyncer.php#L216](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L216)
+- [CouponSyncer.php#L305](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L305)
+- [WooCommercePreOrders.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Integration/WooCommercePreOrders.php#L111)
+- [WooCommercePreOrders.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Integration/WooCommercePreOrders.php#L131)
+- [Settings.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Settings.php#L110)
+- [Connection.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Connection.php#L95)
+- [MapiProductsService.php#L83](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Mapi/Services/MapiProductsService.php#L83)
+- [Middleware.php#L498](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L498)
+- [Connection.php#L86](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/YouTube/Connection.php#L86)
+- [Connection.php#L329](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/YouTube/Connection.php#L329)
+- [IncentivesController.php#L142](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/Ads/IncentivesController.php#L142)
+- [AccountController.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/YouTube/AccountController.php#L167)
+- [SettingsSyncController.php#L96](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L96)
+- [RequestReviewController.php#L340](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L340)
+- [ContactInformationController.php#L242](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php#L242)
+- [ProductVisibilityController.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L193)
+- [ReconnectWordPress.php#L124](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Notes/ReconnectWordPress.php#L124)
+- [NoteInitializer.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Notes/NoteInitializer.php#L74)
+- [NoteInitializer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Notes/NoteInitializer.php#L116)
+- [ClearProductStatsCache.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Event/ClearProductStatsCache.php#L61)
+- [PluginUpdate.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/Update/PluginUpdate.php#L80)
+- [GoogleServiceProvider.php#L439](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Internal/DependencyManagement/GoogleServiceProvider.php#L439)
+- [GoogleServiceProvider.php#L450](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Internal/DependencyManagement/GoogleServiceProvider.php#L450)
+- [Migration20260813T1653383133.php#L184](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/DB/Migration/Migration20260813T1653383133.php#L184)
 
 ## woocommerce_gla_force_product_resync
 
@@ -465,7 +465,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BatchProductHelper.php#L662](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L662)
+- [BatchProductHelper.php#L662](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/BatchProductHelper.php#L662)
 
 ## woocommerce_gla_force_run_install
 
@@ -473,7 +473,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Installer.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Installer.php#L67)
+- [Installer.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Installer.php#L67)
 
 ## woocommerce_gla_get_google_product_offer_id
 
@@ -481,8 +481,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L246](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L246)
-- [WCProductAdapter.php#L301](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L301)
+- [WCProductInputAdapter.php#L246](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L246)
+- [WCProductAdapter.php#L301](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L301)
 
 ## woocommerce_gla_get_sync_ready_products_filter
 
@@ -490,7 +490,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductFilter.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductFilter.php#L61)
+- [ProductFilter.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductFilter.php#L61)
 
 ## woocommerce_gla_get_sync_ready_products_pre_filter
 
@@ -498,7 +498,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductFilter.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductFilter.php#L47)
+- [ProductFilter.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductFilter.php#L47)
 
 ## woocommerce_gla_get_wc_product_id
 
@@ -506,7 +506,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductHelper.php#L359](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L359)
+- [ProductHelper.php#L359](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductHelper.php#L359)
 
 ## woocommerce_gla_google_connect_return_url
 
@@ -514,7 +514,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountController.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Google/AccountController.php#L109)
+- [AccountController.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/Google/AccountController.php#L109)
 
 ## woocommerce_gla_gtag_consent
 
@@ -522,7 +522,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GlobalSiteTag.php#L329](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Google/GlobalSiteTag.php#L329)
+- [GlobalSiteTag.php#L329](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Google/GlobalSiteTag.php#L329)
 
 ## woocommerce_gla_gtin_migration_value
 
@@ -530,7 +530,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GTINMigrationUtilities.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/HelperTraits/GTINMigrationUtilities.php#L167)
+- [GTINMigrationUtilities.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/HelperTraits/GTINMigrationUtilities.php#L167)
 
 ## woocommerce_gla_guzzle_client_exception
 
@@ -538,29 +538,29 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Connection.php#L70](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Connection.php#L70)
-- [Connection.php#L91](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Connection.php#L91)
-- [Connection.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Connection.php#L126)
-- [Middleware.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L75)
-- [Middleware.php#L190](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L190)
-- [Middleware.php#L241](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L241)
-- [Middleware.php#L284](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L284)
-- [Middleware.php#L373](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L373)
-- [Middleware.php#L423](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L423)
-- [Middleware.php#L461](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L461)
-- [Middleware.php#L495](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L495)
-- [Middleware.php#L629](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L629)
-- [Middleware.php#L736](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L736)
-- [Middleware.php#L812](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L812)
-- [Middleware.php#L860](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L860)
-- [Connection.php#L63](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L63)
-- [Connection.php#L82](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L82)
-- [Connection.php#L114](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L114)
-- [Connection.php#L142](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L142)
-- [Connection.php#L194](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L194)
-- [Connection.php#L319](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L319)
-- [AccountController.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/YouTube/AccountController.php#L208)
-- [GoogleServiceProvider.php#L466](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Internal/DependencyManagement/GoogleServiceProvider.php#L466)
+- [Connection.php#L70](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Connection.php#L70)
+- [Connection.php#L91](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Connection.php#L91)
+- [Connection.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Connection.php#L126)
+- [Middleware.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L75)
+- [Middleware.php#L190](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L190)
+- [Middleware.php#L241](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L241)
+- [Middleware.php#L284](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L284)
+- [Middleware.php#L373](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L373)
+- [Middleware.php#L423](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L423)
+- [Middleware.php#L461](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L461)
+- [Middleware.php#L495](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L495)
+- [Middleware.php#L629](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L629)
+- [Middleware.php#L736](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L736)
+- [Middleware.php#L812](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L812)
+- [Middleware.php#L860](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L860)
+- [Connection.php#L63](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/YouTube/Connection.php#L63)
+- [Connection.php#L82](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/YouTube/Connection.php#L82)
+- [Connection.php#L114](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/YouTube/Connection.php#L114)
+- [Connection.php#L142](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/YouTube/Connection.php#L142)
+- [Connection.php#L194](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/YouTube/Connection.php#L194)
+- [Connection.php#L319](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/YouTube/Connection.php#L319)
+- [AccountController.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/YouTube/AccountController.php#L208)
+- [GoogleServiceProvider.php#L466](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Internal/DependencyManagement/GoogleServiceProvider.php#L466)
 
 ## woocommerce_gla_guzzle_invalid_response
 
@@ -568,21 +568,21 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Connection.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Connection.php#L66)
-- [Connection.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Connection.php#L121)
-- [Middleware.php#L163](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L163)
-- [Middleware.php#L236](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L236)
-- [Middleware.php#L278](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L278)
-- [Middleware.php#L368](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L368)
-- [Middleware.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L418)
-- [Middleware.php#L621](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L621)
-- [Middleware.php#L728](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L728)
-- [Middleware.php#L773](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L773)
-- [Connection.php#L59](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L59)
-- [Connection.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L109)
-- [Connection.php#L137](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L137)
-- [Connection.php#L189](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L189)
-- [AccountController.php#L204](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/YouTube/AccountController.php#L204)
+- [Connection.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Connection.php#L66)
+- [Connection.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Connection.php#L121)
+- [Middleware.php#L163](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L163)
+- [Middleware.php#L236](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L236)
+- [Middleware.php#L278](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L278)
+- [Middleware.php#L368](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L368)
+- [Middleware.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L418)
+- [Middleware.php#L621](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L621)
+- [Middleware.php#L728](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L728)
+- [Middleware.php#L773](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L773)
+- [Connection.php#L59](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/YouTube/Connection.php#L59)
+- [Connection.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/YouTube/Connection.php#L109)
+- [Connection.php#L137](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/YouTube/Connection.php#L137)
+- [Connection.php#L189](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/YouTube/Connection.php#L189)
+- [AccountController.php#L204](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/YouTube/AccountController.php#L204)
 
 ## woocommerce_gla_handle_shipping_method_to_rates
 
@@ -590,7 +590,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ZoneMethodsParser.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Shipping/ZoneMethodsParser.php#L109)
+- [ZoneMethodsParser.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Shipping/ZoneMethodsParser.php#L109)
 
 ## woocommerce_gla_hidden_coupon_types
 
@@ -598,7 +598,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L391](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L391)
+- [CouponSyncer.php#L391](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L391)
 
 ## woocommerce_gla_jetpack_connect_return_url
 
@@ -606,7 +606,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountController.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Jetpack/AccountController.php#L131)
+- [AccountController.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/Jetpack/AccountController.php#L131)
 
 ## woocommerce_gla_job_failure_rate_threshold
 
@@ -614,7 +614,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ActionSchedulerJobMonitor.php#L186](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/ActionSchedulerJobMonitor.php#L186)
+- [ActionSchedulerJobMonitor.php#L186](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/ActionSchedulerJobMonitor.php#L186)
 
 ## woocommerce_gla_job_failure_timeframe
 
@@ -622,7 +622,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ActionSchedulerJobMonitor.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/ActionSchedulerJobMonitor.php#L195)
+- [ActionSchedulerJobMonitor.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/ActionSchedulerJobMonitor.php#L195)
 
 ## woocommerce_gla_language_currencies
 
@@ -630,7 +630,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L198](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L198)
+- [WPML.php#L198](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Integration/WPML.php#L198)
 
 ## woocommerce_gla_mapi_batch_size
 
@@ -638,7 +638,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MapiProductInputsService.php#L445](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Mapi/Services/MapiProductInputsService.php#L445)
+- [MapiProductInputsService.php#L445](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Mapi/Services/MapiProductInputsService.php#L445)
 
 ## woocommerce_gla_mapi_product_concurrency
 
@@ -646,7 +646,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L269](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L269)
+- [ProductSyncer.php#L269](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L269)
 
 ## woocommerce_gla_mapi_report_query_response
 
@@ -654,7 +654,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MapiReportQuery.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Query/MapiReportQuery.php#L90)
+- [MapiReportQuery.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Query/MapiReportQuery.php#L90)
 
 ## woocommerce_gla_mapi_retry_limit
 
@@ -662,7 +662,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GoogleServiceProvider.php#L243](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Internal/DependencyManagement/GoogleServiceProvider.php#L243)
+- [GoogleServiceProvider.php#L243](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Internal/DependencyManagement/GoogleServiceProvider.php#L243)
 
 ## woocommerce_gla_mapping_rules_change
 
@@ -670,9 +670,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeMappingRulesController.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L143)
-- [AttributeMappingRulesController.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L166)
-- [AttributeMappingRulesController.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L188)
+- [AttributeMappingRulesController.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L143)
+- [AttributeMappingRulesController.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L166)
+- [AttributeMappingRulesController.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L188)
 
 ## woocommerce_gla_market_added
 
@@ -680,7 +680,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MarketService.php#L645](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MarketService.php#L645)
+- [MarketService.php#L645](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/MarketService.php#L645)
 
 ## woocommerce_gla_market_deleted
 
@@ -688,7 +688,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MarketService.php#L1299](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MarketService.php#L1299)
+- [MarketService.php#L1299](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/MarketService.php#L1299)
 
 ## woocommerce_gla_market_updated
 
@@ -696,7 +696,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MarketService.php#L1226](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MarketService.php#L1226)
+- [MarketService.php#L1226](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/MarketService.php#L1226)
 
 ## woocommerce_gla_mc_account_review_lifetime
 
@@ -704,7 +704,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [RequestReviewStatuses.php#L182](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Google/RequestReviewStatuses.php#L182)
+- [RequestReviewStatuses.php#L182](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Google/RequestReviewStatuses.php#L182)
 
 ## woocommerce_gla_mc_client_exception
 
@@ -712,12 +712,12 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Merchant.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L188)
-- [Merchant.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L220)
-- [Merchant.php#L239](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L239)
-- [Merchant.php#L296](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L296)
-- [Merchant.php#L314](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L314)
-- [MerchantApiException.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Mapi/MerchantApiException.php#L47)
+- [Merchant.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Merchant.php#L188)
+- [Merchant.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Merchant.php#L220)
+- [Merchant.php#L239](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Merchant.php#L239)
+- [Merchant.php#L296](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Merchant.php#L296)
+- [Merchant.php#L314](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Merchant.php#L314)
+- [MerchantApiException.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Mapi/MerchantApiException.php#L47)
 
 ## woocommerce_gla_mc_settings_sync
 
@@ -725,7 +725,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SettingsSyncController.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L69)
+- [SettingsSyncController.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L69)
 
 ## woocommerce_gla_mc_status_lifetime
 
@@ -733,7 +733,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L1152](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantStatuses.php#L1152)
+- [MerchantStatuses.php#L1152](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/MerchantStatuses.php#L1152)
 
 ## woocommerce_gla_mc_under_review_lifetime
 
@@ -741,7 +741,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [RequestReviewStatuses.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Google/RequestReviewStatuses.php#L191)
+- [RequestReviewStatuses.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Google/RequestReviewStatuses.php#L191)
 
 ## woocommerce_gla_merchant_id
 
@@ -749,7 +749,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L129](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Options/Options.php#L129)
+- [Options.php#L129](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Options/Options.php#L129)
 
 ## woocommerce_gla_merchant_issue_override
 
@@ -757,7 +757,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IssuesController.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L85)
+- [IssuesController.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L85)
 
 ## woocommerce_gla_merchant_status_presync_issues_chunk
 
@@ -765,7 +765,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L750](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantStatuses.php#L750)
+- [MerchantStatuses.php#L750](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/MerchantStatuses.php#L750)
 
 ## woocommerce_gla_onboarding_completed
 
@@ -773,7 +773,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [OnboardingController.php#L50](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/OnboardingController.php#L50)
+- [OnboardingController.php#L50](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/OnboardingController.php#L50)
 
 ## woocommerce_gla_options_deleted_
 
@@ -781,7 +781,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L107](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Options/Options.php#L107)
+- [Options.php#L107](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Options/Options.php#L107)
 
 ## woocommerce_gla_options_updated_
 
@@ -789,8 +789,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Options/Options.php#L69)
-- [Options.php#L89](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Options/Options.php#L89)
+- [Options.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Options/Options.php#L69)
+- [Options.php#L89](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Options/Options.php#L89)
 
 ## woocommerce_gla_partner_app_auth_failure
 
@@ -798,7 +798,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Middleware.php#L722](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L722)
+- [Middleware.php#L722](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L722)
 
 ## woocommerce_gla_prepared_response_->GET_ROUTE_NAME
 
@@ -806,7 +806,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BaseController.php#L160](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/BaseController.php#L160)
+- [BaseController.php#L160](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/BaseController.php#L160)
 
 ## woocommerce_gla_product_attribute_types
 
@@ -814,7 +814,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeManager.php#L316](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/Attributes/AttributeManager.php#L316)
+- [AttributeManager.php#L316](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/Attributes/AttributeManager.php#L316)
 
 ## woocommerce_gla_product_attribute_value_
 
@@ -822,10 +822,10 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L770](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L770)
-- [WCProductInputAdapter.php#L797](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L797)
-- [WCProductAdapter.php#L998](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L998)
-- [WCProductAdapter.php#L1100](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L1100)
+- [WCProductInputAdapter.php#L770](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L770)
+- [WCProductInputAdapter.php#L797](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L797)
+- [WCProductAdapter.php#L998](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L998)
+- [WCProductAdapter.php#L1100](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L1100)
 
 ## woocommerce_gla_product_attribute_value_description
 
@@ -833,8 +833,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L292)
-- [WCProductAdapter.php#L369](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L369)
+- [WCProductInputAdapter.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L292)
+- [WCProductAdapter.php#L369](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L369)
 
 ## woocommerce_gla_product_attribute_value_options_::get_id
 
@@ -842,7 +842,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesForm.php#L128](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Product/Attributes/AttributesForm.php#L128)
+- [AttributesForm.php#L128](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Admin/Product/Attributes/AttributesForm.php#L128)
 
 ## woocommerce_gla_product_attribute_value_price
 
@@ -850,10 +850,10 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L406](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L406)
-- [WCProductInputAdapter.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L418)
-- [WCProductAdapter.php#L657](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L657)
-- [WCProductAdapter.php#L686](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L686)
+- [WCProductInputAdapter.php#L406](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L406)
+- [WCProductInputAdapter.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L418)
+- [WCProductAdapter.php#L657](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L657)
+- [WCProductAdapter.php#L686](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L686)
 
 ## woocommerce_gla_product_attribute_value_sale_price
 
@@ -861,9 +861,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L545](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L545)
-- [WCProductAdapter.php#L726](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L726)
-- [WCProductAdapter.php#L774](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L774)
+- [WCProductInputAdapter.php#L545](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L545)
+- [WCProductAdapter.php#L726](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L726)
+- [WCProductAdapter.php#L774](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L774)
 
 ## woocommerce_gla_product_attribute_values
 
@@ -871,8 +871,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L976](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L976)
-- [WCProductAdapter.php#L183](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L183)
+- [WCProductInputAdapter.php#L976](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L976)
+- [WCProductAdapter.php#L183](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L183)
 
 ## woocommerce_gla_product_description_apply_shortcodes
 
@@ -880,8 +880,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L282](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L282)
-- [WCProductAdapter.php#L338](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L338)
+- [WCProductInputAdapter.php#L282](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L282)
+- [WCProductAdapter.php#L338](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L338)
 
 ## woocommerce_gla_product_property_value_is_virtual
 
@@ -889,8 +889,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L755](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L755)
-- [WCProductAdapter.php#L864](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L864)
+- [WCProductInputAdapter.php#L755](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L755)
+- [WCProductAdapter.php#L864](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L864)
 
 ## woocommerce_gla_product_query_args
 
@@ -898,7 +898,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductRepository.php#L472](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductRepository.php#L472)
+- [ProductRepository.php#L472](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductRepository.php#L472)
 
 ## woocommerce_gla_product_view_report_page_size
 
@@ -906,8 +906,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantReport.php#L68](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/MerchantReport.php#L68)
-- [UpdateMerchantProductStatuses.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/UpdateMerchantProductStatuses.php#L113)
+- [MerchantReport.php#L68](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/MerchantReport.php#L68)
+- [UpdateMerchantProductStatuses.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/UpdateMerchantProductStatuses.php#L113)
 
 ## woocommerce_gla_products_delete_retry_on_failure
 
@@ -915,7 +915,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L580](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L580)
+- [ProductSyncer.php#L580](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L580)
 
 ## woocommerce_gla_products_update_retry_on_failure
 
@@ -923,7 +923,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L524](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L524)
+- [ProductSyncer.php#L524](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L524)
 
 ## woocommerce_gla_ready_for_syncing
 
@@ -931,7 +931,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantCenterService.php#L135](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantCenterService.php#L135)
+- [MerchantCenterService.php#L135](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/MerchantCenterService.php#L135)
 
 ## woocommerce_gla_request_review_failure
 
@@ -939,8 +939,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [RequestReviewController.php#L119](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L119)
-- [RequestReviewController.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L131)
+- [RequestReviewController.php#L119](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L119)
+- [RequestReviewController.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L131)
 
 ## woocommerce_gla_request_review_response
 
@@ -948,7 +948,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [RequestReviewController.php#L337](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L337)
+- [RequestReviewController.php#L337](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L337)
 
 ## woocommerce_gla_retry_delete_coupons
 
@@ -956,7 +956,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L455](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L455)
+- [CouponSyncer.php#L455](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L455)
 
 ## woocommerce_gla_retry_update_coupons
 
@@ -964,7 +964,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L417](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L417)
+- [CouponSyncer.php#L417](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L417)
 
 ## woocommerce_gla_site_claim_failure
 
@@ -972,10 +972,10 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Merchant.php#L114](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L114)
-- [Middleware.php#L279](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L279)
-- [Middleware.php#L285](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L285)
-- [AccountService.php#L414](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L414)
+- [Merchant.php#L114](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Merchant.php#L114)
+- [Middleware.php#L279](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L279)
+- [Middleware.php#L285](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L285)
+- [AccountService.php#L414](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/AccountService.php#L414)
 
 ## woocommerce_gla_site_claim_overwrite_required
 
@@ -983,7 +983,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L409](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L409)
+- [AccountService.php#L409](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/AccountService.php#L409)
 
 ## woocommerce_gla_site_claim_success
 
@@ -991,8 +991,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Merchant.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L111)
-- [Middleware.php#L274](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L274)
+- [Merchant.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Merchant.php#L111)
+- [Middleware.php#L274](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/Middleware.php#L274)
 
 ## woocommerce_gla_site_url
 
@@ -1000,7 +1000,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [PluginHelper.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/PluginHelper.php#L188)
+- [PluginHelper.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/PluginHelper.php#L188)
 
 ## woocommerce_gla_site_verify_failure
 
@@ -1008,9 +1008,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L58](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/SiteVerification.php#L58)
-- [SiteVerification.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/SiteVerification.php#L66)
-- [SiteVerification.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/SiteVerification.php#L87)
+- [SiteVerification.php#L58](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/SiteVerification.php#L58)
+- [SiteVerification.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/SiteVerification.php#L66)
+- [SiteVerification.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/SiteVerification.php#L87)
 
 ## woocommerce_gla_site_verify_success
 
@@ -1018,7 +1018,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/SiteVerification.php#L85)
+- [SiteVerification.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/SiteVerification.php#L85)
 
 ## woocommerce_gla_supported_coupon_types
 
@@ -1026,7 +1026,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L378](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L378)
+- [CouponSyncer.php#L378](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L378)
 
 ## woocommerce_gla_supported_product_types
 
@@ -1034,7 +1034,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L502](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L502)
+- [ProductSyncer.php#L502](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductSyncer.php#L502)
 
 ## woocommerce_gla_sv_client_exception
 
@@ -1042,8 +1042,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L120](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/SiteVerification.php#L120)
-- [SiteVerification.php#L162](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/SiteVerification.php#L162)
+- [SiteVerification.php#L120](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/SiteVerification.php#L120)
+- [SiteVerification.php#L162](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Google/SiteVerification.php#L162)
 
 ## woocommerce_gla_sync_hash_freshness
 
@@ -1051,7 +1051,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BatchProductHelper.php#L681](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L681)
+- [BatchProductHelper.php#L681](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/BatchProductHelper.php#L681)
 
 ## woocommerce_gla_tax_excluded
 
@@ -1059,8 +1059,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L1032](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L1032)
-- [WCProductAdapter.php#L618](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L618)
+- [WCProductInputAdapter.php#L1032](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L1032)
+- [WCProductAdapter.php#L618](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L618)
 
 ## woocommerce_gla_track_event
 
@@ -1068,16 +1068,16 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [OAuthService.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/WP/OAuthService.php#L172)
-- [OAuthService.php#L200](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/WP/OAuthService.php#L200)
-- [OAuthService.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/WP/OAuthService.php#L220)
-- [SetupCompleteController.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/SetupCompleteController.php#L75)
-- [CampaignController.php#L184](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/CampaignController.php#L184)
-- [CampaignController.php#L272](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/CampaignController.php#L272)
-- [CampaignController.php#L313](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/CampaignController.php#L313)
-- [SettingsSyncController.php#L83](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L83)
-- [AccountService.php#L641](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L641)
-- [AccountService.php#L661](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L661)
+- [OAuthService.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/WP/OAuthService.php#L172)
+- [OAuthService.php#L200](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/WP/OAuthService.php#L200)
+- [OAuthService.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/WP/OAuthService.php#L220)
+- [SetupCompleteController.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/Ads/SetupCompleteController.php#L75)
+- [CampaignController.php#L184](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/Ads/CampaignController.php#L184)
+- [CampaignController.php#L272](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/Ads/CampaignController.php#L272)
+- [CampaignController.php#L313](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/Ads/CampaignController.php#L313)
+- [SettingsSyncController.php#L83](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L83)
+- [AccountService.php#L641](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/AccountService.php#L641)
+- [AccountService.php#L661](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/AccountService.php#L661)
 
 ## woocommerce_gla_updated_campaign
 
@@ -1085,9 +1085,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CampaignController.php#L204](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/CampaignController.php#L204)
-- [CampaignController.php#L283](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/CampaignController.php#L283)
-- [CampaignController.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/CampaignController.php#L321)
+- [CampaignController.php#L204](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/Ads/CampaignController.php#L204)
+- [CampaignController.php#L283](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/Ads/CampaignController.php#L283)
+- [CampaignController.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/API/Site/Controllers/Ads/CampaignController.php#L321)
 
 ## woocommerce_gla_updated_coupon
 
@@ -1095,7 +1095,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L182](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L182)
+- [CouponSyncer.php#L182](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Coupon/CouponSyncer.php#L182)
 
 ## woocommerce_gla_url_switch_required
 
@@ -1103,7 +1103,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L494](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L494)
+- [AccountService.php#L494](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/AccountService.php#L494)
 
 ## woocommerce_gla_url_switch_success
 
@@ -1111,7 +1111,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L517](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L517)
+- [AccountService.php#L517](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/MerchantCenter/AccountService.php#L517)
 
 ## woocommerce_gla_use_short_description
 
@@ -1119,8 +1119,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L268](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L268)
-- [WCProductAdapter.php#L315](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L315)
+- [WCProductInputAdapter.php#L268](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L268)
+- [WCProductAdapter.php#L315](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L315)
 
 ## woocommerce_gla_wcs_url
 
@@ -1128,8 +1128,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [PluginHelper.php#L174](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/PluginHelper.php#L174)
-- [PluginHelper.php#L177](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/PluginHelper.php#L177)
+- [PluginHelper.php#L174](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/PluginHelper.php#L174)
+- [PluginHelper.php#L177](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/PluginHelper.php#L177)
 
 ## woocommerce_gla_weight_unit
 
@@ -1137,8 +1137,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L728](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L728)
-- [WCProductAdapter.php#L449](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L449)
+- [WCProductInputAdapter.php#L728](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductInputAdapter.php#L728)
+- [WCProductAdapter.php#L449](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/WCProductAdapter.php#L449)
 
 ## woocommerce_gla_youtube_order_ids_job_date
 
@@ -1146,8 +1146,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CreateMerchantReportedConversionReport.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateMerchantReportedConversionReport.php#L104)
-- [CreateYouTubeOrderIdsCache.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateYouTubeOrderIdsCache.php#L85)
+- [CreateMerchantReportedConversionReport.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/CreateMerchantReportedConversionReport.php#L104)
+- [CreateYouTubeOrderIdsCache.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/CreateYouTubeOrderIdsCache.php#L85)
 
 ## woocommerce_gla_youtube_orders_csv_delete_on_complete
 
@@ -1155,7 +1155,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CreateMerchantReportedConversionReport.php#L241](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateMerchantReportedConversionReport.php#L241)
+- [CreateMerchantReportedConversionReport.php#L241](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Jobs/CreateMerchantReportedConversionReport.php#L241)
 
 ## woocommerce_hide_invisible_variations
 
@@ -1163,7 +1163,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductHelper.php#L447](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L447)
+- [ProductHelper.php#L447](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Product/ProductHelper.php#L447)
 
 ## wpml_active_languages
 
@@ -1171,7 +1171,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L131)
+- [WPML.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Integration/WPML.php#L131)
 
 ## wpml_current_language
 
@@ -1179,7 +1179,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L71](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L71)
+- [WPML.php#L71](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Integration/WPML.php#L71)
 
 ## wpml_default_language
 
@@ -1187,7 +1187,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L93](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L93)
+- [WPML.php#L93](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Integration/WPML.php#L93)
 
 ## wpml_post_language_details
 
@@ -1195,7 +1195,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L110)
+- [WPML.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Integration/WPML.php#L110)
 
 ## wpml_switch_language
 
@@ -1203,6 +1203,6 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L73](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L73)
-- [WPML.php#L79](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L79)
+- [WPML.php#L73](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Integration/WPML.php#L73)
+- [WPML.php#L79](https://github.com/woocommerce/google-listings-and-ads/blob/1756defbfae87633fa3fcbf76c10640fc36e6afa/src/Integration/WPML.php#L79)
 

--- a/src/Hooks/README.md
+++ b/src/Hooks/README.md
@@ -8,7 +8,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BulkEditInitializer.php#L36](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Admin/BulkEdit/BulkEditInitializer.php#L36)
+- [BulkEditInitializer.php#L36](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/BulkEdit/BulkEditInitializer.php#L36)
 
 ## google_for_woocommerce_admin_menu_notification_count
 
@@ -16,7 +16,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [NotificationManager.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Menu/NotificationManager.php#L166)
+- [NotificationManager.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Menu/NotificationManager.php#L166)
 
 ## jetpack_verify_api_authorization_request_error_double_encode
 
@@ -24,7 +24,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [JetpackWPCOM.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Integration/JetpackWPCOM.php#L223)
+- [JetpackWPCOM.php#L223](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/JetpackWPCOM.php#L223)
 
 ## wcml_raw_price_amount
 
@@ -32,9 +32,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L233](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Integration/WPML.php#L233)
-- [WPML.php#L277](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Integration/WPML.php#L277)
-- [WPML.php#L333](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Integration/WPML.php#L333)
+- [WPML.php#L233](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L233)
+- [WPML.php#L277](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L277)
+- [WPML.php#L333](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L333)
 
 ## woocommerce_adjust_non_base_location_prices
 
@@ -42,7 +42,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L463](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L463)
+- [WCProductInputAdapter.php#L463](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L463)
 
 ## woocommerce_admin_disabled
 
@@ -50,7 +50,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCAdminValidator.php#L38](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Internal/Requirements/WCAdminValidator.php#L38)
+- [WCAdminValidator.php#L38](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Internal/Requirements/WCAdminValidator.php#L38)
 
 ## woocommerce_gla_ads_billing_setup_status
 
@@ -58,8 +58,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Ads.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Ads.php#L113)
-- [Ads.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Ads.php#L122)
+- [Ads.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L113)
+- [Ads.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L122)
 
 ## woocommerce_gla_ads_client_exception
 
@@ -67,36 +67,36 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AdsAssetGenerationService.php#L151](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Ads/AdsAssetGenerationService.php#L151)
-- [AdsAssetGenerationService.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Ads/AdsAssetGenerationService.php#L220)
-- [AdsAssetGroup.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsAssetGroup.php#L122)
-- [AdsAssetGroup.php#L329](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsAssetGroup.php#L329)
-- [AdsAssetGroup.php#L402](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsAssetGroup.php#L402)
-- [AdsAssetGroup.php#L458](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsAssetGroup.php#L458)
-- [AdsIncentives.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsIncentives.php#L109)
-- [AdsIncentives.php#L200](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsIncentives.php#L200)
-- [Ads.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Ads.php#L74)
-- [Ads.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Ads.php#L118)
-- [Ads.php#L163](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Ads.php#L163)
-- [Ads.php#L205](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Ads.php#L205)
-- [Ads.php#L315](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Ads.php#L315)
-- [LocationIDTrait.php#L132](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/LocationIDTrait.php#L132)
-- [AdsConversionAction.php#L100](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsConversionAction.php#L100)
-- [AdsConversionAction.php#L146](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsConversionAction.php#L146)
-- [BudgetRecommendations.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/BudgetRecommendations.php#L125)
-- [AdsReport.php#L170](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsReport.php#L170)
-- [AdsCampaign.php#L181](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsCampaign.php#L181)
-- [AdsCampaign.php#L227](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsCampaign.php#L227)
-- [AdsCampaign.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsCampaign.php#L273)
-- [AdsCampaign.php#L378](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsCampaign.php#L378)
-- [AdsCampaign.php#L441](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsCampaign.php#L441)
-- [AdsCampaign.php#L485](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsCampaign.php#L485)
-- [AdsCampaign.php#L548](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsCampaign.php#L548)
-- [AdsCampaign.php#L1091](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsCampaign.php#L1091)
-- [AdsCampaign.php#L1140](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsCampaign.php#L1140)
-- [BudgetMetrics.php#L137](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/BudgetMetrics.php#L137)
-- [AdsAssetGroupAsset.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsAssetGroupAsset.php#L136)
-- [AdsAssetGroupAsset.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsAssetGroupAsset.php#L208)
+- [AdsAssetGenerationService.php#L151](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Ads/AdsAssetGenerationService.php#L151)
+- [AdsAssetGenerationService.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Ads/AdsAssetGenerationService.php#L220)
+- [AdsAssetGroup.php#L122](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsAssetGroup.php#L122)
+- [AdsAssetGroup.php#L329](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsAssetGroup.php#L329)
+- [AdsAssetGroup.php#L402](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsAssetGroup.php#L402)
+- [AdsAssetGroup.php#L458](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsAssetGroup.php#L458)
+- [AdsIncentives.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsIncentives.php#L109)
+- [AdsIncentives.php#L200](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsIncentives.php#L200)
+- [Ads.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L74)
+- [Ads.php#L118](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L118)
+- [Ads.php#L163](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L163)
+- [Ads.php#L205](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L205)
+- [Ads.php#L315](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Ads.php#L315)
+- [LocationIDTrait.php#L132](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/LocationIDTrait.php#L132)
+- [AdsConversionAction.php#L100](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsConversionAction.php#L100)
+- [AdsConversionAction.php#L146](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsConversionAction.php#L146)
+- [BudgetRecommendations.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/BudgetRecommendations.php#L125)
+- [AdsReport.php#L170](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsReport.php#L170)
+- [AdsCampaign.php#L181](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L181)
+- [AdsCampaign.php#L227](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L227)
+- [AdsCampaign.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L273)
+- [AdsCampaign.php#L378](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L378)
+- [AdsCampaign.php#L441](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L441)
+- [AdsCampaign.php#L485](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L485)
+- [AdsCampaign.php#L548](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L548)
+- [AdsCampaign.php#L1091](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L1091)
+- [AdsCampaign.php#L1140](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsCampaign.php#L1140)
+- [BudgetMetrics.php#L137](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/BudgetMetrics.php#L137)
+- [AdsAssetGroupAsset.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsAssetGroupAsset.php#L136)
+- [AdsAssetGroupAsset.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsAssetGroupAsset.php#L208)
 
 ## woocommerce_gla_ads_id
 
@@ -104,7 +104,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L119](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Options/Options.php#L119)
+- [Options.php#L119](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Options/Options.php#L119)
 
 ## woocommerce_gla_ads_setup_completed
 
@@ -112,7 +112,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SetupCompleteController.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/Ads/SetupCompleteController.php#L66)
+- [SetupCompleteController.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/SetupCompleteController.php#L66)
 
 ## woocommerce_gla_attribute_applicable_product_types_
 
@@ -120,8 +120,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeManager.php#L368](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/Attributes/AttributeManager.php#L368)
-- [AttributesForm.php#L99](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Admin/Product/Attributes/AttributesForm.php#L99)
+- [AttributeManager.php#L368](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/Attributes/AttributeManager.php#L368)
+- [AttributesForm.php#L99](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Product/Attributes/AttributesForm.php#L99)
 
 ## woocommerce_gla_attribute_hidden_product_types_
 
@@ -129,7 +129,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesForm.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Admin/Product/Attributes/AttributesForm.php#L104)
+- [AttributesForm.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Product/Attributes/AttributesForm.php#L104)
 
 ## woocommerce_gla_attribute_mapping_sources
 
@@ -137,7 +137,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L31](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L31)
+- [IsFieldTrait.php#L31](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L31)
 
 ## woocommerce_gla_attribute_mapping_sources_custom_attributes
 
@@ -145,7 +145,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L125)
+- [IsFieldTrait.php#L125](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L125)
 
 ## woocommerce_gla_attribute_mapping_sources_global_attributes
 
@@ -153,7 +153,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L64](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L64)
+- [IsFieldTrait.php#L64](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L64)
 
 ## woocommerce_gla_attribute_mapping_sources_product_fields
 
@@ -161,7 +161,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L115)
+- [IsFieldTrait.php#L115](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L115)
 
 ## woocommerce_gla_attribute_mapping_sources_taxonomies
 
@@ -169,7 +169,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IsFieldTrait.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L65)
+- [IsFieldTrait.php#L65](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/AttributeMapping/Traits/IsFieldTrait.php#L65)
 
 ## woocommerce_gla_attributes_tab_applicable_product_types
 
@@ -177,7 +177,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesTrait.php#L18](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Admin/Product/Attributes/AttributesTrait.php#L18)
+- [AttributesTrait.php#L18](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Product/Attributes/AttributesTrait.php#L18)
 
 ## woocommerce_gla_batch_deleted_products
 
@@ -185,8 +185,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L394](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L394)
-- [ProductSyncer.php#L455](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L455)
+- [ProductSyncer.php#L401](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L401)
+- [ProductSyncer.php#L462](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L462)
 
 ## woocommerce_gla_batch_retry_delete_products
 
@@ -194,7 +194,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L574](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L574)
+- [ProductSyncer.php#L581](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L581)
 
 ## woocommerce_gla_batch_retry_update_products
 
@@ -202,7 +202,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L518](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L518)
+- [ProductSyncer.php#L525](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L525)
 
 ## woocommerce_gla_batch_updated_products
 
@@ -210,7 +210,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L172)
+- [ProductSyncer.php#L179](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L179)
 
 ## woocommerce_gla_batched_cli_size
 
@@ -218,7 +218,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPCLIMigrationGTIN.php#L151](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Utility/WPCLIMigrationGTIN.php#L151)
+- [WPCLIMigrationGTIN.php#L151](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Utility/WPCLIMigrationGTIN.php#L151)
 
 ## woocommerce_gla_batched_job_size
 
@@ -226,11 +226,11 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [UpdateSyncableProductsCount.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/UpdateSyncableProductsCount.php#L74)
-- [UpdateEuPoliticalCampaigns.php#L89](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/UpdateEuPoliticalCampaigns.php#L89)
-- [CreateMerchantReportedConversionReport.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/CreateMerchantReportedConversionReport.php#L90)
-- [AbstractBatchedActionSchedulerJob.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104)
-- [CreateYouTubeOrderIdsCache.php#L71](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/CreateYouTubeOrderIdsCache.php#L71)
+- [UpdateSyncableProductsCount.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/UpdateSyncableProductsCount.php#L74)
+- [UpdateEuPoliticalCampaigns.php#L89](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/UpdateEuPoliticalCampaigns.php#L89)
+- [CreateMerchantReportedConversionReport.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateMerchantReportedConversionReport.php#L90)
+- [AbstractBatchedActionSchedulerJob.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/AbstractBatchedActionSchedulerJob.php#L104)
+- [CreateYouTubeOrderIdsCache.php#L71](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateYouTubeOrderIdsCache.php#L71)
 
 ## woocommerce_gla_bulk_update_coupon
 
@@ -238,7 +238,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponBulkEdit.php#L133](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Admin/BulkEdit/CouponBulkEdit.php#L133)
+- [CouponBulkEdit.php#L133](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/BulkEdit/CouponBulkEdit.php#L133)
 
 ## woocommerce_gla_conversion_action_name
 
@@ -246,7 +246,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AdsConversionAction.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/AdsConversionAction.php#L67)
+- [AdsConversionAction.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/AdsConversionAction.php#L67)
 
 ## woocommerce_gla_coupon_destinations
 
@@ -254,7 +254,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCCouponAdapter.php#L439](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/WCCouponAdapter.php#L439)
+- [WCCouponAdapter.php#L439](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/WCCouponAdapter.php#L439)
 
 ## woocommerce_gla_coupons_delete_retry_on_failure
 
@@ -262,7 +262,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L450](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L450)
+- [CouponSyncer.php#L450](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L450)
 
 ## woocommerce_gla_coupons_update_retry_on_failure
 
@@ -270,7 +270,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L412](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L412)
+- [CouponSyncer.php#L412](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L412)
 
 ## woocommerce_gla_custom_merchant_issues
 
@@ -278,7 +278,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L622](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/MerchantStatuses.php#L622)
+- [MerchantStatuses.php#L626](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantStatuses.php#L626)
 
 ## woocommerce_gla_debug_message
 
@@ -286,43 +286,43 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AdsRecommendationsService.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Ads/AdsRecommendationsService.php#L90)
-- [ProductRepository.php#L402](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductRepository.php#L402)
-- [BatchProductHelper.php#L299](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/BatchProductHelper.php#L299)
-- [BatchProductHelper.php#L330](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/BatchProductHelper.php#L330)
-- [BatchProductHelper.php#L347](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/BatchProductHelper.php#L347)
-- [BatchProductHelper.php#L430](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/BatchProductHelper.php#L430)
-- [BatchProductHelper.php#L443](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/BatchProductHelper.php#L443)
-- [BatchProductHelper.php#L464](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/BatchProductHelper.php#L464)
-- [ProductHelper.php#L540](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductHelper.php#L540)
-- [ProductHelper.php#L573](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductHelper.php#L573)
-- [SyncerHooks.php#L221](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/SyncerHooks.php#L221)
-- [WCProductAdapter.php#L222](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L222)
-- [CouponHelper.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponHelper.php#L247)
-- [CouponHelper.php#L284](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponHelper.php#L284)
-- [CouponSyncer.php#L114](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L114)
-- [CouponSyncer.php#L127](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L127)
-- [CouponSyncer.php#L152](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L152)
-- [CouponSyncer.php#L168](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L168)
-- [CouponSyncer.php#L185](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L185)
-- [CouponSyncer.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L208)
-- [CouponSyncer.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L273)
-- [CouponSyncer.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L321)
-- [CouponSyncer.php#L340](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L340)
-- [SyncerHooks.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/SyncerHooks.php#L208)
-- [MapiProductInputsService.php#L435](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Mapi/Services/MapiProductInputsService.php#L435)
-- [IssuesController.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L95)
-- [PriceBenchmarks.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/PriceBenchmarks.php#L193)
-- [MerchantStatuses.php#L410](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/MerchantStatuses.php#L410)
-- [MerchantStatuses.php#L751](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/MerchantStatuses.php#L751)
-- [MerchantStatuses.php#L1000](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/MerchantStatuses.php#L1000)
-- [MerchantCenterService.php#L317](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/MerchantCenterService.php#L317)
-- [AccountService.php#L712](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/AccountService.php#L712)
-- [AccountService.php#L720](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/AccountService.php#L720)
-- [ActionSchedulerJobMonitor.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/ActionSchedulerJobMonitor.php#L117)
-- [ActionSchedulerJobMonitor.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/ActionSchedulerJobMonitor.php#L126)
-- [CleanupSyncedProducts.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/CleanupSyncedProducts.php#L74)
-- [MigrateGTIN.php#L169](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/MigrateGTIN.php#L169)
+- [AdsRecommendationsService.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Ads/AdsRecommendationsService.php#L90)
+- [ProductRepository.php#L402](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductRepository.php#L402)
+- [BatchProductHelper.php#L302](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L302)
+- [BatchProductHelper.php#L333](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L333)
+- [BatchProductHelper.php#L350](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L350)
+- [BatchProductHelper.php#L438](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L438)
+- [BatchProductHelper.php#L451](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L451)
+- [BatchProductHelper.php#L472](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L472)
+- [ProductHelper.php#L540](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L540)
+- [ProductHelper.php#L573](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L573)
+- [SyncerHooks.php#L221](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/SyncerHooks.php#L221)
+- [WCProductAdapter.php#L222](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L222)
+- [CouponHelper.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponHelper.php#L247)
+- [CouponHelper.php#L284](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponHelper.php#L284)
+- [CouponSyncer.php#L114](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L114)
+- [CouponSyncer.php#L127](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L127)
+- [CouponSyncer.php#L152](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L152)
+- [CouponSyncer.php#L168](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L168)
+- [CouponSyncer.php#L185](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L185)
+- [CouponSyncer.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L208)
+- [CouponSyncer.php#L273](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L273)
+- [CouponSyncer.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L321)
+- [CouponSyncer.php#L340](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L340)
+- [SyncerHooks.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/SyncerHooks.php#L208)
+- [MapiProductInputsService.php#L435](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Mapi/Services/MapiProductInputsService.php#L435)
+- [IssuesController.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L95)
+- [PriceBenchmarks.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/PriceBenchmarks.php#L193)
+- [MerchantStatuses.php#L409](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantStatuses.php#L409)
+- [MerchantStatuses.php#L884](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantStatuses.php#L884)
+- [MerchantStatuses.php#L1133](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantStatuses.php#L1133)
+- [MerchantCenterService.php#L353](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantCenterService.php#L353)
+- [AccountService.php#L712](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L712)
+- [AccountService.php#L720](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L720)
+- [ActionSchedulerJobMonitor.php#L117](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/ActionSchedulerJobMonitor.php#L117)
+- [ActionSchedulerJobMonitor.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/ActionSchedulerJobMonitor.php#L126)
+- [CleanupSyncedProducts.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CleanupSyncedProducts.php#L74)
+- [MigrateGTIN.php#L169](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/MigrateGTIN.php#L169)
 
 ## woocommerce_gla_deleted_promotions
 
@@ -330,7 +330,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L334](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L334)
+- [CouponSyncer.php#L334](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L334)
 
 ## woocommerce_gla_dimension_unit
 
@@ -338,8 +338,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L694](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L694)
-- [WCProductAdapter.php#L448](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L448)
+- [WCProductInputAdapter.php#L694](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L694)
+- [WCProductAdapter.php#L448](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L448)
 
 ## woocommerce_gla_disable_gtag_tracking
 
@@ -347,7 +347,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GlobalSiteTag.php#L539](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Google/GlobalSiteTag.php#L539)
+- [GlobalSiteTag.php#L539](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Google/GlobalSiteTag.php#L539)
 
 ## woocommerce_gla_enable_connection_test
 
@@ -355,7 +355,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ConnectionTest.php#L89](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/ConnectionTest.php#L89)
+- [ConnectionTest.php#L89](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/ConnectionTest.php#L89)
 
 ## woocommerce_gla_enable_debug_logging
 
@@ -363,7 +363,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [DebugLogger.php#L33](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Logging/DebugLogger.php#L33)
+- [DebugLogger.php#L33](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Logging/DebugLogger.php#L33)
 
 ## woocommerce_gla_enable_mcm
 
@@ -371,7 +371,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GLAChannel.php#L86](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MultichannelMarketing/GLAChannel.php#L86)
+- [GLAChannel.php#L86](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MultichannelMarketing/GLAChannel.php#L86)
 
 ## woocommerce_gla_enable_reports
 
@@ -379,7 +379,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Admin.php#L421](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Admin/Admin.php#L421)
+- [Admin.php#L421](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Admin.php#L421)
 
 ## woocommerce_gla_error
 
@@ -387,35 +387,35 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BatchProductHelper.php#L395](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/BatchProductHelper.php#L395)
-- [ProductHelper.php#L432](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductHelper.php#L432)
-- [ProductHelper.php#L649](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductHelper.php#L649)
-- [AttributeManager.php#L342](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/Attributes/AttributeManager.php#L342)
-- [ProductSyncer.php#L521](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L521)
-- [ProductSyncer.php#L544](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L544)
-- [ProductSyncer.php#L577](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L577)
-- [ProductSyncer.php#L592](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L592)
-- [ProductSyncer.php#L599](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L599)
-- [ProductMetaHandler.php#L183](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductMetaHandler.php#L183)
-- [PHPView.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/View/PHPView.php#L136)
-- [PHPView.php#L164](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/View/PHPView.php#L164)
-- [PHPView.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/View/PHPView.php#L208)
-- [CouponMetaHandler.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponMetaHandler.php#L220)
-- [CouponSyncer.php#L422](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L422)
-- [CouponSyncer.php#L460](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L460)
-- [CouponSyncer.php#L516](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L516)
-- [CouponSyncer.php#L531](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L531)
-- [MapiDataSourcesService.php#L301](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Mapi/Services/MapiDataSourcesService.php#L301)
-- [MerchantApiClient.php#L240](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Mapi/MerchantApiClient.php#L240)
-- [OAuthService.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/WP/OAuthService.php#L247)
-- [RESTControllers.php#L59](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/RESTControllers.php#L59)
-- [RESTControllers.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/RESTControllers.php#L67)
-- [CreateMerchantReportedConversionReport.php#L204](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/CreateMerchantReportedConversionReport.php#L204)
-- [CreateMerchantReportedConversionReport.php#L260](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/CreateMerchantReportedConversionReport.php#L260)
-- [CreateYouTubeOrderIdsCache.php#L128](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/CreateYouTubeOrderIdsCache.php#L128)
-- [AbstractShippingSettingsAdapter.php#L169](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php#L169)
-- [AbstractShippingSettingsAdapter.php#L201](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php#L201)
-- [ProductMetaQueryHelper.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/DB/ProductMetaQueryHelper.php#L87)
+- [BatchProductHelper.php#L403](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L403)
+- [ProductHelper.php#L432](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L432)
+- [ProductHelper.php#L649](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L649)
+- [AttributeManager.php#L342](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/Attributes/AttributeManager.php#L342)
+- [ProductSyncer.php#L528](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L528)
+- [ProductSyncer.php#L551](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L551)
+- [ProductSyncer.php#L584](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L584)
+- [ProductSyncer.php#L599](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L599)
+- [ProductSyncer.php#L606](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L606)
+- [ProductMetaHandler.php#L183](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductMetaHandler.php#L183)
+- [PHPView.php#L136](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/View/PHPView.php#L136)
+- [PHPView.php#L164](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/View/PHPView.php#L164)
+- [PHPView.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/View/PHPView.php#L208)
+- [CouponMetaHandler.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponMetaHandler.php#L220)
+- [CouponSyncer.php#L422](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L422)
+- [CouponSyncer.php#L460](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L460)
+- [CouponSyncer.php#L516](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L516)
+- [CouponSyncer.php#L531](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L531)
+- [MapiDataSourcesService.php#L301](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Mapi/Services/MapiDataSourcesService.php#L301)
+- [MerchantApiClient.php#L240](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Mapi/MerchantApiClient.php#L240)
+- [OAuthService.php#L247](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/WP/OAuthService.php#L247)
+- [RESTControllers.php#L59](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/RESTControllers.php#L59)
+- [RESTControllers.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/RESTControllers.php#L67)
+- [CreateMerchantReportedConversionReport.php#L204](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateMerchantReportedConversionReport.php#L204)
+- [CreateMerchantReportedConversionReport.php#L260](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateMerchantReportedConversionReport.php#L260)
+- [CreateYouTubeOrderIdsCache.php#L128](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateYouTubeOrderIdsCache.php#L128)
+- [AbstractShippingSettingsAdapter.php#L169](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php#L169)
+- [AbstractShippingSettingsAdapter.php#L201](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Shipping/GoogleAdapter/AbstractShippingSettingsAdapter.php#L201)
+- [ProductMetaQueryHelper.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/DB/ProductMetaQueryHelper.php#L87)
 
 ## woocommerce_gla_exception
 
@@ -423,40 +423,41 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BaseAsset.php#L218](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Assets/BaseAsset.php#L218)
-- [ScriptWithBuiltDependenciesAsset.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Assets/ScriptWithBuiltDependenciesAsset.php#L66)
-- [ProductHelper.php#L311](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductHelper.php#L311)
-- [ProductSyncer.php#L137](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L137)
-- [ProductSyncer.php#L364](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L364)
-- [ProductSyncer.php#L432](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L432)
-- [CouponChannelVisibilityMetaBox.php#L205](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php#L205)
-- [ChannelVisibilityMetaBox.php#L201](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L201)
-- [DateTime.php#L44](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Admin/Input/DateTime.php#L44)
-- [DateTime.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Admin/Input/DateTime.php#L80)
-- [PHPView.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/View/PHPView.php#L87)
-- [CouponSyncer.php#L216](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L216)
-- [CouponSyncer.php#L305](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L305)
-- [WooCommercePreOrders.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Integration/WooCommercePreOrders.php#L111)
-- [WooCommercePreOrders.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Integration/WooCommercePreOrders.php#L131)
-- [Settings.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Settings.php#L110)
-- [Connection.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Connection.php#L95)
-- [MapiProductsService.php#L83](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Mapi/Services/MapiProductsService.php#L83)
-- [Middleware.php#L498](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L498)
-- [Connection.php#L86](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/YouTube/Connection.php#L86)
-- [Connection.php#L329](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/YouTube/Connection.php#L329)
-- [IncentivesController.php#L142](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/Ads/IncentivesController.php#L142)
-- [AccountController.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/YouTube/AccountController.php#L167)
-- [SettingsSyncController.php#L96](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L96)
-- [RequestReviewController.php#L340](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L340)
-- [ContactInformationController.php#L242](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php#L242)
-- [ProductVisibilityController.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L193)
-- [NoteInitializer.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Notes/NoteInitializer.php#L74)
-- [NoteInitializer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Notes/NoteInitializer.php#L116)
-- [ClearProductStatsCache.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Event/ClearProductStatsCache.php#L61)
-- [PluginUpdate.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/Update/PluginUpdate.php#L80)
-- [GoogleServiceProvider.php#L394](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Internal/DependencyManagement/GoogleServiceProvider.php#L394)
-- [GoogleServiceProvider.php#L404](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Internal/DependencyManagement/GoogleServiceProvider.php#L404)
-- [Migration20260813T1653383133.php#L184](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/DB/Migration/Migration20260813T1653383133.php#L184)
+- [BaseAsset.php#L218](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Assets/BaseAsset.php#L218)
+- [ScriptWithBuiltDependenciesAsset.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Assets/ScriptWithBuiltDependenciesAsset.php#L66)
+- [ProductHelper.php#L311](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L311)
+- [ProductSyncer.php#L144](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L144)
+- [ProductSyncer.php#L371](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L371)
+- [ProductSyncer.php#L439](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L439)
+- [CouponChannelVisibilityMetaBox.php#L205](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/MetaBox/CouponChannelVisibilityMetaBox.php#L205)
+- [ChannelVisibilityMetaBox.php#L201](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/MetaBox/ChannelVisibilityMetaBox.php#L201)
+- [DateTime.php#L44](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Input/DateTime.php#L44)
+- [DateTime.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Input/DateTime.php#L80)
+- [PHPView.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/View/PHPView.php#L87)
+- [CouponSyncer.php#L216](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L216)
+- [CouponSyncer.php#L305](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L305)
+- [WooCommercePreOrders.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WooCommercePreOrders.php#L111)
+- [WooCommercePreOrders.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WooCommercePreOrders.php#L131)
+- [Settings.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Settings.php#L110)
+- [Connection.php#L95](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Connection.php#L95)
+- [MapiProductsService.php#L83](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Mapi/Services/MapiProductsService.php#L83)
+- [Middleware.php#L498](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L498)
+- [Connection.php#L86](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L86)
+- [Connection.php#L329](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L329)
+- [IncentivesController.php#L142](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/IncentivesController.php#L142)
+- [AccountController.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/YouTube/AccountController.php#L167)
+- [SettingsSyncController.php#L96](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L96)
+- [RequestReviewController.php#L340](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L340)
+- [ContactInformationController.php#L242](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/ContactInformationController.php#L242)
+- [ProductVisibilityController.php#L193](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/ProductVisibilityController.php#L193)
+- [ReconnectWordPress.php#L124](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Notes/ReconnectWordPress.php#L124)
+- [NoteInitializer.php#L74](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Notes/NoteInitializer.php#L74)
+- [NoteInitializer.php#L116](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Notes/NoteInitializer.php#L116)
+- [ClearProductStatsCache.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Event/ClearProductStatsCache.php#L61)
+- [PluginUpdate.php#L80](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/Update/PluginUpdate.php#L80)
+- [GoogleServiceProvider.php#L439](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Internal/DependencyManagement/GoogleServiceProvider.php#L439)
+- [GoogleServiceProvider.php#L450](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Internal/DependencyManagement/GoogleServiceProvider.php#L450)
+- [Migration20260813T1653383133.php#L184](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/DB/Migration/Migration20260813T1653383133.php#L184)
 
 ## woocommerce_gla_force_product_resync
 
@@ -464,7 +465,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BatchProductHelper.php#L654](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/BatchProductHelper.php#L654)
+- [BatchProductHelper.php#L662](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L662)
 
 ## woocommerce_gla_force_run_install
 
@@ -472,7 +473,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Installer.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Installer.php#L67)
+- [Installer.php#L67](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Installer.php#L67)
 
 ## woocommerce_gla_get_google_product_offer_id
 
@@ -480,8 +481,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L246](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L246)
-- [WCProductAdapter.php#L301](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L301)
+- [WCProductInputAdapter.php#L246](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L246)
+- [WCProductAdapter.php#L301](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L301)
 
 ## woocommerce_gla_get_sync_ready_products_filter
 
@@ -489,7 +490,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductFilter.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductFilter.php#L61)
+- [ProductFilter.php#L61](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductFilter.php#L61)
 
 ## woocommerce_gla_get_sync_ready_products_pre_filter
 
@@ -497,7 +498,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductFilter.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductFilter.php#L47)
+- [ProductFilter.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductFilter.php#L47)
 
 ## woocommerce_gla_get_wc_product_id
 
@@ -505,7 +506,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductHelper.php#L359](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductHelper.php#L359)
+- [ProductHelper.php#L359](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L359)
 
 ## woocommerce_gla_google_connect_return_url
 
@@ -513,7 +514,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountController.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/Google/AccountController.php#L109)
+- [AccountController.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Google/AccountController.php#L109)
 
 ## woocommerce_gla_gtag_consent
 
@@ -521,7 +522,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GlobalSiteTag.php#L329](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Google/GlobalSiteTag.php#L329)
+- [GlobalSiteTag.php#L329](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Google/GlobalSiteTag.php#L329)
 
 ## woocommerce_gla_gtin_migration_value
 
@@ -529,7 +530,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GTINMigrationUtilities.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/HelperTraits/GTINMigrationUtilities.php#L167)
+- [GTINMigrationUtilities.php#L167](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/HelperTraits/GTINMigrationUtilities.php#L167)
 
 ## woocommerce_gla_guzzle_client_exception
 
@@ -537,29 +538,29 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Connection.php#L70](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Connection.php#L70)
-- [Connection.php#L91](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Connection.php#L91)
-- [Connection.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Connection.php#L126)
-- [Middleware.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L75)
-- [Middleware.php#L190](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L190)
-- [Middleware.php#L241](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L241)
-- [Middleware.php#L284](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L284)
-- [Middleware.php#L373](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L373)
-- [Middleware.php#L423](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L423)
-- [Middleware.php#L461](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L461)
-- [Middleware.php#L495](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L495)
-- [Middleware.php#L629](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L629)
-- [Middleware.php#L736](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L736)
-- [Middleware.php#L812](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L812)
-- [Middleware.php#L860](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L860)
-- [Connection.php#L63](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/YouTube/Connection.php#L63)
-- [Connection.php#L82](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/YouTube/Connection.php#L82)
-- [Connection.php#L114](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/YouTube/Connection.php#L114)
-- [Connection.php#L142](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/YouTube/Connection.php#L142)
-- [Connection.php#L194](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/YouTube/Connection.php#L194)
-- [Connection.php#L319](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/YouTube/Connection.php#L319)
-- [AccountController.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/YouTube/AccountController.php#L208)
-- [GoogleServiceProvider.php#L423](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Internal/DependencyManagement/GoogleServiceProvider.php#L423)
+- [Connection.php#L70](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Connection.php#L70)
+- [Connection.php#L91](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Connection.php#L91)
+- [Connection.php#L126](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Connection.php#L126)
+- [Middleware.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L75)
+- [Middleware.php#L190](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L190)
+- [Middleware.php#L241](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L241)
+- [Middleware.php#L284](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L284)
+- [Middleware.php#L373](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L373)
+- [Middleware.php#L423](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L423)
+- [Middleware.php#L461](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L461)
+- [Middleware.php#L495](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L495)
+- [Middleware.php#L629](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L629)
+- [Middleware.php#L736](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L736)
+- [Middleware.php#L812](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L812)
+- [Middleware.php#L860](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L860)
+- [Connection.php#L63](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L63)
+- [Connection.php#L82](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L82)
+- [Connection.php#L114](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L114)
+- [Connection.php#L142](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L142)
+- [Connection.php#L194](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L194)
+- [Connection.php#L319](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L319)
+- [AccountController.php#L208](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/YouTube/AccountController.php#L208)
+- [GoogleServiceProvider.php#L466](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Internal/DependencyManagement/GoogleServiceProvider.php#L466)
 
 ## woocommerce_gla_guzzle_invalid_response
 
@@ -567,21 +568,21 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Connection.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Connection.php#L66)
-- [Connection.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Connection.php#L121)
-- [Middleware.php#L163](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L163)
-- [Middleware.php#L236](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L236)
-- [Middleware.php#L278](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L278)
-- [Middleware.php#L368](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L368)
-- [Middleware.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L418)
-- [Middleware.php#L621](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L621)
-- [Middleware.php#L728](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L728)
-- [Middleware.php#L773](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L773)
-- [Connection.php#L59](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/YouTube/Connection.php#L59)
-- [Connection.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/YouTube/Connection.php#L109)
-- [Connection.php#L137](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/YouTube/Connection.php#L137)
-- [Connection.php#L189](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/YouTube/Connection.php#L189)
-- [AccountController.php#L204](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/YouTube/AccountController.php#L204)
+- [Connection.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Connection.php#L66)
+- [Connection.php#L121](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Connection.php#L121)
+- [Middleware.php#L163](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L163)
+- [Middleware.php#L236](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L236)
+- [Middleware.php#L278](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L278)
+- [Middleware.php#L368](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L368)
+- [Middleware.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L418)
+- [Middleware.php#L621](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L621)
+- [Middleware.php#L728](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L728)
+- [Middleware.php#L773](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L773)
+- [Connection.php#L59](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L59)
+- [Connection.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L109)
+- [Connection.php#L137](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L137)
+- [Connection.php#L189](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/YouTube/Connection.php#L189)
+- [AccountController.php#L204](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/YouTube/AccountController.php#L204)
 
 ## woocommerce_gla_handle_shipping_method_to_rates
 
@@ -589,7 +590,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ZoneMethodsParser.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Shipping/ZoneMethodsParser.php#L109)
+- [ZoneMethodsParser.php#L109](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Shipping/ZoneMethodsParser.php#L109)
 
 ## woocommerce_gla_hidden_coupon_types
 
@@ -597,7 +598,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L391](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L391)
+- [CouponSyncer.php#L391](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L391)
 
 ## woocommerce_gla_jetpack_connect_return_url
 
@@ -605,7 +606,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountController.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/Jetpack/AccountController.php#L131)
+- [AccountController.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Jetpack/AccountController.php#L131)
 
 ## woocommerce_gla_job_failure_rate_threshold
 
@@ -613,7 +614,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ActionSchedulerJobMonitor.php#L186](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/ActionSchedulerJobMonitor.php#L186)
+- [ActionSchedulerJobMonitor.php#L186](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/ActionSchedulerJobMonitor.php#L186)
 
 ## woocommerce_gla_job_failure_timeframe
 
@@ -621,7 +622,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ActionSchedulerJobMonitor.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/ActionSchedulerJobMonitor.php#L195)
+- [ActionSchedulerJobMonitor.php#L195](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/ActionSchedulerJobMonitor.php#L195)
 
 ## woocommerce_gla_language_currencies
 
@@ -629,7 +630,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L198](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Integration/WPML.php#L198)
+- [WPML.php#L198](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L198)
 
 ## woocommerce_gla_mapi_batch_size
 
@@ -637,7 +638,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MapiProductInputsService.php#L444](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Mapi/Services/MapiProductInputsService.php#L444)
+- [MapiProductInputsService.php#L445](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Mapi/Services/MapiProductInputsService.php#L445)
 
 ## woocommerce_gla_mapi_product_concurrency
 
@@ -645,7 +646,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L262](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L262)
+- [ProductSyncer.php#L269](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L269)
 
 ## woocommerce_gla_mapi_report_query_response
 
@@ -653,7 +654,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MapiReportQuery.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Query/MapiReportQuery.php#L90)
+- [MapiReportQuery.php#L90](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Query/MapiReportQuery.php#L90)
 
 ## woocommerce_gla_mapi_retry_limit
 
@@ -661,7 +662,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [GoogleServiceProvider.php#L214](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Internal/DependencyManagement/GoogleServiceProvider.php#L214)
+- [GoogleServiceProvider.php#L243](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Internal/DependencyManagement/GoogleServiceProvider.php#L243)
 
 ## woocommerce_gla_mapping_rules_change
 
@@ -669,9 +670,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeMappingRulesController.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L143)
-- [AttributeMappingRulesController.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L166)
-- [AttributeMappingRulesController.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L188)
+- [AttributeMappingRulesController.php#L143](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L143)
+- [AttributeMappingRulesController.php#L166](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L166)
+- [AttributeMappingRulesController.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/AttributeMapping/AttributeMappingRulesController.php#L188)
 
 ## woocommerce_gla_market_added
 
@@ -679,7 +680,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MarketService.php#L645](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/MarketService.php#L645)
+- [MarketService.php#L645](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MarketService.php#L645)
 
 ## woocommerce_gla_market_deleted
 
@@ -687,7 +688,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MarketService.php#L1299](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/MarketService.php#L1299)
+- [MarketService.php#L1299](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MarketService.php#L1299)
 
 ## woocommerce_gla_market_updated
 
@@ -695,7 +696,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MarketService.php#L1226](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/MarketService.php#L1226)
+- [MarketService.php#L1226](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MarketService.php#L1226)
 
 ## woocommerce_gla_mc_account_review_lifetime
 
@@ -703,7 +704,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [RequestReviewStatuses.php#L182](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Google/RequestReviewStatuses.php#L182)
+- [RequestReviewStatuses.php#L182](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Google/RequestReviewStatuses.php#L182)
 
 ## woocommerce_gla_mc_client_exception
 
@@ -711,12 +712,12 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Merchant.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Merchant.php#L188)
-- [Merchant.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Merchant.php#L220)
-- [Merchant.php#L239](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Merchant.php#L239)
-- [Merchant.php#L296](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Merchant.php#L296)
-- [Merchant.php#L314](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Merchant.php#L314)
-- [MerchantApiException.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Mapi/MerchantApiException.php#L47)
+- [Merchant.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L188)
+- [Merchant.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L220)
+- [Merchant.php#L239](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L239)
+- [Merchant.php#L296](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L296)
+- [Merchant.php#L314](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L314)
+- [MerchantApiException.php#L47](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Mapi/MerchantApiException.php#L47)
 
 ## woocommerce_gla_mc_settings_sync
 
@@ -724,7 +725,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SettingsSyncController.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L69)
+- [SettingsSyncController.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L69)
 
 ## woocommerce_gla_mc_status_lifetime
 
@@ -732,7 +733,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L1019](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/MerchantStatuses.php#L1019)
+- [MerchantStatuses.php#L1152](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantStatuses.php#L1152)
 
 ## woocommerce_gla_mc_under_review_lifetime
 
@@ -740,7 +741,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [RequestReviewStatuses.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Google/RequestReviewStatuses.php#L191)
+- [RequestReviewStatuses.php#L191](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Google/RequestReviewStatuses.php#L191)
 
 ## woocommerce_gla_merchant_id
 
@@ -748,7 +749,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L129](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Options/Options.php#L129)
+- [Options.php#L129](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Options/Options.php#L129)
 
 ## woocommerce_gla_merchant_issue_override
 
@@ -756,7 +757,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [IssuesController.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L85)
+- [IssuesController.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/IssuesController.php#L85)
 
 ## woocommerce_gla_merchant_status_presync_issues_chunk
 
@@ -764,7 +765,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantStatuses.php#L680](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/MerchantStatuses.php#L680)
+- [MerchantStatuses.php#L750](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantStatuses.php#L750)
 
 ## woocommerce_gla_onboarding_completed
 
@@ -772,7 +773,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [OnboardingController.php#L50](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/OnboardingController.php#L50)
+- [OnboardingController.php#L50](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/OnboardingController.php#L50)
 
 ## woocommerce_gla_options_deleted_
 
@@ -780,7 +781,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L107](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Options/Options.php#L107)
+- [Options.php#L107](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Options/Options.php#L107)
 
 ## woocommerce_gla_options_updated_
 
@@ -788,8 +789,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Options.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Options/Options.php#L69)
-- [Options.php#L89](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Options/Options.php#L89)
+- [Options.php#L69](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Options/Options.php#L69)
+- [Options.php#L89](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Options/Options.php#L89)
 
 ## woocommerce_gla_partner_app_auth_failure
 
@@ -797,7 +798,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Middleware.php#L722](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L722)
+- [Middleware.php#L722](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L722)
 
 ## woocommerce_gla_prepared_response_->GET_ROUTE_NAME
 
@@ -805,7 +806,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BaseController.php#L160](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/BaseController.php#L160)
+- [BaseController.php#L160](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/BaseController.php#L160)
 
 ## woocommerce_gla_product_attribute_types
 
@@ -813,7 +814,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributeManager.php#L316](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/Attributes/AttributeManager.php#L316)
+- [AttributeManager.php#L316](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/Attributes/AttributeManager.php#L316)
 
 ## woocommerce_gla_product_attribute_value_
 
@@ -821,10 +822,10 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L770](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L770)
-- [WCProductInputAdapter.php#L797](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L797)
-- [WCProductAdapter.php#L998](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L998)
-- [WCProductAdapter.php#L1100](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L1100)
+- [WCProductInputAdapter.php#L770](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L770)
+- [WCProductInputAdapter.php#L797](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L797)
+- [WCProductAdapter.php#L998](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L998)
+- [WCProductAdapter.php#L1100](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L1100)
 
 ## woocommerce_gla_product_attribute_value_description
 
@@ -832,8 +833,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L292)
-- [WCProductAdapter.php#L369](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L369)
+- [WCProductInputAdapter.php#L292](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L292)
+- [WCProductAdapter.php#L369](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L369)
 
 ## woocommerce_gla_product_attribute_value_options_::get_id
 
@@ -841,7 +842,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AttributesForm.php#L128](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Admin/Product/Attributes/AttributesForm.php#L128)
+- [AttributesForm.php#L128](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Admin/Product/Attributes/AttributesForm.php#L128)
 
 ## woocommerce_gla_product_attribute_value_price
 
@@ -849,10 +850,10 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L406](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L406)
-- [WCProductInputAdapter.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L418)
-- [WCProductAdapter.php#L657](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L657)
-- [WCProductAdapter.php#L686](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L686)
+- [WCProductInputAdapter.php#L406](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L406)
+- [WCProductInputAdapter.php#L418](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L418)
+- [WCProductAdapter.php#L657](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L657)
+- [WCProductAdapter.php#L686](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L686)
 
 ## woocommerce_gla_product_attribute_value_sale_price
 
@@ -860,9 +861,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L545](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L545)
-- [WCProductAdapter.php#L726](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L726)
-- [WCProductAdapter.php#L774](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L774)
+- [WCProductInputAdapter.php#L545](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L545)
+- [WCProductAdapter.php#L726](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L726)
+- [WCProductAdapter.php#L774](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L774)
 
 ## woocommerce_gla_product_attribute_values
 
@@ -870,8 +871,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L976](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L976)
-- [WCProductAdapter.php#L183](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L183)
+- [WCProductInputAdapter.php#L976](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L976)
+- [WCProductAdapter.php#L183](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L183)
 
 ## woocommerce_gla_product_description_apply_shortcodes
 
@@ -879,8 +880,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L282](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L282)
-- [WCProductAdapter.php#L338](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L338)
+- [WCProductInputAdapter.php#L282](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L282)
+- [WCProductAdapter.php#L338](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L338)
 
 ## woocommerce_gla_product_property_value_is_virtual
 
@@ -888,8 +889,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L755](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L755)
-- [WCProductAdapter.php#L864](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L864)
+- [WCProductInputAdapter.php#L755](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L755)
+- [WCProductAdapter.php#L864](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L864)
 
 ## woocommerce_gla_product_query_args
 
@@ -897,7 +898,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductRepository.php#L472](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductRepository.php#L472)
+- [ProductRepository.php#L472](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductRepository.php#L472)
 
 ## woocommerce_gla_product_view_report_page_size
 
@@ -905,7 +906,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantReport.php#L64](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/MerchantReport.php#L64)
+- [MerchantReport.php#L68](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/MerchantReport.php#L68)
+- [UpdateMerchantProductStatuses.php#L113](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/UpdateMerchantProductStatuses.php#L113)
 
 ## woocommerce_gla_products_delete_retry_on_failure
 
@@ -913,7 +915,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L573](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L573)
+- [ProductSyncer.php#L580](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L580)
 
 ## woocommerce_gla_products_update_retry_on_failure
 
@@ -921,7 +923,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L517](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L517)
+- [ProductSyncer.php#L524](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L524)
 
 ## woocommerce_gla_ready_for_syncing
 
@@ -929,7 +931,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [MerchantCenterService.php#L120](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/MerchantCenterService.php#L120)
+- [MerchantCenterService.php#L135](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/MerchantCenterService.php#L135)
 
 ## woocommerce_gla_request_review_failure
 
@@ -937,8 +939,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [RequestReviewController.php#L119](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L119)
-- [RequestReviewController.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L131)
+- [RequestReviewController.php#L119](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L119)
+- [RequestReviewController.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L131)
 
 ## woocommerce_gla_request_review_response
 
@@ -946,7 +948,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [RequestReviewController.php#L337](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L337)
+- [RequestReviewController.php#L337](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/RequestReviewController.php#L337)
 
 ## woocommerce_gla_retry_delete_coupons
 
@@ -954,7 +956,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L455](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L455)
+- [CouponSyncer.php#L455](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L455)
 
 ## woocommerce_gla_retry_update_coupons
 
@@ -962,7 +964,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L417](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L417)
+- [CouponSyncer.php#L417](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L417)
 
 ## woocommerce_gla_site_claim_failure
 
@@ -970,10 +972,10 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Merchant.php#L114](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Merchant.php#L114)
-- [Middleware.php#L279](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L279)
-- [Middleware.php#L285](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L285)
-- [AccountService.php#L414](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/AccountService.php#L414)
+- [Merchant.php#L114](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L114)
+- [Middleware.php#L279](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L279)
+- [Middleware.php#L285](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L285)
+- [AccountService.php#L414](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L414)
 
 ## woocommerce_gla_site_claim_overwrite_required
 
@@ -981,7 +983,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L409](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/AccountService.php#L409)
+- [AccountService.php#L409](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L409)
 
 ## woocommerce_gla_site_claim_success
 
@@ -989,8 +991,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [Merchant.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Merchant.php#L111)
-- [Middleware.php#L274](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/Middleware.php#L274)
+- [Merchant.php#L111](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Merchant.php#L111)
+- [Middleware.php#L274](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/Middleware.php#L274)
 
 ## woocommerce_gla_site_url
 
@@ -998,7 +1000,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [PluginHelper.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/PluginHelper.php#L188)
+- [PluginHelper.php#L188](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/PluginHelper.php#L188)
 
 ## woocommerce_gla_site_verify_failure
 
@@ -1006,9 +1008,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L58](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/SiteVerification.php#L58)
-- [SiteVerification.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/SiteVerification.php#L66)
-- [SiteVerification.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/SiteVerification.php#L87)
+- [SiteVerification.php#L58](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/SiteVerification.php#L58)
+- [SiteVerification.php#L66](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/SiteVerification.php#L66)
+- [SiteVerification.php#L87](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/SiteVerification.php#L87)
 
 ## woocommerce_gla_site_verify_success
 
@@ -1016,7 +1018,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/SiteVerification.php#L85)
+- [SiteVerification.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/SiteVerification.php#L85)
 
 ## woocommerce_gla_supported_coupon_types
 
@@ -1024,7 +1026,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L378](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L378)
+- [CouponSyncer.php#L378](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L378)
 
 ## woocommerce_gla_supported_product_types
 
@@ -1032,7 +1034,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductSyncer.php#L495](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductSyncer.php#L495)
+- [ProductSyncer.php#L502](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductSyncer.php#L502)
 
 ## woocommerce_gla_sv_client_exception
 
@@ -1040,8 +1042,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [SiteVerification.php#L120](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/SiteVerification.php#L120)
-- [SiteVerification.php#L162](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Google/SiteVerification.php#L162)
+- [SiteVerification.php#L120](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/SiteVerification.php#L120)
+- [SiteVerification.php#L162](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Google/SiteVerification.php#L162)
 
 ## woocommerce_gla_sync_hash_freshness
 
@@ -1049,7 +1051,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [BatchProductHelper.php#L673](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/BatchProductHelper.php#L673)
+- [BatchProductHelper.php#L681](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/BatchProductHelper.php#L681)
 
 ## woocommerce_gla_tax_excluded
 
@@ -1057,8 +1059,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L1032](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L1032)
-- [WCProductAdapter.php#L618](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L618)
+- [WCProductInputAdapter.php#L1032](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L1032)
+- [WCProductAdapter.php#L618](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L618)
 
 ## woocommerce_gla_track_event
 
@@ -1066,16 +1068,16 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [OAuthService.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/WP/OAuthService.php#L172)
-- [OAuthService.php#L200](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/WP/OAuthService.php#L200)
-- [OAuthService.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/WP/OAuthService.php#L220)
-- [SetupCompleteController.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/Ads/SetupCompleteController.php#L75)
-- [CampaignController.php#L184](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/Ads/CampaignController.php#L184)
-- [CampaignController.php#L272](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/Ads/CampaignController.php#L272)
-- [CampaignController.php#L313](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/Ads/CampaignController.php#L313)
-- [SettingsSyncController.php#L83](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L83)
-- [AccountService.php#L641](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/AccountService.php#L641)
-- [AccountService.php#L661](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/AccountService.php#L661)
+- [OAuthService.php#L172](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/WP/OAuthService.php#L172)
+- [OAuthService.php#L200](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/WP/OAuthService.php#L200)
+- [OAuthService.php#L220](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/WP/OAuthService.php#L220)
+- [SetupCompleteController.php#L75](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/SetupCompleteController.php#L75)
+- [CampaignController.php#L184](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/CampaignController.php#L184)
+- [CampaignController.php#L272](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/CampaignController.php#L272)
+- [CampaignController.php#L313](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/CampaignController.php#L313)
+- [SettingsSyncController.php#L83](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/MerchantCenter/SettingsSyncController.php#L83)
+- [AccountService.php#L641](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L641)
+- [AccountService.php#L661](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L661)
 
 ## woocommerce_gla_updated_campaign
 
@@ -1083,9 +1085,9 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CampaignController.php#L204](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/Ads/CampaignController.php#L204)
-- [CampaignController.php#L283](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/Ads/CampaignController.php#L283)
-- [CampaignController.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/API/Site/Controllers/Ads/CampaignController.php#L321)
+- [CampaignController.php#L204](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/CampaignController.php#L204)
+- [CampaignController.php#L283](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/CampaignController.php#L283)
+- [CampaignController.php#L321](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/API/Site/Controllers/Ads/CampaignController.php#L321)
 
 ## woocommerce_gla_updated_coupon
 
@@ -1093,7 +1095,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CouponSyncer.php#L182](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Coupon/CouponSyncer.php#L182)
+- [CouponSyncer.php#L182](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Coupon/CouponSyncer.php#L182)
 
 ## woocommerce_gla_url_switch_required
 
@@ -1101,7 +1103,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L494](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/AccountService.php#L494)
+- [AccountService.php#L494](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L494)
 
 ## woocommerce_gla_url_switch_success
 
@@ -1109,7 +1111,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [AccountService.php#L517](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/MerchantCenter/AccountService.php#L517)
+- [AccountService.php#L517](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/MerchantCenter/AccountService.php#L517)
 
 ## woocommerce_gla_use_short_description
 
@@ -1117,8 +1119,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L268](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L268)
-- [WCProductAdapter.php#L315](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L315)
+- [WCProductInputAdapter.php#L268](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L268)
+- [WCProductAdapter.php#L315](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L315)
 
 ## woocommerce_gla_wcs_url
 
@@ -1126,8 +1128,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [PluginHelper.php#L174](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/PluginHelper.php#L174)
-- [PluginHelper.php#L177](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/PluginHelper.php#L177)
+- [PluginHelper.php#L174](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/PluginHelper.php#L174)
+- [PluginHelper.php#L177](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/PluginHelper.php#L177)
 
 ## woocommerce_gla_weight_unit
 
@@ -1135,8 +1137,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WCProductInputAdapter.php#L728](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductInputAdapter.php#L728)
-- [WCProductAdapter.php#L449](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/WCProductAdapter.php#L449)
+- [WCProductInputAdapter.php#L728](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductInputAdapter.php#L728)
+- [WCProductAdapter.php#L449](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/WCProductAdapter.php#L449)
 
 ## woocommerce_gla_youtube_order_ids_job_date
 
@@ -1144,8 +1146,8 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CreateMerchantReportedConversionReport.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/CreateMerchantReportedConversionReport.php#L104)
-- [CreateYouTubeOrderIdsCache.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/CreateYouTubeOrderIdsCache.php#L85)
+- [CreateMerchantReportedConversionReport.php#L104](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateMerchantReportedConversionReport.php#L104)
+- [CreateYouTubeOrderIdsCache.php#L85](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateYouTubeOrderIdsCache.php#L85)
 
 ## woocommerce_gla_youtube_orders_csv_delete_on_complete
 
@@ -1153,7 +1155,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [CreateMerchantReportedConversionReport.php#L241](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Jobs/CreateMerchantReportedConversionReport.php#L241)
+- [CreateMerchantReportedConversionReport.php#L241](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Jobs/CreateMerchantReportedConversionReport.php#L241)
 
 ## woocommerce_hide_invisible_variations
 
@@ -1161,7 +1163,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [ProductHelper.php#L447](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Product/ProductHelper.php#L447)
+- [ProductHelper.php#L447](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Product/ProductHelper.php#L447)
 
 ## wpml_active_languages
 
@@ -1169,7 +1171,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Integration/WPML.php#L131)
+- [WPML.php#L131](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L131)
 
 ## wpml_current_language
 
@@ -1177,7 +1179,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L71](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Integration/WPML.php#L71)
+- [WPML.php#L71](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L71)
 
 ## wpml_default_language
 
@@ -1185,7 +1187,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L93](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Integration/WPML.php#L93)
+- [WPML.php#L93](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L93)
 
 ## wpml_post_language_details
 
@@ -1193,7 +1195,7 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Integration/WPML.php#L110)
+- [WPML.php#L110](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L110)
 
 ## wpml_switch_language
 
@@ -1201,6 +1203,6 @@ A list of hooks, e.g. `actions` and `filters`, that are defined or used in this 
 
 **Used in**:
 
-- [WPML.php#L73](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Integration/WPML.php#L73)
-- [WPML.php#L79](https://github.com/woocommerce/google-listings-and-ads/blob/0ad2566cd0e20977207db787526b751053ed7fe1/src/Integration/WPML.php#L79)
+- [WPML.php#L73](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L73)
+- [WPML.php#L79](https://github.com/woocommerce/google-listings-and-ads/blob/d1ee3afb7463d5597099a6807b4d340db750b7ec/src/Integration/WPML.php#L79)
 

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -21,6 +21,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsAsset;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetMetrics;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\BudgetRecommendations;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\JetpackAuthCircuitBreaker;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountBusinessInfoService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountHomepageService;
@@ -64,6 +65,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\Conn
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\RequestException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\HandlerStack;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Middleware as GuzzleMiddleware;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Promise\Create as PromiseCreate;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Psr7\Utils;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\League\Container\Definition\Definition;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Psr\Http\Message\RequestInterface;
@@ -95,6 +97,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		ShoppingContent::class                    => true,
 		GoogleAdsClient::class                    => true,
 		GuzzleClient::class                       => true,
+		JetpackAuthCircuitBreaker::class          => true,
 		Middleware::class                         => true,
 		Merchant::class                           => true,
 		MerchantMetrics::class                    => true,
@@ -145,6 +148,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$this->register_ads_client();
 		$this->register_google_classes();
 		$this->share( Middleware::class );
+		$this->share( JetpackAuthCircuitBreaker::class );
 		$this->add( Connection::class );
 		$this->add( Settings::class );
 
@@ -183,6 +187,9 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$callback = function () {
 			$handler_stack = HandlerStack::create();
 			$handler_stack->remove( 'http_errors' );
+			// Outermost of the plugin's own middlewares: after the Connect Server has rejected the
+			// Jetpack token once during this PHP request, no further HTTP request is sent through this client.
+			$handler_stack->push( $this->short_circuit_after_auth_failure(), 'auth_failure_short_circuit' );
 			$handler_stack->push( $this->error_handler(), 'http_errors' );
 			$handler_stack->push( $this->add_auth_header(), 'auth_header' );
 			$handler_stack->push( $this->add_plugin_version_header(), 'plugin_version_header' );
@@ -201,6 +208,28 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 
 		$this->share_concrete( GuzzleClient::class, new Definition( GuzzleClient::class, $callback ) );
 		$this->share_concrete( ClientInterface::class, new Definition( GuzzleClient::class, $callback ) );
+	}
+
+	/**
+	 * Middleware that rejects every request after the Connect Server rejected the
+	 * Jetpack token earlier in the same PHP request. The rejection is permanent for
+	 * the site until it reconnects, so repeating the request for every product in a
+	 * batch only multiplies the failures.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return callable
+	 */
+	protected function short_circuit_after_auth_failure(): callable {
+		return function ( callable $handler ) {
+			return function ( RequestInterface $request, array $options ) use ( $handler ) {
+				if ( $this->get_circuit_breaker()->was_tripped_in_request() ) {
+					return PromiseCreate::rejectionFor( AccountReconnect::jetpack_disconnected() );
+				}
+
+				return $handler( $request, $options );
+			};
+		};
 	}
 
 	/**
@@ -345,6 +374,9 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	/**
 	 * Custom error handler to detect and handle a disconnected status.
 	 *
+	 * The response status is the only evidence the plugin has about the Jetpack token, so
+	 * this is also where an accepted response marks Jetpack as connected and ends a pause.
+	 *
 	 * @return callable
 	 */
 	protected function error_handler(): callable {
@@ -362,6 +394,12 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 						}
 
 						if ( $code < 400 ) {
+							if ( $code < 300 ) {
+								// Only an accepted response proves the Jetpack token is valid.
+								$this->set_jetpack_connected( true );
+								$this->get_circuit_breaker()->reset();
+							}
+
 							return $response;
 						}
 
@@ -378,7 +416,9 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 
 	/**
 	 * Handle a 401 unauthorized error.
-	 * Marks either the Jetpack or the Google account as disconnected.
+	 * Marks either the Jetpack or the Google account as disconnected. A Jetpack
+	 * authentication failure also pauses syncing (see JetpackAuthCircuitBreaker);
+	 * a Google one already stops it through the GOOGLE_CONNECTED option.
 	 *
 	 * @since 1.12.5
 	 *
@@ -394,6 +434,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 			do_action( 'woocommerce_gla_exception', RequestException::create( $request, $response ), __METHOD__ );
 
 			$this->set_jetpack_connected( false );
+			$this->get_circuit_breaker()->trip();
 			throw AccountReconnect::jetpack_disconnected();
 		}
 
@@ -416,9 +457,6 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 			return function ( RequestInterface $request, array $options ) use ( $handler ) {
 				try {
 					$request = $request->withHeader( 'Authorization', $this->generate_auth_header() );
-
-					// Getting a valid authorization token, indicates Jetpack is connected.
-					$this->set_jetpack_connected( true );
 				} catch ( WPError $error ) {
 					do_action( 'woocommerce_gla_guzzle_client_exception', $error, __METHOD__ . ' in add_auth_header()' );
 
@@ -557,6 +595,13 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		$parts = wp_parse_url( $this->get_connect_server_url_root( 'google/google-ads' ) );
 		$port  = empty( $parts['port'] ) ? 443 : $parts['port'];
 		return sprintf( '%s:%d%s', $parts['host'], $port, $parts['path'] );
+	}
+
+	/**
+	 * @return JetpackAuthCircuitBreaker
+	 */
+	protected function get_circuit_breaker(): JetpackAuthCircuitBreaker {
+		return $this->getContainer()->get( JetpackAuthCircuitBreaker::class );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -627,14 +627,17 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 		/** @var Options $options */
 		$options = $this->getContainer()->get( OptionsInterface::class );
 
-		// Save previous connected status before updating.
 		$previous_connected = boolval( $options->get( OptionsInterface::JETPACK_CONNECTED ) );
 
-		$options->update( OptionsInterface::JETPACK_CONNECTED, $connected );
-
-		if ( $previous_connected !== $connected ) {
-			$this->jetpack_connected_change( $connected );
+		// Comparing here avoids a wp_options write on every accepted response: WordPress stores
+		// the value as '1' and compares it strictly against the boolean, so update_option()
+		// would issue an UPDATE each time even though nothing changes.
+		if ( $previous_connected === $connected ) {
+			return;
 		}
+
+		$options->update( OptionsInterface::JETPACK_CONNECTED, $connected );
+		$this->jetpack_connected_change( $connected );
 	}
 
 	/**

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -216,7 +216,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	 * the site until it reconnects, so repeating the request for every product in a
 	 * batch only multiplies the failures.
 	 *
-	 * @since x.x.x
+	 * @since 3.9.3
 	 *
 	 * @return callable
 	 */

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -373,7 +373,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 
 	/**
 	 * Middleware that turns the response status into connection state and exceptions:
-	 * an accepted response marks Jetpack as connected and ends a sync pause, a 401 marks
+	 * a successful (2xx) response marks Jetpack as connected and ends a sync pause, a 401 marks
 	 * the Jetpack or Google account as disconnected, and any other error status is thrown
 	 * as a RequestException. The response status is the only evidence the plugin has about
 	 * the Jetpack token, which is why both connection state transitions live here.
@@ -397,8 +397,10 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 						}
 
 						if ( $code < 400 ) {
+							// Only a 2xx proves the token is valid. A 3xx is not treated as proof, but
+							// the proxy does not redirect and the client follows any redirect before
+							// this runs, so the final status seen here is 2xx or an error.
 							if ( $code < 300 ) {
-								// Only an accepted response proves the Jetpack token is valid.
 								$this->set_jetpack_connected( true );
 								$this->get_circuit_breaker()->reset();
 							}

--- a/src/Internal/DependencyManagement/GoogleServiceProvider.php
+++ b/src/Internal/DependencyManagement/GoogleServiceProvider.php
@@ -190,7 +190,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 			// Outermost of the plugin's own middlewares: after the Connect Server has rejected the
 			// Jetpack token once during this PHP request, no further HTTP request is sent through this client.
 			$handler_stack->push( $this->short_circuit_after_auth_failure(), 'auth_failure_short_circuit' );
-			$handler_stack->push( $this->error_handler(), 'http_errors' );
+			$handler_stack->push( $this->handle_response_status(), 'http_errors' );
 			$handler_stack->push( $this->add_auth_header(), 'auth_header' );
 			$handler_stack->push( $this->add_plugin_version_header(), 'plugin_version_header' );
 			$handler_stack->push( $this->strip_apply_incentive_duplicates(), 'strip_incentive_duplicates' );
@@ -200,7 +200,7 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 				$handler_stack->push( $this->override_http_url(), 'override_http_url' );
 			}
 
-			// Innermost: retry transient failures before the error handler turns them into exceptions.
+			// Innermost: retry transient failures before handle_response_status() turns them into exceptions.
 			$handler_stack->push( $this->retry_on_transient_error(), 'retry_on_transient_error' );
 
 			return new GuzzleClient( [ 'handler' => $handler_stack ] );
@@ -372,14 +372,17 @@ class GoogleServiceProvider extends AbstractServiceProvider {
 	}
 
 	/**
-	 * Custom error handler to detect and handle a disconnected status.
+	 * Middleware that turns the response status into connection state and exceptions:
+	 * an accepted response marks Jetpack as connected and ends a sync pause, a 401 marks
+	 * the Jetpack or Google account as disconnected, and any other error status is thrown
+	 * as a RequestException. The response status is the only evidence the plugin has about
+	 * the Jetpack token, which is why both connection state transitions live here.
 	 *
-	 * The response status is the only evidence the plugin has about the Jetpack token, so
-	 * this is also where an accepted response marks Jetpack as connected and ends a pause.
+	 * Registered under Guzzle's `http_errors` name, replacing the built-in middleware.
 	 *
 	 * @return callable
 	 */
-	protected function error_handler(): callable {
+	protected function handle_response_status(): callable {
 		return function ( callable $handler ) {
 			return function ( RequestInterface $request, array $options ) use ( $handler ) {
 				return $handler( $request, $options )->then(

--- a/src/Internal/DependencyManagement/JobServiceProvider.php
+++ b/src/Internal/DependencyManagement/JobServiceProvider.php
@@ -14,7 +14,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Admin\Exports\Writer\CsvExportWr
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\AdsCampaign;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings as GoogleSettings;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantReport;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Middleware;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidClass;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
@@ -183,7 +183,7 @@ class JobServiceProvider extends AbstractServiceProvider {
 		$this->share_action_scheduler_job( CreateYouTubeOrderIdsCache::class, YouTubeOrders::class, JobRepository::class );
 		$this->share_action_scheduler_job( CreateMerchantReportedConversionReport::class, OrderItemRowBuilder::class, CsvExportWriter::class, YouTubeConnection::class );
 
-		$this->share_action_scheduler_job( UpdateMerchantProductStatuses::class, MerchantCenterService::class, MerchantReport::class, MerchantStatuses::class );
+		$this->share_action_scheduler_job( UpdateMerchantProductStatuses::class, MerchantCenterService::class, MapiProductsService::class, MerchantStatuses::class );
 
 		$this->share_action_scheduler_job( UpdateMerchantPriceBenchmarks::class, MerchantCenterService::class, PriceBenchmarks::class );
 

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -78,16 +78,17 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 	/**
 	 * Process the job.
 	 *
-	 * @param int[] $items An array of job arguments.
+	 * @param array $items Job arguments, optionally carrying the next_page_token to continue from.
 	 *
-	 * @throws JobException If the merchant product statuses cannot be retrieved..
+	 * @throws JobException If the merchant product statuses cannot be retrieved.
 	 */
 	public function process_items( array $items ) {
 		try {
 			$next_page_token = $items['next_page_token'] ?? null;
 
-			// Clear the cache if we're starting from the beginning.
-			if ( ! $next_page_token ) {
+			// Clear the cache if we're starting from the beginning. Strict check: a
+			// pagination token is an opaque string, and PHP would treat "0" as falsy.
+			if ( null === $next_page_token ) {
 				$this->merchant_statuses->clear_product_statuses_cache_and_issues();
 				$this->merchant_statuses->refresh_account_and_presync_issues();
 			}
@@ -113,7 +114,7 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 
 			$this->merchant_statuses->process_mapi_products( $page['products'] );
 
-			if ( $next_page_token ) {
+			if ( null !== $next_page_token ) {
 				$this->schedule( [ [ 'next_page_token' => $next_page_token ] ] );
 			} else {
 				$this->merchant_statuses->handle_complete_mc_statuses_fetching();

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -5,7 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Jobs;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantReport;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Throwable;
 
@@ -29,9 +29,9 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 	protected $merchant_center;
 
 	/**
-	 * @var MerchantReport
+	 * @var MapiProductsService
 	 */
-	protected $merchant_report;
+	protected $mapi_products;
 
 	/**
 	 * @var MerchantStatuses
@@ -45,13 +45,13 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 	 * @param ActionSchedulerInterface  $action_scheduler
 	 * @param ActionSchedulerJobMonitor $monitor
 	 * @param MerchantCenterService     $merchant_center
-	 * @param MerchantReport            $merchant_report
+	 * @param MapiProductsService       $mapi_products
 	 * @param MerchantStatuses          $merchant_statuses
 	 */
-	public function __construct( ActionSchedulerInterface $action_scheduler, ActionSchedulerJobMonitor $monitor, MerchantCenterService $merchant_center, MerchantReport $merchant_report, MerchantStatuses $merchant_statuses ) {
+	public function __construct( ActionSchedulerInterface $action_scheduler, ActionSchedulerJobMonitor $monitor, MerchantCenterService $merchant_center, MapiProductsService $mapi_products, MerchantStatuses $merchant_statuses ) {
 		parent::__construct( $action_scheduler, $monitor );
 		$this->merchant_center   = $merchant_center;
-		$this->merchant_report   = $merchant_report;
+		$this->mapi_products     = $mapi_products;
 		$this->merchant_statuses = $merchant_statuses;
 	}
 
@@ -92,10 +92,26 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 				$this->merchant_statuses->refresh_account_and_presync_issues();
 			}
 
-			$results         = $this->merchant_report->get_product_view_report( $next_page_token );
-			$next_page_token = $results['next_page_token'];
+			// One list page per action: the token travels in the action args, exactly
+			// like the report page token did, but each page also carries the item-level
+			// issues, so the whole refresh costs ceil(N/1000) requests in total.
+			/**
+			 * Filters the products.list page size used by the status refresh.
+			 *
+			 * Successor of the tuning point the retired report-driven flow exposed as
+			 * woocommerce_gla_product_view_report_page_size; a constrained host can lower
+			 * it to trade request count for peak memory. Clamped to the API range 1-1000.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param int $page_size Products per list page. Default 1000, the API maximum.
+			 */
+			$page_size = min( 1000, max( 1, (int) apply_filters( 'woocommerce_gla_mapi_products_list_page_size', 1000 ) ) );
 
-			$this->merchant_statuses->process_product_statuses( $results['statuses'] );
+			$page            = $this->mapi_products->list_page( $next_page_token, $page_size );
+			$next_page_token = $page['next_page_token'];
+
+			$this->merchant_statuses->process_mapi_products( $page['products'] );
 
 			if ( $next_page_token ) {
 				$this->schedule( [ [ 'next_page_token' => $next_page_token ] ] );

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -96,17 +96,17 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 			// like the report page token did, but each page also carries the item-level
 			// issues, so the whole refresh costs ceil(N/1000) requests in total.
 			/**
-			 * Filters the products.list page size used by the status refresh.
+			 * Filters the page size of the status refresh source.
 			 *
-			 * Successor of the tuning point the retired report-driven flow exposed as
-			 * woocommerce_gla_product_view_report_page_size; a constrained host can lower
-			 * it to trade request count for peak memory. Clamped to the API range 1-1000.
+			 * The hook predates the list-driven refresh: it originally sized the
+			 * product_view report pages, and its name is kept on purpose so caps set
+			 * by constrained hosts keep working now that the pages come from
+			 * products.list instead. Default 1000 (500 in the report era), clamped
+			 * to the API range 1-1000.
 			 *
-			 * @since x.x.x
-			 *
-			 * @param int $page_size Products per list page. Default 1000, the API maximum.
+			 * @param int $page_size Products per list page.
 			 */
-			$page_size = min( 1000, max( 1, (int) apply_filters( 'woocommerce_gla_mapi_products_list_page_size', 1000 ) ) );
+			$page_size = min( 1000, max( 1, (int) apply_filters( 'woocommerce_gla_product_view_report_page_size', 1000 ) ) );
 
 			$page            = $this->mapi_products->list_page( $next_page_token, $page_size );
 			$next_page_token = $page['next_page_token'];

--- a/src/Jobs/UpdateMerchantProductStatuses.php
+++ b/src/Jobs/UpdateMerchantProductStatuses.php
@@ -95,19 +95,22 @@ class UpdateMerchantProductStatuses extends AbstractActionSchedulerJob {
 
 			// One list page per action: the token travels in the action args, exactly
 			// like the report page token did, but each page also carries the item-level
-			// issues, so the whole refresh costs ceil(N/1000) requests in total.
+			// issues, so the whole refresh costs one request per list page.
 			/**
 			 * Filters the page size of the status refresh source.
 			 *
 			 * The hook predates the list-driven refresh: it originally sized the
 			 * product_view report pages, and its name is kept on purpose so caps set
 			 * by constrained hosts keep working now that the pages come from
-			 * products.list instead. Default 1000 (500 in the report era), clamped
-			 * to the API range 1-1000.
+			 * products.list instead. The default stays at the report era's 500: a
+			 * list entry is far heavier than a report row (productStatus carries the
+			 * item-level issues with per-reporting-context country lists), so a full
+			 * 1000-entry page can cost hundreds of MB of decode peak on issue-heavy
+			 * catalogues. Clamped to the API range 1-1000.
 			 *
 			 * @param int $page_size Products per list page.
 			 */
-			$page_size = min( 1000, max( 1, (int) apply_filters( 'woocommerce_gla_product_view_report_page_size', 1000 ) ) );
+			$page_size = min( 1000, max( 1, (int) apply_filters( 'woocommerce_gla_product_view_report_page_size', 500 ) ) );
 
 			$page            = $this->mapi_products->list_page( $next_page_token, $page_size );
 			$next_page_token = $page['next_page_token'];

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\JetpackAuthCircuitBreaker;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
@@ -48,6 +49,7 @@ defined( 'ABSPATH' ) || exit;
  * - WP
  * - TargetAudience
  * - GoogleHelper
+ * - JetpackAuthCircuitBreaker
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter
  */
@@ -100,8 +102,9 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 
 	/**
 	 * Whether we are able to sync data to the Merchant Center account.
-	 * Account must be connected, the WordPress.com connection must have an owner,
-	 * and the URL we claimed with must match the site URL.
+	 * Account must be connected, the WordPress.com connection must have an owner
+	 * and not be paused after an authentication failure, and the URL we claimed
+	 * with must match the site URL.
 	 * URL matches is stored in a transient to prevent it from being refetched in cases
 	 * where the site is unable to access account data.
 	 *
@@ -114,6 +117,11 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 		}
 
 		if ( ! $this->is_jetpack_owner_connected() ) {
+			return false;
+		}
+
+		// Paused after the Connect Server rejected the Jetpack token.
+		if ( $this->container->get( JetpackAuthCircuitBreaker::class )->is_open() ) {
 			return false;
 		}
 

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
@@ -35,6 +36,7 @@ defined( 'ABSPATH' ) || exit;
  * - AddressUtility
  * - AdsService
  * - ContactInformation
+ * - Manager
  * - Merchant
  * - MerchantAccountState
  * - MerchantStatuses
@@ -98,7 +100,8 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 
 	/**
 	 * Whether we are able to sync data to the Merchant Center account.
-	 * Account must be connected and the URL we claimed with must match the site URL.
+	 * Account must be connected, the WordPress.com connection must have an owner,
+	 * and the URL we claimed with must match the site URL.
 	 * URL matches is stored in a transient to prevent it from being refetched in cases
 	 * where the site is unable to access account data.
 	 *
@@ -107,6 +110,10 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 */
 	public function is_ready_for_syncing(): bool {
 		if ( ! $this->is_connected() ) {
+			return false;
+		}
+
+		if ( ! $this->is_jetpack_owner_connected() ) {
 			return false;
 		}
 
@@ -133,6 +140,27 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 */
 	public function should_push(): bool {
 		return $this->is_ready_for_syncing();
+	}
+
+	/**
+	 * Whether the WordPress.com (Jetpack) connection has a connected owner user.
+	 *
+	 * Every request to Google goes through the Connect Server proxy signed with the
+	 * site's blog token, and the proxy resolves the acting user from the connection
+	 * owner. A connection without an owner is therefore rejected with 401 on every
+	 * request, so syncing is gated on the owner here, before any job is scheduled or
+	 * request is sent. This is a local check: it cannot detect a token that
+	 * WordPress.com has revoked remotely.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	public function is_jetpack_owner_connected(): bool {
+		/** @var Manager $manager */
+		$manager = $this->container->get( Manager::class );
+
+		return $manager->is_connected() && $manager->has_connected_owner();
 	}
 
 	/**

--- a/src/MerchantCenter/MerchantCenterService.php
+++ b/src/MerchantCenter/MerchantCenterService.php
@@ -160,7 +160,7 @@ class MerchantCenterService implements ContainerAwareInterface, OptionsAwareInte
 	 * request is sent. This is a local check: it cannot detect a token that
 	 * WordPress.com has revoked remotely.
 	 *
-	 * @since x.x.x
+	 * @since 3.9.3
 	 *
 	 * @return bool
 	 */

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -385,7 +385,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * Get MC product issues from a list of Product View statuses.
 	 *
 	 * @param array $statuses The list of Product View statuses.
-	 * @param array $products_by_google_id Merchant API products keyed by product id; issues are read from these, so no request is made here.
+	 * @param array $products_by_google_id Merchant API products keyed by their Merchant API product id (the resource name's last segment, e.g. en~US~gla_123); issues are read from these, so no request is made here.
 	 * @throws NotFoundExceptionInterface  If the class is not found in the container.
 	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 *
@@ -772,7 +772,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * Process product status statistics.
 	 *
 	 * @param array $product_view_statuses Product View statuses.
-	 * @param array $products_by_google_id Merchant API products keyed by product id, the source of item-level issues.
+	 * @param array $products_by_google_id Merchant API products keyed by their Merchant API product id (the resource name's last segment, e.g. en~US~gla_123), the source of item-level issues.
 	 * @see UpdateMerchantProductStatuses::process_items
 	 *
 	 * @throws NotFoundExceptionInterface  If the class is not found in the container.

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -430,7 +430,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			return [];
 		}
 
-		$created_at     = $this->cache_created_time->format( 'Y-m-d H:i:s' );
+		$created_at = $this->cache_created_time->format( 'Y-m-d H:i:s' );
+		// Issues come only from the provided page, so a product whose synced variants
+		// (multiple google ids) span list pages gets its applicable countries from the
+		// last page written rather than a cross-variant merge. Today the plugin creates
+		// one input per product, so variants never split; revisit if multi-feed lands.
 		$products       = array_intersect_key( $products_by_google_id, $google_id_to_wc_id );
 		$product_issues = [];
 
@@ -752,7 +756,13 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 
 			$expiration_date = null;
 			if ( $product_status->get_google_expiration_date() ) {
-				$expiration_date = new DateTime( $product_status->get_google_expiration_date() );
+				try {
+					$expiration_date = new DateTime( $product_status->get_google_expiration_date() );
+				} catch ( Exception $e ) {
+					// An unparsable timestamp only loses the expiring hint; it must not
+					// fail the page and, through the retry chain, kill the refresh.
+					$expiration_date = null;
+				}
 			}
 
 			$statuses[ $wc_product_id ] = [
@@ -772,7 +782,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * Process product status statistics.
 	 *
 	 * @param array $product_view_statuses Product View statuses.
-	 * @param array $products_by_google_id Merchant API products keyed by their Merchant API product id (the resource name's last segment, e.g. en~US~gla_123), the source of item-level issues.
+	 * @param array $products_by_google_id Merchant API products keyed by their Merchant API product id (the resource name's last segment, e.g. en~US~gla_123), the source of item-level issues. When omitted, no product issues are written.
 	 * @see UpdateMerchantProductStatuses::process_items
 	 *
 	 * @throws NotFoundExceptionInterface  If the class is not found in the container.

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -431,10 +431,11 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		}
 
 		$created_at = $this->cache_created_time->format( 'Y-m-d H:i:s' );
-		// Issues come only from the provided page, so a product whose synced variants
-		// (multiple google ids) span list pages gets its applicable countries from the
-		// last page written rather than a cross-variant merge. Today the plugin creates
-		// one input per product, so variants never split; revisit if multi-feed lands.
+		// Issues come only from the provided page. A product synced to several feeds
+		// (markets, and languages with WPML) has one Merchant Center entry per feed,
+		// and those entries can land on different list pages; the countries seen by
+		// the pages processed before this one are folded back in by
+		// merge_issue_countries_from_earlier_pages().
 		$products       = array_intersect_key( $products_by_google_id, $google_id_to_wc_id );
 		$product_issues = [];
 
@@ -642,6 +643,8 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 */
 	protected function refresh_product_issues( array $product_issues ): void {
+		$stale_row_ids = $this->merge_issue_countries_from_earlier_pages( $product_issues );
+
 		// Alphabetize all product/issue country lists.
 		array_walk(
 			$this->product_issue_countries,
@@ -651,10 +654,14 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		);
 
 		// Product issue cleanup: sorting (by product ID) and encode applicable countries.
+		// The countries are de-duplicated: the source repeats them once per reporting
+		// context, and merging earlier pages in would compound that repetition.
 		ksort( $product_issues );
 		$product_issues = array_map(
 			function ( $unique_key, $issue ) {
-				$issue['applicable_countries'] = wp_json_encode( $this->product_issue_countries[ $unique_key ] );
+				$issue['applicable_countries'] = wp_json_encode(
+					array_values( array_unique( $this->product_issue_countries[ $unique_key ] ) )
+				);
 				return $issue;
 			},
 			array_keys( $product_issues ),
@@ -664,6 +671,65 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		/** @var MerchantIssueQuery $issue_query */
 		$issue_query = $this->container->get( MerchantIssueQuery::class );
 		$issue_query->update_or_insert( array_values( $product_issues ) );
+
+		// Deleted only after the merged rows are written: a page interrupted in
+		// between leaves duplicate rows, which the next page or cycle absorbs,
+		// instead of losing the countries collected by earlier pages.
+		if ( ! empty( $stale_row_ids ) ) {
+			$this->container->get( MerchantIssueTable::class )->delete_by_ids( $stale_row_ids );
+		}
+	}
+
+	/**
+	 * Fold in the product issue rows written by the pages processed before this one.
+	 *
+	 * One status refresh spans several list pages, each processed in its own
+	 * scheduled action, and a product synced to several feeds (markets, and
+	 * languages with WPML) can have its Merchant Center entries spread over
+	 * several of those pages. Each page only sees the item-level issues of its
+	 * own entries, so the rows written so far carry the applicable countries of
+	 * earlier pages. Merging them into this page's countries, and replacing them
+	 * because the table has no unique key an upsert could update through, leaves
+	 * one row per product and issue whose country list is the union across all
+	 * of the product's entries, the same result a single-page refresh produces.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $product_issues Product issue rows about to be written, keyed by product ID and hashed issue text.
+	 *
+	 * @return int[] IDs of the folded-in rows, for deletion once the merged rows are written.
+	 * @throws NotFoundExceptionInterface  If the class is not found in the container.
+	 * @throws ContainerExceptionInterface If the container throws an exception.
+	 */
+	protected function merge_issue_countries_from_earlier_pages( array $product_issues ): array {
+		if ( empty( $product_issues ) ) {
+			return [];
+		}
+
+		/** @var MerchantIssueQuery $issue_query */
+		$issue_query = $this->container->get( MerchantIssueQuery::class );
+		$issue_query->where( 'product_id', array_unique( array_column( $product_issues, 'product_id' ) ), 'IN' );
+		$issue_query->where( 'source', 'mc' );
+		$issue_query->where( 'type', self::TYPE_PRODUCT );
+
+		$stale_row_ids = [];
+		foreach ( $issue_query->get_results() as $row ) {
+			$unique_key = $row['product_id'] . '__' . md5( $row['issue'] );
+			if ( ! isset( $product_issues[ $unique_key ] ) ) {
+				continue;
+			}
+
+			$stale_row_ids[] = (int) $row['id'];
+
+			$stored_countries = json_decode( $row['applicable_countries'], true );
+
+			$this->product_issue_countries[ $unique_key ] = array_merge(
+				$this->product_issue_countries[ $unique_key ] ?? [],
+				is_array( $stored_countries ) ? $stored_countries : []
+			);
+		}
+
+		return $stale_row_ids;
 	}
 
 	/**
@@ -789,7 +855,14 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 */
 	public function process_product_statuses( array $product_view_statuses, array $products_by_google_id = [] ): void {
-		$this->mc_statuses         = [];
+		$this->mc_statuses = [];
+		// This service is a shared singleton, so in a long-lived process the map
+		// still holds the countries of previously processed pages, or of an earlier
+		// refresh cycle entirely. Earlier pages of the current cycle are re-supplied
+		// from their rows by merge_issue_countries_from_earlier_pages(); anything
+		// older would pollute the new rows, so each page starts from an empty map.
+		$this->product_issue_countries = [];
+
 		$product_repository        = $this->container->get( ProductRepository::class );
 		$this->product_data_lookup = $product_repository->find_by_ids_as_associative_array( array_column( $product_view_statuses, 'product_id' ) );
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -653,9 +653,10 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 			}
 		);
 
-		// Product issue cleanup: sorting (by product ID) and encode applicable countries.
-		// The countries are de-duplicated: the source repeats them once per reporting
-		// context, and merging earlier pages in would compound that repetition.
+		// Product issue cleanup: sort by unique key for a deterministic write order
+		// and encode applicable countries. The countries are de-duplicated: the source
+		// repeats them once per reporting context, and merging earlier pages in would
+		// compound that repetition.
 		ksort( $product_issues );
 		$product_issues = array_map(
 			function ( $unique_key, $issue ) {

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -4,7 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\ProductMetaQueryHelper;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\MerchantIssueQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Table\MerchantIssueTable;
@@ -385,16 +385,15 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * Get MC product issues from a list of Product View statuses.
 	 *
 	 * @param array $statuses The list of Product View statuses.
+	 * @param array $products_by_google_id Merchant API products keyed by product id; issues are read from these, so no request is made here.
 	 * @throws NotFoundExceptionInterface  If the class is not found in the container.
 	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 *
 	 * @return array The list of product issues.
 	 */
-	protected function get_product_issues( array $statuses ): array {
+	protected function get_product_issues( array $statuses, array $products_by_google_id = [] ): array {
 		/** @var ProductHelper $product_helper */
 		$product_helper = $this->container->get( ProductHelper::class );
-		/** @var MapiProductsService $mapi_products */
-		$mapi_products = $this->container->get( MapiProductsService::class );
 		/** @var BatchProductHelper $batch_product_helper */
 		$batch_product_helper = $this->container->get( BatchProductHelper::class );
 		$visibility_meta_key  = $this->prefix_meta_key( ProductMetaHandler::KEY_VISIBILITY );
@@ -432,7 +431,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		}
 
 		$created_at     = $this->cache_created_time->format( 'Y-m-d H:i:s' );
-		$products       = $mapi_products->get_many( array_keys( $google_id_to_wc_id ) );
+		$products       = array_intersect_key( $products_by_google_id, $google_id_to_wc_id );
 		$product_issues = [];
 
 		foreach ( $products as $google_id => $product ) {
@@ -721,15 +720,65 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	}
 
 	/**
+	 * Convert one page of Merchant API products into product view statuses and process them.
+	 *
+	 * Replaces the product_view report as the driver of the status refresh: the aggregated
+	 * status is derived from each product's destination statuses, and the same page of
+	 * products doubles as the item-level issue source, so no further request is needed.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param Product[] $products One page of Merchant API products.
+	 */
+	public function process_mapi_products( array $products ): void {
+		$product_helper        = $this->container->get( ProductHelper::class );
+		$statuses              = [];
+		$products_by_google_id = [];
+
+		foreach ( $products as $product ) {
+			$product_status = $product->get_product_status();
+			$aggregated     = $product_status ? $product_status->get_aggregated_reporting_context_status() : '';
+
+			// No destination statuses yet: the product is still processing, and the
+			// product_view report would not return it either. Skip it for parity.
+			if ( '' === $aggregated ) {
+				continue;
+			}
+
+			$wc_product_id = $product_helper->get_wc_product_id( $product->get_id() );
+			if ( ! $wc_product_id ) {
+				continue;
+			}
+
+			$expiration_date = null;
+			if ( $product_status->get_google_expiration_date() ) {
+				$expiration_date = new DateTime( $product_status->get_google_expiration_date() );
+			}
+
+			$statuses[ $wc_product_id ] = [
+				'mc_id'           => $product->get_id(),
+				'product_id'      => $wc_product_id,
+				'status'          => MCStatus::from_aggregated_reporting_context_status( $aggregated ),
+				'expiration_date' => $expiration_date,
+			];
+
+			$products_by_google_id[ $product->get_id() ] = $product;
+		}
+
+		$this->process_product_statuses( $statuses, $products_by_google_id );
+	}
+
+	/**
 	 * Process product status statistics.
 	 *
 	 * @param array $product_view_statuses Product View statuses.
-	 * @see MerchantReport::get_product_view_report
+	 * @param array $products_by_google_id Merchant API products keyed by product id, the source of item-level issues.
+	 * @see UpdateMerchantProductStatuses::process_items
 	 *
 	 * @throws NotFoundExceptionInterface  If the class is not found in the container.
 	 * @throws ContainerExceptionInterface If the container throws an exception.
 	 */
-	public function process_product_statuses( array $product_view_statuses ): void {
+	public function process_product_statuses( array $product_view_statuses, array $products_by_google_id = [] ): void {
 		$this->mc_statuses         = [];
 		$product_repository        = $this->container->get( ProductRepository::class );
 		$this->product_data_lookup = $product_repository->find_by_ids_as_associative_array( array_column( $product_view_statuses, 'product_id' ) );
@@ -779,7 +828,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 		$this->update_products_meta_with_mc_status();
 		$this->update_intermediate_product_statistics();
 
-		$product_issues = $this->get_product_issues( $product_view_statuses );
+		$product_issues = $this->get_product_issues( $product_view_statuses, $products_by_google_id );
 		$this->refresh_product_issues( $product_issues );
 	}
 

--- a/src/MerchantCenter/MerchantStatuses.php
+++ b/src/MerchantCenter/MerchantStatuses.php
@@ -694,7 +694,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * one row per product and issue whose country list is the union across all
 	 * of the product's entries, the same result a single-page refresh produces.
 	 *
-	 * @since x.x.x
+	 * @since 3.9.3
 	 *
 	 * @param array $product_issues Product issue rows about to be written, keyed by product ID and hashed issue text.
 	 *
@@ -797,7 +797,7 @@ class MerchantStatuses implements Service, ContainerAwareInterface, OptionsAware
 	 * status is derived from each product's destination statuses, and the same page of
 	 * products doubles as the item-level issue source, so no further request is needed.
 	 *
-	 * @since x.x.x
+	 * @since 3.9.3
 	 *
 	 * @param Product[] $products One page of Merchant API products.
 	 */

--- a/src/Notes/ReconnectWordPress.php
+++ b/src/Notes/ReconnectWordPress.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
 use Automattic\WooCommerce\GoogleListingsAndAds\HelperTraits\Utilities;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
 
 defined( 'ABSPATH' ) || exit;
@@ -77,6 +78,7 @@ class ReconnectWordPress extends AbstractNote implements MerchantCenterAwareInte
 	/**
 	 * Checks if a note can and should be added.
 	 *
+	 * - Checks if the WordPress.com connection has no owner (syncing is paused).
 	 * - Triggers a status check if not already disconnected.
 	 * - Checks if Jetpack is disconnected.
 	 *
@@ -85,6 +87,16 @@ class ReconnectWordPress extends AbstractNote implements MerchantCenterAwareInte
 	public function should_be_added(): bool {
 		if ( $this->has_been_added() || ! $this->merchant_center->is_setup_complete() ) {
 			return false;
+		}
+
+		// A missing owner is known locally, so the note is added without a request to the server.
+		// The connected option is cleared as well, so the note follows the same lifecycle as after
+		// a rejected token: no second copy on the next 401, and removal when an accepted response
+		// flips the state back to connected.
+		if ( ! $this->merchant_center->is_jetpack_owner_connected() ) {
+			$this->options->update( OptionsInterface::JETPACK_CONNECTED, false );
+
+			return true;
 		}
 
 		$this->maybe_check_status();

--- a/src/Notes/ReconnectWordPress.php
+++ b/src/Notes/ReconnectWordPress.php
@@ -95,7 +95,10 @@ class ReconnectWordPress extends AbstractNote implements MerchantCenterAwareInte
 		// a rejected token: no second copy on the next 401, and removal when an accepted response
 		// flips the state back to connected.
 		if ( ! $this->merchant_center->is_jetpack_owner_connected() ) {
-			$this->options->update( OptionsInterface::JETPACK_CONNECTED, false );
+			// Guard the write like set_jetpack_connected() does, so a daily no-owner run is a no-op.
+			if ( false !== boolval( $this->options->get( OptionsInterface::JETPACK_CONNECTED ) ) ) {
+				$this->options->update( OptionsInterface::JETPACK_CONNECTED, false );
+			}
 
 			return true;
 		}

--- a/src/Notes/ReconnectWordPress.php
+++ b/src/Notes/ReconnectWordPress.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwa
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterAwareTrait;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
 use Automattic\WooCommerce\GoogleListingsAndAds\PluginHelper;
+use Exception;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -101,7 +102,8 @@ class ReconnectWordPress extends AbstractNote implements MerchantCenterAwareInte
 
 		$this->maybe_check_status();
 
-		return ! $this->is_jetpack_connected();
+		// The status check itself may have added the note through the 401 handling.
+		return ! $this->is_jetpack_connected() && ! $this->has_been_added();
 	}
 
 	/**
@@ -116,7 +118,7 @@ class ReconnectWordPress extends AbstractNote implements MerchantCenterAwareInte
 		try {
 			$this->connection->get_status();
 		} catch ( Exception $e ) {
-			return;
+			do_action( 'woocommerce_gla_exception', $e, __METHOD__ );
 		}
 	}
 }

--- a/src/Options/OptionsInterface.php
+++ b/src/Options/OptionsInterface.php
@@ -35,6 +35,7 @@ interface OptionsInterface {
 	public const INSTALL_TIMESTAMP                         = 'install_timestamp';
 	public const INSTALL_VERSION                           = 'install_version';
 	public const JETPACK_CONNECTED                         = 'jetpack_connected';
+	public const JETPACK_AUTH_FAILED_AT                    = 'jetpack_auth_failed_at';
 	public const MAPI_DATA_SOURCES                         = 'mapi_data_sources';
 	public const MC_SETUP_COMPLETED_AT                     = 'mc_setup_completed_at';
 	public const MERCHANT_ACCOUNT_STATE                    = 'merchant_account_state';
@@ -85,6 +86,7 @@ interface OptionsInterface {
 		self::INSTALL_TIMESTAMP                         => true,
 		self::INSTALL_VERSION                           => true,
 		self::JETPACK_CONNECTED                         => true,
+		self::JETPACK_AUTH_FAILED_AT                    => true,
 		self::MAPI_DATA_SOURCES                         => true,
 		self::MC_SETUP_COMPLETED_AT                     => true,
 		self::MERCHANT_ACCOUNT_STATE                    => true,

--- a/src/Product/BatchProductHelper.php
+++ b/src/Product/BatchProductHelper.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiExcep
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\GoogleListingsAndAdsException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\ValidateInterface;
@@ -255,6 +256,8 @@ class BatchProductHelper implements Service {
 	 * @param WC_Product[] $products
 	 *
 	 * @return array<int, array{product: WC_Product, country: string, input: ProductInput, hash: string}>
+	 *
+	 * @throws AccountReconnect When the Connect Server rejects the Jetpack token while resolving a data source.
 	 */
 	public function generate_mapi_update_entries( array $products ): array {
 		$entries       = [];
@@ -390,6 +393,11 @@ class BatchProductHelper implements Service {
 				if ( ! empty( $product_entries ) ) {
 					array_push( $entries, ...$product_entries );
 				}
+			} catch ( AccountReconnect $exception ) {
+				// An authentication failure is account-wide, not specific to this product. Rethrow to
+				// fail the run loudly instead of silently skipping every product and re-attempting it
+				// against the same rejected token.
+				throw $exception;
 			} catch ( GoogleListingsAndAdsException $exception ) {
 				do_action(
 					'woocommerce_gla_error',

--- a/src/Product/ProductSyncer.php
+++ b/src/Product/ProductSyncer.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Product;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiException;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\ConnectException;
 use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Exception\RequestException;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
@@ -101,7 +102,13 @@ class ProductSyncer implements Service {
 	public function update( array $products ): BatchProductResponse {
 		$this->validate_merchant_center_setup();
 
-		$entries = $this->batch_helper->generate_mapi_update_entries( $products );
+		try {
+			$entries = $this->batch_helper->generate_mapi_update_entries( $products );
+		} catch ( AccountReconnect $exception ) {
+			// Surface an account-wide auth failure as a ProductSyncerException, like the other sync
+			// paths, so update()'s contract holds and callers catching that type still handle it.
+			throw new ProductSyncerException( $exception->getMessage(), 0, $exception );
+		}
 
 		return $this->update_mapi_entries( $entries );
 	}

--- a/src/Value/MCStatus.php
+++ b/src/Value/MCStatus.php
@@ -65,4 +65,30 @@ class MCStatus implements ValueInterface {
 	public function __toString(): string {
 		return $this->get();
 	}
+
+	/**
+	 * Map a Merchant API aggregated reporting context status (as returned by the
+	 * product_view report, or derived from a product's destination statuses) to
+	 * the plugin's MC status vocabulary.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $status Aggregated reporting context status, e.g. 'ELIGIBLE'.
+	 *
+	 * @return string One of the MCStatus constants.
+	 */
+	public static function from_aggregated_reporting_context_status( string $status ): string {
+		switch ( $status ) {
+			case 'ELIGIBLE':
+				return self::APPROVED;
+			case 'ELIGIBLE_LIMITED':
+				return self::PARTIALLY_APPROVED;
+			case 'NOT_ELIGIBLE_OR_DISAPPROVED':
+				return self::DISAPPROVED;
+			case 'PENDING':
+				return self::PENDING;
+			default:
+				return self::NOT_SYNCED;
+		}
+	}
 }

--- a/src/Value/MCStatus.php
+++ b/src/Value/MCStatus.php
@@ -71,7 +71,7 @@ class MCStatus implements ValueInterface {
 	 * product_view report, or derived from a product's destination statuses) to
 	 * the plugin's MC status vocabulary.
 	 *
-	 * @since x.x.x
+	 * @since 3.9.3
 	 *
 	 * @param string $status Aggregated reporting context status, e.g. 'ELIGIBLE'.
 	 *

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -134,6 +134,18 @@ class ClientTest extends UnitTest {
 	}
 
 	/**
+	 * Confirm that an accepted response does not rewrite an unchanged connected state.
+	 */
+	public function test_handle_response_status_regular_response_skips_unchanged_state() {
+		$this->options->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( true );
+		$this->options->expects( $this->never() )->method( 'update' );
+		$this->note->expects( $this->never() )->method( 'delete' );
+
+		$client = $this->mock_client_with_handler( 'handle_response_status', [ new Response( 200, [], 'response' ) ] );
+		$client->request( 'GET', 'https://testing.local' );
+	}
+
+	/**
 	 * Confirm that once the Jetpack token was rejected in this request, later requests are not sent.
 	 */
 	public function test_short_circuit_after_auth_failure_rejects_without_sending() {

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -105,14 +105,14 @@ class ClientTest extends UnitTest {
 	}
 
 	/**
-	 * Confirm that the error handler does not intervene for regular responses.
+	 * Confirm that the response status handler does not intervene for regular responses.
 	 */
-	public function test_error_handler_regular_response() {
+	public function test_handle_response_status_regular_response() {
 		$mocked_responses = [
 			new Response( 200, [], 'response' ),
 		];
 
-		$client   = $this->mock_client_with_handler( 'error_handler', $mocked_responses );
+		$client   = $this->mock_client_with_handler( 'handle_response_status', $mocked_responses );
 		$response = $client->request( 'GET', 'https://testing.local' );
 
 		$this->assertEquals( 200, $response->getStatusCode() );
@@ -122,14 +122,14 @@ class ClientTest extends UnitTest {
 	/**
 	 * Confirm that an accepted response is what marks Jetpack as connected and ends a sync pause.
 	 */
-	public function test_error_handler_regular_response_marks_jetpack_connected() {
+	public function test_handle_response_status_regular_response_marks_jetpack_connected() {
 		// Set Jetpack as previously disconnected to trigger removal of note.
 		$this->options->expects( $this->once() )->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( false );
 		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::JETPACK_CONNECTED, true );
 		$this->note->expects( $this->once() )->method( 'delete' );
 		$this->circuit_breaker->expects( $this->once() )->method( 'reset' );
 
-		$client = $this->mock_client_with_handler( 'error_handler', [ new Response( 200, [], 'response' ) ] );
+		$client = $this->mock_client_with_handler( 'handle_response_status', [ new Response( 200, [], 'response' ) ] );
 		$client->request( 'GET', 'https://testing.local' );
 	}
 
@@ -195,10 +195,10 @@ class ClientTest extends UnitTest {
 		$client->request( 'GET', 'https://testing.local' );
 	}
 
-	public function test_retry_runs_before_the_error_handler_on_the_full_stack() {
-		// Real stack order: error_handler pushed first (outermost), retry last (innermost). This
+	public function test_retry_runs_before_the_response_status_handler_on_the_full_stack() {
+		// Real stack order: handle_response_status pushed first (outermost), retry last (innermost). This
 		// POST is one is_retryable_request() rejects, so a 429 can only retry via the response
-		// branch, proving retry sees the response before error_handler throws.
+		// branch, proving retry sees the response before handle_response_status throws.
 		$handler_stack = HandlerStack::create(
 			new MockHandler(
 				[
@@ -208,7 +208,7 @@ class ClientTest extends UnitTest {
 			)
 		);
 		$handler_stack->remove( 'http_errors' );
-		$handler_stack->push( $this->invoke_handler( 'error_handler' ), 'http_errors' );
+		$handler_stack->push( $this->invoke_handler( 'handle_response_status' ), 'http_errors' );
 		$handler_stack->push( $this->invoke_handler( 'retry_on_transient_error' ), 'retry_on_transient_error' );
 
 		$response = ( new Client( [ 'handler' => $handler_stack ] ) )
@@ -324,9 +324,9 @@ class ClientTest extends UnitTest {
 	}
 
 	/**
-	 * Confirm that the error handler throws an error to reconnect Jetpack when the header is not included.
+	 * Confirm that the response status handler throws an error to reconnect Jetpack when the header is not included.
 	 */
-	public function test_error_handler_reconnect_jetpack() {
+	public function test_handle_response_status_reconnect_jetpack() {
 		$mocked_responses = [
 			new Response( 401, [ 'www-authenticate' => 'X_JP_Auth' ], 'error' ),
 		];
@@ -346,14 +346,14 @@ class ClientTest extends UnitTest {
 		$this->expectException( AccountReconnect::class );
 		$this->expectExceptionMessage( AccountReconnect::jetpack_disconnected()->getMessage() );
 
-		$client   = $this->mock_client_with_handler( 'error_handler', $mocked_responses );
+		$client   = $this->mock_client_with_handler( 'handle_response_status', $mocked_responses );
 		$response = $client->request( 'GET', 'https://testing.local' );
 	}
 
 	/**
-	 * Confirm that the error handler throws an error to reconnect Google with a permission denied status.
+	 * Confirm that the response status handler throws an error to reconnect Google with a permission denied status.
 	 */
-	public function test_error_handler_reconnect_google() {
+	public function test_handle_response_status_reconnect_google() {
 		$mocked_responses = [
 			new Response( 401, [], 'error' ),
 		];
@@ -364,14 +364,14 @@ class ClientTest extends UnitTest {
 		$this->expectException( AccountReconnect::class );
 		$this->expectExceptionMessage( AccountReconnect::google_disconnected()->getMessage() );
 
-		$client   = $this->mock_client_with_handler( 'error_handler', $mocked_responses );
+		$client   = $this->mock_client_with_handler( 'handle_response_status', $mocked_responses );
 		$response = $client->request( 'GET', 'https://testing.local' );
 	}
 
 	/**
 	 * Confirm that a request to listAccessibleCustomers does not return a redirect error.
 	 */
-	public function test_error_handler_list_accessible_customers() {
+	public function test_handle_response_status_list_accessible_customers() {
 		$mocked_responses = [
 			new Response( 401, [], 'error' ),
 		];
@@ -379,14 +379,14 @@ class ClientTest extends UnitTest {
 		$this->expectException( RequestException::class );
 		$this->expectExceptionMessage( 'error' );
 
-		$client   = $this->mock_client_with_handler( 'error_handler', $mocked_responses );
+		$client   = $this->mock_client_with_handler( 'handle_response_status', $mocked_responses );
 		$response = $client->request( 'GET', 'https://testing.local/google/google-ads/customers:listAccessibleCustomers' );
 	}
 
 	/**
-	 * Confirm that the error handler throws a generic error when the status code is higher than 400 except a 401.
+	 * Confirm that the response status handler throws a generic error when the status code is higher than 400 except a 401.
 	 */
-	public function test_error_handler_generic_error_response() {
+	public function test_handle_response_status_generic_error_response() {
 		$mocked_responses = [
 			new Response( 404, [], 'not found' ),
 		];
@@ -394,7 +394,7 @@ class ClientTest extends UnitTest {
 		$this->expectException( RequestException::class );
 		$this->expectExceptionMessage( 'not found' );
 
-		$client   = $this->mock_client_with_handler( 'error_handler', $mocked_responses );
+		$client   = $this->mock_client_with_handler( 'handle_response_status', $mocked_responses );
 		$response = $client->request( 'GET', 'https://testing.local' );
 	}
 

--- a/tests/Unit/API/ClientTest.php
+++ b/tests/Unit/API/ClientTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API;
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Connection\Tokens;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\JetpackAuthCircuitBreaker;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\Ads\GoogleAdsClient;
 use Automattic\WooCommerce\GoogleListingsAndAds\Internal\DependencyManagement\GoogleServiceProvider;
@@ -32,6 +33,9 @@ defined( 'ABSPATH' ) || exit;
 class ClientTest extends UnitTest {
 	use PluginHelper;
 
+	/** @var MockObject|JetpackAuthCircuitBreaker $circuit_breaker */
+	protected $circuit_breaker;
+
 	/** @var MockObject|Manager $manager */
 	protected $manager;
 
@@ -57,11 +61,13 @@ class ClientTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->manager = $this->createMock( Manager::class );
-		$this->note    = $this->createMock( ReconnectWordPress::class );
-		$this->options = $this->createMock( OptionsInterface::class );
+		$this->circuit_breaker = $this->createMock( JetpackAuthCircuitBreaker::class );
+		$this->manager         = $this->createMock( Manager::class );
+		$this->note            = $this->createMock( ReconnectWordPress::class );
+		$this->options         = $this->createMock( OptionsInterface::class );
 
 		$this->container = new Container();
+		$this->container->addShared( JetpackAuthCircuitBreaker::class, $this->circuit_breaker );
 		$this->container->addShared( Manager::class, $this->manager );
 		$this->container->addShared( ReconnectWordPress::class, $this->note );
 		$this->container->addShared( OptionsInterface::class, $this->options );
@@ -80,6 +86,7 @@ class ClientTest extends UnitTest {
 		// Get string representation of the handler stack (fetches handlers from main container).
 		$handlers = (string) woogle_get_container()->get( Client::class )->getConfig( 'handler' );
 
+		$this->assertStringContainsString( 'auth_failure_short_circuit', $handlers );
 		$this->assertStringContainsString( 'http_errors', $handlers );
 		$this->assertStringContainsString( 'auth_header', $handlers );
 		$this->assertStringContainsString( 'plugin_version_header', $handlers );
@@ -110,6 +117,54 @@ class ClientTest extends UnitTest {
 
 		$this->assertEquals( 200, $response->getStatusCode() );
 		$this->assertEquals( 'response', $response->getBody() );
+	}
+
+	/**
+	 * Confirm that an accepted response is what marks Jetpack as connected and ends a sync pause.
+	 */
+	public function test_error_handler_regular_response_marks_jetpack_connected() {
+		// Set Jetpack as previously disconnected to trigger removal of note.
+		$this->options->expects( $this->once() )->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( false );
+		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::JETPACK_CONNECTED, true );
+		$this->note->expects( $this->once() )->method( 'delete' );
+		$this->circuit_breaker->expects( $this->once() )->method( 'reset' );
+
+		$client = $this->mock_client_with_handler( 'error_handler', [ new Response( 200, [], 'response' ) ] );
+		$client->request( 'GET', 'https://testing.local' );
+	}
+
+	/**
+	 * Confirm that once the Jetpack token was rejected in this request, later requests are not sent.
+	 */
+	public function test_short_circuit_after_auth_failure_rejects_without_sending() {
+		$this->circuit_breaker->method( 'was_tripped_in_request' )->willReturn( true );
+
+		$mock     = new MockHandler( [ new Response( 200, [], 'never sent' ) ] );
+		$handlers = HandlerStack::create( $mock );
+		$handlers->push( $this->invoke_handler( 'short_circuit_after_auth_failure' ) );
+		$client = new Client( [ 'handler' => $handlers ] );
+
+		try {
+			$client->request( 'GET', 'https://testing.local' );
+			$this->fail( 'Expected AccountReconnect to be thrown.' );
+		} catch ( AccountReconnect $exception ) {
+			$this->assertEquals( AccountReconnect::jetpack_disconnected()->getMessage(), $exception->getMessage() );
+		}
+
+		// The mocked response is still queued: nothing reached the transport.
+		$this->assertSame( 1, $mock->count() );
+	}
+
+	/**
+	 * Confirm that the short circuit is transparent while no failure was recorded.
+	 */
+	public function test_short_circuit_after_auth_failure_passes_requests_through() {
+		$this->circuit_breaker->method( 'was_tripped_in_request' )->willReturn( false );
+
+		$client   = $this->mock_client_with_handler( 'short_circuit_after_auth_failure', [ new Response( 200, [], 'sent' ) ] );
+		$response = $client->request( 'GET', 'https://testing.local' );
+
+		$this->assertEquals( 'sent', $response->getBody() );
 	}
 
 	public function test_retry_on_transient_error_retries_transient_status() {
@@ -285,6 +340,9 @@ class ClientTest extends UnitTest {
 		// Expect ReconnectWordPress note to be triggered.
 		$this->note->expects( $this->once() )->method( 'get_entry' );
 
+		// Expect syncing to be paused.
+		$this->circuit_breaker->expects( $this->once() )->method( 'trip' );
+
 		$this->expectException( AccountReconnect::class );
 		$this->expectExceptionMessage( AccountReconnect::jetpack_disconnected()->getMessage() );
 
@@ -356,11 +414,9 @@ class ClientTest extends UnitTest {
 		);
 		$this->manager->expects( $this->once() )->method( 'get_tokens' )->willReturn( $tokens );
 
-		// Set Jetpack as previously disconnected to trigger removal of note.
-		$this->options->expects( $this->once() )->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( false );
-
-		// Expect ReconnectWordPress note to be removed.
-		$this->note->expects( $this->once() )->method( 'delete' );
+		// Having a token locally proves nothing about its validity: the connected state is left alone.
+		$this->options->expects( $this->never() )->method( 'update' );
+		$this->note->expects( $this->never() )->method( 'delete' );
 
 		$this->invoke_handler( 'add_auth_header' )(
 			function ( $request, $options ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed

--- a/tests/Unit/API/Google/JetpackAuthCircuitBreakerTest.php
+++ b/tests/Unit/API/Google/JetpackAuthCircuitBreakerTest.php
@@ -1,0 +1,111 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\JetpackAuthCircuitBreaker;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class JetpackAuthCircuitBreakerTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google
+ */
+class JetpackAuthCircuitBreakerTest extends UnitTest {
+
+	/** @var MockObject|OptionsInterface $options */
+	protected $options;
+
+	/** @var JetpackAuthCircuitBreaker $breaker */
+	protected $breaker;
+
+	/**
+	 * Runs before each test is executed.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->breaker = new JetpackAuthCircuitBreaker();
+		$this->breaker->set_options_object( $this->options );
+	}
+
+	public function test_trip_records_the_failure_and_short_circuits_the_request() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT, 0 )
+			->willReturn( 0 );
+		$this->options->expects( $this->once() )
+			->method( 'update' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT, $this->greaterThan( 0 ) );
+
+		$this->assertFalse( $this->breaker->was_tripped_in_request() );
+
+		$this->breaker->trip();
+
+		$this->assertTrue( $this->breaker->was_tripped_in_request() );
+	}
+
+	public function test_trip_does_not_extend_an_open_window() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT, 0 )
+			->willReturn( time() - 60 );
+		$this->options->expects( $this->never() )->method( 'update' );
+
+		$this->breaker->trip();
+
+		$this->assertTrue( $this->breaker->was_tripped_in_request() );
+	}
+
+	public function test_is_open_within_the_pause_window() {
+		$failed_at = time() - 60;
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT, 0 )
+			->willReturn( $failed_at );
+
+		$this->assertTrue( $this->breaker->is_open() );
+		$this->assertSame( $failed_at + HOUR_IN_SECONDS, $this->breaker->get_retry_time() );
+	}
+
+	public function test_is_not_open_after_the_pause_window() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT, 0 )
+			->willReturn( time() - HOUR_IN_SECONDS - 1 );
+
+		$this->assertFalse( $this->breaker->is_open() );
+	}
+
+	public function test_is_not_open_without_a_recorded_failure() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT, 0 )
+			->willReturn( 0 );
+
+		$this->assertFalse( $this->breaker->is_open() );
+		$this->assertSame( 0, $this->breaker->get_retry_time() );
+	}
+
+	public function test_reset_clears_the_failure() {
+		$this->options->method( 'get' )
+			->willReturn( time() );
+		$this->options->expects( $this->once() )
+			->method( 'delete' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT );
+
+		$this->breaker->trip();
+		$this->breaker->reset();
+
+		$this->assertFalse( $this->breaker->was_tripped_in_request() );
+	}
+
+	public function test_reset_without_a_failure_does_not_write() {
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_AUTH_FAILED_AT )
+			->willReturn( null );
+		$this->options->expects( $this->never() )->method( 'delete' );
+
+		$this->breaker->reset();
+	}
+}

--- a/tests/Unit/API/Google/Mapi/Models/ProductStatusTest.php
+++ b/tests/Unit/API/Google/Mapi/Models/ProductStatusTest.php
@@ -50,5 +50,143 @@ class ProductStatusTest extends UnitTest {
 		$this->assertSame( [], $status->get_item_level_issues() );
 		$this->assertSame( [], $status->get_destination_statuses() );
 		$this->assertNull( $status->get_last_update_date() );
+		$this->assertNull( $status->get_google_expiration_date() );
+	}
+
+	public function test_from_array_populates_google_expiration_date() {
+		$status = ProductStatus::from_array( [ 'googleExpirationDate' => '2026-10-02T16:35:10.725858Z' ] );
+
+		$this->assertSame( '2026-10-02T16:35:10.725858Z', $status->get_google_expiration_date() );
+	}
+
+	/**
+	 * @dataProvider aggregated_status_provider
+	 *
+	 * @param array  $destination_statuses
+	 * @param string $expected
+	 */
+	public function test_get_aggregated_reporting_context_status( array $destination_statuses, string $expected ) {
+		$status = ProductStatus::from_array( [ 'destinationStatuses' => $destination_statuses ] );
+
+		$this->assertSame( $expected, $status->get_aggregated_reporting_context_status() );
+	}
+
+	/**
+	 * Matrix following the official enum semantics.
+	 *
+	 * @return array
+	 */
+	public function aggregated_status_provider(): array {
+		$ads  = 'SHOPPING_ADS';
+		$free = 'FREE_LISTINGS';
+
+		return [
+			'approved everywhere'                        => [
+				[
+					[
+						'reportingContext'  => $ads,
+						'approvedCountries' => [ 'US', 'CA' ],
+					],
+				],
+				'ELIGIBLE',
+			],
+			'approved in all contexts'                   => [
+				[
+					[
+						'reportingContext'  => $ads,
+						'approvedCountries' => [ 'US' ],
+					],
+					[
+						'reportingContext'  => $free,
+						'approvedCountries' => [ 'US' ],
+					],
+				],
+				'ELIGIBLE',
+			],
+			'approved and disapproved mix'               => [
+				[
+					[
+						'reportingContext'     => $ads,
+						'approvedCountries'    => [ 'US' ],
+						'disapprovedCountries' => [ 'CA' ],
+					],
+				],
+				'ELIGIBLE_LIMITED',
+			],
+			'approved in one context, disapproved other' => [
+				[
+					[
+						'reportingContext'  => $ads,
+						'approvedCountries' => [ 'US' ],
+					],
+					[
+						'reportingContext'     => $free,
+						'disapprovedCountries' => [ 'US' ],
+					],
+				],
+				'ELIGIBLE_LIMITED',
+			],
+			'approved and pending mix'                   => [
+				[
+					[
+						'reportingContext'  => $ads,
+						'approvedCountries' => [ 'US' ],
+					],
+					[
+						'reportingContext' => $free,
+						'pendingCountries' => [ 'US' ],
+					],
+				],
+				'ELIGIBLE_LIMITED',
+			],
+			'pending everywhere'                         => [
+				[
+					[
+						'reportingContext' => $ads,
+						'pendingCountries' => [ 'US' ],
+					],
+					[
+						'reportingContext' => $free,
+						'pendingCountries' => [ 'US' ],
+					],
+				],
+				'PENDING',
+			],
+			'disapproved everywhere'                     => [
+				[
+					[
+						'reportingContext'     => $ads,
+						'disapprovedCountries' => [ 'US' ],
+					],
+				],
+				'NOT_ELIGIBLE_OR_DISAPPROVED',
+			],
+			'pending and disapproved, no approval'       => [
+				[
+					[
+						'reportingContext'     => $ads,
+						'disapprovedCountries' => [ 'US' ],
+					],
+					[
+						'reportingContext' => $free,
+						'pendingCountries' => [ 'US' ],
+					],
+				],
+				'NOT_ELIGIBLE_OR_DISAPPROVED',
+			],
+			'no destination statuses (still processing)' => [
+				[],
+				'',
+			],
+			'contexts with empty country lists'          => [
+				[
+					[
+						'reportingContext'  => $ads,
+						'approvedCountries' => [],
+					],
+				],
+				'',
+			],
+		];
 	}
 }

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductInputsServiceTest.php
@@ -295,6 +295,13 @@ class MapiProductInputsServiceTest extends UnitTest {
 		$this->assertSame( 503, $result['failures'][0]->get_http_status() );
 	}
 
+	public function test_default_batch_size_is_100() {
+		$method = new \ReflectionMethod( MapiProductInputsService::class, 'get_batch_size' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 100, $method->invoke( $this->service ) );
+	}
+
 	public function test_insert_many_chunks_into_multiple_batches_and_keys_by_original_index() {
 		add_filter(
 			'woocommerce_gla_mapi_batch_size',

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
@@ -180,6 +180,26 @@ class MapiProductsServiceTest extends UnitTest {
 		$this->assertSame( 'tok/2', $page['next_page_token'] );
 	}
 
+	public function test_list_page_clamps_page_size_to_api_bounds() {
+		$matcher = $this->exactly( 2 );
+		$this->client->expects( $matcher )
+			->method( 'get' )
+			->willReturnCallback(
+				function ( string $path ) use ( $matcher ) {
+					if ( 1 === $matcher->getInvocationCount() ) {
+						$this->assertStringContainsString( 'pageSize=1000', $path );
+					} else {
+						$this->assertStringContainsString( 'pageSize=1', $path );
+					}
+
+					return [ 'products' => [] ];
+				}
+			);
+
+		$this->service->list_page( null, 5000 );
+		$this->service->list_page( null, 0 );
+	}
+
 	public function test_list_page_encodes_token_and_ends_pagination() {
 		$this->client->expects( $this->once() )
 			->method( 'get' )

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
@@ -186,10 +186,12 @@ class MapiProductsServiceTest extends UnitTest {
 			->method( 'get' )
 			->willReturnCallback(
 				function ( string $path ) use ( $matcher ) {
+					// The token is null, so pageSize is the final query argument; an
+					// exact suffix match cannot be satisfied by a longer number.
 					if ( 1 === $matcher->getInvocationCount() ) {
-						$this->assertStringContainsString( 'pageSize=1000', $path );
+						$this->assertStringEndsWith( 'pageSize=1000', $path );
 					} else {
-						$this->assertStringContainsString( 'pageSize=1', $path );
+						$this->assertStringEndsWith( 'pageSize=1', $path );
 					}
 
 					return [ 'products' => [] ];

--- a/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
+++ b/tests/Unit/API/Google/Mapi/Services/MapiProductsServiceTest.php
@@ -157,6 +157,41 @@ class MapiProductsServiceTest extends UnitTest {
 		$this->assertSame( $boom, $captured[0][0] );
 	}
 
+	public function test_list_page_requests_first_page_at_default_size_1000() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( 'products/v1/accounts/12345/products?pageSize=1000' )
+			->willReturn(
+				[
+					'products'      => [
+						[
+							'name'    => 'accounts/12345/products/en~US~gla_1',
+							'offerId' => 'gla_1',
+						],
+					],
+					'nextPageToken' => 'tok/2',
+				]
+			);
+
+		$page = $this->service->list_page();
+
+		$this->assertCount( 1, $page['products'] );
+		$this->assertInstanceOf( Product::class, $page['products'][0] );
+		$this->assertSame( 'tok/2', $page['next_page_token'] );
+	}
+
+	public function test_list_page_encodes_token_and_ends_pagination() {
+		$this->client->expects( $this->once() )
+			->method( 'get' )
+			->with( 'products/v1/accounts/12345/products?pageSize=1000&pageToken=tok%2F2' )
+			->willReturn( [ 'products' => [] ] );
+
+		$page = $this->service->list_page( 'tok/2' );
+
+		$this->assertSame( [], $page['products'] );
+		$this->assertNull( $page['next_page_token'] );
+	}
+
 	public function test_list_follows_pagination_and_returns_products() {
 		$this->client->expects( $this->exactly( 2 ) )
 			->method( 'get' )

--- a/tests/Unit/DB/Table/MerchantIssueTableTest.php
+++ b/tests/Unit/DB/Table/MerchantIssueTableTest.php
@@ -66,6 +66,30 @@ class MerchantIssueTableTest extends UnitTest {
 		$this->mock_merchant_issue->delete_specific_product_issues( [ 1 ] );
 	}
 
+	public function test_delete_by_ids_with_empty_array() {
+		$this->wpdb->expects( $this->never() )
+		->method( 'query' );
+
+		$this->mock_merchant_issue->delete_by_ids( [] );
+	}
+
+	public function test_delete_by_ids_deletes_the_given_rows() {
+		$this->mock_merchant_issue->method( 'get_sql_safe_name' )->willReturn( 'wp_gla_merchant_issues' );
+
+		$this->wpdb->method( 'prepare' )
+		->willReturnCallback(
+			function ( $query, $args ) {
+				return vsprintf( str_replace( '%d', '%s', $query ), (array) $args );
+			}
+		);
+
+		$this->wpdb->expects( $this->once() )
+		->method( 'query' )
+		->with( 'DELETE FROM `wp_gla_merchant_issues` WHERE `id` IN (5,8)' );
+
+		$this->mock_merchant_issue->delete_by_ids( [ 5, 8 ] );
+	}
+
 	/**
 	 * Test installing the DB table to ensure there are no errors during install.
 	 */

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -234,7 +234,7 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 
 		$this->mapi_products->expects( $this->once() )
 			->method( 'list_page' )
-			->with( '0', 1000 )
+			->with( '0', 500 )
 			->willReturn(
 				[
 					'products'        => [],

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -184,10 +184,30 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		$this->job->schedule();
 	}
 
-	public function test_page_size_filter_is_applied_and_clamped() {
+	public function test_page_size_filter_is_applied() {
 		$this->merchant_center_service->method( 'is_connected' )->willReturn( true );
 
-		add_filter( 'woocommerce_gla_mapi_products_list_page_size', fn() => 5000 );
+		add_filter( 'woocommerce_gla_product_view_report_page_size', fn() => 250 );
+
+		$this->mapi_products->expects( $this->once() )
+			->method( 'list_page' )
+			->with( null, 250 )
+			->willReturn(
+				[
+					'products'        => [],
+					'next_page_token' => null,
+				]
+			);
+
+		do_action( self::PROCESS_ITEM_HOOK, [] );
+
+		remove_all_filters( 'woocommerce_gla_product_view_report_page_size' );
+	}
+
+	public function test_page_size_filter_is_clamped_to_the_api_maximum() {
+		$this->merchant_center_service->method( 'is_connected' )->willReturn( true );
+
+		add_filter( 'woocommerce_gla_product_view_report_page_size', fn() => 5000 );
 
 		$this->mapi_products->expects( $this->once() )
 			->method( 'list_page' )
@@ -201,7 +221,7 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 
 		do_action( self::PROCESS_ITEM_HOOK, [] );
 
-		remove_all_filters( 'woocommerce_gla_mapi_products_list_page_size' );
+		remove_all_filters( 'woocommerce_gla_product_view_report_page_size' );
 	}
 
 	public function test_update_merchant_product_statuses_when_view_report_throws_error() {

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -224,6 +224,49 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		remove_all_filters( 'woocommerce_gla_product_view_report_page_size' );
 	}
 
+	public function test_a_zero_string_page_token_does_not_restart_the_refresh() {
+		$this->merchant_center_service->method( 'is_connected' )->willReturn( true );
+
+		$this->merchant_statuses->expects( $this->never() )
+			->method( 'clear_product_statuses_cache_and_issues' );
+		$this->merchant_statuses->expects( $this->never() )
+			->method( 'refresh_account_and_presync_issues' );
+
+		$this->mapi_products->expects( $this->once() )
+			->method( 'list_page' )
+			->with( '0', 1000 )
+			->willReturn(
+				[
+					'products'        => [],
+					'next_page_token' => null,
+				]
+			);
+
+		do_action( self::PROCESS_ITEM_HOOK, [ 'next_page_token' => '0' ] );
+	}
+
+	public function test_a_zero_string_page_token_continues_pagination() {
+		$this->merchant_center_service->method( 'is_connected' )->willReturn( true );
+
+		$this->mapi_products->expects( $this->once() )
+			->method( 'list_page' )
+			->willReturn(
+				[
+					'products'        => [],
+					'next_page_token' => '0',
+				]
+			);
+
+		$this->action_scheduler->expects( $this->once() )
+			->method( 'schedule_immediate' )
+			->with( self::PROCESS_ITEM_HOOK, [ [ 'next_page_token' => '0' ] ] );
+
+		$this->merchant_statuses->expects( $this->never() )
+			->method( 'handle_complete_mc_statuses_fetching' );
+
+		do_action( self::PROCESS_ITEM_HOOK, [] );
+	}
+
 	public function test_update_merchant_product_statuses_when_view_report_throws_error() {
 		$this->merchant_center_service->method( 'is_connected' )
 		->willReturn( true );

--- a/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
+++ b/tests/Unit/Jobs/UpdateMerchantProductStatusesTest.php
@@ -8,10 +8,10 @@ use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerI
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateMerchantProductStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\MerchantReport;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\Product;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
 use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Exception;
@@ -33,8 +33,8 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 	/** @var MockObject|MerchantCenterService $merchant_center_service */
 	protected $merchant_center_service;
 
-	/** @var MockObject|MerchantReport $merchant_report */
-	protected $merchant_report;
+	/** @var MockObject|MapiProductsService $mapi_products */
+	protected $mapi_products;
 
 	/** @var MockObject|MerchantStatuses $merchant_statuses */
 	protected $merchant_statuses;
@@ -54,17 +54,33 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		$this->action_scheduler        = $this->createMock( ActionSchedulerInterface::class );
 		$this->monitor                 = $this->createMock( ActionSchedulerJobMonitor::class );
 		$this->merchant_center_service = $this->createMock( MerchantCenterService::class );
-		$this->merchant_report         = $this->createMock( MerchantReport::class );
+		$this->mapi_products           = $this->createMock( MapiProductsService::class );
 		$this->merchant_statuses       = $this->createMock( MerchantStatuses::class );
 		$this->job                     = new UpdateMerchantProductStatuses(
 			$this->action_scheduler,
 			$this->monitor,
 			$this->merchant_center_service,
-			$this->merchant_report,
+			$this->mapi_products,
 			$this->merchant_statuses
 		);
 
 		$this->job->init();
+	}
+
+	/**
+	 * Build a minimal Merchant API product for the given id.
+	 *
+	 * @param string $google_id
+	 *
+	 * @return Product
+	 */
+	protected function make_product( string $google_id ): Product {
+		return Product::from_array(
+			[
+				'name'    => 'accounts/12345/products/' . $google_id,
+				'offerId' => explode( '~', $google_id )[2],
+			]
+		);
 	}
 
 	public function test_update_merchant_product_statuses_not_connected() {
@@ -78,55 +94,44 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		$this->merchant_center_service->method( 'is_connected' )
 			->willReturn( true );
 
+		$pages = [
+			[
+				'products'        => [ $this->make_product( 'en~US~gla_1' ) ],
+				'next_page_token' => 'ABC=',
+			],
+			[
+				'products'        => [ $this->make_product( 'en~US~gla_2' ) ],
+				'next_page_token' => 'DEF=',
+			],
+			[
+				'products'        => [ $this->make_product( 'en~US~gla_3' ) ],
+				'next_page_token' => null,
+			],
+		];
+
 		$matcher = $this->exactly( 3 );
-		$this->merchant_report->expects( $matcher )
-			->method( 'get_product_view_report' )
+		$this->mapi_products->expects( $matcher )
+			->method( 'list_page' )
 			->will(
 				$this->returnCallback(
-					function ( $next_page_token ) use ( $matcher ) {
+					function ( $next_page_token ) use ( $matcher, $pages ) {
 						$invocation_count = $matcher->getInvocationCount();
 
 						if ( $invocation_count === 1 ) {
-
 							$this->assertNull( $next_page_token );
-							return [
-								'statuses'        => [
-									[
-										'product_id' => 1,
-										'status'     => MCStatus::APPROVED,
-									],
-								],
-								'next_page_token' => 'ABC=',
-							];
 						}
-
 						if ( $invocation_count === 2 ) {
 							$this->assertEquals( 'ABC=', $next_page_token );
-							return [
-								'statuses'        => [
-									[
-										'product_id' => 2,
-										'status'     => MCStatus::APPROVED,
-									],
-								],
-								'next_page_token' => 'DEF=',
-							];
 						}
-
 						if ( $invocation_count === 3 ) {
 							$this->assertEquals( 'DEF=', $next_page_token );
-							return [
-								'statuses'        => [
-									[
-										'product_id' => 3,
-										'status'     => MCStatus::APPROVED,
-									],
-								],
-								'next_page_token' => null,
-							];
 						}
 
-						throw new Exception( 'Invalid next page token' );
+						if ( ! isset( $pages[ $invocation_count - 1 ] ) ) {
+							throw new Exception( 'Invalid next page token' );
+						}
+
+						return $pages[ $invocation_count - 1 ];
 					}
 				)
 			);
@@ -158,46 +163,12 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 
 			$matcher = $this->exactly( 3 );
 			$this->merchant_statuses->expects( $matcher )
-				->method( 'process_product_statuses' )
+				->method( 'process_mapi_products' )
 				->willReturnCallback(
-					function ( $statuses ) use ( $matcher ) {
+					function ( $products ) use ( $matcher, $pages ) {
 						$invocation_count = $matcher->getInvocationCount();
 
-						if ( $invocation_count === 1 ) {
-							$this->assertEquals(
-								[
-									[
-										'product_id' => 1,
-										'status'     => MCStatus::APPROVED,
-									],
-								],
-								$statuses
-							);
-						}
-
-						if ( $invocation_count === 2 ) {
-							$this->assertEquals(
-								[
-									[
-										'product_id' => 2,
-										'status'     => MCStatus::APPROVED,
-									],
-								],
-								$statuses
-							);
-						}
-
-						if ( $invocation_count === 3 ) {
-							$this->assertEquals(
-								[
-									[
-										'product_id' => 3,
-										'status'     => MCStatus::APPROVED,
-									],
-								],
-								$statuses
-							);
-						}
+						$this->assertEquals( $pages[ $invocation_count - 1 ]['products'], $products );
 					}
 				);
 
@@ -213,12 +184,32 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		$this->job->schedule();
 	}
 
+	public function test_page_size_filter_is_applied_and_clamped() {
+		$this->merchant_center_service->method( 'is_connected' )->willReturn( true );
+
+		add_filter( 'woocommerce_gla_mapi_products_list_page_size', fn() => 5000 );
+
+		$this->mapi_products->expects( $this->once() )
+			->method( 'list_page' )
+			->with( null, 1000 )
+			->willReturn(
+				[
+					'products'        => [],
+					'next_page_token' => null,
+				]
+			);
+
+		do_action( self::PROCESS_ITEM_HOOK, [] );
+
+		remove_all_filters( 'woocommerce_gla_mapi_products_list_page_size' );
+	}
+
 	public function test_update_merchant_product_statuses_when_view_report_throws_error() {
 		$this->merchant_center_service->method( 'is_connected' )
 		->willReturn( true );
 
-		$this->merchant_report->expects( $this->exactly( 1 ) )
-		->method( 'get_product_view_report' )
+		$this->mapi_products->expects( $this->exactly( 1 ) )
+		->method( 'list_page' )
 		->willThrowException( new Error( 'error' ) );
 
 		$this->merchant_statuses->expects( $this->exactly( 1 ) )
@@ -235,8 +226,8 @@ class UpdateMerchantProductStatusesTest extends UnitTest {
 		$this->merchant_center_service->method( 'is_connected' )
 		->willReturn( true );
 
-		$this->merchant_report->expects( $this->exactly( 1 ) )
-		->method( 'get_product_view_report' )
+		$this->mapi_products->expects( $this->exactly( 1 ) )
+		->method( 'list_page' )
 		->willThrowException( new Exception( 'error' ) );
 
 		$this->merchant_statuses->expects( $this->exactly( 1 ) )

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -3,6 +3,7 @@ declare( strict_types=1 );
 
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
 
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
@@ -47,6 +48,9 @@ class MerchantCenterServiceTest extends UnitTest {
 
 	/** @var MockObject|GoogleHelper $google_helper */
 	protected $google_helper;
+
+	/** @var MockObject|Manager $manager */
+	protected $manager;
 
 	/** @var MockObject|Merchant $merchant */
 	protected $merchant;
@@ -98,6 +102,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->ads_service            = $this->createMock( AdsService::class );
 		$this->contact_information    = $this->createMock( ContactInformation::class );
 		$this->google_helper          = $this->createMock( GoogleHelper::class );
+		$this->manager                = $this->createMock( Manager::class );
 		$this->merchant               = $this->createMock( Merchant::class );
 		$this->merchant_account_state = $this->createMock( MerchantAccountState::class );
 		$this->merchant_statuses      = $this->createMock( MerchantStatuses::class );
@@ -115,6 +120,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->container->addShared( AdsService::class, $this->ads_service );
 		$this->container->addShared( ContactInformation::class, $this->contact_information );
 		$this->container->addShared( GoogleHelper::class, $this->google_helper );
+		$this->container->addShared( Manager::class, $this->manager );
 		$this->container->addShared( Merchant::class, $this->merchant );
 		$this->container->addShared( MerchantAccountState::class, $this->merchant_account_state );
 		$this->container->addShared( MerchantStatuses::class, $this->merchant_statuses );
@@ -129,6 +135,17 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->mc_service = new MerchantCenterService();
 		$this->mc_service->set_container( $this->container );
 		$this->mc_service->set_options_object( $this->options );
+	}
+
+	/**
+	 * Stub the Jetpack connection state.
+	 *
+	 * @param bool $connected Whether the site has a blog token.
+	 * @param bool $has_owner Whether the connection has an owner user.
+	 */
+	protected function mock_jetpack_connection( bool $connected, bool $has_owner ): void {
+		$this->manager->method( 'is_connected' )->willReturn( $connected );
+		$this->manager->method( 'has_connected_owner' )->willReturn( $has_owner );
 	}
 
 	public function test_is_setup_complete() {
@@ -192,6 +209,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_is_ready_for_syncing() {
+		$this->mock_jetpack_connection( true, true );
 		$hash = md5( site_url() );
 		$this->merchant->method( 'get_claimed_url_hash' )->willReturn( $hash );
 		$this->options->method( 'get' )
@@ -208,6 +226,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_is_ready_for_syncing_not_setup() {
+		$this->mock_jetpack_connection( true, true );
 		$hash = md5( site_url() );
 		$this->merchant->method( 'get_claimed_url_hash' )->willReturn( $hash );
 		$this->options->method( 'get' )
@@ -228,6 +247,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_is_ready_for_syncing_filter_override() {
+		$this->mock_jetpack_connection( true, true );
 		$hash = md5( 'https://staging-site.test' );
 		$this->merchant->method( 'get_claimed_url_hash' )->willReturn( $hash );
 		$this->options->method( 'get' )
@@ -246,6 +266,7 @@ class MerchantCenterServiceTest extends UnitTest {
 	}
 
 	public function test_is_ready_for_syncing_fetch_from_transient() {
+		$this->mock_jetpack_connection( true, true );
 		$hash = md5( site_url() );
 		$this->merchant->expects( $this->once() )
 			->method( 'get_claimed_url_hash' )
@@ -281,6 +302,50 @@ class MerchantCenterServiceTest extends UnitTest {
 		// Call twice to ensure we are getting the value from the transient the second time.
 		$this->assertTrue( $this->mc_service->is_ready_for_syncing() );
 		$this->assertTrue( $this->mc_service->is_ready_for_syncing() );
+	}
+
+	public function test_is_ready_for_syncing_without_jetpack_owner() {
+		$this->mock_jetpack_connection( true, false );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::GOOGLE_CONNECTED, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				self::TEST_SETUP_COMPLETED
+			);
+
+		// The claimed URL must not be checked once the owner check fails.
+		$this->merchant->expects( $this->never() )->method( 'get_claimed_url_hash' );
+		$this->transients->expects( $this->never() )->method( 'get' );
+
+		$this->assertFalse( $this->mc_service->is_ready_for_syncing() );
+	}
+
+	public function test_is_ready_for_syncing_without_jetpack_connection() {
+		$this->mock_jetpack_connection( false, false );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::GOOGLE_CONNECTED, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				self::TEST_SETUP_COMPLETED
+			);
+
+		$this->assertFalse( $this->mc_service->is_ready_for_syncing() );
+	}
+
+	public function test_is_jetpack_owner_connected() {
+		$this->mock_jetpack_connection( true, true );
+		$this->assertTrue( $this->mc_service->is_jetpack_owner_connected() );
+	}
+
+	public function test_is_jetpack_owner_connected_without_owner() {
+		$this->mock_jetpack_connection( true, false );
+		$this->assertFalse( $this->mc_service->is_jetpack_owner_connected() );
 	}
 
 	public function test_is_store_country_supported() {

--- a/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
+++ b/tests/Unit/MerchantCenter/MerchantCenterServiceTest.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\MerchantCenter;
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\WooCommerce\GoogleListingsAndAds\Ads\AdsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\JetpackAuthCircuitBreaker;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Merchant;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Settings;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\ShippingRateQuery;
@@ -48,6 +49,9 @@ class MerchantCenterServiceTest extends UnitTest {
 
 	/** @var MockObject|GoogleHelper $google_helper */
 	protected $google_helper;
+
+	/** @var MockObject|JetpackAuthCircuitBreaker $circuit_breaker */
+	protected $circuit_breaker;
 
 	/** @var MockObject|Manager $manager */
 	protected $manager;
@@ -102,6 +106,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->ads_service            = $this->createMock( AdsService::class );
 		$this->contact_information    = $this->createMock( ContactInformation::class );
 		$this->google_helper          = $this->createMock( GoogleHelper::class );
+		$this->circuit_breaker        = $this->createMock( JetpackAuthCircuitBreaker::class );
 		$this->manager                = $this->createMock( Manager::class );
 		$this->merchant               = $this->createMock( Merchant::class );
 		$this->merchant_account_state = $this->createMock( MerchantAccountState::class );
@@ -120,6 +125,7 @@ class MerchantCenterServiceTest extends UnitTest {
 		$this->container->addShared( AdsService::class, $this->ads_service );
 		$this->container->addShared( ContactInformation::class, $this->contact_information );
 		$this->container->addShared( GoogleHelper::class, $this->google_helper );
+		$this->container->addShared( JetpackAuthCircuitBreaker::class, $this->circuit_breaker );
 		$this->container->addShared( Manager::class, $this->manager );
 		$this->container->addShared( Merchant::class, $this->merchant );
 		$this->container->addShared( MerchantAccountState::class, $this->merchant_account_state );
@@ -140,12 +146,14 @@ class MerchantCenterServiceTest extends UnitTest {
 	/**
 	 * Stub the Jetpack connection state.
 	 *
-	 * @param bool $connected Whether the site has a blog token.
-	 * @param bool $has_owner Whether the connection has an owner user.
+	 * @param bool $connected   Whether the site has a blog token.
+	 * @param bool $has_owner   Whether the connection has an owner user.
+	 * @param bool $auth_paused Whether syncing is paused after an authentication failure.
 	 */
-	protected function mock_jetpack_connection( bool $connected, bool $has_owner ): void {
+	protected function mock_jetpack_connection( bool $connected, bool $has_owner, bool $auth_paused = false ): void {
 		$this->manager->method( 'is_connected' )->willReturn( $connected );
 		$this->manager->method( 'has_connected_owner' )->willReturn( $has_owner );
+		$this->circuit_breaker->method( 'is_open' )->willReturn( $auth_paused );
 	}
 
 	public function test_is_setup_complete() {
@@ -334,6 +342,24 @@ class MerchantCenterServiceTest extends UnitTest {
 				true,
 				self::TEST_SETUP_COMPLETED
 			);
+
+		$this->assertFalse( $this->mc_service->is_ready_for_syncing() );
+	}
+
+	public function test_is_ready_for_syncing_while_jetpack_auth_paused() {
+		$this->mock_jetpack_connection( true, true, true );
+		$this->options->method( 'get' )
+			->withConsecutive(
+				[ OptionsInterface::GOOGLE_CONNECTED, false ],
+				[ OptionsInterface::MC_SETUP_COMPLETED_AT, false ]
+			)
+			->willReturnOnConsecutiveCalls(
+				true,
+				self::TEST_SETUP_COMPLETED
+			);
+
+		$this->merchant->expects( $this->never() )->method( 'get_claimed_url_hash' );
+		$this->transients->expects( $this->never() )->method( 'get' );
 
 		$this->assertFalse( $this->mc_service->is_ready_for_syncing() );
 	}

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -687,6 +687,10 @@ class MerchantStatusesTest extends UnitTest {
 			$this->get_mapi_id( $product_4->get_id() ) => $this->get_mapi_product( $product_4->get_id() ),
 		];
 
+		// No rows from earlier pages of the refresh, so none are deleted.
+		$this->merchant_issue_query->method( 'get_results' )->willReturn( [] );
+		$this->merchant_issue_table->expects( $this->never() )->method( 'delete_by_ids' );
+
 		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
 			[
 				[
@@ -854,6 +858,8 @@ class MerchantStatusesTest extends UnitTest {
 			}
 		);
 
+		$this->merchant_issue_query->method( 'get_results' )->willReturn( [] );
+
 		// Products are provided under both id forms; only the valid Merchant API id may
 		// produce issues, the legacy colon-format id is filtered out of the id map.
 		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
@@ -909,9 +915,11 @@ class MerchantStatusesTest extends UnitTest {
 			}
 		);
 
+		$this->merchant_issue_query->method( 'get_results' )->willReturn( [] );
+
 		// Products are provided under both id forms; issues may only come from the
-		// Merchant API id. The countries assertion is the discriminator: if the legacy
-		// id leaked through, both copies would merge into ["ES","ES"].
+		// Merchant API id. The countries assertion is the discriminator: the copy under
+		// the legacy id carries FR, so a leak would produce ["ES","FR"].
 		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
 			$this->callback(
 				function ( array $issues ) use ( $product ) {
@@ -932,9 +940,217 @@ class MerchantStatusesTest extends UnitTest {
 				],
 			],
 			[
-				$this->get_mc_id( $product->get_id() )   => $this->get_mapi_product( $product->get_id() ),
+				$this->get_mc_id( $product->get_id() )   => $this->get_mapi_product( $product->get_id(), 'merchant_action', [ 'FR' ] ),
 				$this->get_mapi_id( $product->get_id() ) => $this->get_mapi_product( $product->get_id() ),
 			]
+		);
+	}
+
+	public function test_refresh_product_issues_folds_in_rows_from_earlier_pages() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->product_repository->method( 'find_by_ids_as_associative_array' )
+		->willReturnCallback(
+			function ( $ids ) use ( $product ) {
+				return array_intersect_key( [ $product->get_id() => $product ], array_flip( $ids ) );
+			}
+		);
+
+		$this->options->method( 'get' )->willReturn( null );
+
+		$this->product_helper->method( 'get_synced_google_product_ids' )
+		->willReturnCallback(
+			function ( $wc_product ) {
+				return [ 'ES' => $this->get_mapi_id( $wc_product->get_id() ) ];
+			}
+		);
+
+		// Rows written by earlier pages of the same refresh: one for the same product
+		// and issue (folded in and deleted) and one for a different issue of the same
+		// product (left untouched).
+		$this->merchant_issue_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'                   => 5,
+					'product_id'           => $product->get_id(),
+					'issue'                => 'issue_description',
+					'applicable_countries' => wp_json_encode( [ 'US', 'GB', 'ES' ] ),
+				],
+				[
+					'id'                   => 6,
+					'product_id'           => $product->get_id(),
+					'issue'                => 'another_issue',
+					'applicable_countries' => wp_json_encode( [ 'US' ] ),
+				],
+			]
+		);
+
+		$where_calls = [];
+		$this->merchant_issue_query->method( 'where' )
+		->willReturnCallback(
+			function ( $column, $value, $compare = '=' ) use ( &$where_calls ) {
+				$where_calls[] = [ $column, $value, $compare ];
+				return $this->merchant_issue_query;
+			}
+		);
+
+		$call_order = [];
+
+		// Only the row for the same product and issue is replaced, and only after
+		// the merged row is written, so an interrupted page cannot lose countries.
+		$this->merchant_issue_table->expects( $this->once() )->method( 'delete_by_ids' )
+		->with( [ 5 ] )
+		->willReturnCallback(
+			function () use ( &$call_order ) {
+				$call_order[] = 'delete';
+			}
+		);
+
+		// The stored countries are the union of the earlier page's row and this page's
+		// entry, de-duplicated (ES appears in both) and sorted.
+		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
+			$this->callback(
+				function ( array $issues ) use ( $product ) {
+					return 1 === count( $issues )
+						&& $issues[0]['product_id'] === $product->get_id()
+						&& wp_json_encode( [ 'ES', 'GB', 'US' ] ) === $issues[0]['applicable_countries'];
+				}
+			)
+		)
+		->willReturnCallback(
+			function () use ( &$call_order ) {
+				$call_order[] = 'insert';
+			}
+		);
+
+		$this->merchant_statuses->process_product_statuses(
+			[
+				[
+					'mc_id'           => $this->get_mapi_id( $product->get_id() ),
+					'product_id'      => $product->get_id(),
+					'status'          => MCStatus::APPROVED,
+					'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
+				],
+			],
+			[ $this->get_mapi_id( $product->get_id() ) => $this->get_mapi_product( $product->get_id() ) ]
+		);
+
+		// The lookup covers exactly this page's products and no other issue source.
+		$this->assertContains( [ 'product_id', [ $product->get_id() ], 'IN' ], $where_calls );
+		$this->assertContains( [ 'source', 'mc', '=' ], $where_calls );
+		$this->assertContains( [ 'type', 'product', '=' ], $where_calls );
+
+		$this->assertSame( [ 'insert', 'delete' ], $call_order );
+	}
+
+	public function test_refresh_product_issues_resets_the_country_map_between_pages() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->product_repository->method( 'find_by_ids_as_associative_array' )
+		->willReturnCallback(
+			function ( $ids ) use ( $product ) {
+				return array_intersect_key( [ $product->get_id() => $product ], array_flip( $ids ) );
+			}
+		);
+
+		$this->options->method( 'get' )->willReturn( null );
+
+		$this->product_helper->method( 'get_synced_google_product_ids' )
+		->willReturnCallback(
+			function ( $wc_product ) {
+				return [ 'ES' => $this->get_mapi_id( $wc_product->get_id() ) ];
+			}
+		);
+
+		// No rows in the table either time: the second call stands for a page of a
+		// later refresh cycle running in the same long-lived process.
+		$this->merchant_issue_query->method( 'get_results' )->willReturn( [] );
+
+		$captured_rows = [];
+		$this->merchant_issue_query->expects( $this->exactly( 2 ) )->method( 'update_or_insert' )
+		->willReturnCallback(
+			function ( array $issues ) use ( &$captured_rows ) {
+				$captured_rows[] = $issues;
+			}
+		);
+
+		$page = [
+			[
+				'mc_id'           => $this->get_mapi_id( $product->get_id() ),
+				'product_id'      => $product->get_id(),
+				'status'          => MCStatus::APPROVED,
+				'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
+			],
+		];
+
+		$this->merchant_statuses->process_product_statuses(
+			$page,
+			[ $this->get_mapi_id( $product->get_id() ) => $this->get_mapi_product( $product->get_id(), 'merchant_action', [ 'FR' ] ) ]
+		);
+		$this->merchant_statuses->process_product_statuses(
+			$page,
+			[ $this->get_mapi_id( $product->get_id() ) => $this->get_mapi_product( $product->get_id() ) ]
+		);
+
+		// Without the per-page reset, the singleton's in-memory map would leak FR
+		// from the first call into the second call's row.
+		$this->assertSame( wp_json_encode( [ 'FR' ] ), $captured_rows[0][0]['applicable_countries'] );
+		$this->assertSame( wp_json_encode( [ 'ES' ] ), $captured_rows[1][0]['applicable_countries'] );
+	}
+
+	public function test_refresh_product_issues_tolerates_malformed_stored_countries() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$this->product_repository->method( 'find_by_ids_as_associative_array' )
+		->willReturnCallback(
+			function ( $ids ) use ( $product ) {
+				return array_intersect_key( [ $product->get_id() => $product ], array_flip( $ids ) );
+			}
+		);
+
+		$this->options->method( 'get' )->willReturn( null );
+
+		$this->product_helper->method( 'get_synced_google_product_ids' )
+		->willReturnCallback(
+			function ( $wc_product ) {
+				return [ 'ES' => $this->get_mapi_id( $wc_product->get_id() ) ];
+			}
+		);
+
+		// A matching row whose stored countries are valid JSON but not an array
+		// contributes nothing, and must not fail the page.
+		$this->merchant_issue_query->method( 'get_results' )->willReturn(
+			[
+				[
+					'id'                   => 7,
+					'product_id'           => $product->get_id(),
+					'issue'                => 'issue_description',
+					'applicable_countries' => '"GB"',
+				],
+			]
+		);
+
+		$this->merchant_issue_table->expects( $this->once() )->method( 'delete_by_ids' )->with( [ 7 ] );
+
+		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
+			$this->callback(
+				function ( array $issues ) {
+					return 1 === count( $issues )
+						&& wp_json_encode( [ 'ES' ] ) === $issues[0]['applicable_countries'];
+				}
+			)
+		);
+
+		$this->merchant_statuses->process_product_statuses(
+			[
+				[
+					'mc_id'           => $this->get_mapi_id( $product->get_id() ),
+					'product_id'      => $product->get_id(),
+					'status'          => MCStatus::APPROVED,
+					'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
+				],
+			],
+			[ $this->get_mapi_id( $product->get_id() ) => $this->get_mapi_product( $product->get_id() ) ]
 		);
 	}
 
@@ -1306,7 +1522,7 @@ class MerchantStatusesTest extends UnitTest {
 		$this->merchant_statuses->clear_product_statuses_cache_and_issues();
 	}
 
-	protected function get_mapi_product( $wc_product_id, string $resolution = 'merchant_action' ): Product {
+	protected function get_mapi_product( $wc_product_id, string $resolution = 'merchant_action', array $countries = [ 'ES' ] ): Product {
 		return Product::from_array(
 			[
 				'name'          => 'accounts/123/products/' . $this->get_mapi_id( $wc_product_id ),
@@ -1319,7 +1535,7 @@ class MerchantStatusesTest extends UnitTest {
 							'documentation'       => 'https://example.com',
 							'resolution'          => $resolution,
 							'severity'            => 'DISAPPROVED',
-							'applicableCountries' => [ 'ES' ],
+							'applicableCountries' => $countries,
 						],
 					],
 				],

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -710,6 +710,41 @@ class MerchantStatusesTest extends UnitTest {
 		);
 	}
 
+	public function test_process_mapi_products_tolerates_a_malformed_expiration_date() {
+		$statuses_spy = $this->createPartialMock( MerchantStatuses::class, [ 'process_product_statuses' ] );
+		$statuses_spy->set_container( $this->container );
+
+		$this->product_helper->method( 'get_wc_product_id' )->willReturn( 11 );
+
+		$product = Product::from_array(
+			[
+				'name'          => 'accounts/123/products/en~ES~gla_11',
+				'productStatus' => [
+					'destinationStatuses'  => [
+						[
+							'reportingContext'  => 'SHOPPING_ADS',
+							'approvedCountries' => [ 'ES' ],
+						],
+					],
+					'googleExpirationDate' => 'not-a-timestamp',
+				],
+			]
+		);
+
+		$statuses_spy->expects( $this->once() )
+		->method( 'process_product_statuses' )
+		->with(
+			$this->callback(
+				function ( array $statuses ) {
+					return null === $statuses[11]['expiration_date'] && MCStatus::APPROVED === $statuses[11]['status'];
+				}
+			),
+			[ 'en~ES~gla_11' => $product ]
+		);
+
+		$statuses_spy->process_mapi_products( [ $product ] );
+	}
+
 	public function test_process_mapi_products_converts_and_skips() {
 		$statuses_spy = $this->createPartialMock( MerchantStatuses::class, [ 'process_product_statuses' ] );
 		$statuses_spy->set_container( $this->container );

--- a/tests/Unit/MerchantCenter/MerchantStatusesTest.php
+++ b/tests/Unit/MerchantCenter/MerchantStatusesTest.php
@@ -26,7 +26,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\Google\Service\ShoppingCo
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\Product;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiAccountIssuesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
-use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\DeleteAllProducts;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\JobRepository;
 use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateAllProducts;
@@ -67,7 +66,6 @@ class MerchantStatusesTest extends UnitTest {
 	protected const MC_STATUS_LIFETIME = 60;
 
 	private $merchant;
-	private $mapi_products_service;
 	private $mapi_account_issues_service;
 	private $merchant_issue_query;
 	private $merchant_center_service;
@@ -94,7 +92,6 @@ class MerchantStatusesTest extends UnitTest {
 	public function setUp(): void {
 		parent::setUp();
 		$this->merchant                             = $this->createMock( Merchant::class );
-		$this->mapi_products_service                = $this->createMock( MapiProductsService::class );
 		$this->mapi_account_issues_service          = $this->createMock( MapiAccountIssuesService::class );
 		$this->merchant_issue_query                 = $this->createMock( MerchantIssueQuery::class );
 		$this->merchant_center_service              = $this->createMock( MerchantCenterService::class );
@@ -112,7 +109,6 @@ class MerchantStatusesTest extends UnitTest {
 
 		$this->container = new Container();
 		$this->container->addShared( Merchant::class, $this->merchant );
-		$this->container->addShared( MapiProductsService::class, $this->mapi_products_service );
 		$this->container->addShared( MapiAccountIssuesService::class, $this->mapi_account_issues_service );
 		$this->container->addShared( MerchantIssueQuery::class, $this->merchant_issue_query );
 		$this->container->addShared( MerchantCenterService::class, $this->merchant_center_service );
@@ -683,25 +679,13 @@ class MerchantStatusesTest extends UnitTest {
 			}
 		);
 
-		// product_4 (DONT_SYNC_AND_SHOW) must be excluded from the fetch; product_2's issue
-		// is pending_processing and must be filtered out of the resulting product issues.
-		$this->mapi_products_service->expects( $this->once() )
-		->method( 'get_many' )
-		->with(
-			[
-				$this->get_mapi_id( $product_1->get_id() ),
-				$this->get_mapi_id( $product_2->get_id() ),
-				$this->get_mapi_id( $product_3->get_id() ),
-				$this->get_mapi_id( $variation_id_1 ),
-				$this->get_mapi_id( $variation_id_2 ),
-			]
-		)
-		->willReturn(
-			[
-				$this->get_mapi_id( $product_1->get_id() ) => $this->get_mapi_product( $product_1->get_id() ),
-				$this->get_mapi_id( $product_2->get_id() ) => $this->get_mapi_product( $product_2->get_id(), 'pending_processing' ),
-			]
-		);
+		// product_4 (DONT_SYNC_AND_SHOW) is provided but must be excluded from the issues;
+		// product_2's issue is pending_processing and must be filtered out as well.
+		$products_by_google_id = [
+			$this->get_mapi_id( $product_1->get_id() ) => $this->get_mapi_product( $product_1->get_id() ),
+			$this->get_mapi_id( $product_2->get_id() ) => $this->get_mapi_product( $product_2->get_id(), 'pending_processing' ),
+			$this->get_mapi_id( $product_4->get_id() ) => $this->get_mapi_product( $product_4->get_id() ),
+		];
 
 		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
 			[
@@ -721,8 +705,89 @@ class MerchantStatusesTest extends UnitTest {
 		);
 
 		$this->merchant_statuses->process_product_statuses(
-			$product_statuses
+			$product_statuses,
+			$products_by_google_id
 		);
+	}
+
+	public function test_process_mapi_products_converts_and_skips() {
+		$statuses_spy = $this->createPartialMock( MerchantStatuses::class, [ 'process_product_statuses' ] );
+		$statuses_spy->set_container( $this->container );
+
+		$this->product_helper->method( 'get_wc_product_id' )
+		->willReturnCallback(
+			function ( string $google_id ) {
+				// The foreign product carries no gla_ offer id and resolves to no WC product.
+				return 'en~ES~foreign_offer' === $google_id ? 0 : (int) substr( $google_id, strrpos( $google_id, '_' ) + 1 );
+			}
+		);
+
+		$approved    = Product::from_array(
+			[
+				'name'          => 'accounts/123/products/en~ES~gla_11',
+				'productStatus' => [
+					'destinationStatuses'  => [
+						[
+							'reportingContext'  => 'SHOPPING_ADS',
+							'approvedCountries' => [ 'ES' ],
+						],
+					],
+					'googleExpirationDate' => '2030-01-01T00:00:00Z',
+				],
+			]
+		);
+		$disapproved = Product::from_array(
+			[
+				'name'          => 'accounts/123/products/en~ES~gla_12',
+				'productStatus' => [
+					'destinationStatuses' => [
+						[
+							'reportingContext'     => 'SHOPPING_ADS',
+							'disapprovedCountries' => [ 'ES' ],
+						],
+					],
+				],
+			]
+		);
+		$processing  = Product::from_array( [ 'name' => 'accounts/123/products/en~ES~gla_13' ] );
+		$foreign     = Product::from_array(
+			[
+				'name'          => 'accounts/123/products/en~ES~foreign_offer',
+				'productStatus' => [
+					'destinationStatuses' => [
+						[
+							'reportingContext'  => 'SHOPPING_ADS',
+							'approvedCountries' => [ 'ES' ],
+						],
+					],
+				],
+			]
+		);
+
+		$statuses_spy->expects( $this->once() )
+		->method( 'process_product_statuses' )
+		->with(
+			[
+				11 => [
+					'mc_id'           => 'en~ES~gla_11',
+					'product_id'      => 11,
+					'status'          => MCStatus::APPROVED,
+					'expiration_date' => new DateTime( '2030-01-01T00:00:00Z' ),
+				],
+				12 => [
+					'mc_id'           => 'en~ES~gla_12',
+					'product_id'      => 12,
+					'status'          => MCStatus::DISAPPROVED,
+					'expiration_date' => null,
+				],
+			],
+			[
+				'en~ES~gla_11' => $approved,
+				'en~ES~gla_12' => $disapproved,
+			]
+		);
+
+		$statuses_spy->process_mapi_products( [ $approved, $disapproved, $processing, $foreign ] );
 	}
 
 	public function test_process_product_statuses_skips_legacy_google_ids() {
@@ -754,11 +819,15 @@ class MerchantStatusesTest extends UnitTest {
 			}
 		);
 
-		// Only the valid Merchant API id reaches the products service; the legacy id is filtered out.
-		$this->mapi_products_service->expects( $this->once() )
-		->method( 'get_many' )
-		->with( [ $this->get_mapi_id( $product_valid->get_id() ) ] )
-		->willReturn( [] );
+		// Products are provided under both id forms; only the valid Merchant API id may
+		// produce issues, the legacy colon-format id is filtered out of the id map.
+		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
+			$this->callback(
+				function ( array $issues ) use ( $product_valid ) {
+					return 1 === count( $issues ) && $issues[0]['product_id'] === $product_valid->get_id();
+				}
+			)
+		);
 
 		$this->merchant_statuses->process_product_statuses(
 			[
@@ -774,6 +843,10 @@ class MerchantStatusesTest extends UnitTest {
 					'status'          => MCStatus::APPROVED,
 					'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
 				],
+			],
+			[
+				$this->get_mapi_id( $product_valid->get_id() )  => $this->get_mapi_product( $product_valid->get_id() ),
+				$this->get_mc_id( $product_legacy->get_id() )   => $this->get_mapi_product( $product_legacy->get_id() ),
 			]
 		);
 	}
@@ -801,11 +874,18 @@ class MerchantStatusesTest extends UnitTest {
 			}
 		);
 
-		// Only the Merchant API id reaches the products service; the legacy id is dropped.
-		$this->mapi_products_service->expects( $this->once() )
-		->method( 'get_many' )
-		->with( [ $this->get_mapi_id( $product->get_id() ) ] )
-		->willReturn( [] );
+		// Products are provided under both id forms; issues may only come from the
+		// Merchant API id. The countries assertion is the discriminator: if the legacy
+		// id leaked through, both copies would merge into ["ES","ES"].
+		$this->merchant_issue_query->expects( $this->once() )->method( 'update_or_insert' )->with(
+			$this->callback(
+				function ( array $issues ) use ( $product ) {
+					return 1 === count( $issues )
+						&& $issues[0]['product_id'] === $product->get_id()
+						&& wp_json_encode( [ 'ES' ] ) === $issues[0]['applicable_countries'];
+				}
+			)
+		);
 
 		$this->merchant_statuses->process_product_statuses(
 			[
@@ -815,6 +895,10 @@ class MerchantStatusesTest extends UnitTest {
 					'status'          => MCStatus::APPROVED,
 					'expiration_date' => ( new DateTime() )->add( new DateInterval( 'P20D' ) ),
 				],
+			],
+			[
+				$this->get_mc_id( $product->get_id() )   => $this->get_mapi_product( $product->get_id() ),
+				$this->get_mapi_id( $product->get_id() ) => $this->get_mapi_product( $product->get_id() ),
 			]
 		);
 	}

--- a/tests/Unit/Notes/ReconnectWordPressTest.php
+++ b/tests/Unit/Notes/ReconnectWordPressTest.php
@@ -70,12 +70,14 @@ class ReconnectWordPressTest extends UnitTest {
 	}
 
 	public function test_should_add_not_added_and_mc_setup_complete() {
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( true );
 		$this->merchant_center->method( 'is_setup_complete' )->willReturn( true );
 
 		$this->assertTrue( $this->note->should_be_added() );
 	}
 
 	public function test_should_add_connected() {
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( true );
 		$this->options->expects( $this->exactly( 2 ) )
 			->method( 'get' )
 			->with( OptionsInterface::JETPACK_CONNECTED )
@@ -87,6 +89,7 @@ class ReconnectWordPressTest extends UnitTest {
 	}
 
 	public function test_should_add_already_disconnected() {
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( true );
 		$this->options->expects( $this->exactly( 2 ) )
 			->method( 'get' )
 			->with( OptionsInterface::JETPACK_CONNECTED )
@@ -100,7 +103,19 @@ class ReconnectWordPressTest extends UnitTest {
 		$this->assertTrue( $this->note->should_be_added() );
 	}
 
+	public function test_should_add_without_jetpack_owner() {
+		$this->merchant_center->method( 'is_setup_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( false );
+
+		$this->options->expects( $this->never() )->method( 'get' );
+		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::JETPACK_CONNECTED, false );
+		$this->connection->expects( $this->never() )->method( 'get_status' );
+
+		$this->assertTrue( $this->note->should_be_added() );
+	}
+
 	public function test_should_add_disconnected_after_status_check() {
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( true );
 		$this->options->expects( $this->exactly( 2 ) )
 			->method( 'get' )
 			->with( OptionsInterface::JETPACK_CONNECTED )

--- a/tests/Unit/Notes/ReconnectWordPressTest.php
+++ b/tests/Unit/Notes/ReconnectWordPressTest.php
@@ -108,8 +108,21 @@ class ReconnectWordPressTest extends UnitTest {
 		$this->merchant_center->method( 'is_setup_complete' )->willReturn( true );
 		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( false );
 
-		$this->options->expects( $this->never() )->method( 'get' );
+		// Connected state still truthy, so it is cleared once.
+		$this->options->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( true );
 		$this->options->expects( $this->once() )->method( 'update' )->with( OptionsInterface::JETPACK_CONNECTED, false );
+		$this->connection->expects( $this->never() )->method( 'get_status' );
+
+		$this->assertTrue( $this->note->should_be_added() );
+	}
+
+	public function test_should_add_without_jetpack_owner_skips_redundant_write() {
+		$this->merchant_center->method( 'is_setup_complete' )->willReturn( true );
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( false );
+
+		// Already disconnected, so no wp_options write is issued.
+		$this->options->method( 'get' )->with( OptionsInterface::JETPACK_CONNECTED )->willReturn( false );
+		$this->options->expects( $this->never() )->method( 'update' );
 		$this->connection->expects( $this->never() )->method( 'get_status' );
 
 		$this->assertTrue( $this->note->should_be_added() );

--- a/tests/Unit/Notes/ReconnectWordPressTest.php
+++ b/tests/Unit/Notes/ReconnectWordPressTest.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Notes;
 
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Connection;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Notes\ReconnectWordPress;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
@@ -112,6 +113,26 @@ class ReconnectWordPressTest extends UnitTest {
 		$this->connection->expects( $this->never() )->method( 'get_status' );
 
 		$this->assertTrue( $this->note->should_be_added() );
+	}
+
+	public function test_should_not_add_when_the_status_check_already_added_it() {
+		$this->merchant_center->method( 'is_jetpack_owner_connected' )->willReturn( true );
+		$this->merchant_center->method( 'is_setup_complete' )->willReturn( true );
+		$this->options->method( 'get' )
+			->with( OptionsInterface::JETPACK_CONNECTED )
+			->will( $this->onConsecutiveCalls( true, false ) );
+
+		// A rejected token adds the note from the 401 handling before the exception surfaces.
+		$this->connection->expects( $this->once() )
+			->method( 'get_status' )
+			->willReturnCallback(
+				function () {
+					$this->note->get_entry()->save();
+					throw AccountReconnect::jetpack_disconnected();
+				}
+			);
+
+		$this->assertFalse( $this->note->should_be_added() );
 	}
 
 	public function test_should_add_disconnected_after_status_check() {

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -354,7 +354,13 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 	public function test_generate_mapi_update_entries_rethrows_account_reconnect() {
 		$products = $this->create_and_return_supported_test_products();
 
-		$this->market_service->method( 'get_primary_market' )->willReturn( [ 'country' => null, 'feed_label' => null, 'language' => 'en' ] );
+		$this->market_service->method( 'get_primary_market' )->willReturn(
+			[
+				'country'    => null,
+				'feed_label' => null,
+				'language'   => 'en',
+			]
+		);
 		$this->market_service->method( 'get_main_feed_label' )->willReturn( 'US' );
 		$this->market_service->method( 'get_all_countries' )->willReturn( [ 'US' ] );
 		$this->validator->method( 'validate' )->willReturn( [] );
@@ -371,7 +377,13 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 	public function test_generate_mapi_update_entries_skips_product_on_other_exception() {
 		$products = $this->create_and_return_supported_test_products();
 
-		$this->market_service->method( 'get_primary_market' )->willReturn( [ 'country' => null, 'feed_label' => null, 'language' => 'en' ] );
+		$this->market_service->method( 'get_primary_market' )->willReturn(
+			[
+				'country'    => null,
+				'feed_label' => null,
+				'language'   => 'en',
+			]
+		);
 		$this->market_service->method( 'get_main_feed_label' )->willReturn( 'US' );
 		$this->market_service->method( 'get_all_countries' )->willReturn( [ 'US' ] );
 		$this->validator->method( 'validate' )->willReturn( [] );

--- a/tests/Unit/Product/BatchProductHelperTest.php
+++ b/tests/Unit/Product/BatchProductHelperTest.php
@@ -7,6 +7,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiExcep
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidClass;
 use Automattic\WooCommerce\GoogleListingsAndAds\Exception\InvalidValue;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchInvalidProductEntry;
@@ -348,6 +349,38 @@ class BatchProductHelperTest extends ContainerAwareUnitTest {
 			$this->assertSame( 'US', $entry['input']->get_feed_label() );
 			$this->assertSame( 'US', $entry['country'] );
 		}
+	}
+
+	public function test_generate_mapi_update_entries_rethrows_account_reconnect() {
+		$products = $this->create_and_return_supported_test_products();
+
+		$this->market_service->method( 'get_primary_market' )->willReturn( [ 'country' => null, 'feed_label' => null, 'language' => 'en' ] );
+		$this->market_service->method( 'get_main_feed_label' )->willReturn( 'US' );
+		$this->market_service->method( 'get_all_countries' )->willReturn( [ 'US' ] );
+		$this->validator->method( 'validate' )->willReturn( [] );
+		$this->rules_query->method( 'get_results' )->willReturn( [] );
+
+		// An account-wide auth failure surfaces while resolving the data source.
+		$this->data_sources->method( 'ensure_data_source_for' )->willThrowException( AccountReconnect::jetpack_disconnected() );
+
+		$this->expectException( AccountReconnect::class );
+
+		$this->batch_product_helper->generate_mapi_update_entries( $products );
+	}
+
+	public function test_generate_mapi_update_entries_skips_product_on_other_exception() {
+		$products = $this->create_and_return_supported_test_products();
+
+		$this->market_service->method( 'get_primary_market' )->willReturn( [ 'country' => null, 'feed_label' => null, 'language' => 'en' ] );
+		$this->market_service->method( 'get_main_feed_label' )->willReturn( 'US' );
+		$this->market_service->method( 'get_all_countries' )->willReturn( [ 'US' ] );
+		$this->validator->method( 'validate' )->willReturn( [] );
+		$this->rules_query->method( 'get_results' )->willReturn( [] );
+
+		// A per-product failure (not account-wide) is still swallowed and the product skipped.
+		$this->data_sources->method( 'ensure_data_source_for' )->willThrowException( new MerchantApiException( 400, [], __METHOD__ ) );
+
+		$this->assertSame( [], $this->batch_product_helper->generate_mapi_update_entries( $products ) );
 	}
 
 	public function test_generate_mapi_update_entries_primary_plus_secondary_two_entries_per_product() {

--- a/tests/Unit/Product/ProductSyncerTest.php
+++ b/tests/Unit/Product/ProductSyncerTest.php
@@ -10,6 +10,7 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiPro
 use Automattic\WooCommerce\GoogleListingsAndAds\DB\Query\AttributeMappingRulesQuery;
 use Automattic\WooCommerce\GoogleListingsAndAds\Google\BatchProductIDRequestEntry;
 use Automattic\WooCommerce\GoogleListingsAndAds\Integration\WPML;
+use Automattic\WooCommerce\GoogleListingsAndAds\Exception\AccountReconnect;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
 use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MarketService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Product\BatchProductHelper;
@@ -675,6 +676,40 @@ class ProductSyncerTest extends ContainerAwareUnitTest {
 			$this->assertNotEmpty( $error_entry->get_errors() );
 			// product is no longer synced if Google API returns Not Found error for it
 			$this->assertFalse( $this->product_helper->is_product_synced( $wc_product ) );
+		}
+	}
+
+	public function test_update_wraps_auth_failure_from_entry_generation() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$batch_helper = $this->getMockBuilder( BatchProductHelper::class )
+								->setMethods( [ 'generate_mapi_update_entries' ] )
+								->setConstructorArgs(
+									[
+										$this->product_meta,
+										$this->product_helper,
+										$this->createMock( ValidatorInterface::class ),
+										$this->container->get( ProductFactory::class ),
+										$this->rules_query,
+										$this->market_service,
+										$this->createMock( WPML::class ),
+										$this->container->get( AttributeManager::class ),
+										$this->createMock( MapiDataSourcesService::class ),
+									]
+								)
+								->getMock();
+		$batch_helper->method( 'generate_mapi_update_entries' )
+			->willThrowException( AccountReconnect::jetpack_disconnected() );
+
+		$product_syncer = $this->get_product_syncer( [ 'batch_helper' => $batch_helper ] );
+
+		// The account-wide auth failure surfaces as a ProductSyncerException, not a raw
+		// AccountReconnect, so update() keeps its documented contract.
+		try {
+			$product_syncer->update( [ $product ] );
+			$this->fail( 'Expected a ProductSyncerException.' );
+		} catch ( ProductSyncerException $exception ) {
+			$this->assertInstanceOf( AccountReconnect::class, $exception->getPrevious() );
 		}
 	}
 

--- a/tests/Unit/Value/MCStatusTest.php
+++ b/tests/Unit/Value/MCStatusTest.php
@@ -1,0 +1,41 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Value;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Value\MCStatus;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class MCStatusTest
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\Value
+ */
+class MCStatusTest extends UnitTest {
+
+	/**
+	 * @dataProvider aggregated_status_provider
+	 *
+	 * @param string $aggregated
+	 * @param string $expected
+	 */
+	public function test_from_aggregated_reporting_context_status( string $aggregated, string $expected ) {
+		$this->assertSame( $expected, MCStatus::from_aggregated_reporting_context_status( $aggregated ) );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function aggregated_status_provider(): array {
+		return [
+			[ 'ELIGIBLE', MCStatus::APPROVED ],
+			[ 'ELIGIBLE_LIMITED', MCStatus::PARTIALLY_APPROVED ],
+			[ 'NOT_ELIGIBLE_OR_DISAPPROVED', MCStatus::DISAPPROVED ],
+			[ 'PENDING', MCStatus::PENDING ],
+			[ 'AGGREGATED_REPORTING_CONTEXT_STATUS_UNSPECIFIED', MCStatus::NOT_SYNCED ],
+			[ '', MCStatus::NOT_SYNCED ],
+		];
+	}
+}

--- a/tests/e2e/specs/search-console/search-console.test.js
+++ b/tests/e2e/specs/search-console/search-console.test.js
@@ -101,19 +101,22 @@ test.describe( 'Google Search Console', () => {
 			await settingsPage.gotoAccounts();
 
 			await expect(
-				settingsPage.searchConsoleAccountCard.getByText( 'Connected', {
-					exact: true,
-				} )
+				settingsPage.getSearchConsoleConnectedBadge()
 			).toBeVisible();
 			await expect(
 				settingsPage.getSearchConsoleConnectButton()
 			).toHaveCount( 0 );
 		} );
 
-		test( 'shows a selector for multiple usable properties, and selecting one completes resolution', async () => {
+		test( 'shows a selector for multiple usable properties, disables the non-usable one, and selecting a usable one completes resolution', async () => {
 			await settingsPage.mockSearchConsoleMultiMatch( [
 				{ siteUrl: 'https://example.com/', usable: true },
 				{ siteUrl: 'sc-domain:example.com', usable: true },
+				{
+					siteUrl: 'https://example.com/unverified/',
+					usable: false,
+					covers: true,
+				},
 			] );
 			await settingsPage.gotoAccounts();
 
@@ -123,13 +126,19 @@ test.describe( 'Google Search Console', () => {
 				)
 			).toBeVisible();
 
+			const propertySelect =
+				settingsPage.getSearchConsolePropertySelect();
 			const saveButton =
 				settingsPage.getSearchConsoleSavePropertyButton();
 			await expect( saveButton ).toBeDisabled();
 
-			await settingsPage
-				.getSearchConsolePropertySelect()
-				.selectOption( 'https://example.com/' );
+			const unusableOption = propertySelect.getByRole( 'option', {
+				name: 'https://example.com/unverified/ (Not yet verified)',
+			} );
+			await expect( unusableOption ).toBeDisabled();
+
+			await propertySelect.selectOption( 'https://example.com/' );
+			await expect( saveButton ).toBeEnabled();
 
 			await settingsPage.fulfillSearchConsoleProperty( {
 				status: 'connected',
@@ -149,9 +158,7 @@ test.describe( 'Google Search Console', () => {
 			} );
 
 			await expect(
-				settingsPage.searchConsoleAccountCard.getByText( 'Connected', {
-					exact: true,
-				} )
+				settingsPage.getSearchConsoleConnectedBadge()
 			).toBeVisible();
 		} );
 
@@ -219,9 +226,7 @@ test.describe( 'Google Search Console', () => {
 			expect( request.postDataJSON() ).toEqual( {} );
 
 			await expect(
-				settingsPage.searchConsoleAccountCard.getByText( 'Connected', {
-					exact: true,
-				} )
+				settingsPage.getSearchConsoleConnectedBadge()
 			).toBeVisible();
 		} );
 	} );
@@ -256,9 +261,7 @@ test.describe( 'Google Search Console', () => {
 			await settingsPage.getSearchConsoleVerifyButton().click();
 
 			await expect(
-				settingsPage.searchConsoleAccountCard.getByText( 'Connected', {
-					exact: true,
-				} )
+				settingsPage.getSearchConsoleConnectedBadge()
 			).toBeVisible();
 			await expect
 				.poll( () =>
@@ -282,9 +285,7 @@ test.describe( 'Google Search Console', () => {
 
 		test( 'shows the Connected badge and the property identifier with an outbound link', async () => {
 			await expect(
-				settingsPage.searchConsoleAccountCard.getByText( 'Connected', {
-					exact: true,
-				} )
+				settingsPage.getSearchConsoleConnectedBadge()
 			).toBeVisible();
 
 			const propertyLink =
@@ -332,16 +333,22 @@ test.describe( 'Google Search Console', () => {
 
 			await settingsPage.getSearchConsoleAccountActionsButton().click();
 			await settingsPage.getSearchConsoleDisconnectMenuItem().click();
-			await page
-				.getByRole( 'checkbox', {
-					name: 'Yes, I want to disconnect my Google Search Console account.',
-				} )
-				.check();
-			await page
-				.getByRole( 'button', {
-					name: 'Disconnect Google Search Console account',
-				} )
-				.click();
+
+			const confirmCheckbox = page.getByRole( 'checkbox', {
+				name: 'Yes, I want to disconnect my Google Search Console account.',
+			} );
+			const confirmButton = page.getByRole( 'button', {
+				name: 'Disconnect Google Search Console account',
+			} );
+
+			// The confirm button stays disabled until the checkbox is agreed to,
+			// so a merchant can't disconnect by mis-clicking through the modal.
+			await expect( confirmButton ).toBeDisabled();
+
+			await confirmCheckbox.check();
+			await expect( confirmButton ).toBeEnabled();
+
+			await confirmButton.click();
 
 			await requestPromise;
 
@@ -370,9 +377,7 @@ test.describe( 'Google Search Console', () => {
 				/path=%2Fgoogle%2Fsettings&section=accounts$/
 			);
 			await expect(
-				settingsPage.searchConsoleAccountCard.getByText( 'Connected', {
-					exact: true,
-				} )
+				settingsPage.getSearchConsoleConnectedBadge()
 			).toBeVisible();
 		} );
 	} );

--- a/tests/e2e/specs/search-console/search-console.test.js
+++ b/tests/e2e/specs/search-console/search-console.test.js
@@ -1,0 +1,338 @@
+/**
+ * External dependencies
+ */
+import { expect, test } from '@playwright/test';
+
+/**
+ * Internal dependencies
+ */
+import { clearOnboardedMerchant, setOnboardedMerchant } from '../../utils/api';
+import SettingsPage from '../../utils/pages/settings';
+
+test.use( { storageState: process.env.ADMINSTATE } );
+
+test.describe.configure( { mode: 'serial' } );
+
+/**
+ * @type {import('../../utils/pages/settings.js').default} settingsPage
+ */
+let settingsPage = null;
+
+/**
+ * @type {import('@playwright/test').Page} page
+ */
+let page = null;
+
+test.describe( 'Google Search Console', () => {
+	test.beforeAll( async ( { browser } ) => {
+		page = await browser.newPage();
+		settingsPage = new SettingsPage( page );
+
+		await setOnboardedMerchant();
+		await settingsPage.mockRequests();
+		await settingsPage.mockAllToursChecked();
+	} );
+
+	test.afterAll( async () => {
+		await clearOnboardedMerchant();
+		await page.close();
+	} );
+
+	test.describe( 'Accounts subtab, not connected', () => {
+		test.beforeAll( async () => {
+			await settingsPage.mockSearchConsoleAccountNotConnected();
+			await settingsPage.gotoAccounts();
+		} );
+
+		test( 'should render the card under Tracking and Site tools with a Connect button', async () => {
+			await expect(
+				page.getByRole( 'heading', { name: 'Tracking and Site tools' } )
+			).toBeVisible();
+			await expect(
+				page
+					.locator( '.gla-account-card__title' )
+					.filter( { hasText: /^Google Search Console$/ } )
+			).toBeVisible();
+			await expect(
+				settingsPage.getSearchConsoleConnectButton()
+			).toBeVisible();
+		} );
+
+		test( 'should request a Search Console connection when Connect is clicked', async () => {
+			await settingsPage
+				.withFulfillTimes( 1 )
+				.mockSearchConsoleConnect(
+					'/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings&section=accounts&from-connect=1'
+				);
+
+			const requestPromise =
+				settingsPage.registerSearchConsoleConnectRequest();
+
+			await settingsPage.getSearchConsoleConnectButton().click();
+
+			await requestPromise;
+
+			await expect( page ).toHaveURL(
+				/path=%2Fgoogle%2Fsettings&section=accounts&from-connect=1$/
+			);
+		} );
+	} );
+
+	test.describe( 'Property resolution', () => {
+		test.afterEach( async () => {
+			await page.unroute( /\/wc\/gla\/search-console\/connection\b/ );
+			await page.unroute( /\/wc\/gla\/search-console\/property\b/ );
+		} );
+
+		test( 'resolves straight to the connected state with no merchant action, whether a single property was auto-selected or none existed to silently create one', async () => {
+			// Both cases resolve server-side within the same status check and are
+			// indistinguishable to the merchant — a single usable property is auto-selected,
+			// or a new one is silently created when none exists — so one mocked response
+			// covers both.
+			await settingsPage.mockSearchConsoleAccountConnected(
+				'https://example.com/',
+				true
+			);
+			await settingsPage.gotoAccounts();
+
+			await expect(
+				settingsPage.searchConsoleAccountCard.getByText( 'Connected', {
+					exact: true,
+				} )
+			).toBeVisible();
+			await expect(
+				settingsPage.getSearchConsoleConnectButton()
+			).toHaveCount( 0 );
+		} );
+
+		test( 'shows a selector for multiple usable properties, and selecting one completes resolution', async () => {
+			await settingsPage.mockSearchConsoleMultiMatch( [
+				{ siteUrl: 'https://example.com/', usable: true },
+				{ siteUrl: 'sc-domain:example.com', usable: true },
+			] );
+			await settingsPage.gotoAccounts();
+
+			await expect(
+				settingsPage.searchConsoleAccountCard.getByText(
+					'We found multiple Google Search Console properties'
+				)
+			).toBeVisible();
+
+			const saveButton =
+				settingsPage.getSearchConsoleSavePropertyButton();
+			await expect( saveButton ).toBeDisabled();
+
+			await settingsPage
+				.getSearchConsolePropertySelect()
+				.selectOption( 'https://example.com/' );
+
+			await settingsPage.fulfillSearchConsoleProperty( {
+				status: 'connected',
+			} );
+			await settingsPage.mockSearchConsoleAccountConnected(
+				'https://example.com/'
+			);
+
+			const requestPromise =
+				settingsPage.registerSearchConsolePropertyRequest();
+
+			await saveButton.click();
+
+			const request = await requestPromise;
+			expect( request.postDataJSON() ).toEqual( {
+				site_url: 'https://example.com/',
+			} );
+
+			await expect(
+				settingsPage.searchConsoleAccountCard.getByText( 'Connected', {
+					exact: true,
+				} )
+			).toBeVisible();
+		} );
+
+		test( 'the "Create new" option completes resolution without an existing selection', async () => {
+			await settingsPage.mockSearchConsoleMultiMatch( [
+				{ siteUrl: 'https://example.com/', usable: true },
+				{ siteUrl: 'https://example.com/shop/', usable: true },
+			] );
+			await settingsPage.gotoAccounts();
+
+			const createNewButton =
+				settingsPage.getSearchConsoleCreateNewPropertyButton();
+			// Wait for the initial multi-match fetch to actually resolve and render
+			// before re-mocking the endpoints it's about to call next — otherwise this
+			// re-mock can race ahead of the app's first fetch and the card mounts
+			// straight into the connected state, skipping the selector entirely.
+			await expect( createNewButton ).toBeVisible();
+
+			await settingsPage.fulfillSearchConsoleProperty( {
+				status: 'connected',
+			} );
+			await settingsPage.mockSearchConsoleAccountConnected(
+				'https://example.com/new-property/'
+			);
+
+			const requestPromise =
+				settingsPage.registerSearchConsolePropertyRequest();
+
+			await createNewButton.click();
+
+			const request = await requestPromise;
+			expect( request.postDataJSON() ).toEqual( {} );
+
+			await expect(
+				settingsPage.searchConsoleAccountCard.getByText( 'Connected', {
+					exact: true,
+				} )
+			).toBeVisible();
+		} );
+	} );
+
+	test.describe( 'Verification', () => {
+		test.afterEach( async () => {
+			await page.unroute( /\/wc\/gla\/search-console\/connection\b/ );
+			await page.unroute( /\/wc\/gla\/search-console\/verify\b/ );
+		} );
+
+		test( 'shows a single Verify site action and completes without a full page reload', async () => {
+			await settingsPage.mockSearchConsoleActionNeeded();
+			await settingsPage.gotoAccounts();
+
+			await expect(
+				settingsPage.searchConsoleAccountCard.getByText(
+					'Verify your site with Google'
+				)
+			).toBeVisible();
+
+			await settingsPage.fulfillSearchConsoleVerify( { status: 'ok' } );
+			await settingsPage.mockSearchConsoleAccountConnected(
+				'https://example.com/'
+			);
+
+			// A marker that only a full page navigation would clear, to confirm the
+			// transition to the connected state happens via a state update, not a reload.
+			await page.evaluate( () => {
+				window.__searchConsoleVerifyMarker = 'persisted';
+			} );
+
+			await settingsPage.getSearchConsoleVerifyButton().click();
+
+			await expect(
+				settingsPage.searchConsoleAccountCard.getByText( 'Connected', {
+					exact: true,
+				} )
+			).toBeVisible();
+			await expect
+				.poll( () =>
+					page.evaluate( () => window.__searchConsoleVerifyMarker )
+				)
+				.toBe( 'persisted' );
+		} );
+	} );
+
+	test.describe( 'Connected state', () => {
+		test.beforeAll( async () => {
+			await settingsPage.mockSearchConsoleAccountConnected(
+				'https://example.com/'
+			);
+			await settingsPage.gotoAccounts();
+		} );
+
+		test.afterAll( async () => {
+			await page.unroute( /\/wc\/gla\/search-console\/connection\b/ );
+		} );
+
+		test( 'shows the Connected badge and the property identifier with an outbound link', async () => {
+			await expect(
+				settingsPage.searchConsoleAccountCard.getByText( 'Connected', {
+					exact: true,
+				} )
+			).toBeVisible();
+
+			const propertyLink =
+				settingsPage.searchConsoleAccountCard.getByRole( 'link', {
+					name: 'https://example.com/',
+				} );
+			await expect( propertyLink ).toHaveAttribute(
+				'href',
+				/^https:\/\/search\.google\.com\/search-console\?resource_id=/
+			);
+		} );
+
+		test( 'shows a "View Organic Search report" action', async () => {
+			await settingsPage.getSearchConsoleAccountActionsButton().click();
+
+			await expect(
+				page.getByRole( 'menuitem', {
+					name: 'View Organic Search report',
+				} )
+			).toBeVisible();
+		} );
+	} );
+
+	test.describe( 'Disconnect', () => {
+		test.beforeAll( async () => {
+			await settingsPage.mockSearchConsoleAccountConnected(
+				'https://example.com/'
+			);
+			await settingsPage.gotoAccounts();
+		} );
+
+		test.afterAll( async () => {
+			await page.unroute( /\/wc\/gla\/search-console\/connection\b/ );
+		} );
+
+		test( 'disconnects via the confirmation modal and returns to the not-connected state', async () => {
+			await settingsPage.mockSearchConsoleAccountNotConnected();
+			await settingsPage.mockSearchConsoleDisconnect();
+
+			const requestPromise =
+				settingsPage.registerSearchConsoleDisconnectRequest();
+
+			await settingsPage.getSearchConsoleAccountActionsButton().click();
+			await settingsPage.getSearchConsoleDisconnectMenuItem().click();
+			await page
+				.getByRole( 'checkbox', {
+					name: 'Yes, I want to disconnect my Google Search Console account.',
+				} )
+				.check();
+			await page
+				.getByRole( 'button', {
+					name: 'Disconnect Google Search Console account',
+				} )
+				.click();
+
+			await requestPromise;
+
+			await expect(
+				settingsPage.getSearchConsoleConnectButton()
+			).toBeVisible();
+		} );
+
+		test( 'reconnecting after a disconnect completes the flow again cleanly', async () => {
+			// Both mocks are armed before clicking Connect: the connect click triggers a
+			// real navigation back to this same accounts URL, which re-mounts the app and
+			// re-fetches connection status fresh — by then it should already report connected.
+			await settingsPage.withFulfillTimes( 1 ).mockSearchConsoleConnect();
+			await settingsPage.mockSearchConsoleAccountConnected(
+				'https://example.com/'
+			);
+
+			const requestPromise =
+				settingsPage.registerSearchConsoleConnectRequest();
+
+			await settingsPage.getSearchConsoleConnectButton().click();
+
+			await requestPromise;
+
+			await expect( page ).toHaveURL(
+				/path=%2Fgoogle%2Fsettings&section=accounts$/
+			);
+			await expect(
+				settingsPage.searchConsoleAccountCard.getByText( 'Connected', {
+					exact: true,
+				} )
+			).toBeVisible();
+		} );
+	} );
+} );

--- a/tests/e2e/specs/search-console/search-console.test.js
+++ b/tests/e2e/specs/search-console/search-console.test.js
@@ -6,7 +6,12 @@ import { expect, test } from '@playwright/test';
 /**
  * Internal dependencies
  */
-import { clearOnboardedMerchant, setOnboardedMerchant } from '../../utils/api';
+import {
+	clearOnboardedMerchant,
+	clearServiceBasedMerchant,
+	setOnboardedMerchant,
+	setServiceBasedMerchant,
+} from '../../utils/api';
 import SettingsPage from '../../utils/pages/settings';
 
 test.use( { storageState: process.env.ADMINSTATE } );
@@ -150,6 +155,39 @@ test.describe( 'Google Search Console', () => {
 			).toBeVisible();
 		} );
 
+		test( 'shows an error notice and re-shows the selector when saving a property fails', async () => {
+			await settingsPage.mockSearchConsoleMultiMatch( [
+				{ siteUrl: 'https://example.com/', usable: true },
+				{ siteUrl: 'sc-domain:example.com', usable: true },
+			] );
+			await settingsPage.gotoAccounts();
+
+			const saveButton =
+				settingsPage.getSearchConsoleSavePropertyButton();
+			// Wait for the initial multi-match fetch to resolve before arming the
+			// failure response, for the same race-avoidance reason as the "Create
+			// new" test below.
+			await expect( saveButton ).toBeDisabled();
+
+			await settingsPage
+				.getSearchConsolePropertySelect()
+				.selectOption( 'https://example.com/' );
+			await settingsPage.fulfillSearchConsoleProperty( {}, 500 );
+
+			await saveButton.click();
+
+			await expect(
+				page.locator(
+					'.components-snackbar:has-text("The selected property is no longer available. Please try again.")'
+				)
+			).toBeVisible();
+			await expect(
+				settingsPage.searchConsoleAccountCard.getByText(
+					'We found multiple Google Search Console properties'
+				)
+			).toBeVisible();
+		} );
+
 		test( 'the "Create new" option completes resolution without an existing selection', async () => {
 			await settingsPage.mockSearchConsoleMultiMatch( [
 				{ siteUrl: 'https://example.com/', usable: true },
@@ -267,6 +305,9 @@ test.describe( 'Google Search Console', () => {
 					name: 'View Organic Search report',
 				} )
 			).toBeVisible();
+
+			// Close the actions dropdown so it doesn't linger into the next block.
+			await page.keyboard.press( 'Escape' );
 		} );
 	} );
 
@@ -332,6 +373,37 @@ test.describe( 'Google Search Console', () => {
 				settingsPage.searchConsoleAccountCard.getByText( 'Connected', {
 					exact: true,
 				} )
+			).toBeVisible();
+		} );
+	} );
+
+	// Placed last: this block's mocks (Merchant Center, Ads, Jetpack, Google, YouTube)
+	// stay registered afterward, same as settings.test.js's own equivalent scenario.
+	test.describe( 'No connected Google Merchant Center account', () => {
+		test.beforeAll( async () => {
+			await setServiceBasedMerchant();
+			await settingsPage.mockJetpackConnected();
+			await settingsPage.mockGoogleConnected();
+			await settingsPage.mockAdsAccountConnected();
+			await settingsPage.mockMCNotConnected();
+			await settingsPage.mockYouTubeAccountNotConnected();
+			await settingsPage.mockTargetAudienceCountries();
+			await settingsPage.mockSearchConsoleAccountNotConnected();
+			await settingsPage.gotoAccounts();
+		} );
+
+		test.afterAll( async () => {
+			await clearServiceBasedMerchant();
+		} );
+
+		test( 'still renders the card in its not-connected state, since Search Console connection is independent of Merchant Center', async () => {
+			await expect(
+				page
+					.locator( '.gla-account-card__title' )
+					.filter( { hasText: /^Google Search Console$/ } )
+			).toBeVisible();
+			await expect(
+				settingsPage.getSearchConsoleConnectButton()
 			).toBeVisible();
 		} );
 	} );

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -1241,6 +1241,30 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Fulfill the tours request.
+	 *
+	 * @param {Object} payload Tours data, keyed by tour ID.
+	 * @return {Promise<void>}
+	 */
+	async fulfillTours( payload ) {
+		await this.fulfillRequest( /\/wc\/gla\/tours\b/, payload, 200, [
+			'GET',
+		] );
+	}
+
+	/**
+	 * Mock every known onboarding tour as already checked/dismissed, so a guide popover
+	 * (e.g. the rebranding tour) doesn't cover page content mid-test.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async mockAllToursChecked() {
+		await this.fulfillTours( {
+			'rebranding-tour': { id: 'rebranding-tour', checked: true },
+		} );
+	}
+
+	/**
 	 * Mocks the fulfillment of requests to the WooCommerce products API endpoint.
 	 *
 	 * @param {Object} payload - The mock response payload to return for the request.
@@ -1482,6 +1506,160 @@ export default class MockRequests {
 				request.url().includes( '/gla/youtube/setup/complete' ) &&
 				request.method() === 'POST'
 		);
+	}
+
+	/**
+	 * Fulfill the Google Search Console account connection status request.
+	 *
+	 * @param {Object} payload
+	 * @param {number} [status=200]
+	 * @param {Array} [methods=['GET']]
+	 * @return {Promise<void>}
+	 */
+	async fulfillSearchConsoleAccountConnection(
+		payload,
+		status = 200,
+		methods = [ 'GET' ]
+	) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/search-console\/connection\b/,
+			payload,
+			status,
+			methods
+		);
+	}
+
+	/**
+	 * Fulfill the Google Search Console connect request.
+	 *
+	 * @param {Object} payload
+	 * @param {number} [status=200]
+	 * @param {Array} [methods=['GET']]
+	 * @return {Promise<void>}
+	 */
+	async fulfillSearchConsoleConnect(
+		payload,
+		status = 200,
+		methods = [ 'GET' ]
+	) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/search-console\/connect\b/,
+			payload,
+			status,
+			methods
+		);
+	}
+
+	/**
+	 * Fulfill the Google Search Console property-selection request.
+	 *
+	 * @param {Object} payload
+	 * @param {number} [status=200]
+	 * @return {Promise<void>}
+	 */
+	async fulfillSearchConsoleProperty( payload, status = 200 ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/search-console\/property\b/,
+			payload,
+			status,
+			[ 'POST' ]
+		);
+	}
+
+	/**
+	 * Fulfill the Google Search Console verification request.
+	 *
+	 * @param {Object} payload
+	 * @param {number} [status=200]
+	 * @return {Promise<void>}
+	 */
+	async fulfillSearchConsoleVerify( payload, status = 200 ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/search-console\/verify\b/,
+			payload,
+			status,
+			[ 'POST' ]
+		);
+	}
+
+	/**
+	 * Mock the Google Search Console connect request.
+	 *
+	 * @param {string} [url] The URL returned by the connect endpoint.
+	 * @return {Promise<void>}
+	 */
+	async mockSearchConsoleConnect(
+		url = '/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings&section=accounts'
+	) {
+		await this.fulfillSearchConsoleConnect( { url } );
+	}
+
+	/**
+	 * Mock the Google Search Console account as not connected.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async mockSearchConsoleAccountNotConnected() {
+		await this.fulfillSearchConsoleAccountConnection( {
+			status: 'disconnected',
+		} );
+	}
+
+	/**
+	 * Mock the Google Search Console account as connected to the given property.
+	 *
+	 * @param {string} [siteUrl] The connected property's identifier.
+	 * @param {boolean} [justResolved] Whether to report the connection as having just
+	 *                                 auto-resolved (single-match auto-select or silent
+	 *                                 no-match creation), showing the one-time success notice.
+	 * @return {Promise<void>}
+	 */
+	async mockSearchConsoleAccountConnected(
+		siteUrl = 'https://example.com/',
+		justResolved = false
+	) {
+		await this.fulfillSearchConsoleAccountConnection( {
+			status: 'connected',
+			site_url: siteUrl,
+			...( justResolved && { just_resolved: true } ),
+		} );
+	}
+
+	/**
+	 * Mock multiple usable Google Search Console properties, showing the property selector.
+	 *
+	 * @param {Array<{siteUrl: string, usable?: boolean, covers?: boolean}>} matches Candidate properties.
+	 * @return {Promise<void>}
+	 */
+	async mockSearchConsoleMultiMatch( matches ) {
+		await this.fulfillSearchConsoleAccountConnection( {
+			status: 'incomplete',
+			matches,
+		} );
+	}
+
+	/**
+	 * Mock the Google Search Console account needing site verification.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async mockSearchConsoleActionNeeded() {
+		await this.fulfillSearchConsoleAccountConnection( {
+			status: 'action-needed',
+		} );
+	}
+
+	/**
+	 * Mock the Google Search Console disconnect request.
+	 *
+	 * wordpress/api-fetch's http-v1 middleware converts DELETE to POST with an
+	 * X-HTTP-Method-Override: DELETE header, so we intercept POST here and let GET
+	 * requests fall through to the connection-state mock.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async mockSearchConsoleDisconnect() {
+		await this.fulfillSearchConsoleAccountConnection( {}, 200, [ 'POST' ] );
 	}
 
 	/**

--- a/tests/e2e/utils/pages/settings.js
+++ b/tests/e2e/utils/pages/settings.js
@@ -18,6 +18,13 @@ export default class SettingsPage extends MockRequests {
 			.filter( {
 				has: this.page.getByText( 'YouTube', { exact: true } ),
 			} );
+		this.searchConsoleAccountCard = this.page
+			.locator( '.gla-account-card' )
+			.filter( {
+				has: this.page.getByText( 'Google Search Console', {
+					exact: true,
+				} ),
+			} );
 	}
 
 	/**
@@ -199,6 +206,125 @@ export default class SettingsPage extends MockRequests {
 			( request ) =>
 				/\/wc\/gla\/youtube\/connect(?:\?|$)/.test( request.url() ) &&
 				request.method() === 'GET'
+		);
+	}
+
+	/**
+	 * Get the Google Search Console Connect button.
+	 *
+	 * @return {Promise<import('@playwright/test').Locator>} The Connect button.
+	 */
+	getSearchConsoleConnectButton() {
+		return this.searchConsoleAccountCard.getByRole( 'button', {
+			name: 'Connect',
+		} );
+	}
+
+	/**
+	 * Get the Google Search Console account actions button.
+	 *
+	 * @return {Promise<import('@playwright/test').Locator>} The actions button.
+	 */
+	getSearchConsoleAccountActionsButton() {
+		return this.searchConsoleAccountCard.getByRole( 'button', {
+			name: 'Account actions for Google Search Console',
+		} );
+	}
+
+	/**
+	 * Get the Google Search Console Disconnect menu item.
+	 *
+	 * @return {Promise<import('@playwright/test').Locator>} The Disconnect menu item.
+	 */
+	getSearchConsoleDisconnectMenuItem() {
+		return this.page.getByRole( 'menuitem', {
+			name: 'Disconnect',
+		} );
+	}
+
+	/**
+	 * Get the Google Search Console property selector.
+	 *
+	 * @return {import('@playwright/test').Locator} The property select control.
+	 */
+	getSearchConsolePropertySelect() {
+		return this.searchConsoleAccountCard.locator( 'select' );
+	}
+
+	/**
+	 * Get the button that saves the selected Google Search Console property.
+	 *
+	 * @return {import('@playwright/test').Locator} The Save button.
+	 */
+	getSearchConsoleSavePropertyButton() {
+		return this.searchConsoleAccountCard.getByRole( 'button', {
+			name: 'Save',
+		} );
+	}
+
+	/**
+	 * Get the button that creates a new Google Search Console property.
+	 *
+	 * @return {import('@playwright/test').Locator} The create-new-property button.
+	 */
+	getSearchConsoleCreateNewPropertyButton() {
+		return this.searchConsoleAccountCard.getByRole( 'button', {
+			name: 'Or, create a new Google Search Console property',
+		} );
+	}
+
+	/**
+	 * Get the Google Search Console Verify site button.
+	 *
+	 * @return {import('@playwright/test').Locator} The Verify site button.
+	 */
+	getSearchConsoleVerifyButton() {
+		return this.searchConsoleAccountCard.getByRole( 'button', {
+			name: 'Verify site',
+		} );
+	}
+
+	/**
+	 * Register a wait for the Google Search Console connect request.
+	 *
+	 * @return {Promise<import('@playwright/test').Request>} The request.
+	 */
+	registerSearchConsoleConnectRequest() {
+		return this.page.waitForRequest(
+			( request ) =>
+				/\/wc\/gla\/search-console\/connect(?:\?|$)/.test(
+					request.url()
+				) && request.method() === 'GET'
+		);
+	}
+
+	/**
+	 * Register a wait for the Google Search Console disconnect request.
+	 *
+	 * Matches the POST that @wordpress/api-fetch sends for DELETE operations,
+	 * identified by the X-HTTP-Method-Override: DELETE header.
+	 *
+	 * @return {Promise<import('@playwright/test').Request>} The request.
+	 */
+	registerSearchConsoleDisconnectRequest() {
+		return this.page.waitForRequest(
+			( request ) =>
+				request.url().includes( '/gla/search-console/connection' ) &&
+				request.method() === 'POST' &&
+				request.headers()[ 'x-http-method-override' ] === 'DELETE'
+		);
+	}
+
+	/**
+	 * Register a wait for the Google Search Console property-selection request.
+	 *
+	 * @return {Promise<import('@playwright/test').Request>} The request.
+	 */
+	registerSearchConsolePropertyRequest() {
+		return this.page.waitForRequest(
+			( request ) =>
+				request.url().includes( '/gla/search-console/property' ) &&
+				request.method() === 'POST'
 		);
 	}
 

--- a/tests/e2e/utils/pages/settings.js
+++ b/tests/e2e/utils/pages/settings.js
@@ -221,6 +221,17 @@ export default class SettingsPage extends MockRequests {
 	}
 
 	/**
+	 * Get the Google Search Console card's "Connected" badge.
+	 *
+	 * @return {import('@playwright/test').Locator} The Connected badge.
+	 */
+	getSearchConsoleConnectedBadge() {
+		return this.searchConsoleAccountCard.getByText( 'Connected', {
+			exact: true,
+		} );
+	}
+
+	/**
 	 * Get the Google Search Console account actions button.
 	 *
 	 * @return {Promise<import('@playwright/test').Locator>} The actions button.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes GOOWOO-1009.

Adds Playwright E2E coverage for the Google Search Console connect flow, which had none — the connect flow (account card, property resolution, verification, connected state, disconnect) had already shipped without any end-to-end tests.

Covers, in `tests/e2e/specs/search-console/search-console.test.js`:
- Settings > Accounts card rendering, including when Merchant Center isn't connected (the two integrations are independent)
- Connecting, including the real navigation the Connect button triggers
- Property resolution: single-match auto-select, silent no-match creation, a multi-match selector with a disabled option for non-usable properties, a "Create new" path, and the error path when saving a property fails
- The site-verification step, confirming it completes without a full page reload
- The connected state's badge, property link, and "View Organic Search report" action
- Disconnect (including the confirm button's disabled/enabled gating) and a clean reconnect afterward

Also adds the Search Console mocks/locators needed to drive these (`tests/e2e/utils/mock-requests.js`, `tests/e2e/utils/pages/settings.js`), following the existing YouTube/Merchant Center conventions already in those files.

### Screenshots:

<!--- Optional --->

Not applicable — test-only change, no UI changes.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. With the e2e environment running (`npm run wp-env:up` if not already), run `npx playwright test --config=tests/e2e/config/playwright.config.js tests/e2e/specs/search-console/search-console.test.js` and confirm all 12 tests pass.
2. Run `npx playwright test --config=tests/e2e/config/playwright.config.js tests/e2e/specs/settings/settings.test.js` and confirm all 27 tests still pass — this PR modifies shared `tests/e2e/utils/mock-requests.js` and `tests/e2e/utils/pages/settings.js` utilities that file also depends on.
3. Run `npm run lint:js` and confirm no new lint errors from the changed files.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>