### PR TITLE
GOOWOO-1026: Show Action needed badge for pending property choice

### DIFF
--- a/js/src/hooks/useGoogleSearchConsoleProperties.js
+++ b/js/src/hooks/useGoogleSearchConsoleProperties.js
@@ -18,20 +18,31 @@ const selectorName = 'getGoogleSearchConsoleProperties';
  * A hook to load the candidate Google Search Console properties the merchant can choose
  * between to complete the connection.
  *
- * @return {{ properties: GoogleSearchConsoleProperty[]|null, hasFinishedResolution: boolean }} The data and its resolution state.
+ * @param {Object} [options] Options.
+ * @param {boolean} [options.skip] When `true`, never calls the store selector — so a caller
+ *   that only needs this data for one particular status (e.g. an indicator shared across every
+ *   incomplete-flow sub-state) doesn't trigger the properties fetch for the others.
+ * @return {{ properties: GoogleSearchConsoleProperty[]|null, hasFinishedResolution: boolean }} The data and its resolution state, or `{ properties: undefined, hasFinishedResolution: false }` while skipped.
  */
-const useGoogleSearchConsoleProperties = () => {
-	return useSelect( ( select ) => {
-		const selector = select( STORE_KEY );
+const useGoogleSearchConsoleProperties = ( { skip = false } = {} ) => {
+	return useSelect(
+		( select ) => {
+			if ( skip ) {
+				return { properties: undefined, hasFinishedResolution: false };
+			}
 
-		return {
-			properties: selector[ selectorName ](),
-			hasFinishedResolution: selector.hasFinishedResolution(
-				selectorName,
-				[]
-			),
-		};
-	}, [] );
+			const selector = select( STORE_KEY );
+
+			return {
+				properties: selector[ selectorName ](),
+				hasFinishedResolution: selector.hasFinishedResolution(
+					selectorName,
+					[]
+				),
+			};
+		},
+		[ skip ]
+	);
 };
 
 export default useGoogleSearchConsoleProperties;

--- a/js/src/hooks/useGoogleSearchConsoleProperties.test.js
+++ b/js/src/hooks/useGoogleSearchConsoleProperties.test.js
@@ -62,4 +62,17 @@ describe( 'useGoogleSearchConsoleProperties', () => {
 			hasFinishedResolution: false,
 		} );
 	} );
+
+	it( 'never calls the store selector when skipped, so no fetch is triggered', () => {
+		const { result } = renderHook( () =>
+			useGoogleSearchConsoleProperties( { skip: true } )
+		);
+
+		expect( result.current ).toEqual( {
+			properties: undefined,
+			hasFinishedResolution: false,
+		} );
+		expect( mockGetGoogleSearchConsoleProperties ).not.toHaveBeenCalled();
+		expect( mockHasFinishedResolution ).not.toHaveBeenCalled();
+	} );
 } );

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.js
@@ -17,6 +17,7 @@ import useDispatchCoreNotices from '~/hooks/useDispatchCoreNotices';
 import useGoogleSearchConsoleProperties from '~/hooks/useGoogleSearchConsoleProperties';
 import GoogleSearchConsoleSelectControl from '../google-search-console-select-control';
 import NoticeDetail from '../notice-detail';
+import './property-selection.scss';
 
 const PROPERTIES_PATH = `${ API_NAMESPACE }/search-console/properties`;
 
@@ -36,8 +37,8 @@ const PROPERTIES_PATH = `${ API_NAMESPACE }/search-console/properties`;
 
 /**
  * Renders the property-selection step's detail: a notice explaining the multi-match, a selector
- * to choose which candidate property to connect, and a "Save" action alongside an explicit
- * "Create new property" action.
+ * to choose which candidate property to connect, and a confirm action alongside an explicit
+ * create-new action.
  *
  * A single match or no match resolves automatically on the backend with zero merchant action,
  * so the selector itself only ever renders when there is a genuine, unresolved multi-match

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.js
@@ -35,8 +35,9 @@ const PROPERTIES_PATH = `${ API_NAMESPACE }/search-console/properties`;
  */
 
 /**
- * Renders the property-selection step's detail: a selector lets the merchant choose which
- * candidate property to connect, alongside an explicit "Or, create a new..." action.
+ * Renders the property-selection step's detail: a notice explaining the multi-match, a selector
+ * to choose which candidate property to connect, and a "Save" action alongside an explicit
+ * "Create new property" action.
  *
  * A single match or no match resolves automatically on the backend with zero merchant action,
  * so the selector itself only ever renders when there is a genuine, unresolved multi-match
@@ -113,56 +114,61 @@ export default function PropertySelection() {
 	}
 
 	return (
-		<NoticeDetail
-			status="info"
-			title={ __(
-				'We found multiple Google Search Console properties',
-				'google-listings-and-ads'
-			) }
-			body={
-				<Flex direction="column" gap={ 4 }>
-					<FlexBlock>
-						<GoogleSearchConsoleSelectControl
-							label={ __(
-								'Pick one to connect, or create a new one.',
-								'google-listings-and-ads'
-							) }
-							properties={ properties }
-							value={ value }
-							onChange={ setValue }
-						/>
-					</FlexBlock>
-					<FlexItem>
-						<AppButton
-							eventName="gla_google_search_console_property_select_button_click"
-							eventProps={ {
-								context: 'settings-search-console',
-							} }
-							onClick={ handleSelectClick }
-							disabled={ ! value }
-							loading={ isSelecting }
-							isSecondary
-						>
-							{ __( 'Save', 'google-listings-and-ads' ) }
-						</AppButton>
-					</FlexItem>
+		<Flex direction="column" gap={ 4 }>
+			<FlexBlock>
+				<NoticeDetail
+					status="info"
+					body={
+						<div className="gla-google-search-console-account-card__property-selection-notice">
+							<p>
+								{ __(
+									'We found multiple Google Search Console properties.',
+									'google-listings-and-ads'
+								) }
+							</p>
+							<p>
+								{ __(
+									'Pick one to connect, or create a new one.',
+									'google-listings-and-ads'
+								) }
+							</p>
+						</div>
+					}
+				/>
+				<GoogleSearchConsoleSelectControl
+					properties={ properties }
+					value={ value }
+					onChange={ setValue }
+				/>
+			</FlexBlock>
+			<FlexItem>
+				<Flex justify="flex-start" gap={ 4 }>
+					<AppButton
+						eventName="gla_google_search_console_property_select_button_click"
+						eventProps={ {
+							context: 'settings-search-console',
+						} }
+						onClick={ handleSelectClick }
+						disabled={ ! value }
+						loading={ isSelecting }
+						isPrimary
+					>
+						{ __( 'Save', 'google-listings-and-ads' ) }
+					</AppButton>
+					<AppButton
+						eventName="gla_google_search_console_property_create_button_click"
+						eventProps={ { context: 'settings-search-console' } }
+						onClick={ handleCreateNewClick }
+						loading={ isCreating }
+						isTertiary
+					>
+						{ __(
+							'Create new property',
+							'google-listings-and-ads'
+						) }
+					</AppButton>
 				</Flex>
-			}
-			actions={ [
-				<AppButton
-					key="create-new"
-					eventName="gla_google_search_console_property_create_button_click"
-					eventProps={ { context: 'settings-search-console' } }
-					onClick={ handleCreateNewClick }
-					loading={ isCreating }
-					isTertiary
-				>
-					{ __(
-						'Or, create a new Google Search Console property',
-						'google-listings-and-ads'
-					) }
-				</AppButton>,
-			] }
-		/>
+			</FlexItem>
+		</Flex>
 	);
 }

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.js
@@ -120,20 +120,20 @@ export default function PropertySelection() {
 				<NoticeDetail
 					status="info"
 					body={
-						<div className="gla-google-search-console-account-card__property-selection-notice">
-							<p>
+						<>
+							<p className="gla-google-search-console-account-card__property-selection-notice">
 								{ __(
 									'We found multiple Google Search Console properties.',
 									'google-listings-and-ads'
 								) }
 							</p>
-							<p>
+							<p className="gla-google-search-console-account-card__property-selection-notice">
 								{ __(
 									'Pick one to connect, or create a new one.',
 									'google-listings-and-ads'
 								) }
 							</p>
-						</div>
+						</>
 					}
 				/>
 				<GoogleSearchConsoleSelectControl

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.scss
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.scss
@@ -1,0 +1,3 @@
+.gla-google-search-console-account-card__property-selection-notice p {
+	margin: 0;
+}

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.scss
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/detail/property-selection.scss
@@ -1,3 +1,3 @@
-.gla-google-search-console-account-card__property-selection-notice p {
+.gla-google-search-console-account-card__property-selection-notice {
 	margin: 0;
 }

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/index.test.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/index.test.js
@@ -180,10 +180,18 @@ describe( 'IncompleteGoogleSearchConsoleAccountCard', () => {
 
 		expect(
 			screen.getByText(
-				'We found multiple Google Search Console properties'
+				'We found multiple Google Search Console properties.'
 			)
 		).toBeInTheDocument();
-		expect( screen.queryByText( 'Action needed' ) ).not.toBeInTheDocument();
+		expect(
+			screen.getByText( 'Pick one to connect, or create a new one.' )
+		).toBeInTheDocument();
+		// A pending multi-match choice surfaces as "Action needed", not the generic
+		// "Resume setup" button — the merchant isn't blocked, but a choice is waiting.
+		expect( screen.getByText( 'Action needed' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Resume setup' } )
+		).not.toBeInTheDocument();
 		expect( screen.queryByText( 'In progress' ) ).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'button', { name: 'Continue' } )
@@ -246,7 +254,7 @@ describe( 'IncompleteGoogleSearchConsoleAccountCard', () => {
 		render( <IncompleteGoogleSearchConsoleAccountCard /> );
 
 		const createButton = screen.getByRole( 'button', {
-			name: 'Or, create a new Google Search Console property',
+			name: 'Create new property',
 		} );
 
 		// Available without selecting anything from the dropdown first.
@@ -292,7 +300,7 @@ describe( 'IncompleteGoogleSearchConsoleAccountCard', () => {
 
 		await user.click(
 			screen.getByRole( 'button', {
-				name: 'Or, create a new Google Search Console property',
+				name: 'Create new property',
 			} )
 		);
 

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/index.test.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/index.test.js
@@ -418,7 +418,9 @@ describe( 'IncompleteGoogleSearchConsoleAccountCard', () => {
 
 	it( 'only fetches the properties list for the incomplete status, skipping it for every other one', () => {
 		mockAccount( { status: ACTION_NEEDED } );
-		const { rerender } = render( <IncompleteGoogleSearchConsoleAccountCard /> );
+		const { rerender } = render(
+			<IncompleteGoogleSearchConsoleAccountCard />
+		);
 		expect( useGoogleSearchConsoleProperties ).toHaveBeenLastCalledWith( {
 			skip: true,
 		} );

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/index.test.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/index.test.js
@@ -415,4 +415,36 @@ describe( 'IncompleteGoogleSearchConsoleAccountCard', () => {
 		);
 		expect( connectClick ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	it( 'only fetches the properties list for the incomplete status, skipping it for every other one', () => {
+		mockAccount( { status: ACTION_NEEDED } );
+		const { rerender } = render( <IncompleteGoogleSearchConsoleAccountCard /> );
+		expect( useGoogleSearchConsoleProperties ).toHaveBeenLastCalledWith( {
+			skip: true,
+		} );
+
+		mockAccount( { status: RECONNECT } );
+		rerender( <IncompleteGoogleSearchConsoleAccountCard /> );
+		expect( useGoogleSearchConsoleProperties ).toHaveBeenLastCalledWith( {
+			skip: true,
+		} );
+
+		mockAccount( { status: CONNECTION_FAILED } );
+		rerender( <IncompleteGoogleSearchConsoleAccountCard /> );
+		expect( useGoogleSearchConsoleProperties ).toHaveBeenLastCalledWith( {
+			skip: true,
+		} );
+
+		mockAccount( { status: TRANSIENT_ERROR } );
+		rerender( <IncompleteGoogleSearchConsoleAccountCard /> );
+		expect( useGoogleSearchConsoleProperties ).toHaveBeenLastCalledWith( {
+			skip: true,
+		} );
+
+		mockAccount( { status: INCOMPLETE } );
+		rerender( <IncompleteGoogleSearchConsoleAccountCard /> );
+		expect( useGoogleSearchConsoleProperties ).toHaveBeenLastCalledWith( {
+			skip: false,
+		} );
+	} );
 } );

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/index.test.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/index.test.js
@@ -145,7 +145,7 @@ describe( 'IncompleteGoogleSearchConsoleAccountCard', () => {
 		).toBeDisabled();
 	} );
 
-	it( 'shows a loading indicator while the properties list is still being fetched', () => {
+	it( 'shows a loading indicator while the properties list is still being fetched, with no indicator badge/button yet', () => {
 		mockProperties( null, false );
 		mockAccount( { status: INCOMPLETE } );
 
@@ -155,6 +155,13 @@ describe( 'IncompleteGoogleSearchConsoleAccountCard', () => {
 			screen.getByText( 'Loading Google Search Console properties…' )
 		).toBeInTheDocument();
 		expect( screen.queryByRole( 'combobox' ) ).not.toBeInTheDocument();
+
+		// The indicator holds off rendering anything until the properties list resolves, rather
+		// than showing "Resume setup" for an instant above this same loading text.
+		expect(
+			screen.queryByRole( 'button', { name: 'Resume setup' } )
+		).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Action needed' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the selector and selects a property when a genuine multi-match is unresolved', async () => {

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/indicator.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/indicator.js
@@ -48,13 +48,20 @@ const DEFAULT_BUTTON_LABEL = __( 'Resume setup', 'google-listings-and-ads' );
  * reconnect, connection-failed, and the generic fallback covering transient-error and anything
  * else unrecognized), which have no accompanying badge.
  *
+ * For `incomplete`, rendering is held back until the candidate-properties list has itself
+ * finished resolving — otherwise, for the instant before that list loads, this would show the
+ * generic recovery button (implying an action the merchant doesn't actually need) directly above
+ * the sibling detail's own "Loading…" text.
+ *
  * @fires gla_google_search_console_connect_button_click
  *
- * @return {JSX.Element|null} The indicator, or `null` until the account has resolved.
+ * @return {JSX.Element|null} The indicator, or `null` until the account (and, for `incomplete`,
+ *   the candidate-properties list) has resolved.
  */
 export default function Indicator() {
 	const { account, hasFinishedResolution } = useGoogleSearchConsoleAccount();
-	const { properties } = useGoogleSearchConsoleProperties();
+	const { properties, hasFinishedResolution: hasResolvedProperties } =
+		useGoogleSearchConsoleProperties();
 	const { connect: handleClick, loading } =
 		useGoogleSearchConsoleConnectRedirect();
 
@@ -63,6 +70,11 @@ export default function Indicator() {
 	}
 
 	const status = account?.status;
+
+	if ( status === INCOMPLETE && ! hasResolvedProperties ) {
+		return null;
+	}
+
 	const hasPendingPropertyChoice =
 		status === INCOMPLETE && properties?.length > 0;
 

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/indicator.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/indicator.js
@@ -60,16 +60,18 @@ const DEFAULT_BUTTON_LABEL = __( 'Resume setup', 'google-listings-and-ads' );
  */
 export default function Indicator() {
 	const { account, hasFinishedResolution } = useGoogleSearchConsoleAccount();
+	const status = account?.status;
+	// Only `incomplete` ever needs the candidate-properties list — skip the fetch entirely for
+	// every other status (action-needed, reconnect, connection-failed, and the initial
+	// not-yet-resolved render) rather than triggering it on every render regardless of status.
 	const { properties, hasFinishedResolution: hasResolvedProperties } =
-		useGoogleSearchConsoleProperties();
+		useGoogleSearchConsoleProperties( { skip: status !== INCOMPLETE } );
 	const { connect: handleClick, loading } =
 		useGoogleSearchConsoleConnectRedirect();
 
 	if ( ! hasFinishedResolution ) {
 		return null;
 	}
-
-	const status = account?.status;
 
 	if ( status === INCOMPLETE && ! hasResolvedProperties ) {
 		return null;

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/indicator.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/indicator.js
@@ -10,9 +10,10 @@ import AppButton from '~/components/app-button';
 import Badge from '~/components/badge';
 import { GOOGLE_SEARCH_CONSOLE_ACCOUNT_STATUS } from '~/constants';
 import useGoogleSearchConsoleAccount from '~/hooks/useGoogleSearchConsoleAccount';
+import useGoogleSearchConsoleProperties from '~/hooks/useGoogleSearchConsoleProperties';
 import useGoogleSearchConsoleConnectRedirect from '../hooks/useGoogleSearchConsoleConnectRedirect';
 
-const { ACTION_NEEDED, RECONNECT, CONNECTION_FAILED } =
+const { INCOMPLETE, ACTION_NEEDED, RECONNECT, CONNECTION_FAILED } =
 	GOOGLE_SEARCH_CONSOLE_ACCOUNT_STATUS;
 
 const ACTION_NEEDED_BADGE = {
@@ -41,10 +42,11 @@ const DEFAULT_BUTTON_LABEL = __( 'Resume setup', 'google-listings-and-ads' );
 
 /**
  * Renders the `AccountCard` `indicator` for the current non-connected/disconnected status: a
- * status badge for the `action-needed` status, whose action lives inside the notice `detail`,
- * or the sole recovery action button itself for the remaining statuses (incomplete, reconnect,
- * connection-failed, and the generic fallback covering transient-error and anything else
- * unrecognized), which have no accompanying badge.
+ * status badge for the `action-needed` status, or for `incomplete` while a genuine multi-match
+ * property choice is pending — both cases whose action lives inside the notice `detail` — or the
+ * sole recovery action button itself for the remaining cases (incomplete with no pending choice,
+ * reconnect, connection-failed, and the generic fallback covering transient-error and anything
+ * else unrecognized), which have no accompanying badge.
  *
  * @fires gla_google_search_console_connect_button_click
  *
@@ -52,6 +54,7 @@ const DEFAULT_BUTTON_LABEL = __( 'Resume setup', 'google-listings-and-ads' );
  */
 export default function Indicator() {
 	const { account, hasFinishedResolution } = useGoogleSearchConsoleAccount();
+	const { properties } = useGoogleSearchConsoleProperties();
 	const { connect: handleClick, loading } =
 		useGoogleSearchConsoleConnectRedirect();
 
@@ -60,11 +63,14 @@ export default function Indicator() {
 	}
 
 	const status = account?.status;
+	const hasPendingPropertyChoice =
+		status === INCOMPLETE && properties?.length > 0;
 
 	const badge = BADGE_BY_STATUS[ status ];
 
-	if ( badge ) {
-		return <Badge intent={ badge.intent }>{ badge.label }</Badge>;
+	if ( badge || hasPendingPropertyChoice ) {
+		const { intent, label } = badge ?? ACTION_NEEDED_BADGE;
+		return <Badge intent={ intent }>{ label }</Badge>;
 	}
 
 	const isError = status === RECONNECT || status === CONNECTION_FAILED;

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/notice-detail.js
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/notice-detail.js
@@ -18,12 +18,12 @@ const ICON_BY_STATUS = {
 /**
  * Renders the colored notice used as the `Detail` content for every incomplete-flow step
  * (property selection, verification, action-needed, reconnect, connection-failed): a
- * status-derived icon, bold title, body copy, optional extra content (e.g. the property
- * selector), and zero or more actions.
+ * status-derived icon and bold title when a title is given, body copy, optional extra content
+ * (e.g. the property selector), and zero or more actions.
  *
  * @param {Object} props Component props.
  * @param {'info'|'warning'|'error'} props.status Notice color; also selects the header icon.
- * @param {string} props.title Bold notice title.
+ * @param {string} [props.title] Bold notice title, shown alongside the icon when provided.
  * @param {string|JSX.Element} props.body Notice body copy — a plain string, or JSX (e.g. the property selector).
  * @param {JSX.Element[]} [props.actions] The step's action controls, each needing its own `key`.
  * @return {JSX.Element} The notice.
@@ -35,12 +35,14 @@ export default function NoticeDetail( { status, title, body, actions = [] } ) {
 			isDismissible={ false }
 			className="gla-google-search-console-account-card__notice"
 		>
-			<div className="gla-google-search-console-account-card__notice-header">
-				<Icon icon={ ICON_BY_STATUS[ status ] } />
-				<span className="gla-google-search-console-account-card__notice-title">
-					{ title }
-				</span>
-			</div>
+			{ title && (
+				<div className="gla-google-search-console-account-card__notice-header">
+					<Icon icon={ ICON_BY_STATUS[ status ] } />
+					<span className="gla-google-search-console-account-card__notice-title">
+						{ title }
+					</span>
+				</div>
+			) }
 			<div className="gla-google-search-console-account-card__notice-body">
 				{ body }
 			</div>

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/notice-detail.scss
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/notice-detail.scss
@@ -15,3 +15,7 @@
 .gla-google-search-console-account-card__notice-actions {
 	margin-top: $grid-unit-10;
 }
+
+.gla-google-search-console-account-card__property-selection-notice p {
+	margin: 0;
+}

--- a/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/notice-detail.scss
+++ b/js/src/pages/settings/accounts/google-search-console-account-card/incomplete-google-search-console-account-card/notice-detail.scss
@@ -15,7 +15,3 @@
 .gla-google-search-console-account-card__notice-actions {
 	margin-top: $grid-unit-10;
 }
-
-.gla-google-search-console-account-card__property-selection-notice p {
-	margin: 0;
-}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes: [GOOWOO-1026](https://linear.app/a8c/issue/GOOWOO-1026/search-console-pending-property-choice-shows-resume-setup-instead-of)

When the Search Console account status is `incomplete` and a genuine multi-match property list is pending, the account card showed a "Resume setup" button instead of an "Action needed" badge. Clicking it just restarted the Google OAuth flow for no reason, since permission was already granted — the property dropdown was still there and usable underneath, the card just didn't signal that a choice was waiting.

- `Indicator` now also reads the candidate-properties list already used by the sibling `PropertySelection` detail, and shows the "Action needed" badge whenever `incomplete` has a non-empty pending list — falling back to "Resume setup" only when there's genuinely nothing to choose yet (unchanged, out of scope here — tracked separately under GOOWOO-968).
- `Indicator` now also waits for that properties list to finish resolving before rendering anything for `incomplete`, so it doesn't briefly flash "Resume setup" above the sibling detail's own "Loading…" text.
- Realigned `PropertySelection`'s layout: the notice now contains only its explanatory copy (no title/dropdown inside it), with the dropdown and the "Save"/"Create new property" actions rendered as plain siblings below — matching the equivalent Google Tag Manager pattern instead of wrapping everything in the notice.
- Moved a small CSS rule into a new co-located `property-selection.scss` instead of a sibling component's stylesheet, and tightened a docblock that quoted today's exact button copy.

No backend/PHP changes — presentation layer only.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Open Settings > Accounts (`/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fsettings`) with your devtool network overrides available.
2. Multi-match / "Action needed" badge: override `GET /wp-json/wc/gla/search-console/connection` → `{"status":"incomplete"}` and `GET /wp-json/wc/gla/search-console/properties` → `[{"siteUrl":"https://a.example.com/","permissionLevel":"siteOwner","covers":true,"usable":true},{"siteUrl":"https://b.example.com/","permissionLevel":"siteFullUser","covers":true,"usable":true}]`, then hard-reload (Cmd+Shift+R — resolvers cache for the page's lifetime, a soft nav won't re-fire the overridden requests). Expect: "Action needed" badge (not "Resume setup"); notice box contains only the two explanatory sentences; dropdown sits plainly below the notice, auto-selecting the first option; "Save" (primary) and "Create new property" (text link) sit side by side below the dropdown.
3. Loading-state check: with the same `connection` override, delay or throttle the `properties` response (e.g. DevTools network throttling on that one request) and confirm the indicator area shows nothing at all — no "Resume setup", no badge — while the body shows "Loading Google Search Console properties…".
4. Regression check — unaffected states still render correctly: `{"status":"action-needed"}`, `{"status":"reconnect"}`, `{"status":"connection-failed"}`, and `{"status":"incomplete"}` with `properties: []` (still shows the plain "Resume setup" button, unchanged).
5. Automated coverage: `npx wp-scripts test-unit-js --testPathPattern="google-search-console-account-card"` — 29 cases should pass.

### Additional details:

### Changelog entry

>