### PR TITLE
GOOWOO-1020: Fix return URL for search console to accounts page

### DIFF
--- a/src/API/Site/Controllers/SearchConsole/AccountController.php
+++ b/src/API/Site/Controllers/SearchConsole/AccountController.php
@@ -105,7 +105,7 @@ class AccountController extends BaseController {
 				return [
 					'url'       => $this->connection->connect(
 						admin_url(
-							'admin.php?page=wc-admin&path=/google/settings'
+							'admin.php?page=wc-admin&path=/google/settings&section=accounts'
 						)
 					),
 					'skip_auth' => $this->connection->should_skip_auth(),

--- a/tests/Unit/API/Site/Controllers/SearchConsole/AccountControllerTest.php
+++ b/tests/Unit/API/Site/Controllers/SearchConsole/AccountControllerTest.php
@@ -38,10 +38,14 @@ class AccountControllerTest extends RESTControllerUnitTest {
 	}
 
 	public function test_connect() {
-		$auth_url = 'https://domain.test?auth=1';
+		$auth_url   = 'https://domain.test?auth=1';
+		$return_url = admin_url(
+			'admin.php?page=wc-admin&path=/google/settings&section=accounts'
+		);
 
 		$this->connection->expects( $this->once() )
 			->method( 'connect' )
+			->with( $return_url )
 			->willReturn( $auth_url );
 
 		$this->connection->expects( $this->once() )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes https://linear.app/a8c/issue/GOOWOO-1020/search-console-connecting-returns-the-merchant-to-settings-general

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. On a store connected to Merchant Center, go to Marketing > Google for WooCommerce > Settings > Accounts and click Connect on the Search Console card.
2. Complete the Google consent screen. Confirm you land back on Settings > Accounts (not General) with the Search Console card visible without switching tabs, in whichever state applies (connected, property selector pending, or verification pending).
3. Repeat, but cancel/deny access at the Google consent screen. Confirm you still land on Settings > Accounts, now showing the connection-failed state.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
