### PR TITLE
Fix / GOOWOO-1024 Search Console: Account Deep Link Fix

### DIFF
--- a/js/src/pages/settings/accounts/google-search-console-account-card/connected-google-search-console-account-card.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/connected-google-search-console-account-card.js
@@ -11,6 +11,7 @@ import AccountCardTextDetail from '../account-card-text-detail';
 import { GOOGLE_SEARCH_CONSOLE_DESCRIPTION } from './constants';
 import ConnectedIndicator from './connected-indicator';
 import ConnectedSuccessNotice from './connected-success-notice';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
 
 /**
  * @typedef { import('~/data/types.js').GoogleSearchConsoleAccount } GoogleSearchConsoleAccount
@@ -29,10 +30,24 @@ const getSearchConsolePropertyUrl = ( siteUrl ) =>
 	) }`;
 
 /**
+ * Wraps a destination URL in Google's own account-selection redirect, so the link resolves
+ * under a specific Google account rather than whichever one is currently active in the browser.
+ *
+ * @param {string} destinationUrl The URL to continue to once an account is resolved.
+ * @param {string} email The Google account email to resolve to.
+ * @return {string} The wrapped, account-aware URL.
+ */
+const getAccountAwareUrl = ( destinationUrl, email ) =>
+	`https://accounts.google.com/accountchooser?continue=${ encodeURIComponent(
+		destinationUrl
+	) }&Email=${ encodeURIComponent( email ) }`;
+
+/**
  * Renders the connected Google Search Console account card: a "Connected" badge, an actions
  * menu offering "View Organic Search report", a link to the connected property in Google
- * Search Console itself, and — immediately after an auto-resolved connection — a one-time
- * success notice.
+ * Search Console itself (resolved to the connected Google account when its email is known,
+ * so the merchant doesn't land in a different signed-in account), and — immediately after an
+ * auto-resolved connection — a one-time success notice.
  *
  * `site_url` and `just_resolved` are a proposed backend addition, not yet sent by the real
  * backend — this degrades to no property link and no success notice until that lands.
@@ -47,6 +62,14 @@ const ConnectedGoogleSearchConsoleAccountCard = ( {
 	onDisconnect,
 } ) => {
 	const siteUrl = account.site_url;
+	const { google } = useGoogleAccount();
+	const email = google?.email;
+
+	const propertyUrl = siteUrl ? getSearchConsolePropertyUrl( siteUrl ) : null;
+	const accountAwarePropertyUrl =
+		propertyUrl && email
+			? getAccountAwareUrl( propertyUrl, email )
+			: propertyUrl;
 
 	return (
 		<AccountCard
@@ -57,9 +80,7 @@ const ConnectedGoogleSearchConsoleAccountCard = ( {
 			detail={
 				siteUrl ? (
 					<AccountCardTextDetail>
-						<ExternalLink
-							href={ getSearchConsolePropertyUrl( siteUrl ) }
-						>
+						<ExternalLink href={ accountAwarePropertyUrl }>
 							{ siteUrl }
 						</ExternalLink>
 					</AccountCardTextDetail>

--- a/js/src/pages/settings/accounts/google-search-console-account-card/index.test.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/index.test.js
@@ -11,10 +11,17 @@ import userEvent from '@testing-library/user-event';
 import GoogleSearchConsoleAccountCard from './index';
 import { GOOGLE_SEARCH_CONSOLE_ACCOUNT_STATUS } from '~/constants';
 import useGoogleSearchConsoleAccount from '~/hooks/useGoogleSearchConsoleAccount';
+import useGoogleAccount from '~/hooks/useGoogleAccount';
 import IncompleteGoogleSearchConsoleAccountCard from './incomplete-google-search-console-account-card';
 
 jest.mock( '~/hooks/useGoogleSearchConsoleAccount', () =>
 	jest.fn().mockName( 'useGoogleSearchConsoleAccount' )
+);
+jest.mock( '~/hooks/useGoogleAccount', () =>
+	jest
+		.fn()
+		.mockName( 'useGoogleAccount' )
+		.mockReturnValue( { google: undefined } )
 );
 jest.mock( './incomplete-google-search-console-account-card', () =>
 	jest
@@ -106,7 +113,24 @@ describe( 'GoogleSearchConsoleAccountCard', () => {
 		expect( onDisconnect ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'renders a link to the connected property in Google Search Console when the backend sends site_url', () => {
+	it( 'renders a link to the connected property in Google Search Console, wrapped for the connected Google account, when the backend sends site_url', () => {
+		useGoogleAccount.mockReturnValue( {
+			google: { email: 'merchant@example.com' },
+		} );
+		mockAccount( { status: CONNECTED, site_url: 'https://example.com/' } );
+
+		render( <GoogleSearchConsoleAccountCard /> );
+
+		expect(
+			screen.getByRole( 'link', { name: /https:\/\/example\.com\// } )
+		).toHaveAttribute(
+			'href',
+			'https://accounts.google.com/accountchooser?continue=https%3A%2F%2Fsearch.google.com%2Fsearch-console%3Fresource_id%3Dhttps%253A%252F%252Fexample.com%252F&Email=merchant%40example.com'
+		);
+	} );
+
+	it( 'falls back to the plain Search Console link when the connected Google account email is not yet available', () => {
+		useGoogleAccount.mockReturnValue( { google: undefined } );
 		mockAccount( { status: CONNECTED, site_url: 'https://example.com/' } );
 
 		render( <GoogleSearchConsoleAccountCard /> );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes: [GOOWOO-1024](https://linear.app/a8c/issue/GOOWOO-1024/search-console-connected-account-deep-link-can-open-the-wrong-google)

The connected Search Console account card's link to view the property in Google Search Console had no account context — if the merchant's browser is signed into more than one Google account, clicking it could open Search Console under whichever account happens to be active, not the one actually connected to this integration.

- Wraps the outbound link through Google's own account-selection redirect, passing the connected account's email (read via the existing `useGoogleAccount` hook - no new backend surface needed, the email was already available and unused here).
- Falls back to today's plain link when that email isn't available yet, matching this card's existing graceful-degradation pattern.

### Screenshots:

N/A - no visual change, this is link-construction logic only.

### Detailed test instructions:

1. `npm run test:js -- js/src/pages/settings/accounts/google-search-console-account-card/index.test.js` — passes (8/8), including the two new/updated cases covering the account-aware link and the fallback.
2. `npx eslint` on the two changed files - clean.
3. On a store with Search Console connected, with your browser signed into a **second** Google account (different from the one connected), click the connected property's link.
4. Confirm it resolves to the **connected** account's Search Console, not whichever account was active in the browser.
5. With only one Google account signed in, confirm the link behaves exactly as before - no visible change.

### Additional details:

Verified live against a real, connected Search Console property with two distinct signed-in Google accounts - confirmed the link correctly reaches the connected account every time.

### Changelog entry

> Fix - The connected Search Console account's link now opens under the correct Google account instead of whichever one happens to be active in the browser.
