### PR TITLE
GOOWOO-1022: Refresh-page notice after creating GTM container

### DIFF
--- a/js/src/pages/settings/accounts/google-tag-manager-account-card/incomplete-google-tag-manager-account-card/container-selection.js
+++ b/js/src/pages/settings/accounts/google-tag-manager-account-card/incomplete-google-tag-manager-account-card/container-selection.js
@@ -18,6 +18,7 @@ import useGoogleTagManagerAccount from '~/hooks/useGoogleTagManagerAccount';
 import useGoogleTagManagerContainers from '../hooks/useGoogleTagManagerContainers';
 import { getGoogleTagManagerAccountUrl } from '~/utils/urls';
 import AdsConversionDuplicateNotice from '../ads-conversion-duplicate-notice';
+import NoticeDetail from '../notice-detail';
 import GoogleTagManagerContainerSelectControl from './google-tag-manager-container-select-control';
 import CreateNewContainerLink from './create-new-container-link';
 
@@ -37,7 +38,9 @@ import './container-selection.scss';
  * Renders the container-selection detail: the already-connected account, and either a container
  * selector with an explicit "Save" action plus an inline "Create new container" link (one or
  * more containers exist), or the "Create new container" link alone in place of the selector
- * (the account has zero containers — there's nothing to select).
+ * (the account has zero containers — there's nothing to select). Clicking "Create new container"
+ * in either state shows a local info notice reminding the merchant to refresh the page once
+ * they've created it, directly above wherever that link renders.
  *
  * @fires gla_google_tag_manager_container_select_button_click
  *
@@ -50,6 +53,8 @@ export default function ContainerSelection() {
 	const { containers, hasFinishedResolution: hasResolvedContainers } =
 		useGoogleTagManagerContainers();
 	const [ containerId, setContainerId ] = useState();
+	const [ hasClickedCreateContainer, setHasClickedCreateContainer ] =
+		useState( false );
 	const [ fetchSelectContainer, { loading } ] = useApiFetchCallback( {
 		path: `${ API_NAMESPACE }/tag-manager/containers`,
 		method: 'POST',
@@ -61,6 +66,26 @@ export default function ContainerSelection() {
 	if ( ! hasResolvedContainers ) {
 		return null;
 	}
+
+	const handleCreateContainerClick = () => {
+		setHasClickedCreateContainer( true );
+	};
+
+	const createContainerNotice = hasClickedCreateContainer ? (
+		<div className="gla-google-tag-manager-account-card__refresh-notice">
+			<NoticeDetail
+				status="info"
+				body={
+					<p>
+						{ __(
+							'Refresh the page to see your new container',
+							'google-listings-and-ads'
+						) }
+					</p>
+				}
+			/>
+		</div>
+	) : null;
 
 	/**
 	 * Handles the "Save" button click: selects the picked container and refreshes connection state.
@@ -119,7 +144,8 @@ export default function ContainerSelection() {
 							value={ containerId }
 							onChange={ setContainerId }
 						/>
-						<Flex justify="start">
+						{ createContainerNotice }
+						<Flex justify="start" gap={ 4 }>
 							<AppButton
 								eventName="gla_google_tag_manager_container_select_button_click"
 								eventProps={ {
@@ -132,7 +158,9 @@ export default function ContainerSelection() {
 							>
 								{ __( 'Save', 'google-listings-and-ads' ) }
 							</AppButton>
-							<CreateNewContainerLink />
+							<CreateNewContainerLink
+								onClick={ handleCreateContainerClick }
+							/>
 						</Flex>
 					</>
 				) : (
@@ -146,7 +174,10 @@ export default function ContainerSelection() {
 								'google-listings-and-ads'
 							) }
 						</p>
-						<CreateNewContainerLink />
+						{ createContainerNotice }
+						<CreateNewContainerLink
+							onClick={ handleCreateContainerClick }
+						/>
 					</>
 				) }
 			</FlexItem>

--- a/js/src/pages/settings/accounts/google-tag-manager-account-card/incomplete-google-tag-manager-account-card/container-selection.scss
+++ b/js/src/pages/settings/accounts/google-tag-manager-account-card/incomplete-google-tag-manager-account-card/container-selection.scss
@@ -1,7 +1,7 @@
 .gla-google-tag-manager-account-card__container-selection-item {
 	display: flex;
 	flex-direction: column;
-	gap: $grid-unit-10;
+	gap: $grid-unit-20;
 }
 
 .gla-google-tag-manager-account-card__container-selection-label {
@@ -16,4 +16,8 @@
 
 .gla-google-tag-manager-account-card__container-selection-text {
 	margin: 0;
+}
+
+.gla-google-tag-manager-account-card__refresh-notice .gla-google-tag-manager-account-card__notice.components-notice:not(.app-notice) {
+	margin-bottom: 0;
 }

--- a/js/src/pages/settings/accounts/google-tag-manager-account-card/incomplete-google-tag-manager-account-card/container-selection.test.js
+++ b/js/src/pages/settings/accounts/google-tag-manager-account-card/incomplete-google-tag-manager-account-card/container-selection.test.js
@@ -230,6 +230,8 @@ describe( 'ContainerSelection', () => {
 						'Refresh the page to see your new container'
 			)
 		).toBeInTheDocument();
+		expect( fetchSelectContainer ).not.toHaveBeenCalled();
+		expect( fetchGoogleTagManagerAccount ).not.toHaveBeenCalled();
 	} );
 
 	it( 'shows the refresh-page notice after clicking "Create new container" from the empty state', async () => {
@@ -252,5 +254,7 @@ describe( 'ContainerSelection', () => {
 						'Refresh the page to see your new container'
 			)
 		).toBeInTheDocument();
+		expect( fetchSelectContainer ).not.toHaveBeenCalled();
+		expect( fetchGoogleTagManagerAccount ).not.toHaveBeenCalled();
 	} );
 } );

--- a/js/src/pages/settings/accounts/google-tag-manager-account-card/incomplete-google-tag-manager-account-card/container-selection.test.js
+++ b/js/src/pages/settings/accounts/google-tag-manager-account-card/incomplete-google-tag-manager-account-card/container-selection.test.js
@@ -190,4 +190,67 @@ describe( 'ContainerSelection', () => {
 		);
 		expect( fetchGoogleTagManagerAccount ).not.toHaveBeenCalled();
 	} );
+
+	it( 'does not show the refresh-page notice before "Create new container" has been clicked', () => {
+		mockContainers( [
+			{ id: '98765432', publicId: 'GTM-PR99HWXX', name: 'woo' },
+		] );
+
+		render( <ContainerSelection /> );
+
+		expect(
+			screen.queryByText(
+				( _, element ) =>
+					element?.tagName === 'P' &&
+					element.textContent ===
+						'Refresh the page to see your new container'
+			)
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the refresh-page notice after clicking "Create new container" from the populated-selector state', async () => {
+		const user = userEvent.setup();
+		mockContainers( [
+			{ id: '98765432', publicId: 'GTM-PR99HWXX', name: 'woo' },
+		] );
+
+		render( <ContainerSelection /> );
+
+		await user.click(
+			screen.getByRole( 'link', {
+				name: 'Create new container (opens in a new tab)',
+			} )
+		);
+
+		expect(
+			screen.getByText(
+				( _, element ) =>
+					element?.tagName === 'P' &&
+					element.textContent ===
+						'Refresh the page to see your new container'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows the refresh-page notice after clicking "Create new container" from the empty state', async () => {
+		const user = userEvent.setup();
+		mockContainers( [] );
+
+		render( <ContainerSelection /> );
+
+		await user.click(
+			screen.getByRole( 'link', {
+				name: 'Create new container (opens in a new tab)',
+			} )
+		);
+
+		expect(
+			screen.getByText(
+				( _, element ) =>
+					element?.tagName === 'P' &&
+					element.textContent ===
+						'Refresh the page to see your new container'
+			)
+		).toBeInTheDocument();
+	} );
 } );

--- a/js/src/pages/settings/accounts/google-tag-manager-account-card/incomplete-google-tag-manager-account-card/create-new-container-link.js
+++ b/js/src/pages/settings/accounts/google-tag-manager-account-card/incomplete-google-tag-manager-account-card/create-new-container-link.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,10 +18,11 @@ import { recordGlaEvent } from '~/utils/tracks';
  * @property {string} context Indicates from which page the button was clicked. Possible value: 'settings-tag-manager'.
  */
 
-const handleClick = () => {
+const handleClick = ( onClick ) => () => {
 	recordGlaEvent( 'gla_google_tag_manager_create_container_button_click', {
 		context: 'settings-tag-manager',
 	} );
+	onClick();
 };
 
 /**
@@ -30,15 +32,18 @@ const handleClick = () => {
  * container is only possible through Google's own UI (the plugin never calls
  * `accounts.containers.create`), so this always opens off-site in a new tab.
  *
+ * @param {Object} props Component props.
+ * @param {Function} [props.onClick] Called after the tracking event fires, alongside it.
+ *
  * @fires gla_google_tag_manager_create_container_button_click
  *
  * @return {JSX.Element} The link.
  */
-export default function CreateNewContainerLink() {
+export default function CreateNewContainerLink( { onClick = noop } ) {
 	return (
 		<ExternalLink
 			href={ getGoogleTagManagerCreateContainerUrl() }
-			onClick={ handleClick }
+			onClick={ handleClick( onClick ) }
 		>
 			{ __( 'Create new container', 'google-listings-and-ads' ) }
 		</ExternalLink>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes GOOWOO-1022.

Clicking "Create new container" — in both the populated-container and zero-container states — now shows a local, non-dismissible info notice reminding the merchant to refresh the page to see the container they just created off-site (the plugin never calls `accounts.containers.create` itself). The notice renders directly above wherever the "Create new container" link appears, and disappears again on refresh — no separate dismiss action.

Also fixed `CreateNewContainerLink`'s optional `onClick` prop to use this codebase's established `noop`-default pattern (`{ onClick = noop }`, called unconditionally) instead of `onClick?.()` — the same correction Asvin flagged on a prior Google Customer Reviews review ("We don't have this pattern anywhere in the codebase. Instead let's use `noop` please.").

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Go to Google for WooCommerce → Settings, with a Google Tag Manager account already connected but no container selected yet, and an account that has zero containers.
2. Click "Create new container" — confirm it opens `https://tagmanager.google.com/` in a new tab, and the refresh-page notice appears directly above the link.
3. Refresh the settings page — confirm the notice is gone.
4. Repeat with an account that already has one or more containers (selector + inline "Create new container" link shown together) — confirm the notice appears above the link in this state too, and behaves the same way on click/refresh.
5. Confirm the "Save" flow (selecting an existing container) is unaffected by this change.


### Additional details:


### Changelog entry

>