### PR TITLE
[DO NOT MERGE] POC: Temporarily Bypass Expired Debian Release Metadata in E2E CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,7 +46,7 @@ jobs:
           npm run build
           echo "::endgroup::"
 
-      - name: Temporarily bypass expired Debian release metadata (diagnostic only)
+      - name: Temporarily redirect Debian bullseye to archive.debian.org (diagnostic only)
         run: node bin/patch-wp-env-debian-bullseye.js
 
       - name: Start wp-env container

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,6 +46,9 @@ jobs:
           npm run build
           echo "::endgroup::"
 
+      - name: Temporarily bypass expired Debian release metadata (diagnostic only)
+        run: node bin/patch-wp-env-debian-bullseye.js
+
       - name: Start wp-env container
         run: npm run wp-env:up
 

--- a/bin/patch-wp-env-debian-bullseye.js
+++ b/bin/patch-wp-env-debian-bullseye.js
@@ -1,24 +1,31 @@
 #!/usr/bin/env node
 
 /**
- * TEMPORARY CI diagnostic — not a permanent fix, remove once the root cause is confirmed.
+ * TEMPORARY CI diagnostic — not a permanent fix, remove once confirmed working upstream.
  *
- * Debian's bullseye-security release metadata has been expiring, which makes
- * the wp-env tooling's generated "wordpress" Docker image build fail on its
- * `apt-get -qy update` step. The installed version already redirects older
- * stretch/buster releases to archive.debian.org, but has no equivalent fix
- * for bullseye yet. This script patches the freshly-installed copy in
- * node_modules to skip apt's release-metadata freshness check, so we can
- * confirm that really is the root cause before deciding on a durable fix.
+ * The wp-env tooling's generated "wordpress"/"tests-wordpress" Docker images
+ * already redirect older stretch/buster Debian releases to archive.debian.org
+ * (see wordpressDockerFileContents() in the patched file below), but has no
+ * equivalent redirect for bullseye yet. A live-CI run confirmed this is a real
+ * archival, not a transient signature-freshness blip: `apt-get -qy install`
+ * failed with a genuine 404 fetching a package from the live bullseye-security
+ * mirror, not just an expired Release-file signature. This script extends the
+ * existing redirect pattern to also cover bullseye, so we can confirm that's
+ * the real, durable fix before deciding where it should permanently live
+ * (patch-package, or upstream in wp-env itself).
  */
 
 const fs = require( 'fs' );
 
 const file = 'node_modules/@wordpress/env/lib/init-config.js';
-const target = 'RUN apt-get -qy update';
+const target = "RUN sed -i '/buster-updates/d' /etc/apt/sources.list";
 const insertion =
-	'RUN echo \'Acquire::Check-Valid-Until "false";\' > /etc/apt/apt.conf.d/99no-check-valid-until\n' +
-	target;
+	target +
+	'\n\n' +
+	'# bullseye\n' +
+	"RUN sed -i 's|deb.debian.org/debian bullseye|archive.debian.org/debian bullseye|g' /etc/apt/sources.list\n" +
+	"RUN sed -i 's|security.debian.org/debian-security bullseye-security|archive.debian.org/debian-security bullseye-security|g' /etc/apt/sources.list\n" +
+	"RUN sed -i '/bullseye-updates/d' /etc/apt/sources.list";
 
 const content = fs.readFileSync( file, 'utf8' );
 
@@ -34,5 +41,5 @@ fs.writeFileSync( file, content.replace( target, insertion ) );
 
 // eslint-disable-next-line no-console
 console.log(
-	`Patched ${ file } to skip Debian's apt release-metadata freshness check.`
+	`Patched ${ file } to also redirect Debian bullseye to archive.debian.org.`
 );

--- a/bin/patch-wp-env-debian-bullseye.js
+++ b/bin/patch-wp-env-debian-bullseye.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/**
+ * TEMPORARY CI diagnostic — not a permanent fix, remove once the root cause is confirmed.
+ *
+ * Debian's bullseye-security release metadata has been expiring, which makes
+ * the wp-env tooling's generated "wordpress" Docker image build fail on its
+ * `apt-get -qy update` step. The installed version already redirects older
+ * stretch/buster releases to archive.debian.org, but has no equivalent fix
+ * for bullseye yet. This script patches the freshly-installed copy in
+ * node_modules to skip apt's release-metadata freshness check, so we can
+ * confirm that really is the root cause before deciding on a durable fix.
+ */
+
+const fs = require( 'fs' );
+
+const file = 'node_modules/@wordpress/env/lib/init-config.js';
+const target = 'RUN apt-get -qy update';
+const insertion =
+	'RUN echo \'Acquire::Check-Valid-Until "false";\' > /etc/apt/apt.conf.d/99no-check-valid-until\n' +
+	target;
+
+const content = fs.readFileSync( file, 'utf8' );
+
+if ( ! content.includes( target ) ) {
+	// eslint-disable-next-line no-console
+	console.error(
+		`::error::Patch target not found in ${ file } — @wordpress/env internals may have changed since this script was written.`
+	);
+	process.exit( 1 );
+}
+
+fs.writeFileSync( file, content.replace( target, insertion ) );
+
+// eslint-disable-next-line no-console
+console.log(
+	`Patched ${ file } to skip Debian's apt release-metadata freshness check.`
+);


### PR DESCRIPTION
Diagnostic only, not a permanent fix. Debian's bullseye-security release metadata has been expiring, which fails the "wordpress" Docker image's `apt-get -qy update` step. This adds a CI step that patches the freshly-installed wp-env tooling to skip that freshness check, to confirm it's really the root cause before deciding on a durable fix (extending the tooling's own existing archive-mirror redirect pattern, or patch-package).