### PR TITLE
Fix / WP ENV Bullseye Apt Mirror

### DIFF
--- a/bin/patch-wp-env-debian-bullseye.js
+++ b/bin/patch-wp-env-debian-bullseye.js
@@ -1,0 +1,35 @@
+/**
+ * wp-env already redirects stretch and buster to archive.debian.org once they
+ * go EOL — bullseye needs the same now. Runs automatically before `wp-env:up`.
+ *
+ * compatibility-code "@wordpress/env <= 10.29.0" -- remove once wp-env ships its own bullseye redirect
+ */
+
+const fs = require( 'fs' );
+
+const file = 'node_modules/@wordpress/env/lib/init-config.js';
+const target = "RUN sed -i '/buster-updates/d' /etc/apt/sources.list";
+const insertion =
+	target +
+	'\n\n' +
+	'# bullseye\n' +
+	"RUN sed -i 's|deb.debian.org/debian bullseye|archive.debian.org/debian bullseye|g' /etc/apt/sources.list\n" +
+	"RUN sed -i '/bullseye-security/d' /etc/apt/sources.list\n" +
+	"RUN sed -i '/bullseye-updates/d' /etc/apt/sources.list";
+
+const content = fs.readFileSync( file, 'utf8' );
+
+if ( ! content.includes( target ) ) {
+	// eslint-disable-next-line no-console
+	console.error(
+		`::error::Patch target not found in ${ file } — @wordpress/env internals may have changed since this script was written.`
+	);
+	process.exit( 1 );
+}
+
+fs.writeFileSync( file, content.replace( target, insertion ) );
+
+// eslint-disable-next-line no-console
+console.log(
+	`Patched ${ file } to also redirect Debian bullseye to archive.debian.org.`
+);

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
 		"test:js:watch": "npm run test:js -- --watch",
 		"test-proxy": "node ./tests/proxy",
 		"wp-env": "wp-env",
+		"prewp-env:up": "node bin/patch-wp-env-debian-bullseye.js",
 		"wp-env:up": "npm run -- wp-env start --update",
 		"wp-env:down": "npm run wp-env stop"
 	},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes: [GOOWOO-1030](https://linear.app/a8c/issue/GOOWOO-1030/e2e-ci-wp-env-docker-build-fails-bullseye-security-apt-mirror)

E2E CI's `wp-env:up` step has been failing consistently (confirmed reproducible on rerun, not transient). `apt-get update` rejects the live `bullseye-security` mirror's expired release signature, and even past that, installing any package 404s outright. Debian 11 (bullseye) has been retired from Debian's live infrastructure, the same way stretch and buster already were. `wp-env` already redirects those two to `archive.debian.org` once each goes EOL, but has no equivalent for bullseye yet, and no fix has shipped upstream.

- Adds a small script that patches the freshly-installed `@wordpress/env` copy to also redirect bullseye, matching wp-env's own existing stretch/buster pattern exactly (and matching Gutenberg trunk's own not-yet-released fix for the same issue).
- Wired in as a `prewp-env:up` script, so it runs automatically before every `wp-env:up` - CI and local development both get the fix, not just CI.

No plugin/product code changes, dev tooling only.

### Screenshots:

N/A - CI/tooling fix only, no user facing change.

### Detailed test instructions:

1. `npm run wp-env:up` (or let CI's E2E job run it agains this branch): completes without the expired-release-file or 404 errors.

Also verified during development (not something a reviewer needs to action): if `@wordpress/env`'s internals ever shift in a future version bump, the script fails loudly with a clear error instead of silently doing nothing. This was tested by pointing it at a copy of the file with the target text removed.

### Additional details:

Confirmed live on CI: an earlier attempt (bypassing apt's release-metadata freshness check) got further but hit a genuine 404 fetching a package. This proved that this is a real Debian archival event, not a transient mirror issue. This fix matches Gutenberg's own real (unreleased) upstream fix for the identical problem.

### Changelog entry

> N/A - dev tooling only, no user facing or plugin behaviour change.
