### PR TITLE
GOOWOO-1009: Fix search-console property-selection test mocks

### DIFF
--- a/tests/e2e/specs/search-console/search-console.test.js
+++ b/tests/e2e/specs/search-console/search-console.test.js
@@ -86,7 +86,7 @@ test.describe( 'Google Search Console', () => {
 	test.describe( 'Property resolution', () => {
 		test.afterEach( async () => {
 			await page.unroute( /\/wc\/gla\/search-console\/connection\b/ );
-			await page.unroute( /\/wc\/gla\/search-console\/property\b/ );
+			await page.unroute( /\/wc\/gla\/search-console\/properties\b/ );
 		} );
 
 		test( 'resolves straight to the connected state with no merchant action, whether a single property was auto-selected or none existed to silently create one', async () => {
@@ -130,31 +130,36 @@ test.describe( 'Google Search Console', () => {
 				settingsPage.getSearchConsolePropertySelect();
 			const saveButton =
 				settingsPage.getSearchConsoleSavePropertyButton();
-			await expect( saveButton ).toBeDisabled();
+
+			// The first usable property is auto-selected on mount, via the same
+			// shared select-control pattern (`autoSelectFirstOption`) used by the
+			// plugin's other account selectors (e.g. Merchant Center, Ads), so Save
+			// starts enabled without any merchant action.
+			await expect( saveButton ).toBeEnabled();
 
 			const unusableOption = propertySelect.getByRole( 'option', {
 				name: 'https://example.com/unverified/ (Not yet verified)',
 			} );
 			await expect( unusableOption ).toBeDisabled();
 
-			await propertySelect.selectOption( 'https://example.com/' );
+			await propertySelect.selectOption( 'sc-domain:example.com' );
 			await expect( saveButton ).toBeEnabled();
 
-			await settingsPage.fulfillSearchConsoleProperty( {
+			await settingsPage.fulfillSearchConsolePropertySelection( {
 				status: 'connected',
 			} );
 			await settingsPage.mockSearchConsoleAccountConnected(
-				'https://example.com/'
+				'sc-domain:example.com'
 			);
 
 			const requestPromise =
-				settingsPage.registerSearchConsolePropertyRequest();
+				settingsPage.registerSearchConsolePropertySelectionRequest();
 
 			await saveButton.click();
 
 			const request = await requestPromise;
 			expect( request.postDataJSON() ).toEqual( {
-				site_url: 'https://example.com/',
+				site_url: 'sc-domain:example.com',
 			} );
 
 			await expect(
@@ -171,15 +176,16 @@ test.describe( 'Google Search Console', () => {
 
 			const saveButton =
 				settingsPage.getSearchConsoleSavePropertyButton();
-			// Wait for the initial multi-match fetch to resolve before arming the
-			// failure response, for the same race-avoidance reason as the "Create
-			// new" test below.
-			await expect( saveButton ).toBeDisabled();
+			// Wait for the initial multi-match fetch to resolve (auto-selecting the
+			// first usable property and enabling Save) before arming the failure
+			// response, for the same race-avoidance reason as the "Create new" test
+			// below.
+			await expect( saveButton ).toBeEnabled();
 
 			await settingsPage
 				.getSearchConsolePropertySelect()
 				.selectOption( 'https://example.com/' );
-			await settingsPage.fulfillSearchConsoleProperty( {}, 500 );
+			await settingsPage.fulfillSearchConsolePropertySelection( {}, 500 );
 
 			await saveButton.click();
 
@@ -210,7 +216,7 @@ test.describe( 'Google Search Console', () => {
 			// straight into the connected state, skipping the selector entirely.
 			await expect( createNewButton ).toBeVisible();
 
-			await settingsPage.fulfillSearchConsoleProperty( {
+			await settingsPage.fulfillSearchConsolePropertySelection( {
 				status: 'connected',
 			} );
 			await settingsPage.mockSearchConsoleAccountConnected(
@@ -218,12 +224,14 @@ test.describe( 'Google Search Console', () => {
 			);
 
 			const requestPromise =
-				settingsPage.registerSearchConsolePropertyRequest();
+				settingsPage.registerSearchConsolePropertySelectionRequest();
 
 			await createNewButton.click();
 
 			const request = await requestPromise;
-			expect( request.postDataJSON() ).toEqual( {} );
+			// "Create new" submits with no `site_url`, so the request carries no body
+			// at all (rather than an empty JSON object).
+			expect( request.postData() ).toBeNull();
 
 			await expect(
 				settingsPage.getSearchConsoleConnectedBadge()

--- a/tests/e2e/utils/mock-requests.js
+++ b/tests/e2e/utils/mock-requests.js
@@ -1551,15 +1551,17 @@ export default class MockRequests {
 	}
 
 	/**
-	 * Fulfill the Google Search Console property-selection request.
+	 * Fulfill the Google Search Console property-selection request. This is the same
+	 * `search-console/properties` endpoint the candidate listing uses, disambiguated
+	 * by HTTP method (`POST` selects/creates, `GET` lists candidates).
 	 *
 	 * @param {Object} payload
 	 * @param {number} [status=200]
 	 * @return {Promise<void>}
 	 */
-	async fulfillSearchConsoleProperty( payload, status = 200 ) {
+	async fulfillSearchConsolePropertySelection( payload, status = 200 ) {
 		await this.fulfillRequest(
-			/\/wc\/gla\/search-console\/property\b/,
+			/\/wc\/gla\/search-console\/properties\b/,
 			payload,
 			status,
 			[ 'POST' ]
@@ -1626,7 +1628,26 @@ export default class MockRequests {
 	}
 
 	/**
+	 * Fulfill the Google Search Console candidate properties listing request.
+	 *
+	 * @param {Array<{siteUrl: string, usable?: boolean, covers_store_url?: boolean}>} properties
+	 * @param {number} [status=200]
+	 * @return {Promise<void>}
+	 */
+	async fulfillSearchConsoleProperties( properties, status = 200 ) {
+		await this.fulfillRequest(
+			/\/wc\/gla\/search-console\/properties\b/,
+			properties,
+			status,
+			[ 'GET' ]
+		);
+	}
+
+	/**
 	 * Mock multiple usable Google Search Console properties, showing the property selector.
+	 *
+	 * The selector is populated from `GET search-console/properties`, a separate request from
+	 * the connection status check, so both must be mocked with the same candidates.
 	 *
 	 * @param {Array<{siteUrl: string, usable?: boolean, covers_store_url?: boolean}>} matches Candidate properties.
 	 * @return {Promise<void>}
@@ -1636,6 +1657,7 @@ export default class MockRequests {
 			status: 'incomplete',
 			matches,
 		} );
+		await this.fulfillSearchConsoleProperties( matches );
 	}
 
 	/**

--- a/tests/e2e/utils/pages/settings.js
+++ b/tests/e2e/utils/pages/settings.js
@@ -280,7 +280,7 @@ export default class SettingsPage extends MockRequests {
 	 */
 	getSearchConsoleCreateNewPropertyButton() {
 		return this.searchConsoleAccountCard.getByRole( 'button', {
-			name: 'Or, create a new Google Search Console property',
+			name: 'Create new property',
 		} );
 	}
 
@@ -331,10 +331,10 @@ export default class SettingsPage extends MockRequests {
 	 *
 	 * @return {Promise<import('@playwright/test').Request>} The request.
 	 */
-	registerSearchConsolePropertyRequest() {
+	registerSearchConsolePropertySelectionRequest() {
 		return this.page.waitForRequest(
 			( request ) =>
-				request.url().includes( '/gla/search-console/property' ) &&
+				request.url().includes( '/gla/search-console/properties' ) &&
 				request.method() === 'POST'
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes GOOWOO-1009.

Fixes 3 broken assumptions in the Search Console "Property resolution" Playwright e2e tests, found while investigating a failing full-suite run on this branch:

- The multi-match property selector fetches its candidate list from a separate `GET search-console/properties` request, not the connection-status response — that request wasn't mocked, so it hit the real (un-authenticated) backend, 401'd, and the app's global reconnect handling silently bounced the page out of the Accounts tab before the assertion ran.
- The property select/create `POST` also targets `search-console/properties` (plural), not the `search-console/property` (singular) path the mocks and request-matcher assumed — so submitting a selection fell through to the real API and the test hung waiting for a request that never matched.
- Three stale assumptions in the assertions themselves: the property select auto-selects its first usable option on mount (the same `autoSelectFirstOption` pattern used by the plugin's other account selectors), so Save starts enabled rather than disabled; the "Create new" button's real label is "Create new property"; and its request carries no body at all, not an empty JSON object.

All 12 tests in `search-console.test.js` now pass, verified both in isolation and in a full e2e-suite run.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Ensure the `tests-wordpress` wp-env instance is running (`npm run wp-env:up`)
2. `npx playwright test --config=tests/e2e/config/playwright.config.js tests/e2e/specs/search-console/search-console.test.js`
3. Confirm all 12 tests pass
4. (Optional) Run the full suite (`npm run test:e2e`) to confirm no regressions elsewhere


### Additional details:

### Changelog entry

>