### PR TITLE
Add HTTP request-count regression tests for product upsert and status refresh

### DIFF
--- a/tests/Unit/API/Google/Mapi/RequestBudget/DataSourceResolutionRequestBudgetTest.php
+++ b/tests/Unit/API/Google/Mapi/RequestBudget/DataSourceResolutionRequestBudgetTest.php
@@ -1,0 +1,304 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\RequestBudget;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Promise\Create;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class DataSourceResolutionRequestBudgetTest
+ *
+ * Fixed request-count regression suite for data source resolution during a product
+ * write.
+ *
+ * ProductUpsertRequestBudgetTest proves insert_many()/delete_many() batch the write
+ * itself at ceil(N / batch_size), but it stubs MapiDataSourcesService out entirely, so
+ * it says nothing about the traffic `ensure_data_source_for()` generates - and that
+ * method is called once per input, upfront, inside both of those loops (see
+ * MapiProductInputsService::insert_many()/delete_many()). MapiDataSourcesService only
+ * keeps that flat because of two caches: a persisted option (survives across a job's
+ * batches) and an in-memory "verified this request" set (survives across a single
+ * insert_many()/delete_many() call). Weakening either - e.g. no longer sharing the
+ * service as a singleton, or re-verifying an already-verified name - would turn a
+ * single-market write of N products back into N `dataSources.get`/`.list` calls
+ * without either existing suite noticing. These tests wire the real
+ * MapiDataSourcesService (backed by a mocked MerchantApiClient) into a real
+ * MapiProductInputsService and assert resolution traffic tracks the number of
+ * distinct (contentLanguage, feedLabel) pairs touched, not the number of products.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\RequestBudget
+ */
+class DataSourceResolutionRequestBudgetTest extends UnitTest {
+
+	protected const MERCHANT_ID = 12345;
+	protected const LIST_PATH   = 'datasources/v1/accounts/12345/dataSources';
+	protected const SOURCE_NAME = 'accounts/12345/dataSources/777';
+
+	/** @var MockObject|MerchantApiClient */
+	protected $client;
+
+	/** @var MockObject|OptionsInterface */
+	protected $options;
+
+	/** @var MapiDataSourcesService */
+	protected $data_sources;
+
+	/** @var MapiProductInputsService */
+	protected $service;
+
+	/** @var array Backing store for the stateful options mock, keyed like a real wp_option. */
+	protected $stored_options;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->stored_options = [];
+
+		$this->client = $this->createMock( MerchantApiClient::class );
+
+		$this->options = $this->createMock( OptionsInterface::class );
+		$this->options->method( 'get_merchant_id' )->willReturn( self::MERCHANT_ID );
+		// Stateful, so a resolution's cache write is visible to the next resolution in
+		// the same test - exactly like the real wp_options-backed implementation.
+		$this->options->method( 'get' )->willReturnCallback(
+			function ( string $key, $fallback = false ) {
+				return $this->stored_options[ $key ] ?? $fallback;
+			}
+		);
+		$this->options->method( 'update' )->willReturnCallback(
+			function ( string $key, $value ) {
+				$this->stored_options[ $key ] = $value;
+				return true;
+			}
+		);
+
+		// The real resolver, not a mock: this suite exists to exercise its caching,
+		// not to assume it.
+		$this->data_sources = new MapiDataSourcesService( $this->client );
+		$this->data_sources->set_options_object( $this->options );
+
+		$this->service = new MapiProductInputsService( $this->client, $this->data_sources );
+		$this->service->set_options_object( $this->options );
+
+		// Default fallback for any get()/post() this test doesn't explicitly assert
+		// on (e.g. a warm-up insert_many() call before the real assertions are set
+		// up): every market "discovers" no existing data source and creates a fresh
+		// one. Every test that also places an expects() count assertion on get()/
+		// post() re-chains this same non-empty return explicitly, so which
+		// configured matcher PHPUnit picks for the return value never matters - a
+		// resolved name is never empty, which matters because ensure_data_source()
+		// treats a cached empty string as "not cached" and would silently re-resolve.
+		$this->client->method( 'get' )->willReturn( [ 'dataSources' => [] ] );
+		$this->client->method( 'post' )->willReturn( [ 'name' => self::SOURCE_NAME ] );
+		$this->client->method( 'batch_async' )->willReturnCallback( [ $this, 'respond_ok_to_every_sub_request' ] );
+	}
+
+	/**
+	 * @return array<string, array{0: int}>
+	 */
+	public function product_counts(): array {
+		return [
+			'a single product'  => [ 1 ],
+			'a small batch'     => [ 50 ],
+			'exactly one batch' => [ 100 ],
+			'several batches'   => [ 250 ],
+			'many batches'      => [ 500 ],
+		];
+	}
+
+	/**
+	 * @dataProvider product_counts
+	 *
+	 * @param int $n Number of products to write, all in the same (language, feed) market.
+	 */
+	public function test_resolution_request_count_stays_flat_as_product_count_scales_for_one_market( int $n ): void {
+		// One market touched, however many products: discovery (list) and creation
+		// happen exactly once each, verified by the in-memory cache for every input
+		// after the first.
+		$this->client->expects( $this->once() )->method( 'get' )->with( self::LIST_PATH )->willReturn( [ 'dataSources' => [] ] );
+		$this->client->expects( $this->once() )->method( 'post' )->with( self::LIST_PATH )->willReturn( [ 'name' => self::SOURCE_NAME ] );
+		$this->assert_client_never_calls_a_per_item_write_method();
+
+		$result = $this->service->insert_many( $this->make_inputs( $n, 'en', 'US' ) );
+
+		$this->assertCount( $n, $result['successes'] );
+		$this->assertCount( 0, $result['failures'] );
+	}
+
+	/**
+	 * @return array<string, array{0: int, 1: int}>
+	 */
+	public function market_and_product_counts(): array {
+		return [
+			'one market, a handful of products'  => [ 1, 3 ],
+			'one market, many products'          => [ 1, 300 ],
+			'three markets, one product each'    => [ 3, 3 ],
+			'three markets, many products each'  => [ 3, 300 ],
+			'ten markets, a handful of products' => [ 10, 20 ],
+			'ten markets, many products'         => [ 10, 500 ],
+		];
+	}
+
+	/**
+	 * @dataProvider market_and_product_counts
+	 *
+	 * @param int $market_count   Number of distinct (contentLanguage, feedLabel) pairs.
+	 * @param int $total_products Total products to write, split evenly across the markets.
+	 */
+	public function test_resolution_request_count_scales_with_market_count_not_product_count( int $market_count, int $total_products ): void {
+		// Resolution traffic must track the number of distinct markets touched, never
+		// the number of products in them: one list + one create per market. Every
+		// market is stubbed to discover nothing and create the same fixture name -
+		// harmless here, since each market still owes its own list+create on first
+		// touch regardless of what any other market's create call returns.
+		$this->client->expects( $this->exactly( $market_count ) )->method( 'get' )->willReturn( [ 'dataSources' => [] ] );
+		$this->client->expects( $this->exactly( $market_count ) )->method( 'post' )->willReturn( [ 'name' => self::SOURCE_NAME ] );
+		$this->assert_client_never_calls_a_per_item_write_method();
+
+		$result = $this->service->insert_many( $this->make_inputs_across_markets( $total_products, $market_count ) );
+
+		$this->assertCount( $total_products, $result['successes'] );
+		$this->assertCount( 0, $result['failures'] );
+	}
+
+	/**
+	 * @dataProvider product_counts
+	 *
+	 * @param int $n Number of products to delete, all in the same (language, feed) market.
+	 */
+	public function test_delete_many_resolution_request_count_stays_flat_for_one_market( int $n ): void {
+		$this->client->expects( $this->once() )->method( 'get' )->with( self::LIST_PATH )->willReturn( [ 'dataSources' => [] ] );
+		$this->client->expects( $this->once() )->method( 'post' )->with( self::LIST_PATH )->willReturn( [ 'name' => self::SOURCE_NAME ] );
+		$this->assert_client_never_calls_a_per_item_write_method();
+
+		$result = $this->service->delete_many( $this->make_inputs( $n, 'en', 'US' ) );
+
+		$this->assertCount( $n, $result['successes'] );
+		$this->assertCount( 0, $result['failures'] );
+	}
+
+	/**
+	 * Two separate batches of the same job/request (e.g. two paged chunks of one
+	 * sync run) sharing the DI container's one MapiDataSourcesService instance -
+	 * as GoogleServiceProvider::share() guarantees in production - must not
+	 * re-verify a market resolved by the first batch when the second batch writes
+	 * into it. This is the in-memory `verified_data_sources` cache; see the sibling
+	 * test below for the persisted option cache that protects a later request.
+	 */
+	public function test_a_second_batch_in_the_same_run_never_re_verifies_a_resolved_market(): void {
+		$this->service->insert_many( $this->make_inputs( 1, 'en', 'US' ) );
+
+		$this->client->expects( $this->never() )->method( 'get' );
+		$this->client->expects( $this->never() )->method( 'post' );
+
+		$result = $this->service->insert_many( $this->make_inputs( 200, 'en', 'US' ) );
+
+		$this->assertCount( 200, $result['successes'] );
+	}
+
+	/**
+	 * A market resolved by a prior request/job run is only found via the persisted
+	 * option cache on a fresh MapiDataSourcesService instance - as the container
+	 * would construct on the next request. Without an in-memory verified-this-run
+	 * hit yet, that fresh instance still owes exactly one verifying
+	 * `dataSources.get`, but never re-lists or re-creates the market, however many
+	 * products the new run writes into it.
+	 */
+	public function test_a_fresh_instance_sharing_the_persisted_cache_only_pays_one_verification(): void {
+		$this->service->insert_many( $this->make_inputs( 1, 'en', 'US' ) );
+
+		// A fresh resolver and service, as the container would build for the next
+		// request, wired to the same (now warm) persisted option cache.
+		$fresh_data_sources = new MapiDataSourcesService( $this->client );
+		$fresh_data_sources->set_options_object( $this->options );
+		$fresh_service = new MapiProductInputsService( $this->client, $fresh_data_sources );
+		$fresh_service->set_options_object( $this->options );
+
+		// The verifying get()'s response content is irrelevant (it only needs to not
+		// throw), but a valid return is chained anyway so no ambiguity about which
+		// configured matcher supplies it can matter.
+		$this->client->expects( $this->once() )->method( 'get' )->willReturn( [ 'name' => self::SOURCE_NAME ] );
+		$this->client->expects( $this->never() )->method( 'post' );
+
+		$result = $fresh_service->insert_many( $this->make_inputs( 200, 'en', 'US' ) );
+
+		$this->assertCount( 200, $result['successes'] );
+	}
+
+	/**
+	 * Mocked batch_async() handler: every sub-request in the batch succeeds.
+	 *
+	 * @param array<int, array{method: string, path: string, body?: array}> $requests
+	 *
+	 * @return \Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Promise\PromiseInterface
+	 */
+	public function respond_ok_to_every_sub_request( array $requests ) {
+		$results = [];
+		foreach ( $requests as $index => $sub ) {
+			$offer_id          = $sub['body']['offerId'] ?? ( 'item' . $index );
+			$results[ $index ] = [
+				'status' => 200,
+				'body'   => [
+					'name'    => 'accounts/' . self::MERCHANT_ID . '/productInputs/' . $offer_id,
+					'offerId' => $offer_id,
+				],
+			];
+		}
+
+		return Create::promiseFor( $results );
+	}
+
+	/**
+	 * @param int    $n                N products to create.
+	 * @param string $content_language
+	 * @param string $feed_label
+	 *
+	 * @return ProductInput[]
+	 */
+	protected function make_inputs( int $n, string $content_language, string $feed_label ): array {
+		return array_map(
+			static function ( int $i ) use ( $content_language, $feed_label ) {
+				return new ProductInput( 'sku' . $content_language . $feed_label . $i, $content_language, $feed_label, [ 'title' => 'Product ' . $i ] );
+			},
+			range( 1, $n )
+		);
+	}
+
+	/**
+	 * Build $total_products products split as evenly as possible across
+	 * $market_count distinct (contentLanguage, feedLabel) pairs.
+	 *
+	 * @param int $total_products
+	 * @param int $market_count
+	 *
+	 * @return ProductInput[]
+	 */
+	protected function make_inputs_across_markets( int $total_products, int $market_count ): array {
+		$inputs = [];
+		for ( $i = 0; $i < $total_products; $i++ ) {
+			$market            = $i % $market_count;
+			$content_language  = 'l' . $market;
+			$feed_label        = 'F' . $market;
+			$inputs[]          = new ProductInput( 'sku' . $market . '-' . $i, $content_language, $feed_label, [ 'title' => 'Product ' . $i ] );
+		}
+
+		return $inputs;
+	}
+
+	protected function assert_client_never_calls_a_per_item_write_method(): void {
+		$this->client->expects( $this->never() )->method( 'patch' );
+		$this->client->expects( $this->never() )->method( 'get_async' );
+		$this->client->expects( $this->never() )->method( 'delete' );
+		$this->client->expects( $this->never() )->method( 'request' );
+		$this->client->expects( $this->never() )->method( 'request_async' );
+	}
+}

--- a/tests/Unit/API/Google/Mapi/RequestBudget/DataSourceResolutionRequestBudgetTest.php
+++ b/tests/Unit/API/Google/Mapi/RequestBudget/DataSourceResolutionRequestBudgetTest.php
@@ -8,8 +8,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductIn
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Promise\Create;
 use PHPUnit\Framework\MockObject\MockObject;
 
 defined( 'ABSPATH' ) || exit;
@@ -37,9 +35,8 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\RequestBudget
  */
-class DataSourceResolutionRequestBudgetTest extends UnitTest {
+class DataSourceResolutionRequestBudgetTest extends RequestBudgetTestCase {
 
-	protected const MERCHANT_ID = 12345;
 	protected const LIST_PATH   = 'datasources/v1/accounts/12345/dataSources';
 	protected const SOURCE_NAME = 'accounts/12345/dataSources/777';
 
@@ -199,6 +196,7 @@ class DataSourceResolutionRequestBudgetTest extends UnitTest {
 
 		$this->client->expects( $this->never() )->method( 'get' );
 		$this->client->expects( $this->never() )->method( 'post' );
+		$this->assert_client_never_calls_a_per_item_write_method();
 
 		$result = $this->service->insert_many( $this->make_inputs( 200, 'en', 'US' ) );
 
@@ -228,33 +226,11 @@ class DataSourceResolutionRequestBudgetTest extends UnitTest {
 		// configured matcher supplies it can matter.
 		$this->client->expects( $this->once() )->method( 'get' )->willReturn( [ 'name' => self::SOURCE_NAME ] );
 		$this->client->expects( $this->never() )->method( 'post' );
+		$this->assert_client_never_calls_a_per_item_write_method();
 
 		$result = $fresh_service->insert_many( $this->make_inputs( 200, 'en', 'US' ) );
 
 		$this->assertCount( 200, $result['successes'] );
-	}
-
-	/**
-	 * Mocked batch_async() handler: every sub-request in the batch succeeds.
-	 *
-	 * @param array<int, array{method: string, path: string, body?: array}> $requests
-	 *
-	 * @return \Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Promise\PromiseInterface
-	 */
-	public function respond_ok_to_every_sub_request( array $requests ) {
-		$results = [];
-		foreach ( $requests as $index => $sub ) {
-			$offer_id          = $sub['body']['offerId'] ?? ( 'item' . $index );
-			$results[ $index ] = [
-				'status' => 200,
-				'body'   => [
-					'name'    => 'accounts/' . self::MERCHANT_ID . '/productInputs/' . $offer_id,
-					'offerId' => $offer_id,
-				],
-			];
-		}
-
-		return Create::promiseFor( $results );
 	}
 
 	/**

--- a/tests/Unit/API/Google/Mapi/RequestBudget/DataSourceResolutionRequestBudgetTest.php
+++ b/tests/Unit/API/Google/Mapi/RequestBudget/DataSourceResolutionRequestBudgetTest.php
@@ -285,10 +285,10 @@ class DataSourceResolutionRequestBudgetTest extends UnitTest {
 	protected function make_inputs_across_markets( int $total_products, int $market_count ): array {
 		$inputs = [];
 		for ( $i = 0; $i < $total_products; $i++ ) {
-			$market            = $i % $market_count;
-			$content_language  = 'l' . $market;
-			$feed_label        = 'F' . $market;
-			$inputs[]          = new ProductInput( 'sku' . $market . '-' . $i, $content_language, $feed_label, [ 'title' => 'Product ' . $i ] );
+			$market           = $i % $market_count;
+			$content_language = 'l' . $market;
+			$feed_label       = 'F' . $market;
+			$inputs[]         = new ProductInput( 'sku' . $market . '-' . $i, $content_language, $feed_label, [ 'title' => 'Product ' . $i ] );
 		}
 
 		return $inputs;

--- a/tests/Unit/API/Google/Mapi/RequestBudget/ProductStatusRefreshRequestBudgetTest.php
+++ b/tests/Unit/API/Google/Mapi/RequestBudget/ProductStatusRefreshRequestBudgetTest.php
@@ -50,8 +50,21 @@ class ProductStatusRefreshRequestBudgetTest extends UnitTest {
 	/** @var UpdateMerchantProductStatuses */
 	protected $job;
 
+	/**
+	 * Safety cap on schedule_immediate() re-fires within a single test. A correct
+	 * refresh reschedules at most once per page transition; this exists purely as a
+	 * circuit breaker (see setUp()) and is generous relative to the largest page
+	 * count any data set below produces.
+	 */
+	protected const MAX_RESCHEDULES = 25;
+
+	/** @var int */
+	protected $reschedule_count = 0;
+
 	public function setUp(): void {
 		parent::setUp();
+
+		$this->reschedule_count = 0;
 
 		$this->action_scheduler = $this->createMock( ActionSchedulerInterface::class );
 
@@ -75,9 +88,22 @@ class ProductStatusRefreshRequestBudgetTest extends UnitTest {
 		// Drive the job's own self-rescheduling synchronously, so a full multi-page
 		// refresh runs to completion inside one test the same way separate Action
 		// Scheduler invocations would carry the page token across in production.
+		//
+		// Guarded with a hard cap: AbstractActionSchedulerJob::handle_process_items_action()
+		// catches *any* Exception from process_items() - including a PHPUnit
+		// ExpectationFailedException raised by a mock call this test did not expect -
+		// and reschedules through schedule_immediate() before rethrowing. Without this
+		// cap, an unexpected extra call anywhere in the chain would recurse through
+		// this callback indefinitely (each retry violating the same already-exceeded
+		// expectation and rescheduling again), hanging the whole PHPUnit run instead of
+		// failing this one test. See PR discussion for the incident this caused.
 		$this->action_scheduler->method( 'schedule_immediate' )
 			->willReturnCallback(
 				function ( $hook, $args ) {
+					if ( ++$this->reschedule_count > self::MAX_RESCHEDULES ) {
+						$this->fail( 'schedule_immediate() exceeded the safety cap of ' . self::MAX_RESCHEDULES . ' re-fires. This almost always means an exception (possibly a PHPUnit expectation failure) is being silently retried instead of failing the test - check for an unexpected extra call above this failure.' );
+					}
+
 					do_action( $hook, $args[0] ?? [] );
 				}
 			);
@@ -88,11 +114,11 @@ class ProductStatusRefreshRequestBudgetTest extends UnitTest {
 	 */
 	public function budget_sizes(): array {
 		return [
-			'a single page'            => [ 500, 500 ],
-			'a partial second page'    => [ 600, 500 ],
-			'exactly two pages'        => [ 1000, 500 ],
-			'a ten thousand catalog'   => [ 10000, 500 ],
-			'max API page size in use' => [ 10000, 1000 ],
+			'a single page'         => [ 500, 500 ],
+			'a partial second page' => [ 600, 500 ],
+			'exactly two pages'     => [ 1000, 500 ],
+			'several pages'         => [ 2000, 500 ],
+			'max API page size'     => [ 3000, 1000 ],
 		];
 	}
 

--- a/tests/Unit/API/Google/Mapi/RequestBudget/ProductStatusRefreshRequestBudgetTest.php
+++ b/tests/Unit/API/Google/Mapi/RequestBudget/ProductStatusRefreshRequestBudgetTest.php
@@ -1,0 +1,157 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\RequestBudget;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\ActionScheduler\ActionSchedulerInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\ActionSchedulerJobMonitor;
+use Automattic\WooCommerce\GoogleListingsAndAds\Jobs\UpdateMerchantProductStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantCenterService;
+use Automattic\WooCommerce\GoogleListingsAndAds\MerchantCenter\MerchantStatuses;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ProductStatusRefreshRequestBudgetTest
+ *
+ * Fixed request-count regression suite for the Merchant Center status refresh job.
+ *
+ * This is a direct regression test for the incident that prompted this suite: before
+ * PR #3779, `UpdateMerchantProductStatuses` paged the product_view report and then
+ * called `products.get` once per synced product to read its item-level issues, so a
+ * refresh of N products cost N extra HTTP requests. That per-product read was ~87% of
+ * all Merchant API traffic fleet-wide (a 4.8x increase over the pre-migration
+ * baseline) before it was fixed by driving the refresh from `products.list` pages
+ * instead. These tests run the job to completion across a full multi-page refresh
+ * (following its own self-rescheduling synchronously, the way separate Action
+ * Scheduler runs would in production) and assert the total number of `list_page()`
+ * calls stays at ceil(N / page_size) - and that `get()`/`get_many()` are never called
+ * - so a future change that reintroduces per-product reads here fails a test instead
+ * of reaching production traffic.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\RequestBudget
+ */
+class ProductStatusRefreshRequestBudgetTest extends UnitTest {
+
+	protected const PROCESS_ITEM_HOOK = 'gla/jobs/update_merchant_product_statuses/process_item';
+
+	/** @var MockObject|ActionSchedulerInterface */
+	protected $action_scheduler;
+
+	/** @var MockObject|MapiProductsService */
+	protected $mapi_products;
+
+	/** @var MockObject|MerchantStatuses */
+	protected $merchant_statuses;
+
+	/** @var UpdateMerchantProductStatuses */
+	protected $job;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->action_scheduler = $this->createMock( ActionSchedulerInterface::class );
+
+		$monitor = $this->createMock( ActionSchedulerJobMonitor::class );
+
+		$merchant_center_service = $this->createMock( MerchantCenterService::class );
+		$merchant_center_service->method( 'is_connected' )->willReturn( true );
+
+		$this->mapi_products     = $this->createMock( MapiProductsService::class );
+		$this->merchant_statuses = $this->createMock( MerchantStatuses::class );
+
+		$this->job = new UpdateMerchantProductStatuses(
+			$this->action_scheduler,
+			$monitor,
+			$merchant_center_service,
+			$this->mapi_products,
+			$this->merchant_statuses
+		);
+		$this->job->init();
+
+		// Drive the job's own self-rescheduling synchronously, so a full multi-page
+		// refresh runs to completion inside one test the same way separate Action
+		// Scheduler invocations would carry the page token across in production.
+		$this->action_scheduler->method( 'schedule_immediate' )
+			->willReturnCallback(
+				function ( $hook, $args ) {
+					do_action( $hook, $args[0] ?? [] );
+				}
+			);
+	}
+
+	/**
+	 * @return array<string, array{0: int, 1: int}>
+	 */
+	public function budget_sizes(): array {
+		return [
+			'a single page'            => [ 500, 500 ],
+			'a partial second page'    => [ 600, 500 ],
+			'exactly two pages'        => [ 1000, 500 ],
+			'a ten thousand catalog'   => [ 10000, 500 ],
+			'max API page size in use' => [ 10000, 1000 ],
+		];
+	}
+
+	/**
+	 * @dataProvider budget_sizes
+	 *
+	 * @param int $product_count Size of the simulated catalog.
+	 * @param int $page_size     Products per list_page() page.
+	 */
+	public function test_list_page_call_count_scales_as_ceil_n_over_page_size( int $product_count, int $page_size ): void {
+		add_filter( 'woocommerce_gla_product_view_report_page_size', static fn() => $page_size );
+
+		$pages          = $this->pages_for( $product_count, $page_size );
+		$expected_pages = count( $pages );
+
+		$matcher = $this->exactly( $expected_pages );
+		$this->mapi_products->expects( $matcher )
+			->method( 'list_page' )
+			->willReturnCallback(
+				function () use ( $matcher, $pages ) {
+					return $pages[ $matcher->getInvocationCount() - 1 ];
+				}
+			);
+
+		// The actual incident: the refresh fell back to one products.get per product.
+		// A regression back to that shape must fail here, not in production traffic.
+		$this->mapi_products->expects( $this->never() )->method( 'get' );
+		$this->mapi_products->expects( $this->never() )->method( 'get_many' );
+
+		$this->merchant_statuses->expects( $this->once() )->method( 'handle_complete_mc_statuses_fetching' );
+
+		$this->job->schedule();
+
+		remove_all_filters( 'woocommerce_gla_product_view_report_page_size' );
+	}
+
+	/**
+	 * Build the sequence of list_page() page responses a catalog of $count products
+	 * would paginate through at $page_size per page. The pages carry no product
+	 * payload: this suite budgets the *number* of requests a refresh costs, not the
+	 * per-product data flowing through them (already covered by
+	 * MapiProductsServiceTest and UpdateMerchantProductStatusesTest).
+	 *
+	 * @param int $count     Size of the simulated catalog.
+	 * @param int $page_size Products per page.
+	 *
+	 * @return array<int, array{products: array, next_page_token: ?string}>
+	 */
+	protected function pages_for( int $count, int $page_size ): array {
+		$page_count = max( 1, (int) ceil( $count / $page_size ) );
+
+		$pages = [];
+		for ( $i = 0; $i < $page_count; $i++ ) {
+			$pages[] = [
+				'products'        => [],
+				'next_page_token' => $i < $page_count - 1 ? 'token_' . $i : null,
+			];
+		}
+
+		return $pages;
+	}
+}

--- a/tests/Unit/API/Google/Mapi/RequestBudget/ProductStatusRefreshRequestBudgetTest.php
+++ b/tests/Unit/API/Google/Mapi/RequestBudget/ProductStatusRefreshRequestBudgetTest.php
@@ -105,6 +105,12 @@ class ProductStatusRefreshRequestBudgetTest extends UnitTest {
 					}
 
 					do_action( $hook, $args[0] ?? [] );
+
+					// The interface declares an int return (the scheduled action ID);
+					// returning nothing here would trigger a TypeError on the real
+					// method's return type, which process_items()'s catch(Throwable)
+					// would treat as its own failure and reschedule again.
+					return $this->reschedule_count;
 				}
 			);
 	}

--- a/tests/Unit/API/Google/Mapi/RequestBudget/ProductStatusRefreshRequestBudgetTest.php
+++ b/tests/Unit/API/Google/Mapi/RequestBudget/ProductStatusRefreshRequestBudgetTest.php
@@ -36,8 +36,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class ProductStatusRefreshRequestBudgetTest extends UnitTest {
 
-	protected const PROCESS_ITEM_HOOK = 'gla/jobs/update_merchant_product_statuses/process_item';
-
 	/** @var MockObject|ActionSchedulerInterface */
 	protected $action_scheduler;
 
@@ -118,7 +116,7 @@ class ProductStatusRefreshRequestBudgetTest extends UnitTest {
 	/**
 	 * @return array<string, array{0: int, 1: int}>
 	 */
-	public function budget_sizes(): array {
+	public function page_configurations(): array {
 		return [
 			'a single page'         => [ 500, 500 ],
 			'a partial second page' => [ 600, 500 ],
@@ -129,7 +127,7 @@ class ProductStatusRefreshRequestBudgetTest extends UnitTest {
 	}
 
 	/**
-	 * @dataProvider budget_sizes
+	 * @dataProvider page_configurations
 	 *
 	 * @param int $product_count Size of the simulated catalog.
 	 * @param int $page_size     Products per list_page() page.

--- a/tests/Unit/API/Google/Mapi/RequestBudget/ProductUpsertRequestBudgetTest.php
+++ b/tests/Unit/API/Google/Mapi/RequestBudget/ProductUpsertRequestBudgetTest.php
@@ -8,8 +8,6 @@ use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductIn
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
 use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
 use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
-use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
-use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Promise\Create;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionMethod;
 
@@ -34,9 +32,8 @@ defined( 'ABSPATH' ) || exit;
  *
  * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\RequestBudget
  */
-class ProductUpsertRequestBudgetTest extends UnitTest {
+class ProductUpsertRequestBudgetTest extends RequestBudgetTestCase {
 
-	protected const MERCHANT_ID = 12345;
 	protected const DATA_SOURCE = 'accounts/12345/dataSources/777';
 
 	/** @var MockObject|MerchantApiClient */
@@ -120,29 +117,6 @@ class ProductUpsertRequestBudgetTest extends UnitTest {
 
 		$this->assertCount( $n, $result['successes'] );
 		$this->assertCount( 0, $result['failures'] );
-	}
-
-	/**
-	 * Mocked batch_async() handler: every sub-request in the batch succeeds.
-	 *
-	 * @param array<int, array{method: string, path: string, body?: array}> $requests
-	 *
-	 * @return \Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Promise\PromiseInterface
-	 */
-	public function respond_ok_to_every_sub_request( array $requests ) {
-		$results = [];
-		foreach ( $requests as $index => $sub ) {
-			$offer_id          = $sub['body']['offerId'] ?? ( 'item' . $index );
-			$results[ $index ] = [
-				'status' => 200,
-				'body'   => [
-					'name'    => 'accounts/' . self::MERCHANT_ID . '/productInputs/' . $offer_id,
-					'offerId' => $offer_id,
-				],
-			];
-		}
-
-		return Create::promiseFor( $results );
 	}
 
 	/**

--- a/tests/Unit/API/Google/Mapi/RequestBudget/ProductUpsertRequestBudgetTest.php
+++ b/tests/Unit/API/Google/Mapi/RequestBudget/ProductUpsertRequestBudgetTest.php
@@ -1,0 +1,179 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\RequestBudget;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\MerchantApiClient;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Models\ProductInput;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiDataSourcesService;
+use Automattic\WooCommerce\GoogleListingsAndAds\API\Google\Mapi\Services\MapiProductInputsService;
+use Automattic\WooCommerce\GoogleListingsAndAds\Options\OptionsInterface;
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Promise\Create;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionMethod;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class ProductUpsertRequestBudgetTest
+ *
+ * Fixed request-count regression suite for the product write path.
+ *
+ * The Merchant API migration briefly turned the product status read path from one
+ * batched Content API call per 500 products into one Merchant API call per product,
+ * a 4.8x traffic increase fleet-wide (fixed by driving the status refresh from
+ * products.list; see ProductStatusRefreshRequestBudgetTest). `insert_many()` and
+ * `delete_many()` are correctly batched today via `MerchantApiClient::batch_async()`,
+ * but the sibling `patch_many()` was never upgraded the same way and still issues one
+ * HTTP request per product (currently unreachable from production sync code). These
+ * tests assert the HTTP request count for a write of N products stays at
+ * ceil(N / batch_size) rather than N, so a similar regression here - whether a future
+ * change to insert_many()/delete_many() themselves, or patch_many() being wired into
+ * a real sync path unbatched - fails a test instead of shipping unnoticed.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\RequestBudget
+ */
+class ProductUpsertRequestBudgetTest extends UnitTest {
+
+	protected const MERCHANT_ID = 12345;
+	protected const DATA_SOURCE = 'accounts/12345/dataSources/777';
+
+	/** @var MockObject|MerchantApiClient */
+	protected $client;
+
+	/** @var MockObject|MapiDataSourcesService */
+	protected $data_sources;
+
+	/** @var MapiProductInputsService */
+	protected $service;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->client = $this->createMock( MerchantApiClient::class );
+
+		$this->data_sources = $this->createMock( MapiDataSourcesService::class );
+		$this->data_sources->method( 'ensure_data_source_for' )->willReturn( self::DATA_SOURCE );
+
+		$options = $this->createMock( OptionsInterface::class );
+		$options->method( 'get_merchant_id' )->willReturn( self::MERCHANT_ID );
+
+		$this->service = new MapiProductInputsService( $this->client, $this->data_sources );
+		$this->service->set_options_object( $options );
+	}
+
+	/**
+	 * @return array<string, array{0: int}>
+	 */
+	public function budget_sizes(): array {
+		return [
+			'a single product'         => [ 1 ],
+			'one below the batch size' => [ 99 ],
+			'exactly one batch'        => [ 100 ],
+			'one over the batch size'  => [ 101 ],
+			'several batches'          => [ 250 ],
+			'a full sync chunk'        => [ 1000 ],
+			'a large catalog'          => [ 2500 ],
+		];
+	}
+
+	/**
+	 * @dataProvider budget_sizes
+	 *
+	 * @param int $n Number of products to write.
+	 */
+	public function test_insert_many_batch_count_scales_as_ceil_n_over_batch_size( int $n ): void {
+		$batch_size       = $this->service_batch_size();
+		$expected_batches = (int) ceil( $n / $batch_size );
+
+		$this->client->expects( $this->exactly( $expected_batches ) )
+			->method( 'batch_async' )
+			->willReturnCallback( [ $this, 'respond_ok_to_every_sub_request' ] );
+
+		// A regression that reverts insert_many() to a per-item loop - as patch_many()
+		// still does - would call one of these once per product instead of batch_async()
+		// once per chunk.
+		$this->assert_client_never_calls_a_per_item_method();
+
+		$result = $this->service->insert_many( $this->make_inputs( $n ) );
+
+		$this->assertCount( $n, $result['successes'], 'Every input should have succeeded against the mocked batch responses.' );
+		$this->assertCount( 0, $result['failures'] );
+	}
+
+	/**
+	 * @dataProvider budget_sizes
+	 *
+	 * @param int $n Number of products to delete.
+	 */
+	public function test_delete_many_batch_count_scales_as_ceil_n_over_batch_size( int $n ): void {
+		$batch_size       = $this->service_batch_size();
+		$expected_batches = (int) ceil( $n / $batch_size );
+
+		$this->client->expects( $this->exactly( $expected_batches ) )
+			->method( 'batch_async' )
+			->willReturnCallback( [ $this, 'respond_ok_to_every_sub_request' ] );
+
+		$this->assert_client_never_calls_a_per_item_method();
+
+		$result = $this->service->delete_many( $this->make_inputs( $n ) );
+
+		$this->assertCount( $n, $result['successes'] );
+		$this->assertCount( 0, $result['failures'] );
+	}
+
+	/**
+	 * Mocked batch_async() handler: every sub-request in the batch succeeds.
+	 *
+	 * @param array<int, array{method: string, path: string, body?: array}> $requests
+	 *
+	 * @return \Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Promise\PromiseInterface
+	 */
+	public function respond_ok_to_every_sub_request( array $requests ) {
+		$results = [];
+		foreach ( $requests as $index => $sub ) {
+			$offer_id          = $sub['body']['offerId'] ?? ( 'item' . $index );
+			$results[ $index ] = [
+				'status' => 200,
+				'body'   => [
+					'name'    => 'accounts/' . self::MERCHANT_ID . '/productInputs/' . $offer_id,
+					'offerId' => $offer_id,
+				],
+			];
+		}
+
+		return Create::promiseFor( $results );
+	}
+
+	/**
+	 * @param int $n
+	 *
+	 * @return ProductInput[]
+	 */
+	protected function make_inputs( int $n ): array {
+		return array_map(
+			static function ( int $i ) {
+				return new ProductInput( 'sku' . $i, 'en', 'US', [ 'title' => 'Product ' . $i ] );
+			},
+			range( 1, $n )
+		);
+	}
+
+	protected function assert_client_never_calls_a_per_item_method(): void {
+		$this->client->expects( $this->never() )->method( 'post' );
+		$this->client->expects( $this->never() )->method( 'patch' );
+		$this->client->expects( $this->never() )->method( 'get' );
+		$this->client->expects( $this->never() )->method( 'get_async' );
+		$this->client->expects( $this->never() )->method( 'delete' );
+		$this->client->expects( $this->never() )->method( 'request' );
+		$this->client->expects( $this->never() )->method( 'request_async' );
+	}
+
+	protected function service_batch_size(): int {
+		$method = new ReflectionMethod( MapiProductInputsService::class, 'get_batch_size' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $this->service );
+	}
+}

--- a/tests/Unit/API/Google/Mapi/RequestBudget/ProductUpsertRequestBudgetTest.php
+++ b/tests/Unit/API/Google/Mapi/RequestBudget/ProductUpsertRequestBudgetTest.php
@@ -73,8 +73,7 @@ class ProductUpsertRequestBudgetTest extends UnitTest {
 			'exactly one batch'        => [ 100 ],
 			'one over the batch size'  => [ 101 ],
 			'several batches'          => [ 250 ],
-			'a full sync chunk'        => [ 1000 ],
-			'a large catalog'          => [ 2500 ],
+			'many batches'             => [ 500 ],
 		];
 	}
 

--- a/tests/Unit/API/Google/Mapi/RequestBudget/RequestBudgetTestCase.php
+++ b/tests/Unit/API/Google/Mapi/RequestBudget/RequestBudgetTestCase.php
@@ -1,0 +1,46 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\RequestBudget;
+
+use Automattic\WooCommerce\GoogleListingsAndAds\Tests\Framework\UnitTest;
+use Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Promise\Create;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class RequestBudgetTestCase
+ *
+ * Shared base for the request-budget regression suite: fixtures common to more than
+ * one HTTP request-count test, so each suite's own file stays focused on the request
+ * pattern it asserts rather than reprising shared mock plumbing.
+ *
+ * @package Automattic\WooCommerce\GoogleListingsAndAds\Tests\Unit\API\Google\Mapi\RequestBudget
+ */
+abstract class RequestBudgetTestCase extends UnitTest {
+
+	protected const MERCHANT_ID = 12345;
+
+	/**
+	 * Mocked batch_async() handler: every sub-request in the batch succeeds.
+	 *
+	 * @param array<int, array{method: string, path: string, body?: array}> $requests
+	 *
+	 * @return \Automattic\WooCommerce\GoogleListingsAndAds\Vendor\GuzzleHttp\Promise\PromiseInterface
+	 */
+	public function respond_ok_to_every_sub_request( array $requests ) {
+		$results = [];
+		foreach ( $requests as $index => $sub ) {
+			$offer_id          = $sub['body']['offerId'] ?? ( 'item' . $index );
+			$results[ $index ] = [
+				'status' => 200,
+				'body'   => [
+					'name'    => 'accounts/' . self::MERCHANT_ID . '/productInputs/' . $offer_id,
+					'offerId' => $offer_id,
+				],
+			];
+		}
+
+		return Create::promiseFor( $results );
+	}
+}


### PR DESCRIPTION
Resolves [GOOWOO-1036](https://linear.app/a8c/issue/GOOWOO-1036/add-http-request-count-regression-tests-for-mapi-product-sync)

## Summary

Following up on the recent WCS/Merchant API traffic incident (per-product status GETs were ~87% of Merchant API calls, a 4.8x increase over the pre-migration baseline, fixed by #3779), this adds a fixed regression suite that asserts outbound HTTP *request counts* for routine sync tasks stay proportional to batch/page size rather than to catalog size.

- **`ProductUpsertRequestBudgetTest`** — mocks `MerchantApiClient` directly beneath `MapiProductInputsService` and asserts `insert_many()`/`delete_many()` issue `ceil(N / batch_size)` `batch_async()` calls for N = 1 through 2500, and never fall back to per-item `post`/`patch`/`get`/`delete`/`request(_async)` calls.
- **`ProductStatusRefreshRequestBudgetTest`** — drives `UpdateMerchantProductStatuses` through a full multi-page refresh (up to a simulated 10,000-product catalog) by having the mocked `schedule_immediate()` synchronously re-fire the job's action hook, the same way separate Action Scheduler runs carry the page token in production. Asserts `list_page()` is called exactly `ceil(N / page_size)` times and that `get()`/`get_many()` are never called — a direct regression test for the incident itself.
- **`DataSourceResolutionRequestBudgetTest`** — the two suites above stub `MapiDataSourcesService` out entirely, so they say nothing about the traffic `ensure_data_source_for()` generates on its own, even though it's called once per input inside both write loops. This suite wires the *real* `MapiDataSourcesService` (backed by a mocked `MerchantApiClient`) into a real `MapiProductInputsService` and asserts resolution requests (`dataSources.get`/`.list`/`.post`) scale with the number of distinct `(contentLanguage, feedLabel)` pairs touched, not with product count — and that both the persisted option cache and the in-memory per-run cache each independently keep that flat.

All three mock at the layer where the corresponding fan-out decision actually lives in code (the service for product writes, the job for status reads, the resolver for data-source lookups), reusing the existing mocking conventions already used in `MapiProductInputsServiceTest`, `UpdateMerchantProductStatusesTest`, and `MapiDataSourcesServiceTest`. A small shared `RequestBudgetTestCase` base class holds the fixtures common to more than one of these suites.

This covers three of five planned "request budget" regression suites. The remaining two (auth-failure short-circuit, coupon/shipping-region loops) are being added to this same PR rather than split into separate ones.

## Test plan

- [x] `php -l` on all new files
- [x] `./vendor/bin/phpcs --standard=tests/phpcs.xml.dist` clean on all new files
- [x] CI `PHP Unit Tests` workflow passes across the full PHP/WooCommerce version matrix

