### PR TITLE
Add / GOOWOO-1006 Disconnect Is Indistinguishable From Never-Connected, Can Silently Auto-Reconnect

### DIFF
--- a/src/API/SearchConsole/Connection.php
+++ b/src/API/SearchConsole/Connection.php
@@ -158,6 +158,12 @@ class Connection implements ContainerAwareInterface, MerchantCenterAwareInterfac
 	 * @throws Exception When a ClientException is caught or the response doesn't contain the oauthUrl.
 	 */
 	public function connect( string $return_url ): string {
+		// Calling this is the merchant's own explicit intent to (re)connect — clear a prior
+		// disconnect so the next status check resolves normally instead of staying stuck.
+		if ( self::STATE_DISCONNECTED === $this->get_connection_data()['state'] ) {
+			$this->update_connection_data( [ 'state' => null ] );
+		}
+
 		try {
 			/** @var Client $client */
 			$client = $this->container->get( Client::class );
@@ -191,15 +197,24 @@ class Connection implements ContainerAwareInterface, MerchantCenterAwareInterfac
 	/**
 	 * Disconnect from the Search Console account.
 	 *
-	 * Purely local. The connection URL is shared with Merchant Center/Ads
+	 * Purely local — the connection URL is shared with Merchant Center/Ads
 	 * (see {@see self::get_connection_url()}), so a remote DELETE here would
-	 * tear down that shared connection instead of just Search Console's own
-	 * state — only the locally stored property/verification data is cleared.
+	 * tear down that shared connection instead. Marks the state as explicitly
+	 * disconnected rather than just clearing the property: the underlying
+	 * scope grant stays intact, so without that marker the next status check
+	 * would just resolve straight back to the same property.
 	 *
 	 * @return string
 	 */
 	public function disconnect(): string {
-		$this->clear_connection_data();
+		$this->update_connection_data(
+			[
+				'property'      => null,
+				'property_type' => null,
+				'verified'      => SiteVerification::VERIFICATION_STATUS_UNVERIFIED,
+				'state'         => self::STATE_DISCONNECTED,
+			]
+		);
 
 		return __( 'Successfully disconnected.', 'google-listings-and-ads' );
 	}
@@ -263,10 +278,17 @@ class Connection implements ContainerAwareInterface, MerchantCenterAwareInterfac
 	 * detection depends on property-selection and verification logic that
 	 * lands separately.
 	 *
+	 * An explicit local disconnect short-circuits all of the above until
+	 * {@see self::connect()} is called again — see that method's own comment.
+	 *
 	 * @return array
 	 */
 	public function get_connection_status(): array {
 		$connection_data = $this->get_connection_data();
+
+		if ( self::STATE_DISCONNECTED === $connection_data['state'] ) {
+			return [ 'status' => self::STATE_DISCONNECTED ];
+		}
 
 		try {
 			$status = $this->get_status();

--- a/tests/Unit/API/SearchConsole/ConnectionTest.php
+++ b/tests/Unit/API/SearchConsole/ConnectionTest.php
@@ -70,6 +70,8 @@ class ConnectionTest extends UnitTest {
 	}
 
 	public function test_connect_returns_oauth_url_on_success() {
+		$this->options->method( 'get' )->willReturn( self::default_connection_data() );
+
 		$mock_handler = new MockHandler(
 			[
 				new Response( 200, [], wp_json_encode( [ 'oauthUrl' => 'https://accounts.google.com/oauth' ] ) ),
@@ -85,6 +87,8 @@ class ConnectionTest extends UnitTest {
 	}
 
 	public function test_connect_requests_the_webmasters_scope_on_the_shared_google_mc_connection() {
+		$this->options->method( 'get' )->willReturn( self::default_connection_data() );
+
 		$mock_handler = new MockHandler(
 			[
 				new Response( 200, [], wp_json_encode( [ 'oauthUrl' => 'https://accounts.google.com/oauth' ] ) ),
@@ -108,6 +112,8 @@ class ConnectionTest extends UnitTest {
 	}
 
 	public function test_connect_throws_exception_when_oauth_url_missing() {
+		$this->options->method( 'get' )->willReturn( self::default_connection_data() );
+
 		$mock_handler = new MockHandler(
 			[
 				new Response( 200, [], wp_json_encode( [] ) ),
@@ -124,6 +130,8 @@ class ConnectionTest extends UnitTest {
 	}
 
 	public function test_connect_throws_exception_on_client_exception() {
+		$this->options->method( 'get' )->willReturn( self::default_connection_data() );
+
 		$mock_handler = new MockHandler(
 			[
 				new RequestException(
@@ -142,16 +150,69 @@ class ConnectionTest extends UnitTest {
 		$this->connection->connect( 'https://example.com/return' );
 	}
 
-	public function test_disconnect_clears_local_connection_data_without_calling_the_remote_endpoint() {
+	public function test_disconnect_persists_an_explicit_disconnected_state_without_calling_the_remote_endpoint() {
 		// The connection URL is shared with Merchant Center/Ads (`google/connection/google-mc`),
 		// so disconnect() must never call it — doing so would tear down that shared connection
 		// instead of just Search Console's own local state. No Client is registered in the
 		// container at all, so any attempt to use one would throw.
+		$this->options->method( 'get' )->willReturn( self::default_connection_data() );
+
 		$this->options->expects( $this->once() )
-			->method( 'delete' )
-			->with( OptionsInterface::SEARCH_CONSOLE );
+			->method( 'update' )
+			->with(
+				OptionsInterface::SEARCH_CONSOLE,
+				[
+					'property'      => null,
+					'property_type' => null,
+					'verified'      => SiteVerification::VERIFICATION_STATUS_UNVERIFIED,
+					'state'         => Connection::STATE_DISCONNECTED,
+				]
+			);
 
 		$this->assertEquals( 'Successfully disconnected.', $this->connection->disconnect() );
+	}
+
+	public function test_get_connection_status_returns_disconnected_without_resolving_property_after_a_local_disconnect() {
+		$this->options->method( 'get' )->willReturn(
+			self::default_connection_data( [ 'state' => Connection::STATE_DISCONNECTED ] )
+		);
+
+		// No Client is registered in the container, and resolve_property() must never be
+		// called — either would only happen if this fell through to the normal remote-status/
+		// property-resolution path instead of short-circuiting on the disconnect first.
+		$this->sites_service->expects( $this->never() )->method( 'resolve_property' );
+
+		$this->assertEquals(
+			[ 'status' => Connection::STATE_DISCONNECTED ],
+			$this->connection->get_connection_status()
+		);
+	}
+
+	public function test_connect_clears_a_prior_local_disconnect() {
+		$stored = self::default_connection_data( [ 'state' => Connection::STATE_DISCONNECTED ] );
+		$this->options->method( 'get' )->willReturnCallback(
+			function () use ( &$stored ) {
+				return $stored;
+			}
+		);
+		$this->options->method( 'update' )->willReturnCallback(
+			function ( $option, $value ) use ( &$stored ) {
+				$stored = $value;
+				return true;
+			}
+		);
+
+		$mock_handler = new MockHandler(
+			[
+				new Response( 200, [], wp_json_encode( [ 'oauthUrl' => 'https://accounts.google.com/oauth' ] ) ),
+			]
+		);
+		$this->container->add( Client::class, new Client( [ 'handler' => HandlerStack::create( $mock_handler ) ] ) );
+
+		$url = $this->connection->connect( 'https://example.com/return' );
+
+		$this->assertEquals( 'https://accounts.google.com/oauth', $url );
+		$this->assertNull( $stored['state'] );
 	}
 
 	public function test_get_status_returns_decoded_response_on_success() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes: [GOOWOO-1006](https://linear.app/a8c/issue/GOOWOO-1006/search-console-disconnect-is-indistinguishable-from-never-connected)

Disconnecting Search Console only ever cleared local plugin state. It never touched the underlying `webmasters` OAuth scope grant (by design; revoking it would tear down the shared Merchant Center/Ads connection). The bug: the connection-status check decided "authorized" purely from whether that scope was still present, which it always was after a local disconnect, so it skipped the disconnected branch entirely and silently re-resolved the same property on the very next status check (e.g. a page reload), with no merchant action.

- `disconnect()` now persists an explicit `disconnected` marker instead of just wiping the option.
- `get_connection_status()` short-circuits on that marker before touching the remote endpoint or resolving a property.
- `connect()` clears the marker, since clicking Connect is the merchant's own explicit reconnect intent. The scope grant itself is never touched, so reconnecting doesn't require re-granting it.

### Screenshots:

N/A- no UI change, this is connection-state logic only.

### Detailed test instructions:

1. `composer install`, `vendor/bin/phpunit --testsuite unit` - full suite passes.
2. `vendor/bin/phpcs` (default ruleset) and `vendor/bin/phpcs --standard=tests/phpcs.xml.dist` (test file changed).
3. On a store with Merchant Center already connected, connect Search Console for real.
4. Disconnect it, then **reload the page** - this is the actual bug. Confirm the card still shows the not-connected/Connect state, not silently reconnected. (Before this fix, the reload alone would silently reconnect to the same property.)
5. Click Connect again - confirm it completes without needing to re-approve the Search Console permission itself (Google's account-chooser screen may still appear; the scope-grant step should be skipped since it was never revoked).
6. Confirm it resolves back to a connected state cleanly.

### Additional details:

Verified live against a real Merchant Center–connected store and the actual WCS Connect Server (not mocked) - full disconnect > reload > reconnect loop confirmed correct.

### Changelog entry

> Fix - Disconnecting Google Search Console now actually stays disconnected instead of silently reconnecting on the next page load.
