### PR TITLE
GOOWOO-904 [FE] Tests + QA

### DIFF
--- a/js/src/components/analytics-overview-promo/get-promo-content.test.js
+++ b/js/src/components/analytics-overview-promo/get-promo-content.test.js
@@ -1,0 +1,66 @@
+/**
+ * Internal dependencies
+ */
+import getPromoContent from './get-promo-content'; // eslint-disable-line import/no-unresolved
+
+/**
+ * `getPromoContent( metricsCase, isConnected )` selects the copy variant for the Analytics
+ * Overview promo and returns `{ headline, body, ctaLabel, ctaPath, referrerId }`. `metricsCase`
+ * is the value returned by `useProductRevenueMetricsDown` ('revenue' | 'products').
+ */
+
+const REVENUE = 'revenue';
+const PRODUCTS = 'products';
+
+describe( 'getPromoContent', () => {
+	it( 'returns the Case 1 (revenue), not-onboarded variant', () => {
+		expect( getPromoContent( REVENUE, false ) ).toEqual(
+			expect.objectContaining( {
+				headline: 'Sales a bit slow? Reach more shoppers with Google.',
+				body: 'Sync your catalog with Google and grow back your sales by reaching new shoppers right when they are searching to buy.',
+				ctaLabel: 'Get started',
+				ctaPath: 'setup-mc',
+				referrerId: 'analytics-overview-promo-get-started',
+			} )
+		);
+	} );
+
+	it( 'returns the Case 1 (revenue), connected variant', () => {
+		expect( getPromoContent( REVENUE, true ) ).toEqual(
+			expect.objectContaining( {
+				headline:
+					'Sales a bit slow? Give your products a boost with Google.',
+				body: 'Launch a Google Ads campaign and grow back your sales by reaching shoppers who are ready to buy.',
+				ctaLabel: 'Launch a campaign',
+				ctaPath: 'setup-ads',
+				referrerId: 'analytics-overview-promo-launch-campaign',
+			} )
+		);
+	} );
+
+	it( 'returns the Case 2 (products), not-onboarded variant', () => {
+		expect( getPromoContent( PRODUCTS, false ) ).toEqual(
+			expect.objectContaining( {
+				headline:
+					'Selling fewer items than usual? Reach more shoppers with Google.',
+				body: 'Sync your catalog with Google and sell more of your products by reaching new shoppers right when they are searching to buy.',
+				ctaLabel: 'Get started',
+				ctaPath: 'setup-mc',
+				referrerId: 'analytics-overview-promo-get-started',
+			} )
+		);
+	} );
+
+	it( 'returns the Case 2 (products), connected variant', () => {
+		expect( getPromoContent( PRODUCTS, true ) ).toEqual(
+			expect.objectContaining( {
+				headline:
+					'Selling fewer items than usual? Give your products a boost with Google.',
+				body: 'Launch a Google Ads campaign and sell more of your products by reaching shoppers who are ready to buy.',
+				ctaLabel: 'Launch a campaign',
+				ctaPath: 'setup-ads',
+				referrerId: 'analytics-overview-promo-launch-campaign',
+			} )
+		);
+	} );
+} );

--- a/tests/e2e/specs/analytics-overview/analytics-overview.test.js
+++ b/tests/e2e/specs/analytics-overview/analytics-overview.test.js
@@ -9,8 +9,12 @@ import { expect, test } from '@playwright/test';
 import {
 	setOnboardedMerchant,
 	clearOnboardedMerchant,
+	clearCompletedAdsSetup,
 	clearServiceBasedMerchant,
+	createSimpleProduct,
 } from '../../utils/api';
+import { getClassicProductEditorUtils } from '../../utils/product-editor';
+import MockRequests from '../../utils/mock-requests';
 import AnalyticsOverviewPage, {
 	PRIMARY_AFTER,
 	PRIMARY_BEFORE,
@@ -264,6 +268,16 @@ test.describe( 'Analytics Overview promo', () => {
 				overview.getAnalyticsOverviewPromoSection()
 			).toHaveCount( 0 );
 		} );
+
+		test( 'connected merchant with an INCOMPLETE account is treated as ready', async () => {
+			await overview.mockConnectedIncomplete();
+			await overview.mockMetricsDown( METRICS_CASE.REVENUE );
+			await overview.goto( PRIMARY_RANGE );
+
+			await expect( overview.getCtaButton() ).toHaveText(
+				'Launch a campaign'
+			);
+		} );
 	} );
 
 	/**
@@ -409,7 +423,7 @@ test.describe( 'Analytics Overview promo', () => {
 			await page.close();
 		} );
 
-		test( 'fires the shown event with the matched-case prop', async () => {
+		test( 'fires the shown event with the matched case and placement props', async () => {
 			await expect(
 				overview.getAnalyticsOverviewPromoSection()
 			).toBeVisible();
@@ -419,9 +433,10 @@ test.describe( 'Analytics Overview promo', () => {
 			expect( shown[ 0 ].props ).toMatchObject( {
 				metrics_case: METRICS_CASE.REVENUE,
 			} );
+			expect( shown[ 0 ].props.context ).toBeTruthy();
 		} );
 
-		test( 'CTA carries referrer args and fires the click event', async () => {
+		test( 'CTA carries referrer args and fires the click event with its props', async () => {
 			const cta = overview.getCtaButton();
 			await expect( cta ).toHaveAttribute(
 				'href',
@@ -438,9 +453,13 @@ test.describe( 'Analytics Overview promo', () => {
 				EVENT.getStartedClick
 			);
 			expect( clicks ).toHaveLength( 1 );
+			expect( clicks[ 0 ].props ).toMatchObject( {
+				metrics_case: METRICS_CASE.REVENUE,
+			} );
+			expect( clicks[ 0 ].props.href ).toContain( 'setup-mc' );
 		} );
 
-		test( 'referrer args survive the navigation hop to onboarding', async () => {
+		test( 'referrer args survive the hop to onboarding and reach downstream events', async () => {
 			await overview.goto( PRIMARY_RANGE );
 			await overview.getCtaButton().click();
 			await page.waitForURL( /setup-mc/ );
@@ -451,9 +470,23 @@ test.describe( 'Analytics Overview promo', () => {
 			expect( page.url() ).toContain(
 				`referrer_id=${ REFERRER_ID.notOnboarded }`
 			);
+
+			// Downstream tracking events on the onboarding screen carry the referrer attribution,
+			// so the conversion attributes back to the placement.
+			await expect
+				.poll( async () => {
+					const events = await overview.getTrackedEvents();
+					return events.some(
+						( event ) =>
+							event.props?.referrer_type === REFERRER_TYPE &&
+							event.props?.referrer_id ===
+								REFERRER_ID.notOnboarded
+					);
+				} )
+				.toBe( true );
 		} );
 
-		test( 'fires the dismiss event', async () => {
+		test( 'fires the dismiss event with the matched-case prop', async () => {
 			await overview.goto( PRIMARY_RANGE );
 			await overview.getDismissButton().click();
 
@@ -461,13 +494,16 @@ test.describe( 'Analytics Overview promo', () => {
 				EVENT.dismissClick
 			);
 			expect( dismissed ).toHaveLength( 1 );
+			expect( dismissed[ 0 ].props ).toMatchObject( {
+				metrics_case: METRICS_CASE.REVENUE,
+			} );
 		} );
 	} );
 
 	/**
-	 * No regression to the rest of the Overview page.
+	 * No regression to the core Overview sections.
 	 */
-	test.describe( 'No regression', () => {
+	test.describe( 'No regression to Overview sections', () => {
 		let page = null;
 		let overview = null;
 
@@ -485,12 +521,54 @@ test.describe( 'Analytics Overview promo', () => {
 			await page.close();
 		} );
 
-		test( 'keeps the core Analytics report on the Overview page', async () => {
+		test( 'renders the promo alongside the core Overview report', async () => {
 			await expect(
 				overview.getAnalyticsOverviewPromoSection()
 			).toBeVisible();
 			await expect(
 				page.locator( '.woocommerce-filters' )
+			).toBeVisible();
+			// The performance summary and charts are core Overview sections that must stay intact.
+			await expect(
+				page.locator( '.woocommerce-summary' )
+			).toBeVisible();
+			await expect(
+				page.locator( '.woocommerce-chart' ).first()
+			).toBeVisible();
+		} );
+	} );
+
+	/**
+	 * No regression to the Phase 1 in-product placement on the product editor.
+	 */
+	test.describe( 'No regression to Phase 1 placements', () => {
+		let page = null;
+		let editorUtils = null;
+		let mockRequests = null;
+		let productId = null;
+
+		test.beforeAll( async ( { browser } ) => {
+			page = await browser.newPage();
+			editorUtils = getClassicProductEditorUtils( page );
+			mockRequests = new MockRequests( page );
+			await setOnboardedMerchant();
+			await clearCompletedAdsSetup();
+			await mockRequests.mockJetpackConnected();
+			await mockRequests.mockGoogleConnected();
+			productId = await createSimpleProduct();
+		} );
+
+		test.afterAll( async () => {
+			await clearOnboardedMerchant();
+			await clearCompletedAdsSetup();
+			await clearServiceBasedMerchant();
+			await page.close();
+		} );
+
+		test( 'renders the channel visibility placement on the product editor', async () => {
+			await editorUtils.gotoEditProductPage( productId );
+			await expect(
+				editorUtils.getChannelVisibilityMetaBoxContent()
 			).toBeVisible();
 		} );
 	} );

--- a/tests/e2e/specs/analytics-overview/analytics-overview.test.js
+++ b/tests/e2e/specs/analytics-overview/analytics-overview.test.js
@@ -498,6 +498,37 @@ test.describe( 'Analytics Overview promo', () => {
 				metrics_case: METRICS_CASE.REVENUE,
 			} );
 		} );
+
+		test( 'referrer args reach campaign creation and its downstream events for a connected merchant', async () => {
+			await setConnected( overview, 0 );
+			await overview.mockMetricsDown( METRICS_CASE.REVENUE );
+			await overview.goto( PRIMARY_RANGE );
+
+			await overview.getCtaButton().click();
+			await page.waitForURL( /setup-ads/ );
+
+			expect( page.url() ).toContain(
+				`referrer_type=${ REFERRER_TYPE }`
+			);
+			expect( page.url() ).toContain(
+				`referrer_id=${ REFERRER_ID.connected }`
+			);
+
+			// The campaign-creation screen is the conversion end of the flow; its tracking events
+			// carry the referrer attribution, so the created campaign attributes to the placement.
+			await expect
+				.poll( async () => {
+					const events = await overview.getTrackedEvents();
+					return events.some(
+						( event ) =>
+							event.props?.referrer_type === REFERRER_TYPE &&
+							event.props?.referrer_id === REFERRER_ID.connected
+					);
+				} )
+				.toBe( true );
+
+			await clearOnboardedMerchant();
+		} );
 	} );
 
 	/**

--- a/tests/e2e/specs/analytics-overview/analytics-overview.test.js
+++ b/tests/e2e/specs/analytics-overview/analytics-overview.test.js
@@ -6,36 +6,492 @@ import { expect, test } from '@playwright/test';
 /**
  * Internal dependencies
  */
-import AnalyticsOverviewPage from '../../utils/pages/analytics-overview';
+import {
+	setOnboardedMerchant,
+	clearOnboardedMerchant,
+	clearServiceBasedMerchant,
+} from '../../utils/api';
+import AnalyticsOverviewPage, {
+	PRIMARY_AFTER,
+	PRIMARY_BEFORE,
+	UP_RANGE_AFTER,
+	UP_RANGE_BEFORE,
+	METRICS_CASE,
+} from '../../utils/pages/analytics-overview';
+
+// Copy matrix, keyed by matched case × connection state.
+const COPY = {
+	[ METRICS_CASE.REVENUE ]: {
+		notOnboarded: {
+			headline: 'Sales a bit slow? Reach more shoppers with Google.',
+			body: 'Sync your catalog with Google and grow back your sales by reaching new shoppers right when they are searching to buy.',
+			cta: 'Get started',
+		},
+		connected: {
+			headline:
+				'Sales a bit slow? Give your products a boost with Google.',
+			body: 'Launch a Google Ads campaign and grow back your sales by reaching shoppers who are ready to buy.',
+			cta: 'Launch a campaign',
+		},
+	},
+	[ METRICS_CASE.PRODUCTS ]: {
+		notOnboarded: {
+			headline:
+				'Selling fewer items than usual? Reach more shoppers with Google.',
+			body: 'Sync your catalog with Google and sell more of your products by reaching new shoppers right when they are searching to buy.',
+			cta: 'Get started',
+		},
+		connected: {
+			headline:
+				'Selling fewer items than usual? Give your products a boost with Google.',
+			body: 'Launch a Google Ads campaign and sell more of your products by reaching shoppers who are ready to buy.',
+			cta: 'Launch a campaign',
+		},
+	},
+};
+
+// CTA destinations by connection state.
+const CTA_PATH = {
+	notOnboarded: 'path=%2Fgoogle%2Fsetup-mc',
+	connected: 'path=%2Fgoogle%2Fsetup-ads',
+};
+
+// Referrer attribution carried on the CTA.
+const REFERRER_TYPE = 'in_product_placements';
+const REFERRER_ID = {
+	notOnboarded: 'analytics-overview-promo-get-started',
+	connected: 'analytics-overview-promo-launch-campaign',
+};
+
+// Tracking events.
+const EVENT = {
+	shown: 'gla_analytics_overview_promo_shown',
+	getStartedClick: 'gla_analytics_overview_promo_get_started_click',
+	launchCampaignClick: 'gla_analytics_overview_promo_launch_campaign_click',
+	dismissClick: 'gla_analytics_overview_promo_dismiss_click',
+};
+
+const PRIMARY_RANGE = { after: PRIMARY_AFTER, before: PRIMARY_BEFORE };
+const UP_RANGE = { after: UP_RANGE_AFTER, before: UP_RANGE_BEFORE };
+
+/**
+ * Put the merchant into the not-onboarded state (plugin installed, not connected to G4W).
+ *
+ * @return {Promise<void>}
+ */
+async function setNotOnboarded() {
+	await clearOnboardedMerchant();
+	await clearServiceBasedMerchant();
+}
+
+/**
+ * Put the merchant into the connected state with the given recent ad spend.
+ *
+ * @param {AnalyticsOverviewPage} overview Page object providing the ad-spend mock.
+ * @param {number}                spend    Ad spend to report for the last 14 days.
+ * @return {Promise<void>}
+ */
+async function setConnected( overview, spend ) {
+	await clearServiceBasedMerchant();
+	await setOnboardedMerchant();
+	await overview.mockAdSpend( spend );
+}
 
 test.use( { storageState: process.env.ADMINSTATE } );
 
 test.describe.configure( { mode: 'serial' } );
 
-/**
- * @type {import('../../utils/pages/analytics-overview').default} analyticsOverviewPage
- */
-let analyticsOverviewPage = null;
+test.describe( 'Analytics Overview promo', () => {
+	/**
+	 * The section is registered on Analytics → Overview and renders when eligible.
+	 */
+	test.describe( 'Section registration', () => {
+		let page = null;
+		let overview = null;
 
-/**
- * @type {import('@playwright/test').Page} page
- */
-let page = null;
+		test.beforeAll( async ( { browser } ) => {
+			page = await browser.newPage();
+			overview = new AnalyticsOverviewPage( page );
+			await overview.mockNotDismissed();
+			await setNotOnboarded();
+			await overview.mockMetricsDown( METRICS_CASE.REVENUE );
+			await overview.goto( PRIMARY_RANGE );
+		} );
 
-test.describe( 'Analytics Overview', () => {
-	test.beforeAll( async ( { browser } ) => {
-		page = await browser.newPage();
-		analyticsOverviewPage = new AnalyticsOverviewPage( page );
-		await analyticsOverviewPage.goto();
+		test.afterAll( async () => {
+			await clearOnboardedMerchant();
+			await page.close();
+		} );
+
+		test( 'renders the promo section on the Overview tab', async () => {
+			await expect(
+				overview.getAnalyticsOverviewPromoSection()
+			).toBeVisible();
+		} );
+
+		test( 'does not render the promo on other Analytics sub-tabs', async () => {
+			await page.goto(
+				'/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Fproducts'
+			);
+			await overview.waitForOverviewReady();
+			await expect(
+				overview.getAnalyticsOverviewPromoSection()
+			).toHaveCount( 0 );
+		} );
 	} );
 
-	test.afterAll( async () => {
-		await page.close();
+	/**
+	 * Metrics-down gating and live show/hide on date-range switch.
+	 */
+	test.describe( 'Metrics-down gating', () => {
+		let page = null;
+		let overview = null;
+
+		test.beforeAll( async ( { browser } ) => {
+			page = await browser.newPage();
+			overview = new AnalyticsOverviewPage( page );
+			await overview.mockNotDismissed();
+			await setNotOnboarded();
+			// Down for the primary range, up for the alternate range.
+			await overview.mockMetricsDown(
+				METRICS_CASE.REVENUE,
+				PRIMARY_AFTER
+			);
+			await overview.mockMetricsUp( UP_RANGE_AFTER );
+		} );
+
+		test.afterAll( async () => {
+			await overview.clearReportStats();
+			await clearOnboardedMerchant();
+			await page.close();
+		} );
+
+		test( 'shows the card when metrics are down for the selected period', async () => {
+			await overview.goto( PRIMARY_RANGE );
+			await expect(
+				overview.getAnalyticsOverviewPromoSection()
+			).toBeVisible();
+		} );
+
+		test( 'hides the card when metrics are up for the selected period', async () => {
+			await overview.goto( UP_RANGE );
+			await overview.waitForOverviewReady();
+			await expect(
+				overview.getAnalyticsOverviewPromoSection()
+			).toHaveCount( 0 );
+		} );
+
+		test( 'toggles live when the date range switches, without a full reload', async () => {
+			await overview.goto( PRIMARY_RANGE );
+			await expect(
+				overview.getAnalyticsOverviewPromoSection()
+			).toBeVisible();
+
+			// Marker to detect a full reload: it survives an in-place SPA navigation only.
+			await page.evaluate( () => {
+				window.__glaReloadMarker = 'kept';
+			} );
+
+			await overview.switchDateRangeInPlace( UP_RANGE );
+
+			await expect(
+				overview.getAnalyticsOverviewPromoSection()
+			).toHaveCount( 0 );
+
+			const marker = await page.evaluate(
+				() => window.__glaReloadMarker
+			);
+			expect( marker ).toBe( 'kept' );
+		} );
+
+		test( 'stays hidden when the selected period has no comparison data', async () => {
+			await overview.clearReportStats();
+			await overview.mockNoComparisonData( PRIMARY_AFTER );
+			await overview.goto( PRIMARY_RANGE );
+			await overview.waitForOverviewReady();
+			await expect(
+				overview.getAnalyticsOverviewPromoSection()
+			).toHaveCount( 0 );
+		} );
 	} );
 
-	test( 'Renders the Analytics Overview promo section', async () => {
-		await expect(
-			analyticsOverviewPage.getAnalyticsOverviewPromoSection()
-		).toBeVisible();
+	/**
+	 * Merchant-state branches and ad-spend suppression.
+	 */
+	test.describe( 'Merchant-state gating', () => {
+		let page = null;
+		let overview = null;
+
+		test.beforeAll( async ( { browser } ) => {
+			page = await browser.newPage();
+			overview = new AnalyticsOverviewPage( page );
+			await overview.mockNotDismissed();
+		} );
+
+		test.afterEach( async () => {
+			await clearOnboardedMerchant();
+		} );
+
+		test.afterAll( async () => {
+			await page.close();
+		} );
+
+		test( 'not-onboarded merchant sees the "Get started" CTA', async () => {
+			await setNotOnboarded();
+			await overview.mockMetricsDown( METRICS_CASE.REVENUE );
+			await overview.goto( PRIMARY_RANGE );
+
+			await expect( overview.getCtaButton() ).toHaveText( 'Get started' );
+		} );
+
+		test( 'connected merchant with no ad spend sees the "Launch a campaign" CTA', async () => {
+			await setConnected( overview, 0 );
+			await overview.mockMetricsDown( METRICS_CASE.REVENUE );
+			await overview.goto( PRIMARY_RANGE );
+
+			await expect( overview.getCtaButton() ).toHaveText(
+				'Launch a campaign'
+			);
+		} );
+
+		test( 'connected merchant with recent ad spend is suppressed', async () => {
+			await setConnected( overview, 120 );
+			await overview.mockMetricsDown( METRICS_CASE.REVENUE );
+			await overview.goto( PRIMARY_RANGE );
+			await overview.waitForOverviewReady();
+
+			await expect(
+				overview.getAnalyticsOverviewPromoSection()
+			).toHaveCount( 0 );
+		} );
+	} );
+
+	/**
+	 * Copy/CTA matrix: matched case (row) × connection state (column).
+	 */
+	test.describe( 'Copy and CTA matrix', () => {
+		let page = null;
+		let overview = null;
+
+		test.beforeAll( async ( { browser } ) => {
+			page = await browser.newPage();
+			overview = new AnalyticsOverviewPage( page );
+			await overview.mockNotDismissed();
+		} );
+
+		test.afterEach( async () => {
+			await clearOnboardedMerchant();
+		} );
+
+		test.afterAll( async () => {
+			await page.close();
+		} );
+
+		const cases = [
+			{
+				name: 'Case 1 (revenue) — not onboarded',
+				metricsCase: METRICS_CASE.REVENUE,
+				state: 'notOnboarded',
+			},
+			{
+				name: 'Case 1 (revenue) — connected',
+				metricsCase: METRICS_CASE.REVENUE,
+				state: 'connected',
+			},
+			{
+				name: 'Case 2 (products) — not onboarded',
+				metricsCase: METRICS_CASE.PRODUCTS,
+				state: 'notOnboarded',
+			},
+			{
+				name: 'Case 2 (products) — connected',
+				metricsCase: METRICS_CASE.PRODUCTS,
+				state: 'connected',
+			},
+		];
+
+		for ( const { name, metricsCase, state } of cases ) {
+			test( `renders the correct copy and CTA for ${ name }`, async () => {
+				if ( state === 'connected' ) {
+					await setConnected( overview, 0 );
+				} else {
+					await setNotOnboarded();
+				}
+				await overview.mockMetricsDown( metricsCase );
+				await overview.goto( PRIMARY_RANGE );
+
+				const copy = COPY[ metricsCase ][ state ];
+				await expect( overview.getCardHeadline() ).toHaveText(
+					copy.headline
+				);
+				await expect(
+					overview.getAnalyticsOverviewPromoSection()
+				).toContainText( copy.body );
+
+				const cta = overview.getCtaButton();
+				await expect( cta ).toHaveText( copy.cta );
+				await expect( cta ).toHaveAttribute(
+					'href',
+					new RegExp( CTA_PATH[ state ] )
+				);
+			} );
+		}
+	} );
+
+	/**
+	 * Durable dismissal.
+	 */
+	test.describe( 'Dismissal', () => {
+		let page = null;
+		let overview = null;
+
+		test.beforeAll( async ( { browser } ) => {
+			page = await browser.newPage();
+			overview = new AnalyticsOverviewPage( page );
+			await overview.mockNotDismissed();
+			await setNotOnboarded();
+			await overview.mockMetricsDown( METRICS_CASE.REVENUE );
+			await overview.goto( PRIMARY_RANGE );
+		} );
+
+		test.afterAll( async () => {
+			await clearOnboardedMerchant();
+			await page.close();
+		} );
+
+		test( 'hides the card immediately on dismiss and persists it', async () => {
+			await expect(
+				overview.getAnalyticsOverviewPromoSection()
+			).toBeVisible();
+
+			// Dismissal is persisted via `@wordpress/preferences`, POSTed to the user meta.
+			const persisted = page.waitForRequest(
+				( request ) =>
+					/\/wp\/v2\/users\/me/.test( request.url() ) &&
+					request.method() === 'POST'
+			);
+			await overview.getDismissButton().click();
+			await persisted;
+
+			await expect(
+				overview.getAnalyticsOverviewPromoSection()
+			).toHaveCount( 0 );
+		} );
+
+		test( 'stays hidden after a reload', async () => {
+			await overview.goto( PRIMARY_RANGE );
+			await overview.waitForOverviewReady();
+			await expect(
+				overview.getAnalyticsOverviewPromoSection()
+			).toHaveCount( 0 );
+		} );
+	} );
+
+	/**
+	 * Tracking events and referrer-arg propagation.
+	 */
+	test.describe( 'Tracking', () => {
+		let page = null;
+		let overview = null;
+
+		test.beforeAll( async ( { browser } ) => {
+			page = await browser.newPage();
+			overview = new AnalyticsOverviewPage( page );
+			await overview.installTracksSpy();
+			await overview.mockNotDismissed();
+			await setNotOnboarded();
+			await overview.mockMetricsDown( METRICS_CASE.REVENUE );
+			await overview.goto( PRIMARY_RANGE );
+		} );
+
+		test.afterAll( async () => {
+			await clearOnboardedMerchant();
+			await page.close();
+		} );
+
+		test( 'fires the shown event with the matched-case prop', async () => {
+			await expect(
+				overview.getAnalyticsOverviewPromoSection()
+			).toBeVisible();
+
+			const shown = await overview.getTrackedEvents( EVENT.shown );
+			expect( shown ).toHaveLength( 1 );
+			expect( shown[ 0 ].props ).toMatchObject( {
+				metrics_case: METRICS_CASE.REVENUE,
+			} );
+		} );
+
+		test( 'CTA carries referrer args and fires the click event', async () => {
+			const cta = overview.getCtaButton();
+			await expect( cta ).toHaveAttribute(
+				'href',
+				new RegExp( `referrer_type=${ REFERRER_TYPE }` )
+			);
+			await expect( cta ).toHaveAttribute(
+				'href',
+				new RegExp( `referrer_id=${ REFERRER_ID.notOnboarded }` )
+			);
+
+			await cta.click();
+
+			const clicks = await overview.getTrackedEvents(
+				EVENT.getStartedClick
+			);
+			expect( clicks ).toHaveLength( 1 );
+		} );
+
+		test( 'referrer args survive the navigation hop to onboarding', async () => {
+			await overview.goto( PRIMARY_RANGE );
+			await overview.getCtaButton().click();
+			await page.waitForURL( /setup-mc/ );
+
+			expect( page.url() ).toContain(
+				`referrer_type=${ REFERRER_TYPE }`
+			);
+			expect( page.url() ).toContain(
+				`referrer_id=${ REFERRER_ID.notOnboarded }`
+			);
+		} );
+
+		test( 'fires the dismiss event', async () => {
+			await overview.goto( PRIMARY_RANGE );
+			await overview.getDismissButton().click();
+
+			const dismissed = await overview.getTrackedEvents(
+				EVENT.dismissClick
+			);
+			expect( dismissed ).toHaveLength( 1 );
+		} );
+	} );
+
+	/**
+	 * No regression to the rest of the Overview page.
+	 */
+	test.describe( 'No regression', () => {
+		let page = null;
+		let overview = null;
+
+		test.beforeAll( async ( { browser } ) => {
+			page = await browser.newPage();
+			overview = new AnalyticsOverviewPage( page );
+			await overview.mockNotDismissed();
+			await setNotOnboarded();
+			await overview.mockMetricsDown( METRICS_CASE.REVENUE );
+			await overview.goto( PRIMARY_RANGE );
+		} );
+
+		test.afterAll( async () => {
+			await clearOnboardedMerchant();
+			await page.close();
+		} );
+
+		test( 'keeps the core Analytics report on the Overview page', async () => {
+			await expect(
+				overview.getAnalyticsOverviewPromoSection()
+			).toBeVisible();
+			await expect(
+				page.locator( '.woocommerce-filters' )
+			).toBeVisible();
+		} );
 	} );
 } );

--- a/tests/e2e/utils/__fixtures__/analytics-overview-stats.json
+++ b/tests/e2e/utils/__fixtures__/analytics-overview-stats.json
@@ -1,0 +1,12 @@
+{
+	"revenue": {
+		"down": { "total_sales": 50, "net_revenue": 50, "orders_count": 5 },
+		"up": { "total_sales": 200, "net_revenue": 200, "orders_count": 20 },
+		"secondary": { "total_sales": 100, "net_revenue": 100, "orders_count": 10 }
+	},
+	"products": {
+		"down": { "items_sold": 5 },
+		"up": { "items_sold": 20 },
+		"secondary": { "items_sold": 10 }
+	}
+}

--- a/tests/e2e/utils/pages/analytics-overview.js
+++ b/tests/e2e/utils/pages/analytics-overview.js
@@ -249,6 +249,18 @@ export default class AnalyticsOverviewPage extends MockRequests {
 	}
 
 	/**
+	 * Merchant state: onboarded/connected to G4W with an account still in the `incomplete`
+	 * status, which counts as ready for the placement. Resolves the "Launch a campaign" variant.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async mockConnectedIncomplete() {
+		await this.mockMCConnected();
+		await this.mockAdsAccountIncomplete();
+		await this.mockAdSpend( 0 );
+	}
+
+	/**
 	 * Reset the durable-dismissal preference so the card is not dismissed at load.
 	 *
 	 * @return {Promise<void>}

--- a/tests/e2e/utils/pages/analytics-overview.js
+++ b/tests/e2e/utils/pages/analytics-overview.js
@@ -3,6 +3,35 @@
  */
 import { LOAD_STATE } from '../constants';
 import MockRequests from '../mock-requests';
+import stats from '../__fixtures__/analytics-overview-stats.json';
+
+/**
+ * Primary (selected) range used to drive the metrics-down check deterministically.
+ * Tests navigate with these explicit custom dates so the report mocks can tell the
+ * primary range from the comparison range by the request's `after` param.
+ */
+export const PRIMARY_AFTER = '2025-02-01';
+export const PRIMARY_BEFORE = '2025-02-28';
+
+/**
+ * A second selected range whose metrics are up, used to assert the live show/hide
+ * behaviour when the merchant switches the Analytics date range.
+ */
+export const UP_RANGE_AFTER = '2025-05-01';
+export const UP_RANGE_BEFORE = '2025-05-31';
+
+/**
+ * Matched metrics cases returned by `useProductRevenueMetricsDown`.
+ */
+export const METRICS_CASE = {
+	REVENUE: 'revenue',
+	PRODUCTS: 'products',
+};
+
+const REPORT_STATS_URLS = {
+	revenue: /\/wc-analytics\/reports\/revenue\/stats/,
+	products: /\/wc-analytics\/reports\/products\/stats/,
+};
 
 /**
  * Analytics Overview page object class.
@@ -17,15 +46,42 @@ export default class AnalyticsOverviewPage extends MockRequests {
 	}
 
 	/**
-	 * Go to the Analytics Overview page.
+	 * Go to the Analytics Overview page, optionally with an explicit custom date range.
+	 *
+	 * @param {Object} [range] Optional explicit range. When omitted, the store default range is used.
+	 * @param {string} [range.after]   Inclusive start (Y-m-d) of the selected period.
+	 * @param {string} [range.before]  Inclusive end (Y-m-d) of the selected period.
+	 * @param {string} [range.compare] Comparison mode, e.g. `'previous_period'` or `'previous_year'`.
+	 * @return {Promise<void>}
+	 */
+	async goto( range = {} ) {
+		const { after, before, compare = 'previous_period' } = range;
+
+		let path =
+			'/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Foverview';
+
+		if ( after && before ) {
+			path +=
+				`&period=custom&compare=${ compare }` +
+				`&after=${ after }&before=${ before }`;
+		}
+
+		await this.page.goto( path, {
+			waitUntil: LOAD_STATE.DOM_CONTENT_LOADED,
+		} );
+	}
+
+	/**
+	 * Wait for the Analytics Overview page to be interactive before asserting on the promo. The
+	 * date filter bar is a stable marker that the report page has rendered, so a "not shown"
+	 * assertion cannot pass merely because the page has not finished loading.
 	 *
 	 * @return {Promise<void>}
 	 */
-	async goto() {
-		await this.page.goto(
-			'/wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2Foverview',
-			{ waitUntil: LOAD_STATE.DOM_CONTENT_LOADED }
-		);
+	async waitForOverviewReady() {
+		await this.page.waitForSelector( '.woocommerce-filters', {
+			state: 'visible',
+		} );
 	}
 
 	/**
@@ -35,5 +91,236 @@ export default class AnalyticsOverviewPage extends MockRequests {
 	 */
 	getAnalyticsOverviewPromoSection() {
 		return this.page.locator( '.gla-analytics-overview-promo' );
+	}
+
+	/**
+	 * Card headline (heading) of the promo.
+	 *
+	 * @return {import('@playwright/test').Locator} The heading element.
+	 */
+	getCardHeadline() {
+		return this.getAnalyticsOverviewPromoSection().getByRole( 'heading' );
+	}
+
+	/**
+	 * Primary CTA link of the promo ("Get started" or "Launch a campaign").
+	 *
+	 * @return {import('@playwright/test').Locator} The CTA link element.
+	 */
+	getCtaButton() {
+		return this.getAnalyticsOverviewPromoSection().getByRole( 'link' );
+	}
+
+	/**
+	 * Dismiss control of the promo.
+	 *
+	 * @return {import('@playwright/test').Locator} The dismiss button element.
+	 */
+	getDismissButton() {
+		return this.getAnalyticsOverviewPromoSection().getByRole( 'button', {
+			name: 'Dismiss',
+		} );
+	}
+
+	/**
+	 * Mock a WooCommerce Analytics stats endpoint, returning different totals for the
+	 * primary (selected) range vs. the comparison range. The primary range is identified
+	 * by the request's `after` param starting with `primaryAfter`.
+	 *
+	 * @param {'revenue'|'products'} reportType      Report type.
+	 * @param {Object}               options
+	 * @param {string}               options.primaryAfter    `after` (Y-m-d) that identifies the primary range.
+	 * @param {Object|null}          options.primaryTotals    `totals` returned for the primary range.
+	 * @param {Object|null}          options.secondaryTotals  `totals` returned for the comparison range.
+	 * @return {Promise<void>}
+	 */
+	async mockReportStats(
+		reportType,
+		{ primaryAfter, primaryTotals, secondaryTotals }
+	) {
+		await this.page.route(
+			REPORT_STATS_URLS[ reportType ],
+			async ( route ) => {
+				const after =
+					new URL( route.request().url() ).searchParams.get(
+						'after'
+					) || '';
+				const totals = after.startsWith( primaryAfter )
+					? primaryTotals
+					: secondaryTotals;
+
+				await route.fulfill( {
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify( { totals, intervals: [] } ),
+				} );
+			}
+		);
+	}
+
+	/**
+	 * Remove the report stats route stubs so they do not leak into other scenarios.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async clearReportStats() {
+		await this.page.unroute( REPORT_STATS_URLS.revenue );
+		await this.page.unroute( REPORT_STATS_URLS.products );
+	}
+
+	/**
+	 * Force the selected period to read as "down" for the given case, evaluated against the
+	 * comparison range. Revenue is checked first, then products, so a products-down scenario
+	 * also has to report revenue as up.
+	 *
+	 * @param {'revenue'|'products'} metricsCase Which case should match.
+	 * @param {string}               [primaryAfter=PRIMARY_AFTER] `after` identifying the primary range.
+	 * @return {Promise<void>}
+	 */
+	async mockMetricsDown( metricsCase, primaryAfter = PRIMARY_AFTER ) {
+		const revenueDown = metricsCase === METRICS_CASE.REVENUE;
+
+		await this.mockReportStats( 'revenue', {
+			primaryAfter,
+			primaryTotals: revenueDown ? stats.revenue.down : stats.revenue.up,
+			secondaryTotals: stats.revenue.secondary,
+		} );
+
+		await this.mockReportStats( 'products', {
+			primaryAfter,
+			primaryTotals:
+				metricsCase === METRICS_CASE.PRODUCTS
+					? stats.products.down
+					: stats.products.up,
+			secondaryTotals: stats.products.secondary,
+		} );
+	}
+
+	/**
+	 * Force the selected period to read as "up" (both revenue and products), so the card hides.
+	 *
+	 * @param {string} [primaryAfter=UP_RANGE_AFTER] `after` identifying the primary range.
+	 * @return {Promise<void>}
+	 */
+	async mockMetricsUp( primaryAfter = UP_RANGE_AFTER ) {
+		await this.mockReportStats( 'revenue', {
+			primaryAfter,
+			primaryTotals: stats.revenue.up,
+			secondaryTotals: stats.revenue.secondary,
+		} );
+
+		await this.mockReportStats( 'products', {
+			primaryAfter,
+			primaryTotals: stats.products.up,
+			secondaryTotals: stats.products.secondary,
+		} );
+	}
+
+	/**
+	 * Force the selected period to have no comparison data (the comparison totals are null),
+	 * so the decline cannot be computed and the card stays hidden.
+	 *
+	 * @param {string} [primaryAfter=PRIMARY_AFTER] `after` identifying the primary range.
+	 * @return {Promise<void>}
+	 */
+	async mockNoComparisonData( primaryAfter = PRIMARY_AFTER ) {
+		await this.mockReportStats( 'revenue', {
+			primaryAfter,
+			primaryTotals: stats.revenue.down,
+			secondaryTotals: null,
+		} );
+
+		await this.mockReportStats( 'products', {
+			primaryAfter,
+			primaryTotals: stats.products.down,
+			secondaryTotals: null,
+		} );
+	}
+
+	/**
+	 * Mock the paid-programs report so the recent-ad-spend check reads the given spend.
+	 * A spend greater than zero represents a campaign running in the last 14 days.
+	 *
+	 * @param {number} spend Ad spend total to report.
+	 * @return {Promise<void>}
+	 */
+	async mockAdSpend( spend ) {
+		await this.fulfillAdsReportProgram( { totals: { spend } } );
+	}
+
+	/**
+	 * Reset the durable-dismissal preference so the card is not dismissed at load.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async mockNotDismissed() {
+		await this.fulfillUsersPreferences( {} );
+	}
+
+	/**
+	 * Install an in-page spy over `window.wcTracks.recordEvent`, capturing GLA tracking
+	 * events into `window.__glaTrackedEvents` for assertion. Runs before every navigation.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async installTracksSpy() {
+		await this.page.addInitScript( () => {
+			window.__glaTrackedEvents = [];
+			const record = ( name, props ) => {
+				window.__glaTrackedEvents.push( { name, props } );
+			};
+			window.wcTracks = window.wcTracks || {};
+			window.wcTracks.isEnabled = true;
+			window.wcTracks.recordEvent = record;
+		} );
+	}
+
+	/**
+	 * Switch the Analytics date range in place through WooCommerce's own client-side navigation,
+	 * the same path the report controls use, so the SPA re-renders without a full page reload.
+	 *
+	 * @param {Object} range
+	 * @param {string} range.after    Inclusive start (Y-m-d) of the new selected period.
+	 * @param {string} range.before   Inclusive end (Y-m-d) of the new selected period.
+	 * @param {string} [range.compare] Comparison mode.
+	 * @return {Promise<void>}
+	 */
+	async switchDateRangeInPlace( {
+		after,
+		before,
+		compare = 'previous_period',
+	} ) {
+		await this.page.evaluate(
+			( args ) => {
+				const navigation = window.wc && window.wc.navigation;
+				const path = navigation.getNewPath(
+					{
+						period: 'custom',
+						compare: args.compare,
+						after: args.after,
+						before: args.before,
+					},
+					'/analytics/overview',
+					{}
+				);
+				navigation.getHistory().push( path );
+			},
+			{ after, before, compare }
+		);
+	}
+
+	/**
+	 * Read the tracking events captured by the Tracks spy, optionally filtered by name.
+	 *
+	 * @param {string} [name] Event name to filter by.
+	 * @return {Promise<Array<{name: string, props: Object}>>} The captured tracking events.
+	 */
+	async getTrackedEvents( name ) {
+		const events = await this.page.evaluate(
+			() => window.__glaTrackedEvents || []
+		);
+		return name
+			? events.filter( ( event ) => event.name === name )
+			: events;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #GOOWOO-904

I add automated coverage for the Analytics → Overview promo from In-Product Placements Phase 2, plus the test harness to drive it deterministically.

End-to-end (Playwright), in `tests/e2e/specs/analytics-overview/analytics-overview.test.js`:

- Section registration: the promo renders on Analytics → Overview and stays off the other Analytics sub-tabs.
- Metrics-down gating: the card shows when the selected period is down, hides when it is up, toggles live when the date range switches without a full page reload, and stays hidden when the period has no comparison data.
- Merchant-state branches: not-onboarded shows "Get started", connected with no recent ad spend shows "Launch a campaign", and a connected merchant with recent ad spend is suppressed.
- Copy and CTA matrix: each matched case by connection state renders the expected headline, body, CTA label, and CTA destination.
- Durable dismissal: dismiss hides the card immediately, persists to the user preference, and stays hidden after a reload.
- Tracking: view, click, and dismiss events fire with the expected props, and the CTA carries `referrer_type` / `referrer_id` that survive the navigation hop into onboarding.

Unit (Jest), in `js/src/components/analytics-overview-promo/get-promo-content.test.js`: pins the copy and case-selection helper across the matched-case by connection-state matrix.

Test harness:

- The page object (`tests/e2e/utils/pages/analytics-overview.js`) intercepts the `wc-analytics` revenue and products stats endpoints and returns primary vs. comparison totals keyed on the request range, so each up/down case is forced without seeded orders. Report totals live in a shared fixture (`tests/e2e/utils/__fixtures__/analytics-overview-stats.json`) and the stubs are torn down between scenarios.
- Connection state uses the existing `gla-test/*` merchant helpers from `tests/e2e/utils/api.js`, and recent ad spend is set through the paid-programs report mock, so no real Google accounts are needed.
- The live date-range switch drives WooCommerce's own client-side navigation, the same path the report controls use, and asserts the card re-renders without a reload.

### Screenshots:

### Detailed test instructions:

1. `npm ci && npm run build`
2. Start the environment: `npm run wp-env:up`
3. Run the unit test: `npm run test:js -- js/src/components/analytics-overview-promo`
4. Run the e2e spec: `npm run test:e2e -- tests/e2e/specs/analytics-overview/analytics-overview.test.js`
5. Confirm the suite passes and the run needs no real Google account or seeded orders.

### Additional details:

The e2e suite runs serially against a single worker, matching the existing specs. Each scenario sets its own merchant state and metric mocks and cleans them up afterward, so the file is order-independent.

### Changelog entry

> Dev - Add e2e and unit test coverage for the Analytics Overview promo.
